### PR TITLE
Add filename to lua `model.getInfo()`

### DIFF
--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -28,7 +28,6 @@
 
 #if defined(SDCARD_YAML)
 #include <storage/sdcard_yaml.h>
-extern uint8_t MODELIDX_STRLEN;
 #endif
 
 /*luadoc

--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -28,8 +28,8 @@
 
 #if defined(SDCARD_YAML)
 #include <storage/sdcard_yaml.h>
-#endif
 extern uint8_t MODELIDX_STRLEN;
+#endif
 
 /*luadoc
 @function model.getInfo()

--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -25,17 +25,11 @@
 #include "lua_api.h"
 #include "../timers.h"
 #include "model_init.h"
-#include <storage/sdcard_common.h>
 
-constexpr uint8_t MODELIDX_STRLEN = sizeof(MODEL_FILENAME_PREFIX "00");
-
-static void getModelNumberStr(uint8_t idx, char* model_idx)
-{
-  memcpy(model_idx, MODEL_FILENAME_PREFIX, sizeof(MODEL_FILENAME_PREFIX));
-  model_idx[sizeof(MODEL_FILENAME_PREFIX)-1] = '0' + idx / 10;
-  model_idx[sizeof(MODEL_FILENAME_PREFIX)]   = '0' + idx % 10;
-  model_idx[sizeof(MODEL_FILENAME_PREFIX)+1] = '\0';
-}
+#if defined(SDCARD_YAML)
+#include <storage/sdcard_yaml.h>
+#endif
+extern uint8_t MODELIDX_STRLEN;
 
 /*luadoc
 @function model.getInfo()

--- a/radio/src/storage/conversions/conversions_220_221.cpp
+++ b/radio/src/storage/conversions/conversions_220_221.cpp
@@ -35,8 +35,8 @@ using namespace bin_storage_220;
 
 #if defined(SDCARD_YAML)
 #include <storage/sdcard_yaml.h>
-#endif
 extern uint8_t MODELIDX_STRLEN;
+#endif
 
 // see "yaml/yaml_datastructs.h"
 namespace yaml_conv_220 {

--- a/radio/src/storage/conversions/conversions_220_221.cpp
+++ b/radio/src/storage/conversions/conversions_220_221.cpp
@@ -33,6 +33,11 @@
 using namespace bin_storage_220;
 #include <storage/sdcard_common.h>
 
+#if defined(SDCARD_YAML)
+#include <storage/sdcard_yaml.h>
+#endif
+extern uint8_t MODELIDX_STRLEN;
+
 // see "yaml/yaml_datastructs.h"
 namespace yaml_conv_220 {
     const YamlNode* get_radiodata_nodes();
@@ -138,15 +143,6 @@ const char* convertRadioData_220_to_221(const char* path)
 
 #include <storage/eeprom_common.h>
 
-constexpr uint8_t MODELIDX_STRLEN = sizeof(MODEL_FILENAME_PREFIX "00");
-
-static void getModelNumberStr(uint8_t idx, char* model_idx)
-{
-  memcpy(model_idx, MODEL_FILENAME_PREFIX, sizeof(MODEL_FILENAME_PREFIX));
-  model_idx[sizeof(MODEL_FILENAME_PREFIX)-1] = '0' + idx / 10;
-  model_idx[sizeof(MODEL_FILENAME_PREFIX)]   = '0' + idx % 10;
-  model_idx[sizeof(MODEL_FILENAME_PREFIX)+1] = '\0';
-}
 
 const char* convertModelData_220_to_221(uint8_t id)
 {

--- a/radio/src/storage/conversions/conversions_220_221.cpp
+++ b/radio/src/storage/conversions/conversions_220_221.cpp
@@ -35,7 +35,6 @@ using namespace bin_storage_220;
 
 #if defined(SDCARD_YAML)
 #include <storage/sdcard_yaml.h>
-extern uint8_t MODELIDX_STRLEN;
 #endif
 
 // see "yaml/yaml_datastructs.h"

--- a/radio/src/storage/sdcard_yaml.cpp
+++ b/radio/src/storage/sdcard_yaml.cpp
@@ -24,7 +24,7 @@
 #include "storage.h"
 #include "sdcard_common.h"
 #include "sdcard_raw.h"
-
+#include "sdcard_yaml.h"
 #include "modelslist.h"
 
 #include "yaml/yaml_tree_walker.h"

--- a/radio/src/storage/sdcard_yaml.cpp
+++ b/radio/src/storage/sdcard_yaml.cpp
@@ -264,8 +264,6 @@ const char * writeModelYaml(const char* filename)
 // EEPROM slot simulation based on file names:
 // - /MODELS/model[00-99].yml
 
-uint8_t MODELIDX_STRLEN = sizeof(MODEL_FILENAME_PREFIX "00");
-
 void getModelNumberStr(uint8_t idx, char* model_idx)
 {
   memcpy(model_idx, MODEL_FILENAME_PREFIX, sizeof(MODEL_FILENAME_PREFIX));

--- a/radio/src/storage/sdcard_yaml.cpp
+++ b/radio/src/storage/sdcard_yaml.cpp
@@ -264,9 +264,9 @@ const char * writeModelYaml(const char* filename)
 // EEPROM slot simulation based on file names:
 // - /MODELS/model[00-99].yml
 
-constexpr uint8_t MODELIDX_STRLEN = sizeof(MODEL_FILENAME_PREFIX "00");
+uint8_t MODELIDX_STRLEN = sizeof(MODEL_FILENAME_PREFIX "00");
 
-static void getModelNumberStr(uint8_t idx, char* model_idx)
+void getModelNumberStr(uint8_t idx, char* model_idx)
 {
   memcpy(model_idx, MODEL_FILENAME_PREFIX, sizeof(MODEL_FILENAME_PREFIX));
   model_idx[sizeof(MODEL_FILENAME_PREFIX)-1] = '0' + idx / 10;

--- a/radio/src/storage/sdcard_yaml.h
+++ b/radio/src/storage/sdcard_yaml.h
@@ -20,6 +20,7 @@
  */
 
 #pragma once
+constexpr uint8_t MODELIDX_STRLEN = sizeof(MODEL_FILENAME_PREFIX "00");
 
 const char * loadRadioSettingsYaml();
 const char * writeModelYaml(const char* filename);

--- a/radio/src/storage/sdcard_yaml.h
+++ b/radio/src/storage/sdcard_yaml.h
@@ -24,3 +24,4 @@
 const char * loadRadioSettingsYaml();
 const char * writeModelYaml(const char* filename);
 const char * readModelYaml(const char * filename, uint8_t * buffer, uint32_t size);
+void getModelNumberStr(uint8_t idx, char* model_idx);


### PR DESCRIPTION
Proposal to add a `filename` table element to model.getInfo, so that the yaml filename can be used in a lua script.

Resolves #1065 

Tested as functional on TX16S (colourlcd) and TX12 (B&W).

@raphaelcoeffic I'm not particularly happy just copying and pasting the `getModelNumberStr` function in... is there a better way to do this?

Test script:
```lua
local w, h

local function run(event)
  lcd.clear()
  local info = model.getInfo()
  if LCD_H > 64
    w, h = lcd.sizeText("Model Info")
  else
    h = 8
  end

  lcd.drawText(1, 0, "Model Info")
  
  if info['name'] then
    lcd.drawText(1, h*2, "Name: "..info['name'])
  else
    lcd.drawText(1, h*2, "Name: none")
  end
  
  if info['bitmap'] then
    lcd.drawText(1, h*3, "Bitmap: "..info['bitmap'])
  else
    lcd.drawText(1, h*3, "Bitmap: none")
  end

  if info['filename'] then
    lcd.drawText(1, h*4, "Filename: "..info['filename'])
  else
    lcd.drawText(1, h*3, "Filename: none")
  end

    if event == EVT_VIRTUAL_ENTER_LONG or
       event == EVT_ENTER_LONG or
       event == EVT_MENU_LONG then
        -- exit script
        return 2
    end

  return 0
end

return {run=run}
```
