### PR TITLE
Invert switch by long press/long touch.

### DIFF
--- a/radio/src/gui/colorlcd/switchchoice.cpp
+++ b/radio/src/gui/colorlcd/switchchoice.cpp
@@ -120,6 +120,11 @@ void SwitchChoice::onEvent(event_t event)
 {
   TRACE_WINDOWS("%s received event 0x%X", getWindowDebugString().c_str(), event);
 
+ if (event == EVT_KEY_LONG(KEY_ENTER)) {
+    int16_t value = getValue();
+    setValue(-value);
+  }
+
   if (event == EVT_KEY_BREAK(KEY_ENTER)) {
     editMode = true;
     invalidate();
@@ -132,9 +137,18 @@ void SwitchChoice::onEvent(event_t event)
 #endif
 
 #if defined(HARDWARE_TOUCH)
-bool SwitchChoice::onTouchEnd(coord_t, coord_t)
+bool SwitchChoice::onTouchEnd(coord_t x, coord_t y)
 {
   setFocus(SET_FOCUS_DEFAULT);
+
+  Window::onTouchEnd(x, y);
+
+  if (isLongPress()) {
+    int16_t val = getValue();
+    setValue(-val);
+    invalidate();
+  }
+
   setEditMode(true);
   openMenu();
   return true;


### PR DESCRIPTION
This pull request implements #437: long press or long touch open channel selection menu on the inverted switch: e.g. if current SD position is UP, the selection will be set on !SD UP.
This required adding "long touch" option to the Window class.
As a result another trick is possible: long touch on the number changes the sign (if possible).
Long Enter press on the number also changes the sign (again, if negative numbers are allowed).