### PR TITLE
Fix companion model edit image names

### DIFF
--- a/companion/src/firmwares/eeprominterface.h
+++ b/companion/src/firmwares/eeprominterface.h
@@ -53,7 +53,10 @@ enum Capability {
   VoicesAsNumbers,
   VoicesMaxLength,
   MultiLangVoice,
-  ModelImage,
+  HasModelImage,
+  ModelImageNameLen,
+  ModelImageFilters,
+  ModelImageKeepExtn,
   CustomFunctions,
   SafetyChannelCustomFunction,
   LogicalSwitches,
@@ -347,6 +350,8 @@ class Firmware
     }
 
     virtual int getCapability(Capability) = 0;
+
+    virtual QString getCapabilityStr(Capability) = 0;
 
     virtual QString getAnalogInputName(unsigned int index) = 0;
 

--- a/companion/src/firmwares/er9x/er9xinterface.cpp
+++ b/companion/src/firmwares/er9x/er9xinterface.cpp
@@ -334,3 +334,8 @@ int Er9xInterface::getCapability(Capability capability)
       return 0;
   }
 }
+
+QString Er9xInterface::getCapabilityStr(Capability capability)
+{
+  return QString();
+}

--- a/companion/src/firmwares/er9x/er9xinterface.h
+++ b/companion/src/firmwares/er9x/er9xinterface.h
@@ -53,8 +53,10 @@ class Er9xInterface : public EEPROMInterface
     virtual int getSize(const GeneralSettings &settings);
 
     virtual bool isAvailable(PulsesProtocol proto, int port=0);
-    
+
     virtual int getCapability(Capability capability);
+
+    virtual QString getCapabilityStr(Capability);
 
   protected:
 

--- a/companion/src/firmwares/ersky9x/ersky9xinterface.cpp
+++ b/companion/src/firmwares/ersky9x/ersky9xinterface.cpp
@@ -387,3 +387,8 @@ int Ersky9xInterface::getCapability(Capability capability)
       return 0;
   }
 }
+
+QString Ersky9xInterface::getCapabilityStr(Capability capability)
+{
+  return QString();
+}

--- a/companion/src/firmwares/ersky9x/ersky9xinterface.h
+++ b/companion/src/firmwares/ersky9x/ersky9xinterface.h
@@ -36,24 +36,26 @@ class Ersky9xInterface : public EEPROMInterface
     virtual ~Ersky9xInterface();
 
     virtual const char * getName();
-    
-    
+
+
     virtual unsigned long load(RadioData &, const uint8_t * eeprom, int size);
 
     virtual unsigned long loadBackup(RadioData &, const uint8_t * eeprom, int esize, int index);
-    
+
     virtual int save(uint8_t * eeprom, const RadioData & radioData, uint8_t version=0, uint32_t variant=0)
     {
       return 0;
     }
 
     virtual int getSize(const ModelData &);
-    
+
     virtual int getSize(const GeneralSettings & settings);
 
     virtual bool isAvailable(PulsesProtocol proto, int port=0);
-    
+
     virtual int getCapability(Capability capability);
+
+    virtual QString getCapabilityStr(Capability);
 
   protected:
 
@@ -61,17 +63,17 @@ class Ersky9xInterface : public EEPROMInterface
 
   private:
     void appendTextElement(QDomDocument * qdoc, QDomElement * pe, QString name, QString value);
-    
+
     void appendNumberElement(QDomDocument * qdoc, QDomElement * pe,QString name, int value, bool forceZeroWrite = false);
-    
+
     void appendCDATAElement(QDomDocument * qdoc, QDomElement * pe,QString name, const char * data, int size);
-    
+
     QDomElement getGeneralDataXML(QDomDocument * qdoc, Ersky9xGeneral * tgen);   //parse out data to XML format
-    
+
     QDomElement getModelDataXML(QDomDocument * qdoc, Ersky9xModelData_v11 * tmod, int modelNum, int mdver); //parse out data to XML format
-    
+
     bool loadRadioSettingsDataXML(QDomDocument * qdoc, Ersky9xGeneral * tgen); // get data from XML
-    
+
     template <class T>
     bool loadModelDataXML(QDomDocument * qdoc, ModelData * model, int modelNum, int stickMode); // get data from XML
 

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -407,6 +407,21 @@ void ModelData::convert(RadioDataConversionState & cstate)
     thrTraceSrc = RawSource(SOURCE_TYPE_STICK, (int)thrTraceSrc + 3).convert(cstate).index - 3;
   }
 
+  Firmware *fw = getCurrentFirmware();
+
+  if (fw->getCapability(HasModelImage) && bitmap[0] != '\0') {
+    QString filename = bitmap;
+    QFileInfo file(filename);
+    if (fw->getCapability(ModelImageKeepExtn) && file.suffix() == "")
+      filename.append(".bmp");  // bmp is assumed default for radios that do not store file extension
+    else if (!fw->getCapability(ModelImageKeepExtn) && file.suffix() != "") {
+      int posn = filename.indexOf("." % file.suffix(), + 1);
+      filename.remove(posn, filename.size() - posn + 1);
+    }
+    memset(bitmap, 0, CPN_MAX_BITMAP_LEN);
+    strncpy(bitmap, filename.toLatin1().data(), fw->getCapability(ModelImageNameLen));
+  }
+
   for (int i = 0; i < CPN_MAX_MODULES; i++) {
     moduleData[i].convert(cstate.withComponentIndex(i));
   }

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -146,7 +146,7 @@ class ModelData {
     unsigned int  rssiSource;
     RSSIAlarmData rssiAlarms;
 
-    char bitmap[CPN_MAX_BITMAP_LEN+1];
+    char bitmap[CPN_MAX_BITMAP_LEN + 1];
 
     unsigned int trainerMode;  // TrainerMode
 

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -80,6 +80,7 @@ enum TrainerMode {
 };
 
 #define INPUT_NAME_LEN 4
+#define CPN_MAX_BITMAP_LEN 14
 
 class ModelData {
   Q_DECLARE_TR_FUNCTIONS(ModelData)
@@ -145,7 +146,7 @@ class ModelData {
     unsigned int  rssiSource;
     RSSIAlarmData rssiAlarms;
 
-    char bitmap[10+1];
+    char bitmap[CPN_MAX_BITMAP_LEN+1];
 
     unsigned int trainerMode;  // TrainerMode
 

--- a/companion/src/firmwares/opentx/opentxinterface.cpp
+++ b/companion/src/firmwares/opentx/opentxinterface.cpp
@@ -447,8 +447,12 @@ int OpenTxFirmware::getCapability(::Capability capability)
         return 60;
     case Imperial:
       return 0;
-    case ModelImage:
+    case HasModelImage:
       return (board == BOARD_TARANIS_X9D || IS_TARANIS_PLUS(board) || board == BOARD_TARANIS_X9DP_2019 || IS_FAMILY_HORUS_OR_T16(board));
+    case ModelImageNameLen:
+      return (IS_FAMILY_HORUS_OR_T16(board) ? 14 : 10); //  including extension if saved and <= CPN_MAX_BITMAP_LEN
+    case ModelImageKeepExtn:
+      return (IS_FAMILY_HORUS_OR_T16(board) ? true : false);
     case HasBeeper:
       return false;
     case HasPxxCountry:
@@ -745,6 +749,16 @@ int OpenTxFirmware::getCapability(::Capability capability)
       return getCapability(LcdWidth) > getCapability(LcdHeight) ? 4 : 2;
     default:
       return 0;
+  }
+}
+
+QString OpenTxFirmware::getCapabilityStr(::Capability capability)
+{
+  switch (capability) {
+    case ModelImageFilters:
+      return IS_FAMILY_HORUS_OR_T16(board) ? "*.bmp|*.jpg|*.png" : "*.bmp";
+    default:
+      return QString();
   }
 }
 

--- a/companion/src/firmwares/opentx/opentxinterface.h
+++ b/companion/src/firmwares/opentx/opentxinterface.h
@@ -118,6 +118,8 @@ class OpenTxFirmware: public Firmware
 
     virtual int getCapability(Capability);
 
+    virtual QString getCapabilityStr(Capability);
+
     virtual QString getAnalogInputName(unsigned int index);
 
     virtual QTime getMaxTimerStart();

--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -1036,62 +1036,51 @@ SetupPanel::SetupPanel(QWidget * parent, ModelData & model, GeneralSettings & ge
   ui->name->setValidator(new QRegExpValidator(rx, this));
   ui->name->setMaxLength(firmware->getCapability(ModelName));
 
-  if (firmware->getCapability(ModelImage)) {
+  if (firmware->getCapability(HasModelImage)) {
+    if (Boards::getCapability(board, Board::HasColorLcd)) {
+      ui->imagePreview->setFixedSize(QSize(192, 114));
+    }
+    else {
+      ui->imagePreview->setFixedSize(QSize(64, 32));
+    }
     QStringList items;
     items.append("");
     QString path = g.profile[g.id()].sdPath();
     path.append("/IMAGES/");
     QDir qd(path);
     if (qd.exists()) {
-      QStringList filters;
-      if(IS_FAMILY_HORUS_OR_T16(board)) {
-        filters << "*.bmp" << "*.jpg" << "*.png";
-        foreach ( QString file, qd.entryList(filters, QDir::Files) ) {
-          QFileInfo fi(file);
-          QString temp = fi.fileName();
-          if (!items.contains(temp) && temp.length() <= 6 + 4) {
-            items.append(temp);
-          }
-        }
-      }
-      else {
-        filters << "*.bmp";
-        foreach (QString file, qd.entryList(filters, QDir::Files)) {
-          QFileInfo fi(file);
-          QString temp = fi.completeBaseName();
-          if (!items.contains(temp) && temp.length() <= 10 + 4) {
-            items.append(temp);
-          }
-        }
+      QStringList filters = firmware->getCapabilityStr(ModelImageFilters).split("|");
+      foreach ( QString file, qd.entryList(filters, QDir::Files) ) {
+        QFileInfo fi(file);
+        QString temp;
+        if (firmware->getCapability(ModelImageKeepExtn))
+          temp = fi.fileName();
+        else
+          temp = fi.completeBaseName();
+        if (!items.contains(temp) && temp.length() <= firmware->getCapability(ModelImageNameLen))
+          items.append(temp);
       }
     }
     if (!items.contains(model.bitmap)) {
       items.append(model.bitmap);
     }
-    items.sort();
+    items.sort(Qt::CaseInsensitive);
     foreach (QString file, items) {
       ui->image->addItem(file);
       if (file == model.bitmap) {
         ui->image->setCurrentIndex(ui->image->count() - 1);
-        QString fileName = path;
-        fileName.append(model.bitmap);
-        if (!IS_FAMILY_HORUS_OR_T16(board))
-          fileName.append(".bmp");
-        QImage image(fileName);
-        if (image.isNull() && !IS_FAMILY_HORUS_OR_T16(board)) {
-          fileName = path;
+        if (!file.isEmpty()) {
+          QString fileName = path;
           fileName.append(model.bitmap);
-          fileName.append(".BMP");
-          image.load(fileName);
-        }
-        if (!image.isNull()) {
-          if (IS_FAMILY_HORUS_OR_T16(board)) {
-            ui->imagePreview->setFixedSize(QSize(192, 114));
-            ui->imagePreview->setPixmap(QPixmap::fromImage(image.scaled(192, 114)));
+          if (!firmware->getCapability(ModelImageKeepExtn)) {
+            QString extn = firmware->getCapabilityStr(ModelImageFilters);
+            if (extn.size() > 0)
+              extn.remove(0, 1);  //  remove *
+            fileName.append(extn);
           }
-          else {
-            ui->imagePreview->setFixedSize(QSize(64, 32));
-            ui->imagePreview->setPixmap(QPixmap::fromImage(image.scaled(64, 32)));
+          QImage image(fileName);
+          if (!image.isNull()) {
+            ui->imagePreview->setPixmap(QPixmap::fromImage(image.scaled(ui->imagePreview->size())));
           }
         }
       }
@@ -1334,36 +1323,23 @@ void SetupPanel::on_name_editingFinished()
 void SetupPanel::on_image_currentIndexChanged(int index)
 {
   if (!lock) {
-    Board::Type board = firmware->getBoard();
-    strncpy(model->bitmap, ui->image->currentText().toLatin1(), 10);
-    QString path = g.profile[g.id()].sdPath();
-    path.append("/IMAGES/");
-    QDir qd(path);
-    if (qd.exists()) {
-      QString fileName=path;
-      fileName.append(model->bitmap);
-      if (!IS_FAMILY_HORUS_OR_T16(board))
-        fileName.append(".bmp");
-      QImage image(fileName);
-      if (image.isNull() && !IS_FAMILY_HORUS_OR_T16(board)) {
-        fileName=path;
-        fileName.append(model->bitmap);
-        fileName.append(".BMP");
-        image.load(fileName);
+    memset(model->bitmap, 0, CPN_MAX_BITMAP_LEN);
+    strncpy(model->bitmap, ui->image->currentText().toLatin1(), CPN_MAX_BITMAP_LEN);
+    if (model->bitmap[0] != '\0') {
+      QString path = g.profile[g.id()].sdPath();
+      path.append("/IMAGES/");
+      path.append(model->bitmap);
+      if (!firmware->getCapability(ModelImageKeepExtn)) {
+        QString extn = firmware->getCapabilityStr(ModelImageFilters);
+        if (extn.size() > 0)
+          extn.remove(0, 1);  //  remove *
+        path.append(extn);
       }
-      if (!image.isNull()) {
-        if (IS_FAMILY_HORUS_OR_T16(board)) {
-          ui->imagePreview->setFixedSize(QSize(192, 114));
-          ui->imagePreview->setPixmap(QPixmap::fromImage(image.scaled(192, 114)));
-        }
-        else {
-          ui->imagePreview->setFixedSize(QSize(64, 32));
-          ui->imagePreview->setPixmap(QPixmap::fromImage(image.scaled(64, 32)));
-        }
-      }
-      else {
+      QImage image(path);
+      if (!image.isNull())
+        ui->imagePreview->setPixmap(QPixmap::fromImage(image.scaled(ui->imagePreview->size())));
+      else
         ui->imagePreview->clear();
-      }
     }
     else {
       ui->imagePreview->clear();

--- a/companion/src/multimodelprinter.cpp
+++ b/companion/src/multimodelprinter.cpp
@@ -313,7 +313,7 @@ QString MultiModelPrinter::printSetup()
   if (!IS_FAMILY_HORUS_OR_T16(firmware->getBoard())) {
     ROWLABELCOMPARECELL(tr("EEprom Size"), 0, modelPrinter->printEEpromSize(), 0);
   }
-  if (firmware->getCapability(ModelImage)) {
+  if (firmware->getCapability(HasModelImage)) {
     ROWLABELCOMPARECELL(tr("Model Image"), 0, model->bitmap, 0);
   }
   ROWLABELCOMPARECELL(tr("Throttle"), 0, modelPrinter->printThrottle(), 0);


### PR DESCRIPTION
Fixes #843
Edited models in Companion and Simulator checking file names up to 10 chars excl .bmp extn for eeprom and 14 chars inc extn for sd card radios. Tested:
- TX16S
- X9D+

Image list sorted case insensitive to match radio.
Use firmware capabilities rather than specifying boards.