### PR TITLE
Re-open selected model category

### DIFF
--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -244,6 +244,7 @@ class ModelCategoryPageBody : public FormWindow
               storageCheck(true);
 
               modelslist.setCurrentModel(model);
+              modelslist.setCurrentCategory(category);
               update();
             });
           }

--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -272,7 +272,7 @@ class ModelCategoryPageBody : public FormWindow
                       .c_str(),
                   [=] {
                     modelslist.removeModel(category, model);
-                    update(index < category->size() - 1 ? index : index - 1);
+                    update((unsigned)index < category->size() - 1 ? index : index - 1);
                   });
             });
           }


### PR DESCRIPTION
Saves the current category so that it is also re-opened when re-visiting the model selection page.

Completes #345, as I would expect both the last model and last category to be visible, if it is not in the first category ;)

Also clears the following compiler warning since I was in the vicinity ;)

Tested with `simu` and TX16S. It's nice to have the category the model belongs to re-opened now! 😃 

```
/src/radio/src/gui/colorlcd/model_select.cpp:275:34: warning: comparison of integer expressions of different signedness: 'const int' and 'std::__cxx11::list<ModelCell*>::size_type' {aka 'unsigned int'} [-Wsign-compare]
  275 |                     update(index < category->size() - 1 ? index : index - 1);
      |                            ~~~~~~^~~~~~~~~~~~~~~~~~~~~~
```