### PR TITLE
Use uint32_t values consistent with underlying data structures

### DIFF
--- a/radio/src/gui/colorlcd/model_inputs.cpp
+++ b/radio/src/gui/colorlcd/model_inputs.cpp
@@ -284,12 +284,12 @@ class InputEditWindow : public Page
 
       // Flight modes
       new StaticText(window, grid.getLabelSlot(), STR_FLMODE);
-      for (uint8_t i=0; i<MAX_FLIGHT_MODES; i++) {
+      for (uint32_t i=0; i<MAX_FLIGHT_MODES; i++) {
         char fm[2] = { char('0' + i), '\0'};
         if (i > 0 && (i % 4) == 0)
           grid.nextLine();
         new TextButton(window, grid.getFieldSlot(4, i % 4), fm,
-                       [=]() -> uint8_t {
+                       [=]() -> uint32_t {
                            BFBIT_FLIP(line->flightModes, bfBit<uint32_t>(i));
                            SET_DIRTY();
                            return !(bfSingleBitGet(line->flightModes, i));

--- a/radio/src/gui/colorlcd/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model_mixes.cpp
@@ -136,13 +136,13 @@ class MixEditWindow : public Page
 
     // Flight modes
     new StaticText(window, grid.getLabelSlot(), STR_FLMODE);
-    for (uint8_t i = 0; i < MAX_FLIGHT_MODES; i++) {
+    for (uint32_t i = 0; i < MAX_FLIGHT_MODES; i++) {
       char fm[2] = {char('0' + i), '\0'};
       if (i > 0 && (i % 4) == 0) grid.nextLine();
       new TextButton(
           window, grid.getFieldSlot(4, i % 4), fm,
-          [=]() -> uint8_t {
-            BFBIT_FLIP(mix->flightModes, bfBit<uint8_t>(i));
+          [=]() -> uint32_t {
+            BFBIT_FLIP(mix->flightModes, bfBit<uint32_t>(i));
             SET_DIRTY();
             return !(bfSingleBitGet(mix->flightModes, i));
           },


### PR DESCRIPTION
Resolves #387 

For some reason, the input page appeared to work, but was mixing uint8_t and uint32_t data types... so I've updated both to align with the underlying uint32_t used by the actual data structures. 

Need to test this further on the TX as only simu tested to verify that the button actually toggled now - I haven't verified the flight mode is behaving correctly yet. 