### PR TITLE
Disable MixerScriptsPage for 2.5 release builds if not LUA=Y

### DIFF
--- a/radio/src/gui/colorlcd/menu_model.cpp
+++ b/radio/src/gui/colorlcd/menu_model.cpp
@@ -48,8 +48,8 @@ ModelMenu::ModelMenu():
   addTab(new ModelGVarsPage());
   addTab(new ModelLogicalSwitchesPage());
   addTab(new SpecialFunctionsPage(g_model.customFn));
-// #if defined(LUA)
-//   addTab(new ModelMixerScriptsPage());
-// #endif
+#if defined(LUA) && defined(LUA_MODEL_SCRIPTS)
+  addTab(new ModelMixerScriptsPage());
+#endif
   addTab(new ModelTelemetryPage());
 }


### PR DESCRIPTION
Since it doesn't work anyway without LUA=Y