### PR TITLE
Remove odt file format option from print model

### DIFF
--- a/companion/src/printdialog.cpp
+++ b/companion/src/printdialog.cpp
@@ -67,10 +67,10 @@ void PrintDialog::on_printButton_clicked()
 
 void PrintDialog::on_printFileButton_clicked()
 {
-  QString fn = QFileDialog::getSaveFileName(this,tr("Select PDF output file"),QString(),tr("ODF files (*.odt);;PDF Files(*.pdf);;HTML-Files (*.htm *.html);;All Files (*)"));
+  QString fn = QFileDialog::getSaveFileName(this,tr("Select output file"),QString(),tr("PDF files(*.pdf);;HTML files (*.htm *.html);;All files (*)"));
   if (fn.isEmpty())
     return;
-  if (! (fn.endsWith(".odt", Qt::CaseInsensitive) || fn.endsWith(".pdf", Qt::CaseInsensitive) || fn.endsWith(".htm", Qt::CaseInsensitive) || fn.endsWith(".html", Qt::CaseInsensitive)) )
+  if (! (fn.endsWith(".pdf", Qt::CaseInsensitive) || fn.endsWith(".htm", Qt::CaseInsensitive) || fn.endsWith(".html", Qt::CaseInsensitive)) )
     fn += ".pdf"; // default
   if (fn.endsWith(".pdf", Qt::CaseInsensitive)) {
     QPrinter printer;
@@ -90,7 +90,7 @@ void PrintDialog::printToFile()
 {
   if (printfilename.isEmpty())
     return;
-  if (! (printfilename.endsWith(".odt", Qt::CaseInsensitive) || printfilename.endsWith(".pdf", Qt::CaseInsensitive) || printfilename.endsWith(".htm", Qt::CaseInsensitive) || printfilename.endsWith(".html", Qt::CaseInsensitive)) )
+  if (! (printfilename.endsWith(".pdf", Qt::CaseInsensitive) || printfilename.endsWith(".htm", Qt::CaseInsensitive) || printfilename.endsWith(".html", Qt::CaseInsensitive)) )
     printfilename += ".pdf"; // default
   if (printfilename.endsWith(".pdf", Qt::CaseInsensitive)) {
     QPrinter printer;


### PR DESCRIPTION
Fixes #854
Fixes in the sense it removes a file format that does not convert the html document generated by the print function with any degree of accuracy