### PR TITLE
Use theme color for poweroff

### DIFF
--- a/radio/src/gui/colorlcd/draw_functions.cpp
+++ b/radio/src/gui/colorlcd/draw_functions.cpp
@@ -84,7 +84,7 @@ void drawSleepBitmap()
   const BitmapBuffer* bitmap = OpenTxTheme::instance()->shutdown;
   if (bitmap) {
     lcd->drawMask((LCD_W-bitmap->width())/2, (LCD_H-bitmap->height())/2,
-                  bitmap, COLOR_THEME_SECONDARY1);
+                  bitmap, COLOR2FLAGS(WHITE));
   }
 
   lcdRefresh();
@@ -101,31 +101,31 @@ void drawShutdownAnimation(uint32_t duration, uint32_t totalDuration,
   static const BitmapBuffer * shutdown = OpenTxTheme::instance()->shutdown;
 
   lcd->reset();
-  lcd->clear(COLOR_THEME_SECONDARY1);
+  lcd->clear(COLOR2FLAGS(BLACK));
   
   if (shutdown) {
     lcd->drawMask((LCD_W - shutdown->width()) / 2,
                   (LCD_H - shutdown->height()) / 2, shutdown,
-                  COLOR_THEME_PRIMARY1);
+                  COLOR2FLAGS(WHITE));
 
     int quarter = duration / (totalDuration / 5);
     if (quarter >= 1)
       lcd->drawBitmapPattern(LCD_W / 2, (LCD_H - SHUTDOWN_CIRCLE_DIAMETER) / 2,
-                             LBM_SHUTDOWN_CIRCLE, COLOR_THEME_PRIMARY1, 0,
+                             LBM_SHUTDOWN_CIRCLE, COLOR2FLAGS(WHITE), 0,
                              SHUTDOWN_CIRCLE_DIAMETER / 2);
     if (quarter >= 2)
       lcd->drawBitmapPattern(LCD_W / 2, LCD_H / 2, LBM_SHUTDOWN_CIRCLE,
-                             COLOR_THEME_PRIMARY1, SHUTDOWN_CIRCLE_DIAMETER / 2,
+                             COLOR2FLAGS(WHITE), SHUTDOWN_CIRCLE_DIAMETER / 2,
                              SHUTDOWN_CIRCLE_DIAMETER / 2);
     if (quarter >= 3)
       lcd->drawBitmapPattern((LCD_W - SHUTDOWN_CIRCLE_DIAMETER) / 2, LCD_H / 2,
-                             LBM_SHUTDOWN_CIRCLE, COLOR_THEME_PRIMARY1,
+                             LBM_SHUTDOWN_CIRCLE, COLOR2FLAGS(WHITE),
                              SHUTDOWN_CIRCLE_DIAMETER,
                              SHUTDOWN_CIRCLE_DIAMETER / 2);
     if (quarter >= 4)
       lcd->drawBitmapPattern((LCD_W - SHUTDOWN_CIRCLE_DIAMETER) / 2,
                              (LCD_H - SHUTDOWN_CIRCLE_DIAMETER) / 2,
-                             LBM_SHUTDOWN_CIRCLE, COLOR_THEME_PRIMARY1,
+                             LBM_SHUTDOWN_CIRCLE, COLOR2FLAGS(WHITE),
                              SHUTDOWN_CIRCLE_DIAMETER * 3 / 2,
                              SHUTDOWN_CIRCLE_DIAMETER / 2);
   } else {
@@ -134,7 +134,7 @@ void drawShutdownAnimation(uint32_t duration, uint32_t totalDuration,
     for (int i = 1; i <= 4; i++) {
       if (quarter >= i) {
         lcd->drawSolidFilledRect(LCD_W / 2 - 70 + 24 * i, LCD_H / 2 - 10, 20,
-                                 20, COLOR_THEME_PRIMARY1);
+                                 20, COLOR2FLAGS(WHITE));
       }
     }
   }

--- a/radio/src/gui/colorlcd/draw_functions.cpp
+++ b/radio/src/gui/colorlcd/draw_functions.cpp
@@ -106,26 +106,26 @@ void drawShutdownAnimation(uint32_t duration, uint32_t totalDuration,
   if (shutdown) {
     lcd->drawMask((LCD_W - shutdown->width()) / 2,
                   (LCD_H - shutdown->height()) / 2, shutdown,
-                  COLOR2FLAGS(WHITE));
+                  COLOR_THEME_PRIMARY1);
 
     int quarter = duration / (totalDuration / 5);
     if (quarter >= 1)
       lcd->drawBitmapPattern(LCD_W / 2, (LCD_H - SHUTDOWN_CIRCLE_DIAMETER) / 2,
-                             LBM_SHUTDOWN_CIRCLE, COLOR2FLAGS(WHITE), 0,
+                             LBM_SHUTDOWN_CIRCLE, COLOR_THEME_PRIMARY1, 0,
                              SHUTDOWN_CIRCLE_DIAMETER / 2);
     if (quarter >= 2)
       lcd->drawBitmapPattern(LCD_W / 2, LCD_H / 2, LBM_SHUTDOWN_CIRCLE,
-                             COLOR2FLAGS(WHITE), SHUTDOWN_CIRCLE_DIAMETER / 2,
+                             COLOR_THEME_PRIMARY1, SHUTDOWN_CIRCLE_DIAMETER / 2,
                              SHUTDOWN_CIRCLE_DIAMETER / 2);
     if (quarter >= 3)
       lcd->drawBitmapPattern((LCD_W - SHUTDOWN_CIRCLE_DIAMETER) / 2, LCD_H / 2,
-                             LBM_SHUTDOWN_CIRCLE, COLOR2FLAGS(WHITE),
+                             LBM_SHUTDOWN_CIRCLE, COLOR_THEME_PRIMARY1,
                              SHUTDOWN_CIRCLE_DIAMETER,
                              SHUTDOWN_CIRCLE_DIAMETER / 2);
     if (quarter >= 4)
       lcd->drawBitmapPattern((LCD_W - SHUTDOWN_CIRCLE_DIAMETER) / 2,
                              (LCD_H - SHUTDOWN_CIRCLE_DIAMETER) / 2,
-                             LBM_SHUTDOWN_CIRCLE, COLOR2FLAGS(WHITE),
+                             LBM_SHUTDOWN_CIRCLE, COLOR_THEME_PRIMARY1,
                              SHUTDOWN_CIRCLE_DIAMETER * 3 / 2,
                              SHUTDOWN_CIRCLE_DIAMETER / 2);
   } else {
@@ -134,7 +134,7 @@ void drawShutdownAnimation(uint32_t duration, uint32_t totalDuration,
     for (int i = 1; i <= 4; i++) {
       if (quarter >= i) {
         lcd->drawSolidFilledRect(LCD_W / 2 - 70 + 24 * i, LCD_H / 2 - 10, 20,
-                                 20, COLOR2FLAGS(WHITE));
+                                 20, COLOR_THEME_PRIMARY1);
       }
     }
   }

--- a/radio/src/gui/colorlcd/draw_functions.cpp
+++ b/radio/src/gui/colorlcd/draw_functions.cpp
@@ -76,9 +76,6 @@ void drawValueOrGVar(BitmapBuffer* dc, coord_t x, coord_t y, gvar_t value,
   }
 }
 
-constexpr LcdFlags splash_background_color =
-  COLOR2FLAGS(((0xC >> 3) << 11) | ((0x3F >> 2) << 5) | (0x66 >> 3));
-
 void drawSleepBitmap()
 {
   lcd->reset();
@@ -87,7 +84,7 @@ void drawSleepBitmap()
   const BitmapBuffer* bitmap = OpenTxTheme::instance()->shutdown;
   if (bitmap) {
     lcd->drawMask((LCD_W-bitmap->width())/2, (LCD_H-bitmap->height())/2,
-                  bitmap, splash_background_color);
+                  bitmap, COLOR_THEME_SECONDARY1);
   }
 
   lcdRefresh();
@@ -104,7 +101,7 @@ void drawShutdownAnimation(uint32_t duration, uint32_t totalDuration,
   static const BitmapBuffer * shutdown = OpenTxTheme::instance()->shutdown;
 
   lcd->reset();
-  lcd->clear(splash_background_color);
+  lcd->clear(COLOR_THEME_SECONDARY1);
   
   if (shutdown) {
     lcd->drawMask((LCD_W - shutdown->width()) / 2,


### PR DESCRIPTION
@JimB40 Are `COLOR_THEME_SECONDARY1` for the background color, and `COLOR_THEME_PRIMARY1`  for the animation the right ones to use here? 

One point to consider is that for the default theme, this makes the animation black. 