### PR TITLE
Taranis-based B/W: Initial Contrast fix

### DIFF
--- a/radio/src/gui/128x64/lcd.cpp
+++ b/radio/src/gui/128x64/lcd.cpp
@@ -952,10 +952,6 @@ void drawGPSSensorValue(coord_t x, coord_t y, TelemetryItem & telemetryItem, Lcd
   drawGPSPosition(x, y, telemetryItem.gps.longitude, telemetryItem.gps.latitude, flags);
 }
 
-void lcdSetContrast()
-{
-  lcdSetRefVolt(g_eeGeneral.contrast);
-}
 
 #define LCD_BYTE_FILTER(p, keep, add) *(p) = (*(p) & (keep)) | (add)
 
@@ -998,6 +994,15 @@ void lcdDraw1bitBitmap(coord_t x, coord_t y, const uint8_t * img, uint8_t idx, L
 }
 
 #endif
+
+void lcdSetContrast(bool useDefault)
+{
+#if defined(BOOT)
+  lcdSetRefVolt(LCD_CONTRAST_DEFAULT);
+#else
+  lcdSetRefVolt(useDefault ? LCD_CONTRAST_DEFAULT : g_eeGeneral.contrast);
+#endif
+}
 
 void lcdMaskPoint(uint8_t * p, uint8_t mask, LcdFlags att)
 {

--- a/radio/src/gui/212x64/lcd.cpp
+++ b/radio/src/gui/212x64/lcd.cpp
@@ -820,11 +820,16 @@ void drawGPSSensorValue(coord_t x, coord_t y, TelemetryItem & telemetryItem, Lcd
   }
 }
 
-void lcdSetContrast()
-{
-  lcdSetRefVolt(g_eeGeneral.contrast);
-}
 #endif // BOOT
+
+void lcdSetContrast(bool useDefault)
+{
+#if defined(BOOT)
+  lcdSetRefVolt(LCD_CONTRAST_DEFAULT);
+#else
+  lcdSetRefVolt(useDefault ? LCD_CONTRAST_DEFAULT : g_eeGeneral.contrast);
+#endif
+}
 
 void lcdMaskPoint(uint8_t *p, uint8_t mask, LcdFlags att)
 {

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -226,6 +226,10 @@ void boardInit()
 #endif
 
   backlightInit();
+
+#if defined(GUI)
+  lcdSetContrast(true);
+#endif
 }
 
 void boardOff()

--- a/radio/src/targets/taranis/board.h
+++ b/radio/src/targets/taranis/board.h
@@ -959,7 +959,9 @@ void lcdRefresh();
 void lcdRefresh(bool wait=true); // TODO uint8_t wait to simplify this
 #endif
 void lcdSetRefVolt(unsigned char val);
-void lcdSetContrast();
+#ifdef __cplusplus
+void lcdSetContrast(bool useDefault = false);
+#endif
 
 // Top LCD driver
 #if defined(TOPLCD_GPIO)

--- a/radio/src/targets/taranis/bootloader/boot_menu.cpp
+++ b/radio/src/targets/taranis/bootloader/boot_menu.cpp
@@ -27,6 +27,7 @@ extern MemoryType memoryType;
 
 void bootloaderInitScreen()
 {
+  lcdSetContrast(true);
 }
 
 static void bootloaderDrawMsg(unsigned int x, const char *str, uint8_t line, bool inverted)


### PR DESCRIPTION
Fixes #1031 

Summary of changes:
Taranis based radios with B/W screens now have LCD_CONTRAST_DEFAULT initialization in bootloader and normal startup.
This prevents 'unreadable (too low or too high contrast' screen in bootloader and 'blink' after 'dots' on Jumper T-Lite and other similar radios.