### PR TITLE
Increase exit button on the widgets setup page

### DIFF
--- a/radio/src/gui/colorlcd/screen_setup.cpp
+++ b/radio/src/gui/colorlcd/screen_setup.cpp
@@ -181,7 +181,7 @@ class SetupWidgetsPage: public FormWindow
 
 #if defined(HARDWARE_TOUCH)
       new Button(
-          this, {0, 0, MENU_HEADER_BUTTON_WIDTH, MENU_HEADER_BUTTON_WIDTH},
+          this, {0, 0, MENU_HEADER_BACK_BUTTON_WIDTH, MENU_HEADER_BACK_BUTTON_HEIGHT},
           [this]() -> uint8_t {
             this->deleteLater();
             return 1;


### PR DESCRIPTION
Increase the size of the virtual RTN button on the widgets setup page. 
Especially important for NV14. 