### PR TITLE
Do not use FreeRTOS functions as long as the scheduler is not started

### DIFF
--- a/radio/src/FreeRTOSConfig.h
+++ b/radio/src/FreeRTOSConfig.h
@@ -74,6 +74,10 @@ to exclude the API function. */
 #define INCLUDE_vTaskDelayUntil         1
 #define INCLUDE_vTaskDelay              1
 
+#if defined(THREADSAFE_MALLOC)
+#define INCLUDE_xTaskGetSchedulerState  1
+#endif
+
 /* Cortex-M specific definitions. */
 #ifdef __NVIC_PRIO_BITS
 	/* __BVIC_PRIO_BITS will be specified when CMSIS is being used. */

--- a/radio/src/syscalls.c
+++ b/radio/src/syscalls.c
@@ -53,13 +53,15 @@ extern caddr_t _sbrk(int nbytes)
 void __malloc_lock(struct _reent *r)
 {
   (void)(r);
-  vTaskSuspendAll();
+  if (xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED)
+    vTaskSuspendAll();
 };
 
 void __malloc_unlock(struct _reent *r)
 {
   (void)(r);
-  (void)xTaskResumeAll();
+  if (xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED)
+    (void)xTaskResumeAll();
 };
 #endif
 


### PR DESCRIPTION
Otherwise interrupts with a logical priority lower than configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY are masked after the first call to xTaskResumeAll() (after the first critical section is entered, and never released).