### PR TITLE
Fix isrm ixjt pulses issues

### DIFF
--- a/radio/src/pulses/pulses.cpp
+++ b/radio/src/pulses/pulses.cpp
@@ -347,7 +347,7 @@ bool setupPulsesExternalModule(uint8_t protocol)
     case PROTOCOL_CHANNELS_PXX2_LOWSPEED:
       extmodulePulsesData.pxx2.setupFrame(EXTERNAL_MODULE);
 #if defined(PCBSKY9X)
-      sheduleNextMixerCalculation(EXTERNAL_MODULE, PXX2_NO_HEARTBEAT_PERIOD);
+      scheduleNextMixerCalculation(EXTERNAL_MODULE, PXX2_NO_HEARTBEAT_PERIOD);
 #endif
       return true;
 #endif
@@ -457,12 +457,9 @@ static void enablePulsesInternalModule(uint8_t protocol)
     case PROTOCOL_CHANNELS_PXX1_PULSES:
       intmodulePxx1PulsesStart();
 #if defined(INTMODULE_HEARTBEAT)
-      // use backup trigger (1 ms later)
       init_intmodule_heartbeat();
-      mixerSchedulerSetPeriod(INTERNAL_MODULE, INTMODULE_PXX1_SERIAL_PERIOD + 1000/*us*/);
-#else
-      mixerSchedulerSetPeriod(INTERNAL_MODULE, INTMODULE_PXX1_SERIAL_PERIOD);
 #endif
+      mixerSchedulerSetPeriod(INTERNAL_MODULE, INTMODULE_PXX1_SERIAL_PERIOD);
       break;
 #endif
 
@@ -470,12 +467,9 @@ static void enablePulsesInternalModule(uint8_t protocol)
     case PROTOCOL_CHANNELS_PXX1_SERIAL:
       intmodulePxx1SerialStart();
 #if defined(INTMODULE_HEARTBEAT)
-      // use backup trigger (1 ms later)
       init_intmodule_heartbeat();
-      mixerSchedulerSetPeriod(INTERNAL_MODULE, INTMODULE_PXX1_SERIAL_PERIOD + 1000/*us*/);
-#else
-      mixerSchedulerSetPeriod(INTERNAL_MODULE, INTMODULE_PXX1_SERIAL_PERIOD);
 #endif
+      mixerSchedulerSetPeriod(INTERNAL_MODULE, INTMODULE_PXX1_SERIAL_PERIOD);
       break;
 #endif
 
@@ -487,10 +481,8 @@ static void enablePulsesInternalModule(uint8_t protocol)
 #if defined(INTMODULE_HEARTBEAT)
       // use backup trigger (1 ms later)
       init_intmodule_heartbeat();
-      mixerSchedulerSetPeriod(INTERNAL_MODULE, PXX2_MAX_HEARTBEAT_PERIOD);
-#else
-      mixerSchedulerSetPeriod(INTERNAL_MODULE, PXX2_NO_HEARTBEAT_PERIOD);
 #endif
+      mixerSchedulerSetPeriod(INTERNAL_MODULE, PXX2_PERIOD);
       break;
 #endif
 
@@ -522,12 +514,6 @@ bool setupPulsesInternalModule(uint8_t protocol)
 #if defined(HARDWARE_INTERNAL_MODULE) && defined(PXX1) && !defined(INTMODULE_USART)
     case PROTOCOL_CHANNELS_PXX1_PULSES:
       intmodulePulsesData.pxx.setupFrame(INTERNAL_MODULE);
-#if defined(INTMODULE_HEARTBEAT)
-      mixerSchedulerResetTimer();
-      mixerSchedulerSetPeriod(INTERNAL_MODULE, INTMODULE_PXX1_SERIAL_PERIOD + 1000 /* backup */);
-#else
-      mixerSchedulerSetPeriod(INTERNAL_MODULE, INTMODULE_PXX1_SERIAL_PERIOD);
-#endif
       return true;
 #endif
 
@@ -545,12 +531,7 @@ bool setupPulsesInternalModule(uint8_t protocol)
         mixerSchedulerSetPeriod(INTERNAL_MODULE, PXX2_TOOLS_PERIOD);
       }
       else {
-#if defined(INTMODULE_HEARTBEAT)
-        mixerSchedulerResetTimer();
-        mixerSchedulerSetPeriod(INTERNAL_MODULE, PXX2_MAX_HEARTBEAT_PERIOD);
-#else
-        mixerSchedulerSetPeriod(INTERNAL_MODULE, PXX2_NO_HEARTBEAT_PERIOD);
-#endif
+        mixerSchedulerSetPeriod(INTERNAL_MODULE, PXX2_PERIOD);
       }
       return result;
     }
@@ -559,8 +540,6 @@ bool setupPulsesInternalModule(uint8_t protocol)
 #if defined(PCBTARANIS) && defined(INTERNAL_MODULE_PPM)
     case PROTOCOL_CHANNELS_PPM:
       setupPulsesPPMInternalModule();
-      // probably useless, as the interval did not change since "enable" function
-      mixerSchedulerSetPeriod(INTERNAL_MODULE, PPM_PERIOD(INTERNAL_MODULE));
       return true;
 #endif
 
@@ -572,7 +551,6 @@ bool setupPulsesInternalModule(uint8_t protocol)
 #endif
 
     default:
-      //mixerSchedulerSetPeriod(INTERNAL_MODULE, 10000 /*us*/); // used for USB sim for example
       return false;
   }
 }

--- a/radio/src/pulses/pxx.h
+++ b/radio/src/pulses/pxx.h
@@ -30,7 +30,7 @@
 #define PXX2_LOWSPEED_BAUDRATE             230400
 #define PXX2_HIGHSPEED_BAUDRATE            450000
 #define PXX2_NO_HEARTBEAT_PERIOD           4000/*us*/
-#define PXX2_MAX_HEARTBEAT_PERIOD          (7000 + 1000)/*us 7ms frame rate + 1ms heartbeat backup*/
+#define PXX2_MAX_HEARTBEAT_PERIOD          (9000 + 1000)/*us longest period (isrm/accst) + 1ms heartbeat backup*/
 #define PXX2_TOOLS_PERIOD                  1000/*us*/
 #define PXX2_FRAME_MAXLENGTH               64
 

--- a/radio/src/pulses/pxx.h
+++ b/radio/src/pulses/pxx.h
@@ -31,6 +31,11 @@
 #define PXX2_HIGHSPEED_BAUDRATE            450000
 #define PXX2_NO_HEARTBEAT_PERIOD           4000/*us*/
 #define PXX2_MAX_HEARTBEAT_PERIOD          (9000 + 1000)/*us longest period (isrm/accst) + 1ms heartbeat backup*/
+#if defined(INTMODULE_HEARTBEAT)
+  #define PXX2_PERIOD                      PXX2_MAX_HEARTBEAT_PERIOD
+#else
+  #define PXX2_PERIOD                      PXX2_NO_HEARTBEAT_PERIOD
+#endif
 #define PXX2_TOOLS_PERIOD                  1000/*us*/
 #define PXX2_FRAME_MAXLENGTH               64
 
@@ -40,10 +45,20 @@
 
 #if defined(PXX_FREQUENCY_HIGH)
   #define INTMODULE_PXX1_SERIAL_BAUDRATE   450000
-  #define INTMODULE_PXX1_SERIAL_PERIOD     4000/*us*/
+  #if defined(INTMODULE_HEARTBEAT)
+    // use backup trigger (1 ms later)
+    #define INTMODULE_PXX1_SERIAL_PERIOD   (4000 + 1000)/*us*/
+  #else
+    #define INTMODULE_PXX1_SERIAL_PERIOD   4000/*us*/
+  #endif
 #else
   #define INTMODULE_PXX1_SERIAL_BAUDRATE   115200
-  #define INTMODULE_PXX1_SERIAL_PERIOD     9000/*us*/
+  #if defined(INTMODULE_HEARTBEAT)
+    // use backup trigger (1 ms later)
+    #define INTMODULE_PXX1_SERIAL_PERIOD   (9000 + 1000)/*us*/
+  #else
+    #define INTMODULE_PXX1_SERIAL_PERIOD   9000/*us*/
+  #endif
 #endif
 
 // Used by the Sky9x family boards

--- a/radio/src/targets/common/arm/stm32/heartbeat_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/heartbeat_driver.cpp
@@ -79,6 +79,7 @@ void check_intmodule_heartbeat()
 #endif
     EXTI_ClearITPendingBit(INTMODULE_HEARTBEAT_EXTI_LINE);
 
+    mixerSchedulerResetTimer();
     mixerSchedulerISRTrigger();
   }
 }


### PR DESCRIPTION
- Use longer period for PXX2 modules triggered by heartbeat signal and reset timer early:
    - This allows to cope for the different frame rates used by ACCESS and ACCST modes.
    - see opentx/opentx#8601 for details.
- Simplify pulses code with respect to period settings with PXX1 and PXX2 (incl. a bit of cleanup).

