### PR TITLE
Fix shift in NV14 switches during Companion import and export

### DIFF
--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -390,7 +390,10 @@ int Boards::getCapability(Board::Type board, Board::Capability capability)
       return getCapability(board, Board::Sticks) + getCapability(board, Board::Pots) + getCapability(board, Board::Sliders) + getCapability(board, Board::MouseAnalogs) + getCapability(board, Board::GyroAnalogs);
 
     case MultiposPots:
-      return IS_HORUS_OR_TARANIS(board) ? getCapability(board, Board::Pots) : 0;
+      if (IS_HORUS_OR_TARANIS(board) && !IS_FLYSKY_NV14(board))
+        return getCapability(board, Board::Pots);
+      else
+        return 0;
 
     case MultiposPotsPositions:
       return IS_HORUS_OR_TARANIS(board) ? 6 : 0;

--- a/companion/src/firmwares/opentx/opentxeeprom.cpp
+++ b/companion/src/firmwares/opentx/opentxeeprom.cpp
@@ -101,6 +101,15 @@ inline int MAX_POTS_SOURCES(Board::Type board, int version)
   return Boards::getCapability(board, Board::Pots);
 }
 
+inline int MAX_XPOTS(Board::Type board, int version)
+{
+  if (version <= 218 && IS_FAMILY_HORUS_OR_T16(board))
+    return 3;
+  if (IS_FAMILY_T12(board))
+    return 2;
+  return Boards::getCapability(board, Board::MultiposPots);
+}
+
 inline int MAX_SLIDERS_STORAGE(Board::Type board, int version)
 {
   if (version >= 219 && (IS_FAMILY_HORUS_OR_T16(board) && !IS_FLYSKY_NV14(board)))
@@ -195,7 +204,7 @@ class SwitchesConversionTable: public ConversionTable {
       }
 
       if (IS_HORUS_OR_TARANIS(board)) {
-        for (int i=1; i<=MAX_POTS(board, version)*6; i++) {
+        for (int i=1; i<=MAX_XPOTS(board, version)*6; i++) {
           addConversion(RawSwitch(SWITCH_TYPE_MULTIPOS_POT, -i), -val+offset);
           addConversion(RawSwitch(SWITCH_TYPE_MULTIPOS_POT, i), val++);
         }


### PR DESCRIPTION
Fixes #814
Cause NV14 has no multi position pots
Companion and Simulator testing:
- no shifts for new models created using TS16S, X9D+ and NV14 profiles
- using NV14 profile importing and converting TS16S models and settings
- using X9D+ profile importing and converting NV14 models and settings
