### PR TITLE
Fix channel override icon state not being updated

### DIFF
--- a/radio/src/gui/colorlcd/channel_bar.h
+++ b/radio/src/gui/colorlcd/channel_bar.h
@@ -272,8 +272,19 @@ class ComboChannelBar : public ChannelBar
         value = newValue;
         invalidate();
       }
+#if defined(OVERRIDE_CHANNEL_FUNCTION)
+      int newSafetyChValue = safetyCh[channel];
+      if (safetyChValue != newSafetyChValue)
+      {
+        safetyChValue = newSafetyChValue;
+        invalidate();
+      }
+#endif
     }
 
   protected:
     int value = 0;
+#if defined(OVERRIDE_CHANNEL_FUNCTION)
+    int safetyChValue = OVERRIDE_CHANNEL_UNDEFINED;
+#endif
 };


### PR DESCRIPTION
Fixing an issue with override channel icon not updating properly in channel monitor (since invalidation was only triggered on channel movement). 

Reported by @mervdale