### PR TITLE
The UARTs of radios are using 3.3V logic level, not TTL / 5V.

### DIFF
--- a/radio/src/translations/cn.h.txt
+++ b/radio/src/translations/cn.h.txt
@@ -718,7 +718,7 @@
 #define TR_COPROC_TEMP                 "主板温度"
 #define TR_CAPAWARNING                 INDENT "电流过低"
 #define TR_TEMPWARNING                 INDENT "过热"
-#define TR_TTL_WARNING                 "注意: 串口仅能使用TTL电平或5V"
+#define TR_TTL_WARNING                 "注意：使用逻辑电平3.3V"
 #define TR_FUNC                        "功能"
 #define TR_V1                          "V1"
 #define TR_V2                          "V2"

--- a/radio/src/translations/cz.h.txt
+++ b/radio/src/translations/cz.h.txt
@@ -805,7 +805,7 @@
 #define TR_COPROC_TEMP                 "Tepl. MB \016>"
 #define TR_CAPAWARNING                 INDENT "Nízká kapacita"
 #define TR_TEMPWARNING                 INDENT "Přehřátí"
-#define TR_TTL_WARNING                 "Warning: use only TLL or 5v"
+#define TR_TTL_WARNING                 "Warning: use 3.3V logic levels"
 #define TR_FUNC                        "Fce."
 #define TR_V1                          "V1"
 #define TR_V2                          "V2"

--- a/radio/src/translations/de.h.txt
+++ b/radio/src/translations/de.h.txt
@@ -810,7 +810,7 @@
 #define TR_COPROC_TEMP                  "MB Temp. \016>"
 #define TR_CAPAWARNING                  INDENT "Kapaz. niedrig" // wg 9XR-Pro
 #define TR_TEMPWARNING                  INDENT "Temp.   größer"  //wg 9XR-Pro
-#define TR_TTL_WARNING                 "Warning: use only TLL or 5v"
+#define TR_TTL_WARNING                  "Warning: use 3.3V logic levels"
 #define TR_FUNC                         "Funktion"
 #define TR_V1                           "V1"
 #define TR_V2                           "V2"

--- a/radio/src/translations/en.h.txt
+++ b/radio/src/translations/en.h.txt
@@ -814,7 +814,7 @@
 #define TR_COPROC_TEMP                 "MB Temp."
 #define TR_CAPAWARNING                 INDENT "Capacity low"
 #define TR_TEMPWARNING                 INDENT "Overheat"
-#define TR_TTL_WARNING                 "Warning: use only TLL or 5v"
+#define TR_TTL_WARNING                 "Warning: use 3.3V logic levels"
 #define TR_FUNC                        "Func"
 #define TR_V1                          "V1"
 #define TR_V2                          "V2"

--- a/radio/src/translations/es.h.txt
+++ b/radio/src/translations/es.h.txt
@@ -812,7 +812,7 @@
 #define TR_COPROC_TEMP         "MB Temp. \016>"
 #define TR_CAPAWARNING         INDENT "Capacidad baja"
 #define TR_TEMPWARNING         INDENT "Sobrecalent"
-#define TR_TTL_WARNING                 "Warning: use only TLL or 5v"
+#define TR_TTL_WARNING         "Warning: use 3.3V logic levels"
 #define TR_FUNC                "Función"
 #define TR_V1                  "V1"
 #define TR_V2                  "V2"

--- a/radio/src/translations/fi.h.txt
+++ b/radio/src/translations/fi.h.txt
@@ -826,7 +826,7 @@
 #define TR_COPROC_TEMP         "MB Temp. \016>"
 #define TR_CAPAWARNING         INDENT "Capacity Low"
 #define TR_TEMPWARNING         INDENT "Overheat"
-#define TR_TTL_WARNING                 "Warning: use only TLL or 5v"
+#define TR_TTL_WARNING         "Warning: use 3.3V logic levels"
 #define TR_FUNC                "Func"
 #define TR_V1                  "V1"
 #define TR_V2                  "V2"

--- a/radio/src/translations/fr.h.txt
+++ b/radio/src/translations/fr.h.txt
@@ -831,7 +831,7 @@
 #define TR_COPROC_TEMP                 "Temp. MB \016>"
 #define TR_CAPAWARNING                 INDENT "Capacité Basse"
 #define TR_TEMPWARNING                 INDENT "Surchauffe"
-#define TR_TTL_WARNING                 "Warning: use only TLL or 5v"
+#define TR_TTL_WARNING                 "Warning: use 3.3V logic levels"
 #define TR_FUNC                        "Fonction"
 #define TR_V1                          "V1"
 #define TR_V2                          "V2"

--- a/radio/src/translations/it.h.txt
+++ b/radio/src/translations/it.h.txt
@@ -832,7 +832,7 @@
 #define TR_COPROC_TEMP         "Temp. MB \016>"
 #define TR_CAPAWARNING         INDENT "Capacità Bassa"
 #define TR_TEMPWARNING         INDENT "Temp. Alta"
-#define TR_TTL_WARNING                 "Warning: use only TLL or 5v"
+#define TR_TTL_WARNING         "Warning: use 3.3V logic levels"
 #define TR_FUNC                "Funz"
 #define TR_V1                  "V1"
 #define TR_V2                  "V2"

--- a/radio/src/translations/nl.h.txt
+++ b/radio/src/translations/nl.h.txt
@@ -815,7 +815,7 @@
 #define TR_COPROC_TEMP         "MB Temp. \016>"
 #define TR_CAPAWARNING         INDENT "Capaciteit laag" // wg 9XR-Pro
 #define TR_TEMPWARNING         INDENT "Overhitting"  //wg 9XR-Pro
-#define TR_TTL_WARNING                 "Warning: use only TLL or 5v"
+#define TR_TTL_WARNING         "Warning: use 3.3V logic levels"
 #define TR_FUNC                "Funktie"
 #define TR_V1                  "V1"
 #define TR_V2                  "V2"

--- a/radio/src/translations/pl.h.txt
+++ b/radio/src/translations/pl.h.txt
@@ -829,7 +829,7 @@
 #define TR_COPROC_TEMP         "Temp. MB"
 #define TR_CAPAWARNING         INDENT "Mała pojemność"
 #define TR_TEMPWARNING         INDENT "Przegrzanie"
-#define TR_TTL_WARNING                 "Warning: use only TLL or 5v"
+#define TR_TTL_WARNING         "Warning: use 3.3V logic levels"
 #define TR_FUNC                "Funkc"
 #define TR_V1                  "V1"
 #define TR_V2                  "V2"

--- a/radio/src/translations/pt.h.txt
+++ b/radio/src/translations/pt.h.txt
@@ -830,7 +830,7 @@
 #define TR_COPROC_TEMP         "MB Temp. \016>"
 #define TR_CAPAWARNING         INDENT "Aviso Capacidade"
 #define TR_TEMPWARNING         INDENT "Temperat. ALTA"
-#define TR_TTL_WARNING                 "Warning: use only TLL or 5v"
+#define TR_TTL_WARNING         "Warning: use 3.3V logic levels"
 #define TR_FUNC                "Funcao"
 #define TR_V1                  "V1"
 #define TR_V2                  "V2"

--- a/radio/src/translations/se.h.txt
+++ b/radio/src/translations/se.h.txt
@@ -832,7 +832,7 @@
 #define TR_COPROC_TEMP         "MB temp. \016>"
 #define TR_CAPAWARNING         INDENT "Låg Kapacitet"
 #define TR_TEMPWARNING         TR(INDENT "Hög Temp ", INDENT "Hög Temperatur")
-#define TR_TTL_WARNING                 "Warning: use only TLL or 5v"
+#define TR_TTL_WARNING         "Warning: use 3.3V logic levels"
 #define TR_FUNC                "Funk"
 #define TR_V1                  "V1"
 #define TR_V2                  "V2"

--- a/radio/src/translations/tw.h.txt
+++ b/radio/src/translations/tw.h.txt
@@ -718,7 +718,7 @@
 #define TR_COPROC_TEMP                  "主板溫度"
 #define TR_CAPAWARNING INDENT           "電流過低"
 #define TR_TEMPWARNING INDENT           "過熱"
-#define TR_TTL_WARNING                  "注意: 端口僅能使用TTL電平或5V"
+#define TR_TTL_WARNING                  "注意：使用逻辑电平3.3V"
 #define TR_FUNC                         "功能"
 #define TR_V1                           "V1"
 #define TR_V2                           "V2"


### PR DESCRIPTION
Adjusts the warning message accordingly (simplified/traditional Chinese is using the same hieroglyphs for this phrase).