### PR TITLE
Owpr keylong

### DIFF
--- a/radio/src/gui/colorlcd/select_fab_carousel.cpp
+++ b/radio/src/gui/colorlcd/select_fab_carousel.cpp
@@ -36,14 +36,10 @@ void SelectFabCarousel::setMaxButtons(uint8_t max)
 void SelectFabCarousel::addButton(uint8_t icon, const char* title,
                                   std::function<uint8_t(void)> pressHandler)
 {
-  coord_t y_pos = 0;//SELECT_BUTTON_BORDER;
-  coord_t x_pos = pageWidth * buttons;// + SELECT_BUTTON_BORDER / 2;
+  coord_t y_pos = 0;
+  coord_t x_pos = pageWidth * buttons;
   buttons++;
 
-  /*auto button =*/ new SelectFabButton(this, x_pos, y_pos, icon, title, pressHandler);
+  new SelectFabButton(this, x_pos, y_pos, icon, title, pressHandler);
   setInnerWidth(pageWidth * buttons);
-
-  // y_pos += button->width() + SELECT_BUTTON_BORDER;
-  // setHeight(y_pos);
-  // setInnerHeight(y_pos);
 }

--- a/radio/src/gui/colorlcd/tabsgroup.cpp
+++ b/radio/src/gui/colorlcd/tabsgroup.cpp
@@ -173,7 +173,7 @@ void TabsGroup::onEvent(event_t event)
     uint8_t current = header.carousel.getCurrentIndex() + 1;
     setCurrentTab(current >= tabs.size() ? 0 : current);
   }
-#if defined(KEYS_GPIO_REG_UP)
+#if defined(KEYS_GPIO_REG_DGUP)
   else if (event == EVT_KEY_BREAK(KEY_PGUP)) {
 #else
   else if (event == EVT_KEY_LONG(KEY_PGDN)) {

--- a/radio/src/gui/colorlcd/tabsgroup.cpp
+++ b/radio/src/gui/colorlcd/tabsgroup.cpp
@@ -169,13 +169,17 @@ void TabsGroup::onEvent(event_t event)
 {
   TRACE_WINDOWS("%s received event 0x%X", getWindowDebugString().c_str(), event);
 
+#if defined(KEYS_GPIO_REG_DGUP)
+  if (event == EVT_KEY_BREAK(KEY_PGDN) || event == EVT_KEY_LONG(KEY_PGDN)) {
+#else
   if (event == EVT_KEY_BREAK(KEY_PGDN)) {
+#endif
     killEvents(event);
     uint8_t current = header.carousel.getCurrentIndex() + 1;
     setCurrentTab(current >= tabs.size() ? 0 : current);
   }
 #if defined(KEYS_GPIO_REG_DGUP)
-  else if (event == EVT_KEY_BREAK(KEY_PGUP)) {
+  else if (event == EVT_KEY_BREAK(KEY_PGUP) || event == EVT_KEY_LONG(KEY_PGUP)) {
 #else
   else if (event == EVT_KEY_LONG(KEY_PGDN)) {
 #endif

--- a/radio/src/gui/colorlcd/tabsgroup.cpp
+++ b/radio/src/gui/colorlcd/tabsgroup.cpp
@@ -170,6 +170,7 @@ void TabsGroup::onEvent(event_t event)
   TRACE_WINDOWS("%s received event 0x%X", getWindowDebugString().c_str(), event);
 
   if (event == EVT_KEY_BREAK(KEY_PGDN)) {
+    killEvents(event);
     uint8_t current = header.carousel.getCurrentIndex() + 1;
     setCurrentTab(current >= tabs.size() ? 0 : current);
   }

--- a/radio/src/gui/colorlcd/tabsgroup.cpp
+++ b/radio/src/gui/colorlcd/tabsgroup.cpp
@@ -169,8 +169,8 @@ void TabsGroup::onEvent(event_t event)
 {
   TRACE_WINDOWS("%s received event 0x%X", getWindowDebugString().c_str(), event);
 
-#if defined(KEYS_GPIO_REG_DGUP)
-  if (event == EVT_KEY_BREAK(KEY_PGDN) || event == EVT_KEY_LONG(KEY_PGDN)) {
+#if defined(KEYS_GPIO_REG_PGUP)
+  if (event == EVT_KEY_FIRST(KEY_PGDN)) {
 #else
   if (event == EVT_KEY_BREAK(KEY_PGDN)) {
 #endif
@@ -178,8 +178,8 @@ void TabsGroup::onEvent(event_t event)
     uint8_t current = header.carousel.getCurrentIndex() + 1;
     setCurrentTab(current >= tabs.size() ? 0 : current);
   }
-#if defined(KEYS_GPIO_REG_DGUP)
-  else if (event == EVT_KEY_BREAK(KEY_PGUP) || event == EVT_KEY_LONG(KEY_PGUP)) {
+#if defined(KEYS_GPIO_REG_PGUP)
+  else if (event == EVT_KEY_FIRST(KEY_PGUP)) {
 #else
   else if (event == EVT_KEY_LONG(KEY_PGDN)) {
 #endif
@@ -187,7 +187,7 @@ void TabsGroup::onEvent(event_t event)
     uint8_t current = header.carousel.getCurrentIndex();
     setCurrentTab(current == 0 ? tabs.size() - 1 : current - 1);
   }
-  else if (event == EVT_KEY_LONG(KEY_EXIT) || event == EVT_KEY_BREAK(KEY_EXIT)) {
+  else if (event == EVT_KEY_FIRST(KEY_EXIT)) {
     killEvents(event);
     ViewMain::instance()->setFocus(SET_FOCUS_DEFAULT);
     deleteLater();

--- a/radio/src/gui/colorlcd/view_main.cpp
+++ b/radio/src/gui/colorlcd/view_main.cpp
@@ -278,6 +278,9 @@ void ViewMain::onEvent(event_t event)
       break;
 
     case EVT_KEY_BREAK(KEY_PGDN):
+#if defined(KEYS_GPIO_REG_PGUP)
+    case EVT_KEY_LONG(KEY_PGDN):
+#endif
       killEvents(event);
       nextMainView();
       break;
@@ -286,6 +289,7 @@ void ViewMain::onEvent(event_t event)
 // -> board code should map the keys as required
 #if defined(KEYS_GPIO_REG_PGUP)
     case EVT_KEY_BREAK(KEY_PGUP):
+    case EVT_KEY_LONG(KEY_PGUP):
 #else
     case EVT_KEY_LONG(KEY_PGDN):
 #endif

--- a/radio/src/gui/colorlcd/view_main.cpp
+++ b/radio/src/gui/colorlcd/view_main.cpp
@@ -257,29 +257,30 @@ bool ViewMain::onTouchEnd(coord_t x, coord_t y)
 void ViewMain::onEvent(event_t event)
 {
   switch (event) {
-    case EVT_KEY_LONG(KEY_MODEL):
+    case EVT_KEY_FIRST(KEY_MODEL):
       killEvents(event);
       new ModelMenu();
       break;
 
-    case EVT_KEY_LONG(KEY_RADIO):
+    case EVT_KEY_FIRST(KEY_RADIO):
       killEvents(event);
       new RadioMenu();
       break;
 
-    case EVT_KEY_LONG(KEY_TELEM):
+    case EVT_KEY_FIRST(KEY_TELEM):
       killEvents(event);
       new ScreenMenu();
       break;
 
-    case EVT_KEY_LONG(KEY_ENTER):
+    case EVT_KEY_FIRST(KEY_ENTER):
       killEvents(event);
       openMenu();
       break;
 
-    case EVT_KEY_BREAK(KEY_PGDN):
 #if defined(KEYS_GPIO_REG_PGUP)
-    case EVT_KEY_LONG(KEY_PGDN):
+    case EVT_KEY_FIRST(KEY_PGDN):
+#else
+    case EVT_KEY_BREAK(KEY_PGDN):
 #endif
       killEvents(event);
       nextMainView();
@@ -288,8 +289,7 @@ void ViewMain::onEvent(event_t event)
 //TODO: these need to go away!
 // -> board code should map the keys as required
 #if defined(KEYS_GPIO_REG_PGUP)
-    case EVT_KEY_BREAK(KEY_PGUP):
-    case EVT_KEY_LONG(KEY_PGUP):
+    case EVT_KEY_FIRST(KEY_PGUP):
 #else
     case EVT_KEY_LONG(KEY_PGDN):
 #endif

--- a/radio/src/gui/colorlcd/view_main.cpp
+++ b/radio/src/gui/colorlcd/view_main.cpp
@@ -257,12 +257,12 @@ bool ViewMain::onTouchEnd(coord_t x, coord_t y)
 void ViewMain::onEvent(event_t event)
 {
   switch (event) {
-    case EVT_KEY_BREAK(KEY_MODEL):
+    case EVT_KEY_LONG(KEY_MODEL):
       killEvents(event);
       new ModelMenu();
       break;
 
-    case EVT_KEY_BREAK(KEY_RADIO):
+    case EVT_KEY_LONG(KEY_RADIO):
       killEvents(event);
       new RadioMenu();
       break;
@@ -272,7 +272,7 @@ void ViewMain::onEvent(event_t event)
       new ScreenMenu();
       break;
 
-    case EVT_KEY_BREAK(KEY_ENTER):
+    case EVT_KEY_LONG(KEY_ENTER):
       killEvents(event);
       openMenu();
       break;
@@ -284,7 +284,7 @@ void ViewMain::onEvent(event_t event)
 
 //TODO: these need to go away!
 // -> board code should map the keys as required
-#if defined(KEYS_GPIO_REG_UP)
+#if defined(KEYS_GPIO_REG_PGUP)
     case EVT_KEY_BREAK(KEY_PGUP):
 #else
     case EVT_KEY_LONG(KEY_PGDN):


### PR DESCRIPTION
This is the continuation of #58. It adds a small fix in libopenui to allow the main menu to work properly. However, I believe that it also changes the default behavior for **all** buttons from **key-release-detection** to **key-press-detection**. I could probably make it less invasive, but this seems to be a necessary change if we want to be consistent (reactive behaviour vs. waiting for key release). Touch behaviour does not change here and works as before.   