### PR TITLE
Reset MultiProtocol subType reset to zero on protocol change

### DIFF
--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -644,6 +644,7 @@ class ModuleWindow : public FormGroup {
       }
 #if defined(MULTIMODULE)
       else if (isModuleMultimodule(moduleIdx)) {
+        Choice * mmSubProtocol = nullptr;
         grid.nextLine();
         new StaticText(this, grid.getLabelSlot(true), STR_RF_PROTOCOL);
 
@@ -653,6 +654,8 @@ class ModuleWindow : public FormGroup {
                               GET_DEFAULT(multiRfProto),
                               [=](int32_t newValue) {
                                 g_model.moduleData[moduleIdx].setMultiProtocol(newValue);
+                                g_model.moduleData[moduleIdx].subType = 0;
+                                if (mmSubProtocol != nullptr) mmSubProtocol->invalidate();     
                                 resetMultiProtocolsOptions(moduleIdx);
                                 SET_DIRTY();
                                 update();
@@ -662,7 +665,7 @@ class ModuleWindow : public FormGroup {
         // Subtype (D16, DSMX,...)
         const mm_protocol_definition * pdef = getMultiProtocolDefinition(g_model.moduleData[moduleIdx].getMultiProtocol());
         if (pdef->maxSubtype > 0)
-          new Choice(this, grid.getFieldSlot(2, 1), pdef->subTypeString, 0, pdef->maxSubtype,GET_SET_DEFAULT(g_model.moduleData[moduleIdx].subType));
+          mmSubProtocol = new Choice(this, grid.getFieldSlot(2, 1), pdef->subTypeString, 0, pdef->maxSubtype,GET_SET_DEFAULT(g_model.moduleData[moduleIdx].subType));
         grid.nextLine();
 
         // Multimodule status


### PR DESCRIPTION
Resolves #410 by ensuring an out of range sub-protocol is not set
when the protocol is changed. Stops the module from complaining
about an invalid protocol, as well as stops simu from crashing.

Tested on TX16S and simu. 

The bug being fixed is easily reproduced in a nightly by:
1. Picking the top entry (FlySky) and then CX20 as the sub-protocol (i.e. fifth sub-protocol).
2. Picking V2x2 (which only has three sub-protocols) , and you'll see the sub-protocol choice is blank, and the module status is "Protocol invalid" instead of showing the version and channel order.

If you do the same steps in `simu`, it will segfault. 