### PR TITLE
Run safety checks on model select and exit menu

### DIFF
--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -246,6 +246,8 @@ class ModelCategoryPageBody : public FormWindow
               modelslist.setCurrentModel(model);
               modelslist.setCurrentCategory(category);
               update();
+              checkAll();
+              this->onEvent(EVT_KEY_FIRST(KEY_EXIT));
             });
           }
           menu->addLine(STR_CREATE_MODEL, getCreateModelAction());

--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -245,7 +245,6 @@ class ModelCategoryPageBody : public FormWindow
 
               modelslist.setCurrentModel(model);
               modelslist.setCurrentCategory(category);
-              update();
               checkAll();
               this->onEvent(EVT_KEY_FIRST(KEY_EXIT));
             });

--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -245,8 +245,8 @@ class ModelCategoryPageBody : public FormWindow
 
               modelslist.setCurrentModel(model);
               modelslist.setCurrentCategory(category);
-              checkAll();
               this->onEvent(EVT_KEY_FIRST(KEY_EXIT));
+              checkAll();
             });
           }
           menu->addLine(STR_CREATE_MODEL, getCreateModelAction());

--- a/radio/src/pulses/pulses.cpp
+++ b/radio/src/pulses/pulses.cpp
@@ -285,12 +285,8 @@ void enablePulsesExternalModule(uint8_t protocol)
       extmoduleSerialStart();
       mixerSchedulerSetPeriod(EXTERNAL_MODULE, MULTIMODULE_PERIOD);
 #endif
-      for (int i = 0; i < NUM_MODULES; i++) {
-        if (isModuleMultimodule(i)) {
-          getMultiModuleStatus(i).failsafeChecked = false;
-          getMultiModuleStatus(i).flags = 0;
-        }
-      }
+      getMultiModuleStatus(EXTERNAL_MODULE).failsafeChecked = false;
+      getMultiModuleStatus(EXTERNAL_MODULE).flags = 0;
       break;
 #endif
 
@@ -497,12 +493,8 @@ static void enablePulsesInternalModule(uint8_t protocol)
       intmodulePulsesData.multi.initFrame();
       intmoduleSerialStart(MULTIMODULE_BAUDRATE, true, USART_Parity_Even, USART_StopBits_2, USART_WordLength_9b);
       mixerSchedulerSetPeriod(INTERNAL_MODULE, MULTIMODULE_PERIOD);
-      for (int i = 0; i < NUM_MODULES; i++) {
-        if (isModuleMultimodule(i)) {
-          getMultiModuleStatus(i).failsafeChecked = false;
-          getMultiModuleStatus(i).flags = 0;
-        }
-      }
+      getMultiModuleStatus(INTERNAL_MODULE).failsafeChecked = false;
+      getMultiModuleStatus(INTERNAL_MODULE).flags = 0;
       break;
 #endif
 

--- a/radio/src/pulses/pulses.cpp
+++ b/radio/src/pulses/pulses.cpp
@@ -285,6 +285,12 @@ void enablePulsesExternalModule(uint8_t protocol)
       extmoduleSerialStart();
       mixerSchedulerSetPeriod(EXTERNAL_MODULE, MULTIMODULE_PERIOD);
 #endif
+      for (int i = 0; i < NUM_MODULES; i++) {
+        if (isModuleMultimodule(i)) {
+          getMultiModuleStatus(i).failsafeChecked = false;
+          getMultiModuleStatus(i).flags = 0;
+        }
+      }
       break;
 #endif
 
@@ -491,6 +497,12 @@ static void enablePulsesInternalModule(uint8_t protocol)
       intmodulePulsesData.multi.initFrame();
       intmoduleSerialStart(MULTIMODULE_BAUDRATE, true, USART_Parity_Even, USART_StopBits_2, USART_WordLength_9b);
       mixerSchedulerSetPeriod(INTERNAL_MODULE, MULTIMODULE_PERIOD);
+      for (int i = 0; i < NUM_MODULES; i++) {
+        if (isModuleMultimodule(i)) {
+          getMultiModuleStatus(i).failsafeChecked = false;
+          getMultiModuleStatus(i).flags = 0;
+        }
+      }
       break;
 #endif
 


### PR DESCRIPTION
Thanks to @eshifri for the hint on exiting the menu.

Triggers the standard safety checks that are would run on startup, so appears to behave exactly the same as how OpenTX did. 

e.g. Throttle warning, switch warning, low rf power, no failsafe set, pre-flight checklist shown if configured (when functional), stuck key warning (when functional). 

Tested on simu and TX16S

Resolves #348 