### PR TITLE
Fix 579 581

### DIFF
--- a/radio/src/gui/colorlcd/topbar.cpp
+++ b/radio/src/gui/colorlcd/topbar.cpp
@@ -57,6 +57,15 @@ SetupTopBarWidgetsPage::SetupTopBarWidgetsPage(ScreenMenu* menu):
     auto widget = new SetupWidgetsPageSlot(this, rect, topbar, i);
     if (i == 0) widget->setFocus();
   }
+#if defined(HARDWARE_TOUCH)
+      new Button(
+          this, {0, 0, MENU_HEADER_BUTTON_WIDTH, MENU_HEADER_BUTTON_WIDTH},
+          [this]() -> uint8_t {
+            this->deleteLater();
+            return 1;
+          },
+          NO_FOCUS | FORM_NO_BORDER);
+#endif
 }
 
 void SetupTopBarWidgetsPage::deleteLater(bool detach, bool trash)

--- a/radio/src/gui/colorlcd/widgets_container.h
+++ b/radio/src/gui/colorlcd/widgets_container.h
@@ -29,7 +29,11 @@
 #define WIDGET_NAME_LEN     10
 #define MAX_WIDGET_OPTIONS   5 // Name?
 
+#if LCD_W > LCD_H
 #define MAX_TOPBAR_ZONES     4
+#else
+#define MAX_TOPBAR_ZONES     2
+#endif
 #define MAX_TOPBAR_OPTIONS   1 // just because of VC++ which doesn't like 0-size arrays :(
 
 // Common 'ZoneOptionValue's among all layouts

--- a/radio/src/hal/adc_driver.cpp
+++ b/radio/src/hal/adc_driver.cpp
@@ -67,7 +67,7 @@ const etx_hal_adc_driver_t* etx_hal_adc_driver = nullptr;
   const uint8_t adcMapping[NUM_ANALOGS] = { 0 /*STICK1*/, 1 /*STICK2*/, 2 /*STICK3*/, 3 /*STICK4*/,
                                             4 /*POT1*/, 5 /*POT2*/, 6 /*SWA*/, 14 /*SWB*/,
                                             7 /*SWC*/,  15 /*SWD*/, 8 /*SWE*/, 9 /*SWF*/,
-                                            10/*SWG*/,  11/*SWH*/,
+                                            11/*SWG*/,  10/*SWH*/,
                                             12 /*TX_VOLTAGE*/, 13 /* TX_VBAT */ };
 
   const int8_t adcDirection[NUM_ANALOGS] = { 0 /*STICK1*/, 0 /*STICK2*/, 0 /*STICK3*/, 0 /*STICK4*/,


### PR DESCRIPTION
This is the fix for #579 and #581.
Added exit button to the topbar widgets setup screen.
Split the maximum number of topbar widgets for horizontal and vertical screens.

Fixed the swap of SWG and SWH switches.