### PR TITLE
Implement tap count for NV14 TP also

### DIFF
--- a/radio/src/targets/nv14/touch_driver.cpp
+++ b/radio/src/targets/nv14/touch_driver.cpp
@@ -1,7 +1,8 @@
 /*
- * Copyright (C) OpenTX
+ * Copyright (C) EdgeTX
  *
  * Based on code named
+ *   opentx - https://github.com/opentx/opentx
  *   th9x - http://code.google.com/p/th9x
  *   er9x - http://code.google.com/p/er9x
  *   gruvin9x - http://code.google.com/p/gruvin9x

--- a/radio/src/targets/nv14/touch_driver.cpp
+++ b/radio/src/targets/nv14/touch_driver.cpp
@@ -524,7 +524,7 @@ void touchPanelRead()
 
   if (ft6x06_TS_DetectTouch(TOUCH_FT6236_I2C_ADDRESS)) {
     handleTouch();
-    if (touchState.event == TE_DOWN)
+    if (touchState.event == TE_DOWN && downTime == 0)
       downTime = now;
   }
   else {
@@ -537,9 +537,11 @@ void touchPanelRead()
           tapCount++;
         touchState.tapCount = tapCount;
         tapTime = now;
+      } else {
+        touchState.tapCount = 0; //not a tap
       }
-    }
-    else {
+      downTime = 0;
+    } else {
       touchState.x = LCD_WIDTH;
       touchState.y = LCD_HEIGHT;
       touchState.event = TE_SLIDE_END;

--- a/radio/src/targets/nv14/touch_driver.cpp
+++ b/radio/src/targets/nv14/touch_driver.cpp
@@ -514,8 +514,7 @@ bool touchPanelEventOccured()
 
 void touchPanelRead()
 {
-  if (!touchEventOccured)
-    return;
+  if (!touchEventOccured) return;
 
   touchEventOccured = false;
 
@@ -524,21 +523,22 @@ void touchPanelRead()
 
   if (ft6x06_TS_DetectTouch(TOUCH_FT6236_I2C_ADDRESS)) {
     handleTouch();
-    if (touchState.event == TE_DOWN && downTime == 0)
+    if (touchState.event == TE_DOWN && downTime == 0) {
       downTime = now;
-  }
-  else {
+    }
+  } else {
     if (touchState.event == TE_DOWN) {
       touchState.event = TE_UP;
       if (now - downTime <= TAP_TIME) {
-        if (now - tapTime > TAP_TIME)
+        if (now - tapTime > TAP_TIME) {
           tapCount = 1;
-        else
+        } else {
           tapCount++;
+        }
         touchState.tapCount = tapCount;
         tapTime = now;
       } else {
-        touchState.tapCount = 0; //not a tap
+        touchState.tapCount = 0;  // not a tap
       }
       downTime = 0;
     } else {


### PR DESCRIPTION
Building on Jespers excellent tap count for the TX16S/T18 targets, this is for the NV14 (_without_ re-writing the handler part of the driver...). 

Double tap is working, ~~but I've just realised the press and hold for menu isn't working~~ press and hold is now working. I haven't verified how the GT911 driver functions, but I gather it only fires the down event once, whereas the ft6x06 on the NV14 continuously fires while pressed, so needed a little more hand-holding. 