### PR TITLE
Fix colour of inactive SF/GF state in header

### DIFF
--- a/radio/src/gui/colorlcd/special_functions.cpp
+++ b/radio/src/gui/colorlcd/special_functions.cpp
@@ -60,7 +60,7 @@ class SpecialFunctionEditPage : public Page
     if (active != isActive()) {
       invalidate();
       headerSF->setTextFlags(isActive() ? FONT(BOLD) | HIGHLIGHT_COLOR
-                                        : MENU_COLOR);
+                                        : FOCUS_COLOR);
       active = !active;
     }
   }


### PR DESCRIPTION
Inactive state was being set to menu background colour... 