### PR TITLE
[nv14] Add crash causing missing curveDataEdit

### DIFF
--- a/radio/src/gui/colorlcd/model_curves.cpp
+++ b/radio/src/gui/colorlcd/model_curves.cpp
@@ -154,17 +154,17 @@ class CurveEditWindow : public Page
 #else
     void buildBody(FormWindow * window)
     {
-      FormGridLayout grid;
-      grid.setMarginLeft(20);
-      grid.setMarginRight(20);
-      grid.setLabelWidth(100);
-      grid.spacer(20);
-
       CurveHeader & curve = g_model.curves[index];
       int8_t * points = curveAddress(index);
 
+      FormGridLayout grid;
+      grid.setMarginLeft(PAGE_PADDING);
+      grid.setMarginRight(PAGE_PADDING);
+      grid.setLabelWidth(100);
+      grid.spacer(PAGE_PADDING);
+
       // Curve editor
-      curveEdit = new CurveEdit(window, { 20, grid.getWindowHeight(), LCD_W - 40, LCD_W - 40}, index);
+      curveEdit = new CurveEdit(window, { 42, grid.getWindowHeight(), LCD_W - 80, LCD_W - 80}, index);
       grid.spacer(curveEdit->height() + 15);
 
       // Name
@@ -229,6 +229,8 @@ class CurveEditWindow : public Page
                      curveEdit->updatePreview();
                    });
       grid.nextLine();
+
+      curveDataEdit = new CurveDataEdit(window, {PAGE_PADDING, grid.getWindowHeight(), coord_t(LCD_W - PAGE_PADDING - 1), window->height() -  grid.getWindowHeight() - PAGE_PADDING}, index, curveEdit);
     }
 #endif
 };

--- a/radio/src/gui/colorlcd/model_inputs.cpp
+++ b/radio/src/gui/colorlcd/model_inputs.cpp
@@ -173,8 +173,9 @@ class InputEditWindow : public Page
           [=]() -> int { return getValue(expoAddress(index)->srcRaw); })
   {
 #if LCD_W > LCD_H
-    body.setWidth(LCD_W - preview.width() - PAGE_PADDING);
-    body.setInnerWidth(LCD_W - preview.width() - PAGE_PADDING);
+    auto BODY_WIDTH = LCD_W - preview.width() - PAGE_PADDING;
+    body.setWidth(BODY_WIDTH);
+    body.setInnerWidth(BODY_WIDTH);
     body.setLeft(preview.width() + PAGE_PADDING);
 #else
     body.setRect({0, INPUT_EDIT_CURVE_TOP + INPUT_EDIT_CURVE_HEIGHT, LCD_W,

--- a/radio/src/gui/colorlcd/model_inputs.cpp
+++ b/radio/src/gui/colorlcd/model_inputs.cpp
@@ -174,6 +174,7 @@ class InputEditWindow : public Page
   {
 #if LCD_W > LCD_H
     body.setWidth(LCD_W - preview.width() - PAGE_PADDING);
+    body.setInnerWidth(LCD_W - preview.width() - PAGE_PADDING);
     body.setLeft(preview.width() + PAGE_PADDING);
 #else
     body.setRect({0, INPUT_EDIT_CURVE_TOP + INPUT_EDIT_CURVE_HEIGHT, LCD_W,

--- a/radio/src/gui/colorlcd/page.h
+++ b/radio/src/gui/colorlcd/page.h
@@ -86,7 +86,7 @@ class Page: public Window
 
     bool onTouchSlide(coord_t x, coord_t y, coord_t startX, coord_t startY, coord_t slideX, coord_t slideY) override
     {
-      Window::onTouchSlide(x, y, startX, startY, 0/*slideX*/, slideY);
+      Window::onTouchSlide(x, y, startX, startY, slideX, slideY);
       return true;
     }
 #endif

--- a/radio/src/gui/colorlcd/view_about.cpp
+++ b/radio/src/gui/colorlcd/view_about.cpp
@@ -35,6 +35,7 @@ AboutUs::AboutUs() :
   MessageDialog(MainWindow::instance(), STR_ABOUT_US, "")
 {
   content->setRect({(LCD_W - ABOUT_WIDTH) / 2, 20, ABOUT_WIDTH, LCD_H - 40});
+  content->setInnerWidth(ABOUT_WIDTH);
 
   messageWidget->setTextFlags(CENTERED | FONT(BOLD) | COLOR_THEME_SECONDARY1);
   messageWidget->setTop(content->top() + 40);


### PR DESCRIPTION
Fixes #963

Also some screen cosmetic changes

Although it is not strictly necessary to resolve the issue, I would also like to make it so `CurveDataEdit` will touch scroll, as without that the NV14 will not be able to edit more than 5 points on radio. The TX16S has the same issue, but is able to get around that due to hardware keys which will make it scroll.