### PR TITLE
[nv14] Boot issue fixes

### DIFF
--- a/radio/src/targets/common/arm/stm32/timers_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/timers_driver.cpp
@@ -43,7 +43,7 @@ void init1msTimer()
   INTERRUPT_xMS_TIMER->CR1 = TIM_CR1_CEN | TIM_CR1_URS;
   INTERRUPT_xMS_TIMER->DIER |= TIM_DIER_UIE;
   NVIC_EnableIRQ(INTERRUPT_xMS_IRQn);
-  NVIC_SetPriority(INTERRUPT_xMS_IRQn, 7);
+  NVIC_SetPriority(INTERRUPT_xMS_IRQn, 4);
 }
 
 void stop1msTimer()

--- a/radio/src/targets/nv14/board.h
+++ b/radio/src/targets/nv14/board.h
@@ -388,7 +388,7 @@ extern "C" {
 
 // Power driver
 #define SOFT_PWR_CTRL
-#define POWER_ON_DELAY               100 // 3s
+#define POWER_ON_DELAY               10 // 1s
 void pwrInit();
 void extModuleInit();
 uint32_t pwrCheck();

--- a/radio/src/targets/nv14/lcd_driver.cpp
+++ b/radio/src/targets/nv14/lcd_driver.cpp
@@ -1216,10 +1216,6 @@ void LCD_Init_LTDC() {
   NVIC_Init( &NVIC_InitStructure );
   DMA2D->IFCR = (unsigned long)DMA2D_IFSR_CTCIF;
 #endif
-
-  // Enable LTDC IRQ in NVIC
-  NVIC_EnableIRQ(LTDC_IRQn);
-  NVIC_SetPriority(LTDC_IRQn, 7);
 }
 
 void LCD_LayerInit() {


### PR DESCRIPTION
Fixed:
- delay shortened.
- adjusted priority of IRQs used before FreeRTOS is started.

Resolves #863