### PR TITLE
Hacky port of FRSKY_FIRMWARE_EXT update menu

### DIFF
--- a/radio/src/gui/colorlcd/radio_sdmanager.cpp
+++ b/radio/src/gui/colorlcd/radio_sdmanager.cpp
@@ -260,26 +260,20 @@ void RadioSdManagerPage::build(FormWindow * window)
               if (information.readMultiFirmwareInformation(name.c_str()) == nullptr) {
 #if defined(INTERNAL_MODULE_MULTI)
                 menu->addLine(STR_FLASH_INTERNAL_MULTI, [=]() {
-                  MultiDeviceFirmwareUpdate deviceFirmwareUpdate(
-                      INTERNAL_MODULE, MULTI_TYPE_MULTIMODULE);
-                  auto dialog = new FlashDialog<MultiDeviceFirmwareUpdate>(
-                      deviceFirmwareUpdate);
-                  dialog->flash(getFullPath(name));
+                  MultiFirmwareUpdate(name, INTERNAL_MODULE,
+                                      MULTI_TYPE_MULTIMODULE);
                 });
 #endif
                 menu->addLine(STR_FLASH_EXTERNAL_MULTI, [=]() {
-                    MultiDeviceFirmwareUpdate deviceFirmwareUpdate(EXTERNAL_MODULE, MULTI_TYPE_MULTIMODULE);
-                    auto dialog = new FlashDialog<MultiDeviceFirmwareUpdate>(deviceFirmwareUpdate);
-                    dialog->flash(getFullPath(name));
+                  MultiFirmwareUpdate(name, EXTERNAL_MODULE,
+                                      MULTI_TYPE_MULTIMODULE);
                 });
               }
             }
 #endif
             else if (!READ_ONLY() && !strcasecmp(ext, ELRS_FIRMWARE_EXT)) {
               menu->addLine(STR_FLASH_EXTERNAL_ELRS, [=]() {
-                  MultiDeviceFirmwareUpdate deviceFirmwareUpdate(EXTERNAL_MODULE, MULTI_TYPE_ELRS);
-                  auto dialog = new FlashDialog<MultiDeviceFirmwareUpdate>(deviceFirmwareUpdate);
-                  dialog->flash(getFullPath(name));
+                MultiFirmwareUpdate(name, EXTERNAL_MODULE, MULTI_TYPE_ELRS);
               });
             }
             // else if (isExtensionMatching(ext, BITMAPS_EXT)) {
@@ -300,24 +294,20 @@ void RadioSdManagerPage::build(FormWindow * window)
             if (!READ_ONLY() && !strcasecmp(ext, FIRMWARE_EXT)) {
               if (isBootloader(name.c_str())) {
                 menu->addLine(STR_FLASH_BOOTLOADER, [=]() {
-                  BootloaderFirmwareUpdate bootloaderFirmwareUpdate;
-                  auto dialog = new FlashDialog<BootloaderFirmwareUpdate>(
-                      bootloaderFirmwareUpdate);
-                  dialog->flash(getFullPath(name));
-                  TRACE("### finished flashing ###");
+                  BootloaderUpdate(name);
                 });
               }
             } else if (!READ_ONLY() && !strcasecmp(ext, SPORT_FIRMWARE_EXT)) {
               if (HAS_SPORT_UPDATE_CONNECTOR()) {
                 menu->addLine(STR_FLASH_EXTERNAL_DEVICE, [=]() {
-                  FrSkyFirmwareUpdate(SPORT_MODULE, name);
+                  FrSkyFirmwareUpdate(name, SPORT_MODULE);
                 });
               }
               menu->addLine(STR_FLASH_INTERNAL_MODULE, [=]() {
-                FrSkyFirmwareUpdate(INTERNAL_MODULE, name);
+                FrSkyFirmwareUpdate(name, INTERNAL_MODULE);
               });
               menu->addLine(STR_FLASH_EXTERNAL_MODULE, [=]() {
-                FrSkyFirmwareUpdate(EXTERNAL_MODULE, name);
+                FrSkyFirmwareUpdate(name, EXTERNAL_MODULE);
               });
             } else if (!READ_ONLY() && !strcasecmp(ext, FRSKY_FIRMWARE_EXT)) {
               FrSkyFirmwareInformation information;
@@ -325,44 +315,42 @@ void RadioSdManagerPage::build(FormWindow * window)
                                                information) == nullptr) {
 #if defined(INTERNAL_MODULE_PXX1) || defined(INTERNAL_MODULE_PXX2)
                 menu->addLine(STR_FLASH_INTERNAL_MODULE, [=]() {
-                  FrSkyFirmwareUpdate(INTERNAL_MODULE, name);
+                  FrSkyFirmwareUpdate(name, INTERNAL_MODULE);
                 });
 #endif
                 if (information.productFamily ==
                     FIRMWARE_FAMILY_EXTERNAL_MODULE) {
                   menu->addLine(STR_FLASH_EXTERNAL_MODULE, [=]() {
-                    FrSkyFirmwareUpdate(EXTERNAL_MODULE, name);
+                    FrSkyFirmwareUpdate(name, EXTERNAL_MODULE);
                   });
                 }
                 if (information.productFamily == FIRMWARE_FAMILY_RECEIVER ||
                     information.productFamily == FIRMWARE_FAMILY_SENSOR) {
                   if (HAS_SPORT_UPDATE_CONNECTOR()) {
                     menu->addLine(STR_FLASH_EXTERNAL_DEVICE, [=]() {
-                      FrSkyFirmwareUpdate(SPORT_MODULE, name);
+                      FrSkyFirmwareUpdate(name, SPORT_MODULE);
                     });
                   } else {
                     menu->addLine(STR_FLASH_EXTERNAL_MODULE, [=]() {
-                      FrSkyFirmwareUpdate(EXTERNAL_MODULE, name);
+                      FrSkyFirmwareUpdate(name, EXTERNAL_MODULE);
                     });
                   }
                 }
-                // TODO: Integrate the remaining options - may just be a matter
-                // of finishing/fixing FrskyDeviceFirmwareUpdate
-                // deviceFirmwareUpdate calls for each
-/*
+// TODO: Integrate the remaining options
+#if 0
 #if defined(PXX2)
                 if (information.productFamily == FIRMWARE_FAMILY_RECEIVER) {
                   if (isReceiverOTAEnabledFromModule(INTERNAL_MODULE,
                                                      information.productId))
                     menu->addLine(
                         STR_FLASH_RECEIVER_BY_INTERNAL_MODULE_OTA, [=]() {
-                          FrSkyFirmwareUpdate(INTERNAL_MODULE_OTA, name);
+                          FrSkyFirmwareUpdate(name, INTERNAL_MODULE_OTA);
                         });
                   if (isReceiverOTAEnabledFromModule(EXTERNAL_MODULE,
                                                      information.productId))
                     menu->addLine(
                         STR_FLASH_RECEIVER_BY_EXTERNAL_MODULE_OTA, [=]() {
-                          FrSkyFirmwareUpdate(EXTERNAL_MODULE_OTA, name);
+                          FrSkyFirmwareUpdate(name, EXTERNAL_MODULE_OTA);
                         });
                 }
                 if (information.productFamily ==
@@ -371,15 +359,15 @@ void RadioSdManagerPage::build(FormWindow * window)
                       STR_FLASH_FLIGHT_CONTROLLER_BY_INTERNAL_MODULE_OTA,
                       [=]() {
                         FrSkyFirmwareUpdate(
-                            STR_FLASH_FLIGHT_CONTROLLER_BY_INTERNAL_MODULE_OTA,
-                            name);
+                            name,
+                            STR_FLASH_FLIGHT_CONTROLLER_BY_INTERNAL_MODULE_OTA);
                       });
                   menu->addLine(
                       STR_FLASH_FLIGHT_CONTROLLER_BY_EXTERNAL_MODULE_OTA,
                       [=]() {
                         FrSkyFirmwareUpdate(
-                            STR_FLASH_FLIGHT_CONTROLLER_BY_INTERNAL_MODULE_OTA,
-                            name);
+                            name,
+                            STR_FLASH_FLIGHT_CONTROLLER_BY_INTERNAL_MODULE_OTA);
                       });
                 }
 #endif
@@ -387,7 +375,7 @@ void RadioSdManagerPage::build(FormWindow * window)
                 if (information.productFamily ==
                     FIRMWARE_FAMILY_BLUETOOTH_CHIP) {
                   menu->addLine(STR_FLASH_BLUETOOTH_MODULE, [=]() {
-                    FrSkyFirmwareUpdate(STR_FLASH_BLUETOOTH_MODULE, name);
+                    FrSkyFirmwareUpdate(name, STR_FLASH_BLUETOOTH_MODULE);
                   });
                 }
 #endif
@@ -395,11 +383,11 @@ void RadioSdManagerPage::build(FormWindow * window)
                 if (information.productFamily ==
                     FIRMWARE_FAMILY_POWER_MANAGEMENT_UNIT) {
                   menu->addLine(STR_FLASH_POWER_MANAGEMENT_UNIT, [=]() {
-                    FrSkyFirmwareUpdate(STR_FLASH_POWER_MANAGEMENT_UNIT, name);
+                    FrSkyFirmwareUpdate(name, STR_FLASH_POWER_MANAGEMENT_UNIT);
                   });
                 }
 #endif
-*/
+#endif
               }
             }
 #if defined(LUA)
@@ -463,12 +451,30 @@ void RadioSdManagerPage::build(FormWindow * window)
   preview->setHeight(max(window->height(), grid.getWindowHeight()));
 }
 
-void RadioSdManagerPage::FrSkyFirmwareUpdate(ModuleIndex module,
-                                             const std::string name)
+void RadioSdManagerPage::BootloaderUpdate(const std::string name)
+{
+  BootloaderFirmwareUpdate bootloaderFirmwareUpdate;
+  auto dialog =
+      new FlashDialog<BootloaderFirmwareUpdate>(bootloaderFirmwareUpdate);
+  dialog->flash(getFullPath(name));
+}
+
+void RadioSdManagerPage::FrSkyFirmwareUpdate(const std::string name,
+                                             ModuleIndex module)
 {
   FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(module);
   auto dialog =
       new FlashDialog<FrskyDeviceFirmwareUpdate>(deviceFirmwareUpdate);
+  dialog->flash(getFullPath(name));
+}
+
+void RadioSdManagerPage::MultiFirmwareUpdate(const std::string name,
+                                             ModuleIndex module,
+                                             MultiModuleType type)
+{
+  MultiDeviceFirmwareUpdate deviceFirmwareUpdate(module, type);
+  auto dialog =
+      new FlashDialog<MultiDeviceFirmwareUpdate>(deviceFirmwareUpdate);
   dialog->flash(getFullPath(name));
 }
 

--- a/radio/src/gui/colorlcd/radio_sdmanager.cpp
+++ b/radio/src/gui/colorlcd/radio_sdmanager.cpp
@@ -229,7 +229,7 @@ void RadioSdManagerPage::build(FormWindow * window)
     // sort directories and files
     directories.sort(compare_nocase);
     files.sort(compare_nocase);
-    
+
     for (auto name: directories) {
       new SDmanagerButton(window, grid.getLabelSlot(), name, [=]() -> uint8_t {
           std::string fullpath = currentPath + "/" + name;
@@ -260,10 +260,8 @@ void RadioSdManagerPage::build(FormWindow * window)
               if (information.readMultiFirmwareInformation(name.c_str()) == nullptr) {
 #if defined(INTERNAL_MODULE_MULTI)
                 menu->addLine(STR_FLASH_INTERNAL_MULTI, [=]() {
-                  MultiDeviceFirmwareUpdate deviceFirmwareUpdate(
-                      INTERNAL_MODULE, MULTI_TYPE_MULTIMODULE);
-                  auto dialog = new FlashDialog<MultiDeviceFirmwareUpdate>(
-                      deviceFirmwareUpdate);
+                  MultiDeviceFirmwareUpdate deviceFirmwareUpdate(INTERNAL_MODULE, MULTI_TYPE_MULTIMODULE);
+                  auto dialog = new FlashDialog<MultiDeviceFirmwareUpdate>(deviceFirmwareUpdate);
                   dialog->flash(getFullPath(name));
                 });
 #endif
@@ -289,7 +287,7 @@ void RadioSdManagerPage::build(FormWindow * window)
               menu->addLine(STR_VIEW_TEXT, [=]() {
                 static char lfn[FF_MAX_LFN + 1];  // TODO optimize that!
                 f_getcwd((TCHAR *)lfn, FF_MAX_LFN);
-   
+
                 auto textView = new ViewTextWindow(lfn, name);
                 textView->setCloseHandler([=]() {
                   //window->clear();
@@ -301,8 +299,7 @@ void RadioSdManagerPage::build(FormWindow * window)
               if (isBootloader(name.c_str())) {
                 menu->addLine(STR_FLASH_BOOTLOADER, [=]() {
                   BootloaderFirmwareUpdate bootloaderFirmwareUpdate;
-                  auto dialog = new FlashDialog<BootloaderFirmwareUpdate>(
-                      bootloaderFirmwareUpdate);
+                  auto dialog = new FlashDialog<BootloaderFirmwareUpdate>(bootloaderFirmwareUpdate);
                   dialog->flash(getFullPath(name));
                   TRACE("### finished flashing ###");
                 });
@@ -310,94 +307,61 @@ void RadioSdManagerPage::build(FormWindow * window)
             } else if (!READ_ONLY() && !strcasecmp(ext, SPORT_FIRMWARE_EXT)) {
               if (HAS_SPORT_UPDATE_CONNECTOR()) {
                 menu->addLine(STR_FLASH_EXTERNAL_DEVICE, [=]() {
-                  FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(SPORT_MODULE);
-                  auto dialog = new FlashDialog<FrskyDeviceFirmwareUpdate>(
-                      deviceFirmwareUpdate);
-                  dialog->flash(getFullPath(name));
+                  FrSkyFirmwareUpdate(SPORT_MODULE, name);
                 });
               }
               menu->addLine(STR_FLASH_INTERNAL_MODULE, [=]() {
-                FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(INTERNAL_MODULE);
-                auto dialog = new FlashDialog<FrskyDeviceFirmwareUpdate>(
-                    deviceFirmwareUpdate);
-                dialog->flash(getFullPath(name));
+                FrSkyFirmwareUpdate(INTERNAL_MODULE, name);
               });
               menu->addLine(STR_FLASH_EXTERNAL_MODULE, [=]() {
-                FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(EXTERNAL_MODULE);
-                auto dialog = new FlashDialog<FrskyDeviceFirmwareUpdate>(
-                    deviceFirmwareUpdate);
-                dialog->flash(getFullPath(name));
+                FrSkyFirmwareUpdate(EXTERNAL_MODULE, name);
               });
             } else if (!READ_ONLY() && !strcasecmp(ext, FRSKY_FIRMWARE_EXT)) {
               FrSkyFirmwareInformation information;
               if (readFrSkyFirmwareInformation(getFullPath(name), information) == nullptr) {
   #if defined(INTERNAL_MODULE_PXX1) || defined(INTERNAL_MODULE_PXX2)
                 menu->addLine(STR_FLASH_INTERNAL_MODULE, [=]() {
-                  FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(INTERNAL_MODULE);
-                  auto dialog = new FlashDialog<FrskyDeviceFirmwareUpdate>(
-                      deviceFirmwareUpdate);
-                  dialog->flash(getFullPath(name));
+                  FrSkyFirmwareUpdate(INTERNAL_MODULE, name);
                 });
   #endif
                 if (information.productFamily == FIRMWARE_FAMILY_EXTERNAL_MODULE)
                 {
                   menu->addLine(STR_FLASH_EXTERNAL_MODULE, [=]() {
-                    FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(EXTERNAL_MODULE);
-                    auto dialog = new FlashDialog<FrskyDeviceFirmwareUpdate>(
-                        deviceFirmwareUpdate);
-                    dialog->flash(getFullPath(name));
-                  });
+                    FrSkyFirmwareUpdate(EXTERNAL_MODULE, name);
+                   });
                 }
                 if (information.productFamily == FIRMWARE_FAMILY_RECEIVER || information.productFamily == FIRMWARE_FAMILY_SENSOR)
                 {
                   if (HAS_SPORT_UPDATE_CONNECTOR()) {
                     menu->addLine(STR_FLASH_EXTERNAL_DEVICE, [=]() {
-                      FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(SPORT_MODULE);
-                      auto dialog = new FlashDialog<FrskyDeviceFirmwareUpdate>(
-                          deviceFirmwareUpdate);
-                      dialog->flash(getFullPath(name));
+                      FrSkyFirmwareUpdate(SPORT_MODULE, name);
                     });
                   } else {
                     menu->addLine(STR_FLASH_EXTERNAL_MODULE, [=]() {
-                      FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(EXTERNAL_MODULE);
-                      auto dialog = new FlashDialog<FrskyDeviceFirmwareUpdate>(
-                          deviceFirmwareUpdate);
-                      dialog->flash(getFullPath(name));
+                      FrSkyFirmwareUpdate(EXTERNAL_MODULE, name);
                     });
                   }
                 }
-// TODO: Integrate the remaining options - may just be a matter of finishing/fixing 
+// TODO: Integrate the remaining options - may just be a matter of finishing/fixing
 // FrskyDeviceFirmwareUpdate deviceFirmwareUpdate calls for each
 /*
 #if defined(PXX2)
               if (information.productFamily == FIRMWARE_FAMILY_RECEIVER) {
                 if (isReceiverOTAEnabledFromModule(INTERNAL_MODULE, information.productId))
                   menu->addLine(STR_FLASH_RECEIVER_BY_INTERNAL_MODULE_OTA, [=]() {
-                    FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(INTERNAL_MODULE_OTA);
-                    auto dialog = new FlashDialog<FrskyDeviceFirmwareUpdate>(
-                        deviceFirmwareUpdate);
-                    dialog->flash(getFullPath(name));
+                    FrSkyFirmwareUpdate(INTERNAL_MODULE_OTA, name);
                   });
                 if (isReceiverOTAEnabledFromModule(EXTERNAL_MODULE, information.productId))
                   menu->addLine(STR_FLASH_RECEIVER_BY_EXTERNAL_MODULE_OTA, [=]() {
-                    FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(EXTERNAL_MODULE_OTA);
-                    auto dialog = new FlashDialog<FrskyDeviceFirmwareUpdate>(
-                        deviceFirmwareUpdate);
-                    dialog->flash(getFullPath(name));
+                    FrSkyFirmwareUpdate(EXTERNAL_MODULE_OTA, name);
                   });
               }
               if (information.productFamily == FIRMWARE_FAMILY_FLIGHT_CONTROLLER) {
                 menu->addLine(STR_FLASH_FLIGHT_CONTROLLER_BY_INTERNAL_MODULE_OTA, [=]() {
-                FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(STR_FLASH_FLIGHT_CONTROLLER_BY_INTERNAL_MODULE_OTA);
-                auto dialog = new FlashDialog<FrskyDeviceFirmwareUpdate>(
-                    deviceFirmwareUpdate);
-                dialog->flash(getFullPath(name));
+                  FrSkyFirmwareUpdate(STR_FLASH_FLIGHT_CONTROLLER_BY_INTERNAL_MODULE_OTA, name);
                 });
                 menu->addLine(STR_FLASH_FLIGHT_CONTROLLER_BY_EXTERNAL_MODULE_OTA, [=]() {
-                FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(STR_FLASH_FLIGHT_CONTROLLER_BY_EXTERNAL_MODULE_OTA);
-                auto dialog = new FlashDialog<FrskyDeviceFirmwareUpdate>(
-                    deviceFirmwareUpdate);
-                dialog->flash(getFullPath(name));
+                  FrSkyFirmwareUpdate(STR_FLASH_FLIGHT_CONTROLLER_BY_INTERNAL_MODULE_OTA, name);
                 });
               }
 #endif
@@ -405,10 +369,7 @@ void RadioSdManagerPage::build(FormWindow * window)
               if (information.productFamily == FIRMWARE_FAMILY_BLUETOOTH_CHIP)
               {
                 menu->addLine(STR_FLASH_BLUETOOTH_MODULE, [=]() {
-                FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(STR_FLASH_BLUETOOTH_MODULE);
-                auto dialog = new FlashDialog<FrskyDeviceFirmwareUpdate>(
-                    deviceFirmwareUpdate);
-                dialog->flash(getFullPath(name));
+                  FrSkyFirmwareUpdate(STR_FLASH_BLUETOOTH_MODULE, name);
                 });
               }
 #endif
@@ -416,10 +377,7 @@ void RadioSdManagerPage::build(FormWindow * window)
               if (information.productFamily == FIRMWARE_FAMILY_POWER_MANAGEMENT_UNIT)
               {
                 menu->addLine(STR_FLASH_POWER_MANAGEMENT_UNIT, [=]() {
-                FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(STR_FLASH_POWER_MANAGEMENT_UNIT);
-                auto dialog = new FlashDialog<FrskyDeviceFirmwareUpdate>(
-                    deviceFirmwareUpdate);
-                dialog->flash(getFullPath(name));
+                  FrSkyFirmwareUpdate(STR_FLASH_POWER_MANAGEMENT_UNIT, name);
                 });
               }
 #endif
@@ -485,6 +443,13 @@ void RadioSdManagerPage::build(FormWindow * window)
 
   window->setInnerHeight(grid.getWindowHeight());
   preview->setHeight(max(window->height(), grid.getWindowHeight()));
+}
+
+void RadioSdManagerPage::FrSkyFirmwareUpdate(ModuleIndex module, const std::string name)
+{
+  FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(module);
+  auto dialog = new FlashDialog<FrskyDeviceFirmwareUpdate>(deviceFirmwareUpdate);
+  dialog->flash(getFullPath(name));
 }
 
 #if 0

--- a/radio/src/gui/colorlcd/radio_sdmanager.cpp
+++ b/radio/src/gui/colorlcd/radio_sdmanager.cpp
@@ -328,6 +328,103 @@ void RadioSdManagerPage::build(FormWindow * window)
                     deviceFirmwareUpdate);
                 dialog->flash(getFullPath(name));
               });
+            } else if (!READ_ONLY() && !strcasecmp(ext, FRSKY_FIRMWARE_EXT)) {
+              FrSkyFirmwareInformation information;
+              if (readFrSkyFirmwareInformation(getFullPath(name), information) == nullptr) {
+  #if defined(INTERNAL_MODULE_PXX1) || defined(INTERNAL_MODULE_PXX2)
+                menu->addLine(STR_FLASH_INTERNAL_MODULE, [=]() {
+                  FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(INTERNAL_MODULE);
+                  auto dialog = new FlashDialog<FrskyDeviceFirmwareUpdate>(
+                      deviceFirmwareUpdate);
+                  dialog->flash(getFullPath(name));
+                });
+  #endif
+                if (information.productFamily == FIRMWARE_FAMILY_EXTERNAL_MODULE)
+                {
+                  menu->addLine(STR_FLASH_EXTERNAL_MODULE, [=]() {
+                    FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(EXTERNAL_MODULE);
+                    auto dialog = new FlashDialog<FrskyDeviceFirmwareUpdate>(
+                        deviceFirmwareUpdate);
+                    dialog->flash(getFullPath(name));
+                  });
+                }
+                if (information.productFamily == FIRMWARE_FAMILY_RECEIVER || information.productFamily == FIRMWARE_FAMILY_SENSOR)
+                {
+                  if (HAS_SPORT_UPDATE_CONNECTOR()) {
+                    menu->addLine(STR_FLASH_EXTERNAL_DEVICE, [=]() {
+                      FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(SPORT_MODULE);
+                      auto dialog = new FlashDialog<FrskyDeviceFirmwareUpdate>(
+                          deviceFirmwareUpdate);
+                      dialog->flash(getFullPath(name));
+                    });
+                  } else {
+                    menu->addLine(STR_FLASH_EXTERNAL_MODULE, [=]() {
+                      FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(EXTERNAL_MODULE);
+                      auto dialog = new FlashDialog<FrskyDeviceFirmwareUpdate>(
+                          deviceFirmwareUpdate);
+                      dialog->flash(getFullPath(name));
+                    });
+                  }
+                }
+// TODO: Integrate the remaining options - may just be a matter of finishing/fixing 
+// FrskyDeviceFirmwareUpdate deviceFirmwareUpdate calls for each
+/*
+#if defined(PXX2)
+              if (information.productFamily == FIRMWARE_FAMILY_RECEIVER) {
+                if (isReceiverOTAEnabledFromModule(INTERNAL_MODULE, information.productId))
+                  menu->addLine(STR_FLASH_RECEIVER_BY_INTERNAL_MODULE_OTA, [=]() {
+                    FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(INTERNAL_MODULE_OTA);
+                    auto dialog = new FlashDialog<FrskyDeviceFirmwareUpdate>(
+                        deviceFirmwareUpdate);
+                    dialog->flash(getFullPath(name));
+                  });
+                if (isReceiverOTAEnabledFromModule(EXTERNAL_MODULE, information.productId))
+                  menu->addLine(STR_FLASH_RECEIVER_BY_EXTERNAL_MODULE_OTA, [=]() {
+                    FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(EXTERNAL_MODULE_OTA);
+                    auto dialog = new FlashDialog<FrskyDeviceFirmwareUpdate>(
+                        deviceFirmwareUpdate);
+                    dialog->flash(getFullPath(name));
+                  });
+              }
+              if (information.productFamily == FIRMWARE_FAMILY_FLIGHT_CONTROLLER) {
+                menu->addLine(STR_FLASH_FLIGHT_CONTROLLER_BY_INTERNAL_MODULE_OTA, [=]() {
+                FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(STR_FLASH_FLIGHT_CONTROLLER_BY_INTERNAL_MODULE_OTA);
+                auto dialog = new FlashDialog<FrskyDeviceFirmwareUpdate>(
+                    deviceFirmwareUpdate);
+                dialog->flash(getFullPath(name));
+                });
+                menu->addLine(STR_FLASH_FLIGHT_CONTROLLER_BY_EXTERNAL_MODULE_OTA, [=]() {
+                FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(STR_FLASH_FLIGHT_CONTROLLER_BY_EXTERNAL_MODULE_OTA);
+                auto dialog = new FlashDialog<FrskyDeviceFirmwareUpdate>(
+                    deviceFirmwareUpdate);
+                dialog->flash(getFullPath(name));
+                });
+              }
+#endif
+#if defined(BLUETOOTH)
+              if (information.productFamily == FIRMWARE_FAMILY_BLUETOOTH_CHIP)
+              {
+                menu->addLine(STR_FLASH_BLUETOOTH_MODULE, [=]() {
+                FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(STR_FLASH_BLUETOOTH_MODULE);
+                auto dialog = new FlashDialog<FrskyDeviceFirmwareUpdate>(
+                    deviceFirmwareUpdate);
+                dialog->flash(getFullPath(name));
+                });
+              }
+#endif
+#if defined(HARDWARE_POWER_MANAGEMENT_UNIT)
+              if (information.productFamily == FIRMWARE_FAMILY_POWER_MANAGEMENT_UNIT)
+              {
+                menu->addLine(STR_FLASH_POWER_MANAGEMENT_UNIT, [=]() {
+                FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(STR_FLASH_POWER_MANAGEMENT_UNIT);
+                auto dialog = new FlashDialog<FrskyDeviceFirmwareUpdate>(
+                    deviceFirmwareUpdate);
+                dialog->flash(getFullPath(name));
+                });
+              }
+#endif
+*/
+            }
             }
 #if defined(LUA)
             else if (isExtensionMatching(ext, SCRIPTS_EXT)) {

--- a/radio/src/gui/colorlcd/radio_sdmanager.cpp
+++ b/radio/src/gui/colorlcd/radio_sdmanager.cpp
@@ -260,8 +260,10 @@ void RadioSdManagerPage::build(FormWindow * window)
               if (information.readMultiFirmwareInformation(name.c_str()) == nullptr) {
 #if defined(INTERNAL_MODULE_MULTI)
                 menu->addLine(STR_FLASH_INTERNAL_MULTI, [=]() {
-                  MultiDeviceFirmwareUpdate deviceFirmwareUpdate(INTERNAL_MODULE, MULTI_TYPE_MULTIMODULE);
-                  auto dialog = new FlashDialog<MultiDeviceFirmwareUpdate>(deviceFirmwareUpdate);
+                  MultiDeviceFirmwareUpdate deviceFirmwareUpdate(
+                      INTERNAL_MODULE, MULTI_TYPE_MULTIMODULE);
+                  auto dialog = new FlashDialog<MultiDeviceFirmwareUpdate>(
+                      deviceFirmwareUpdate);
                   dialog->flash(getFullPath(name));
                 });
 #endif
@@ -299,7 +301,8 @@ void RadioSdManagerPage::build(FormWindow * window)
               if (isBootloader(name.c_str())) {
                 menu->addLine(STR_FLASH_BOOTLOADER, [=]() {
                   BootloaderFirmwareUpdate bootloaderFirmwareUpdate;
-                  auto dialog = new FlashDialog<BootloaderFirmwareUpdate>(bootloaderFirmwareUpdate);
+                  auto dialog = new FlashDialog<BootloaderFirmwareUpdate>(
+                      bootloaderFirmwareUpdate);
                   dialog->flash(getFullPath(name));
                   TRACE("### finished flashing ###");
                 });
@@ -318,20 +321,21 @@ void RadioSdManagerPage::build(FormWindow * window)
               });
             } else if (!READ_ONLY() && !strcasecmp(ext, FRSKY_FIRMWARE_EXT)) {
               FrSkyFirmwareInformation information;
-              if (readFrSkyFirmwareInformation(getFullPath(name), information) == nullptr) {
-  #if defined(INTERNAL_MODULE_PXX1) || defined(INTERNAL_MODULE_PXX2)
+              if (readFrSkyFirmwareInformation(getFullPath(name),
+                                               information) == nullptr) {
+#if defined(INTERNAL_MODULE_PXX1) || defined(INTERNAL_MODULE_PXX2)
                 menu->addLine(STR_FLASH_INTERNAL_MODULE, [=]() {
                   FrSkyFirmwareUpdate(INTERNAL_MODULE, name);
                 });
-  #endif
-                if (information.productFamily == FIRMWARE_FAMILY_EXTERNAL_MODULE)
-                {
+#endif
+                if (information.productFamily ==
+                    FIRMWARE_FAMILY_EXTERNAL_MODULE) {
                   menu->addLine(STR_FLASH_EXTERNAL_MODULE, [=]() {
                     FrSkyFirmwareUpdate(EXTERNAL_MODULE, name);
-                   });
+                  });
                 }
-                if (information.productFamily == FIRMWARE_FAMILY_RECEIVER || information.productFamily == FIRMWARE_FAMILY_SENSOR)
-                {
+                if (information.productFamily == FIRMWARE_FAMILY_RECEIVER ||
+                    information.productFamily == FIRMWARE_FAMILY_SENSOR) {
                   if (HAS_SPORT_UPDATE_CONNECTOR()) {
                     menu->addLine(STR_FLASH_EXTERNAL_DEVICE, [=]() {
                       FrSkyFirmwareUpdate(SPORT_MODULE, name);
@@ -342,47 +346,61 @@ void RadioSdManagerPage::build(FormWindow * window)
                     });
                   }
                 }
-// TODO: Integrate the remaining options - may just be a matter of finishing/fixing
-// FrskyDeviceFirmwareUpdate deviceFirmwareUpdate calls for each
+                // TODO: Integrate the remaining options - may just be a matter
+                // of finishing/fixing FrskyDeviceFirmwareUpdate
+                // deviceFirmwareUpdate calls for each
 /*
 #if defined(PXX2)
-              if (information.productFamily == FIRMWARE_FAMILY_RECEIVER) {
-                if (isReceiverOTAEnabledFromModule(INTERNAL_MODULE, information.productId))
-                  menu->addLine(STR_FLASH_RECEIVER_BY_INTERNAL_MODULE_OTA, [=]() {
-                    FrSkyFirmwareUpdate(INTERNAL_MODULE_OTA, name);
-                  });
-                if (isReceiverOTAEnabledFromModule(EXTERNAL_MODULE, information.productId))
-                  menu->addLine(STR_FLASH_RECEIVER_BY_EXTERNAL_MODULE_OTA, [=]() {
-                    FrSkyFirmwareUpdate(EXTERNAL_MODULE_OTA, name);
-                  });
-              }
-              if (information.productFamily == FIRMWARE_FAMILY_FLIGHT_CONTROLLER) {
-                menu->addLine(STR_FLASH_FLIGHT_CONTROLLER_BY_INTERNAL_MODULE_OTA, [=]() {
-                  FrSkyFirmwareUpdate(STR_FLASH_FLIGHT_CONTROLLER_BY_INTERNAL_MODULE_OTA, name);
-                });
-                menu->addLine(STR_FLASH_FLIGHT_CONTROLLER_BY_EXTERNAL_MODULE_OTA, [=]() {
-                  FrSkyFirmwareUpdate(STR_FLASH_FLIGHT_CONTROLLER_BY_INTERNAL_MODULE_OTA, name);
-                });
-              }
+                if (information.productFamily == FIRMWARE_FAMILY_RECEIVER) {
+                  if (isReceiverOTAEnabledFromModule(INTERNAL_MODULE,
+                                                     information.productId))
+                    menu->addLine(
+                        STR_FLASH_RECEIVER_BY_INTERNAL_MODULE_OTA, [=]() {
+                          FrSkyFirmwareUpdate(INTERNAL_MODULE_OTA, name);
+                        });
+                  if (isReceiverOTAEnabledFromModule(EXTERNAL_MODULE,
+                                                     information.productId))
+                    menu->addLine(
+                        STR_FLASH_RECEIVER_BY_EXTERNAL_MODULE_OTA, [=]() {
+                          FrSkyFirmwareUpdate(EXTERNAL_MODULE_OTA, name);
+                        });
+                }
+                if (information.productFamily ==
+                    FIRMWARE_FAMILY_FLIGHT_CONTROLLER) {
+                  menu->addLine(
+                      STR_FLASH_FLIGHT_CONTROLLER_BY_INTERNAL_MODULE_OTA,
+                      [=]() {
+                        FrSkyFirmwareUpdate(
+                            STR_FLASH_FLIGHT_CONTROLLER_BY_INTERNAL_MODULE_OTA,
+                            name);
+                      });
+                  menu->addLine(
+                      STR_FLASH_FLIGHT_CONTROLLER_BY_EXTERNAL_MODULE_OTA,
+                      [=]() {
+                        FrSkyFirmwareUpdate(
+                            STR_FLASH_FLIGHT_CONTROLLER_BY_INTERNAL_MODULE_OTA,
+                            name);
+                      });
+                }
 #endif
 #if defined(BLUETOOTH)
-              if (information.productFamily == FIRMWARE_FAMILY_BLUETOOTH_CHIP)
-              {
-                menu->addLine(STR_FLASH_BLUETOOTH_MODULE, [=]() {
-                  FrSkyFirmwareUpdate(STR_FLASH_BLUETOOTH_MODULE, name);
-                });
-              }
+                if (information.productFamily ==
+                    FIRMWARE_FAMILY_BLUETOOTH_CHIP) {
+                  menu->addLine(STR_FLASH_BLUETOOTH_MODULE, [=]() {
+                    FrSkyFirmwareUpdate(STR_FLASH_BLUETOOTH_MODULE, name);
+                  });
+                }
 #endif
 #if defined(HARDWARE_POWER_MANAGEMENT_UNIT)
-              if (information.productFamily == FIRMWARE_FAMILY_POWER_MANAGEMENT_UNIT)
-              {
-                menu->addLine(STR_FLASH_POWER_MANAGEMENT_UNIT, [=]() {
-                  FrSkyFirmwareUpdate(STR_FLASH_POWER_MANAGEMENT_UNIT, name);
-                });
-              }
+                if (information.productFamily ==
+                    FIRMWARE_FAMILY_POWER_MANAGEMENT_UNIT) {
+                  menu->addLine(STR_FLASH_POWER_MANAGEMENT_UNIT, [=]() {
+                    FrSkyFirmwareUpdate(STR_FLASH_POWER_MANAGEMENT_UNIT, name);
+                  });
+                }
 #endif
 */
-            }
+              }
             }
 #if defined(LUA)
             else if (isExtensionMatching(ext, SCRIPTS_EXT)) {
@@ -445,10 +463,12 @@ void RadioSdManagerPage::build(FormWindow * window)
   preview->setHeight(max(window->height(), grid.getWindowHeight()));
 }
 
-void RadioSdManagerPage::FrSkyFirmwareUpdate(ModuleIndex module, const std::string name)
+void RadioSdManagerPage::FrSkyFirmwareUpdate(ModuleIndex module,
+                                             const std::string name)
 {
   FrskyDeviceFirmwareUpdate deviceFirmwareUpdate(module);
-  auto dialog = new FlashDialog<FrskyDeviceFirmwareUpdate>(deviceFirmwareUpdate);
+  auto dialog =
+      new FlashDialog<FrskyDeviceFirmwareUpdate>(deviceFirmwareUpdate);
   dialog->flash(getFullPath(name));
 }
 

--- a/radio/src/gui/colorlcd/radio_sdmanager.h
+++ b/radio/src/gui/colorlcd/radio_sdmanager.h
@@ -20,6 +20,7 @@
  */
 
 #include "tabsgroup.h"
+#include "dataconstants.h"
 
 class RadioSdManagerPage: public PageTab {
   public:
@@ -28,5 +29,6 @@ class RadioSdManagerPage: public PageTab {
     void build(FormWindow * window) override;
 
   protected:
+    void FrSkyFirmwareUpdate(ModuleIndex module, const std::string name);
     void rebuild(FormWindow * window);
 };

--- a/radio/src/gui/colorlcd/radio_sdmanager.h
+++ b/radio/src/gui/colorlcd/radio_sdmanager.h
@@ -19,16 +19,21 @@
  * GNU General Public License for more details.
  */
 
-#include "tabsgroup.h"
 #include "dataconstants.h"
+#include "tabsgroup.h"
+enum MultiModuleType : short;
 
-class RadioSdManagerPage: public PageTab {
-  public:
-    RadioSdManagerPage();
+class RadioSdManagerPage : public PageTab
+{
+ public:
+  RadioSdManagerPage();
 
-    void build(FormWindow * window) override;
+  void build(FormWindow* window) override;
 
-  protected:
-    void FrSkyFirmwareUpdate(ModuleIndex module, const std::string name);
-    void rebuild(FormWindow * window);
+ protected:
+  void BootloaderUpdate(const std::string name);
+  void FrSkyFirmwareUpdate(const std::string name, ModuleIndex module);
+  void MultiFirmwareUpdate(const std::string name, ModuleIndex module,
+                           MultiModuleType type);
+  void rebuild(FormWindow* window);
 };

--- a/radio/src/io/multi_firmware_update.h
+++ b/radio/src/io/multi_firmware_update.h
@@ -104,7 +104,7 @@ class MultiFirmwareInformation
     const char * readV2Signature(const char * buffer);
 };
 
-enum MultiModuleType
+enum MultiModuleType : short
 {
   MULTI_TYPE_MULTIMODULE = 0,
   MULTI_TYPE_ELRS,


### PR DESCRIPTION
Completely stab in the dark implementation based on OTX code and no hardware to test. `simu` seems to identify a frsk file as the correct update type. 

More work is needed to integrate/test the remaining menu items
May just be a matter of correct parameters for deviceFirmwareUpdate

