### PR TITLE
Model Setup, Model Name: Add extra chars

### DIFF
--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -1033,7 +1033,8 @@ void ModelSetupPage::build(FormWindow * window)
 
   // Model name
   new StaticText(window, grid.getLabelSlot(), STR_MODELNAME);
-  auto text = new RadioTextEdit(window, grid.getFieldSlot(), g_model.header.name, sizeof(g_model.header.name));
+  auto text = new RadioTextEdit(window, grid.getFieldSlot(), g_model.header.name, sizeof(g_model.header.name),
+          0, "_-.,:;<=>");
   text->setChangeHandler([=] {
       modelslist.load();
       auto model = modelslist.getCurrentModel();

--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -1026,6 +1026,8 @@ void onBindMenu(const char * result)
 
 const char * STR_TIMER_MODES[] = {"OFF", "ON", "Start", "Throttle", "Throttle %", "Throttle Start"};
 
+const char MODEL_NAME_EXTRA_CHARS[] = "_-.,:;<=>";
+
 void ModelSetupPage::build(FormWindow * window)
 {
   FormGridLayout grid;
@@ -1034,7 +1036,7 @@ void ModelSetupPage::build(FormWindow * window)
   // Model name
   new StaticText(window, grid.getLabelSlot(), STR_MODELNAME);
   auto text = new RadioTextEdit(window, grid.getFieldSlot(), g_model.header.name, sizeof(g_model.header.name),
-          0, "_-.,:;<=>");
+          0, MODEL_NAME_EXTRA_CHARS);
   text->setChangeHandler([=] {
       modelslist.load();
       auto model = modelslist.getCurrentModel();

--- a/radio/src/gui/colorlcd/textedits.h
+++ b/radio/src/gui/colorlcd/textedits.h
@@ -27,8 +27,8 @@
 class ModelTextEdit: public TextEdit
 {
   public:
-    ModelTextEdit(Window * parent, const rect_t & rect, char * value, uint8_t length, LcdFlags windowFlags = 0):
-      TextEdit(parent, rect, value, length, windowFlags)
+    ModelTextEdit(Window * parent, const rect_t & rect, char * value, uint8_t length, LcdFlags windowFlags = 0, const char * extra_chars = nullptr):
+      TextEdit(parent, rect, value, length, windowFlags, extra_chars)
     {
       setChangeHandler([](){
           storageDirty(EE_MODEL);
@@ -39,8 +39,8 @@ class ModelTextEdit: public TextEdit
 class RadioTextEdit: public TextEdit
 {
   public:
-    RadioTextEdit(Window * parent, const rect_t & rect, char * value, uint8_t length, LcdFlags windowFlags = 0):
-      TextEdit(parent, rect, value, length, windowFlags)
+    RadioTextEdit(Window * parent, const rect_t & rect, char * value, uint8_t length, LcdFlags windowFlags = 0, const char * extra_chars = nullptr):
+      TextEdit(parent, rect, value, length, windowFlags, extra_chars)
     {
       setChangeHandler([](){
           storageDirty(EE_GENERAL);


### PR DESCRIPTION
PR complementing issue https://github.com/EdgeTX/edgetx/issues/431

adds more extra chars to the text edit field for model name.

it does so only for model name. If it should happen that similar extension should be desired elsewhere, it would be easy to add, and maybe the extra char string defined more globally, but all this and such should be part of a separate PR, IMHO.

tested on tx16s
