### PR TITLE
Add key handling for lua scripts

### DIFF
--- a/radio/src/keys.h
+++ b/radio/src/keys.h
@@ -190,4 +190,9 @@ bool keyDown();
 extern uint8_t rotencSpeed;
 #endif
 
+void lockKeys(uint16_t mask);
+void unlockKeys(void);
+void checkEventLockTmo(void); //per10ms()
+bool eventIsLocked(event_t evt);
+
 #endif // _KEYS_H_

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1751,7 +1751,37 @@ static int luaSerialRead(lua_State * L)
   return 1;
 }
 
+static int luaGetEvent(lua_State * L)
+{
+  event_t event = s_evt;
+  // only allow locked keys & ROT events to get through
+  if (eventIsLocked(event) || (event == EVT_ROTARY_LEFT) || (event == EVT_ROTARY_RIGHT)) {
+    s_evt = 0; // clear event
+  }
+  else {
+    event = 0; // do not pass on
+  }
+  lua_pushinteger(L, event);
+  return 1;
+}
+
+static int luaLockKeys(lua_State * L)
+{
+  uint16_t mask = luaL_checkunsigned(L, 1);
+  lockKeys(mask);
+  return 0;
+}
+
+static int luaUnlockKeys(lua_State * L)
+{
+  unlockKeys();
+  return 0;
+}
+
 const luaL_Reg opentxLib[] = {
+  { "getEvent", luaGetEvent },
+  { "lockKeys", luaLockKeys },
+  { "unlockKeys", luaUnlockKeys },
   { "getTime", luaGetTime },
   { "getDateTime", luaGetDateTime },
 #if defined(RTCLOCK)
@@ -2028,6 +2058,14 @@ const luaR_value_entry opentxConstants[] = {
 
 #if defined(KEYS_GPIO_REG_DOWN) && defined(COLORLCD)
   { "EVT_RTN_FIRST", EVT_KEY_BREAK(KEY_EXIT) },
+  { "EVT_RTN_BREAK", EVT_KEY_BREAK(KEY_EXIT) },
+  { "EVT_RTN_LONG", EVT_KEY_LONG(KEY_EXIT) },
+  { "EVT_RTN_REPT", EVT_KEY_REPT(KEY_EXIT) },
+  { "KEY_ENTER", (1<<KEY_ENTER) },
+  { "KEY_MODEL", (1<<KEY_MODEL) },
+  { "KEY_TELEM", (1<<KEY_TELEM) },
+  { "KEY_SYS", (1<<KEY_RADIO) },
+  { "KEY_RTN", (1<<KEY_EXIT) },
 #else
   KEY_EVENTS(DOWN, KEY_DOWN),
 #endif

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -225,6 +225,8 @@ void per10ms()
 
   outputTelemetryBuffer.per10ms();
 
+  checkEventLockTmo();
+
   heartbeat |= HEART_TIMER_10MS;
 }
 


### PR DESCRIPTION
Adds key handling capabilities to lua widget scripts.

It's a complement and pretty much requirement for the MAVLink for EdgeTx PR.

This is actually a tricky one, and the taken approach probably won't last "forever". It does work however for me and for the current purpose, so it might be considered acceptable as a first approach.

Test lua widget:
You may use this for testing (yeah, not nice, but...): [main.zip](https://github.com/EdgeTX/edgetx/files/6565937/main.zip)
Install it as a second main view with full screen and all other things disabled. You can then jump in and out to it with the page keys.

Some history & background:
When I was doing this for the otx2.3 branch I initially wanted to pass in the event as a function variable to the refresh function, pretty much like what @raphaelcoeffic did in his old PR https://github.com/opentx/opentx/pull/6688, but at that time I failed (and I didn't yet had seen this PR). I ended up with what you can now also see in this PR here.
In order to do it now for EdgeTx I revisited https://github.com/opentx/opentx/pull/6688, since from the moment I had seen this PR I was thinking that's how one should do it. However, going over it again now, I realized that it has some substantial shortcomings and does not actually solve the task in a usable way. It basically only allows us to monitor key events, but it does not allow us to - so to say - overtake control and disable the usual key action, which is however actually needed for a responsive lua widget. Pondering over it and trying different things, I eventually came back to my "old" solution, which even though not nice at least gets the job done.

Limitations:
The taken approach is not yet fully satisfying on the long run: 
* It is not widget specific. That is, if there would be two or more widgets which want to use keys for responsiveness, they would have to "cooperate" in friendly ways for each to work. In a full solution the events should be forwarded to only the "top" widget.
* It can miss events. This can be notable especially for the scroll wheels with a complex lua widget script. I think that there needs to be some buffering.
* No touch, only keys and scroll.
* It may not compile for all targets, some proper #ifdef may be missing.

I should add that IMHO the whole events handling in libopenui has serious flaws and needs to be revisited (I guess I will eventually open an issue to write up my evidence and thoughts on this). In this sense, any lua widget key handling attempt today will be short lived, which may further suggest that the current crude approach may be acceptable enough for the moment.

Open question:
I seem to not fully understand the "new" lua widgets. The background function is supposed to call the unlockEvents() function in order to realese them to the system if teh widget is not top, but it seems that it is never called. Coincidentially I had implemented a fall back timeout mechanism, to not get stuck in case a widget crashes or doesn't work, and it now seems that it is actually this fallback mechanism which makes the things to work. Maybe someone can explain to me how the refresh and background functions do work now.

Weird observation:
I have no explanation for it, but when I tried to push this PR, my sourcetree didn't complete but gave an error, which in the last lines says 
```
 ! [rejected]            nightly -> nightly (already exists)
updating local tracking ref 'refs/remotes/origin/owpr-mavtelem-keys'
error: failed to push some refs to 'https://github.com/olliw42/edgetx.git'
hint: Updates were rejected because the tag already exists in the remote.
```
I never had seen this before, it seems to be specific to this PR here. Any ideas?