### PR TITLE
Prevent USB activation while flashing firmware

### DIFF
--- a/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
+++ b/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
@@ -289,7 +289,7 @@ int main()
     if (tenms) {
       tenms = 0;
 
-      if (state != ST_USB) {
+      if (state != ST_USB && state != ST_FLASHING) {
         if (usbPlugged()) {
           state = ST_USB;
           if (!unlocked) {

--- a/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
+++ b/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
@@ -289,7 +289,7 @@ int main()
     if (tenms) {
       tenms = 0;
 
-      if (state != ST_USB && state != ST_FLASHING) {
+      if (state != ST_USB && state != ST_FLASHING && state != ST_FLASH_DONE) {
         if (usbPlugged()) {
           state = ST_USB;
           if (!unlocked) {


### PR DESCRIPTION
Don't allow switching to USB mode whilst firmware is being flashed!

Only tested once on TX16S - allowed firmware to finish flashing and then jumped to USB mode on completion. 

Perhaps also on `ST_FLASH_DONE` so that the completion screen is shown?