### PR TITLE
Split window touch toр carousel start #981

### DIFF
--- a/radio/src/gui/colorlcd/view_main.cpp
+++ b/radio/src/gui/colorlcd/view_main.cpp
@@ -244,9 +244,8 @@ bool ViewMain::onTouchEnd(coord_t x, coord_t y)
   if (Window::onTouchEnd(x,y)) return true;
   if (!hasFocus()) {
     setFocus();
-  }
-  else {
-    openMenu();
+  } else {
+    openMenu((uint8_t)(x > parent->width() / 2));
   }
   return true;
 }
@@ -273,7 +272,7 @@ void ViewMain::onEvent(event_t event)
 
     case EVT_KEY_FIRST(KEY_ENTER):
       killEvents(event);
-      openMenu();
+      openMenu(0);
       break;
 
 #if defined(KEYS_GPIO_REG_PGUP)
@@ -310,9 +309,9 @@ void ViewMain::onEvent(event_t event)
 }
 #endif
 
-void ViewMain::openMenu()
+void ViewMain::openMenu(uint8_t half)
 {
-  new ViewMainMenu(this);
+  new ViewMainMenu(this, half);
 }
 
 void ViewMain::paint(BitmapBuffer * dc)

--- a/radio/src/gui/colorlcd/view_main.h
+++ b/radio/src/gui/colorlcd/view_main.h
@@ -102,7 +102,7 @@ class ViewMain: public Window
 
     void paint(BitmapBuffer * dc) override;
 
-    void openMenu();
+    void openMenu(uint8_t half = 0);
 };
 
 #endif // _VIEW_MAIN_H_

--- a/radio/src/gui/colorlcd/view_main_menu.cpp
+++ b/radio/src/gui/colorlcd/view_main_menu.cpp
@@ -33,7 +33,7 @@
 #include "select_fab_carousel.h"
 #include "view_text.h"
 
-ViewMainMenu::ViewMainMenu(Window* parent) :
+ViewMainMenu::ViewMainMenu(Window* parent, uint8_t half) :
     Window(parent->getFullScreenWindow(), {})
 {
   // Save focus
@@ -121,6 +121,8 @@ ViewMainMenu::ViewMainMenu(Window* parent) :
 
   carousel->setCloseHandler([=]() { deleteLater(); });
   carousel->setFocus();
+
+  if (half) pushEvent(EVT_ROTARY_LEFT);
 }
 
 uint16_t* lcdGetBackupBuffer();

--- a/radio/src/gui/colorlcd/view_main_menu.h
+++ b/radio/src/gui/colorlcd/view_main_menu.h
@@ -26,7 +26,7 @@
 class ViewMainMenu: public Window
 {
 public:
-    ViewMainMenu(Window * parent);
+    ViewMainMenu(Window * parent, uint8_t half = 0);
     void paint(BitmapBuffer * dc) override;
     void deleteLater(bool detach=true, bool trash=true) override;
 


### PR DESCRIPTION
This PR implement feature #981 
Touching the top bar or free window space on the right side brings the last carousel icon instead of the first one.