### PR TITLE
[nv14] Fix translation strings used

### DIFF
--- a/radio/src/translations.h
+++ b/radio/src/translations.h
@@ -74,8 +74,8 @@
 #endif
 
 #if LCD_W < LCD_H    // Portrait mode
-  #define TR3(x, y, z) x
-  #define TR2(x, y) x
+  #define TR3(x, y, z) z
+  #define TR2(x, y) y
 #elif LCD_W >= 480
   #define TR3(x, y, z) z
   #define TR2(x, y) y


### PR DESCRIPTION
Strings defined for "x" (shortest) are mostly defined if "LCD_W < 212", which is not the case for the NV14, thus leading to faulty static strings (see TR_VFSWRESET in en.h.txt translation for example).

Resolves #756 