### PR TITLE
Add 50 mW TX power level to CRSF protocol 

### DIFF
--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -137,7 +137,7 @@ void processCrossfireTelemetryFrame()
       for (unsigned int i=0; i<=TX_SNR_INDEX; i++) {
         if (getCrossfireTelemetryValue<1>(3+i, value)) {
           if (i == TX_POWER_INDEX) {
-            static const int32_t power_values[] = { 0, 10, 25, 100, 500, 1000, 2000, 250 };
+            static const int32_t power_values[] = { 0, 10, 25, 100, 500, 1000, 2000, 250, 50 };
             value = ((unsigned)value < DIM(power_values) ? power_values[value] : 0);
           }
           processCrossfireTelemetryValue(i, value);


### PR DESCRIPTION
This PR adds the 50 mW TX power level to the CRSF protocol. TBS is adding this power level in a future firmware version and they already added support for it in OpenTX. ExpressLRS uses 50 mW but cannot include it in the link statistics until the various projects that use CRSF support it, hence this PR.