### PR TITLE
[bw] set multi binding mode only if multimodule

### DIFF
--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -1432,7 +1432,8 @@ void menuModelSetup(event_t event)
             }
             uint8_t newFlag = 0;
 #if defined(MULTIMODULE)
-            if (getMultiBindStatus(moduleIdx) == MULTI_BIND_FINISHED) {
+            if (isModuleMultimodule(moduleIdx) &&
+                getMultiBindStatus(moduleIdx) == MULTI_BIND_FINISHED) {
               setMultiBindStatus(moduleIdx, MULTI_BIND_NONE);
               s_editMode = 0;
             }
@@ -1488,11 +1489,11 @@ void menuModelSetup(event_t event)
             moduleState[moduleIdx].mode = newFlag;
 
 #if defined(MULTIMODULE)
-            if (newFlag == MODULE_MODE_BIND) {
+            if (isModuleMultimodule(moduleIdx) &&
+                (newFlag == MODULE_MODE_BIND)) {
               setMultiBindStatus(moduleIdx, MULTI_BIND_INITIATED);
             }
 #endif
-
           }
         }
         break;

--- a/radio/src/gui/212x64/model_setup.cpp
+++ b/radio/src/gui/212x64/model_setup.cpp
@@ -1255,7 +1255,8 @@ void menuModelSetup(event_t event)
             }
             uint8_t newFlag = 0;
 #if defined(MULTIMODULE)
-            if (getMultiBindStatus(moduleIdx) == MULTI_BIND_FINISHED) {
+            if (isModuleMultimodule(moduleIdx) &&
+                getMultiBindStatus(moduleIdx) == MULTI_BIND_FINISHED) {
               setMultiBindStatus(moduleIdx, MULTI_BIND_NONE);
               s_editMode = 0;
             }
@@ -1294,7 +1295,8 @@ void menuModelSetup(event_t event)
             }
             moduleState[moduleIdx].mode = newFlag;
 #if defined(MULTIMODULE)
-            if (newFlag == MODULE_MODE_BIND) {
+            if (isModuleMultimodule(moduleIdx) &&
+                (newFlag == MODULE_MODE_BIND)) {
               setMultiBindStatus(moduleIdx, MULTI_BIND_INITIATED);
             }
 #endif


### PR DESCRIPTION
This should fix the annoying sound continuing after binding has been completed on D8 / D16 internal XJT (and maybe others).