### PR TITLE
GP911: stop is missing according to data sheet. Lockup mitigation?

### DIFF
--- a/radio/src/targets/horus/tp_gt911.cpp
+++ b/radio/src/targets/horus/tp_gt911.cpp
@@ -581,6 +581,11 @@ bool I2C_GT911_ReadRegister(u16 reg, uint8_t * buf, uint8_t len)
   if (!I2C_WaitEvent(I2C_EVENT_MASTER_BYTE_TRANSMITTED))
     return false;
 
+  // see GP911 data sheet, chapter 6.1.c, page 12, diagram for reading data
+  I2C_GenerateSTOP(I2C, ENABLE);
+  if (!I2C_WaitEventCleared(I2C_FLAG_BUSY))
+    return false;
+
   I2C_GenerateSTART(I2C, ENABLE);
   if (!I2C_WaitEvent(I2C_EVENT_MASTER_MODE_SELECT))
     return false;


### PR DESCRIPTION
@rotorman 

hey risto, 
concerning the GP911 lockup you've spend so massive time on, I took the liberty to briefly look into the GP911 data sheet and the code for writing and reading, and noticed this:
for reading, the data sheet's diagram shows on page 12 that a stop should come before the start for reading (the text does not mention)

I've thus added it, and tested that the change works on tx16s

if it helps with the GP911 lockup I can't tell at all, since I get this only very rarely, so no good chance. But it is what the datasheet suggest ... and it at least would be exactly the sort of typical issue which tends to make a slave hangup ... so it could help, but this would need proof, right LOL

have fun

edit: maybe double-check that I did the correct wait for flag after the stop, I only spend short time on this, it's working for me on tx16s, but ...