### PR TITLE
Don't remove 2POS from avail switches for invert

### DIFF
--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -298,6 +298,7 @@ bool isLogicalSwitchAvailable(int index)
 bool isSwitchAvailable(int swtch, SwitchContext context)
 {
   bool negative = false;
+  (void)negative;
 
   if (swtch < 0) {
     if (swtch == -SWSRC_ON || swtch == -SWSRC_ONE) {
@@ -319,9 +320,6 @@ bool isSwitchAvailable(int swtch, SwitchContext context)
       return false;
     }
     if (!IS_CONFIG_3POS(swinfo.quot)) {
-      if (negative) {
-        return false;
-      }
       if (swinfo.rem == 1) {
         // mid position not available for 2POS switches
         return false;


### PR DESCRIPTION
Resolves #178 by removing the blocking of negative states for 2POS switches. Only `simu` tested at present.

Also prevent 'unused variable' compiler warning that results from change. 

Remo