### PR TITLE
Correctly turn off or restore MPM to normal after running spectrum analyser

### DIFF
--- a/radio/src/gui/colorlcd/radio_spectrum_analyser.cpp
+++ b/radio/src/gui/colorlcd/radio_spectrum_analyser.cpp
@@ -1,7 +1,8 @@
 /*
- * Copyright (C) OpenTX
+ * Copyright (C) EdgeTX
  *
  * Based on code named
+ *   opentx - https://github.com/opentx/opentx
  *   th9x - http://code.google.com/p/th9x
  *   er9x - http://code.google.com/p/er9x
  *   gruvin9x - http://code.google.com/p/gruvin9x

--- a/radio/src/gui/colorlcd/radio_spectrum_analyser.cpp
+++ b/radio/src/gui/colorlcd/radio_spectrum_analyser.cpp
@@ -270,11 +270,9 @@ void RadioSpectrumAnalyser::stop()
         &reusableBuffer.moduleSetup.pxx2.moduleInformation, PXX2_HW_INFO_TX_ID,
         PXX2_HW_INFO_TX_ID);
   } else if (isModuleMultimodule(moduleIdx)) {
-    if (reusableBuffer.spectrumAnalyser.moduleOFF) {
+    moduleState[moduleIdx].mode = MODULE_MODE_NORMAL;
+    if (reusableBuffer.spectrumAnalyser.moduleOFF)
       setModuleType(INTERNAL_MODULE, MODULE_TYPE_NONE);
-    } else {
-      moduleState[moduleIdx].mode = MODULE_MODE_NORMAL;
-    }
   }
   /* wait 1s to resume normal operation before leaving */
   //  watchdogSuspend(1000);

--- a/radio/src/gui/colorlcd/radio_spectrum_analyser.cpp
+++ b/radio/src/gui/colorlcd/radio_spectrum_analyser.cpp
@@ -206,6 +206,16 @@ RadioSpectrumAnalyser::RadioSpectrumAnalyser(uint8_t moduleIdx) :
   start();
 }
 
+#if defined(HARDWARE_KEYS)
+void RadioSpectrumAnalyser::onEvent(event_t event)
+{
+  if (event == EVT_KEY_LONG(KEY_EXIT) || event == EVT_KEY_BREAK(KEY_EXIT)) {
+    stop();
+  }
+  Page::onEvent(event);
+}
+#endif
+
 void RadioSpectrumAnalyser::buildHeader(Window * window)
 {
   new StaticText(window, {PAGE_TITLE_LEFT, PAGE_TITLE_TOP + 10, LCD_W - PAGE_TITLE_LEFT, PAGE_LINE_HEIGHT}, STR_MENU_SPECTRUM_ANALYSER, 0, COLOR_THEME_SECONDARY1);

--- a/radio/src/gui/colorlcd/radio_spectrum_analyser.cpp
+++ b/radio/src/gui/colorlcd/radio_spectrum_analyser.cpp
@@ -226,6 +226,8 @@ void RadioSpectrumAnalyser::init()
   if (moduleIdx == INTERNAL_MODULE &&
       g_model.moduleData[INTERNAL_MODULE].type == MODULE_TYPE_NONE) {
     reusableBuffer.spectrumAnalyser.moduleOFF = true;
+    // this needs to be set BEFORE the module is set to prevent proto list scanning
+    moduleState[moduleIdx].mode = MODULE_MODE_SPECTRUM_ANALYSER;
     setModuleType(INTERNAL_MODULE, MODULE_TYPE_MULTIMODULE);
   } else {
     reusableBuffer.spectrumAnalyser.moduleOFF = false;

--- a/radio/src/gui/colorlcd/radio_spectrum_analyser.h
+++ b/radio/src/gui/colorlcd/radio_spectrum_analyser.h
@@ -27,6 +27,7 @@ class RadioSpectrumAnalyser: public Page
 {
   public:
     explicit RadioSpectrumAnalyser(uint8_t moduleIdx);
+    void onEvent(event_t event) override;
 
   protected:
     uint8_t moduleIdx;

--- a/radio/src/gui/colorlcd/radio_spectrum_analyser.h
+++ b/radio/src/gui/colorlcd/radio_spectrum_analyser.h
@@ -27,7 +27,6 @@ class RadioSpectrumAnalyser: public Page
 {
   public:
     explicit RadioSpectrumAnalyser(uint8_t moduleIdx);
-    void onEvent(event_t event) override;
 
   protected:
     uint8_t moduleIdx;

--- a/radio/src/io/multi_protolist.cpp
+++ b/radio/src/io/multi_protolist.cpp
@@ -205,7 +205,9 @@ void MultiRfProtocols::fillList(std::function<void(const RfProto&)> addProto) co
 
 bool MultiRfProtocols::triggerScan()
 {
-  if (scanState == ScanStop) {
+  if (scanState == ScanStop
+      && moduleState[moduleIdx].mode == MODULE_MODE_NORMAL) {
+
     proto2idx.clear();
     protoList.clear();
     scanState = ScanBegin;


### PR DESCRIPTION
Resolves #465 

Adds a `closeHandler` to _actually_ run the spectrum analyser stop code, as well as remove now non-functional "stopping" dialog message. 

Additionally, always remember the MPM on or off state, not just the on state, so that it is correctly handed on stop. 

And finally, always return module back to normal state - otherwise if you had the MPM off, use the spectrum analyser, and then turn it on, it will be stuck in analyser mode. :-O

Have had TX16S going in and out of analyser using touch and keys, MPM on and off, and has been working perfectl, so just needs sanity checking and some more testing please!