### PR TITLE
stdio.h missing in 6 files

### DIFF
--- a/radio/src/bluetooth.cpp
+++ b/radio/src/bluetooth.cpp
@@ -18,6 +18,7 @@
  * GNU General Public License for more details.
  */
 
+#include <stdio.h>
 #include "opentx.h"
 #include "io/frsky_firmware_update.h"
 

--- a/radio/src/gui/common/stdlcd/radio_sdmanager.cpp
+++ b/radio/src/gui/common/stdlcd/radio_sdmanager.cpp
@@ -18,6 +18,7 @@
  * GNU General Public License for more details.
  */
 
+#include <stdio.h>
 #include "opentx.h"
 #include "io/frsky_firmware_update.h"
 #include "io/multi_firmware_update.h"

--- a/radio/src/io/bootloader_flash.cpp
+++ b/radio/src/io/bootloader_flash.cpp
@@ -18,6 +18,7 @@
  * GNU General Public License for more details.
  */
 
+#include <stdio.h>
 #include "opentx.h"
 #include "bootloader_flash.h"
 

--- a/radio/src/io/frsky_firmware_update.cpp
+++ b/radio/src/io/frsky_firmware_update.cpp
@@ -18,6 +18,7 @@
  * GNU General Public License for more details.
  */
 
+#include <stdio.h>
 #include "opentx.h"
 #include "frsky_firmware_update.h"
 

--- a/radio/src/io/multi_firmware_update.cpp
+++ b/radio/src/io/multi_firmware_update.cpp
@@ -20,6 +20,7 @@
 
 #if !defined(DISABLE_MULTI_UPDATE)
 
+#include <stdio.h>
 #include "opentx.h"
 #include "multi_firmware_update.h"
 #include "stk500.h"

--- a/radio/src/sdcard.cpp
+++ b/radio/src/sdcard.cpp
@@ -18,6 +18,7 @@
  * GNU General Public License for more details.
  */
 
+#include <stdio.h>
 #include <stdint.h>
 #include "opentx.h"
 #include "diskio.h"


### PR DESCRIPTION
Fixes compile errors for T12, X7 and X9D+ with GNU Arm Toolchain v10 2020-q4.