### PR TITLE
Squashed GT911 lockup fix attempt

### DIFF
--- a/radio/src/gui/colorlcd/radio_diaganas.cpp
+++ b/radio/src/gui/colorlcd/radio_diaganas.cpp
@@ -48,8 +48,8 @@ class RadioAnalogsDiagsWindow: public Window {
         dc->drawNumber(x + ANA_OFFSET, y, (int16_t) calibratedAnalogs[CONVERT_MODE(i)] * 25 / 256, RIGHT);
       }
 
-#if defined(HARDWARE_TOUCH)
-      constexpr coord_t y = MENU_CONTENT_TOP + 6 * FH;
+#if defined(HARDWARE_TOUCH) && !defined(SIMU)
+      constexpr coord_t y = MENU_CONTENT_TOP + 5 * FH;
 
       if (touchState.event != TE_NONE && touchState.event != TE_SLIDE_END) {
         coord_t x = dc->drawText(MENUS_MARGIN_LEFT, y, STR_TOUCH_PANEL);
@@ -59,6 +59,13 @@ class RadioAnalogsDiagsWindow: public Window {
         dc->drawLine(touchState.x - 10, touchState.y - 8 - parent->top(), touchState.x + 10, touchState.y + 8 - parent->top(), SOLID, 0);
         dc->drawLine(touchState.x - 10, touchState.y + 8 - parent->top(), touchState.x + 10, touchState.y - 8- parent->top(), SOLID, 0);
       }
+
+      constexpr coord_t y1 = MENU_CONTENT_TOP + 6 * FH;
+      constexpr coord_t x1 = MENUS_MARGIN_LEFT;
+      dc->drawText(x1, y1, "Touch GT911 FW ver:");
+      dc->drawNumber(x1 + 150, y1, touchGT911fwver, LEFT, 4);
+      dc->drawText(x1 + 200, y1, "Hiccups:");
+      dc->drawNumber(x1 + 260, y1, touchGT911hiccups, LEFT, 5);
 #endif
     };
 

--- a/radio/src/gui/colorlcd/radio_diaganas.cpp
+++ b/radio/src/gui/colorlcd/radio_diaganas.cpp
@@ -48,7 +48,7 @@ class RadioAnalogsDiagsWindow: public Window {
         dc->drawNumber(x + ANA_OFFSET, y, (int16_t) calibratedAnalogs[CONVERT_MODE(i)] * 25 / 256, RIGHT);
       }
 
-#if defined(HARDWARE_TOUCH) && !defined(SIMU)
+#if defined(HARDWARE_TOUCH)
       constexpr coord_t y = MENU_CONTENT_TOP + 5 * FH;
 
       if (touchState.event != TE_NONE && touchState.event != TE_SLIDE_END) {
@@ -60,12 +60,14 @@ class RadioAnalogsDiagsWindow: public Window {
         dc->drawLine(touchState.x - 10, touchState.y + 8 - parent->top(), touchState.x + 10, touchState.y - 8- parent->top(), SOLID, 0);
       }
 
+#if !defined(SIMU)
       constexpr coord_t y1 = MENU_CONTENT_TOP + 6 * FH;
       constexpr coord_t x1 = MENUS_MARGIN_LEFT;
       dc->drawText(x1, y1, "Touch GT911 FW ver:");
       dc->drawNumber(x1 + 150, y1, touchGT911fwver, LEFT, 4);
       dc->drawText(x1 + 200, y1, "Hiccups:");
       dc->drawNumber(x1 + 260, y1, touchGT911hiccups, LEFT, 5);
+#endif
 #endif
     };
 

--- a/radio/src/targets/horus/hal.h
+++ b/radio/src/targets/horus/hal.h
@@ -728,7 +728,7 @@
   #define I2C_SCL_GPIO_PinSource          GPIO_PinSource8
   #define I2C_SDA_GPIO_PinSource          GPIO_PinSource9
 #endif
-#define I2C_SPEED                       400000
+#define I2C_SPEED                       100000
 
 // Haptic
 #define HAPTIC_PWM

--- a/radio/src/targets/horus/hal.h
+++ b/radio/src/targets/horus/hal.h
@@ -728,7 +728,7 @@
   #define I2C_SCL_GPIO_PinSource          GPIO_PinSource8
   #define I2C_SDA_GPIO_PinSource          GPIO_PinSource9
 #endif
-#define I2C_SPEED                       100000
+#define I2C_SPEED                       400000
 
 // Haptic
 #define HAPTIC_PWM

--- a/radio/src/targets/horus/tp_gt911.cpp
+++ b/radio/src/targets/horus/tp_gt911.cpp
@@ -670,7 +670,7 @@ bool touchPanelInit(void)
       I2C_GT911_ReadRegister(GT_CFGS_REG, tmp, 1);
 
       TRACE("Chip config Ver:%x\r\n", tmp[0]);
-      if (tmp[0] < GT911_CFG_NUMER)  //Config ver
+      if (tmp[0] <= GT911_CFG_NUMER)  //Config ver
       {
         TRACE("Sending new config %d", GT911_CFG_NUMER);
         I2C_GT911_SendConfig(1);
@@ -725,9 +725,9 @@ void touchPanelRead()
   uint32_t startReadStatus = RTOS_GET_MS();
   do {
     if (!I2C_GT911_ReadRegister(GT911_READ_XY_REG, &state, 1)) {
+      touchPanelDeInit();
       touchGT911hiccups++;
       TRACE("GT911 I2C read XY error");
-      touchPanelDeInit();
       touchPanelInit();
       return;
     }
@@ -746,9 +746,9 @@ void touchPanelRead()
     if (pointsCount > 0 && pointsCount <= GT911_MAX_TP) {
       if (!I2C_GT911_ReadRegister(GT911_READ_XY_REG + 1, touchData.data,
                                   pointsCount * sizeof(TouchPoint))) {
+        touchPanelDeInit();
         touchGT911hiccups++;
         TRACE("GT911 I2C data read error");
-        touchPanelDeInit();
         touchPanelInit();
         return;
       }

--- a/radio/src/targets/horus/tp_gt911.cpp
+++ b/radio/src/targets/horus/tp_gt911.cpp
@@ -418,7 +418,7 @@ static void TOUCH_AF_ExtiStop(void)
   EXTI_StructInit(&EXTI_InitStructure);
   EXTI_InitStructure.EXTI_Line = TOUCH_INT_EXTI_LINE1;
   EXTI_InitStructure.EXTI_Mode = EXTI_Mode_Interrupt;
-  EXTI_InitStructure.EXTI_Trigger = EXTI_Trigger_Rising_Falling;
+  EXTI_InitStructure.EXTI_Trigger = EXTI_Trigger_Rising;
   EXTI_InitStructure.EXTI_LineCmd = DISABLE;
   EXTI_Init(&EXTI_InitStructure);
 }
@@ -431,7 +431,7 @@ static void TOUCH_AF_ExtiConfig(void)
   EXTI_StructInit(&EXTI_InitStructure);
   EXTI_InitStructure.EXTI_Line = TOUCH_INT_EXTI_LINE1;
   EXTI_InitStructure.EXTI_Mode = EXTI_Mode_Interrupt;
-  EXTI_InitStructure.EXTI_Trigger = EXTI_Trigger_Rising_Falling;
+  EXTI_InitStructure.EXTI_Trigger = EXTI_Trigger_Rising;
   EXTI_InitStructure.EXTI_LineCmd = ENABLE;
   EXTI_Init(&EXTI_InitStructure);
 

--- a/radio/src/targets/horus/tp_gt911.cpp
+++ b/radio/src/targets/horus/tp_gt911.cpp
@@ -412,7 +412,7 @@ struct TouchData touchData;
 
 static void TOUCH_AF_ExtiStop(void)
 {
-  SYSCFG_EXTILineConfig(TOUCH_INT_EXTI_PortSource, TOUCH_INT_EXTI_PinSource1);
+  NVIC_DisableIRQ(TOUCH_INT_EXTI_IRQn1);
 
   EXTI_InitTypeDef EXTI_InitStructure;
   EXTI_StructInit(&EXTI_InitStructure);
@@ -421,14 +421,6 @@ static void TOUCH_AF_ExtiStop(void)
   EXTI_InitStructure.EXTI_Trigger = EXTI_Trigger_Rising_Falling;
   EXTI_InitStructure.EXTI_LineCmd = DISABLE;
   EXTI_Init(&EXTI_InitStructure);
-
-
-  NVIC_InitTypeDef NVIC_InitStructure;
-  NVIC_InitStructure.NVIC_IRQChannel = TOUCH_INT_EXTI_IRQn1;
-  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 9;
-  NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0; /* Not used as 4 bits are used for the pre-emption priority. */;
-  NVIC_InitStructure.NVIC_IRQChannelCmd = DISABLE;
-  NVIC_Init(&NVIC_InitStructure);
 }
 
 static void TOUCH_AF_ExtiConfig(void)

--- a/radio/src/targets/horus/tp_gt911.cpp
+++ b/radio/src/targets/horus/tp_gt911.cpp
@@ -575,6 +575,11 @@ bool I2C_GT911_ReadRegister(u16 reg, uint8_t * buf, uint8_t len)
   I2C_SendData(I2C, (uint8_t)(reg & 0x00FF));
   if (!I2C_WaitEvent(I2C_EVENT_MASTER_BYTE_TRANSMITTED))
     return false;
+    
+  // see GP911 data sheet, chapter 6.1.c, page 12, diagram for reading data
+  I2C_GenerateSTOP(I2C, ENABLE);
+  if (!I2C_WaitEventCleared(I2C_FLAG_BUSY))
+    return false;    
 
   I2C_GenerateSTART(I2C, ENABLE);
   if (!I2C_WaitEvent(I2C_EVENT_MASTER_MODE_SELECT))

--- a/radio/src/targets/horus/tp_gt911.h
+++ b/radio/src/targets/horus/tp_gt911.h
@@ -23,6 +23,8 @@
 #define HAS_TOUCH_PANEL()     touchGT911Flag == true
 
 extern uint8_t touchGT911Flag;
+extern uint16_t touchGT911fwver;
+extern uint16_t touchGT911hiccups;
 extern bool touchPanelInit();
 
 void touchPanelRead();

--- a/radio/src/targets/horus/tp_gt911.h
+++ b/radio/src/targets/horus/tp_gt911.h
@@ -22,7 +22,7 @@
 
 #define HAS_TOUCH_PANEL()     touchGT911Flag == true
 
-extern uint8_t touchGT911Flag;
+extern bool touchGT911Flag;
 extern uint16_t touchGT911fwver;
 extern uint16_t touchGT911hiccups;
 extern bool touchPanelInit();

--- a/radio/src/targets/nv14/touch_driver.cpp
+++ b/radio/src/targets/nv14/touch_driver.cpp
@@ -21,7 +21,7 @@
 #include "opentx.h"
 #include "touch_driver.h"
 
-static bool touchEventOccured;
+volatile static bool touchEventOccured;
 
 #define FT6x06_MAX_INSTANCE  1
 


### PR DESCRIPTION
Follow-up version of #408

Max the refresh rate from 10 ms to 20 ms

Increase X Y threshold to 1

Reset GT911 on error

Extract GT911 firmware version and display it on radio analogs diagnose screen and on debug output.

Added hiccup counter to Analogs Diagnose page