### PR TITLE
Widget Options Dialog quickfix

### DIFF
--- a/radio/src/gui/colorlcd/widget_settings.cpp
+++ b/radio/src/gui/colorlcd/widget_settings.cpp
@@ -28,9 +28,9 @@
 
 static const rect_t widgetSettingsDialogRect = {
   LCD_W / 10, // x
-  LCD_H / 4,  // y
+  LCD_H / 5,  // y
   LCD_W - 2 * LCD_W / 10, // width
-  LCD_H - 2 * LCD_H / 4   // height
+  LCD_H - 2 * LCD_H / 5   // height
 };
 
 WidgetSettings::WidgetSettings(Window * parent, Widget * widget) :


### PR DESCRIPTION
Options dialog for widgets is a fixed size, and doesn't have enough space for widgets with five options, which some built-in widgets now do.

Make dialog slightly bigger and move up to match. 

Next stage should be to either move options to a full-screen page or make the dialog dynamically resize. The caveat with the latter option will be it will limit options to smallest screen height, which is why I lean towards a proper full screen and scrollable page.