### PR TITLE
Fixes EX3 and EX4 bug caused by myself

### DIFF
--- a/radio/src/dataconstants.h
+++ b/radio/src/dataconstants.h
@@ -604,6 +604,10 @@ enum MixSources {
 #if defined(PCBX10)
   MIXSRC_EXT1,                          LUA_EXPORT("ext1", "Ext 1")
   MIXSRC_EXT2,                          LUA_EXPORT("ext2", "Ext 2")
+#if defined(RADIO_TX16S) && defined(FLYSKY_HALL_STICKS)
+  MIXSRC_EXT3,                          LUA_EXPORT("ext3", "Ext 3")
+  MIXSRC_EXT4,                          LUA_EXPORT("ext4", "Ext 4")
+#endif
 #endif
   MIXSRC_FIRST_SLIDER SKIP,
 #if defined(PCBX12S)


### PR DESCRIPTION
Resolves #736 when FlySky hall sticks are built into firmware.

Before this bugfix:
![BeforeBugfix](https://user-images.githubusercontent.com/21011587/133603459-75bcc082-39d5-4cd2-8f08-f69fdae462fe.png)

After this bugfix:
![AfterBugfix](https://user-images.githubusercontent.com/21011587/133603478-ecc73cf3-eaab-4c9a-b226-aa337adc0714.png)
