### PR TITLE
When changing widget go directly to widget settings

### DIFF
--- a/radio/src/gui/colorlcd/screen_setup.cpp
+++ b/radio/src/gui/colorlcd/screen_setup.cpp
@@ -121,6 +121,8 @@ SetupWidgetsPageSlot::SetupWidgetsPageSlot(FormGroup * parent, const rect_t & re
           for (auto factory: getRegisteredWidgets()) {
             menu->addLine(factory->getName(), [=]() {
                 container->createWidget(slotIndex, factory);
+                auto widget = container->getWidget(slotIndex);
+                new WidgetSettings(parent, widget);        
             });
           }
       });


### PR DESCRIPTION
Currently when user selects a (new) widget the SW returns to the main widget setup screen.
This may be confusing.
This PR after widget selection takes user directly to the widget setup menu.