### PR TITLE
Make 'back' hitbox bigger for touch

### DIFF
--- a/radio/src/gui/colorlcd/page.cpp
+++ b/radio/src/gui/colorlcd/page.cpp
@@ -26,7 +26,7 @@ PageHeader::PageHeader(Page * parent, uint8_t icon):
   FormGroup(parent, { 0, 0, LCD_W, MENU_HEADER_HEIGHT }, OPAQUE),
   icon(icon)
 #if defined(HARDWARE_TOUCH)
-  , back(this, { 0, 0, MENU_HEADER_BUTTON_WIDTH, MENU_HEADER_BUTTON_WIDTH },
+  , back(this, { 0, 0, MENU_HEADER_BACK_BUTTON_WIDTH, MENU_HEADER_BACK_BUTTON_HEIGHT },
        [=]() -> uint8_t {
          parent->deleteLater();
          return 0;

--- a/radio/src/gui/colorlcd/tabsgroup.cpp
+++ b/radio/src/gui/colorlcd/tabsgroup.cpp
@@ -32,7 +32,7 @@
 TabsGroupHeader::TabsGroupHeader(TabsGroup * parent, uint8_t icon):
   FormGroup(parent, { 0, 0, LCD_W, MENU_BODY_TOP }, OPAQUE),
 #if defined(HARDWARE_TOUCH)
-  back(this, { 0, 0, MENU_HEADER_BUTTON_WIDTH, MENU_HEADER_BUTTON_WIDTH },
+  back(this, { 0, 0, MENU_HEADER_BACK_BUTTON_WIDTH, MENU_HEADER_BACK_BUTTON_HEIGHT },
        [=]() -> uint8_t {
          parent->deleteLater();
          ViewMain::instance()->setFocus((SET_FOCUS_DEFAULT));

--- a/radio/src/targets/horus/libopenui_config.h
+++ b/radio/src/targets/horus/libopenui_config.h
@@ -61,6 +61,9 @@ constexpr uint32_t MENU_FOOTER_TOP =               LCD_H - MENU_FOOTER_HEIGHT;
 constexpr uint32_t MENU_BODY_HEIGHT =              MENU_FOOTER_TOP - MENU_BODY_TOP;
 constexpr uint32_t MENUS_MARGIN_LEFT =             6;
 
+constexpr uint32_t MENU_HEADER_BACK_BUTTON_WIDTH  = MENU_HEADER_HEIGHT;
+constexpr uint32_t MENU_HEADER_BACK_BUTTON_HEIGHT = MENU_HEADER_HEIGHT;
+
 constexpr coord_t PAGE_PADDING =                   6;
 constexpr uint32_t PAGE_LINE_HEIGHT =              20;
 constexpr uint32_t PAGE_LINE_SPACING =             2;

--- a/radio/src/targets/nv14/libopenui_config.h
+++ b/radio/src/targets/nv14/libopenui_config.h
@@ -61,6 +61,9 @@ constexpr uint32_t MENU_FOOTER_TOP =               LCD_H - MENU_FOOTER_HEIGHT;
 constexpr uint32_t MENU_BODY_HEIGHT =              MENU_FOOTER_TOP - MENU_BODY_TOP;
 constexpr uint32_t MENUS_MARGIN_LEFT =             6;
 
+constexpr uint32_t MENU_HEADER_BACK_BUTTON_WIDTH  = MENU_HEADER_HEIGHT;
+constexpr uint32_t MENU_HEADER_BACK_BUTTON_HEIGHT = MENU_HEADER_HEIGHT;
+
 constexpr coord_t  PAGE_PADDING =                  6;
 constexpr uint32_t PAGE_LINE_HEIGHT =              20;
 constexpr uint32_t PAGE_LINE_SPACING =             2;


### PR DESCRIPTION
Make it so the invisible 'back' hitbox is bigger, and not linked to header icon size since it's a different sized icon. 

Has been bugging me since #609 ;)