### PR TITLE
fix split touch window for carousel #1088

### DIFF
--- a/radio/src/gui/colorlcd/view_main.cpp
+++ b/radio/src/gui/colorlcd/view_main.cpp
@@ -247,7 +247,10 @@ bool ViewMain::onTouchEnd(coord_t x, coord_t y)
   }
   else {
     openMenu();
-    if(x > getParent()->width() / 2)
+    int x1 = x;
+    int w1 = getParent()->width();
+    while (x1 > w1)   x1 -= w1;
+    if (x1 > w1 / 2)
       pushEvent(EVT_ROTARY_LEFT);
   }
   return true;


### PR DESCRIPTION
Fixes #1088 

Summary of changes:
take into account that for multiple main screens the x coordinate may be bigger than the screen width.