### PR TITLE
Invert direction of slider when painting

### DIFF
--- a/radio/src/gui/colorlcd/layouts/sliders.cpp
+++ b/radio/src/gui/colorlcd/layouts/sliders.cpp
@@ -35,7 +35,7 @@ void MainViewHorizontalSlider::paint(BitmapBuffer * dc)
   }
 
   // The square
-  x = width() - TRIM_SQUARE_SIZE - divRoundClosest((width() - TRIM_SQUARE_SIZE) * (-value + RESX), 2 * RESX);
+  x = divRoundClosest((width() - TRIM_SQUARE_SIZE) * (value + RESX), 2 * RESX);
   drawTrimSquare(dc, x, 0, TRIM_BGCOLOR);
 }
 

--- a/radio/src/gui/colorlcd/layouts/sliders.cpp
+++ b/radio/src/gui/colorlcd/layouts/sliders.cpp
@@ -35,7 +35,7 @@ void MainViewHorizontalSlider::paint(BitmapBuffer * dc)
   }
 
   // The square
-  x = width() - TRIM_SQUARE_SIZE - divRoundClosest((width() - TRIM_SQUARE_SIZE) * (value + RESX), 2 * RESX);
+  x = width() - TRIM_SQUARE_SIZE - divRoundClosest((width() - TRIM_SQUARE_SIZE) * (-value + RESX), 2 * RESX);
   drawTrimSquare(dc, x, 0, TRIM_BGCOLOR);
 }
 


### PR DESCRIPTION
Resolves https://github.com/EdgeTX/edgetx/issues/40

Whist this does align the direction of the pot with the direction the slider moves, is this really the right way to do it? Since the pot seems to be right everywhere else, is it just when it is displayed that is the problem?

Tested against TX16S, S1 and S2 pots