### PR TITLE
Add some graphics plotting functions

### DIFF
--- a/radio/src/gui/colorlcd/draw_functions.h
+++ b/radio/src/gui/colorlcd/draw_functions.h
@@ -86,4 +86,9 @@ void drawShutdownAnimation(uint32_t duration, uint32_t totalDuration, const char
 void drawMainPots();
 void drawTrims(uint8_t flightMode);
 
+//could all or partially eventually go into libopenui
+void drawFilledTriangle(BitmapBuffer * dc, coord_t x0, coord_t y0, coord_t x1, coord_t y1, coord_t x2, coord_t y2, LcdFlags flags);
+void drawLineWithClipping(BitmapBuffer * dc, coord_t x0, coord_t y0, coord_t x1, coord_t y1, coord_t xmin, coord_t xmax, coord_t ymin, coord_t ymax, uint8_t pat, LcdFlags flags);
+void drawHudRectangle(BitmapBuffer * dc, float pitch, float roll, coord_t xmin, coord_t xmax, coord_t ymin, coord_t ymax, LcdFlags flags);
+
 #endif // _DRAW_FUNCTIONS_H_

--- a/radio/src/lua/api_colorlcd.cpp
+++ b/radio/src/lua/api_colorlcd.cpp
@@ -787,6 +787,185 @@ static int luaRGB(lua_State *L)
   return 1;
 }
 
+static int luaLcdDrawCircle(lua_State *L)
+{
+  if (!luaLcdAllowed || !luaLcdBuffer)
+    return 0;
+
+  coord_t x = luaL_checkunsigned(L, 1);
+  coord_t y = luaL_checkunsigned(L, 2);
+  coord_t r = luaL_checkunsigned(L, 3);
+  LcdFlags flags = luaL_checkunsigned(L, 4);
+
+  flags = (flags & 0xFFFF) | COLOR(COLOR_VAL(flags));
+
+  luaLcdBuffer->drawCircle(x, y, r, flags);
+
+  return 0;
+}
+
+static int luaLcdDrawFilledCircle(lua_State *L)
+{
+  if (!luaLcdAllowed || !luaLcdBuffer)
+    return 0;
+
+  coord_t x = luaL_checkunsigned(L, 1);
+  coord_t y = luaL_checkunsigned(L, 2);
+  coord_t r = luaL_checkunsigned(L, 3);
+  LcdFlags flags = luaL_checkunsigned(L, 4);
+
+  flags = (flags & 0xFFFF) | COLOR(COLOR_VAL(flags));
+
+  luaLcdBuffer->drawFilledCircle(x, y, r, flags);
+
+  return 0;
+}
+
+static int luaLcdDrawTriangle(lua_State *L)
+{
+  if (!luaLcdAllowed || !luaLcdBuffer)
+    return 0;
+
+  coord_t x1 = luaL_checkunsigned(L, 1);
+  coord_t y1 = luaL_checkunsigned(L, 2);
+  coord_t x2 = luaL_checkunsigned(L, 3);
+  coord_t y2 = luaL_checkunsigned(L, 4);
+  coord_t x3 = luaL_checkunsigned(L, 5);
+  coord_t y3 = luaL_checkunsigned(L, 6);
+  LcdFlags flags = luaL_checkunsigned(L, 7);
+
+  flags = (flags & 0xFFFF) | COLOR(COLOR_VAL(flags));
+
+  luaLcdBuffer->drawLine(x1, y1, x2, y2, SOLID, flags);
+  luaLcdBuffer->drawLine(x2, y2, x3, y3, SOLID, flags);
+  luaLcdBuffer->drawLine(x3, y3, x1, y1, SOLID, flags);
+
+  return 0;
+}
+
+static int luaLcdDrawFilledTriangle(lua_State *L)
+{
+  if (!luaLcdAllowed || !luaLcdBuffer)
+    return 0;
+
+  coord_t x1 = luaL_checkunsigned(L, 1);
+  coord_t y1 = luaL_checkunsigned(L, 2);
+  coord_t x2 = luaL_checkunsigned(L, 3);
+  coord_t y2 = luaL_checkunsigned(L, 4);
+  coord_t x3 = luaL_checkunsigned(L, 5);
+  coord_t y3 = luaL_checkunsigned(L, 6);
+  LcdFlags flags = luaL_checkunsigned(L, 7);
+
+  flags = (flags & 0xFFFF) | COLOR(COLOR_VAL(flags));
+
+  drawFilledTriangle(luaLcdBuffer, x1, y1, x2, y2, x3, y3, flags);
+
+  return 0;
+}
+
+static int luaLcdDrawArc(lua_State *L)
+{
+  if (!luaLcdAllowed || !luaLcdBuffer)
+    return 0;
+
+  coord_t x = luaL_checkunsigned(L, 1);
+  coord_t y = luaL_checkunsigned(L, 2);
+  coord_t r = luaL_checkunsigned(L, 3);
+  int start = luaL_checkunsigned(L, 4);
+  int end = luaL_checkunsigned(L, 5);
+  LcdFlags flags = luaL_checkunsigned(L, 6);
+
+  flags = (flags & 0xFFFF) | COLOR(COLOR_VAL(flags));
+
+  if (r > 0)
+    luaLcdBuffer->drawAnnulusSector(x, y, r - 1, r, start, end, flags);
+
+  return 0;
+}
+
+static int luaLcdDrawPie(lua_State *L)
+{
+  if (!luaLcdAllowed || !luaLcdBuffer)
+    return 0;
+
+  coord_t x = luaL_checkunsigned(L, 1);
+  coord_t y = luaL_checkunsigned(L, 2);
+  coord_t r = luaL_checkunsigned(L, 3);
+  int start = luaL_checkunsigned(L, 4);
+  int end = luaL_checkunsigned(L, 5);
+  LcdFlags flags = luaL_checkunsigned(L, 6);
+
+  flags = (flags & 0xFFFF) | COLOR(COLOR_VAL(flags));
+
+  if (r > 0)
+    luaLcdBuffer->drawAnnulusSector(x, y, 0, r, start, end, flags);
+
+  return 0;
+}
+
+static int luaLcdDrawAnnulus(lua_State *L)
+{
+  if (!luaLcdAllowed || !luaLcdBuffer)
+    return 0;
+
+  coord_t x = luaL_checkunsigned(L, 1);
+  coord_t y = luaL_checkunsigned(L, 2);
+  coord_t r1 = luaL_checkunsigned(L, 3);
+  coord_t r2 = luaL_checkunsigned(L, 4);
+  int start = luaL_checkunsigned(L, 5);
+  int end = luaL_checkunsigned(L, 6);
+  LcdFlags flags = luaL_checkunsigned(L, 7);
+
+  flags = (flags & 0xFFFF) | COLOR(COLOR_VAL(flags));
+
+  luaLcdBuffer->drawAnnulusSector(x, y, r1, r2, start, end, flags);
+
+  return 0;
+}
+
+static int luaLcdDrawLineWithClipping(lua_State *L)
+{
+  if (!luaLcdAllowed || !luaLcdBuffer)
+    return 0;
+
+  coord_t x1 = luaL_checkunsigned(L, 1);
+  coord_t y1 = luaL_checkunsigned(L, 2);
+  coord_t x2 = luaL_checkunsigned(L, 3);
+  coord_t y2 = luaL_checkunsigned(L, 4);
+  coord_t xmin = luaL_checkunsigned(L, 5);
+  coord_t xmax = luaL_checkunsigned(L, 6);
+  coord_t ymin = luaL_checkunsigned(L, 7);
+  coord_t ymax = luaL_checkunsigned(L, 8);
+  uint8_t pat = luaL_checkunsigned(L, 9);
+  LcdFlags flags = luaL_checkunsigned(L, 10);
+
+  flags = (flags & 0xFFFF) | COLOR(COLOR_VAL(flags));
+
+  drawLineWithClipping(luaLcdBuffer, x1, y1, x2, y2, xmin, xmax, ymin, ymax, pat, flags);
+
+  return 0;
+}
+
+static int luaLcdDrawHudRectangle(lua_State *L)
+{
+  if (!luaLcdAllowed || !luaLcdBuffer)
+    return 0;
+
+  float pitch = luaL_checknumber(L, 1);
+  float roll = luaL_checknumber(L, 2);
+  coord_t xmin = luaL_checkunsigned(L, 3);
+  coord_t xmax = luaL_checkunsigned(L, 4);
+  coord_t ymin = luaL_checkunsigned(L, 5);
+  coord_t ymax = luaL_checkunsigned(L, 6);
+  LcdFlags flags = luaL_checkunsigned(L, 7);
+
+  flags = (flags & 0xFFFF) | COLOR(COLOR_VAL(flags));
+
+  drawHudRectangle(luaLcdBuffer, pitch, roll, xmin, xmax, ymin, ymax, flags);
+
+  return 0;
+}
+
 const luaL_Reg lcdLib[] = {
   { "refresh", luaLcdRefresh },
   { "clear", luaLcdClear },
@@ -806,5 +985,14 @@ const luaL_Reg lcdLib[] = {
   { "setColor", luaLcdSetColor },
   { "getColor", luaLcdGetColor },
   { "RGB", luaRGB },
+  { "drawCircle", luaLcdDrawCircle },
+  { "drawFilledCircle", luaLcdDrawFilledCircle },
+  { "drawTriangle", luaLcdDrawTriangle },
+  { "drawFilledTriangle", luaLcdDrawFilledTriangle },
+  { "drawArc", luaLcdDrawArc },
+  { "drawPie", luaLcdDrawPie },
+  { "drawAnnulus", luaLcdDrawAnnulus },
+  { "drawLineWithClipping", luaLcdDrawLineWithClipping },
+  { "drawHudRectangle", luaLcdDrawHudRectangle },
   { NULL, NULL }  /* sentinel */
 };


### PR DESCRIPTION
This adds some more lua plotting functions.

It is kind of a requirement and prerequisite for MAVLink for EdgeTx, to make it fully usable.

The functions should be of general use however and can really be used independently, hence this separate PR.

Tested on T16.

Script to test: [main.zip](https://github.com/EdgeTX/edgetx/files/6568521/main.zip)

Note:
* Some of the functions added here to draw_functions.h/cpp might eventually go into libopenui, but maybe also not. Not my decision. I have no opinion at all here.

Further notes, not directly related to this PR:
* There are some little bugs and issues with the OTHER lua drawing functions, which I however will address in a separate PR, since they are totally unrelated to the code additions of this PR.
* There seems to be a more serious bug/issue with the drawing in lua scripts, since I do observe some "flickering". The test script should reveal that to you too.

Lastly, totally OT, I again got this 

```
 ! [rejected]            nightly -> nightly (already exists)
updating local tracking ref 'refs/remotes/origin/owpr-mavtelem-keys'
error: failed to push some refs to 'https://github.com/olliw42/edgetx.git'
hint: Updates were rejected because the tag already exists in the remote.
```

when pushing, to which you said "You need to either no fetch the tags, or force the tags to update your local tags.". Sadly, I could not yet figure out what to exactly do, I just note that since I did had this before something must have changed in the edgetx repo few days ago which now triggers that ... it somehow would be good to better communicate/know about such more serious changes to the main repo ;)