### PR TITLE
colorlcd: fix for BOLD font h/v offsets, fix for lcd.clear()

### DIFF
--- a/radio/src/lua/api_colorlcd.cpp
+++ b/radio/src/lua/api_colorlcd.cpp
@@ -82,7 +82,7 @@ Clear the LCD screen
 static int luaLcdClear(lua_State * L)
 {
   if (luaLcdAllowed && luaLcdBuffer) {
-    LcdFlags color = luaL_optunsigned(L, 1, DEFAULT_BGCOLOR);
+    LcdFlags color = luaL_optunsigned(L, 1, DEFAULT_BGCOLOR_INDEX << 16u);
     luaLcdBuffer->clear(COLOR(COLOR_VAL(color)));
   }
   return 0;

--- a/radio/src/lua/api_colorlcd.h
+++ b/radio/src/lua/api_colorlcd.h
@@ -33,8 +33,8 @@
 
 constexpr coord_t INVERT_BOX_MARGIN = 2;
 
-constexpr int8_t text_horizontal_offset[7] {-2,-2,-2,-2,-2,-2,-2};
-constexpr int8_t text_vertical_offset[7] {2,0,0,2,3,3,7};
+constexpr int8_t text_horizontal_offset[7] {-2,-1,-2,-2,-2,-2,-2};
+constexpr int8_t text_vertical_offset[7] {2,2,0,2,3,3,7};
 
 extern bool           luaLcdAllowed;
 extern BitmapBuffer * luaLcdBuffer;


### PR DESCRIPTION
this should fix the BOLD font offsets and hopefully the lcd.clear() issue reported by @JimB40