### PR TITLE
double tap exits full screen widget mode (#821)

### DIFF
--- a/radio/src/gui/colorlcd/widget.cpp
+++ b/radio/src/gui/colorlcd/widget.cpp
@@ -76,6 +76,10 @@ bool Widget::onTouchEnd(coord_t x, coord_t y)
 
   if (fullscreen) {
     //TODO: forward to widget (lua for instance)
+
+    if(touchState.tapCount > 1) {
+      setFullscreen(false);
+    }
     return true;
   }
 


### PR DESCRIPTION
Double tap on the full screen widget returns to main screen.
Fix #821 