### PR TITLE
Missing TR_MENUWHENDONE for CN & TW

### DIFF
--- a/radio/src/translations/cn.h.txt
+++ b/radio/src/translations/cn.h.txt
@@ -498,6 +498,7 @@
   #define TR_MENUTOSTART               TR_ENTER " 开始"
   #define TR_SETMIDPOINT               "将摇杆、旋钮和滑块居中"
   #define TR_MOVESTICKSPOTS            "转动摇杆、旋钮和滑块到最大边界"
+  #define TR_MENUWHENDONE              CENTER "\006" TR_ENTER " 完成后"
 #endif
 #define TR_RXBATT                      "Rx Batt:"
 #define TR_TXnRX                       "Tx:\0Rx:"

--- a/radio/src/translations/tw.h.txt
+++ b/radio/src/translations/tw.h.txt
@@ -498,6 +498,7 @@
   #define TR_MENUTOSTART                TR_ENTER " 開始"
   #define TR_SETMIDPOINT                "將搖桿、旋鈕和滑塊居中"
   #define TR_MOVESTICKSPOTS             "轉動搖桿、旋鈕和滑塊到最大邊界"
+  #define TR_MENUWHENDONE               CENTER "\006" TR_ENTER " 完成后"
 #endif
 #define TR_RXBATT                       "Rx Batt:"
 #define TR_TXnRX                        "Tx:\0Rx:"


### PR DESCRIPTION
This missing entry breaks a lot of the B&W builds

@richardclli Can you proof and let me know what, if any corrections/changes are needed (since it is Google Translate originated :grin:) I just need something in place so the CN & TW builds actually build rather than fail miserably. (And yes, I know this only fixes a symptom, since CN/TW for B&W is ... unusable... but one problem at a time 😁 )

English original is 
```
  #define TR_MENUWHENDONE              CENTER "\006" TR_ENTER " WHEN DONE"
```