### PR TITLE
Add line to the bottom of the model_setup screen for NV!4

### DIFF
--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -592,6 +592,9 @@ class TrainerModuleWindow  : public FormGroup {
         new Choice(this, grid.getFieldSlot(3, 2), STR_PPM_POL, 0, 1, GET_SET_DEFAULT(g_model.trainerData.pulsePol ));
         grid.nextLine();
       }
+#if defined(PCBNV14)
+      new StaticText(this, grid.getLabelSlot(true) );
+#endif  
       getParent()->moveWindowsTop(top() + 1, adjustHeight());
     }
 
@@ -1565,9 +1568,6 @@ void ModelSetupPage::build(FormWindow * window)
     grid.addWindow(new TrainerModuleWindow(window, {0, grid.getWindowHeight(), LCD_W, 0}));
   }
 
-#if defined(PCBNV14)
-  grid.nextLine();
-#endif  
 
   window->setInnerHeight(grid.getWindowHeight());
 }


### PR DESCRIPTION
Add empty string to the bottom of the model_setup screen (trainer setup) to simplify access 