### PR TITLE
Fix certain widget options being changed not triggering storageDirty

### DIFF
--- a/radio/src/gui/colorlcd/widget_settings.cpp
+++ b/radio/src/gui/colorlcd/widget_settings.cpp
@@ -79,6 +79,7 @@ WidgetSettings::WidgetSettings(Window * parent, Widget * widget) :
                      },
                      [=](int8_t newValue) {
                          widget->getOptionValue(optIdx)->boolValue = newValue;
+                         SET_DIRTY();
                      });
         break;
 
@@ -96,6 +97,7 @@ WidgetSettings::WidgetSettings(Window * parent, Widget * widget) :
                                    },
                                    [=](int newValue) {   // setValue
                                        widget->getOptionValue(optIdx)->unsignedValue = (uint32_t) newValue;
+                                       SET_DIRTY();
                                    });
         break;
       }


### PR DESCRIPTION
Fixes #958

Running through the various widget option types, it appears that changes to Bool and TextSize options didn't trigger SET_DIRTY/storageDirty for saving.

Other options all appear to trigger saving correct.