### PR TITLE
Eshifri/nv14 range

### DIFF
--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -1296,7 +1296,7 @@ class ModuleWindow : public FormGroup {
                 moduleState[moduleIdx].mode = MODULE_MODE_NORMAL;
               }
               if (moduleState[moduleIdx].mode == MODULE_MODE_RANGECHECK) {
-                moduleState[moduleIdx].mode = MODULE_MODE_NORMAL;                
+                moduleState[moduleIdx].mode = MODULE_MODE_NORMAL;
                 return 0;
               } else {
                 moduleState[moduleIdx].mode = MODULE_MODE_RANGECHECK;

--- a/radio/src/pulses/modules_helpers.h
+++ b/radio/src/pulses/modules_helpers.h
@@ -32,6 +32,8 @@
 #include "telemetry/multi.h"
 #endif
 
+extern uint32_t NV14internalModuleFwVersion;
+
 #define CROSSFIRE_CHANNELS_COUNT        16
 #define GHOST_CHANNELS_COUNT            16
 
@@ -616,7 +618,7 @@ inline bool isModuleRangeAvailable(uint8_t moduleIdx)
 {
   return isModuleBindRangeAvailable(moduleIdx)
     && !IS_RX_MULTI(moduleIdx)
-    && !isModuleFlySky(moduleIdx);
+    && (!isModuleFlySky(moduleIdx) || NV14internalModuleFwVersion >= 0x1000E);
 }
 
 constexpr uint8_t MAX_RXNUM = 63;

--- a/radio/src/translations.cpp
+++ b/radio/src/translations.cpp
@@ -936,3 +936,7 @@ const char STR_ABOUTUS[] = TR_ABOUTUS;
 const char STR_AUTH_FAILURE[] = TR_AUTH_FAILURE;
 const char STR_PROTOCOL[] = TR_PROTOCOL;
 const char STR_RACING_MODE[] = TR_RACING_MODE;
+
+#if defined(PCBNV14)
+const char STR_RFPOWER_AFHDS2[] = TR_RFPOWER_AFHDS2;
+#endif

--- a/radio/src/translations/untranslated.h
+++ b/radio/src/translations/untranslated.h
@@ -190,6 +190,10 @@
 #define LEN_PWR_OFF_DELAYS             "\002"
 #define TR_PWR_OFF_DELAYS              "0s""1s""2s""4s"
 
+#if defined(PCBNV14)
+#define  TR_RFPOWER_AFHDS2             "\007" "Default\0""High\0"
+#endif
+
 #define TR_SENSOR_RSSI                      "RSSI"
 #define TR_SENSOR_R9PW                      "R9PW"
 #define TR_SENSOR_RAS                       "SWR"


### PR DESCRIPTION
This PR adds "Range" and "Power" buttons for NV1`4 if the installed RF module firmware supports it.
The current RF FW is available here:
https://www.rcgroups.com/forums/showpost.php?p=45357535
FW update is implemented in the NV14 OTX (and many users installed it).
FW updated can ported into edgeTX of course.