### PR TITLE
Fix display in mixes screen the user  script name

### DIFF
--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -443,7 +443,8 @@ char * getSourceString(char * dest, mixsrc_t idx)
     if (qr.quot < MAX_SCRIPTS && qr.rem < scriptInputsOutputs[qr.quot].outputsCount) {
       *dest++ = CHAR_LUA;
       // *dest++ = '1'+qr.quot;
-      strcpy(dest, scriptInputsOutputs[qr.quot].outputs[qr.rem].name);
+      //strcpy(dest, scriptInputsOutputs[qr.quot].outputs[qr.rem].name);
+      strcpy(dest, g_model.scriptsData[qr.quot].name);
     }
 #else
     strcpy(dest, "N/A");


### PR DESCRIPTION
When you use a mix script the name appair in screen is the name of the script output. Now the name is the user name defined in lua script screen