### PR TITLE
Extend lua getVersion()

### DIFF
--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -72,6 +72,8 @@
   #define RADIO_VERSION FLAVOUR
 #endif
 
+#define VERSION_OSNAME "EdgeTX"
+
 #define FIND_FIELD_DESC  0x01
 
 #define KEY_EVENTS(xxx, yyy)  \
@@ -91,22 +93,15 @@ Return OpenTX version
 
 @retval string OpenTX version (ie "2.1.5")
 
-@retval multiple (available since 2.1.7) returns 5 values:
+@retval multiple values (available since 2.1.7):
  * (string) OpenTX version (ie "2.1.5")
  * (string) radio type: `x12s`, `x10`, `x9e`, `x9d+`, `x9d` or `x7`.
 If running in simulator the "-simu" is added
  * (number) major version (ie 2 if version 2.1.5)
  * (number) minor version (ie 1 if version 2.1.5)
  * (number) revision number (ie 5 if version 2.1.5)
-
-@retval multiple (available since 2.1.7) returns 6 values:
- * (string) OpenTX version (ie "2.1.5")
- * (string) radio type: `x12s`, `x10`, `x9e`, `x9d+`, `x9d` or `x7`.
-If running in simulator the "-simu" is added
- * (number) major version (ie 2 if version 2.1.5)
- * (number) minor version (ie 1 if version 2.1.5)
- * (number) revision number (ie 5 if version 2.1.5)
- * (string) OS name ( i.e. EdgeTX or nil if OpenTX)
+Since EdgeTX 2.4.0, sixth value added
+ * (string) OS name (i.e. EdgeTX or nil if OpenTX)
 
 @status current Introduced in 2.0.0, expanded in 2.1.7, radio type strings changed in 2.2.0, os name added in EdgeTX 2.4.0
 
@@ -130,11 +125,12 @@ return {  run=run }
 ```
 Output of the above script in simulator:
 ```
-version: 2.1.7
-radio: taranis-simu
+version: 2.4.0
+radio: tx16s-simu
 maj: 2
-minor: 1
-rev: 7
+minor: 4
+rev: 0
+osname: EdgeTX
 ```
 */
 static int luaGetVersion(lua_State * L)
@@ -144,7 +140,7 @@ static int luaGetVersion(lua_State * L)
   lua_pushnumber(L, VERSION_MAJOR);
   lua_pushnumber(L, VERSION_MINOR);
   lua_pushnumber(L, VERSION_REVISION);
-  lua_pushstring(L, "EdgeTX");
+  lua_pushstring(L, VERSION_OSNAME);
   return 6;
 }
 

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -99,7 +99,16 @@ If running in simulator the "-simu" is added
  * (number) minor version (ie 1 if version 2.1.5)
  * (number) revision number (ie 5 if version 2.1.5)
 
-@status current Introduced in 2.0.0, expanded in 2.1.7, radio type strings changed in 2.2.0
+@retval multiple (available since 2.1.7) returns 6 values:
+ * (string) OpenTX version (ie "2.1.5")
+ * (string) radio type: `x12s`, `x10`, `x9e`, `x9d+`, `x9d` or `x7`.
+If running in simulator the "-simu" is added
+ * (number) major version (ie 2 if version 2.1.5)
+ * (number) minor version (ie 1 if version 2.1.5)
+ * (number) revision number (ie 5 if version 2.1.5)
+ * (string) OS name ( i.e. EdgeTX or nil if OpenTX)
+
+@status current Introduced in 2.0.0, expanded in 2.1.7, radio type strings changed in 2.2.0, os name added in EdgeTX 2.4.0
 
 ### Example
 
@@ -107,12 +116,13 @@ This example also runs in OpenTX versions where the function returned only one v
 
 ```lua
 local function run(event)
-  local ver, radio, maj, minor, rev = getVersion()
+  local ver, radio, maj, minor, rev, osname = getVersion()
   print("version: "..ver)
   if radio then print ("radio: "..radio) end
   if maj then print ("maj: "..maj) end
   if minor then print ("minor: "..minor) end
   if rev then print ("rev: "..rev) end
+  if osname then print ("osname: "..osname) end
   return 1
 end
 
@@ -134,7 +144,8 @@ static int luaGetVersion(lua_State * L)
   lua_pushnumber(L, VERSION_MAJOR);
   lua_pushnumber(L, VERSION_MINOR);
   lua_pushnumber(L, VERSION_REVISION);
-  return 5;
+  lua_pushstring(L, "EdgeTX");
+  return 6;
 }
 
 /*luadoc


### PR DESCRIPTION
Resolves #319 

Extends lua getVersion() so that it returns a sixth parameter, the OS name, allowing scripts to identify if running on OTX or ETX. 

Didn't see a readily usable pre-existing define that had `EdgeTX` in it so added `VERSION_OSNAME` 