### PR TITLE
allow mixes without source

### DIFF
--- a/radio/src/gui/colorlcd/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model_mixes.cpp
@@ -24,6 +24,7 @@
 #include "bitfield.h"
 #include "model_inputs.h"
 #include "gvar_numberedit.h"
+#include "dataconstants.h"
 
 #define SET_DIRTY()     storageDirty(EE_MODEL)
 
@@ -374,7 +375,7 @@ void ModelMixesPage::build(FormWindow * window, int8_t focusMixIndex)
   int mixIndex = 0;
   MixData * mix = g_model.mixData;
   for (uint8_t ch = 0; ch < MAX_OUTPUT_CHANNELS; ch++) {
-    if (mixIndex < MAX_MIXERS && mix->srcRaw > 0 && mix->destCh == ch) {
+    if (mixIndex < MAX_MIXERS && mix->destCh == ch) {
 
       coord_t h = grid.getWindowHeight();
       auto txt = new MixLineTitle(window, grid.getLabelSlot(),
@@ -382,7 +383,9 @@ void ModelMixesPage::build(FormWindow * window, int8_t focusMixIndex)
                                   BUTTON_BACKGROUND, COLOR_THEME_PRIMARY1 | CENTERED);
 
       uint8_t count = 0;
-      while (mixIndex < MAX_MIXERS && mix->srcRaw > 0 && mix->destCh == ch) {
+      while (mixIndex < MAX_MIXERS && mix->destCh == ch) {
+        // First mix cannot be empty
+        if(!mixIndex && !mix->srcRaw)  break;
         Button * button = new MixLineButton(window, grid.getFieldSlot(), mixIndex);
         button->setPressHandler([=]() -> uint8_t {
           button->bringToTop();

--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -648,7 +648,11 @@ void evalFlightModeMixes(uint8_t mode, uint8_t tick10ms)
       MixData * md = mixAddress(i);
 
       if (md->srcRaw == 0)
+#if defined(COLORLCD)
+        continue;
+#else
         break;
+#endif
 
       mixsrc_t stickIndex = md->srcRaw - MIXSRC_Rud;
 


### PR DESCRIPTION
This resolves #658 allowing mix with "--" source in the middle of the mixes list.
The b/w version is not affected. :-)
