### PR TITLE
Fix theme editor

### DIFF
--- a/radio/src/gui/colorlcd/listbox.cpp
+++ b/radio/src/gui/colorlcd/listbox.cpp
@@ -80,17 +80,15 @@ void ListBase::drawLine(BitmapBuffer *dc, const rect_t &rect, uint32_t index, Lc
 void ListBase::paint(BitmapBuffer *dc)
 {
   dc->clear(COLOR_THEME_SECONDARY3);
-  uint32_t bgColor = 0;
-  bgColor = hasFocus() ? COLOR_THEME_FOCUS : COLOR_THEME_SECONDARY1;
 
   int curY = 0;
   for (int n = 0; n < (int)names.size(); n++) {
-    if (n == selected) {
-      dc->drawSolidFilledRect(1, curY, rect.w - 2, lineHeight, bgColor);
-    }
+    //if (n == selected) {
+      dc->drawSolidFilledRect(1, curY, rect.w - 2, lineHeight, n == selected ? COLOR_THEME_FOCUS : COLOR_THEME_PRIMARY2);
+    //}
 
     LcdFlags textColor =
-        n == selected ? COLOR_THEME_PRIMARY2 : COLOR_THEME_PRIMARY1;
+        n == selected ? COLOR_THEME_PRIMARY2 : COLOR_THEME_SECONDARY1;
 
     auto fontHeight = getFontHeight(FONT(STD));
     drawLine(dc, { 8, curY  + (lineHeight - fontHeight) / 2, rect.w, lineHeight}, n, textColor);

--- a/radio/src/gui/colorlcd/preview_window.h
+++ b/radio/src/gui/colorlcd/preview_window.h
@@ -111,6 +111,9 @@ class ThemedCheckBox : public CheckBox
       CheckBox(parent, rect, [=]() { return checked; }, [](uint8_t value) {}, NO_FOCUS),
       checked(checked)
   {
+    enable(false);
+    setFocusHandler([] (bool focus) {
+    });
   }
 
 #if defined(HARDWARE_KEYS)

--- a/radio/src/gui/colorlcd/preview_window.h
+++ b/radio/src/gui/colorlcd/preview_window.h
@@ -86,15 +86,22 @@ class ThemedTextEdit : public TextEdit
 class ThemedStaticText : public StaticText
 {
  public:
-  using StaticText::StaticText;
+  ThemedStaticText(FormGroup *window, const rect_t &rect, std::string text, LcdColorIndex colorIndex) :
+    StaticText(window, rect, text, 0, COLOR(colorIndex)),
+    _colorIndex(colorIndex)
+  {
+  }
 
   void paint(BitmapBuffer *dc) override
   {
     colorMaintainer.applyColorValues();
-    setTextFlags(COLOR_THEME_PRIMARY1);
+    setTextFlags(COLOR(_colorIndex));
     StaticText::paint(dc);
     colorMaintainer.restoreColorValues();
   }
+
+  protected:
+    LcdColorIndex _colorIndex;
 };
 
 class ThemedCheckBox : public CheckBox
@@ -120,14 +127,14 @@ class ThemedCheckBox : public CheckBox
 
 class ThemedMainViewHorizontalTrim : public MainViewHorizontalTrim
 {
- public:
-  using MainViewHorizontalTrim::MainViewHorizontalTrim;
-  void paint(BitmapBuffer *dc) override
-  {
-    colorMaintainer.applyColorValues();
-    MainViewHorizontalTrim::paint(dc);
-    colorMaintainer.restoreColorValues();
-  }
+  public:
+    using MainViewHorizontalTrim::MainViewHorizontalTrim;
+    void paint(BitmapBuffer *dc) override
+    {
+      colorMaintainer.applyColorValues();
+      MainViewHorizontalTrim::paint(dc);
+      colorMaintainer.restoreColorValues();
+    }
 };
 
 class ThemedMainViewHorizontalSlider : public MainViewHorizontalSlider
@@ -142,6 +149,29 @@ class ThemedMainViewHorizontalSlider : public MainViewHorizontalSlider
   }
 };
 
+class ThemedButton : public TextButton
+{
+  public:
+    ThemedButton(FormGroup *window, const rect_t &rect, std::string text, WindowFlags windowFlags, 
+                 LcdColorIndex colorIndex) :
+      TextButton(window, rect, text, nullptr, windowFlags, COLOR(colorIndex)),
+      _colorIndex(colorIndex)
+    {
+      setPressHandler([=] () { return true; });
+    }
+
+    void paint(BitmapBuffer *dc) override
+    {
+      colorMaintainer.applyColorValues();
+      setTextFlags(COLOR(_colorIndex));
+      TextButton::paint(dc);
+      colorMaintainer.restoreColorValues();
+    }
+  protected:
+    LcdColorIndex _colorIndex;
+};
+
+
 // display controls using the appropriate theme.
 class PreviewWindow : public FormGroup
 {
@@ -150,14 +180,14 @@ class PreviewWindow : public FormGroup
                 std::vector<ColorEntry> colorList) :
       FormGroup(window, rect, NO_FOCUS), _colorList(colorList)
   {
-    new ThemedStaticText(this, {5, 40, 100, LINE_HEIGHT}, "Checkbox", 0,
-                         COLOR_THEME_PRIMARY1);
+    new ThemedStaticText(this, {5, 40, 100, LINE_HEIGHT}, "Checkbox", COLOR_THEME_PRIMARY1_INDEX);
     new ThemedCheckBox(this, {100 + 15, 40, 20, LINE_HEIGHT}, true);
     new ThemedCheckBox(this, {140 + 15, 40, 20, LINE_HEIGHT}, false);
-    new ThemedMainViewHorizontalTrim(this,
-                                     {5, 65, HORIZONTAL_SLIDERS_WIDTH, 20}, 0);
-    new ThemedMainViewHorizontalSlider(
-        this, {5, 87, HORIZONTAL_SLIDERS_WIDTH, 20}, 0);
+    new ThemedMainViewHorizontalTrim(this, {5, 65, HORIZONTAL_SLIDERS_WIDTH, 20}, 0);
+    new ThemedMainViewHorizontalSlider(this, {5, 87, HORIZONTAL_SLIDERS_WIDTH, 20}, 0);
+    new ThemedButton(this, {5, 109, 100, LINE_HEIGHT + 10}, "Checked", BUTTON_CHECKED, COLOR_THEME_PRIMARY1_INDEX);
+    new ThemedButton(this, {110, 109, 100, LINE_HEIGHT + 10}, "Regular", 0, COLOR_THEME_PRIMARY1_INDEX);
+    new ThemedStaticText(this, {5, 145, 100, LINE_HEIGHT}, "Warning Text", COLOR_THEME_WARNING_INDEX);
     ticks = getTicks();
   }
 
@@ -214,26 +244,23 @@ class PreviewWindow : public FormGroup
     dc->clear(COLOR_THEME_SECONDARY3);
 
     // top bar background
-    dc->drawSolidFilledRect(0, 0, rect.w, TOPBAR_HEIGHT,
-                            COLOR_THEME_SECONDARY1);
+    dc->drawSolidFilledRect(0, 0, rect.w, TOPBAR_HEIGHT, COLOR_THEME_SECONDARY1);
 
     int width;
     int x = 5;
     // topbar icons
-    auto bm = getBitmap(mask_menu_radio, COLOR_THEME_SECONDARY1,
-                        COLOR_THEME_PRIMARY2, &width);
+    auto bm = getBitmap(mask_menu_radio, COLOR_THEME_SECONDARY1, COLOR_THEME_PRIMARY2, &width);
     dc->drawBitmap(x, 5, bm);
     x += MENU_HEADER_BUTTON_WIDTH + 2;
     delete bm;
 
-    bm = getBitmap(mask_radio_tools, COLOR_THEME_SECONDARY1,
-                   COLOR_THEME_PRIMARY2, &width);
+    dc->drawSolidFilledRect(x - 2, 0, MENU_HEADER_BUTTON_WIDTH + 2, TOPBAR_HEIGHT, COLOR_THEME_FOCUS);
+    bm = getBitmap(mask_radio_tools, COLOR_THEME_FOCUS, COLOR_THEME_PRIMARY2, &width);
     dc->drawBitmap(x, 5, bm);
     x += MENU_HEADER_BUTTON_WIDTH + 2;
     delete bm;
 
-    bm = getBitmap(mask_radio_setup, COLOR_THEME_SECONDARY1,
-                   COLOR_THEME_PRIMARY2, &width);
+    bm = getBitmap(mask_radio_setup, COLOR_THEME_SECONDARY1, COLOR_THEME_PRIMARY2, &width);
     dc->drawBitmap(x, 5, bm);
     delete bm;
 

--- a/radio/src/gui/colorlcd/preview_window.h
+++ b/radio/src/gui/colorlcd/preview_window.h
@@ -108,11 +108,17 @@ class ThemedCheckBox : public CheckBox
 {
  public:
   ThemedCheckBox(Window *parent, rect_t rect, bool checked) :
-      CheckBox(
-          parent, rect, [=]() { return checked; }, [](uint8_t value) {}),
+      CheckBox(parent, rect, [=]() { return checked; }, [](uint8_t value) {}, NO_FOCUS),
       checked(checked)
   {
   }
+
+#if defined(HARDWARE_KEYS)
+  void onEvent(event_t event) override
+  {
+    return parent->onEvent(event);
+  }
+#endif
 
   void paint(BitmapBuffer *dc) override
   {
@@ -152,13 +158,21 @@ class ThemedMainViewHorizontalSlider : public MainViewHorizontalSlider
 class ThemedButton : public TextButton
 {
   public:
-    ThemedButton(FormGroup *window, const rect_t &rect, std::string text, WindowFlags windowFlags, 
+    ThemedButton(FormGroup *window, const rect_t &rect, std::string text, bool isChecked, WindowFlags windowFlags, 
                  LcdColorIndex colorIndex) :
-      TextButton(window, rect, text, nullptr, windowFlags, COLOR(colorIndex)),
-      _colorIndex(colorIndex)
+      TextButton(window, rect, text, nullptr, windowFlags | NO_FOCUS, COLOR(colorIndex)),
+      _colorIndex(colorIndex),
+      _isChecked(isChecked)
     {
-      setPressHandler([=] () { return true; });
+      setPressHandler([=] () { return _isChecked; });
     }
+
+#if defined(HARDWARE_KEYS)
+    void onEvent(event_t event) override
+    {
+      parent->onEvent(event);
+    }
+#endif
 
     void paint(BitmapBuffer *dc) override
     {
@@ -169,6 +183,7 @@ class ThemedButton : public TextButton
     }
   protected:
     LcdColorIndex _colorIndex;
+    bool _isChecked = true;
 };
 
 
@@ -185,8 +200,8 @@ class PreviewWindow : public FormGroup
     new ThemedCheckBox(this, {140 + 15, 40, 20, LINE_HEIGHT}, false);
     new ThemedMainViewHorizontalTrim(this, {5, 65, HORIZONTAL_SLIDERS_WIDTH, 20}, 0);
     new ThemedMainViewHorizontalSlider(this, {5, 87, HORIZONTAL_SLIDERS_WIDTH, 20}, 0);
-    new ThemedButton(this, {5, 109, 100, LINE_HEIGHT + 10}, "Checked", BUTTON_CHECKED, COLOR_THEME_PRIMARY1_INDEX);
-    new ThemedButton(this, {110, 109, 100, LINE_HEIGHT + 10}, "Regular", 0, COLOR_THEME_PRIMARY1_INDEX);
+    new ThemedButton(this, {5, 109, 100, LINE_HEIGHT + 10}, "Checked", true, BUTTON_CHECKED, COLOR_THEME_PRIMARY1_INDEX);
+    new ThemedButton(this, {110, 109, 100, LINE_HEIGHT + 10}, "Regular", false, 0, COLOR_THEME_PRIMARY1_INDEX);
     new ThemedStaticText(this, {5, 145, 100, LINE_HEIGHT}, "Warning Text", COLOR_THEME_WARNING_INDEX);
     ticks = getTicks();
   }

--- a/radio/src/gui/colorlcd/radio_theme.cpp
+++ b/radio/src/gui/colorlcd/radio_theme.cpp
@@ -64,8 +64,8 @@ constexpr int COLOR_BOX_LEFT = 3;
 constexpr int COLOR_BOX_WIDTH = 45;
 constexpr int COLOR_BOX_HEIGHT = 27;
 #else
-constexpr int BUTTON_HEIGHT = 25;
-constexpr int BUTTON_WIDTH  = 50;
+constexpr int BUTTON_HEIGHT = 30;
+constexpr int BUTTON_WIDTH  = 65;
 constexpr LcdFlags textFont = FONT(XS);
 constexpr rect_t detailsDialogRect = {5, 50, LCD_W - 10, 340};
 constexpr int labelWidth = 120;
@@ -586,7 +586,7 @@ void ThemeSetupPage::build(FormWindow *window)
 
   // author and name of theme on right side of screen
   r.x += 7;
-  r.y += 130;
+  r.y += 135;
   r.h = 20;
   nameText = new StaticText(window, r, theme != nullptr ? theme->getName() : "", 0, 
                             COLOR_THEME_PRIMARY1);

--- a/radio/src/gui/colorlcd/radio_theme.cpp
+++ b/radio/src/gui/colorlcd/radio_theme.cpp
@@ -479,18 +479,15 @@ void ThemeSetupPage::displayThemeMenu(Window *window, ThemePersistance *tp)
 
     new ThemeDetailsDialog(window, newTheme, [=] (ThemeFile theme) {
       if (strlen(theme.getName()) != 0) {
-        char path[NAME_LENGTH + 20];
-        strncpy(path, theme.getName(), NAME_LENGTH + 19);
-        removeAllWhiteSpace(path);
-        strncat(path, ".yml", NAME_LENGTH + 19);
-        theme.setPath(path);
-
+        char name[NAME_LENGTH + 20];
+        strncpy(name, theme.getName(), NAME_LENGTH + 19);
+        removeAllWhiteSpace(name);
         // use the current themes color list to make the new theme
         auto curTheme = tp->getCurrentTheme();
         for (auto color : curTheme->getColorList())
           theme.setColor(color.colorNumber, color.colorValue);
 
-        theme.serialize();
+        tp->createNewTheme(name, theme);
         tp->refresh();
         listBox->setNames(tp->getNames());
         listBox->setSelected(currentTheme);
@@ -504,7 +501,7 @@ void ThemeSetupPage::displayThemeMenu(Window *window, ThemePersistance *tp)
       if (confirmationDialog("Delete Theme?", tp->getThemeByIndex(listBox->getSelected())->getName())) {
         tp->deleteThemeByIndex(listBox->getSelected());
         listBox->setNames(tp->getNames());
-        listBox->setSelected(currentTheme);
+        listBox->setSelected(min<int>(currentTheme, tp->getNames().size() - 1));
       }
     });
   }
@@ -530,7 +527,10 @@ void ThemeSetupPage::setupListbox(FormWindow *window, rect_t r, ThemePersistance
   listBox->setActiveIndex(tp->getThemeIndex());
   listBox->setTitle(STR_THEME + std::string("s"));
   listBox->setLongPressHandler([=] (event_t event) { displayThemeMenu(window, tp); });
-  listBox->setPressHandler([=] (event_t event) { displayThemeMenu(window, tp); });
+  listBox->setPressHandler([=] (event_t event) { 
+    if (event != 0)
+      displayThemeMenu(window, tp); 
+  });
 }
 
 void ThemeSetupPage::build(FormWindow *window)

--- a/radio/src/gui/colorlcd/radio_theme.cpp
+++ b/radio/src/gui/colorlcd/radio_theme.cpp
@@ -557,7 +557,6 @@ void ThemeSetupPage::build(FormWindow *window)
   setupListbox(window, r, tp);
 
   rect_t colorPreviewRect;
-  rect_t previewRect;
   if (LCD_W > LCD_H) {
     r.x = LEFT_LIST_WIDTH + MARGIN_WIDTH;
     r.w = LCD_W - r.x;
@@ -566,7 +565,7 @@ void ThemeSetupPage::build(FormWindow *window)
     r.y += LEFT_LIST_HEIGHT + 4;
     r.x = 0;
     r.w = LCD_W;
-    colorPreviewRect = {0, LEFT_LIST_HEIGHT + 3, COLOR_PREVIEW_WIDTH, COLOR_PREVIEW_HEIGHT};
+    colorPreviewRect = {0, LEFT_LIST_HEIGHT + 6, COLOR_PREVIEW_WIDTH, COLOR_PREVIEW_HEIGHT};
   }
 
   // setup ThemeColorPreview()
@@ -580,7 +579,7 @@ void ThemeSetupPage::build(FormWindow *window)
     r.x += COLOR_PREVIEW_WIDTH;
   } else {
     r.y += COLOR_PREVIEW_HEIGHT;
-    r.h = LEFT_LIST_HEIGHT - COLOR_PREVIEW_HEIGHT - 6;
+    r.h = LEFT_LIST_HEIGHT - COLOR_PREVIEW_HEIGHT - 50;
   }
   auto fileNames = theme != nullptr ? theme->getThemeImageFileNames() : std::vector<std::string>();
   fileCarosell = new FileCarosell(window, r, fileNames, listBox);

--- a/radio/src/gui/colorlcd/radio_theme.cpp
+++ b/radio/src/gui/colorlcd/radio_theme.cpp
@@ -320,6 +320,7 @@ class ThemeEditPage : public Page
           focus->getNextField()->setFocus(SET_FOCUS_FORWARD, focus);
         }
       } else if (event == EVT_KEY_FIRST(KEY_EXIT)) {
+        killEvents(event);
         deleteLater();
       } else {
         Window::onEvent(event);

--- a/radio/src/gui/colorlcd/radio_theme.cpp
+++ b/radio/src/gui/colorlcd/radio_theme.cpp
@@ -40,11 +40,15 @@
   #define COLOR_PREVIEW_HEIGHT  (LCD_H - TOPBAR_HEIGHT - 30)
   #define LEFT_LIST_WIDTH (LCD_W / 2) - COLOR_PREVIEW_WIDTH
   #define LEFT_LIST_HEIGHT (LCD_H - TOPBAR_HEIGHT - 37)
+  #define COLOR_LIST_WIDTH ((LCD_W * 3)/10)
+  #define COLOR_LIST_HEIGHT (LCD_H - TOPBAR_HEIGHT)
 #else
-  #define COLOR_PREVIEW_WIDTH 18
-  #define COLOR_PREVIEW_HEIGHT  (LCD_H - TOPBAR_HEIGHT - 30)
+  #define COLOR_PREVIEW_WIDTH LCD_W
+  #define COLOR_PREVIEW_HEIGHT  18
   #define LEFT_LIST_WIDTH LCD_W
   #define LEFT_LIST_HEIGHT (LCD_H / 2 - 38)
+  #define COLOR_LIST_WIDTH LCD_W
+  #define COLOR_LIST_HEIGHT (LCD_H / 2 - 38)
 #endif
 
 #define MARGIN_WIDTH 5
@@ -74,8 +78,6 @@ constexpr int COLOR_BUTTON_WIDTH = COLOR_BOX_WIDTH;
 constexpr int COLOR_BUTTON_HEIGHT = 20;
 #endif
 
-#define COLOR_LIST_WIDTH ((LCD_W * 3)/10)
-#define COLOR_LIST_HEIGHT (LCD_H - TOPBAR_HEIGHT)
 
 
 class ThemeDetailsDialog: public Dialog
@@ -227,7 +229,11 @@ protected:
     _hexBox = new StaticText(window, r, "", 0, COLOR_THEME_PRIMARY1 | FONT(L) | RIGHT);
     setHexStr(_hexBox, _theme.getColorEntryByIndex(_indexOfColor)->colorValue);
 
-    r = { COLOR_BOX_LEFT, COLOR_BOX_HEIGHT + 7, COLOR_LIST_WIDTH, window->height() - COLOR_BOX_HEIGHT - 7};
+    if (LCD_W > LCD_H)
+      r = { COLOR_BOX_LEFT, COLOR_BOX_HEIGHT + 7, COLOR_LIST_WIDTH, window->height() - COLOR_BOX_HEIGHT - 7};
+    else
+      r = { COLOR_BOX_LEFT, COLOR_BOX_HEIGHT + 7, COLOR_LIST_WIDTH, LCD_H / 2 - COLOR_BOX_HEIGHT - 20 };
+
     _colorEditor = new ColorEditor(window, r, _theme.getColorEntryByIndex(_indexOfColor)->colorValue,
       [=](uint32_t rgb) {
         _theme.setColor(_indexOfColor, rgb);
@@ -550,24 +556,32 @@ void ThemeSetupPage::build(FormWindow *window)
   rect_t r = { 2, 3, LEFT_LIST_WIDTH, LEFT_LIST_HEIGHT };
   setupListbox(window, r, tp);
 
+  rect_t colorPreviewRect;
+  rect_t previewRect;
   if (LCD_W > LCD_H) {
     r.x = LEFT_LIST_WIDTH + MARGIN_WIDTH;
     r.w = LCD_W - r.x;
+    colorPreviewRect = {LEFT_LIST_WIDTH + 6, 0, COLOR_PREVIEW_WIDTH, COLOR_PREVIEW_HEIGHT};
   } else {
     r.y += LEFT_LIST_HEIGHT + 4;
     r.x = 0;
     r.w = LCD_W;
+    colorPreviewRect = {0, LEFT_LIST_HEIGHT + 3, COLOR_PREVIEW_WIDTH, COLOR_PREVIEW_HEIGHT};
   }
 
   // setup ThemeColorPreview()
   auto colorList = theme != nullptr ? theme->getColorList() : std::vector<ColorEntry>();
-  rect_t colorPreviewRect = {LEFT_LIST_WIDTH + 6, 0, COLOR_PREVIEW_WIDTH, COLOR_PREVIEW_HEIGHT};
   themeColorPreview = new ThemeColorPreview(window, colorPreviewRect, colorList);
   
   // setup FileCarosell()
-  r.h = 130;
-  r.w -= COLOR_PREVIEW_WIDTH;
-  r.x += COLOR_PREVIEW_WIDTH;
+  if (LCD_W > LCD_H) {
+    r.w -= COLOR_PREVIEW_WIDTH;
+    r.h = 130;
+    r.x += COLOR_PREVIEW_WIDTH;
+  } else {
+    r.y += COLOR_PREVIEW_HEIGHT;
+    r.h = LEFT_LIST_HEIGHT - COLOR_PREVIEW_HEIGHT - 6;
+  }
   auto fileNames = theme != nullptr ? theme->getThemeImageFileNames() : std::vector<std::string>();
   fileCarosell = new FileCarosell(window, r, fileNames, listBox);
 

--- a/radio/src/gui/colorlcd/screen_setup.cpp
+++ b/radio/src/gui/colorlcd/screen_setup.cpp
@@ -421,7 +421,7 @@ void ScreenUserInterfacePage::build(FormWindow * window)
 
   grid.nextLine();
   auto theme = tp->getCurrentTheme();
-  auto themeImage = theme->getThemeImageFileName();
+  auto themeImage = theme->getThemeImageFileNames();
 
   grid.spacer(8);
 
@@ -443,7 +443,7 @@ void ScreenUserInterfacePage::build(FormWindow * window)
     rect_t {0, r.h, LCD_W- 12, window->height()} :
     rect_t {LCD_W / 2 + 6, 30, LCD_W / 2 - 12, window->height()};
   auto preview = new FilePreview(window, previewRect);
-  preview->setFile(themeImage.c_str());
+  preview->setFile(themeImage.size() > 0 ? themeImage[0].c_str() : "");
 
   window->setInnerHeight(grid.getWindowHeight());
 }

--- a/radio/src/gui/colorlcd/screen_setup.cpp
+++ b/radio/src/gui/colorlcd/screen_setup.cpp
@@ -402,19 +402,6 @@ void ScreenUserInterfacePage::build(FormWindow * window)
       build(window);
   });
 
-  std::function<uint8_t ()> launchEditor = [=]() {
-    auto theme = tp->getCurrentTheme();
-    auto te = new ThemeEditorPage(window, theme);
-    te->setCloseHandler([=] () {
-      window->clear();
-      build(window);
-    });
-
-    return 0;
-  };
-
-  // new TextButton(window, grid.getFieldSlot(3, 2), STR_EDIT, launchEditor, BUTTON_BACKGROUND | OPAQUE, COLOR_THEME_PRIMARY2);
-  
   bool bNarrowScreen = LCD_W < LCD_H;
   if (bNarrowScreen)
     grid.setLabelWidth(LCD_W);
@@ -440,7 +427,7 @@ void ScreenUserInterfacePage::build(FormWindow * window)
   new StaticText(window, r, info, 0, COLOR_THEME_PRIMARY1);
 
   rect_t previewRect = bNarrowScreen ? 
-    rect_t {0, r.h, LCD_W- 12, window->height()} :
+    rect_t {0, r.h, LCD_W, window->height()} :
     rect_t {LCD_W / 2 + 6, 30, LCD_W / 2 - 12, window->height()};
   auto preview = new FilePreview(window, previewRect);
   preview->setFile(themeImage.size() > 0 ? themeImage[0].c_str() : "");

--- a/radio/src/gui/colorlcd/theme.h
+++ b/radio/src/gui/colorlcd/theme.h
@@ -25,6 +25,7 @@
 #include <list>
 #include <vector>
 #include "zone.h"
+#include "ffconf.h"
 #include "thirdparty/libopenui/src/theme.h"
 
 class BitmapBuffer;
@@ -82,6 +83,12 @@ class OpenTxTheme: public Theme
 
     ZoneOptionValue * getOptionValue(unsigned int index) const;
 
+    virtual void setBackgroundImageFileName(const char *fileName)
+    {
+      strncpy(backgroundImageFileName, fileName, FF_MAX_LFN);
+      backgroundImageFileName[FF_MAX_LFN] = '\0'; // ensure string termination
+    }
+
     virtual void load() const;
 
     virtual void drawBackground(BitmapBuffer * dc) const;
@@ -112,6 +119,7 @@ class OpenTxTheme: public Theme
     const char * name;
     const ZoneOption * options;
     BitmapBuffer * thumb;
+    char backgroundImageFileName[FF_MAX_LFN + 1];
 
   public:
     static const BitmapBuffer * error;

--- a/radio/src/gui/colorlcd/theme_manager.h
+++ b/radio/src/gui/colorlcd/theme_manager.h
@@ -112,7 +112,7 @@ class ThemeFile
     void setColorByIndex(int index, uint32_t color);
 
     virtual std::vector<std::string> getThemeImageFileNames();
-    virtual void applyTheme();
+    void applyTheme();
 
   protected:
     std::string path;
@@ -121,6 +121,8 @@ class ThemeFile
     char info[INFO_LENGTH + 1];
     std::vector<ColorEntry> colorList;
     std::vector<std::string> _imageFileNames;
+    void applyColors();
+    virtual void applyBackground();
 
     enum ScanState
     {

--- a/radio/src/gui/colorlcd/theme_manager.h
+++ b/radio/src/gui/colorlcd/theme_manager.h
@@ -55,13 +55,7 @@ class ThemeFile
       info[0] = '\0';
     }
     
-    ThemeFile(std::string themePath) :
-      path(themePath)
-    {
-        if (themePath.size()) {
-            deSerialize();
-        }
-    }
+    ThemeFile(std::string themePath);
     ThemeFile(const ThemeFile &theme)
     {
         path = theme.path;
@@ -117,7 +111,6 @@ class ThemeFile
     void setColor(LcdColorIndex colorIndex, uint32_t color);
     void setColorByIndex(int index, uint32_t color);
 
-    virtual std::string getThemeImageFileName();
     virtual std::vector<std::string> getThemeImageFileNames();
     virtual void applyTheme();
 
@@ -127,6 +120,7 @@ class ThemeFile
     char author[AUTHOR_LENGTH + 1];
     char info[INFO_LENGTH + 1];
     std::vector<ColorEntry> colorList;
+    std::vector<std::string> _imageFileNames;
 
     enum ScanState
     {
@@ -158,6 +152,7 @@ class ThemePersistance
     void deleteDefaultTheme();
     static char **getColorNames();
     bool deleteThemeByIndex(int index);
+    bool createNewTheme(std::string name, ThemeFile &theme);
 
     std::vector<std::string> getNames()
     {
@@ -206,4 +201,5 @@ class ThemePersistance
     void scanForThemes();
     void insertDefaultTheme();
     void clearThemes();
+    void scanThemeFolder(char *fullPath);
 };

--- a/radio/src/gui/colorlcd/themes/480_default.cpp
+++ b/radio/src/gui/colorlcd/themes/480_default.cpp
@@ -186,6 +186,15 @@ class Theme480: public OpenTxTheme
       delete dot;
     }
 
+    void setBackgroundImageFileName(const char *fileName) override
+    {
+      // ensure you delete old bitmap
+      if (strcmp(backgroundImageFileName, fileName) != 0 && backgroundBitmap != nullptr)
+        delete backgroundBitmap;
+      OpenTxTheme::setBackgroundImageFileName(fileName);  // set the filename
+      backgroundBitmap = BitmapBuffer::loadBitmap(backgroundImageFileName);
+    }
+
     void loadThemeBitmaps() const
     {
       // Calibration screen


### PR DESCRIPTION
Please note that pull requests are NOT an appropriate way to ask questions or support.

Fixes #1064 

Summary of changes:

1. Fix KEY_EXIT processing when theme changed
2. Also fixes some color issues on ListBox()
3. Fixes various issues with PreviewWindow()
4. theme file structure implementation to match #897 
5. Sort theme names
6. changed touch handling on Theme List.  You now need to long-press to bring up the menu.
7. Added more controls to PreviewWindow() 
