### PR TITLE
Slave/Jack - more channels, Bluetooth/Slave bug fix

### DIFF
--- a/radio/src/bluetooth.cpp
+++ b/radio/src/bluetooth.cpp
@@ -151,7 +151,7 @@ void Bluetooth::processTrainerFrame(const uint8_t * buffer)
 {
   BLUETOOTH_TRACE(CRLF);
 
-  for (uint8_t channel=0, i=1; channel<8; channel+=2, i+=3) {
+  for (uint8_t channel=0, i=1; channel<BLUETOOTH_TRAINER_CHANNELS; channel+=2, i+=3) {
     // +-500 != 512, but close enough.
     ppmInput[channel] = buffer[i] + ((buffer[i+1] & 0xf0) << 4) - 1500;
     ppmInput[channel+1] = ((buffer[i+1] & 0x0f) << 4) + ((buffer[i+2] & 0xf0) >> 4) + ((buffer[i+2] & 0x0f) << 8) - 1500;
@@ -251,7 +251,7 @@ void Bluetooth::sendTrainer()
   int16_t PPM_range = g_model.extendedLimits ? 640*2 : 512*2;
 
   int firstCh = g_model.trainerData.channelsStart;
-  int lastCh = firstCh + 8;
+  int lastCh = firstCh + BLUETOOTH_TRAINER_CHANNELS;
 
   uint8_t * cur = buffer;
   bufferIndex = 0;

--- a/radio/src/bluetooth.cpp
+++ b/radio/src/bluetooth.cpp
@@ -259,7 +259,7 @@ void Bluetooth::sendTrainer()
 
   buffer[bufferIndex++] = START_STOP; // start byte
   pushByte(TRAINER_FRAME);
-  for (int channel=0; channel<lastCh; channel+=2, cur+=3) {
+  for (int channel=firstCh; channel<lastCh; channel+=2, cur+=3) {
     uint16_t channelValue1 = PPM_CH_CENTER(channel) + limit((int16_t)-PPM_range, channelOutputs[channel], (int16_t)PPM_range) / 2;
     uint16_t channelValue2 = PPM_CH_CENTER(channel+1) + limit((int16_t)-PPM_range, channelOutputs[channel+1], (int16_t)PPM_range) / 2;
     pushByte(channelValue1 & 0x00ff);

--- a/radio/src/bluetooth.h
+++ b/radio/src/bluetooth.h
@@ -48,6 +48,7 @@ enum BluetoothStates {
 #define MAX_BLUETOOTH_DISTANT_ADDR      6
 #define BLUETOOTH_PACKET_SIZE           14
 #define BLUETOOTH_LINE_LENGTH           32
+#define BLUETOOTH_TRAINER_CHANNELS      8
 
 #if defined(LOG_BLUETOOTH)
   #define BLUETOOTH_TRACE(...)  \

--- a/radio/src/dataconstants.h
+++ b/radio/src/dataconstants.h
@@ -46,6 +46,8 @@
   #define MAX_SPECIAL_FUNCTIONS        64 // number of functions assigned to switches
   #define MAX_SCRIPTS                  9
   #define MAX_INPUTS                   32
+  #define MIN_TRAINER_CHANNELS         4
+  #define DEF_TRAINER_CHANNELS         8
   #define MAX_TRAINER_CHANNELS         16
   #define MAX_TELEMETRY_SENSORS        60
   #define MAX_CUSTOM_SCREENS           5
@@ -59,6 +61,8 @@
   #define MAX_SPECIAL_FUNCTIONS        64 // number of functions assigned to switches
   #define MAX_SCRIPTS                  7
   #define MAX_INPUTS                   32
+  #define MIN_TRAINER_CHANNELS         4
+  #define DEF_TRAINER_CHANNELS         8
   #define MAX_TRAINER_CHANNELS         16
   #define MAX_TELEMETRY_SENSORS        60
 #elif defined(PCBTARANIS)
@@ -71,6 +75,8 @@
   #define MAX_SPECIAL_FUNCTIONS        64 // number of functions assigned to switches
   #define MAX_SCRIPTS                  7
   #define MAX_INPUTS                   32
+  #define MIN_TRAINER_CHANNELS         4
+  #define DEF_TRAINER_CHANNELS         8
   #define MAX_TRAINER_CHANNELS         16
   #define MAX_TELEMETRY_SENSORS        40
 #else

--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -584,11 +584,11 @@ class TrainerModuleWindow : public FormGroup
                        COLOR_THEME_PRIMARY1);
         channelStart = new NumberEdit(
             this, grid.getFieldSlot(2, 0), 1,
-            MAX_OUTPUT_CHANNELS - 8 + g_model.trainerData.channelsCount + 1,
+            MAX_OUTPUT_CHANNELS - BLUETOOTH_TRAINER_CHANNELS + 1,
             GET_DEFAULT(1 + g_model.trainerData.channelsStart));
         char chend[6];
         snprintf(chend, sizeof(chend), "%s%d", STR_CH,
-                 g_model.trainerData.channelsStart + 8);
+                 g_model.trainerData.channelsStart + BLUETOOTH_TRAINER_CHANNELS);
 
         btChannelEnd = new StaticText(this, grid.getFieldSlot(2, 1), chend, 0,
                                       COLOR_THEME_PRIMARY1);
@@ -597,7 +597,7 @@ class TrainerModuleWindow : public FormGroup
           g_model.trainerData.channelsStart = newValue - 1;
           char chend[6];
           snprintf(chend, sizeof(chend), "%s%d", STR_CH,
-                   g_model.trainerData.channelsStart + 8);
+                   g_model.trainerData.channelsStart + BLUETOOTH_TRAINER_CHANNELS);
           SET_DIRTY();
           btChannelEnd->setText(chend);
         });

--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -606,37 +606,36 @@ class TrainerModuleWindow : public FormGroup
       } else
 #endif
           if (g_model.trainerData.mode == TRAINER_MODE_SLAVE) {
+        #define PPMCH_START_MIN 1
+        #define PPMCH_START_MAX (MAX_OUTPUT_CHANNELS - g_model.trainerData.channelsCount + 1 - DEF_TRAINER_CHANNELS)
+        #define PPMCH_END_MIN (g_model.trainerData.channelsStart + MIN_TRAINER_CHANNELS)
+        #define PPMCH_END_MAX min<uint8_t>(g_model.trainerData.channelsStart + MAX_TRAINER_CHANNELS, MAX_OUTPUT_CHANNELS)
+
         new StaticText(this, grid.getLabelSlot(true), STR_CHANNELRANGE, 0,
                        COLOR_THEME_PRIMARY1);
         channelStart = new NumberEdit(
-            this, grid.getFieldSlot(2, 0), 1,
-            MAX_OUTPUT_CHANNELS - 8 + g_model.trainerData.channelsCount + 1,
+            this, grid.getFieldSlot(2, 0), PPMCH_START_MIN, PPMCH_START_MAX,
             GET_DEFAULT(1 + g_model.trainerData.channelsStart));
-        channelEnd =
-            new NumberEdit(this, grid.getFieldSlot(2, 1),
-                           g_model.trainerData.channelsStart + 1,
-                           min<int8_t>(MAX_TRAINER_CHANNELS,
-                                       g_model.trainerData.channelsStart +
-                                           MAX_TRAINER_CHANNELS_M8),
-                           GET_DEFAULT(g_model.trainerData.channelsStart + 8 +
-                                       g_model.trainerData.channelsCount));
+        channelEnd = new NumberEdit(
+            this, grid.getFieldSlot(2, 1), PPMCH_END_MIN, PPMCH_END_MAX,
+            GET_DEFAULT((g_model.trainerData.channelsStart +
+                         DEF_TRAINER_CHANNELS +
+                         g_model.trainerData.channelsCount)));
         channelStart->setPrefix(STR_CH);
         channelEnd->setPrefix(STR_CH);
         channelStart->setSetValueHandler([=](int32_t newValue) {
           g_model.trainerData.channelsStart = newValue - 1;
           SET_DIRTY();
-          channelEnd->setMin(g_model.trainerData.channelsStart + 1);
-          channelEnd->setMax(min<int8_t>(
-              MAX_TRAINER_CHANNELS,
-              g_model.trainerData.channelsStart + MAX_TRAINER_CHANNELS_M8));
+          channelEnd->setMin(PPMCH_END_MIN);
+          channelEnd->setMax(PPMCH_END_MAX);
           channelEnd->invalidate();
         });
         channelEnd->setSetValueHandler([=](int32_t newValue) {
           g_model.trainerData.channelsCount =
-              newValue - g_model.trainerData.channelsStart - 8;
+              newValue - g_model.trainerData.channelsStart -
+              DEF_TRAINER_CHANNELS;
           SET_DIRTY();
-          channelStart->setMax(MAX_TRAINER_CHANNELS - 8 +
-                               g_model.trainerData.channelsCount + 1);
+          channelStart->setMax(PPMCH_START_MAX);
         });
 
         grid.nextLine();

--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -595,6 +595,7 @@ class TrainerModuleWindow : public FormGroup
         channelStart->setPrefix(STR_CH);
         channelStart->setSetValueHandler([=](int32_t newValue) {
           g_model.trainerData.channelsStart = newValue - 1;
+          g_model.trainerData.channelsCount = BLUETOOTH_TRAINER_CHANNELS - DEF_TRAINER_CHANNELS;
           char chend[6];
           snprintf(chend, sizeof(chend), "%s%d", STR_CH,
                    g_model.trainerData.channelsStart + BLUETOOTH_TRAINER_CHANNELS);

--- a/radio/src/translations/untranslated.h
+++ b/radio/src/translations/untranslated.h
@@ -173,7 +173,7 @@
 #define TR_AFHDS3_POWERS               "25 mW\0""100 mW""500 mW""1 W\0  ""2 W\0  "
 
 #define LEN_PPM_POL                    "\001"
-#define TR_PPM_POL                     "+""-"
+#define TR_PPM_POL                     "-""+"
 
 #define LEN_SBUS_INVERSION_VALUES      "\014"
 #define TR_SBUS_INVERSION_VALUES       "normal\0     ""not inverted"


### PR DESCRIPTION
I have modified the GUI so that you can select between 4-16 channels of PPM output channels with values adjustable in dataconstants.h, on color LCD.. B/W still uses fixed values.

Also found a bug in Bluetooth/Slave where if you choose a starting channel slave/jack other than 1 then switch to slave/bluetooth the data isn't sent **properly** anymore. Also a bug of mine where you could set the start channel on BT higher MAX_OUTPUT_CHANNELS should have gone ;)

I did notice that the PPM polarity is backwards (EdgeTX Tx16s) & (OpenTX/Taranis) (Should it be flipped?)

On EdgeTX (**ColorLCD**), With + polarity you get,
![image](https://user-images.githubusercontent.com/281145/133186980-9640d30a-2700-4264-819b-5af710832091.png)

On OpenTx with + polarity you get,
![image](https://user-images.githubusercontent.com/281145/133187073-1f8d635e-d300-4a12-983c-594113967924.png)
