### PR TITLE
Change lcd.sizeText() name to lcd.getTextSize()

### DIFF
--- a/radio/src/lua/api_colorlcd.cpp
+++ b/radio/src/lua/api_colorlcd.cpp
@@ -270,7 +270,8 @@ static int luaLcdDrawText(lua_State *L)
 }
 
 /*luadoc
-@function lcd.sizeText(text [, flags])
+@function lcd.sizeText(text [, flags]) deprecated, please replace by
+@function lcd.getSizeText(text [, flags])
 
 Get the width and height of a text string drawn with flags
 
@@ -282,7 +283,7 @@ Get the width and height of a text string drawn with flags
 
 @status current Introduced in 2.5.0
 */
-static int luaLcdSizeText(lua_State *L)
+static int luaLcdGetSizeText(lua_State *L)
 {
   const char * s = luaL_checkstring(L, 1);
   LcdFlags flags = luaL_optunsigned(L, 2, 0);
@@ -1247,7 +1248,8 @@ const luaL_Reg lcdLib[] = {
   { "drawFilledRectangle", luaLcdDrawFilledRectangle },
   { "drawText", luaLcdDrawText },
   { "drawTextLines", luaLcdDrawTextLines },
-  { "sizeText", luaLcdSizeText },
+  { "sizeText", luaLcdGetSizeText },
+  { "getSizeText", luaLcdGetSizeText },
   { "drawTimer", luaLcdDrawTimer },
   { "drawNumber", luaLcdDrawNumber },
   { "drawChannel", luaLcdDrawChannel },


### PR DESCRIPTION
Resolves #774
Needs corresponding update to luadocs