### PR TITLE
[color] Dynamic MPM proto list

### DIFF
--- a/radio/src/gui/colorlcd/CMakeLists.txt
+++ b/radio/src/gui/colorlcd/CMakeLists.txt
@@ -92,6 +92,10 @@ if(PXX2 OR MULTIMODULE)
   add_gui_src(radio_spectrum_analyser.cpp)
 endif()
 
+if(MULTIMODULE)
+  add_gui_src(multi_rfprotos.cpp)
+endif()
+
 if(GHOST)
   add_gui_src(radio_ghost_module_config.cpp)
 endif()

--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -19,93 +19,14 @@
  */
 
 #include "model_setup.h"
+#include "multi_rfprotos.h"
+
 #include "opentx.h"
 #include "libopenui.h"
 #include "storage/modelslist.h"
 #include "algorithm"
 
 #define SET_DIRTY()     storageDirty(EE_MODEL)
-
-class RFProtocols
-{
-private:
-    const char * protocols;
-    int maxProtocols;
-    std::vector<std::string> labels;
-    uint8_t getProtoStringLength();
-
-public:
-    RFProtocols(const char * rfProtocols, int max);
-    int findProtocolIndex(int rfProtcolIndex);
-    int lookupProtocolIndex(int selectedIndex);
-    std::vector<std::string> &getLabels();
-};
-
-uint8_t RFProtocols::getProtoStringLength()
-{
-    return protocols[0];
-}
-
-RFProtocols::RFProtocols(const char *protocols, int max)
-{
-    this->protocols = protocols;
-    maxProtocols = max;
-
-    uint8_t len = protocols[0];
-    const char * value = &protocols[1];
-
-    for (int i = 0; i <= max; i++)
-    {
-        std::string label = std::string(value, min<uint8_t>(len, strlen(value)));
-        labels.emplace_back(label);
-
-        value += len;
-    }
-    std::sort(labels.begin(), labels.end());
-}
-
-std::vector<std::string> &RFProtocols::getLabels()
-{
-    return labels;
-}
-
-int RFProtocols::lookupProtocolIndex(int selectedIndex)
-{
-    uint8_t len = getProtoStringLength();
-    const char *p = &protocols[1];
-
-    const char *protocolLabel = labels.at(selectedIndex).c_str();
-
-    int protocolIndex = 0;
-    for (; protocolIndex < maxProtocols; protocolIndex++)
-    {
-        if (strncmp(p, protocolLabel, min((int)strlen(protocolLabel), (int)len)) == 0)
-            break;
-
-        p += len;
-    }
-    assert(protocolIndex < maxProtocols);
-
-    return protocolIndex;
-}
-
-int RFProtocols::findProtocolIndex(int rfProtocolIndex)
-{
-    uint8_t len = getProtoStringLength();
-    const char *protocolLabel = &protocols[1] + len * rfProtocolIndex;
-
-    auto result = std::find_if(labels.begin(), labels.end(), [protocolLabel, len](std::string &a) {
-        auto theSame = strncmp(a.c_str(), protocolLabel, max((int)a.length(), (int)len)) == 0;
-        return theSame;
-    });
-    assert(result != labels.end());
-    return result - labels.begin();
-}
-
-// global pointer intialized once on the first call to update()
-RFProtocols *rfProtocols = nullptr;
-
-
 
 std::string switchWarninglabel(swsrc_t index)
 {
@@ -722,33 +643,23 @@ class ModuleWindow : public FormGroup {
       else if (isModuleMultimodule(moduleIdx)) {
         Choice * mmSubProtocol = nullptr;
         grid.nextLine();
-        new StaticText(this, grid.getLabelSlot(true), STR_RF_PROTOCOL, 0, COLOR_THEME_PRIMARY1);
+        new StaticText(this, grid.getLabelSlot(true), STR_RF_PROTOCOL, 0,
+                       COLOR_THEME_PRIMARY1);
 
-        // Multi type (CUSTOM, brand A, brand B,...)
-        int multiRfProto = g_model.moduleData[moduleIdx].getMultiProtocol();
 
-        // initialize rfProtocols if it is not initialized already.  This is a hack
-        // because i dont know how to construct it at the exact right time after the module
-        // is loaded
-        if (rfProtocols == nullptr)
-            rfProtocols = new RFProtocols(STR_MULTI_PROTOCOLS, MODULE_SUBTYPE_MULTI_LAST);
 
-        multiRfProto = rfProtocols->findProtocolIndex(multiRfProto);
+        // Grid count for narrow/wide screen
+        int count =
+            LCD_W < LCD_H
+                ? 1
+                : (g_model.moduleData[moduleIdx].multi.customProto ? 3 : 2);
 
-				// Grid count for narrow/wide screen
-				int count = LCD_W < LCD_H ? 1 : (g_model.moduleData[moduleIdx].multi.customProto ? 3 : 2);
- 
-        rfChoice = new Choice(
-            this,
-            grid.getFieldSlot(count, 0),
-            rfProtocols->getLabels(), MODULE_SUBTYPE_MULTI_FIRST,
-            MODULE_SUBTYPE_MULTI_LAST, GET_DEFAULT(multiRfProto),
+        rfChoice = new MultiProtoChoice(
+            this, grid.getFieldSlot(count, 0), moduleIdx,
             [=](int32_t newValue) {
-
-              newValue = rfProtocols->lookupProtocolIndex(newValue);
-
               g_model.moduleData[moduleIdx].setMultiProtocol(newValue);
               g_model.moduleData[moduleIdx].subType = 0;
+              getMultiModuleStatus(moduleIdx).protocolName[0] = '\0';
               if (mmSubProtocol != nullptr) mmSubProtocol->invalidate(); // always null ???
               resetMultiProtocolsOptions(moduleIdx);
               SET_DIRTY();
@@ -758,15 +669,14 @@ class ModuleWindow : public FormGroup {
 
         if (MULTIMODULE_HAS_SUBTYPE(moduleIdx)) {
           // Subtype (D16, DSMX,...)
-					
-					// Grid count for narrow/wide screen
-					count = LCD_W < LCD_H ? 1 : 2;
-					int index = 1;
-					if (count == 1)
-					{
-						grid.nextLine();
-						index = 0;
-					}
+
+          // Grid count for narrow/wide screen
+          count = LCD_W < LCD_H ? 1 : 2;
+          int index = 1;
+          if (count == 1) {
+            grid.nextLine();
+            index = 0;
+          }
           const mm_protocol_definition *pdef = getMultiProtocolDefinition(
               g_model.moduleData[moduleIdx].getMultiProtocol());
           if (pdef->maxSubtype > 0) {
@@ -1192,7 +1102,9 @@ class ModuleWindow : public FormGroup {
 
     void checkEvents() override
     {
-      if (isModuleFailsafeAvailable(moduleIdx) != hasFailsafe) {
+      if (isModuleFailsafeAvailable(moduleIdx) != hasFailsafe
+          && rfChoice && !rfChoice->isEditMode()) {
+
         hasFailsafe = isModuleFailsafeAvailable(moduleIdx);
         update();
       }
@@ -1207,6 +1119,13 @@ class ModuleWindow : public FormGroup {
 ModelSetupPage::ModelSetupPage() :
   PageTab(STR_MENU_MODEL_SETUP, ICON_MODEL_SETUP)
 {
+}
+
+ModelSetupPage::~ModelSetupPage()
+{
+#if defined(MULTIMODULE)
+  MultiProtoChoice::removeInstances();
+#endif
 }
 
 uint8_t g_moduleIdx;

--- a/radio/src/gui/colorlcd/multi_rfprotos.cpp
+++ b/radio/src/gui/colorlcd/multi_rfprotos.cpp
@@ -1,0 +1,322 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "multi_rfprotos.h"
+#include "strhelpers.h"
+#include "audio.h"
+#include "translations.h"
+#include "pulses/modules_helpers.h"
+#include "gui_common.h"
+#include <algorithm>
+
+class MultiRfProtocols
+{
+  static constexpr uint8_t ScanStartProto = MODULE_SUBTYPE_MULTI_CONFIG;
+  static MultiRfProtocols* _instance[NUM_MODULES];
+  
+  struct RfProto {
+    int         proto;
+    std::string label;
+
+    RfProto(int proto, const char* label)
+      : proto(proto), label(label)
+    {}
+  };
+  std::list<RfProto> protoList;
+
+  unsigned int moduleIdx;
+
+  enum ScanState {
+    ScanStop,
+    ScanBegin,
+    Scanning,
+    ScanInvalid,
+    ScanEnd
+  };
+
+  ScanState scanState = ScanStop;
+  uint8_t   scanProto = ScanStartProto;
+  tmr10ms_t lastScan  = 0;
+
+  MultiRfProtocols(unsigned int moduleIdx)
+    : moduleIdx(moduleIdx)
+  {
+  }
+  
+  void scanNext()
+  {
+    TRACE("scan with proto=%d", scanProto);
+    g_model.moduleData[moduleIdx].setMultiProtocol(scanProto);
+
+    // record start time (timeout)
+    lastScan = get_tmr10ms();
+    scanState = Scanning;
+
+    // invalidate update status (force timeout)
+    MultiModuleStatus& status = getMultiModuleStatus(moduleIdx);
+    status.lastUpdate = get_tmr10ms() - 500;
+  }
+
+public:
+  static MultiRfProtocols* instance(unsigned int moduleIdx)
+  {
+    if (moduleIdx >= NUM_MODULES) return nullptr;
+    if (!_instance[moduleIdx]) {
+      _instance[moduleIdx] = new MultiRfProtocols(moduleIdx);
+    }
+    return _instance[moduleIdx];
+  }
+
+  static void removeInstances()
+  {
+    for (int i=0; i<NUM_MODULES; i++) {
+      delete _instance[i];
+      _instance[i] = nullptr;
+    }
+  }
+
+  std::string getProtoLabel(unsigned int proto)
+  {
+    if (scanState != ScanEnd) {
+      MultiModuleStatus& status = getMultiModuleStatus(moduleIdx);
+      if (status.protocolName[0] && status.isValid()) {
+        return std::string(status.protocolName);
+      } else if (proto <= MODULE_SUBTYPE_MULTI_LAST) {
+        char tmp[8];
+        getStringAtIndex(tmp, STR_MULTI_PROTOCOLS, proto);
+        return std::string(tmp);
+      }
+    } else {
+      auto it = std::find_if(
+          protoList.begin(), protoList.end(),
+          [=](const RfProto& p) { return p.proto == (const int)proto; });
+      if (it != protoList.end()) {
+        return it->label;
+      }
+    }
+    return std::string();
+  }
+
+  bool isScanning() {
+    return scanState != ScanStop && scanState != ScanEnd;
+  }
+
+  int getNProtos() {
+    return protoList.size();
+  }
+
+  std::string getLastProtoLabel() const
+  {
+    auto it = protoList.rbegin();
+    if (it != protoList.rend()) {
+      return it->label;
+    }
+    return std::string();
+  }
+  
+  void triggerScan()
+  {
+    if (scanState == ScanStop)
+      scanState = ScanBegin;
+  }
+
+  void stateMachine(MultiProtoChoice* choice)
+  {
+    //TRACE("%p: <%d|%d|%d>", this, scanState, scanProto, get_tmr10ms() - lastScan);
+
+    switch(scanState) {
+
+    case ScanBegin:
+      scanNext();
+      break;
+
+    case Scanning: {
+      MultiModuleStatus& status = getMultiModuleStatus(moduleIdx);
+      if (status.isValid()) {
+
+        // TRACE("scanProto = %d; prev=%d; next=%d",
+        //       scanProto,
+        //       status.protocolPrev,
+        //       status.protocolNext);
+
+        // new status received
+        if ((scanProto == ScanStartProto) || // special proto to detect start of list
+            (status.protocolPrev == status.protocolNext)) {
+
+          TRACE("detected start of proto list!");
+          scanProto = convertMultiToOtx(status.protocolNext);
+          scanNext();
+          break;
+        }
+
+        if (status.protocolValid()) {
+          
+          TRACE("proto(%d): '%s'/%d/%d",
+                scanProto,
+                status.protocolName,
+                convertMultiToOtx(status.protocolPrev),
+                convertMultiToOtx(status.protocolNext));
+
+          protoList.emplace_back(scanProto, status.protocolName);
+          choice->addProto(scanProto, status.protocolName);
+
+          if (status.protocolNext == scanProto) {
+            TRACE("proto scan ended sucessfully!");
+            scanState = ScanEnd;
+          } else {
+            scanProto = convertMultiToOtx(status.protocolNext);
+            scanNext();
+          }
+        } else {
+          // search led to an invalid proto: feature probably not supported
+          TRACE("search led to an invalid proto!");
+          scanState = ScanInvalid;
+        }
+
+      } else if (get_tmr10ms() - lastScan >= 50) {
+        // Timeout = 500ms
+        // MPM takes on average 110ms to reply
+        TRACE("proto scan timeout!");
+        scanState = ScanInvalid;
+      }
+    } break;
+
+    case ScanInvalid:
+      //TODO: fill with static list (sorted)
+      scanState = ScanEnd;
+      break;
+
+    default:
+      break;
+    }
+  }
+
+  void fillList(MultiProtoChoice* choice)
+  {
+    for(const auto& p : protoList) {
+      choice->addProto(p.proto, p.label.c_str());
+    }
+  }
+};
+
+MultiRfProtocols* MultiRfProtocols::_instance[NUM_MODULES] = {};
+
+class RfScanDialog : public MessageDialog
+{
+  MultiRfProtocols* protos;
+
+ public:
+  RfScanDialog(Window* parent, MultiRfProtocols* protos) :
+    MessageDialog(parent, "Scanning protocols", ""),
+    protos(protos)
+  {
+    setFocus();
+  }
+
+  // void deleteLater(bool detach = true, bool trash = true) override
+  // {
+  //   if (_deleted) return;
+  //   FullScreenDialog::deleteLater(detach, trash);
+  // }
+
+  void showProgress()
+  {
+    // TODO
+    char msg[64] = {'\0'};
+    char* s = msg;
+
+    s = strAppend(s, "Protocols: ");
+    s = strAppendSigned(s, protos->getNProtos());
+    s = strAppend(s, " / Found: ");
+    s = strAppend(s, protos->getLastProtoLabel().c_str());
+    setInfoText(msg);
+    if (MainWindow::instance()->refresh()) {
+      lcdRefresh();
+    }
+  }
+};
+
+MultiProtoChoice::MultiProtoChoice(FormGroup* parent, const rect_t& rect,
+                                   unsigned int moduleIdx,
+                                   std::function<void(int)> setValue) :
+    Choice(
+        parent, rect, 0, 0,
+        [=] { return g_model.moduleData[moduleIdx].getMultiProtocol(); },
+        setValue),
+    moduleIdx(moduleIdx)
+{
+  //protoBackup = getValue();
+  protos = MultiRfProtocols::instance(moduleIdx);
+
+  setTextHandler([=](int value) {
+    TRACE("textHandler(%d)", value);
+    return protos->getProtoLabel(value);
+  });
+  TRACE("MultiProtoChoice::MultiProtoChoice(%p)", this);
+}
+
+void MultiProtoChoice::openMenu()
+{
+  menu = new Menu(this);
+
+  if (!menuTitle.empty()) menu->setTitle(menuTitle);
+  menu->setCloseHandler([=]() { setEditMode(false); });
+
+  setEditMode(true);
+  invalidate();
+
+  int proto = getValue();
+  protos->triggerScan();
+  if (protos->isScanning()) {
+    RfScanDialog* rfScan = new RfScanDialog(this, protos);
+    do {
+      // MPM takes on average 110ms to reply
+#if defined(SIMU)
+      RTOS_WAIT_MS(200);
+#else
+      RTOS_WAIT_MS(20);
+#endif
+      protos->stateMachine(this);
+      rfScan->showProgress();
+    } while(protos->isScanning());
+
+    rfScan->deleteLater();
+    g_model.moduleData[moduleIdx].setMultiProtocol(proto);
+    getMultiModuleStatus(moduleIdx).protocolName[0] = '\0';
+  } else {
+    //TODO: fill with existing protos
+    protos->fillList(this);
+  }
+
+  // TODO: find current element
+}
+
+void MultiProtoChoice::addProto(unsigned int proto, const char* protocolName)
+{
+  // proto2idx[scanProto] = vmax;
+  addValue(protocolName);
+  menu->addLine(protocolName, [=]() { setValue(proto); });
+}
+
+void MultiProtoChoice::removeInstances()
+{
+  MultiRfProtocols::removeInstances();
+}

--- a/radio/src/gui/colorlcd/multi_rfprotos.h
+++ b/radio/src/gui/colorlcd/multi_rfprotos.h
@@ -1,7 +1,8 @@
 /*
- * Copyright (C) OpenTX
+ * Copyright (C) EdgeTX
  *
  * Based on code named
+ *   opentx - https://github.com/opentx/opentx
  *   th9x - http://code.google.com/p/th9x
  *   er9x - http://code.google.com/p/er9x
  *   gruvin9x - http://code.google.com/p/gruvin9x
@@ -18,12 +19,25 @@
  * GNU General Public License for more details.
  */
 
-#include "tabsgroup.h"
+#pragma once
+#include "libopenui.h"
 
-class ModelSetupPage: public PageTab {
-  public:
-    ModelSetupPage();
-    ~ModelSetupPage() override;
+class MultiRfProtocols;
 
-    void build(FormWindow * window) override;
+class MultiProtoChoice : public Choice
+{
+  unsigned int moduleIdx;
+
+  MultiRfProtocols* protos = nullptr;
+  Menu* menu = nullptr;
+
+ public:
+  MultiProtoChoice(FormGroup *parent, const rect_t &rect, unsigned int moduleIdx,
+                   std::function<void(int)> setValue);
+
+  void openMenu() override;
+  void addProto(unsigned int proto, const char* protocolName);
+
+  static void removeInstances();
 };
+

--- a/radio/src/gui/gui_common.h
+++ b/radio/src/gui/gui_common.h
@@ -274,8 +274,9 @@ inline bool MULTIMODULE_PROTOCOL_KNOWN(uint8_t moduleIdx)
 inline bool MULTIMODULE_HAS_SUBTYPE(uint8_t moduleIdx)
 {
   MultiModuleStatus &status = getMultiModuleStatus(moduleIdx);
+  int proto = g_model.moduleData[moduleIdx].getMultiProtocol();
 
-  if (g_model.moduleData[moduleIdx].getMultiProtocol() == MODULE_SUBTYPE_MULTI_FRSKY) {
+  if (proto == MODULE_SUBTYPE_MULTI_FRSKY) {
     return true;
   }
 
@@ -284,11 +285,12 @@ inline bool MULTIMODULE_HAS_SUBTYPE(uint8_t moduleIdx)
   }
   else
   {
-    if (g_model.moduleData[moduleIdx].getMultiProtocol() > MODULE_SUBTYPE_MULTI_LAST) {
+    if (proto > MODULE_SUBTYPE_MULTI_LAST) {
       return true;
     }
     else {
-      return getMultiProtocolDefinition(g_model.moduleData[moduleIdx].getMultiProtocol())->subTypeString != nullptr;
+      auto subProto = getMultiProtocolDefinition(proto);
+      return subProto->subTypeString != nullptr;
     }
   }
 }

--- a/radio/src/telemetry/multi.cpp
+++ b/radio/src/telemetry/multi.cpp
@@ -207,7 +207,6 @@ static void processMultiStatusPacket(const uint8_t * data, uint8_t module, uint8
   // At least two status packets without bind flag
   bool wasBinding = status.isBinding();
 
-  status.lastUpdate = get_tmr10ms();
   status.flags = data[0];
   status.major = data[1];
   status.minor = data[2];
@@ -240,6 +239,9 @@ static void processMultiStatusPacket(const uint8_t * data, uint8_t module, uint8
   
   if (wasBinding && !status.isBinding() && getMultiBindStatus(module) == MULTI_BIND_INITIATED)
     setMultiBindStatus(module, MULTI_BIND_FINISHED);
+
+  // update timestamp last to avoid race conditions
+  status.lastUpdate = get_tmr10ms();
 }
 
 static void processMultiSyncPacket(const uint8_t * data, uint8_t module)

--- a/radio/src/telemetry/multi.h
+++ b/radio/src/telemetry/multi.h
@@ -125,6 +125,13 @@ struct MultiModuleStatus {
   inline bool protocolValid() const { return (bool) (flags & 0x04); }
   inline bool serialMode() const { return (bool) (flags & 0x02); }
   inline bool inputDetected() const { return (bool) (flags & 0x01); }
+
+  inline void invalidate() {
+    lastUpdate = get_tmr10ms() - 500;
+    protocolSubNbr = 0;
+    protocolName[0] = '\0';
+    protocolSubName[0] = '\0';
+  }
 };
 
 MultiModuleStatus& getMultiModuleStatus(uint8_t module);

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -138,6 +138,7 @@ void telemetryWakeup()
     if (!status.isValid()) {
       status.flags = 0;
       status.protocolName[0] = '\0';
+      status.protocolSubNbr = 0;
       uint8_t proto = g_model.moduleData[INTERNAL_MODULE].getMultiProtocol();
       uint8_t subtype = g_model.moduleData[INTERNAL_MODULE].subType;
       switch (proto) {
@@ -145,23 +146,27 @@ void telemetryWakeup()
         strcpy(status.protocolName, "FrSky");
         status.protocolPrev = MODULE_SUBTYPE_MULTI_FRSKY + 1;
         status.protocolNext = MODULE_SUBTYPE_MULTI_FRSKYX2 + 3;
+        status.protocolSubNbr = 8;
         if (subtype != MM_RF_FRSKY_SUBTYPE_D8 && subtype != MM_RF_FRSKY_SUBTYPE_D8_CLONED) {
           status.flags |= 0x20; // failsafe supported
         }
         break;
       case MODULE_SUBTYPE_MULTI_FRSKYX2:
         strcpy(status.protocolName, "FrSkyX2");
+        status.protocolSubNbr = 6;
         status.protocolPrev = MODULE_SUBTYPE_MULTI_FRSKY + 1;
         status.protocolNext = MODULE_SUBTYPE_MULTI_FRSKYL + 3;
         status.flags |= 0x20; // failsafe supported
         break;
       case MODULE_SUBTYPE_MULTI_FRSKYL:
         strcpy(status.protocolName, "FrSkyL");
+        status.protocolSubNbr = 2;
         status.protocolPrev = MODULE_SUBTYPE_MULTI_FRSKYX2 + 3;
         status.protocolNext = MODULE_SUBTYPE_MULTI_FRSKYX_RX + 3;
         break;
       case MODULE_SUBTYPE_MULTI_FRSKYX_RX:
         strcpy(status.protocolName, "FrSkyRX");
+        //status.protocolSubNbr = 2;
         status.protocolPrev = MODULE_SUBTYPE_MULTI_FRSKYL + 3;
         status.protocolNext = proto;
         break;


### PR DESCRIPTION
This implements the dynamic protocol list as returned by the MPM. This is based on scanning the MPM by switching to each protocol in the right order according to previous/next protocol returned by MPM status packets.

At the moment, it takes around 110-120ms per protocol. With the "normal" 4in1 MPM, it takes around 6-7 seconds to fetch the complete list.

TODOs:
- [ ] use dynamic subtypes as well.
- [ ] use sorted static list in case MPM does not reply properly? mostly due to bugs / unplugged module, is it really useful? 
- [ ] nicer animation / text dialog?

