### PR TITLE
Lua widgets

### DIFF
--- a/radio/src/gui/colorlcd/widget.cpp
+++ b/radio/src/gui/colorlcd/widget.cpp
@@ -30,7 +30,6 @@
 #endif
 
 constexpr uint32_t WIDGET_FOCUS_TIMEOUT = 10*1000; // 10 seconds
-constexpr uint32_t FULLSCREEN_HINT_DELAY = 5*1000; //  5 seconds
 
 static void openWidgetMenu(Widget * parent)
 {
@@ -125,11 +124,6 @@ void Widget::paint(BitmapBuffer * dc)
     }
     dc->drawRect(0, 0, width(), height(), 2, STASHED, COLOR_THEME_FOCUS);
   }
-
-  if (fullscreen && (RTOS_GET_MS() - fsStartedTS < FULLSCREEN_HINT_DELAY)) {
-    dc->drawText(width() / 2, height() / 2, "Press [RTN] long to exit",
-                 FONT(XL) | CENTERED | VCENTERED | COLOR_THEME_PRIMARY3);
-  }
 }
 
 #if defined(HARDWARE_KEYS)
@@ -186,7 +180,6 @@ void Widget::setFullscreen(bool fullscreen)
     setRect(parent->getRect());
     setLeft(parent->getScrollPositionX());
     this->fullscreen = true;
-    fsStartedTS = RTOS_GET_MS();
     bringToTop();
   }
 }

--- a/radio/src/gui/colorlcd/widget.h
+++ b/radio/src/gui/colorlcd/widget.h
@@ -111,7 +111,6 @@ class Widget : public Button
     PersistentData * persistentData;
     uint32_t focusGainedTS = 0;
     bool fullscreen = false;
-    uint32_t fsStartedTS = 0;
 };
 
 void registerWidget(const WidgetFactory * factory);

--- a/radio/src/lua/api_colorlcd.cpp
+++ b/radio/src/lua/api_colorlcd.cpp
@@ -22,10 +22,11 @@
 #include <cstdio>
 #include "opentx.h"
 #include "libopenui.h"
-
+#include "widget.h"
 #include "api_colorlcd.h"
 
 BitmapBuffer* luaLcdBuffer  = nullptr;
+Widget* runningFS = nullptr;
  
 static int8_t getTextHorizontalOffset(LcdFlags flags)
 {
@@ -1216,6 +1217,25 @@ static int luaLcdDrawHudRectangle(lua_State *L)
   return 0;
 }
 
+/*luadoc
+@function lcd.exitFullScreen()
+
+Exit full screen widget mode.
+
+@notice Only available on radios with color display
+
+@status current Introduced in 2.5.0
+*/
+static int luaLcdExitFullScreen(lua_State *L)
+{
+  if (runningFS) {
+    Widget* rfs = runningFS;
+    runningFS = nullptr;
+    rfs->setFullscreen(false);
+  }
+  return 0;
+}
+
 const luaL_Reg lcdLib[] = {
   { "refresh", luaLcdRefresh },
   { "clear", luaLcdClear },
@@ -1246,5 +1266,6 @@ const luaL_Reg lcdLib[] = {
   { "drawAnnulus", luaLcdDrawAnnulus },
   { "drawLineWithClipping", luaLcdDrawLineWithClipping },
   { "drawHudRectangle", luaLcdDrawHudRectangle },
+  { "exitFullScreen", luaLcdExitFullScreen },
   { NULL, NULL }  /* sentinel */
 };

--- a/radio/src/lua/api_colorlcd.h
+++ b/radio/src/lua/api_colorlcd.h
@@ -39,5 +39,6 @@ constexpr int8_t text_vertical_offset[7] {2,2,0,2,3,3,7};
 
 extern bool           luaLcdAllowed;
 extern BitmapBuffer * luaLcdBuffer;
+extern Widget *       runningFS;
 
 LcdFlags flagsRGB(LcdFlags flags);

--- a/radio/src/lua/widgets.cpp
+++ b/radio/src/lua/widgets.cpp
@@ -100,20 +100,6 @@ void luaSetInstructionsLimit(lua_State * L, int count)
 #endif
 }
 
-void exec(int function, int nresults=0)
-{
-  if (lsWidgets == 0) return;
-
-  if (function) {
-    luaSetInstructionsLimit(lsWidgets, WIDGET_SCRIPTS_MAX_INSTRUCTIONS);
-    lua_rawgeti(lsWidgets, LUA_REGISTRYINDEX, function);
-    if (lua_pcall(lsWidgets, 0, nresults, 0) != 0) {
-      TRACE("Error in theme  %s", lua_tostring(lsWidgets, -1));
-      // TODO disable theme - revert back to default theme???
-    }
-  }
-}
-
 ZoneOption * createOptionsArray(int reference, uint8_t maxOptions)
 {
   if (reference == 0) {

--- a/radio/src/lua/widgets.cpp
+++ b/radio/src/lua/widgets.cpp
@@ -515,10 +515,12 @@ void LuaWidget::refresh(BitmapBuffer* dc)
   // This little hack is needed to not interfere with the LCD usage of preempted scripts
   bool lla = luaLcdAllowed;
   luaLcdAllowed = true;
+  runningFS = this;
 
   if (lua_pcall(lsWidgets, 3, 0, 0) != 0) {
     setErrorMessage("refresh()");
   }
+  runningFS = nullptr;
   // Remove LCD
   luaLcdAllowed = lla;
   luaLcdBuffer = nullptr;
@@ -537,9 +539,11 @@ void LuaWidget::background()
   if (factory->backgroundFunction) {
     lua_rawgeti(lsWidgets, LUA_REGISTRYINDEX, factory->backgroundFunction);
     lua_rawgeti(lsWidgets, LUA_REGISTRYINDEX, luaWidgetDataRef);
+    runningFS = this;
     if (lua_pcall(lsWidgets, 1, 0, 0) != 0) {
       setErrorMessage("background()");
     }
+    runningFS = nullptr;
   }
 }
 


### PR DESCRIPTION
Added Lua function lcd.exitFullScreen().
Removed full screen message "Press [RTN] long to exit".
Removed unused function exec().
Set error message when script fails in create().