### PR TITLE
Nv14-screen-width-fixes

### DIFF
--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -304,16 +304,12 @@ class ModelCategoryPageBody : public FormWindow
 
       index++;
 
-#if LCD_W > LCD_H
       if (index % MODEL_CELLS_PER_LINE == 0) {
         x = MODEL_CELL_PADDING;
         y += MODEL_SELECT_CELL_HEIGHT + MODEL_CELL_PADDING;
       } else {
         x += MODEL_CELL_PADDING + MODEL_SELECT_CELL_WIDTH;
       }
-#else
-      y += MODEL_SELECT_CELL_HEIGHT + MODEL_CELL_PADDING;
-#endif
     }
 
     if (index % MODEL_CELLS_PER_LINE != 0) {

--- a/radio/src/gui/colorlcd/radio_version.cpp
+++ b/radio/src/gui/colorlcd/radio_version.cpp
@@ -214,16 +214,9 @@ void RadioVersionPage::build(FormWindow * window)
   // Radio type
   new StaticText(window, grid.getLineSlot(), fw_stamp, 0, COLOR_THEME_PRIMARY1);
   grid.nextLine();
-#if LCD_W > LCD_H
-  new StaticText(window, grid.getLineSlot(), vers_stamp, 0, COLOR_THEME_PRIMARY1);
-#else
-  memcpy(reusableBuffer.version.id, vers_stamp, strcspn(vers_stamp, " "));
-  new StaticText(window, grid.getFieldSlot(), reusableBuffer.version.id, 0, COLOR_THEME_PRIMARY1);
-  grid.nextLine();
 
-  strAppend(reusableBuffer.version.id, strpbrk(vers_stamp, " "));
-  new StaticText(window, grid.getFieldSlot(), reusableBuffer.version.id, 0, COLOR_THEME_PRIMARY1);
-#endif
+  // Firmware version
+  new StaticText(window, grid.getLineSlot(), vers_stamp, 0, COLOR_THEME_PRIMARY1);
   grid.nextLine();
 
   // Firmware date


### PR DESCRIPTION
Fixes version string on SYS menu having been deliberately (but unnecessarily) indented on NV14.

Also fix only one column of models being shown on NV14 model select screen when there was room for two ;) Resolves #636

![image](https://user-images.githubusercontent.com/5500713/134095843-6a528156-a4ff-4c89-aa42-4e44bbb698e4.png)

![image](https://user-images.githubusercontent.com/5500713/134096076-45316767-7283-4cca-9bcc-74c1f32ae782.png)

