### PR TITLE
Lua: make lcd.setColor backward compatible with OpenTX

### DIFF
--- a/radio/src/lua/api_colorlcd.cpp
+++ b/radio/src/lua/api_colorlcd.cpp
@@ -782,8 +782,16 @@ Please notice that changing theme colors affects not only other Lua widgets, but
 static int luaLcdSetColor(lua_State *L)
 {
   unsigned int index = COLOR_VAL(luaL_checkunsigned(L, 1));
-  uint16_t color = COLOR_VAL(flagsRGB(luaL_checkunsigned(L, 2)));
-
+  unsigned int color_arg = luaL_checkunsigned(L, 2);
+  uint16_t color = COLOR_VAL(flagsRGB(color_arg));
+  // make setColor compatible with OpenTX
+  // we check if color_arg is a 16bit value (RGB656 format)
+  // and if so we do not try to convert to RGB888 space
+  // and assume is a legit color index
+  if (color_arg >> 16u == 0) {
+    color = color_arg;
+  }
+  
   if (index < LCD_COLOR_COUNT && lcdColorTable[index] != color) {
     lcdColorTable[index] = color;
     if (index != CUSTOM_COLOR_INDEX)


### PR DESCRIPTION
This makes lcd.setColor() backward compatible with OpenTX, tested with this script

```
local function run(event)
  lcd.setColor(CUSTOM_COLOR, 0x0AB1)
  lcd.clear(CUSTOM_COLOR)
  lcd.setColor(CUSTOM_COLOR, 0xFFFF)
  lcd.drawText(0,0,"WHITE TEXT 0xFFFF",SMLSIZE+CUSTOM_COLOR)
  lcd.setColor(CUSTOM_COLOR, lcd.RGB(0xFF,0xFF,0xFF))
  lcd.drawText(0,20,"WHITE TEXT lcd.RGB()",SMLSIZE+CUSTOM_COLOR)
  lcd.setColor(CUSTOM_COLOR, 0xFFFF8000)
  lcd.drawText(0,40,"WHITE TEXT 0xFFFF8000",SMLSIZE+CUSTOM_COLOR)
  return 0
end

local function init()
end

return {run=run, init=init}
```
![image](https://user-images.githubusercontent.com/30294218/132670333-e494bb19-4ae4-49f5-adde-bbaca0a235c8.png)
