### PR TITLE
Only enable HARDWARE_TOUCH for TX16 & T18 (Horus targets) by default

### DIFF
--- a/radio/src/targets/horus/CMakeLists.txt
+++ b/radio/src/targets/horus/CMakeLists.txt
@@ -157,9 +157,6 @@ set(RADIO_DEPENDENCIES
   truetype_fonts
   )
 
-set(HARDWARE_TOUCH ON)
-set(SOFTWARE_KEYBOARD ON)
-
 set(FIRMWARE_DEPENDENCIES datacopy)
 
 add_definitions(-DPCBHORUS -DSTM32F429_439xx -DSDRAM -DCCMRAM -DCOLORLCD -DHARDWARE_KEYS)
@@ -250,6 +247,7 @@ set(TARGET_SRC
 if(HARDWARE_TOUCH)
   set(TOUCH_DRIVER tp_gt911.cpp i2c_driver.cpp)
   add_definitions(-DHARDWARE_TOUCH)
+  set(SOFTWARE_KEYBOARD ON)
 endif()
 
 if(USB_CHARGER)


### PR DESCRIPTION
As TX16S and T18 are only Horus targets with hardware touch as standard
Also only enable SOFTWARE_KEYBOARD with HARDWARE_TOUCH

- Jumper T16 builds work again with this change
- RM TX16S touch / software keyboard is still functional

Also, a check of my understanding... I beleive CMake only cares about booleans - so does this mean duplicate declarations like 

```
set(HARDWARE_TOUCH YES)

set(HARDWARE_TOUCH ON)
```

could be cleaned up?