### PR TITLE
Fix stack alignment

### DIFF
--- a/radio/src/bin_allocator.h
+++ b/radio/src/bin_allocator.h
@@ -83,8 +83,8 @@ public:
 typedef BinAllocator<39,300> BinAllocator_slots1;
 typedef BinAllocator<79,100> BinAllocator_slots2;
 #else
-typedef BinAllocator<39,200> BinAllocator_slots1;
-typedef BinAllocator<91,64> BinAllocator_slots2;
+typedef BinAllocator<27,200> BinAllocator_slots1;
+typedef BinAllocator<91,50> BinAllocator_slots2;
 #endif
 
 #if defined(USE_BIN_ALLOCATOR)

--- a/radio/src/bin_allocator.h
+++ b/radio/src/bin_allocator.h
@@ -83,8 +83,8 @@ public:
 typedef BinAllocator<39,300> BinAllocator_slots1;
 typedef BinAllocator<79,100> BinAllocator_slots2;
 #else
-typedef BinAllocator<29,200> BinAllocator_slots1;
-typedef BinAllocator<91,50> BinAllocator_slots2;
+typedef BinAllocator<39,200> BinAllocator_slots1;
+typedef BinAllocator<91,64> BinAllocator_slots2;
 #endif
 
 #if defined(USE_BIN_ALLOCATOR)


### PR DESCRIPTION
29+1 is not dividable with 4.

After this fix, EdgeTX builds with latest GNU Arm Toolchain v10 2020-q4 under Windows and runs without HardFaulting on RM TX16S.

Interestingly, the binaries built under Ubuntu with 6 2017-q2 without this fix. also ran on radio without hanging... which almost makes me think GNU Arm 6 2017 q2 was having an issue as well, as the unfixed code here was causing misaligned memory.

Thx @raphaelcoeffic , this was nice team-work!