### PR TITLE
fix touch slide deltaX/deltaY not resetting

### DIFF
--- a/radio/src/targets/horus/tp_gt911.cpp
+++ b/radio/src/targets/horus/tp_gt911.cpp
@@ -745,6 +745,8 @@ struct TouchState touchPanelRead()
     RTOS_WAIT_MS(1);
   } while(RTOS_GET_MS() - startReadStatus < GT911_TIMEOUT);
 
+  internalTouchState.deltaX = 0;
+  internalTouchState.deltaY = 0;
   TRACE("touch state = 0x%x", state);
   if (state & 0x80u) {
     uint8_t pointsCount = (state & 0x0Fu);

--- a/radio/src/targets/nv14/touch_driver.cpp
+++ b/radio/src/targets/nv14/touch_driver.cpp
@@ -550,5 +550,8 @@ TouchState touchPanelRead()
       internalTouchState.event = TE_SLIDE_END;
     }
   }
-  return internalTouchState;
+  TouchState ret = internalTouchState;
+  internalTouchState.deltaX = 0;
+  internalTouchState.deltaY = 0;
+  return ret;
 }


### PR DESCRIPTION
Summary of changes:
fixes deltaX and deltaY values in touch events not being resetet
