### PR TITLE
Add missing SF "Adjust" label, dependent on source

### DIFF
--- a/radio/src/gui/colorlcd/special_functions.cpp
+++ b/radio/src/gui/colorlcd/special_functions.cpp
@@ -308,7 +308,7 @@ class SpecialFunctionEditPage : public Page
                              0, MIXSRC_LAST_CH, GET_SET_DEFAULT(CFN_PARAM(cfn)));
             break;
           case FUNC_ADJUST_GVAR_GVAR: {
-            new StaticText(specialFunctionOneWindow, grid.getLabelSlot(), STR_GLOBAL_VAR);
+            new StaticText(specialFunctionOneWindow, grid.getLabelSlot(), STR_GLOBALVAR);
             auto gvarchoice =
                 new Choice(specialFunctionOneWindow, grid.getFieldSlot(), 0,
                            MAX_GVARS - 1, GET_SET_DEFAULT(CFN_PARAM(cfn)));

--- a/radio/src/gui/colorlcd/special_functions.cpp
+++ b/radio/src/gui/colorlcd/special_functions.cpp
@@ -294,7 +294,7 @@ class SpecialFunctionEditPage : public Page
 
         switch (CFN_GVAR_MODE(cfn)) {
           case FUNC_ADJUST_GVAR_CONSTANT: {
-            //TODO: label
+            new StaticText(specialFunctionOneWindow, grid.getLabelSlot(), STR_CONSTANT);
             int16_t val_min, val_max;
             getMixSrcRange(CFN_GVAR_INDEX(cfn) + MIXSRC_FIRST_GVAR, val_min,
                            val_max);
@@ -303,11 +303,12 @@ class SpecialFunctionEditPage : public Page
             break;
           }
           case FUNC_ADJUST_GVAR_SOURCE:
-            //TODO: label
+            new StaticText(specialFunctionOneWindow, grid.getLabelSlot(), STR_MIXSOURCE);
             new SourceChoice(specialFunctionOneWindow, grid.getFieldSlot(),
                              0, MIXSRC_LAST_CH, GET_SET_DEFAULT(CFN_PARAM(cfn)));
             break;
           case FUNC_ADJUST_GVAR_GVAR: {
+            new StaticText(specialFunctionOneWindow, grid.getLabelSlot(), STR_GLOBAL_VAR);
             auto gvarchoice =
                 new Choice(specialFunctionOneWindow, grid.getFieldSlot(), 0,
                            MAX_GVARS - 1, GET_SET_DEFAULT(CFN_PARAM(cfn)));
@@ -320,6 +321,7 @@ class SpecialFunctionEditPage : public Page
             break;
           }
           case FUNC_ADJUST_GVAR_INCDEC: {
+            new StaticText(specialFunctionOneWindow, grid.getLabelSlot(), STR_INCDEC);
             int16_t val_min, val_max;
             getMixSrcRange(CFN_GVAR_INDEX(cfn) + MIXSRC_FIRST_GVAR, val_min, val_max);
             getGVarIncDecRange(val_min, val_max);


### PR DESCRIPTION
Resolves #531 by adding missing the text for the 'Adjust' Special Function 'source' (input field above the enable checkbox). 

I was going to simply use 'STR_VALUE' for all of them, then thought it would be nicer if the label synced with the drop_down that changes the input the label is for.

![snapshot_02](https://user-images.githubusercontent.com/5500713/127757770-96d0b34d-e1c1-436f-8b70-7c1c3fc3a49b.png)
![snapshot_05](https://user-images.githubusercontent.com/5500713/127757858-360724d2-68af-4623-838c-39b0e90a890f.png)
![snapshot_04](https://user-images.githubusercontent.com/5500713/127757775-09a2c18e-ce31-42d8-8691-ea3c7c8c6a08.png)
![snapshot_01](https://user-images.githubusercontent.com/5500713/127757776-057c054e-5980-4526-b9dd-2e9f570b13d4.png)


