### PR TITLE
Show RSSI if RF Freq Fine tuning supported

### DIFF
--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -681,10 +681,10 @@ class ModuleWindow : public FormGroup {
             if (getMultiOptionTitle(moduleIdx) == STR_MULTI_RFTUNE)
             {
               new DynamicText(this, grid.getFieldSlot(2, 1), [=] {
-              char buf[10];
-              sprintf(buf, "RSSI(%i)", TELEMETRY_RSSI());
-              return std::string(buf);
-            });
+                  char buf[16];
+                  sprintf(buf, "RSSI (%i)", TELEMETRY_RSSI());
+                  return std::string(buf);
+              });
             }
           }
         }

--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -676,6 +676,16 @@ class ModuleWindow : public FormGroup {
           }
           else {
             new NumberEdit(this, grid.getFieldSlot(2,0), -128, 127, GET_SET_DEFAULT(g_model.moduleData[moduleIdx].multi.optionValue));
+
+            //Show RSSI next to RF Freq Fine Tune
+            if (getMultiOptionTitle(moduleIdx) == STR_MULTI_RFTUNE)
+            {
+              new DynamicText(this, grid.getFieldSlot(2, 1), [=] {
+              char buf[10];
+              sprintf(buf, "RSSI(%i)", TELEMETRY_RSSI());
+              return std::string(buf);
+            });
+            }
           }
         }
 

--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -680,11 +680,8 @@ class ModuleWindow : public FormGroup {
             //Show RSSI next to RF Freq Fine Tune
             if (getMultiOptionTitle(moduleIdx) == STR_MULTI_RFTUNE)
             {
-              new DynamicText(this, grid.getFieldSlot(2, 1), [=] {
-                  char msg[64] = "";
-                  sprintf(msg, "RSSI (%i)", TELEMETRY_RSSI());
-                  return std::string(msg);
-              });
+              new DynamicNumber<int>(this, grid.getFieldSlot(2, 1), [] {
+                  return (int)TELEMETRY_RSSI();}, 0, "RSSI: ", " db");
             }
           }
         }

--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -681,9 +681,9 @@ class ModuleWindow : public FormGroup {
             if (getMultiOptionTitle(moduleIdx) == STR_MULTI_RFTUNE)
             {
               new DynamicText(this, grid.getFieldSlot(2, 1), [=] {
-                  char buf[16];
-                  sprintf(buf, "RSSI (%i)", TELEMETRY_RSSI());
-                  return std::string(buf);
+                  char msg[64] = "";
+                  sprintf(msg, "RSSI (%i)", TELEMETRY_RSSI());
+                  return std::string(msg);
               });
             }
           }


### PR DESCRIPTION
Currently missing, and was present on OTX. Without it, fine tuning is impractical to do at best. 

If it can be right aligned, even better, but it appears to be functional on TX16S - the RSSI value updates continuously, and more importantly, while the fine tune value is being changed. 

I started with just copying the format from OTX as is... 
![image](https://user-images.githubusercontent.com/5500713/124118563-d35d2f00-dab4-11eb-8fae-c68ac33e4f68.png)

... and currently have this:
![image](https://user-images.githubusercontent.com/5500713/124204213-ed812680-db21-11eb-9965-b784ee98e200.png)

Interestingly, the latter implementation doesn't show up on `simu`. 

This is probably a squash merge candidate ;)
