### PR TITLE
pots warning enabled fix

### DIFF
--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -117,26 +117,26 @@ static inline void check_struct()
 
 #if defined(PCBXLITES)
   CHKSIZE(RadioData, 862);
-  CHKSIZE(ModelData, 6157);
+  CHKSIZE(ModelData, 6158);
 #elif defined(PCBXLITE)
   CHKSIZE(RadioData, 860);
-  CHKSIZE(ModelData, 6157);
+  CHKSIZE(ModelData, 6158);
 #elif defined(PCBX7)
   CHKSIZE(RadioData, 866);
-  CHKSIZE(ModelData, 6157);
+  CHKSIZE(ModelData, 6158);
 #elif defined(PCBX9E)
   CHKSIZE(RadioData, 962);
-  CHKSIZE(ModelData, 6614);
+  CHKSIZE(ModelData, 6615);
 #elif defined(PCBX9D) || defined(PCBX9DP)
   CHKSIZE(RadioData, 900);
-  CHKSIZE(ModelData, 6604);
+  CHKSIZE(ModelData, 6605);
 #elif defined(PCBHORUS)
   #if defined(PCBX10)
     CHKSIZE(RadioData, 921);
-    CHKSIZE(ModelData, 11022);
+    CHKSIZE(ModelData, 11023);
   #else
     CHKSIZE(RadioData, 903);
-    CHKSIZE(ModelData, 11020);
+    CHKSIZE(ModelData, 11021);
   #endif
 #endif
 

--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -687,7 +687,7 @@ PACK(struct ModelData {
   SCRIPT_DATA
 
   NOBACKUP(char inputNames[MAX_INPUTS][LEN_INPUT_NAME]);
-  NOBACKUP(uint8_t potsWarnEnabled);
+  NOBACKUP(uint16_t potsWarnEnabled);
   NOBACKUP(int8_t potsWarnPosition[STORAGE_NUM_POTS+STORAGE_NUM_SLIDERS]);
 
   NOBACKUP(TelemetrySensor telemetrySensors[MAX_TELEMETRY_SENSORS];)

--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -1514,7 +1514,7 @@ void ModelSetupPage::build(FormWindow * window)
         GridLayout centerGrid(group);
         for (int i = POT_FIRST, j = 0; i <= POT_LAST; i++) {
           char s[8];
-          if ((IS_POT(i) || IS_POT_MULTIPOS(i))) {
+          if ((IS_POT(i) || IS_POT_MULTIPOS(i)) && IS_POT_AVAILABLE(i)) {
             if (j > 0 && ((j % 4) == 0)) centerGrid.nextLine();
 
             auto button = new TextButton(
@@ -1563,9 +1563,9 @@ void ModelSetupPage::build(FormWindow * window)
                   (g_model.potsWarnEnabled & (1 << (j + NUM_POTS)))) {
                 SAVE_POT_POSITION(j + NUM_POTS);
               }
-              button->check(g_model.potsWarnEnabled & (1 << (j + NUM_POTS)));
+              button->check(g_model.potsWarnEnabled & (1 << (j + NUM_POTS)) ? true : false);
               SET_DIRTY();
-              return (g_model.potsWarnEnabled & (1 << (j + NUM_POTS)));
+              return (g_model.potsWarnEnabled & (1 << (j + NUM_POTS)) ? 1 : 0);
             });
             j++;
           }

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -276,7 +276,7 @@ void memswap(void * a, void * b, uint8_t size);
   #define IS_POT_AVAILABLE(x)          (IS_POT(x) && POT_CONFIG(x)!=POT_NONE)
   #define IS_POT_SLIDER_AVAILABLE(x)   (IS_POT_AVAILABLE(x) || IS_SLIDER_AVAILABLE(x))
   #define IS_MULTIPOS_CALIBRATED(cal)  (cal->count>0 && cal->count<XPOTS_MULTIPOS_COUNT)
-#elif defined(PCBX7) || defined(PCBXLITE)
+#elif defined(PCBX7) || defined(PCBXLITE) || defined(PCBNV14)
   #define POT_CONFIG(x)                ((g_eeGeneral.potsConfig >> (2*((x)-POT1)))&0x03)
   #define IS_POT_MULTIPOS(x)           (IS_POT(x) && POT_CONFIG(x)==POT_MULTIPOS_SWITCH)
   #define IS_POT_WITHOUT_DETENT(x)     (IS_POT(x) && POT_CONFIG(x)==POT_WITHOUT_DETENT)

--- a/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
@@ -864,7 +864,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 9, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 32, 32, struct_string_32, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 8 ),
+  YAML_UNSIGNED( "potsWarnEnabled", 16),
   YAML_ARRAY("potsWarnPosition", 8, 5, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 60, struct_TelemetrySensor, NULL),
   YAML_ARRAY("screenData", 6800, 5, struct_CustomScreenData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
@@ -864,7 +864,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 9, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 32, 32, struct_string_32, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 16),
+  YAML_UNSIGNED( "potsWarnEnabled", 16 ),
   YAML_ARRAY("potsWarnPosition", 8, 5, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 60, struct_TelemetrySensor, NULL),
   YAML_ARRAY("screenData", 6800, 5, struct_CustomScreenData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_t12.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t12.cpp
@@ -833,7 +833,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 7, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 24, 32, struct_string_24, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 8 ),
+  YAML_UNSIGNED( "potsWarnEnabled", 16),
   YAML_ARRAY("potsWarnPosition", 8, 2, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 40, struct_TelemetrySensor, NULL),
   YAML_PADDING( 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_t12.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t12.cpp
@@ -833,7 +833,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 7, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 24, 32, struct_string_24, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 16),
+  YAML_UNSIGNED( "potsWarnEnabled", 16 ),
   YAML_ARRAY("potsWarnPosition", 8, 2, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 40, struct_TelemetrySensor, NULL),
   YAML_PADDING( 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_t8.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t8.cpp
@@ -833,7 +833,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 7, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 24, 32, struct_string_24, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 8 ),
+  YAML_UNSIGNED( "potsWarnEnabled", 16),
   YAML_ARRAY("potsWarnPosition", 8, 2, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 40, struct_TelemetrySensor, NULL),
   YAML_PADDING( 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_t8.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t8.cpp
@@ -833,7 +833,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 7, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 24, 32, struct_string_24, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 16),
+  YAML_UNSIGNED( "potsWarnEnabled", 16 ),
   YAML_ARRAY("potsWarnPosition", 8, 2, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 40, struct_TelemetrySensor, NULL),
   YAML_PADDING( 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_tlite.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tlite.cpp
@@ -833,7 +833,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 7, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 24, 32, struct_string_24, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 8 ),
+  YAML_UNSIGNED( "potsWarnEnabled", 16),
   YAML_ARRAY("potsWarnPosition", 8, 2, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 40, struct_TelemetrySensor, NULL),
   YAML_PADDING( 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_tlite.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tlite.cpp
@@ -833,7 +833,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 7, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 24, 32, struct_string_24, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 16),
+  YAML_UNSIGNED( "potsWarnEnabled", 16 ),
   YAML_ARRAY("potsWarnPosition", 8, 2, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 40, struct_TelemetrySensor, NULL),
   YAML_PADDING( 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_tx12.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tx12.cpp
@@ -833,7 +833,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 7, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 24, 32, struct_string_24, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 8 ),
+  YAML_UNSIGNED( "potsWarnEnabled", 16),
   YAML_ARRAY("potsWarnPosition", 8, 2, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 40, struct_TelemetrySensor, NULL),
   YAML_PADDING( 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_tx12.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tx12.cpp
@@ -833,7 +833,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 7, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 24, 32, struct_string_24, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 16),
+  YAML_UNSIGNED( "potsWarnEnabled", 16 ),
   YAML_ARRAY("potsWarnPosition", 8, 2, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 40, struct_TelemetrySensor, NULL),
   YAML_PADDING( 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_x10.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x10.cpp
@@ -883,7 +883,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 9, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 32, 32, struct_string_32, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 8 ),
+  YAML_UNSIGNED( "potsWarnEnabled", 16),
   YAML_ARRAY("potsWarnPosition", 8, 11, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 60, struct_TelemetrySensor, NULL),
   YAML_ARRAY("screenData", 6800, 5, struct_CustomScreenData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_x10.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x10.cpp
@@ -91,7 +91,7 @@ const struct YamlIdStr enum_Functions[] = {
   {  0, NULL  }
 };
 const struct YamlIdStr enum_UartModes[] = {
-  {  UART_MODE_DEBUG, "MODE_DEBUG"  },
+  {  UART_MODE_NONE, "MODE_NONE"  },
   {  UART_MODE_TELEMETRY_MIRROR, "MODE_TELEMETRY_MIRROR"  },
   {  UART_MODE_TELEMETRY, "MODE_TELEMETRY"  },
   {  UART_MODE_SBUS_TRAINER, "MODE_SBUS_TRAINER"  },

--- a/radio/src/storage/yaml/yaml_datastructs_x10.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x10.cpp
@@ -91,7 +91,7 @@ const struct YamlIdStr enum_Functions[] = {
   {  0, NULL  }
 };
 const struct YamlIdStr enum_UartModes[] = {
-  {  UART_MODE_NONE, "MODE_NONE"  },
+  {  UART_MODE_DEBUG, "MODE_DEBUG"  },
   {  UART_MODE_TELEMETRY_MIRROR, "MODE_TELEMETRY_MIRROR"  },
   {  UART_MODE_TELEMETRY, "MODE_TELEMETRY"  },
   {  UART_MODE_SBUS_TRAINER, "MODE_SBUS_TRAINER"  },
@@ -883,7 +883,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 9, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 32, 32, struct_string_32, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 16),
+  YAML_UNSIGNED( "potsWarnEnabled", 16 ),
   YAML_ARRAY("potsWarnPosition", 8, 11, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 60, struct_TelemetrySensor, NULL),
   YAML_ARRAY("screenData", 6800, 5, struct_CustomScreenData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
@@ -91,7 +91,7 @@ const struct YamlIdStr enum_Functions[] = {
   {  0, NULL  }
 };
 const struct YamlIdStr enum_UartModes[] = {
-  {  UART_MODE_NONE, "MODE_NONE"  },
+  {  UART_MODE_DEBUG, "MODE_DEBUG"  },
   {  UART_MODE_TELEMETRY_MIRROR, "MODE_TELEMETRY_MIRROR"  },
   {  UART_MODE_TELEMETRY, "MODE_TELEMETRY"  },
   {  UART_MODE_SBUS_TRAINER, "MODE_SBUS_TRAINER"  },
@@ -881,7 +881,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 9, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 32, 32, struct_string_32, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 16),
+  YAML_UNSIGNED( "potsWarnEnabled", 16 ),
   YAML_ARRAY("potsWarnPosition", 8, 9, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 60, struct_TelemetrySensor, NULL),
   YAML_ARRAY("screenData", 6800, 5, struct_CustomScreenData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
@@ -91,7 +91,7 @@ const struct YamlIdStr enum_Functions[] = {
   {  0, NULL  }
 };
 const struct YamlIdStr enum_UartModes[] = {
-  {  UART_MODE_DEBUG, "MODE_DEBUG"  },
+  {  UART_MODE_NONE, "MODE_NONE"  },
   {  UART_MODE_TELEMETRY_MIRROR, "MODE_TELEMETRY_MIRROR"  },
   {  UART_MODE_TELEMETRY, "MODE_TELEMETRY"  },
   {  UART_MODE_SBUS_TRAINER, "MODE_SBUS_TRAINER"  },

--- a/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
@@ -881,7 +881,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 9, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 32, 32, struct_string_32, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 8 ),
+  YAML_UNSIGNED( "potsWarnEnabled", 16),
   YAML_ARRAY("potsWarnPosition", 8, 9, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 60, struct_TelemetrySensor, NULL),
   YAML_ARRAY("screenData", 6800, 5, struct_CustomScreenData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_x7.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x7.cpp
@@ -833,7 +833,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 7, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 24, 32, struct_string_24, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 8 ),
+  YAML_UNSIGNED( "potsWarnEnabled", 16),
   YAML_ARRAY("potsWarnPosition", 8, 2, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 40, struct_TelemetrySensor, NULL),
   YAML_PADDING( 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_x7.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x7.cpp
@@ -833,7 +833,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 7, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 24, 32, struct_string_24, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 16),
+  YAML_UNSIGNED( "potsWarnEnabled", 16 ),
   YAML_ARRAY("potsWarnPosition", 8, 2, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 40, struct_TelemetrySensor, NULL),
   YAML_PADDING( 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
@@ -848,7 +848,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 7, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 32, 32, struct_string_32, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 8 ),
+  YAML_UNSIGNED( "potsWarnEnabled", 16),
   YAML_ARRAY("potsWarnPosition", 8, 5, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 60, struct_TelemetrySensor, NULL),
   YAML_PADDING( 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
@@ -848,7 +848,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 7, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 32, 32, struct_string_32, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 16),
+  YAML_UNSIGNED( "potsWarnEnabled", 16 ),
   YAML_ARRAY("potsWarnPosition", 8, 5, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 60, struct_TelemetrySensor, NULL),
   YAML_PADDING( 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
@@ -887,7 +887,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 7, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 32, 32, struct_string_32, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 8 ),
+  YAML_UNSIGNED( "potsWarnEnabled", 16),
   YAML_ARRAY("potsWarnPosition", 8, 8, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 60, struct_TelemetrySensor, NULL),
   YAML_UNSIGNED( "toplcdTimer", 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
@@ -887,7 +887,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 7, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 32, 32, struct_string_32, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 16),
+  YAML_UNSIGNED( "potsWarnEnabled", 16 ),
   YAML_ARRAY("potsWarnPosition", 8, 8, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 60, struct_TelemetrySensor, NULL),
   YAML_UNSIGNED( "toplcdTimer", 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_x9lite.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9lite.cpp
@@ -818,7 +818,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 7, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 24, 32, struct_string_24, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 16),
+  YAML_UNSIGNED( "potsWarnEnabled", 16 ),
   YAML_ARRAY("potsWarnPosition", 8, 1, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 40, struct_TelemetrySensor, NULL),
   YAML_PADDING( 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_x9lite.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9lite.cpp
@@ -818,7 +818,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 7, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 24, 32, struct_string_24, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 8 ),
+  YAML_UNSIGNED( "potsWarnEnabled", 16),
   YAML_ARRAY("potsWarnPosition", 8, 1, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 40, struct_TelemetrySensor, NULL),
   YAML_PADDING( 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_x9lites.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9lites.cpp
@@ -828,7 +828,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 7, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 24, 32, struct_string_24, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 16),
+  YAML_UNSIGNED( "potsWarnEnabled", 16 ),
   YAML_ARRAY("potsWarnPosition", 8, 1, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 40, struct_TelemetrySensor, NULL),
   YAML_PADDING( 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_x9lites.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9lites.cpp
@@ -828,7 +828,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 7, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 24, 32, struct_string_24, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 8 ),
+  YAML_UNSIGNED( "potsWarnEnabled", 16),
   YAML_ARRAY("potsWarnPosition", 8, 1, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 40, struct_TelemetrySensor, NULL),
   YAML_PADDING( 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_xlite.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_xlite.cpp
@@ -825,7 +825,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 7, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 24, 32, struct_string_24, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 16),
+  YAML_UNSIGNED( "potsWarnEnabled", 16 ),
   YAML_ARRAY("potsWarnPosition", 8, 2, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 40, struct_TelemetrySensor, NULL),
   YAML_PADDING( 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_xlite.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_xlite.cpp
@@ -825,7 +825,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 7, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 24, 32, struct_string_24, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 8 ),
+  YAML_UNSIGNED( "potsWarnEnabled", 16),
   YAML_ARRAY("potsWarnPosition", 8, 2, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 40, struct_TelemetrySensor, NULL),
   YAML_PADDING( 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
@@ -829,7 +829,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 7, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 24, 32, struct_string_24, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 8 ),
+  YAML_UNSIGNED( "potsWarnEnabled", 16),
   YAML_ARRAY("potsWarnPosition", 8, 2, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 40, struct_TelemetrySensor, NULL),
   YAML_PADDING( 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
@@ -829,7 +829,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_STRUCT("trainerData", 40, struct_TrainerModuleData, NULL),
   YAML_ARRAY("scriptsData", 192, 7, struct_ScriptData, NULL),
   YAML_ARRAY("inputNames", 24, 32, struct_string_24, NULL),
-  YAML_UNSIGNED( "potsWarnEnabled", 16),
+  YAML_UNSIGNED( "potsWarnEnabled", 16 ),
   YAML_ARRAY("potsWarnPosition", 8, 2, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 40, struct_TelemetrySensor, NULL),
   YAML_PADDING( 8 ),


### PR DESCRIPTION
Fixes #1124 

Summary of changes:
1. Do not display non-existent potentiometers in the warnings group.
2. Increase the size of the potsWarnEnabled field in the ModelData to 16 bits in order to save all possible potentiometers and sliders.
