### PR TITLE
TextEdit should trigger Model save, not Radio save

### DIFF
--- a/radio/src/gui/colorlcd/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model_mixes.cpp
@@ -89,7 +89,7 @@ class MixEditWindow : public Page
 
     // Mix name
     new StaticText(window, grid.getLabelSlot(), STR_MIXNAME);
-    new RadioTextEdit(window, grid.getFieldSlot(), mix->name,
+    new ModelTextEdit(window, grid.getFieldSlot(), mix->name,
                       sizeof(mix->name));
     grid.nextLine();
 

--- a/radio/src/gui/colorlcd/model_outputs.cpp
+++ b/radio/src/gui/colorlcd/model_outputs.cpp
@@ -60,7 +60,7 @@ class OutputEditWindow : public Page {
 
       // Name
       new StaticText(window, grid.getLabelSlot(), STR_NAME);
-      new RadioTextEdit(window, grid.getFieldSlot(), output->name, sizeof(output->name));
+      new ModelTextEdit(window, grid.getFieldSlot(), output->name, sizeof(output->name));
       grid.nextLine();
 
       // Offset
@@ -130,7 +130,7 @@ class OutputLineButton : public Button {
       LcdFlags bgColor   = FIELD_BGCOLOR;
 
       dc->drawSolidFilledRect(0, 0, width(), height(), bgColor);
-      
+
       // first line
       dc->drawNumber(FIELD_PADDING_LEFT, FIELD_PADDING_TOP, output->min - 1000,
                      PREC1 | textColor);


### PR DESCRIPTION
Fixes #460, whereby editing the name of a mix or output would result it it not being save to storage, and being lost as soon as you changed models or powered of the radio. It looks like a when the value was changed, it triggered radio settings to be saved, not model settings, which is why changing another value at the same time worked, as that did trigger model settings to be saved.

Has been tested on `simu`, not hardware yet as off to bed. However, simu is now acting as expected, and saying the right thing... i.e. 

```
13.16 eeprom write model
```

instead of 

```
11.18 eeprom write general
```

like it was doing before... 