### PR TITLE
Touch backlight handling

### DIFF
--- a/radio/src/main.cpp
+++ b/radio/src/main.cpp
@@ -375,7 +375,7 @@ void guiMain(event_t evt)
 #endif
 #if defined(HARDWARE_TOUCH)
   MainWindow* mainWin = MainWindow::instance();
-  mainWin->setTouchEnabled(!isFunctionActive(FUNCTION_DISABLE_TOUCH));
+  mainWin->setTouchEnabled(!isFunctionActive(FUNCTION_DISABLE_TOUCH) && isBacklightEnabled());
 #endif
   MainWindow::instance()->run();
 

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -541,7 +541,7 @@ void checkBacklight()
       }
     }
 
-#if defined(HARDWARE_TOUCH) /*&& defined(PCBNV14)*/
+#if defined(HARDWARE_TOUCH)
     if (MainWindow::instance()->touchEventOccured() && (g_eeGeneral.backlightMode & e_backlight_mode_keys)) {
       resetBacklightTimeout();
     }

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -540,8 +540,9 @@ void checkBacklight()
         resetBacklightTimeout();
       }
     }
-#if defined(HARDWARE_TOUCH) && defined(PCBNV14)
-    if (touchPanelEventOccured() && (g_eeGeneral.backlightMode & e_backlight_mode_keys)) {
+
+#if defined(HARDWARE_TOUCH) /*&& defined(PCBNV14)*/
+    if (MainWindow::instance()->touchEventOccured() && (g_eeGeneral.backlightMode & e_backlight_mode_keys)) {
       resetBacklightTimeout();
     }
 #endif

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -43,6 +43,7 @@ extern "C" {
 extern void flysky_hall_stick_init( void );
 
 HardwareOptions hardwareOptions;
+bool boardBacklightOn = false;
 
 void watchdogInit(unsigned int duration)
 {
@@ -329,4 +330,11 @@ uint16_t getBatteryVoltage()
 {
   int32_t instant_vbat = anaIn(TX_VOLTAGE);  // using filtered ADC value on purpose
   return (uint16_t)((instant_vbat * (1000 + g_eeGeneral.txVoltageCalibration)) / BATTERY_DIVIDER);
+}
+
+bool isBacklightEnabled()
+{
+  if(globalData.unexpectedShutdown)
+    return true;
+  return boardBacklightOn;
 }

--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -597,9 +597,11 @@ void backlightEnable(uint8_t dutyCycle = 0);
 #else
 #define BACKLIGHT_LEVEL_MIN   46
 #endif
-#define BACKLIGHT_ENABLE()    backlightEnable(globalData.unexpectedShutdown ? BACKLIGHT_LEVEL_MAX : BACKLIGHT_LEVEL_MAX - currentBacklightBright)
-#define BACKLIGHT_DISABLE()   backlightEnable(globalData.unexpectedShutdown ? BACKLIGHT_LEVEL_MAX : ((g_eeGeneral.blOffBright == BACKLIGHT_LEVEL_MIN) && (g_eeGeneral.backlightMode != e_backlight_mode_off)) ? 0 : g_eeGeneral.blOffBright)
-#define isBacklightEnabled()  true
+
+extern bool boardBacklightOn;
+#define BACKLIGHT_ENABLE()    {boardBacklightOn = true; backlightEnable(globalData.unexpectedShutdown ? BACKLIGHT_LEVEL_MAX : BACKLIGHT_LEVEL_MAX - currentBacklightBright);}
+#define BACKLIGHT_DISABLE()   {boardBacklightOn = false; backlightEnable(globalData.unexpectedShutdown ? BACKLIGHT_LEVEL_MAX : ((g_eeGeneral.blOffBright == BACKLIGHT_LEVEL_MIN) && (g_eeGeneral.backlightMode != e_backlight_mode_off)) ? 0 : g_eeGeneral.blOffBright);}
+bool isBacklightEnabled();
 
 #if !defined(SIMU)
 void usbJoystickUpdate();

--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -597,11 +597,16 @@ void backlightEnable(uint8_t dutyCycle = 0);
 #else
 #define BACKLIGHT_LEVEL_MIN   46
 #endif
-
+#if defined(SIMU)
+#define BACKLIGHT_ENABLE()
+#define BACKLIGHT_DISABLE()
+#define isBacklightEnabled(...) true
+#else
 extern bool boardBacklightOn;
 #define BACKLIGHT_ENABLE()    {boardBacklightOn = true; backlightEnable(globalData.unexpectedShutdown ? BACKLIGHT_LEVEL_MAX : BACKLIGHT_LEVEL_MAX - currentBacklightBright);}
 #define BACKLIGHT_DISABLE()   {boardBacklightOn = false; backlightEnable(globalData.unexpectedShutdown ? BACKLIGHT_LEVEL_MAX : ((g_eeGeneral.blOffBright == BACKLIGHT_LEVEL_MIN) && (g_eeGeneral.backlightMode != e_backlight_mode_off)) ? 0 : g_eeGeneral.blOffBright);}
 bool isBacklightEnabled();
+#endif
 
 #if !defined(SIMU)
 void usbJoystickUpdate();

--- a/radio/src/targets/horus/tp_gt911.cpp
+++ b/radio/src/targets/horus/tp_gt911.cpp
@@ -416,7 +416,7 @@ short tapCount = 0;
 
 I2C_HandleTypeDef hi2c1;
 
-static TouchState internalTouchState ={};
+static TouchState internalTouchState = {};
 
 static void TOUCH_AF_ExtiStop(void)
 {
@@ -810,10 +810,6 @@ struct TouchState touchPanelRead()
 extern "C" void TOUCH_INT_EXTI_IRQHandler1(void)
 {
   if (EXTI_GetITStatus(TOUCH_INT_EXTI_LINE1) != RESET) {
-    if (g_eeGeneral.backlightMode & e_backlight_mode_keys) {
-      // on touch turn the light on
-      resetBacklightTimeout();
-    }
     touchEventOccured = true;
     EXTI_ClearITPendingBit(TOUCH_INT_EXTI_LINE1);
   }

--- a/radio/src/targets/horus/tp_gt911.h
+++ b/radio/src/targets/horus/tp_gt911.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include "touch.h"
+
 #define HAS_TOUCH_PANEL()     touchGT911Flag == true
 
 extern bool touchGT911Flag;
@@ -28,7 +30,7 @@ extern uint16_t touchGT911fwver;
 extern uint32_t touchGT911hiccups;
 extern bool touchPanelInit();
 
-void touchPanelRead();
+struct TouchState touchPanelRead();
 bool touchPanelEventOccured();
 
 #define GT911_TIMEOUT           3 // 3ms

--- a/radio/src/targets/nv14/board.h
+++ b/radio/src/targets/nv14/board.h
@@ -553,6 +553,6 @@ extern AuxSerialRxFifo auxSerialRxFifo;
 
 // Touch panel driver
 bool touchPanelEventOccured();
-void touchPanelRead();
+struct TouchState touchPanelRead();
 
 #endif // _BOARD_H_

--- a/radio/src/targets/simu/opentxsimulator.cpp
+++ b/radio/src/targets/simu/opentxsimulator.cpp
@@ -315,7 +315,7 @@ void OpenTxSimulator::touchEvent(int type, int x, int y)
 {
   #if defined(HARDWARE_TOUCH)
     tmr10ms_t now = get_tmr10ms();
-    touchState.tapCount = 0;
+    simTouchState.tapCount = 0;
   #endif
 
   switch (type) {
@@ -323,9 +323,9 @@ void OpenTxSimulator::touchEvent(int type, int x, int y)
       TRACE_WINDOWS("[Mouse Press] %d %d", x, y);
 
 #if defined(HARDWARE_TOUCH)
-      touchState.event = TE_DOWN;
-      touchState.startX = touchState.x = x;
-      touchState.startY = touchState.y = y;
+      simTouchState.event = TE_DOWN;
+      simTouchState.startX = simTouchState.x = x;
+      simTouchState.startY = simTouchState.y = y;
       downTime = now;
 #endif
       break;
@@ -334,20 +334,20 @@ void OpenTxSimulator::touchEvent(int type, int x, int y)
       TRACE_WINDOWS("[Mouse Release] %d %d", x, y);
 
 #if defined(HARDWARE_TOUCH)
-      if (touchState.event == TE_DOWN) {
-        touchState.event = TE_UP;
-        touchState.x = touchState.startX;
-        touchState.y = touchState.startY;
+      if (simTouchState.event == TE_DOWN) {
+        simTouchState.event = TE_UP;
+        simTouchState.x = simTouchState.startX;
+        simTouchState.y = simTouchState.startY;
         if (now - downTime <= TAP_TIME) {
           if (now - tapTime > TAP_TIME)
             tapCount = 1;
           else
             tapCount++;
-          touchState.tapCount = tapCount;
+          simTouchState.tapCount = tapCount;
           tapTime = now;
         }
       } else {
-        touchState.event = TE_SLIDE_END;
+        simTouchState.event = TE_SLIDE_END;
       }
 #endif
       break;
@@ -356,18 +356,21 @@ void OpenTxSimulator::touchEvent(int type, int x, int y)
       TRACE_WINDOWS("[Mouse Move] %d %d", x, y);
 
 #if defined(HARDWARE_TOUCH)
-      touchState.deltaX += x - touchState.x;
-      touchState.deltaY += y - touchState.y;
-      if (touchState.event == TE_SLIDE ||
-          abs(touchState.deltaX) >= SLIDE_RANGE ||
-          abs(touchState.deltaY) >= SLIDE_RANGE) {
-        touchState.event = TE_SLIDE;
-        touchState.x = x;
-        touchState.y = y;
+      simTouchState.deltaX += x - simTouchState.x;
+      simTouchState.deltaY += y - simTouchState.y;
+      if (simTouchState.event == TE_SLIDE ||
+          abs(simTouchState.deltaX) >= SLIDE_RANGE ||
+          abs(simTouchState.deltaY) >= SLIDE_RANGE) {
+        simTouchState.event = TE_SLIDE;
+        simTouchState.x = x;
+        simTouchState.y = y;
       }
 #endif
       break;
   }
+#if defined(HARDWARE_TOUCH)
+  simTouchOccured=true;
+#endif
 }
 
 void OpenTxSimulator::setTrainerTimeout(uint16_t ms)

--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -894,11 +894,22 @@ void check_intmodule_heartbeat()
 }
 #endif
 
+#if defined(HARDWARE_TOUCH)
+struct TouchState simTouchState = {};
+bool simTouchOccured = false;
+
 bool touchPanelEventOccured()
 {
+  if(simTouchOccured)
+  {
+    simTouchOccured = false;
+    return true;
+  }
   return false;
 }
 
-void touchPanelRead()
+struct TouchState touchPanelRead()
 {
+  return simTouchState;
 }
+#endif

--- a/radio/src/targets/simu/simpgmspace.h
+++ b/radio/src/targets/simu/simpgmspace.h
@@ -321,4 +321,9 @@ void simuMain();
   #define TRACE_SIMPGMSPACE(...)
 #endif
 
+#if defined(HARDWARE_TOUCH)
+  extern struct TouchState simTouchState;
+  extern bool simTouchOccured;
+#endif
+
 #endif // _SIMPGMSPACE_H_

--- a/radio/src/touch.h
+++ b/radio/src/touch.h
@@ -45,8 +45,9 @@ struct TouchState
   short tapCount;
 };
 
-constexpr uint8_t SLIDE_RANGE = 6;
 
-extern TouchState touchState;
+#define SLIDE_RANGE 6
+
+extern struct TouchState touchState;
 
 #endif // _TOUCH_H_


### PR DESCRIPTION
this PR needs https://github.com/EdgeTX/libopenui/pull/34 to compile and work correctly.
With this PR touch handling is modified to prevent touch events from happening, if the backlight is off.
For this to work, touch drivers now need to return the TouchEvent structure instead of writing into a libopenui global variable.
The interface between touch driver and backlight control now hast to go through libopenui, to be able to filter touch event there, without activating the backlight before libopenui can handle the event.

The touch driver for NV14 got the necessary modifications and compiles, but is untested.

This should close #420 