### PR TITLE
NV14 topbar icon tweaks

### DIFF
--- a/radio/src/gui/colorlcd/layouts/topbar_impl.cpp
+++ b/radio/src/gui/colorlcd/layouts/topbar_impl.cpp
@@ -112,11 +112,11 @@ void TopbarImpl::paint(BitmapBuffer * dc)
       flags = MENU_TITLE_DISABLE_COLOR;
     }
 
-    dc->drawBitmapPattern(LCD_W - 98, 8, LBM_TOPMENU_USB, flags);
+    dc->drawBitmapPattern(USB_X, 8, LBM_TOPMENU_USB, flags);
   }
   // Logs
   else if (isFunctionActive(FUNCTION_LOGS) && BLINK_ON_PHASE) {
-    dc->drawBitmapPattern(LCD_W - 98, 6, LBM_DOT, FOCUS_COLOR);
+    dc->drawBitmapPattern(LOG_X, 6, LBM_DOT, FOCUS_COLOR);
   }
 
   // RSSI

--- a/radio/src/gui/colorlcd/layouts/topbar_impl.cpp
+++ b/radio/src/gui/colorlcd/layouts/topbar_impl.cpp
@@ -98,15 +98,14 @@ void TopbarImpl::paint(BitmapBuffer * dc)
   if (gpsData.fix) {
     char s[10];
     sprintf(s, "%d", gpsData.numSat);
-    dc->drawText(LCD_W-148, 4, s, FONT(XS) | CENTERED | FOCUS_COLOR);
+    dc->drawText(GPS_X, 4, s, FONT(XS) | CENTERED | FOCUS_COLOR);
   }
-  dc->drawBitmapPattern(LCD_W - 158, 22, LBM_TOPMENU_GPS,
+  dc->drawBitmapPattern(GPS_X - 10, 22, LBM_TOPMENU_GPS,
                         (gpsData.fix) ? FOCUS_COLOR : MENU_TITLE_DISABLE_COLOR);
 #endif
 
   // USB icon
   if (usbPlugged()) {
-
     LcdFlags flags = FOCUS_COLOR;
     if (getSelectedUsbMode() == USB_UNSELECTED_MODE) {
       flags = MENU_TITLE_DISABLE_COLOR;
@@ -132,7 +131,7 @@ void TopbarImpl::paint(BitmapBuffer * dc)
 
 #if defined(INTERNAL_MODULE_PXX1) && defined(EXTERNAL_ANTENNA)
   if (isModuleXJT(INTERNAL_MODULE) && isExternalAntennaEnabled()) {
-    dc->drawBitmapPattern(LCD_W-94, 4, LBM_TOPMENU_ANTENNA, FOCUS_COLOR);
+    dc->drawBitmapPattern(RSSI_X - 4, 4, LBM_TOPMENU_ANTENNA, FOCUS_COLOR);
   }
 #endif
 

--- a/radio/src/targets/horus/libopenui_config.h
+++ b/radio/src/targets/horus/libopenui_config.h
@@ -88,6 +88,7 @@ constexpr uint32_t RSSI_X =                        LCD_W - 90;
 constexpr uint32_t AUDIO_X =                       LCD_W - 130;
 constexpr uint32_t USB_X =                         LCD_W - 98;
 constexpr uint32_t LOG_X =                         LCD_W - 98;
+constexpr uint32_t GPS_X =                         LCD_W - 148;
 
 constexpr uint32_t MENUS_TOOLBAR_BUTTON_WIDTH =    30;
 constexpr uint32_t MENUS_TOOLBAR_BUTTON_PADDING =  3;

--- a/radio/src/targets/horus/libopenui_config.h
+++ b/radio/src/targets/horus/libopenui_config.h
@@ -86,6 +86,8 @@ constexpr uint32_t DATETIME_MIDDLE =               (LCD_W + DATETIME_SEPARATOR_X
 
 constexpr uint32_t RSSI_X =                        LCD_W - 90;
 constexpr uint32_t AUDIO_X =                       LCD_W - 130;
+constexpr uint32_t USB_X =                         LCD_W - 98;
+constexpr uint32_t LOG_X =                         LCD_W - 98;
 
 constexpr uint32_t MENUS_TOOLBAR_BUTTON_WIDTH =    30;
 constexpr uint32_t MENUS_TOOLBAR_BUTTON_PADDING =  3;

--- a/radio/src/targets/nv14/libopenui_config.h
+++ b/radio/src/targets/nv14/libopenui_config.h
@@ -88,6 +88,7 @@ constexpr uint32_t RSSI_X =                        LCD_W - 80;
 constexpr uint32_t AUDIO_X =                       LCD_W - 115;
 constexpr uint32_t USB_X =                         LCD_W - 82;
 constexpr uint32_t LOG_X =                         LCD_W - 82;
+constexpr uint32_t GPS_X =                         LCD_W - 130;
 
 constexpr uint32_t MENUS_TOOLBAR_BUTTON_WIDTH =    30;
 constexpr uint32_t MENUS_TOOLBAR_BUTTON_PADDING =  3;

--- a/radio/src/targets/nv14/libopenui_config.h
+++ b/radio/src/targets/nv14/libopenui_config.h
@@ -86,6 +86,8 @@ constexpr uint32_t DATETIME_MIDDLE =               (LCD_W + DATETIME_SEPARATOR_X
 
 constexpr uint32_t RSSI_X =                        LCD_W - 80;
 constexpr uint32_t AUDIO_X =                       LCD_W - 115;
+constexpr uint32_t USB_X =                         LCD_W - 82;
+constexpr uint32_t LOG_X =                         LCD_W - 82;
 
 constexpr uint32_t MENUS_TOOLBAR_BUTTON_WIDTH =    30;
 constexpr uint32_t MENUS_TOOLBAR_BUTTON_PADDING =  3;


### PR DESCRIPTION
A few more tweaks to the top bar icons
* moved USB and SD logging icons for NV14
* moved GPS and EXT_ANT icons for NV14 just because
* made remaining icon positions controllable by target

Will merge if checks complete. 
