### PR TITLE
[color] use own protocol counter for MPM proto list

### DIFF
--- a/radio/src/io/multi_protolist.cpp
+++ b/radio/src/io/multi_protolist.cpp
@@ -211,8 +211,8 @@ bool MultiRfProtocols::triggerScan()
     proto2idx.clear();
     protoList.clear();
     scanState = ScanBegin;
+    currentProto = MULTI_INVALID_PROTO;
     moduleState[moduleIdx].mode = MODULE_MODE_GET_HARDWARE_INFO;
-    moduleState[moduleIdx].counter = MULTI_INVALID_PROTO;
     scanStart = lastScan = RTOS_GET_MS();
     return true;
   }
@@ -232,7 +232,7 @@ bool MultiRfProtocols::scanReply(const uint8_t* packet, uint8_t len)
 
         // new status received
         if (replyProtoId != MULTI_INVALID_PROTO) {
-          if (moduleState[moduleIdx].counter == MULTI_INVALID_PROTO) {
+          if (currentProto == MULTI_INVALID_PROTO) {
             //TRACE("# of protos: %d", totalProtos);
             totalProtos = replyProtoId;
             scanState = Scanning;
@@ -271,7 +271,7 @@ bool MultiRfProtocols::scanReply(const uint8_t* packet, uint8_t len)
             }
           }
 
-          moduleState[moduleIdx].counter++;
+          currentProto++;
           lastScan = RTOS_GET_MS();
           return true;
 

--- a/radio/src/io/multi_protolist.h
+++ b/radio/src/io/multi_protolist.h
@@ -39,6 +39,7 @@ class MultiRfProtocols
 
   uint32_t scanStart = 0;
   uint32_t lastScan = 0;
+  uint8_t currentProto = 0;
   uint8_t totalProtos = 0;
 
   MultiRfProtocols(unsigned int moduleIdx) : moduleIdx(moduleIdx) {}
@@ -78,6 +79,7 @@ class MultiRfProtocols
 
   std::string getLastProtoLabel() const;
   bool triggerScan();
+  uint8_t getScanProto() { return currentProto; }
 
   bool scanReply(const uint8_t * packet = nullptr, uint8_t len = 0);
   void fillList(std::function<void(const RfProto&)> addProto) const;

--- a/radio/src/pulses/multi.cpp
+++ b/radio/src/pulses/multi.cpp
@@ -177,8 +177,11 @@ void setupPulsesMulti(uint8_t moduleIdx)
     sendChannels(moduleIdx);
 
   // Multi V1.3.X.X -> Send byte 26, Protocol (bits 7 & 6), RX_Num (bits 5 & 4), invert, not used, disable telemetry, disable mapping
-  if ((moduleState[moduleIdx].mode == MODULE_MODE_SPECTRUM_ANALYSER) ||
-      (moduleState[moduleIdx].mode == MODULE_MODE_GET_HARDWARE_INFO)) {
+  if ((moduleState[moduleIdx].mode == MODULE_MODE_SPECTRUM_ANALYSER)
+#if defined(MULTI_PROTOLIST)
+      || (moduleState[moduleIdx].mode == MODULE_MODE_GET_HARDWARE_INFO)
+#endif
+      ) {
     sendMulti(moduleIdx, invert[moduleIdx] & 0x08);
   }
   else {
@@ -371,17 +374,19 @@ void sendFrameProtocolHeader(uint8_t moduleIdx, bool failsafe)
     return;
   }
 
+#if defined(MULTI_PROTOLIST)
   if (moduleMode == MODULE_MODE_GET_HARDWARE_INFO) {
     sendMulti(moduleIdx, (uint8_t) 0x55); // Header byte
     sendMulti(moduleIdx, (uint8_t) 0);    // PROTOLIST custom protocol
     sendMulti(moduleIdx, (uint8_t) 0);
 
     // proto array item
-    uint8_t protoIdx = moduleState[moduleIdx].counter;
+    uint8_t protoIdx = MultiRfProtocols::instance(moduleIdx)->getScanProto();
     TRACE("scan [%d]", protoIdx);
     sendMulti(moduleIdx, protoIdx);
     return;
   }
+#endif
 
   if (moduleMode == MODULE_MODE_BIND)
     protoByte |= MULTI_SEND_BIND;

--- a/radio/src/pulses/pulses.cpp
+++ b/radio/src/pulses/pulses.cpp
@@ -473,7 +473,9 @@ static void enablePulsesInternalModule(uint8_t protocol)
       getMultiModuleStatus(INTERNAL_MODULE).failsafeChecked = false;
       getMultiModuleStatus(INTERNAL_MODULE).flags = 0;
 #if defined(MULTI_PROTOLIST)
+      TRACE("enablePulsesInternalModule(): trigger scan");
       MultiRfProtocols::instance(INTERNAL_MODULE)->triggerScan();
+      TRACE("counter = %d", moduleState[INTERNAL_MODULE].counter);
 #endif
       break;
 #endif


### PR DESCRIPTION
Overloading the frame counter causes aa race condition with the UI thread (see SEND_FAILSAFE_1S()).