### PR TITLE
Fix for issue #537

### DIFF
--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -971,7 +971,10 @@ static bool resumeLua(bool init, bool allowLcdUsage)
     }
     else
 #endif
+    if (lua_status(lsScripts) == LUA_YIELD)
       return scriptWasRun;
+    else
+      luaLcdAllowed = allowLcdUsage;
   }
  
   do {


### PR DESCRIPTION
The function luaResume(...) assumed that it was called alternatingly in the background and the foreground.
But on color LCD radios it is only called in the foreground by standalone and tools script, and otherwise only in the background by mixer and function scripts. So it got stuck waiting for a foreground call.