### PR TITLE
Better match simulator colors to color radio display

### DIFF
--- a/radio/src/simu.cpp
+++ b/radio/src/simu.cpp
@@ -527,7 +527,7 @@ void OpenTxSim::refreshDisplay()
             setPixel(x, y, FXRGB(255, 255, 255));
           }
           else {
-            FXColor color = FXRGB(255*((z&0xF800)>>11)/0x1f, 255*((z&0x07E0)>>5)/0x3F, 255*(z&0x001F)/0x01F);
+            FXColor color = FXRGB(((z & 0xF800) >> 8) + ((z & 0xE000) >> 13), ((z & 0x07E0) >> 3) + ((z & 0x0600) >> 9), (((z & 0x001F) << 3) & 0x00F8) + ((z & 0x001C) >> 2));
             setPixel(x, y, color);
           }
     	}


### PR DESCRIPTION
At least with Jumper T16 and RM TX16S. the RGB565 connection scheme is not just cutting/zeroing the 3 lowest bits of red and blue and 2 lowest bits of green, but is actually using a copy of the highest bits for the "missing" bits instead.
Example: let red be (in binary, MSB first) b'abcdefgh', green b'ijklmnop' and blue b'qrstuvwx' then the resulting RGB value used by the the LCD is NOT:
red b'abcde**000**', green b'ijklmn**00**', blue b'qrstu**000**', but instead
red b'abcde**abc**', green b'ijklmn**ij**', blue b'qrstu**qrs**'.

Here the schematic snippet of RM TX16S LCD hookup showing this (see Jumper T16 schem [here](https://github.com/opentx/opentx/files/5035629/T16.Schematic.pdf) for similar hookup):

![LCD_connection](https://user-images.githubusercontent.com/21011587/121801976-6afbfa00-cc3a-11eb-9232-9c155465cf56.png)

This PR matches the usage of lower 3 bits of red and blue and lower 2 bits of green of simulator color display with the radio hardware hookup.

It first isolates the appropriate bits of the color:
```
R = z & 0xF800 // rrrr r000 0000 0000
G = z & 0x07E0 // 0000 0ggg ggg0 0000
B = z & 0x001F // 0000 0000 000b bbbb
```
then shifts them to be the upper bits of an 8 bit value:
```
R = ((z & 0xF800) >> 8) // 0000 0000 rrrr r000
G = ((z & 0x07E0) >> 3) // 0000 0000 gggg gg00
B = (((z & 0x001F) << 3) & 0x00F8) // 0000 0000 bbbb b000
```

The addition and improvement of this PR is the addition of lower bits, taken from the most significant bits, matching the radio schematic LCD hookup:
```
R += ((z & 0xE000) >> 13) // 0000 0000 0000 0rrr
G += ((z & 0x0600) >> 9) // 0000 0000 0000 00gg
B += ((z & 0x001C) >> 2) // 0000 0000 0000 0bbb
```

put all together, this evaluates for the red, green and blue:
```
R = ((z & 0xF800) >> 8) + ((z & 0xE000) >> 13)
G = ((z & 0x07E0) >> 3) + ((z & 0x0600) >> 9)
B = (((z & 0x001F) << 3) & 0x00F8) + ((z & 0x001C) >> 2)
```