### PR TITLE
[color] Dynamic MPM proto list

### DIFF
--- a/radio/src/gui/colorlcd/CMakeLists.txt
+++ b/radio/src/gui/colorlcd/CMakeLists.txt
@@ -93,6 +93,10 @@ if(PXX2 OR MULTIMODULE)
   add_gui_src(radio_spectrum_analyser.cpp)
 endif()
 
+if(MULTIMODULE)
+  add_gui_src(multi_rfprotos.cpp)
+endif()
+
 if(GHOST)
   add_gui_src(radio_ghost_module_config.cpp)
 endif()

--- a/radio/src/gui/colorlcd/multi_rfprotos.cpp
+++ b/radio/src/gui/colorlcd/multi_rfprotos.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "io/multi_protolist.h"
+#include "multi_rfprotos.h"
+#include "strhelpers.h"
+
+#include "progress.h"
+
+// TODO: format for LCD_WIDTH > LCD_HEIGHT
+constexpr rect_t RFSCAN_DIALOG_RECT = {
+  50, 100, LCD_W - 100, LCD_H - 200
+};
+
+// TODO: translation
+const char* RFSCAN_TITLE = "Scanning protocols";
+
+class RfScanDialog : public Dialog
+{
+  MultiRfProtocols* protos;
+  uint32_t lastUpdate = 0;
+
+  Progress* progress;
+  std::function<void()> onClose;
+
+ public:
+  RfScanDialog(Window* parent, MultiRfProtocols* protos,
+               std::function<void()> onClose) :
+      Dialog(parent, RFSCAN_TITLE, RFSCAN_DIALOG_RECT),
+      protos(protos),
+      progress(new Progress(&content->form,
+                            {PAGE_PADDING, PAGE_PADDING,
+                             content->form.width() - 2 * PAGE_PADDING,
+                             content->form.height() - 2 * PAGE_PADDING})),
+      onClose(std::move(onClose))
+  {
+    // disable canceling dialog
+    setCloseWhenClickOutside(false);
+    setFocus();
+  }
+
+  void showProgress()
+  {
+    progress->setValue((int)(protos->getProgress() * 100.0));
+  }
+
+  // disable keys
+  void onEvent(event_t) override { return; }
+  
+  void checkEvents() override
+  {
+    if (!protos->isScanning()) {
+      deleteLater();
+      onClose();
+    } else if (RTOS_GET_MS() - lastUpdate >= 200) {
+      showProgress();
+      lastUpdate = RTOS_GET_MS();
+    }
+    
+    Dialog::checkEvents();
+  }
+};
+
+MultiProtoChoice::MultiProtoChoice(FormGroup* parent, const rect_t& rect,
+                                   unsigned int moduleIdx,
+                                   std::function<void(int)> setValue,
+                                   std::function<void()> updateForm) :
+    Choice(
+        parent, rect, 0, 0,
+        [=] { return g_model.moduleData[moduleIdx].getMultiProtocol(); },
+        setValue),
+    moduleIdx(moduleIdx)
+{
+  TRACE("MultiProtoChoice::MultiProtoChoice(%p)", this);
+  protos = MultiRfProtocols::instance(moduleIdx);
+  protos->triggerScan();
+
+  if (protos->isScanning()) {
+    new RfScanDialog(parent, protos, std::move(updateForm));
+  } else {
+    TRACE("!protos->isScanning()");
+  }
+
+  setTextHandler([=](int value) {
+    return protos->getProtoLabel(value);
+  });
+}
+
+void MultiProtoChoice::openMenu()
+{
+  menu = new Menu(this);
+
+  if (!menuTitle.empty()) menu->setTitle(menuTitle);
+  menu->setCloseHandler([=]() { setEditMode(false); });
+
+  setEditMode(true);
+  invalidate();
+
+  protos->fillList([=](const MultiRfProtocols::RfProto& p){
+      addProto(p.proto, p.label.c_str());
+    });
+
+  int idx = protos->getIndex(g_model.moduleData[moduleIdx].getMultiProtocol());
+  if (idx >= 0) menu->select(idx);
+}
+
+void MultiProtoChoice::addProto(unsigned int proto, const char* protocolName)
+{
+  addValue(protocolName);
+  menu->addLine(protocolName, [=]() { setValue(proto); });
+}
+

--- a/radio/src/gui/colorlcd/multi_rfprotos.cpp
+++ b/radio/src/gui/colorlcd/multi_rfprotos.cpp
@@ -31,7 +31,7 @@ constexpr rect_t RFSCAN_DIALOG_RECT = {
 };
 
 // TODO: translation
-const char* RFSCAN_TITLE = "Scanning protocols";
+const char* RFSCAN_TITLE = "MPM: Scanning protocols...";
 
 class RfScanDialog : public Dialog
 {

--- a/radio/src/gui/colorlcd/multi_rfprotos.h
+++ b/radio/src/gui/colorlcd/multi_rfprotos.h
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+#include "libopenui.h"
+
+class MultiRfProtocols;
+
+class MultiProtoChoice : public Choice
+{
+  unsigned int moduleIdx;
+
+  MultiRfProtocols* protos = nullptr;
+  Menu* menu = nullptr;
+
+ public:
+  MultiProtoChoice(FormGroup *parent, const rect_t &rect, unsigned int moduleIdx,
+                   std::function<void(int)> setValue, std::function<void()> updateForm);
+
+  void openMenu() override;
+  void addProto(unsigned int proto, const char* protocolName);
+
+};
+

--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -952,7 +952,7 @@ const char STR_SUBTYPE_HUBSAN[] =     "\004""H107""H301""H501";
 const char STR_SUBTYPE_FRSKY[] =      "\011""D16\0     ""D8\0      ""D16 8ch\0 ""V8\0      ""LBT(EU)\0 ""LBT 8ch\0 ""D8Cloned\0""D16Cloned";
 const char STR_SUBTYPE_HISKY[] =      "\005""Std\0 ""HK310";
 const char STR_SUBTYPE_V2X2[] =       "\006""Std\0  ""JXD506""MR101\0";
-const char STR_SUBTYPE_DSM[] =        "\004""2 1F""2 2F""X 1F""X 2F";
+const char STR_SUBTYPE_DSM[] =        "\004""2 1F""2 2F""X 1F""X 2F""Auto""R 1F";
 const char STR_SUBTYPE_DEVO[] =       "\004""8ch\0""10ch""12ch""6ch\0""7ch\0";
 const char STR_SUBTYPE_YD717[] =      "\007""Std\0   ""SkyWlkr""Syma X4""XINXUN\0""NIHUI\0 ";
 const char STR_SUBTYPE_KN[] =         "\006""WLtoys""FeiLun";
@@ -1031,7 +1031,7 @@ const mm_protocol_definition multi_protocols[] = {
   {MODULE_SUBTYPE_MULTI_FRSKY,      7, false, false,  STR_SUBTYPE_FRSKY,     STR_MULTI_RFTUNE},
   {MODULE_SUBTYPE_MULTI_HISKY,      1, false, true,   STR_SUBTYPE_HISKY,     nullptr},
   {MODULE_SUBTYPE_MULTI_V2X2,       2, false, false,  STR_SUBTYPE_V2X2,      nullptr},
-  {MODULE_SUBTYPE_MULTI_DSM2,       3, false, true,   STR_SUBTYPE_DSM,       STR_MULTI_MAX_THROW},
+  {MODULE_SUBTYPE_MULTI_DSM2,       5, false, true,   STR_SUBTYPE_DSM,       STR_MULTI_MAX_THROW},
   {MODULE_SUBTYPE_MULTI_DEVO,       4, false, true,   STR_SUBTYPE_DEVO,      STR_MULTI_FIXEDID},
   {MODULE_SUBTYPE_MULTI_YD717,      4, false, false,  STR_SUBTYPE_YD717,     nullptr},
   {MODULE_SUBTYPE_MULTI_KN,         1, false, false,  STR_SUBTYPE_KN,        nullptr},

--- a/radio/src/gui/gui_common.h
+++ b/radio/src/gui/gui_common.h
@@ -274,21 +274,24 @@ inline bool MULTIMODULE_PROTOCOL_KNOWN(uint8_t moduleIdx)
 inline bool MULTIMODULE_HAS_SUBTYPE(uint8_t moduleIdx)
 {
   MultiModuleStatus &status = getMultiModuleStatus(moduleIdx);
+  int proto = g_model.moduleData[moduleIdx].getMultiProtocol();
 
-  if (g_model.moduleData[moduleIdx].getMultiProtocol() == MODULE_SUBTYPE_MULTI_FRSKY) {
+  if (proto == MODULE_SUBTYPE_MULTI_FRSKY) {
     return true;
   }
 
   if (status.isValid()) {
+    TRACE("(%d) status.protocolSubNbr = %d", proto, status.protocolSubNbr);
     return status.protocolSubNbr > 0;
   }
   else
   {
-    if (g_model.moduleData[moduleIdx].getMultiProtocol() > MODULE_SUBTYPE_MULTI_LAST) {
+    if (proto > MODULE_SUBTYPE_MULTI_LAST) {
       return true;
     }
     else {
-      return getMultiProtocolDefinition(g_model.moduleData[moduleIdx].getMultiProtocol())->subTypeString != nullptr;
+      auto subProto = getMultiProtocolDefinition(proto);
+      return subProto->subTypeString != nullptr;
     }
   }
 }

--- a/radio/src/io/multi_firmware_update.cpp
+++ b/radio/src/io/multi_firmware_update.cpp
@@ -32,6 +32,10 @@
   #include "libopenui/src/libopenui_file.h"
 #endif
 
+#if defined(MULTI_PROTOLIST)
+  #include "io/multi_protolist.h"
+#endif
+
 #define UPDATE_MULTI_EXT_BIN ".bin"
 
 class MultiFirmwareUpdateDriver
@@ -648,6 +652,9 @@ bool MultiDeviceFirmwareUpdate::flashFirmware(const char * filename, ProgressHan
 
 #if defined(HARDWARE_INTERNAL_MODULE)
   if (intPwr) {
+#if defined(MULTI_PROTOLIST)
+    MultiRfProtocols::removeInstance(INTERNAL_MODULE);
+#endif
     INTERNAL_MODULE_ON();
     setupPulsesInternalModule();
   }
@@ -655,6 +662,9 @@ bool MultiDeviceFirmwareUpdate::flashFirmware(const char * filename, ProgressHan
 
 #if defined(HARDWARE_EXTERNAL_MODULE)
   if (extPwr) {
+#if defined(MULTI_PROTOLIST)
+    MultiRfProtocols::removeInstance(EXTERNAL_MODULE);
+#endif
     EXTERNAL_MODULE_ON();
     setupPulsesExternalModule();
   }

--- a/radio/src/io/multi_protolist.cpp
+++ b/radio/src/io/multi_protolist.cpp
@@ -1,0 +1,343 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "multi_protolist.h"
+#include "multi_rfprotos.h"
+#include "strhelpers.h"
+#include "audio.h"
+#include "translations.h"
+#include "pulses/modules_helpers.h"
+#include "pulses/pulses.h"
+#include "gui_common.h"
+
+#include "opentx.h" // reusableBuffer
+
+#include <algorithm>
+
+MultiRfProtocols* MultiRfProtocols::_instance[NUM_MODULES] = {};
+
+// MPM telemetry packet format type = MultiProtoDef (0x11)
+//
+// data[0]     = protocol number, 0xFF is an invalid list entry
+//               (Option value too large) and nothing sent after
+// data[1..n]  = protocol name null terminated
+// data[n+1]   = flags
+//                flags>>4 Option text number to be displayed
+//                         (check multi status for description)
+//                flags&0x01 failsafe supported
+//                flags&0x02 Channel Map Disabled supported
+// data[n+2]   = number of sub protocols
+// data[n+3]   = sub protocols text length, only sent if nbr_sub != 0
+// data[n+4..] = sub protocol names, only sent if nbr_sub != 0
+
+constexpr uint8_t MULTI_INVALID_PROTO = 0xFF;
+constexpr uint32_t MULTI_PROTOLIST_TIMEOUT = 100; // 100ms
+constexpr uint32_t MULTI_PROTOLIST_START_TIMEOUT = 3000; // 3s
+
+bool MultiRfProtocols::RfProto::parse(const uint8_t* data, uint8_t len)
+{
+  const char* s = (const char*)data;
+
+  uint8_t subProtoNr = 0;
+  uint8_t subProtoLen = 0;
+
+  // special case handling for Frsky protos
+  if (proto == MODULE_SUBTYPE_MULTI_FRSKY) {
+    const mm_protocol_definition* def = getMultiProtocolDefinition(proto);
+    if (!def) return false;
+
+    label = "Frsky";
+    flags = 0x20;
+    subProtoNr = def->maxSubtype + 1;
+    subProtoLen = def->subTypeString[0];
+    s = def->subTypeString + 1;
+
+  } else {
+    // proto label string
+    while (*s && len--) s++;
+    if (*s || !len) return false;
+    label = (const char*)data;
+    s++;
+    len--;
+
+    // flags, subProtoNr, subProto label max length
+    if (len < 2) return false;
+    flags = (uint8_t) * (s++);
+    //TRACE("flags: 0x%02X", flags);
+
+    subProtoNr = (uint8_t) * (s++);
+    len -= 2;
+
+    if (!len) return true;
+    subProtoLen = (uint8_t) * (s++);
+    len--;
+
+    if (len < subProtoNr * subProtoLen) return false;
+  }
+
+  fillSubProtoList(s, subProtoNr, subProtoLen);
+  return true;
+}
+
+void MultiRfProtocols::RfProto::fillSubProtoList(const char* str, int n, int len)
+{
+  char tmp[len + 1];
+  subProtos.reserve(n);
+
+  for (int i = 0; i < n; i++, str += len) {
+    strncpy(tmp, str, len);
+    tmp[len] = '\0';
+    subProtos.emplace_back((const char*)tmp);
+    //TRACE("%s: '%s'", label.c_str(), subProtos.back().c_str());
+  }
+}
+
+uint8_t MultiRfProtocols::RfProto::getOption() const
+{
+  uint8_t opt = flags >> 4;
+  if (opt >= getMaxMultiOptions()) {
+    opt = 1; // Unknown options are defaulted to type 1 (basic option)
+  }
+  return opt;
+}
+
+const char* MultiRfProtocols::RfProto::getOptionStr() const
+{
+  return mm_options_strings::options[getOption()];
+}
+
+MultiRfProtocols* MultiRfProtocols::instance(unsigned int moduleIdx)
+{
+  if (moduleIdx >= NUM_MODULES) return nullptr;
+  if (!_instance[moduleIdx]) {
+    _instance[moduleIdx] = new MultiRfProtocols(moduleIdx);
+  }
+  return _instance[moduleIdx];
+}
+
+void MultiRfProtocols::removeInstance(unsigned int moduleIdx)
+{
+  delete _instance[moduleIdx];
+  _instance[moduleIdx] = nullptr;
+}
+
+int MultiRfProtocols::getIndex(unsigned int proto) const
+{
+  auto it = proto2idx.find(proto);
+  return it != proto2idx.end() ? it->second : -1;
+}
+
+const MultiRfProtocols::RfProto* MultiRfProtocols::getProto(unsigned int proto) const
+{
+  int idx = getIndex(proto);
+  if (idx >= 0 && (unsigned)idx < protoList.size())
+    return &protoList[idx];
+
+  return nullptr;
+}
+
+std::string MultiRfProtocols::getProtoLabel(unsigned int proto) const
+{
+  if (scanState != ScanEnd) {
+    MultiModuleStatus& status = getMultiModuleStatus(moduleIdx);
+    if (status.protocolName[0] && status.isValid()) {
+      return std::string(status.protocolName);
+    } else if (proto <= MODULE_SUBTYPE_MULTI_LAST) {
+      char tmp[8];
+      getStringAtIndex(tmp, STR_MULTI_PROTOCOLS, proto);
+      return std::string(tmp);
+    }
+  } else {
+    int idx = getIndex(proto);
+    if (idx >= 0 && (unsigned)idx < protoList.size()) {
+      return protoList[idx].label;
+    }
+  }
+  return std::string();
+}
+
+std::string MultiRfProtocols::getLastProtoLabel() const
+{
+  if (!protoList.empty())
+    return protoList.back().label;
+
+  return std::string();
+}
+
+float MultiRfProtocols::getProgress() const
+{
+  constexpr float WAIT_TIME_RATIO = 0.7; // wait time accounts for 70%
+  constexpr float PROTOS_RATIO = 1.0 - WAIT_TIME_RATIO;
+  
+  if (scanState == ScanStop)  return 0.0;
+  if (scanState == ScanBegin) {
+    float t = (float)(RTOS_GET_MS() - scanStart) / (float)MULTI_PROTOLIST_START_TIMEOUT;
+    return t * WAIT_TIME_RATIO;
+  }
+
+  return WAIT_TIME_RATIO + ((float)getNProtos() / (float)totalProtos) * PROTOS_RATIO;
+}
+
+void MultiRfProtocols::fillList(std::function<void(const RfProto&)> addProto) const
+{
+  for (const auto& p : protoList) {
+    addProto(p);
+  }
+}
+
+bool MultiRfProtocols::triggerScan()
+{
+  if (scanState == ScanStop) {
+    proto2idx.clear();
+    protoList.clear();
+    scanState = ScanBegin;
+    moduleState[moduleIdx].mode = MODULE_MODE_GET_HARDWARE_INFO;
+    moduleState[moduleIdx].counter = MULTI_INVALID_PROTO;
+    scanStart = lastScan = RTOS_GET_MS();
+    return true;
+  }
+
+  return false;
+}
+
+bool MultiRfProtocols::scanReply(const uint8_t* packet, uint8_t len)
+{
+  switch (scanState) {
+    case ScanBegin:
+    case Scanning:
+      if (packet && len) {
+        uint8_t replyProtoId = *packet;
+        len--;
+        packet++;
+
+        // new status received
+        if (replyProtoId != MULTI_INVALID_PROTO) {
+          if (moduleState[moduleIdx].counter == MULTI_INVALID_PROTO) {
+            //TRACE("# of protos: %d", totalProtos);
+            totalProtos = replyProtoId;
+            scanState = Scanning;
+            protoList.reserve(totalProtos);
+          } else {
+            //TRACE("Proto = %d; label = '%s'", replyProtoId,
+            //      (const char*)packet);
+
+            int proto = convertMultiToOtx(replyProtoId);
+            if (proto != MODULE_SUBTYPE_MULTI_CONFIG &&
+                proto != MODULE_SUBTYPE_MULTI_SCANNER) {
+              bool insertProto = true;
+              if (proto == MODULE_SUBTYPE_MULTI_FRSKY) {
+                auto it = std::find_if(protoList.begin(), protoList.end(),
+                                       [=](const RfProto& p) {
+                                         return p.proto == (const int)proto;
+                                       });
+                if (it != protoList.end()) {
+                  // FRSKY proto already added
+                  insertProto = false;
+                }
+              }
+
+              if (insertProto) {
+                RfProto rfProto(proto);
+                if (rfProto.parse(packet, len)) {
+                  proto2idx[proto] = protoList.size();
+                  protoList.emplace_back(rfProto);
+                } else {
+                  TRACE("Error parsing proto [%d]", proto);
+                }
+              }
+            } else {
+              // do not count excluded protocols
+              totalProtos--;
+            }
+          }
+
+          moduleState[moduleIdx].counter++;
+          lastScan = RTOS_GET_MS();
+          return true;
+
+        } else {
+          scanState = ScanEnd;
+          setModuleMode(moduleIdx, MODULE_MODE_NORMAL);
+          break;
+        }
+      } else {
+        uint32_t timeout = MULTI_PROTOLIST_TIMEOUT;
+
+        if (scanState == ScanBegin) {
+          // Timeout = 3s solely because of the very slow start time of the
+          // MPM...
+          timeout = MULTI_PROTOLIST_START_TIMEOUT;
+        }
+
+        if (RTOS_GET_MS() - lastScan >= timeout) {
+          TRACE("proto scan timeout!");
+          scanState = ScanInvalid;
+        }
+      }
+      break;
+
+    case ScanInvalid: {
+      // TODO: fill with static list (sorted)
+      const mm_protocol_definition* pdef =
+          getMultiProtocolDefinition(MODULE_SUBTYPE_MULTI_FIRST);
+
+      // build the list of static protos
+      protoList.clear();
+      protoList.reserve(MODULE_SUBTYPE_MULTI_LAST - MODULE_SUBTYPE_MULTI_FIRST + 1);
+      for (; pdef->protocol != 0xfe; pdef++) {
+        RfProto rfProto(pdef->protocol);
+
+        char tmp[8];
+        rfProto.label =
+            getStringAtIndex(tmp, STR_MULTI_PROTOCOLS, pdef->protocol);
+        rfProto.flags =
+            (pdef->failsafe ? 0x01 : 0) | (pdef->disable_ch_mapping ? 0x02 : 0);
+
+        if (pdef->subTypeString) {
+          int st_len = pdef->subTypeString[0];
+          const char* s = pdef->subTypeString + 1;
+
+          rfProto.fillSubProtoList(s, pdef->maxSubtype + 1, st_len);
+        }
+
+        protoList.emplace_back(rfProto);
+      }
+
+      // sort it by label
+      std::sort(
+          protoList.begin(), protoList.end(),
+          [](const RfProto& a, const RfProto& b) { return a.label < b.label; });
+
+      // index the sorted list
+      proto2idx.clear();
+      for (unsigned int i = 0; i < protoList.size(); i++)
+        proto2idx[protoList[i].proto] = i;
+
+      scanState = ScanEnd;
+      setModuleMode(moduleIdx, MODULE_MODE_NORMAL);
+    } break;
+
+    default:
+      break;
+  }
+
+  return false;
+}

--- a/radio/src/io/multi_protolist.h
+++ b/radio/src/io/multi_protolist.h
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "dataconstants.h"
+#include "opentx_types.h"
+
+#include <functional>
+#include <string>
+#include <vector>
+#include <map>
+
+class MultiRfProtocols
+{
+  static MultiRfProtocols* _instance[NUM_MODULES];
+
+  unsigned int moduleIdx;
+
+  enum ScanState { ScanStop, ScanBegin, Scanning, ScanInvalid, ScanEnd };
+
+  ScanState scanState = ScanStop;
+
+  uint32_t scanStart = 0;
+  uint32_t lastScan = 0;
+  uint8_t totalProtos = 0;
+
+  MultiRfProtocols(unsigned int moduleIdx) : moduleIdx(moduleIdx) {}
+
+ public:
+
+  struct RfProto {
+    int proto;
+    std::string label;
+
+    uint8_t flags = 0;
+    std::vector<std::string> subProtos;
+
+    RfProto(int proto) : proto(proto) {}
+
+    bool parse(const uint8_t* data, uint8_t len);
+    void fillSubProtoList(const char* str, int n, int len);
+
+    uint8_t getOption() const;
+    const char* getOptionStr() const;
+    
+    bool supportsFailsafe() const { return flags & 0x01; }
+    bool supportsDisableMapping() const { return flags & 0x02; }
+  };
+
+  static MultiRfProtocols* instance(unsigned int moduleIdx);
+  static void removeInstance(unsigned int moduleIdx);
+
+  int getIndex(unsigned int proto) const;
+  const RfProto* getProto(unsigned int proto) const;
+  std::string getProtoLabel(unsigned int proto) const;
+
+  bool isScanning() const { return scanState != ScanStop && scanState != ScanEnd; }
+  int  getNProtos() const { return protoList.size(); }
+  int  getTotalProtos() const { return totalProtos; }
+  float getProgress() const;
+
+  std::string getLastProtoLabel() const;
+  bool triggerScan();
+
+  bool scanReply(const uint8_t * packet = nullptr, uint8_t len = 0);
+  void fillList(std::function<void(const RfProto&)> addProto) const;
+
+ private:
+  std::vector<RfProto> protoList;
+  std::map<int,int>    proto2idx;
+};

--- a/radio/src/pulses/pulses.cpp
+++ b/radio/src/pulses/pulses.cpp
@@ -22,6 +22,7 @@
 #include "io/frsky_pxx2.h"
 #include "pulses/pxx2.h"
 #include "mixer_scheduler.h"
+#include "io/multi_protolist.h"
 
 uint8_t s_pulses_paused = 0;
 ModuleState moduleState[NUM_MODULES];
@@ -291,6 +292,9 @@ void enablePulsesExternalModule(uint8_t protocol)
 #endif
       getMultiModuleStatus(EXTERNAL_MODULE).failsafeChecked = false;
       getMultiModuleStatus(EXTERNAL_MODULE).flags = 0;
+#if defined(MULTI_PROTOLIST)
+      MultiRfProtocols::instance(EXTERNAL_MODULE)->triggerScan();
+#endif
       break;
 #endif
 
@@ -468,6 +472,9 @@ static void enablePulsesInternalModule(uint8_t protocol)
       mixerSchedulerSetPeriod(INTERNAL_MODULE, MULTIMODULE_PERIOD);
       getMultiModuleStatus(INTERNAL_MODULE).failsafeChecked = false;
       getMultiModuleStatus(INTERNAL_MODULE).flags = 0;
+#if defined(MULTI_PROTOLIST)
+      MultiRfProtocols::instance(EXTERNAL_MODULE)->triggerScan();
+#endif
       break;
 #endif
 

--- a/radio/src/storage/storage_common.cpp
+++ b/radio/src/storage/storage_common.cpp
@@ -19,7 +19,13 @@
  */
 
 #include "opentx.h"
-#include "pulses/multi.h"
+
+#if defined(MULTIMODULE)
+  #include "pulses/multi.h"
+  #if defined(MULTI_PROTOLIST)
+    #include "io/multi_protolist.h"
+  #endif
+#endif
 
 uint8_t   storageDirtyMsk;
 tmr10ms_t storageDirtyTime10ms;
@@ -159,6 +165,9 @@ void postModelLoad(bool alarms)
 #if defined(MULTIMODULE)
   else if (isModuleMultimodule(EXTERNAL_MODULE))
     multiPatchCustom(EXTERNAL_MODULE);
+#if defined(MULTI_PROTOLIST)
+  MultiRfProtocols::removeInstance(EXTERNAL_MODULE);
+#endif
 #endif
 
   AUDIO_FLUSH();

--- a/radio/src/targets/horus/CMakeLists.txt
+++ b/radio/src/targets/horus/CMakeLists.txt
@@ -303,11 +303,17 @@ if(BOOTLOADER)
     )
 endif()
 
-set(SRC
-  ${SRC}
+set(SRC ${SRC}
   io/frsky_firmware_update.cpp
   io/multi_firmware_update.cpp
   )
+
+if (MULTIMODULE)
+  add_definitions(-DMULTI_PROTOLIST)
+  set(SRC ${SRC}
+    io/multi_protolist.cpp
+    )
+endif()
 
 set(STM32LIB_SRC
   STM32F4xx_StdPeriph_Driver/src/stm32f4xx_sdio.c

--- a/radio/src/targets/nv14/CMakeLists.txt
+++ b/radio/src/targets/nv14/CMakeLists.txt
@@ -152,6 +152,13 @@ set(SRC
   io/multi_firmware_update.cpp
   )
 
+if (MULTIMODULE)
+  add_definitions(-DMULTI_PROTOLIST)
+  set(SRC ${SRC}
+    io/multi_protolist.cpp
+    )
+endif()
+
 set(STM32LIB_SRC
   STM32F4xx_StdPeriph_Driver/src/stm32f4xx_sdio.c
   STM32F4xx_StdPeriph_Driver/src/stm32f4xx_fmc.c

--- a/radio/src/telemetry/multi.h
+++ b/radio/src/telemetry/multi.h
@@ -125,6 +125,13 @@ struct MultiModuleStatus {
   inline bool protocolValid() const { return (bool) (flags & 0x04); }
   inline bool serialMode() const { return (bool) (flags & 0x02); }
   inline bool inputDetected() const { return (bool) (flags & 0x01); }
+
+  inline void invalidate() {
+    lastUpdate = get_tmr10ms() - 500;
+    protocolSubNbr = 0;
+    protocolName[0] = '\0';
+    protocolSubName[0] = '\0';
+  }
 };
 
 MultiModuleStatus& getMultiModuleStatus(uint8_t module);
@@ -137,6 +144,9 @@ enum MultiBindStatus : uint8_t {
 
 uint8_t getMultiBindStatus(uint8_t module);
 void setMultiBindStatus(uint8_t module, uint8_t bindStatus);
+
+bool isMultiModeScanning(uint8_t module);
+bool isMultiTelemReceiving(uint8_t module);
 
 void checkFailsafeMulti();
 

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -22,6 +22,7 @@
 #include "multi.h"
 #include "pulses/afhds3.h"
 #include "mixer_scheduler.h"
+#include "io/multi_protolist.h"
 
 #if defined(LIBOPENUI)
   #include "libopenui.h"
@@ -137,6 +138,11 @@ void telemetryWakeup()
       LOG_TELEMETRY_WRITE_BYTE(data);
     } while (intmoduleFifo.pop(data));
   }
+#if defined(MULTI_PROTOLIST)
+  if (MultiRfProtocols::instance(INTERNAL_MODULE)->isScanning()) {
+    MultiRfProtocols::instance(INTERNAL_MODULE)->scanReply();
+  }
+#endif
 #endif
 
 #if defined(STM32)
@@ -147,6 +153,14 @@ void telemetryWakeup()
       LOG_TELEMETRY_WRITE_BYTE(data);
     } while (telemetryGetByte(&data));
   }
+
+#if defined(MULTI_PROTOLIST)
+  if (isModuleMultimodule(EXTERNAL_MODULE) &&
+      MultiRfProtocols::instance(EXTERNAL_MODULE)->isScanning()) {    
+    MultiRfProtocols::instance(EXTERNAL_MODULE)->scanReply();    
+  }
+#endif
+  
 #elif defined(PCBSKY9X)
   if (telemetryProtocol == PROTOCOL_TELEMETRY_FRSKY_D_SECONDARY) {
     while (telemetrySecondPortReceive(data)) {


### PR DESCRIPTION
This is implementing a new and better method as in #682.

## Description

Previously, the dynamic proto list used was based on the status packet returned by the MPM after switching to a protocol. It would return basically the previous/next protocol number, and a couple of attributes. However, when populating the protocol drop-down on ETX, this would have required to switch to each and every protocol to know those valid and the order. Due to the fact that the MPM would physically enable this protocol first (thus reseting all the radio chips, etc), it was very slow.

The new protocol implemented by Pascal to fetch the list is much faster. It is uses the proto number `0` and returns upon request a full description of the protocol queried:
```
MPM telemetry packet format type = MultiProtoDef (0x11)

data[0]     = protocol number, 0xFF is an invalid list entry
              (Option value too large) and nothing sent after
data[1..n]  = protocol name null terminated
data[n+1]   = flags
               flags>>4 Option text number to be displayed
                        (check multi status for description)
               flags&0x01 failsafe supported
               flags&0x02 Channel Map Disabled supported
data[n+2]   = number of sub protocols
data[n+3]   = sub protocols text length, only sent if nbr_sub != 0
data[n+4..] = sub protocol names, only sent if nbr_sub != 0
```

All together, this now takes around 1.2s to fetch all the protocols (83):
<img width="1165" alt="Screenshot 2021-09-11 at 10 54 49" src="https://user-images.githubusercontent.com/1050031/132942377-9a051b2e-77e7-4f2b-a5a8-bb71a0db7479.png">

The protocols are fetched on 3 occasions:
- When the module is enabled for the first time (either on boot or after the module has been turned ON).
- After a model change for the external module.
- After a MPM firmware upgrade (either module).

As you would expect, this PR requires the latest MPM firmware (not released yet). You can test using the latest from `master` by fetching the latest build from the `actions` on the MPM github repository (https://github.com/pascallanger/DIY-Multiprotocol-TX-Module/actions).

Until that code is released and you installed that latest release, the MPM status will display `Update recommended`. The target MPM release is `1.3.3.0`.

When the protocol list is fetched, you will see a progress bar that will prevent you from using the model setup screen until the operation has completed. This might happen after booting if you go straight to the model setup screen, or when you enable the MPM.

## Caveat

If the protocol list cannot be fetch for whatever reasons, the static list as stored in the ETX code will be used and might not be accurate.

As the module takes ages to start and be responsive, it might take up to 3s (normally 2s) for the module to be operational. Here is a diagram showing the timeline when switching the module on:
<img width="1105" alt="Screenshot 2021-09-11 at 11 04 16" src="https://user-images.githubusercontent.com/1050031/132942601-58c8c5c5-a859-477d-9bb5-b2242a237282.png">
