### PR TITLE
Touch Lockup Recovery

### DIFF
--- a/radio/src/gui/colorlcd/radio_diaganas.cpp
+++ b/radio/src/gui/colorlcd/radio_diaganas.cpp
@@ -49,7 +49,7 @@ class RadioAnalogsDiagsWindow: public Window {
       }
 
 #if defined(HARDWARE_TOUCH)
-      constexpr coord_t y = MENU_CONTENT_TOP + 6 * FH;
+      constexpr coord_t y = MENU_CONTENT_TOP + 5 * FH;
 
       if (touchState.event != TE_NONE && touchState.event != TE_SLIDE_END) {
         coord_t x = dc->drawText(MENUS_MARGIN_LEFT, y, STR_TOUCH_PANEL);
@@ -59,6 +59,14 @@ class RadioAnalogsDiagsWindow: public Window {
         dc->drawLine(touchState.x - 10, touchState.y - 8 - parent->top(), touchState.x + 10, touchState.y + 8 - parent->top(), SOLID, 0);
         dc->drawLine(touchState.x - 10, touchState.y + 8 - parent->top(), touchState.x + 10, touchState.y - 8- parent->top(), SOLID, 0);
       }
+#if !defined(SIMU)
+      constexpr coord_t y1 = MENU_CONTENT_TOP + 6 * FH;
+      constexpr coord_t x1 = MENUS_MARGIN_LEFT;
+      dc->drawText(x1, y1, "Touch GT911 FW ver:");
+      dc->drawNumber(x1 + 150, y1, touchGT911fwver, LEFT, 4);
+      dc->drawText(x1 + 200, y1, "Hiccups:");
+      dc->drawNumber(x1 + 260, y1, touchGT911hiccups, LEFT, 5);
+#endif
 #endif
     };
 

--- a/radio/src/targets/horus/hal.h
+++ b/radio/src/targets/horus/hal.h
@@ -728,7 +728,7 @@
   #define I2C_SCL_GPIO_PinSource          GPIO_PinSource8
   #define I2C_SDA_GPIO_PinSource          GPIO_PinSource9
 #endif
-#define I2C_SPEED                       400000
+#define I2C_SPEED                       100000
 
 // Haptic
 #define HAPTIC_PWM

--- a/radio/src/targets/horus/hal.h
+++ b/radio/src/targets/horus/hal.h
@@ -728,7 +728,7 @@
   #define I2C_SCL_GPIO_PinSource          GPIO_PinSource8
   #define I2C_SDA_GPIO_PinSource          GPIO_PinSource9
 #endif
-#define I2C_SPEED                       100000
+#define I2C_SPEED                       400000
 
 // Haptic
 #define HAPTIC_PWM

--- a/radio/src/targets/horus/tp_gt911.cpp
+++ b/radio/src/targets/horus/tp_gt911.cpp
@@ -888,10 +888,10 @@ void touchPanelRead()
 {
   uint8_t state = 0;
 
-  if (!touchEventOccured)
-    return;
+  // if (!touchEventOccured)
+  //   return;
 
-  touchEventOccured = false;
+  // touchEventOccured = false;
 
   uint32_t startReadStatus = RTOS_GET_MS();
   do {

--- a/radio/src/targets/horus/tp_gt911.h
+++ b/radio/src/targets/horus/tp_gt911.h
@@ -23,6 +23,8 @@
 #define HAS_TOUCH_PANEL()     touchGT911Flag == true
 
 extern bool touchGT911Flag;
+extern uint16_t touchGT911fwver;
+extern uint16_t touchGT911hiccups;
 extern bool touchPanelInit();
 
 void touchPanelRead();

--- a/radio/src/targets/horus/tp_gt911.h
+++ b/radio/src/targets/horus/tp_gt911.h
@@ -30,7 +30,7 @@ extern bool touchPanelInit();
 void touchPanelRead();
 bool touchPanelEventOccured();
 
-#define GT911_TIMEOUT 20 // 20ms
+#define GT911_TIMEOUT 3 // 3ms
 
 #define GT911_MAX_TP            5
 #define GT911_CFG_NUMER         0x6C

--- a/radio/src/targets/horus/tp_gt911.h
+++ b/radio/src/targets/horus/tp_gt911.h
@@ -22,7 +22,7 @@
 
 #define HAS_TOUCH_PANEL()     touchGT911Flag == true
 
-extern uint8_t touchGT911Flag;
+extern bool touchGT911Flag;
 extern bool touchPanelInit();
 
 void touchPanelRead();

--- a/radio/src/targets/nv14/touch_driver.cpp
+++ b/radio/src/targets/nv14/touch_driver.cpp
@@ -21,7 +21,7 @@
 #include "opentx.h"
 #include "touch_driver.h"
 
-static bool touchEventOccured;
+volatile static bool touchEventOccured;
 
 #define FT6x06_MAX_INSTANCE  1
 


### PR DESCRIPTION
Based on PR #408 ff34616 that according to @rcvideoreviews on Discord works.

Added:
* @olliw42 PR #415 STOP condition fix.
* @raphaelcoeffic EXTI_Trigger_Rising from PR #413 
* fixed some uint8_t / bool confusions
* added volatile keyword to touchEventOccured that is set from ISR and accessed from main code
* changed to upload GT911 config also if config version is the same