### PR TITLE
Enables AUX1 again when FlySky Hall sticks are used

### DIFF
--- a/radio/src/targets/horus/CMakeLists.txt
+++ b/radio/src/targets/horus/CMakeLists.txt
@@ -185,7 +185,6 @@ endif()
 if(FLYSKY_HALL_STICKS)
   add_definitions(-DFLYSKY_HALL_STICKS)
   add_definitions(-DFLYSKY_HALL_STICKS_REVERSE)
-  set(AUX_SERIAL OFF)
   set(FLYSKY_HALL_STICKS_DRIVER flyskyHallStick_driver.cpp)
 endif()
 


### PR DESCRIPTION
Tested on RM TX16S, AUX1/USART3 and FlySky Hall Sticks on UART4, both now work simultaneously.