### PR TITLE
Use correct index on 128 B&W radios for MPM status

### DIFF
--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -1802,7 +1802,7 @@ void menuModelSetup(event_t event)
 #endif
       {
         lcdDrawTextAlignedLeft(y, STR_MODULE_STATUS);
-        getModuleStatusString(EXTERNAL_MODULE, reusableBuffer.moduleSetup.msg);
+        getModuleStatusString(moduleIdx, reusableBuffer.moduleSetup.msg);
         lcdDrawText(MODEL_SETUP_2ND_COLUMN, y, reusableBuffer.moduleSetup.msg);
         break;
       }


### PR DESCRIPTION
Fixes #656

Looks to be a copy and paste error from the 212x64 radios