### PR TITLE
Reset logical switch v2 range if v1 changes

### DIFF
--- a/radio/src/gui/colorlcd/model_logical_switches.cpp
+++ b/radio/src/gui/colorlcd/model_logical_switches.cpp
@@ -165,10 +165,6 @@ class LogicalSwitchEditPage: public Page
                            {
                              int16_t v2_min = 0, v2_max = 0;
                              getMixSrcRange(cs->v1, v2_min, v2_max);
-                             if ((cs->v2 < v2_min) || (cs->v2 > v2_max))
-                             {
-                               v2Edit->setValue(0);
-                             }
                              v2Edit->setMin(v2_min);
                              v2Edit->setMax(v2_max);
                              v2Edit->invalidate();

--- a/radio/src/gui/colorlcd/model_logical_switches.cpp
+++ b/radio/src/gui/colorlcd/model_logical_switches.cpp
@@ -165,7 +165,7 @@ class LogicalSwitchEditPage: public Page
                            {
                              int16_t v2_min = 0, v2_max = 0;
                              getMixSrcRange(cs->v1, v2_min, v2_max);
-                             if ((cs->v2 <= v2_min) || (cs->v2 >= v2_max))
+                             if ((cs->v2 < v2_min) || (cs->v2 > v2_max))
                              {
                                v2Edit->setValue(0);
                              }

--- a/radio/src/gui/colorlcd/model_logical_switches.cpp
+++ b/radio/src/gui/colorlcd/model_logical_switches.cpp
@@ -162,6 +162,13 @@ class LogicalSwitchEditPage: public Page
                            cs->v1 = newValue;
                            SET_DIRTY();
                            v2Edit->invalidate();
+                           if (v2Edit != nullptr)
+                           {
+                             int16_t v2_min = 0, v2_max = 0;
+                             getMixSrcRange(cs->v1, v2_min, v2_max);
+                             v2Edit->setMin(v2_min);
+                             v2Edit->setMax(v2_max);
+                           }
                          });
         grid.nextLine();
 

--- a/radio/src/gui/colorlcd/model_logical_switches.cpp
+++ b/radio/src/gui/colorlcd/model_logical_switches.cpp
@@ -161,13 +161,17 @@ class LogicalSwitchEditPage: public Page
                          [=](int32_t newValue) {
                            cs->v1 = newValue;
                            SET_DIRTY();
-                           v2Edit->invalidate();
                            if (v2Edit != nullptr)
                            {
                              int16_t v2_min = 0, v2_max = 0;
                              getMixSrcRange(cs->v1, v2_min, v2_max);
+                             if ((cs->v2 <= v2_min) || (cs->v2 >= v2_max))
+                             {
+                               v2Edit->setValue(0);
+                             }
                              v2Edit->setMin(v2_min);
                              v2Edit->setMax(v2_max);
+                             v2Edit->invalidate();
                            }
                          });
         grid.nextLine();


### PR DESCRIPTION
Resolves #375 

Use the v1 handler to update v2 range if the v2 source box has already
been created, so that the min/max values are correctly updated from v1.

Read it and weep over my atrocious code. :-P

As always, open to suggestions and being told there's a better way to do it. TX16S hasn't crashed yet :-P