### PR TITLE
Add VSCode Development Containers support

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,12 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.187.0/containers/cpp
+{
+	"name": "edgetx-dev",
+	"image": "ghcr.io/edgetx/edgetx-dev:2.4",
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"ms-vscode.cpptools"
+	],
+
+}


### PR DESCRIPTION
Add VSCode Docker [Development Container](https://aka.ms/vscode-remote/containers/getting-started) support, and possibly also [GitHub Codespaces](https://github.com/features/codespaces) when it becomes generally available. 

I would like independent verification that this is functional before it merges, as I already have an environment setup, so it could be 'just working' for me because it already does. I should be able to test this in a day or two on a clean laptop with Linux and Windows 10 on it. 

Ideally, one should only have to install the pre-requisites detailed in the link above, and it should prompt to open the repo inside a "remote/development container" and auto download and spin up the docker image, launching a terminal into the container ready for use. 

