### PR TITLE
Refresh display when logical switch state changes

### DIFF
--- a/radio/src/gui/colorlcd/model_logical_switches.cpp
+++ b/radio/src/gui/colorlcd/model_logical_switches.cpp
@@ -66,7 +66,8 @@ class LogicalSwitchEditPage: public Page
     {
       Page::checkEvents();
       if (active != isActive()) {
-        headerSwitchName->setTextFlags(isActive() ? FONT(BOLD) | HIGHLIGHT_COLOR : MENU_COLOR);
+        invalidate();
+        headerSwitchName->setTextFlags(isActive() ? FONT(BOLD) | HIGHLIGHT_COLOR : FOCUS_COLOR);
         active = !active;
       }
     }


### PR DESCRIPTION
Similar to #325, colour was wrong with logical switch was inactive, but worse, the display was never updated when the state changed! 😆 