### PR TITLE
Bypass widget options setup when they are not available #890

### DIFF
--- a/radio/src/gui/colorlcd/screen_setup.cpp
+++ b/radio/src/gui/colorlcd/screen_setup.cpp
@@ -124,14 +124,16 @@ SetupWidgetsPageSlot::SetupWidgetsPageSlot(FormGroup * parent, const rect_t & re
             menu->addLine(factory->getName(), [=]() {
                 container->createWidget(slotIndex, factory);
                 auto widget = container->getWidget(slotIndex);
-                new WidgetSettings(parent, widget);        
+                if(widget->getOptions() && widget->getOptions()->name)
+                  new WidgetSettings(parent, widget);        
             });
           }
       });
 
       if (container->getWidget(slotIndex)) {
-        menu->addLine(TR_WIDGET_SETTINGS, [=]() {
-            auto widget = container->getWidget(slotIndex);
+        auto widget = container->getWidget(slotIndex);
+        if(widget->getOptions() && widget->getOptions()->name)
+          menu->addLine(TR_WIDGET_SETTINGS, [=]() {
             new WidgetSettings(parent, widget);
         });
         menu->addLine(STR_REMOVE_WIDGET, [=]() {

--- a/radio/src/gui/colorlcd/widget.cpp
+++ b/radio/src/gui/colorlcd/widget.cpp
@@ -38,7 +38,8 @@ static void openWidgetMenu(Widget * parent)
   menu->addLine("Full screen", [=]() {
       parent->setFullscreen(true);
     });
-  menu->addLine(TR_WIDGET_SETTINGS, [=]() {
+  if(parent->getOptions() && parent->getOptions()->name)  
+    menu->addLine(TR_WIDGET_SETTINGS, [=]() {
       new WidgetSettings(parent, parent);
     });
 }


### PR DESCRIPTION
This PR implements (hopefully) #890 
widget setup is not included into the menu if widget does not have options and WidgetSetup is not called during widget creation.