### PR TITLE
Main Menu: Change order of buttons for easier access

### DIFF
--- a/radio/src/gui/colorlcd/view_main_menu.cpp
+++ b/radio/src/gui/colorlcd/view_main_menu.cpp
@@ -51,15 +51,21 @@ ViewMainMenu::ViewMainMenu(Window* parent) :
   //                "Tasks", 0, FOCUS_COLOR | FONT(XL) | CENTERED);
   // pos += title->height() + PAGE_LINE_SPACING;
 
-  carousel->addButton(ICON_RADIO_TOOLS, "Model\nSettings", [=]() -> uint8_t {
-    deleteLater();
-    new ModelMenu();
-    return 0;
-  });
-
   carousel->addButton(ICON_MODEL, "Select\nModel", [=]() -> uint8_t {
     deleteLater();
     new ModelSelectMenu();
+    return 0;
+  });
+
+  carousel->addButton(ICON_MONITOR, "Channel\nMonitor", [=]() -> uint8_t {
+    deleteLater();
+    new ChannelsViewMenu();
+    return 0;
+  });
+
+  carousel->addButton(ICON_RADIO_TOOLS, "Model\nSettings", [=]() -> uint8_t {
+    deleteLater();
+    new ModelMenu();
     return 0;
   });
 
@@ -69,15 +75,9 @@ ViewMainMenu::ViewMainMenu(Window* parent) :
     return 0;
   });
 
-  carousel->addButton(ICON_THEME, "Screens\nSetup", [=]() -> uint8_t {
+  carousel->addButton(ICON_THEME, "Screens\nSettings", [=]() -> uint8_t {
     deleteLater();
     new ScreenMenu();
-    return 0;
-  });
-
-  carousel->addButton(ICON_MONITOR, "Channel\nMonitor", [=]() -> uint8_t {
-    deleteLater();
-    new ChannelsViewMenu();
     return 0;
   });
 


### PR DESCRIPTION
This PR
* changes the order of the buttons in the main menu so that "Select Model" and "Channel Monitor" come first. IMHO that's much more user friendly, since the both the "Model Settings" and "Radio Settings" options are also and quicker available through "SYS" and "MDL" keys, while the "Select Model" and "Channel Monitor" are not, so that the user might want to get them first in the main menu.
* renames the button "Screens Setup" to "Screens Settings". This so to make the naming more systematic. "Setup" is used in the other menus for sub categories while "Settings" is used for the option name.

Before:

![IMG_20210530_062339](https://user-images.githubusercontent.com/6089567/120092285-0dcc5880-c112-11eb-9b03-c586f2a93624.jpg)

After:


![IMG_20210530_063309](https://user-images.githubusercontent.com/6089567/120092290-145ad000-c112-11eb-9d10-750d0a0966be.jpg)

