### PR TITLE
improve backlight handling on color lcd radios

### DIFF
--- a/companion/src/generaledit/generalsetup.cpp
+++ b/companion/src/generaledit/generalsetup.cpp
@@ -328,7 +328,8 @@ void GeneralSetupPanel::populateBacklightCB()
   QString strings[] = { tr("OFF"), tr("Keys"), tr("Sticks"), tr("Keys + Sticks"), tr("ON"), NULL };
 
   b->clear();
-  for (int i=0; !strings[i].isNull(); i++) {
+  int startValue = (firmware->getCapability(LcdDepth)>=8)?1:0;
+  for (int i=startValue; !strings[i].isNull(); i++) {
     b->addItem(strings[i], 0);
     if (generalSettings.backlightMode == i) {
       b->setCurrentIndex(b->count()-1);

--- a/radio/src/gui/colorlcd/radio_setup.h
+++ b/radio/src/gui/colorlcd/radio_setup.h
@@ -26,4 +26,9 @@ class RadioSetupPage: public PageTab {
     RadioSetupPage();
 
     void build(FormWindow * window) override;
+  private:
+    void updateBacklightControls();
+    FormField* backlightTimeout = nullptr;
+    FormField* backlightOnBright = nullptr;
+    FormField* backlightOffBright = nullptr;
 };

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1890,6 +1890,10 @@ void opentxInit()
 
 #if defined(COLORLCD)
   loadTheme();
+  if (g_eeGeneral.backlightMode == e_backlight_mode_off) {
+    // no backlight mode off on color lcd radios
+    g_eeGeneral.backlightMode = e_backlight_mode_keys;
+  }
 #endif
 
   if (g_eeGeneral.backlightMode != e_backlight_mode_off) {

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -559,12 +559,7 @@ void checkBacklight()
         backlightOn = !backlightOn;
       }
       if (backlightOn) {
-        uint8_t backlightBrightness = requiredBacklightBright;
-        if(g_eeGeneral.backlightMode != e_backlight_mode_on)
-        {
-          backlightBrightness = std::min<uint8_t>(requiredBacklightBright, BACKLIGHT_LEVEL_MAX - g_eeGeneral.blOffBright);
-        }
-        currentBacklightBright = backlightBrightness;
+        currentBacklightBright = requiredBacklightBright;
         BACKLIGHT_ENABLE();
       }
       else {

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -559,7 +559,12 @@ void checkBacklight()
         backlightOn = !backlightOn;
       }
       if (backlightOn) {
-        currentBacklightBright = requiredBacklightBright;
+        uint8_t backlightBrightness = requiredBacklightBright;
+        if(g_eeGeneral.backlightMode != e_backlight_mode_on)
+        {
+          backlightBrightness = std::min<uint8_t>(requiredBacklightBright, BACKLIGHT_LEVEL_MAX - g_eeGeneral.blOffBright);
+        }
+        currentBacklightBright = backlightBrightness;
         BACKLIGHT_ENABLE();
       }
       else {


### PR DESCRIPTION
no more backlight off for color lcd radios

disable backlight input controls in radio setup screen, when they are not used by the selected backlight mode -> needs PR ~~https://github.com/EdgeTX/libopenui/pull/34~~ to work

https://github.com/EdgeTX/libopenui/pull/33

force backlight on to be at least the brightness of backlight off
