### PR TITLE
Widget colours

### DIFF
--- a/radio/src/gui/colorlcd/themes/480_default.cpp
+++ b/radio/src/gui/colorlcd/themes/480_default.cpp
@@ -51,7 +51,7 @@ class Theme480: public OpenTxTheme
     {
       TRACE("Load EdgeTX theme colors");
       lcdColorTable[ALARM_COLOR_INDEX] = RED;
-      lcdColorTable[BARGRAPH1_COLOR_INDEX] = RED;
+      lcdColorTable[BARGRAPH1_COLOR_INDEX] = __BACKGROUND_COLOR;
       lcdColorTable[BARGRAPH2_COLOR_INDEX] = RGB(167, 167, 167);
       lcdColorTable[BARGRAPH_BGCOLOR_INDEX] = RGB(222, 222, 222);
       lcdColorTable[BATTERY_CHARGE_COLOR_INDEX] = GREEN;

--- a/radio/src/gui/colorlcd/themes/480_default.cpp
+++ b/radio/src/gui/colorlcd/themes/480_default.cpp
@@ -71,7 +71,7 @@ class Theme480: public OpenTxTheme
       lcdColorTable[HEADER_ICON_BGCOLOR_INDEX] = __BACKGROUND_COLOR;
       lcdColorTable[HIGHLIGHT_COLOR_INDEX] = __ACTIVE_MARKER_COLOR;
       lcdColorTable[LINE_COLOR_INDEX] = GREY;
-      lcdColorTable[MAINVIEW_GRAPHICS_COLOR_INDEX] = RED;
+      lcdColorTable[MAINVIEW_GRAPHICS_COLOR_INDEX] = __BACKGROUND_COLOR;
       lcdColorTable[MAINVIEW_PANES_COLOR_INDEX] = WHITE;
 
       lcdColorTable[MENU_BGCOLOR_INDEX] = WHITE;

--- a/radio/src/gui/colorlcd/themes/480_default.cpp
+++ b/radio/src/gui/colorlcd/themes/480_default.cpp
@@ -51,7 +51,7 @@ class Theme480: public OpenTxTheme
     {
       TRACE("Load EdgeTX theme colors");
       lcdColorTable[ALARM_COLOR_INDEX] = RED;
-      lcdColorTable[BARGRAPH1_COLOR_INDEX] = __BACKGROUND_COLOR;
+      lcdColorTable[BARGRAPH1_COLOR_INDEX] = __FOCUS_COLOR;
       lcdColorTable[BARGRAPH2_COLOR_INDEX] = RGB(167, 167, 167);
       lcdColorTable[BARGRAPH_BGCOLOR_INDEX] = RGB(222, 222, 222);
       lcdColorTable[BATTERY_CHARGE_COLOR_INDEX] = GREEN;
@@ -71,7 +71,7 @@ class Theme480: public OpenTxTheme
       lcdColorTable[HEADER_ICON_BGCOLOR_INDEX] = __BACKGROUND_COLOR;
       lcdColorTable[HIGHLIGHT_COLOR_INDEX] = __ACTIVE_MARKER_COLOR;
       lcdColorTable[LINE_COLOR_INDEX] = GREY;
-      lcdColorTable[MAINVIEW_GRAPHICS_COLOR_INDEX] = __BACKGROUND_COLOR;
+      lcdColorTable[MAINVIEW_GRAPHICS_COLOR_INDEX] = __FOCUS_COLOR;
       lcdColorTable[MAINVIEW_PANES_COLOR_INDEX] = WHITE;
 
       lcdColorTable[MENU_BGCOLOR_INDEX] = WHITE;


### PR DESCRIPTION
Finally looked at how to get rid of some more of that red ;)

First up is the timer, before on the left, after on the right:
![timer](https://user-images.githubusercontent.com/5500713/123232658-b8227a80-d51c-11eb-813f-d5a205d981d1.png)

Then since I saw that the colour change also had some impact on the output bar widget... I thought I'd de-redify it also.
![outputs](https://user-images.githubusercontent.com/5500713/123232842-e43dfb80-d51c-11eb-9e44-e12a08171791.png)

I leave it up to you if you want to merge one or both - hence two commits. The colour isn't that good for the text on the output bars when they overlap, but it also isn't that great with the red... so I think for now it's an acceptable compromise until we decide what happens with the widgets and colours. 

The colour variables tweaked only seem to apply two those two widgets. 

Closes #258