### PR TITLE
Fixes DFU-Util "Unexpected argument" error

### DIFF
--- a/companion/src/radiointerface.cpp
+++ b/companion/src/radiointerface.cpp
@@ -50,7 +50,7 @@ QStringList getDfuArgs(const QString & cmd, const QString & filename)
   if (cmd == "-U")
     args.last().append(":" % QString::number(Boards::getFlashSize(getCurrentBoard())));
   args << "--device" << "0483:df11";
-  args << "" << cmd % filename;
+  args << cmd % filename;
   return args;
 }
 


### PR DESCRIPTION
Tested under Ubuntu 20.04.1 with dfu-util v0.11