### PR TITLE
Companion set new curves (-100,-100) to (100,100)

### DIFF
--- a/companion/src/firmwares/curvedata.cpp
+++ b/companion/src/firmwares/curvedata.cpp
@@ -19,7 +19,7 @@
  */
 
 #include "curvedata.h"
-#include "radiodata.h"
+#include "datahelpers.h"
 
 CurveData::CurveData()
 {
@@ -30,19 +30,27 @@ void CurveData::clear(int count)
 {
   memset(reinterpret_cast<void *>(this), 0, sizeof(CurveData));
   this->count = count;
+
+  int incr = 200 / (count - 1);
+
+  //  points[0].x must be -100
+  for (int i = 0; i < count; i++) {
+    if (i < count - 1)
+      points[i].x = -100 + incr * i;
+    else
+      points[i].x = 100;    // points[last].x must be +100 do not risk a rounding issue using incr
+
+    points[i].y = points[i].x;
+  }
 }
 
 bool CurveData::isEmpty() const
 {
-  for (int i = 0; i < count; i++) {
-    if (points[i].y != 0) {
-      return false;
-    }
-  }
-  return true;
+  CurveData tmp;
+  return !memcmp(this, &tmp, sizeof(CurveData));
 }
 
 QString CurveData::nameToString(const int idx) const
 {
-  return RadioData::getElementName(tr("CV"), idx + 1, name);
+  return DataHelpers::getElementName(tr("CV"), idx + 1, name);
 }


### PR DESCRIPTION
Fixes #1067 (on Companion side)

Summary of changes:
Assigning the proposed default to an input, mix or output has no effect on the target value and thus is safer especially if applied to a throttle.
Some housekeeping.