### PR TITLE
Implement Jump to Curve Edit from input and mixer screens

### DIFF
--- a/radio/src/gui/colorlcd/CMakeLists.txt
+++ b/radio/src/gui/colorlcd/CMakeLists.txt
@@ -66,6 +66,7 @@ set(GUI_SRC
   menu_screen.cpp
   screen_setup.cpp
   switch_warn_dialog.cpp
+  choiceex.cpp
   )
 
 macro(add_gui_src src)

--- a/radio/src/gui/colorlcd/choiceex.cpp
+++ b/radio/src/gui/colorlcd/choiceex.cpp
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) OpenTX
+ *
+ * Based on code named
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "choiceex.h"
+
+void ChoiceEx::setLongPressHandler(std::function<void(event_t)> handler)
+{
+  longPressHandler = handler;
+}
+
+ChoiceEx::ChoiceEx(FormGroup * parent, const rect_t & rect, int vmin, int vmax, std::function<int()> getValue, std::function<void(int)> setValue, WindowFlags windowFlags) :
+  Choice(parent, rect, vmin, vmax, getValue, setValue, windowFlags)
+{
+}
+
+bool ChoiceEx::onTouchEnd(coord_t x, coord_t y)
+{
+  return Choice::onTouchEnd(x,y);
+}
+
+void ChoiceEx::onEvent(event_t event)
+{
+  if (event == EVT_KEY_LONG(KEY_ENTER)) {
+    if (longPressHandler) {
+      killEvents(event);
+      longPressHandler(event);
+      return;
+    }
+  }
+
+  Choice::onEvent(event);
+}
+

--- a/radio/src/gui/colorlcd/choiceex.cpp
+++ b/radio/src/gui/colorlcd/choiceex.cpp
@@ -1,7 +1,8 @@
 /*
- * Copyright (C) OpenTX
+ * Copyright (C) EdgeTX
  *
  * Based on code named
+ *   opentx - https://github.com/opentx/opentx
  *   th9x - http://code.google.com/p/th9x
  *   er9x - http://code.google.com/p/er9x
  *   gruvin9x - http://code.google.com/p/gruvin9x
@@ -17,7 +18,6 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
-
 #include "choiceex.h"
 
 void ChoiceEx::setLongPressHandler(std::function<void(event_t)> handler)

--- a/radio/src/gui/colorlcd/choiceex.h
+++ b/radio/src/gui/colorlcd/choiceex.h
@@ -1,7 +1,8 @@
 /*
- * Copyright (C) OpenTX
+ * Copyright (C) EdgeTX
  *
  * Based on code named
+ *   opentx - https://github.com/opentx/opentx
  *   th9x - http://code.google.com/p/th9x
  *   er9x - http://code.google.com/p/er9x
  *   gruvin9x - http://code.google.com/p/gruvin9x

--- a/radio/src/gui/colorlcd/choiceex.h
+++ b/radio/src/gui/colorlcd/choiceex.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) OpenTX
+ *
+ * Based on code named
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+#include "libopenui.h"
+
+class ChoiceEx : public Choice
+{
+  public:
+    ChoiceEx(FormGroup * parent, const rect_t &rect, int vmin, int vmax, std::function<int()> getValue, std::function<void(int)> setValue = nullptr, WindowFlags windowFlags = 0);
+    void setLongPressHandler(std::function<void(event_t)> handler);
+
+#if defined(HARDWARE_KEYS)
+    void onEvent(event_t event) override;
+#endif
+
+#if defined(HARDWARE_TOUCH)
+    bool onTouchEnd(coord_t x, coord_t y) override;
+#endif
+
+#if defined(DEBUG_WINDOWS)
+    std::string getName() const override
+    {
+      return "CurvesListChoice";
+    }
+#endif
+
+protected:
+    std::function<void(event_t)> longPressHandler = nullptr;
+};
+

--- a/radio/src/gui/colorlcd/menu_model.h
+++ b/radio/src/gui/colorlcd/menu_model.h
@@ -25,6 +25,12 @@
 
 class ModelMenu: public TabsGroup {
   public:
+#if defined(DEBUG_WINDOWS)
+  std::string getName() const override
+  {
+    return "ModelMenu";
+  }
+#endif  
     ModelMenu();
 };
 

--- a/radio/src/gui/colorlcd/model_curves.cpp
+++ b/radio/src/gui/colorlcd/model_curves.cpp
@@ -24,6 +24,19 @@
 
 #define SET_DIRTY() storageDirty(EE_MODEL)
 
+
+// initialize a new curves points to the default for a 5 point
+// curve.
+void initPoints(const CurveHeader &curve, int8_t *points)
+{
+  int dx = 2000 / (5 + curve.points - 1);
+  for (uint8_t i = 0; i < 5 + curve.points; i++) {
+    int x = -1000 + i * dx;
+    points[i] = x / 10;
+  }
+}
+
+
 class CurveEditWindow : public Page
 {
   public:
@@ -264,6 +277,20 @@ ModelCurvesPage::ModelCurvesPage() :
 {
 }
 
+
+// can be called from any other screen to edit a curve.
+// currently called from model_mixes.cpp on longpress.
+void ModelCurvesPage::pushEditCurve(int index)
+{
+  if (! isCurveUsed(index)) {
+    CurveHeader &curve = g_model.curves[index];
+    int8_t * points = curveAddress(index);
+    initPoints(curve, points);
+  }
+  
+  new CurveEditWindow(index);
+}
+
 void ModelCurvesPage::rebuild(FormWindow * window, int8_t focusIndex)
 {
   coord_t scrollPosition = window->getScrollPositionY();
@@ -364,11 +391,7 @@ void ModelCurvesPage::build(FormWindow * window, int8_t focusIndex)
       button->setPressHandler([=]() {
         Menu *menu = new Menu(window);
         menu->addLine(STR_EDIT, [=]() {
-            int dx = 2000 / (5 + curve.points - 1);
-            for (uint8_t i = 0; i < 5 + curve.points; i++) {
-              int x = -1000 + i * dx;
-              points[i] = x / 10;
-            }
+            initPoints(curve, points);
             editCurve(window, index);
         });
         menu->addLine(STR_CURVE_PRESET, presetCurveFct);

--- a/radio/src/gui/colorlcd/model_curves.h
+++ b/radio/src/gui/colorlcd/model_curves.h
@@ -27,6 +27,7 @@
 class ModelCurvesPage: public PageTab {
   public:
     ModelCurvesPage();
+    static void pushEditCurve(int index);
 
     virtual void build(FormWindow * window) override
     {

--- a/radio/src/gui/colorlcd/model_inputs.cpp
+++ b/radio/src/gui/colorlcd/model_inputs.cpp
@@ -22,6 +22,8 @@
 #include "opentx.h"
 #include "gvar_numberedit.h"
 #include "libopenui.h"
+#include "choiceex.h"
+#include "model_curves.h"
 
 #define SET_DIRTY() storageDirty(EE_MODEL)
 
@@ -173,9 +175,16 @@ class InputEditWindow : public Page
         break;
 
       case CURVE_REF_CUSTOM: {
-        auto choice = new Choice(curveParamField, rect, -MAX_CURVES, MAX_CURVES,
+        auto choice = new ChoiceEx(curveParamField, rect, -MAX_CURVES, MAX_CURVES,
                                  GET_SET_DEFAULT(line->curve.value));
         choice->setTextHandler([](int value) { return getCurveString(value); });
+        choice->setLongPressHandler([this](event_t event) {
+          ExpoData *line = expoAddress(index);
+
+          // if no curve is specified then dont link to curve page
+          if (line->curve.value != 0)
+            ModelCurvesPage::pushEditCurve(abs(line->curve.value) - 1);
+        });
         break;
       }
     }

--- a/radio/src/gui/colorlcd/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model_mixes.cpp
@@ -236,7 +236,6 @@ class MixEditWindow : public Page
         choice->setTextHandler([](int value) { return getCurveString(value); });
         choice->setLongPressHandler([this](event_t event) {
           MixData *mix = mixAddress(mixIndex);
-          auto a = parent->getName();
           // if no curve is specified then dont link to curve page
           if (mix->curve.value != 0)
             ModelCurvesPage::pushEditCurve(abs(mix->curve.value) - 1);

--- a/radio/src/gui/colorlcd/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model_mixes.cpp
@@ -21,6 +21,7 @@
 #include "model_mixes.h"
 #include "opentx.h"
 #include "libopenui.h"
+#include "choiceex.h"
 #include "bitfield.h"
 #include "model_inputs.h"
 #include "gvar_numberedit.h"
@@ -30,59 +31,6 @@
 #define SET_DIRTY()     storageDirty(EE_MODEL)
 #define PASTE_BEFORE    -2
 #define PASTE_AFTER     -1
-
-class CurvesListChoice : public Choice
-{
-  public:
-    CurvesListChoice(FormGroup * parent, const rect_t &rect, int vmin, int vmax, std::function<int()> getValue, std::function<void(int)> setValue = nullptr, WindowFlags windowFlags = 0);
-    void setLongPressHandler(std::function<void(event_t)> handler);
-
-#if defined(HARDWARE_KEYS)
-    void onEvent(event_t event) override;
-#endif
-
-#if defined(HARDWARE_TOUCH)
-    bool onTouchEnd(coord_t x, coord_t y) override;
-#endif
-
-#if defined(DEBUG_WINDOWS)
-    std::string getName() const override
-    {
-      return "CurvesListChoice";
-    }
-#endif
-
-protected:
-    std::function<void(event_t)> longPressHandler = nullptr;
-};
-
-void CurvesListChoice::setLongPressHandler(std::function<void(event_t)> handler)
-{
-  longPressHandler = handler;
-}
-
-CurvesListChoice::CurvesListChoice(FormGroup * parent, const rect_t & rect, int vmin, int vmax, std::function<int()> getValue, std::function<void(int)> setValue, WindowFlags windowFlags) :
-  Choice(parent, rect, vmin, vmax, getValue, setValue, windowFlags)
-{
-}
-
-bool CurvesListChoice::onTouchEnd(coord_t x, coord_t y)
-{
-  return Choice::onTouchEnd(x,y);
-}
-
-void CurvesListChoice::onEvent(event_t event)
-{
-  if (event == EVT_KEY_LONG(KEY_ENTER)) {
-    if (longPressHandler) {
-      killEvents(event);
-      longPressHandler(event);
-      return;
-    }
-  }
-
-  Choice::onEvent(event);
-}
 
 uint8_t getMixesCount()
 {
@@ -282,7 +230,7 @@ class MixEditWindow : public Page
         break;
 
       case CURVE_REF_CUSTOM: {
-        auto choice = new CurvesListChoice(curveParamField, rect, -MAX_CURVES, MAX_CURVES,
+        auto choice = new ChoiceEx(curveParamField, rect, -MAX_CURVES, MAX_CURVES,
                                  GET_SET_DEFAULT(line->curve.value));
         choice->setTextHandler([](int value) { return getCurveString(value); });
         choice->setLongPressHandler([this](event_t event) {

--- a/radio/src/gui/colorlcd/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model_mixes.cpp
@@ -24,11 +24,65 @@
 #include "bitfield.h"
 #include "model_inputs.h"
 #include "gvar_numberedit.h"
+#include "model_curves.h"
+
 
 #define SET_DIRTY()     storageDirty(EE_MODEL)
-
 #define PASTE_BEFORE    -2
 #define PASTE_AFTER     -1
+
+class CurvesListChoice : public Choice
+{
+  public:
+    CurvesListChoice(FormGroup * parent, const rect_t &rect, int vmin, int vmax, std::function<int()> getValue, std::function<void(int)> setValue = nullptr, WindowFlags windowFlags = 0);
+    void setLongPressHandler(std::function<void(event_t)> handler);
+
+#if defined(HARDWARE_KEYS)
+    void onEvent(event_t event) override;
+#endif
+
+#if defined(HARDWARE_TOUCH)
+    bool onTouchEnd(coord_t x, coord_t y) override;
+#endif
+
+#if defined(DEBUG_WINDOWS)
+    std::string getName() const override
+    {
+      return "CurvesListChoice";
+    }
+#endif
+
+protected:
+    std::function<void(event_t)> longPressHandler = nullptr;
+};
+
+void CurvesListChoice::setLongPressHandler(std::function<void(event_t)> handler)
+{
+  longPressHandler = handler;
+}
+
+CurvesListChoice::CurvesListChoice(FormGroup * parent, const rect_t & rect, int vmin, int vmax, std::function<int()> getValue, std::function<void(int)> setValue, WindowFlags windowFlags) :
+  Choice(parent, rect, vmin, vmax, getValue, setValue, windowFlags)
+{
+}
+
+bool CurvesListChoice::onTouchEnd(coord_t x, coord_t y)
+{
+  return Choice::onTouchEnd(x,y);
+}
+
+void CurvesListChoice::onEvent(event_t event)
+{
+  if (event == EVT_KEY_LONG(KEY_ENTER)) {
+    if (longPressHandler) {
+      killEvents(event);
+      longPressHandler(event);
+      return;
+    }
+  }
+
+  Choice::onEvent(event);
+}
 
 uint8_t getMixesCount()
 {
@@ -228,9 +282,16 @@ class MixEditWindow : public Page
         break;
 
       case CURVE_REF_CUSTOM: {
-        auto choice = new Choice(curveParamField, rect, -MAX_CURVES, MAX_CURVES,
+        auto choice = new CurvesListChoice(curveParamField, rect, -MAX_CURVES, MAX_CURVES,
                                  GET_SET_DEFAULT(line->curve.value));
         choice->setTextHandler([](int value) { return getCurveString(value); });
+        choice->setLongPressHandler([this](event_t event) {
+          MixData *mix = mixAddress(mixIndex);
+          auto a = parent->getName();
+          // if no curve is specified then dont link to curve page
+          if (mix->curve.value != 0)
+            ModelCurvesPage::pushEditCurve(abs(mix->curve.value) - 1);
+        });
         break;
       }
     }


### PR DESCRIPTION
This PR implements a jump to curve edit screen from long-press of curve Choice() on the input screen and mixer screen.  I implemented a ChoiceEx which handles long-press and passes it back to the creator to take action.  This ideally should be in libopenui