### PR TITLE
modelBmp options and tweaks

### DIFF
--- a/radio/src/gui/colorlcd/screen_setup.cpp
+++ b/radio/src/gui/colorlcd/screen_setup.cpp
@@ -121,7 +121,7 @@ SetupWidgetsPageSlot::SetupWidgetsPageSlot(FormGroup * parent, const rect_t & re
       menu->addLine(TR_SELECT_WIDGET, [=]() {
           Menu * menu = new Menu(parent);
           for (auto factory: getRegisteredWidgets()) {
-            menu->addLine(factory->getName(), [=]() {
+            menu->addLine(factory->getFriendlyName(), [=]() {
                 container->createWidget(slotIndex, factory);
                 auto widget = container->getWidget(slotIndex);
                 if(widget->getOptions() && widget->getOptions()->name)

--- a/radio/src/gui/colorlcd/screen_setup.cpp
+++ b/radio/src/gui/colorlcd/screen_setup.cpp
@@ -121,11 +121,11 @@ SetupWidgetsPageSlot::SetupWidgetsPageSlot(FormGroup * parent, const rect_t & re
       menu->addLine(TR_SELECT_WIDGET, [=]() {
           Menu * menu = new Menu(parent);
           for (auto factory: getRegisteredWidgets()) {
-            menu->addLine(factory->getFriendlyName(), [=]() {
+            menu->addLine(factory->getDisplayName(), [=]() {
                 container->createWidget(slotIndex, factory);
                 auto widget = container->getWidget(slotIndex);
                 if(widget->getOptions() && widget->getOptions()->name)
-                  new WidgetSettings(parent, widget);        
+                  new WidgetSettings(parent, widget);
             });
           }
       });

--- a/radio/src/gui/colorlcd/widget.h
+++ b/radio/src/gui/colorlcd/widget.h
@@ -120,8 +120,9 @@ void unregisterWidget(const WidgetFactory * factory);
 class WidgetFactory
 {
   public:
-    explicit WidgetFactory(const char * name, const ZoneOption * options = nullptr):
+    explicit WidgetFactory(const char * name, const ZoneOption * options = nullptr, const char * friendlyName = nullptr):
       name(name),
+      friendlyName(friendlyName),
       options(options)
     {
       registerWidget(this);
@@ -137,6 +138,14 @@ class WidgetFactory
     inline const ZoneOption * getOptions() const
     {
       return options;
+    }
+
+    inline const char * getFriendlyName() const
+    {
+        if (friendlyName)
+          return friendlyName;
+        else
+          return name;
     }
 
     void initPersistentData(Widget::PersistentData * persistentData) const
@@ -157,6 +166,7 @@ class WidgetFactory
 
   protected:
     const char * name;
+    const char * friendlyName;
     const ZoneOption * options;
 };
 

--- a/radio/src/gui/colorlcd/widget.h
+++ b/radio/src/gui/colorlcd/widget.h
@@ -120,9 +120,9 @@ void unregisterWidget(const WidgetFactory * factory);
 class WidgetFactory
 {
   public:
-    explicit WidgetFactory(const char * name, const ZoneOption * options = nullptr, const char * friendlyName = nullptr):
+    explicit WidgetFactory(const char * name, const ZoneOption * options = nullptr, const char * displayName = nullptr):
       name(name),
-      friendlyName(friendlyName),
+      displayName(displayName),
       options(options)
     {
       registerWidget(this);
@@ -140,10 +140,10 @@ class WidgetFactory
       return options;
     }
 
-    inline const char * getFriendlyName() const
+    inline const char * getDisplayName() const
     {
-        if (friendlyName)
-          return friendlyName;
+        if (displayName)
+          return displayName;
         else
           return name;
     }
@@ -166,7 +166,7 @@ class WidgetFactory
 
   protected:
     const char * name;
-    const char * friendlyName;
+    const char * displayName;
     const ZoneOption * options;
 };
 

--- a/radio/src/gui/colorlcd/widgets/modelbmp.cpp
+++ b/radio/src/gui/colorlcd/widgets/modelbmp.cpp
@@ -123,10 +123,10 @@ class ModelBitmapWidget: public Widget
 };
 
 const ZoneOption ModelBitmapWidget::options[] = {
-    {STR_COLOR, ZoneOption::Color, OPTION_VALUE_UNSIGNED(DEFAULT_COLOR>>16)},
+    {STR_COLOR, ZoneOption::Color, OPTION_VALUE_UNSIGNED(COLOR_THEME_SECONDARY1>>16)},
     {STR_SIZE, ZoneOption::TextSize, OPTION_VALUE_UNSIGNED(FONT_STD_INDEX)},
     {STR_FILL_BACKGROUND, ZoneOption::Bool, OPTION_VALUE_BOOL(false)},
-    {STR_BG_COLOR, ZoneOption::Color, OPTION_VALUE_UNSIGNED(DEFAULT_BGCOLOR>>16)},
+    {STR_BG_COLOR, ZoneOption::Color, OPTION_VALUE_UNSIGNED(COLOR_THEME_SECONDARY3>>16)},
     {nullptr, ZoneOption::Bool}};
 
 BaseWidgetFactory<ModelBitmapWidget> modelBitmapWidget("ModelBmp", ModelBitmapWidget::options, "Models");

--- a/radio/src/gui/colorlcd/widgets/modelbmp.cpp
+++ b/radio/src/gui/colorlcd/widgets/modelbmp.cpp
@@ -35,6 +35,7 @@ class ModelBitmapWidget: public Widget
 
     void refresh(BitmapBuffer * dc) override
     {
+      std::string filename = std::string(g_model.header.bitmap);
       if (buffer &&
           ((buffer->width() != width()) || (buffer->height() != height()) ||
            (deps_hash != getHash()))) {
@@ -46,7 +47,7 @@ class ModelBitmapWidget: public Widget
       // big space to draw
       if (rect.h >= 96 && rect.w >= 120) {
 
-        if (buffer) {
+        if (!filename.empty() && buffer) {
           dc->drawBitmap(0, 38, buffer.get());
         }
 
@@ -60,8 +61,10 @@ class ModelBitmapWidget: public Widget
         dc->drawSolidFilledRect(39, 27, rect.w - 48, 2, COLOR_THEME_SECONDARY1);
       }
       // smaller space to draw
-      else if (buffer) {
+      else {
+        if (!filename.empty() && buffer) {
         dc->drawBitmap(0, 0, buffer.get());
+        }
       }
     }
 

--- a/radio/src/gui/colorlcd/widgets/modelbmp.cpp
+++ b/radio/src/gui/colorlcd/widgets/modelbmp.cpp
@@ -47,7 +47,7 @@ class ModelBitmapWidget: public Widget
       if (rect.h >= 96 && rect.w >= 120) {
 
         if (buffer) {
-          dc->drawBitmap(0, 0, buffer.get());
+          dc->drawBitmap(0, 38, buffer.get());
         }
 
         auto iconMask = theme->getIconMask(ICON_MODEL);
@@ -100,7 +100,7 @@ class ModelBitmapWidget: public Widget
         }
 
         if (rect.h >= 96 && rect.w >= 120) {
-          buffer->drawScaledBitmap(bitmap.get(), 0, 38, width(), height() - 38);
+          buffer->drawScaledBitmap(bitmap.get(), 0, 0, width(), height() - 38);
         } else {
           buffer->drawScaledBitmap(bitmap.get(), 0, 0, width(), height());
         }

--- a/radio/src/gui/colorlcd/widgets/modelbmp.cpp
+++ b/radio/src/gui/colorlcd/widgets/modelbmp.cpp
@@ -123,10 +123,10 @@ class ModelBitmapWidget: public Widget
 };
 
 const ZoneOption ModelBitmapWidget::options[] = {
-    {STR_COLOR, ZoneOption::Color, OPTION_VALUE_UNSIGNED(DEFAULT_COLOR_INDEX)},
+    {STR_COLOR, ZoneOption::Color, OPTION_VALUE_UNSIGNED(DEFAULT_COLOR>>16)},
     {STR_SIZE, ZoneOption::TextSize, OPTION_VALUE_UNSIGNED(FONT_STD_INDEX)},
     {STR_FILL_BACKGROUND, ZoneOption::Bool, OPTION_VALUE_BOOL(false)},
-    {STR_BG_COLOR, ZoneOption::Color, OPTION_VALUE_UNSIGNED(DEFAULT_BGCOLOR_INDEX)},
+    {STR_BG_COLOR, ZoneOption::Color, OPTION_VALUE_UNSIGNED(DEFAULT_BGCOLOR>>16)},
     {nullptr, ZoneOption::Bool}};
 
 BaseWidgetFactory<ModelBitmapWidget> modelBitmapWidget("ModelBmp", ModelBitmapWidget::options);

--- a/radio/src/gui/colorlcd/widgets/modelbmp.cpp
+++ b/radio/src/gui/colorlcd/widgets/modelbmp.cpp
@@ -129,4 +129,4 @@ const ZoneOption ModelBitmapWidget::options[] = {
     {STR_BG_COLOR, ZoneOption::Color, OPTION_VALUE_UNSIGNED(DEFAULT_BGCOLOR>>16)},
     {nullptr, ZoneOption::Bool}};
 
-BaseWidgetFactory<ModelBitmapWidget> modelBitmapWidget("ModelBmp", ModelBitmapWidget::options);
+BaseWidgetFactory<ModelBitmapWidget> modelBitmapWidget("ModelBmp", ModelBitmapWidget::options, "Models");

--- a/radio/src/gui/colorlcd/widgets/modelbmp.cpp
+++ b/radio/src/gui/colorlcd/widgets/modelbmp.cpp
@@ -123,10 +123,10 @@ class ModelBitmapWidget: public Widget
 };
 
 const ZoneOption ModelBitmapWidget::options[] = {
-    {STR_COLOR, ZoneOption::Color, OPTION_VALUE_UNSIGNED(DEFAULT_COLOR)},
-    {STR_SIZE, ZoneOption::TextSize, OPTION_VALUE_UNSIGNED(3)},
+    {STR_COLOR, ZoneOption::Color, OPTION_VALUE_UNSIGNED(DEFAULT_COLOR_INDEX)},
+    {STR_SIZE, ZoneOption::TextSize, OPTION_VALUE_UNSIGNED(FONT_STD_INDEX)},
     {STR_FILL_BACKGROUND, ZoneOption::Bool, OPTION_VALUE_BOOL(false)},
-    {STR_BG_COLOR, ZoneOption::Color, OPTION_VALUE_UNSIGNED(DEFAULT_BGCOLOR)},
+    {STR_BG_COLOR, ZoneOption::Color, OPTION_VALUE_UNSIGNED(DEFAULT_BGCOLOR_INDEX)},
     {nullptr, ZoneOption::Bool}};
 
 BaseWidgetFactory<ModelBitmapWidget> modelBitmapWidget("ModelBmp", ModelBitmapWidget::options);

--- a/radio/src/gui/colorlcd/widgets/modelbmp.cpp
+++ b/radio/src/gui/colorlcd/widgets/modelbmp.cpp
@@ -63,7 +63,11 @@ class ModelBitmapWidget: public Widget
       // smaller space to draw
       else {
         if (!filename.empty() && buffer) {
-        dc->drawBitmap(0, 0, buffer.get());
+          dc->drawBitmap(0, 0, buffer.get());
+        }
+        else {
+          dc->drawSizedText(0, 0, g_model.header.name, LEN_MODEL_NAME,
+                            FONT(XS) | DEFAULT_COLOR);
         }
       }
     }

--- a/radio/src/gui/colorlcd/widgets/modelbmp.cpp
+++ b/radio/src/gui/colorlcd/widgets/modelbmp.cpp
@@ -37,11 +37,15 @@ class ModelBitmapWidget: public Widget
     {
       std::string filename = std::string(g_model.header.bitmap);
 
-      // set font colour from options[0]
-      lcdSetColor(persistentData->options[0].value.unsignedValue);
+      // set font colour from options[0], if use theme color option off
+      LcdFlags fontColor;
+      if (persistentData->options[4].value.boolValue)
+        fontColor = COLOR_THEME_SECONDARY1;
+      else
+        fontColor = COLOR2FLAGS(persistentData->options[0].value.unsignedValue);
 
       // get font size from options[1]
-      LcdFlags fontsize = persistentData->options[1].value.unsignedValue << 8u;
+      LcdFlags fontSize = persistentData->options[1].value.unsignedValue << 8u;
 
       // fill bg from options[3] if options[2] set
       if (persistentData->options[2].value.boolValue) {
@@ -64,7 +68,7 @@ class ModelBitmapWidget: public Widget
           dc->drawBitmap(0, 38, buffer.get());
         }
 
-        dc->drawSizedText(5, 5, g_model.header.name, LEN_MODEL_NAME, fontsize | COLOR_THEME_SECONDARY1);
+        dc->drawSizedText(5, 5, g_model.header.name, LEN_MODEL_NAME, fontSize | fontColor);
       }
       // smaller space to draw
       else {
@@ -72,7 +76,7 @@ class ModelBitmapWidget: public Widget
           dc->drawBitmap(0, 0, buffer.get());
         }
         else {
-          dc->drawSizedText(0, 0, g_model.header.name, LEN_MODEL_NAME, fontsize | COLOR_THEME_SECONDARY1);
+          dc->drawSizedText(0, 0, g_model.header.name, LEN_MODEL_NAME, fontSize | fontColor);
         }
       }
     }
@@ -127,6 +131,7 @@ const ZoneOption ModelBitmapWidget::options[] = {
     {STR_SIZE, ZoneOption::TextSize, OPTION_VALUE_UNSIGNED(FONT_STD_INDEX)},
     {STR_FILL_BACKGROUND, ZoneOption::Bool, OPTION_VALUE_BOOL(false)},
     {STR_BG_COLOR, ZoneOption::Color, OPTION_VALUE_UNSIGNED(COLOR_THEME_SECONDARY3>>16)},
+    {STR_USE_THEME_COLOR, ZoneOption::Bool, OPTION_VALUE_BOOL(true)},
     {nullptr, ZoneOption::Bool}};
 
 BaseWidgetFactory<ModelBitmapWidget> modelBitmapWidget("ModelBmp", ModelBitmapWidget::options, "Models");

--- a/radio/src/gui/colorlcd/widgets/widgets_container_impl.h
+++ b/radio/src/gui/colorlcd/widgets/widgets_container_impl.h
@@ -160,8 +160,8 @@ template<class T>
 class BaseWidgetFactory: public WidgetFactory
 {
   public:
-    BaseWidgetFactory(const char * name, const ZoneOption * options):
-      WidgetFactory(name, options)
+    BaseWidgetFactory(const char * name, const ZoneOption * options, const char * friendlyName = nullptr):
+      WidgetFactory(name, options, friendlyName)
     {
     }
 

--- a/radio/src/gui/colorlcd/widgets/widgets_container_impl.h
+++ b/radio/src/gui/colorlcd/widgets/widgets_container_impl.h
@@ -160,8 +160,8 @@ template<class T>
 class BaseWidgetFactory: public WidgetFactory
 {
   public:
-    BaseWidgetFactory(const char * name, const ZoneOption * options, const char * friendlyName = nullptr):
-      WidgetFactory(name, options, friendlyName)
+    BaseWidgetFactory(const char * name, const ZoneOption * options, const char * displayName = nullptr):
+      WidgetFactory(name, options, displayName)
     {
     }
 

--- a/radio/src/translations.cpp
+++ b/radio/src/translations.cpp
@@ -940,3 +940,5 @@ const char STR_RACING_MODE[] = TR_RACING_MODE;
 #if defined(PCBNV14)
 const char STR_RFPOWER_AFHDS2[] = TR_RFPOWER_AFHDS2;
 #endif
+
+const char STR_USE_THEME_COLOR[] = TR_USE_THEME_COLOR;

--- a/radio/src/translations.h
+++ b/radio/src/translations.h
@@ -1120,6 +1120,8 @@ extern const char STR_AUTH_FAILURE[];
 extern const char STR_PROTOCOL[];
 extern const char STR_RACING_MODE[];
 
+extern const char STR_USE_THEME_COLOR[];
+
 #define CHR_HOUR   TR_CHR_HOUR
 #define CHR_INPUT  TR_CHR_INPUT
 

--- a/radio/src/translations/untranslated.h
+++ b/radio/src/translations/untranslated.h
@@ -331,3 +331,5 @@
 #define CHAR_CHANNEL   STR_CHAR_CHANNEL[0]
 #define CHAR_TELEMETRY STR_CHAR_TELEMETRY[0]
 #define CHAR_LUA       STR_CHAR_LUA[0]
+
+#define TR_USE_THEME_COLOR "Use theme color"


### PR DESCRIPTION
Add options for text colour, size, fill enable and colour

I've mostly tried this on `simu`,  but also on the TX16S. 

There are a couple of things I would like help with / feedback on:
- [x] option defaults doesn't seem to be importing colours... ie. `DEFAULT_COLOR` - it was a light blue, but option defaults to black
- [x] how do I get the buffer background to go to transparent rather than a colour (resolved by #878)
- [x] are we happy with losing the icon and horizontal bar - I felt it was plane specific, and also a hinderance when changing font size