### PR TITLE
Model Telemetry page: terrible alignment and issue with discovery button

### DIFF
--- a/radio/src/gui/colorlcd/model_telemetry.cpp
+++ b/radio/src/gui/colorlcd/model_telemetry.cpp
@@ -387,8 +387,7 @@ void ModelTelemetryPage::editSensor(FormWindow * window, uint8_t index)
 void ModelTelemetryPage::build(FormWindow * window, int8_t focusSensorIndex)
 {
   FormGridLayout grid;
-  grid.spacer(8);
-  grid.setLabelWidth(170);
+  grid.spacer(PAGE_PADDING);
 
   this->window = window;
 
@@ -470,7 +469,7 @@ void ModelTelemetryPage::build(FormWindow * window, int8_t focusSensorIndex)
   }
 
   // Autodiscover button
-  auto discover = new TextButton(window, grid.getFieldSlot(2, 0), STR_DISCOVER_SENSORS);
+  auto discover = new TextButton(window, grid.getFieldSlot(2, 0), (allowNewSensors) ? STR_STOP_DISCOVER_SENSORS : STR_DISCOVER_SENSORS);
   discover->setPressHandler([=]() {
     allowNewSensors = !allowNewSensors;
     if (allowNewSensors) {
@@ -509,14 +508,15 @@ void ModelTelemetryPage::build(FormWindow * window, int8_t focusSensorIndex)
     grid.nextLine();
   }
 
+  // restore aligned layout
+  grid.setLabelWidth(PAGE_LABEL_WIDTH);
+
   // Ignore instance button
-  grid.setLabelWidth(170);
   new StaticText(window, grid.getLabelSlot(true), STR_IGNORE_INSTANCE);
   new CheckBox(window, grid.getFieldSlot(), GET_SET_DEFAULT(g_model.ignoreSensorIds));
   grid.nextLine();
 
   // Vario
-  grid.setLabelWidth(100);
   new Subtitle(window, grid.getLineSlot(), STR_VARIO);
   grid.nextLine();
   new StaticText(window, grid.getLabelSlot(true), STR_SOURCE);


### PR DESCRIPTION
the alignment of the fields in the model telemetry page is terrible, this PR corrects this following the general design layout

there is also an issue with the discovery button, in that if it is pressed the first time it does not show stop discovery. The change made in this PR appears to correct that. I specifically write "appears to correct" it, since it's not clear how that thing in the handler is supposed to work, and the coloring might not be as intended either, and so on ... all I can say that from a usage point of view it behaves more like it should

risto and me are seeing that then telemetry is streamed on can't switch off anymore. This is not addressed here, it is just UI.

before:

![IMG_20210517_170940](https://user-images.githubusercontent.com/6089567/118525516-91b03900-b73f-11eb-8da0-0faf4e423918.jpg)

after:

![IMG_20210517_182218](https://user-images.githubusercontent.com/6089567/118525534-95dc5680-b73f-11eb-80ef-262c4f57f85f.jpg)
