### PR TITLE
Fix building for X9E

### DIFF
--- a/radio/src/targets/common/arm/stm32/stm32_hal_adc.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_hal_adc.cpp
@@ -217,14 +217,14 @@ static uint16_t* ADC_MAIN_get_dma_buffer()
 #if defined(ADC_EXT) && defined(ADC_EXT_DMA_Stream)
 static uint16_t* ADC_EXT_get_dma_buffer()
 {
+#if defined(RADIO_FAMILY_T16) || defined(PCBNV14)  
     if (globalData.flyskygimbals)
     {
         return adcValues + NUM_ANALOGS_ADC_FS + FIRST_ANALOG_ADC_FS;
     }
     else
-    {
-        return adcValues + NUM_ANALOGS_ADC + FIRST_ANALOG_ADC;
-    }
+#endif
+      return adcValues + NUM_ANALOGS_ADC + FIRST_ANALOG_ADC;
 }
 #endif
 


### PR DESCRIPTION
Forgot to handle X9E in my FlySky gimbal auto-detection. According to feedback from Discord, this PR fixes it for X9E: https://discord.com/channels/839849772864503828/839856795781431317/911686864237396029