### PR TITLE
Removes FlySky digital hall gimbal double value conversion

### DIFF
--- a/radio/src/gui/colorlcd/radio_diaganas.cpp
+++ b/radio/src/gui/colorlcd/radio_diaganas.cpp
@@ -59,7 +59,7 @@ class RadioAnalogsDiagsWindow: public Window {
           dc->drawNumber(x, y, i + 1, LEADING0 | LEFT, 2);
           dc->drawText(x + 2 * 15 - 2, y, ":");
           dc->drawNumber(x + 3 * 15 - 1, y, hall_raw_values[i], LEFT);
-          dc->drawNumber(x + ANA_OFFSET, y, hall_adc_values[i], RIGHT);
+          dc->drawNumber(x + ANA_OFFSET, y, (int16_t) calibratedAnalogs[CONVERT_MODE(i)] * 25 / 256, RIGHT);
         }
 
         for (uint8_t i = FLYSKY_HALL_CHANNEL_COUNT; i < NUM_STICKS + NUM_POTS + NUM_SLIDERS; i++) {

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1020,7 +1020,11 @@ void checkTrims()
 }
 
 #if !defined(SIMU)
+#if defined(FLYSKY_HALL_STICKS)
+uint32_t s_anaFilt[NUM_ANALOGS];
+#else
 uint16_t s_anaFilt[NUM_ANALOGS];
+#endif
 #endif
 
 #if defined(JITTER_MEASURE)
@@ -1064,9 +1068,8 @@ void getADC()
   DEBUG_TIMER_STOP(debugTimerAdcRead);
 
   for (uint8_t x=0; x<NUM_ANALOGS; x++) {
-    uint16_t v;
-
 #if defined(FLYSKY_HALL_STICKS)
+    uint32_t v;
     if (x < 4) {
       v = get_flysky_hall_adc_value(x) >> (1 - ANALOG_SCALE);
     } else {
@@ -1085,6 +1088,7 @@ void getADC()
       #endif
     }
 #else
+    uint16_t v;
     v = getAnalogValue(x) >> (1 - ANALOG_SCALE);
 #endif
 
@@ -1122,8 +1126,13 @@ void getADC()
     // Variables mapping:
     //   * <in> = v
     //   * <out> = s_anaFilt[x]
+#if defined(FLYSKY_HALL_STICKS)
+    uint32_t previous = s_anaFilt[x] / JITTER_ALPHA;
+    uint32_t diff = (v > previous) ? (v - previous) : (previous - v);
+#else
     uint16_t previous = s_anaFilt[x] / JITTER_ALPHA;
     uint16_t diff = (v > previous) ? (v - previous) : (previous - v);
+#endif
     if (!g_eeGeneral.jitterFilter && diff < (10*ANALOG_MULTIPLIER)) { // g_eeGeneral.jitterFilter is inverted, 0 - active
       // apply jitter filter
       s_anaFilt[x] = (s_anaFilt[x] - previous) + v;

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1020,11 +1020,7 @@ void checkTrims()
 }
 
 #if !defined(SIMU)
-#if defined(FLYSKY_HALL_STICKS)
 uint32_t s_anaFilt[NUM_ANALOGS];
-#else
-uint16_t s_anaFilt[NUM_ANALOGS];
-#endif
 #endif
 
 #if defined(JITTER_MEASURE)
@@ -1068,8 +1064,8 @@ void getADC()
   DEBUG_TIMER_STOP(debugTimerAdcRead);
 
   for (uint8_t x=0; x<NUM_ANALOGS; x++) {
-#if defined(FLYSKY_HALL_STICKS)
     uint32_t v;
+#if defined(FLYSKY_HALL_STICKS)
     if (x < 4) {
       v = get_flysky_hall_adc_value(x) >> (1 - ANALOG_SCALE);
     } else {
@@ -1088,7 +1084,6 @@ void getADC()
       #endif
     }
 #else
-    uint16_t v;
     v = getAnalogValue(x) >> (1 - ANALOG_SCALE);
 #endif
 
@@ -1126,13 +1121,8 @@ void getADC()
     // Variables mapping:
     //   * <in> = v
     //   * <out> = s_anaFilt[x]
-#if defined(FLYSKY_HALL_STICKS)
     uint32_t previous = s_anaFilt[x] / JITTER_ALPHA;
     uint32_t diff = (v > previous) ? (v - previous) : (previous - v);
-#else
-    uint16_t previous = s_anaFilt[x] / JITTER_ALPHA;
-    uint16_t diff = (v > previous) ? (v - previous) : (previous - v);
-#endif
     if (!g_eeGeneral.jitterFilter && diff < (10*ANALOG_MULTIPLIER)) { // g_eeGeneral.jitterFilter is inverted, 0 - active
       // apply jitter filter
       s_anaFilt[x] = (s_anaFilt[x] - previous) + v;

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -1280,11 +1280,7 @@ extern Clipboard clipboard;
 #endif
 
 #if !defined(SIMU)
-#if defined(FLYSKY_HALL_STICKS)
 extern uint32_t s_anaFilt[NUM_ANALOGS];
-#else
-extern uint16_t s_anaFilt[NUM_ANALOGS];
-#endif
 #endif
 
 #if defined(JITTER_MEASURE)

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -1280,7 +1280,11 @@ extern Clipboard clipboard;
 #endif
 
 #if !defined(SIMU)
+#if defined(FLYSKY_HALL_STICKS)
+extern uint32_t s_anaFilt[NUM_ANALOGS];
+#else
 extern uint16_t s_anaFilt[NUM_ANALOGS];
+#endif
 #endif
 
 #if defined(JITTER_MEASURE)

--- a/radio/src/targets/horus/flyskyHallStick_driver.h
+++ b/radio/src/targets/horus/flyskyHallStick_driver.h
@@ -23,28 +23,10 @@
 #define FLYSKY_HALL_BAUDRATE            ( 921600 )
 #define FLYSKY_HALL_CHANNEL_COUNT       ( 4 )
 
-#define MAX_ADC_CHANNEL_VALUE           ( 4095 )
-#define MIN_ADC_CHANNLE_VALUE           ( 0 )
-#define MIDDLE_ADC_CHANNLE_VALUE        ( 2047 )
+#define FLYSKY_OFFSET_VALUE             ( 16384 )
 
 #define FLYSKY_HALL_PROTOLO_HEAD        0x55
-#define FLYSKY_HALL_RESP_TYPE_CALIB     0x0e
 #define FLYSKY_HALL_RESP_TYPE_VALUES    0x0c
-#define FLYSKY_HALL_ERROR_OFFSET        10
-
-typedef  struct
-{
-  signed short min;
-  signed short mid;
-  signed short max;
-} STRUCT_STICK_CALIBRATION;
-
-typedef  struct
-{
-  STRUCT_STICK_CALIBRATION sticksCalibration[4];
-  unsigned char reststate;
-  unsigned short CRC16;
-} STRUCT_STICK_CALIBRATION_PACK;
 
 typedef  struct
 {
@@ -53,12 +35,6 @@ typedef  struct
   unsigned short CRC16;
 } STRUCT_CHANNEL_PACK;
 
-typedef  union
-{
-  STRUCT_STICK_CALIBRATION_PACK channelPack;
-  STRUCT_CHANNEL_PACK sticksCalibrationPack;
-} UNION_DATA;
-
 typedef  struct
 {
   unsigned char start;
@@ -66,7 +42,7 @@ typedef  struct
   unsigned char receiverID:2;
   unsigned char packetID:4;
   unsigned char length;
-  UNION_DATA    payload;
+  STRUCT_CHANNEL_PACK payload;
 } STRUCT_HALLDATA;
 
 typedef  struct


### PR DESCRIPTION
Removes FlySky digital hall gimbal double value conversion. The existing code was first using the FlySky factory calibration values min,mid and max to convert the gimbal +/- ca. 2500 input signal to 0 to 4095. Second, this value was converted again into EdgeTX internal 11-bit range 0 to 2047.

The removal of such double conversion has the added benefit of precision increase and also avoiding unnecessary computation. The code also does not need to read out the FlySky factory calibration values at all anymore - these are close, but not perfectly matching the real min, mid, max values, as I tested.
I needed to change internally some variables from uint16_t to uint32_t, as the jitter removal computation would otherwise go over the 16-bit range due to the resolution increase of the FlySky digital hall gimbals, when compared to std. analog sticks with 12-bit only (+/- ca. 2500 vs. 12-bit std. ADC of 0 to 4096). ~As 16-bit computation can be left for "normal" sticks, added a special define just for FLYSKY_HALL_STICKS.~

In addition this PR changes back the radio analogs diagnose page second column also for FlySky digital hall sticks to show +/- 100, as with this PR, with the data in the first and the second column we already cover all internal ranges used (thus should also solve the issues reported end of #618)

Tested on RM TX16S with FlySky digital hall sticks.

@richardclli and/or @pfeerick could you please review - thank you!

**For anyone wanting to test this - due to new value range of the sticks, you need to re-calibrate the sticks after flashing the firmware of this PR!**