### PR TITLE
Select the first element by default, even if hardware touch is supported

### DIFF
--- a/radio/src/gui/colorlcd/sourcechoice.cpp
+++ b/radio/src/gui/colorlcd/sourcechoice.cpp
@@ -76,11 +76,7 @@ void SourceChoice::fillMenu(Menu * menu, const std::function<bool(int16_t)> & fi
 {
   auto value = getValue();
   int count = 0;
-#if defined(HARDWARE_TOUCH)
-  int current = -1;
-#else
   int current = 0;
-#endif
 
   menu->removeLines();
 

--- a/radio/src/gui/colorlcd/switchchoice.cpp
+++ b/radio/src/gui/colorlcd/switchchoice.cpp
@@ -60,11 +60,7 @@ void SwitchChoice::fillMenu(Menu * menu, std::function<bool(int16_t)> filter)
 {
   auto value = getValue();
   int count = 0;
-#if defined(HARDWARE_TOUCH)
-  int current = -1;
-#else
   int current = 0;
-#endif
 
   menu->removeLines();
 


### PR DESCRIPTION
Resolves #57