### PR TITLE
Take 2 on Issue817

### DIFF
--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1882,7 +1882,7 @@ static int luaSetStickySwitch(lua_State * L)
 }
 
 /*luadoc
-@function getLS(id)
+@function getLogicalSwitchValue(id)
 
 @param id: integer identifying the logical switch (zero for LS1 etc.).
 
@@ -1893,7 +1893,7 @@ Reads the value of a logical switch.
 @status current Introduced in 2.6
 */
 
-static int luaGetLS(lua_State * L)
+static int luaGetLogicalSwitchValue(lua_State * L)
 {
   int id = luaL_checkinteger(L, 1);
 
@@ -1964,7 +1964,7 @@ const luaL_Reg opentxLib[] = {
   { "getShmVar", luaGetShmVar },
 #endif
   { "setStickySwitch", luaSetStickySwitch },
-  { "getLS", luaGetLS },
+  { "getLogicalSwitchValue", luaGetLogicalSwitchValue },
   { nullptr, nullptr }  /* sentinel */
 };
 

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1848,12 +1848,10 @@ static int luaGetShmVar(lua_State * L)
 }
 #endif
 
-//api_general.cpp
-
 /*luadoc
 @function setStickySwitch(id, value) 
 
-@param id: integer identifying the sticky logical switch.
+@param id: integer identifying the sticky logical switch (zero for LS1 etc.).
 
 @param value: true/false. The new value of the sticky logical switch.
 
@@ -1879,7 +1877,30 @@ static int luaSetStickySwitch(lua_State * L)
   if (value) msg |= (1 << 7);
   msg |= (id & 0x3F);
 
-  lua_pushboolean (L, luaSetStickySwitchBuffer.write(msg));
+  lua_pushboolean(L, luaSetStickySwitchBuffer.write(msg));
+  return 1;
+}
+
+/*luadoc
+@function getLS(id)
+
+@param id: integer identifying the logical switch (zero for LS1 etc.).
+
+@retval value: true/false.
+
+Reads the value of a logical switch.
+
+@status current Introduced in 2.6
+*/
+
+static int luaGetLS(lua_State * L)
+{
+  int id = luaL_checkinteger(L, 1);
+
+  if (id >= 0 && id < MAX_LOGICAL_SWITCHES)
+    lua_pushboolean(L, getSwitch(SWSRC_FIRST_LOGICAL_SWITCH + id));
+  else
+    lua_pushnil(L);
   return 1;
 }
 
@@ -1943,6 +1964,7 @@ const luaL_Reg opentxLib[] = {
   { "getShmVar", luaGetShmVar },
 #endif
   { "setStickySwitch", luaSetStickySwitch },
+  { "getLS", luaGetLS },
   { nullptr, nullptr }  /* sentinel */
 };
 

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1848,6 +1848,41 @@ static int luaGetShmVar(lua_State * L)
 }
 #endif
 
+//api_general.cpp
+
+/*luadoc
+@function setStickySwitch(id, value) 
+
+@param id: integer identifying the sticky logical switch.
+
+@param value: true/false. The new value of the sticky logical switch.
+
+@retval bufferFull: true/false. This function sends a message from Lua to the logical switch processor 
+via a buffer with eight slots that are read 10 times per second. If the buffer is full, then a true value 
+is returned and no messages was sent (i.e. the switch was not changed).
+
+Sets the value of a sticky logical switch.
+
+@status current Introduced in 2.6
+*/
+
+#if (MAX_LOGICAL_SWITCHES != 64)
+#warning "The following code assumes that MAX_LOGICAL_SWITCHES == 64!"
+#endif
+
+static int luaSetStickySwitch(lua_State * L)
+{
+  int id = luaL_checkinteger(L, 1);
+  bool value = lua_toboolean(L, 2);
+
+  uint8_t msg = (1 << 6);       // This bit is always set to have a non-zero value
+  if (value) msg |= (1 << 7);
+  msg |= (id & 0x3F);
+
+  lua_pushboolean (L, luaSetStickySwitchBuffer.write(msg));
+  return 1;
+}
+
 const luaL_Reg opentxLib[] = {
   { "getTime", luaGetTime },
   { "getDateTime", luaGetDateTime },
@@ -1907,6 +1942,7 @@ const luaL_Reg opentxLib[] = {
   { "setShmVar", luaSetShmVar },
   { "getShmVar", luaGetShmVar },
 #endif
+  { "setStickySwitch", luaSetStickySwitch },
   { nullptr, nullptr }  /* sentinel */
 };
 

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -1310,3 +1310,5 @@ inline bool isAsteriskDisplayed()
 }
 
 #include "module.h"
+
+extern CircularBuffer<uint8_t, 8> luaSetStickySwitchBuffer;

--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -803,6 +803,15 @@ void logicalSwitchesTimerTick()
       for (uint8_t fm=0; fm<MAX_FLIGHT_MODES; fm++) {
         ls_sticky_struct & lastValue = (ls_sticky_struct &)LS_LAST_VALUE(fm, i);
         lastValue.state = s;
+        bool now;
+        if (s)
+          now = getSwitch(ls->v2);
+        else
+          now = getSwitch(ls->v1);
+        if (now)
+          lastValue.last |= 1;
+        else
+          lastValue.last &= ~1;
       }
     }
     msg = luaSetStickySwitchBuffer.read();

--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -53,6 +53,7 @@ PACK(struct LogicalSwitchesFlightModeContext {
   LogicalSwitchContext lsw[MAX_LOGICAL_SWITCHES];
 });
 LogicalSwitchesFlightModeContext lswFm[MAX_FLIGHT_MODES];
+CircularBuffer<uint8_t, 8> luaSetStickySwitchBuffer;
 
 #define LS_LAST_VALUE(fm, idx) lswFm[fm].lsw[idx].lastValue
 
@@ -789,6 +790,25 @@ void checkSwitches()
 
 void logicalSwitchesTimerTick()
 {
+#if (MAX_LOGICAL_SWITCHES != 64)
+#warning "The following code assumes that MAX_LOGICAL_SWITCHES == 64!"
+#endif
+  // Read messages from Lua in the buffer and flick switches
+  uint8_t msg = luaSetStickySwitchBuffer.read();
+  while(msg) {
+    uint8_t i = msg & 0x3F;
+    uint8_t s = msg >> 7;
+    LogicalSwitchData * ls = lswAddress(i);
+    if (ls->func == LS_FUNC_STICKY) {
+      for (uint8_t fm=0; fm<MAX_FLIGHT_MODES; fm++) {
+        ls_sticky_struct & lastValue = (ls_sticky_struct &)LS_LAST_VALUE(fm, i);
+        lastValue.state = s;
+      }
+    }
+    msg = luaSetStickySwitchBuffer.read();
+  }
+  
+  // Update logical switches
   for (uint8_t fm=0; fm<MAX_FLIGHT_MODES; fm++) {
     for (uint8_t i=0; i<MAX_LOGICAL_SWITCHES; i++) {
       LogicalSwitchData * ls = lswAddress(i);
@@ -900,6 +920,8 @@ void logicalSwitchesReset()
       LS_LAST_VALUE(fm, i) = CS_LAST_VALUE_INIT;
     }
   }
+  
+  luaSetStickySwitchBuffer.clear();
 }
 
 getvalue_t convertLswTelemValue(LogicalSwitchData * ls)


### PR DESCRIPTION
Here is another go at adding a Lua function to set the value sticky logical switches (Issue #817). It uses a circular buffer to send data from Lua to `logicalSwitchesTimerTick()`.
@raphaelcoeffic @rotorman please review!