### PR TITLE
colorlcd: fixes for lcd.clear() and lcd.drawGauge()

### DIFF
--- a/radio/src/lua/api_colorlcd.cpp
+++ b/radio/src/lua/api_colorlcd.cpp
@@ -61,7 +61,7 @@ static int luaLcdClear(lua_State * L)
 {
   if (luaLcdAllowed && luaLcdBuffer) {
     LcdFlags color = luaL_optunsigned(L, 1, DEFAULT_BGCOLOR);
-    luaLcdBuffer->clear(color);
+    luaLcdBuffer->clear(COLOR(COLOR_VAL(color)));
   }
   return 0;
 }

--- a/radio/src/lua/api_colorlcd.cpp
+++ b/radio/src/lua/api_colorlcd.cpp
@@ -665,6 +665,8 @@ static int luaLcdDrawGauge(lua_State *L)
   int den = luaL_checkinteger(L, 6);
   unsigned int flags = luaL_optunsigned(L, 7, 0);
 
+  flags = (flags & 0xFFFF) | COLOR(COLOR_VAL(flags));
+
   luaLcdBuffer->drawRect(x, y, w, h, 1, 0xff, flags);
   uint8_t len = limit((uint8_t)1, uint8_t(w*num/den), uint8_t(w));
   luaLcdBuffer->drawSolidFilledRect(x+1, y+1, len, h-2, flags);


### PR DESCRIPTION
this fixes color handling for lcd.clear() and lcd.drawGauge()

![image](https://user-images.githubusercontent.com/30294218/120895422-6917b280-c60c-11eb-8a17-c04e4fe62055.png)
