### PR TITLE
KillEvents(): prevent possible race condition

### DIFF
--- a/radio/src/keys.cpp
+++ b/radio/src/keys.cpp
@@ -142,7 +142,7 @@ void Key::pauseEvents()
 void Key::killEvents()
 {
   // TRACE("key %d killed", key());
-  m_state = KSTATE_KILLED;
+  if (m_state) m_state = KSTATE_KILLED;
 }
 
 


### PR DESCRIPTION
this is a tricky one

keys input() is called in a 10 ms isr, i.e., independently on whatever task

in the tasks one often can find code like

```
if (event == EVT_KEY_BREAK(xxx)) {
  killEvents(event)
}
```

This can lead to race condition as follows:
BREAK is emitted when the key is down for the debounce time, and then kill events is called, but in the mean time a bounce glitch on the key pin may have occurred, so that m_val is not zero and the condition

`if (m_state && m_vals == 0)`

which would clear the kill would not be fullfilled.

The simple solution proposed here is to not allow a kill state when the key is not active.

Although it is hard to prove such things, it seems to me that it helped e.g. with https://github.com/EdgeTX/edgetx/issues/60, while I could get it relatively easily before I now couldn't anymore. As said, purely annecdotical evidence.
EDIT: I was imprecise here: I  can't get it anymore by doing what I did before ... there are still other ways to get corrupted tools listing, see https://github.com/EdgeTX/edgetx/pull/66#issuecomment-846434508

I could not yet observe any negative side effect of the change here.


COMMENT; As a general recommendation, one should go through all code and watch out for code pieces there the killEvents() is not executed directly after the if test, but some stuff is done in between. I remember having seen such places. E.g. 

    case EVT_KEY_FIRST(KEY_MODEL):
      pushMenu(menuChannelsView);
      killEvents(event);
      break;

Such kind of changes would need very careful testing however.