### PR TITLE
Tweak Max channels

### DIFF
--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -567,6 +567,7 @@ class ModuleWindow : public FormGroup {
         channelStart->setMax(MAX_OUTPUT_CHANNELS - sentModuleChannels(moduleIdx) + 1);
       });
       channelEnd->enable(minModuleChannels(moduleIdx) < maxModuleChannels(moduleIdx));
+      if (channelEnd->getValue() > channelEnd->getMax()) channelEnd->setValue(channelEnd->getMax());
     }
 
     void update()

--- a/radio/src/pulses/modules_helpers.h
+++ b/radio/src/pulses/modules_helpers.h
@@ -371,7 +371,7 @@ inline int8_t maxModuleChannels_M8(uint8_t moduleIdx)
     return 0; // 8 channels
   }
   else if (isModuleMultimoduleDSM2(moduleIdx)) {
-    return -1; // 7 channels
+    return 4; // 12 channels
   }
   //TODO: This should be based on the selected protocol
   else if(isModuleMultimodule(moduleIdx)) {

--- a/radio/src/pulses/modules_helpers.h
+++ b/radio/src/pulses/modules_helpers.h
@@ -367,6 +367,16 @@ inline int8_t maxModuleChannels_M8(uint8_t moduleIdx)
   else if (isModuleAFHDS3(moduleIdx)) {
     return 10;
   }
+  else if (isModuleDSM2(moduleIdx)) {
+    return 0; // 8 channels
+  }
+  else if (isModuleMultimoduleDSM2(moduleIdx)) {
+    return -1; // 7 channels
+  }
+  //TODO: This should be based on the selected protocol
+  else if(isModuleMultimodule(moduleIdx)) {
+    return 8; // 16 channels
+  }
   else {
     return maxChannelsModules_M8[g_model.moduleData[moduleIdx].type];
   }


### PR DESCRIPTION
Partially resolves https://github.com/EdgeTX/edgetx/issues/521 by setting DSM2 and MPM DSM2 max channel values, and treating rest of MPM as 16 channels max for now. Only tested in `simu` at present, just offering this up whilst I get around to trying it out on hardware in the next day or so. 

Also kicks the max channel value if you change the protocol and the value is now out of range (i.e. switching from XJT (16 CH) to DSM2 (7/8 CH) would leave it at 16 before). 

Either way, maxModuleChannels_M8 seems to be the culprit. 