### PR TITLE
Accumulate (slideX, slideY) with touch slide events to Lua

### DIFF
--- a/radio/src/lua/widgets.cpp
+++ b/radio/src/lua/widgets.cpp
@@ -482,6 +482,8 @@ void LuaWidget::refresh(BitmapBuffer* dc)
         if (swiped)
           swipeTimeOut = get_tmr10ms() + EVT_TOUCH_SWIPE_TIMEOUT;
       }
+      slideX = 0;
+      slideY = 0;
     }
   } else
 #endif
@@ -584,8 +586,8 @@ bool LuaWidget::onTouchSlide(coord_t x, coord_t y, coord_t startX, coord_t start
     touchY = y;
     LuaWidget::startX = startX;
     LuaWidget::startY = startY;
-    LuaWidget::slideX = slideX;
-    LuaWidget::slideY = slideY;
+    LuaWidget::slideX += slideX;
+    LuaWidget::slideY += slideY;
     lastTouchDown = 0;
     
     return true;


### PR DESCRIPTION
Apparently, onTouchSlide gets called more frequently than Lua widgets, and hence we miss some of the sliding if we do not accumulate between calls to Lua.