### PR TITLE
Color options for Lua widget get translated to Lua color flags

### DIFF
--- a/radio/src/lua/api_colorlcd.cpp
+++ b/radio/src/lua/api_colorlcd.cpp
@@ -54,7 +54,7 @@ static int8_t getTextVerticalOffset(LcdFlags flags)
 }
 
 // Return flags with RGB color value instead of indexed theme color
-static LcdFlags flagsRGB(LcdFlags flags)
+LcdFlags flagsRGB(LcdFlags flags)
 {
   // RGB or indexed color?
   if (flags & RGB_FLAG)

--- a/radio/src/lua/api_colorlcd.h
+++ b/radio/src/lua/api_colorlcd.h
@@ -39,3 +39,5 @@ constexpr int8_t text_vertical_offset[7] {2,2,0,2,3,3,7};
 
 extern bool           luaLcdAllowed;
 extern BitmapBuffer * luaLcdBuffer;
+
+LcdFlags flagsRGB(LcdFlags flags);

--- a/radio/src/lua/widgets.cpp
+++ b/radio/src/lua/widgets.cpp
@@ -177,10 +177,14 @@ ZoneOption * createOptionsArray(int reference, uint8_t maxOptions)
               // TRACE("default signed = %d", option->deflt.signedValue);
             }
             else if (option->type == ZoneOption::Source ||
-                     option->type == ZoneOption::TextSize ||
-                     option->type == ZoneOption::Color) {
+                     option->type == ZoneOption::TextSize) {
               luaL_checktype(lsWidgets, -1, LUA_TNUMBER); // value is number
               option->deflt.unsignedValue = lua_tounsigned(lsWidgets, -1);
+              // TRACE("default unsigned = %u", option->deflt.unsignedValue);
+            }
+            else if (option->type == ZoneOption::Color) {
+              luaL_checktype(lsWidgets, -1, LUA_TNUMBER); // value is number
+              option->deflt.unsignedValue = COLOR_VAL(flagsRGB(lua_tounsigned(lsWidgets, -1)));
               // TRACE("default unsigned = %u", option->deflt.unsignedValue);
             }
             else if (option->type == ZoneOption::Bool) {
@@ -418,7 +422,11 @@ void LuaWidget::update()
   lua_newtable(lsWidgets);
   int i = 0;
   for (const ZoneOption * option = getOptions(); option->name; option++, i++) {
-    l_pushtableint(option->name, persistentData->options[i].value.signedValue);
+    int32_t value = persistentData->options[i].value.signedValue;
+    if (option->type == ZoneOption::Color)
+      l_pushtableint(option->name, COLOR2FLAGS(value) | RGB_FLAG);      
+    else
+      l_pushtableint(option->name, value);
   }
 
   if (lua_pcall(lsWidgets, 2, 0, 0) != 0) {


### PR DESCRIPTION
To support new color encoding in Lua widgets.
@pfeerick please check if this solved the color option problem for Lua widgets!