### PR TITLE
Concurrency fixes related to MPM protolist

### DIFF
--- a/radio/src/pulses/pulses.cpp
+++ b/radio/src/pulses/pulses.cpp
@@ -584,8 +584,8 @@ bool setupPulsesInternalModule()
 
   if (moduleState[INTERNAL_MODULE].protocol != protocol) {
     intmoduleStop();
-    moduleState[INTERNAL_MODULE].protocol = protocol;
     enablePulsesInternalModule(protocol);
+    moduleState[INTERNAL_MODULE].protocol = protocol;
     return false;
   }
   else {
@@ -612,8 +612,8 @@ bool setupPulsesExternalModule()
 
   if (moduleState[EXTERNAL_MODULE].protocol != protocol) {
     extmoduleStop();
-    moduleState[EXTERNAL_MODULE].protocol = protocol;
     enablePulsesExternalModule(protocol);
+    moduleState[EXTERNAL_MODULE].protocol = protocol;
     return false;
   }
   else {

--- a/radio/src/syscalls.c
+++ b/radio/src/syscalls.c
@@ -45,6 +45,24 @@ extern caddr_t _sbrk(int nbytes)
   }
 }
 
+#if defined(THREADSAFE_MALLOC) && !defined(BOOT)
+
+#include <FreeRTOS.h>
+#include <task.h>
+
+void __malloc_lock(struct _reent *r)
+{
+  (void)(r);
+  vTaskSuspendAll();
+};
+
+void __malloc_unlock(struct _reent *r)
+{
+  (void)(r);
+  (void)xTaskResumeAll();
+};
+#endif
+
 #if !defined(SEMIHOSTING)
 extern int _gettimeofday(void *p1, void *p2)
 {

--- a/radio/src/targets/horus/CMakeLists.txt
+++ b/radio/src/targets/horus/CMakeLists.txt
@@ -325,6 +325,9 @@ if (MULTIMODULE)
     )
 endif()
 
+# Make malloc() thread-safe
+add_definitions(-DTHREADSAFE_MALLOC)
+
 set(STM32LIB_SRC
   STM32F4xx_StdPeriph_Driver/src/stm32f4xx_sdio.c
   STM32F4xx_StdPeriph_Driver/src/stm32f4xx_fmc.c

--- a/radio/src/targets/nv14/CMakeLists.txt
+++ b/radio/src/targets/nv14/CMakeLists.txt
@@ -161,6 +161,9 @@ if (MULTIMODULE)
     )
 endif()
 
+# Make malloc() thread-safe
+add_definitions(-DTHREADSAFE_MALLOC)
+
 set(STM32LIB_SRC
   STM32F4xx_StdPeriph_Driver/src/stm32f4xx_sdio.c
   STM32F4xx_StdPeriph_Driver/src/stm32f4xx_fmc.c

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -133,18 +133,22 @@ void telemetryWakeup()
 #endif
 
 #if defined(INTERNAL_MODULE_MULTI)
-  if (intmoduleFifo.pop(data)) {
-    LOG_TELEMETRY_WRITE_START();
-    do {
-      processMultiTelemetryData(data, INTERNAL_MODULE);
-      LOG_TELEMETRY_WRITE_BYTE(data);
-    } while (intmoduleFifo.pop(data));
-  }
+  if (isModuleMultimodule(INTERNAL_MODULE)) {
+    if (intmoduleFifo.pop(data)) {
+      LOG_TELEMETRY_WRITE_START();
+      do {
+        processMultiTelemetryData(data, INTERNAL_MODULE);
+        LOG_TELEMETRY_WRITE_BYTE(data);
+      } while (intmoduleFifo.pop(data));
+    }
 #if defined(MULTI_PROTOLIST)
-  if (MultiRfProtocols::instance(INTERNAL_MODULE)->isScanning()) {
-    MultiRfProtocols::instance(INTERNAL_MODULE)->scanReply();
-  }
+    if ((moduleState[INTERNAL_MODULE].protocol ==
+         PROTOCOL_CHANNELS_MULTIMODULE) &&
+        MultiRfProtocols::instance(INTERNAL_MODULE)->isScanning()) {
+      MultiRfProtocols::instance(INTERNAL_MODULE)->scanReply();
+    }
 #endif
+  }
 #endif
 
 #if defined(PCBNV14)
@@ -170,11 +174,13 @@ void telemetryWakeup()
 
 #if defined(MULTI_PROTOLIST)
   if (isModuleMultimodule(EXTERNAL_MODULE) &&
-      MultiRfProtocols::instance(EXTERNAL_MODULE)->isScanning()) {    
-    MultiRfProtocols::instance(EXTERNAL_MODULE)->scanReply();    
+      (moduleState[EXTERNAL_MODULE].protocol ==
+       PROTOCOL_CHANNELS_MULTIMODULE) &&
+      MultiRfProtocols::instance(EXTERNAL_MODULE)->isScanning()) {
+    MultiRfProtocols::instance(EXTERNAL_MODULE)->scanReply();
   }
 #endif
-  
+
 #elif defined(PCBSKY9X)
   if (telemetryProtocol == PROTOCOL_TELEMETRY_FRSKY_D_SECONDARY) {
     while (telemetrySecondPortReceive(data)) {


### PR DESCRIPTION
This has been discovered while debugging with the TX18S, hunting #802. It is however not related.

This PR does 2 things:
- make `malloc()` thread-safe in the FreeRTOS context by suspending the scheduler between `__malloc_lock` and `__malloc_unlock`. This assumes that `malloc()` is never used from an ISR, which is our case.
- makes sure that the MPM is started from the UI thread on boot to solves a potential conflict while allocating the protolist singleton related to the module started. Otherwise, the polling loop for telemetry could potentially interfere while the module is not yet fully enabled.