### PR TITLE
View Main Decoration, three issues

### DIFF
--- a/radio/src/gui/colorlcd/layouts/sliders.cpp
+++ b/radio/src/gui/colorlcd/layouts/sliders.cpp
@@ -35,7 +35,7 @@ void MainViewHorizontalSlider::paint(BitmapBuffer * dc)
   }
 
   // The square
-  x = width() - TRIM_SQUARE_SIZE - divRoundClosest((width() - TRIM_SQUARE_SIZE) * (value + RESX), 2 * RESX);
+  x = divRoundClosest((width() - TRIM_SQUARE_SIZE) * (value + RESX), 2 * RESX);
   drawTrimSquare(dc, x, 0, TRIM_BGCOLOR);
 }
 
@@ -58,19 +58,18 @@ void MainView6POS::paint(BitmapBuffer * dc)
 
 void MainViewVerticalSlider::paint(BitmapBuffer * dc)
 {
-  uint8_t slidersTick = height() / 5;
-  // The ticks
-  int delta = (height() - TRIM_SQUARE_SIZE) / slidersTick;
-  coord_t y = TRIM_SQUARE_SIZE / 2;
-  for (uint8_t i = 0; i <= slidersTick; i++) {
-    if (i == 0 || i == slidersTick / 2 || i == slidersTick)
-      dc->drawSolidHorizontalLine(2, y, 13, DEFAULT_COLOR);
-    else
-      dc->drawSolidHorizontalLine(4, y, 9, DEFAULT_COLOR);
-    y += delta;
-  }
+    // The ticks
+    int delta = (height() - TRIM_SQUARE_SIZE) / SLIDER_TICKS_COUNT;
+    coord_t y = TRIM_SQUARE_SIZE / 2;
+    for (uint8_t i = 0; i <= SLIDER_TICKS_COUNT; i++) {
+      if (i == 0 || i == SLIDER_TICKS_COUNT / 2 || i == SLIDER_TICKS_COUNT)
+        dc->drawSolidHorizontalLine(2, y, 13, DEFAULT_COLOR);
+      else
+        dc->drawSolidHorizontalLine(4, y, 9, DEFAULT_COLOR);
+      y += delta;
+    }
 
   // The square
-  y = height() - TRIM_SQUARE_SIZE - divRoundClosest((height() - TRIM_SQUARE_SIZE) * (value + RESX), 2 * RESX);
+  y = divRoundClosest((height() - TRIM_SQUARE_SIZE) * (-value + RESX), 2 * RESX);
   drawTrimSquare(dc, 0, y, TRIM_BGCOLOR);
 }

--- a/radio/src/gui/colorlcd/view_main_decoration.cpp
+++ b/radio/src/gui/colorlcd/view_main_decoration.cpp
@@ -300,8 +300,8 @@ void ViewMainDecoration::createTrims()
     VERTICAL_SLIDERS_HEIGHT
   }; 
 
-  trims[TRIMS_LV] = new MainViewVerticalTrim(this, r, 2);
-  trims[TRIMS_RV] = new MainViewVerticalTrim(this, r, 1);
+  trims[TRIMS_LV] = new MainViewVerticalTrim(this, r, 1);
+  trims[TRIMS_RV] = new MainViewVerticalTrim(this, r, 2);
 }
 
 void ViewMainDecoration::createFlightMode()


### PR DESCRIPTION
the view main decoration has three issues:

* the ticks for the left and right sliders LS, RS are too short
* the displaying of T2, T3 is swapped
* the displaying of potis S1, S2 is reverted

for correcting the last point there had been just also a pr by pfeerick,  https://github.com/EdgeTX/edgetx/pull/43. You may want me to remove that change here and rather use his pr, which only would be fair.

observed and tested on T16

:)