### PR TITLE
colorlcd: fix for drawNumber INVERS and text per font size h/v offsets

### DIFF
--- a/radio/src/lua/api_colorlcd.h
+++ b/radio/src/lua/api_colorlcd.h
@@ -33,5 +33,8 @@
 
 constexpr coord_t INVERT_BOX_MARGIN = 2;
 
+constexpr int8_t text_horizontal_offset[7] {-2,-2,-2,-2,-2,-2,-2};
+constexpr int8_t text_vertical_offset[7] {2,0,0,2,3,3,7};
+
 extern bool           luaLcdAllowed;
 extern BitmapBuffer * luaLcdBuffer;


### PR DESCRIPTION
requires https://github.com/EdgeTX/libopenui/pull/4

probably the vertical offset is needed in other lua draw* methods as well, needs checking