### PR TITLE
Play "Welcome to..." before switch checks, SF

### DIFF
--- a/radio/src/audio.cpp
+++ b/radio/src/audio.cpp
@@ -546,10 +546,6 @@ void audioTask(void * pdata)
   }
 #endif
 
-  if (!globalData.unexpectedShutdown) {
-    AUDIO_HELLO();
-  }
-
   while (true) {
     DEBUG_TIMER_SAMPLE(debugTimerAudioIterval);
     DEBUG_TIMER_START(debugTimerAudioDuration);

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1406,6 +1406,7 @@ void opentxStart(const uint8_t startOptions = OPENTX_START_DEFAULT_ARGS)
 #if defined(GUI)
   if (!calibration_needed && !(startOptions & OPENTX_START_NO_SPLASH)) {
     doSplash();
+    AUDIO_HELLO();
   }
 #endif
 

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1405,8 +1405,8 @@ void opentxStart(const uint8_t startOptions = OPENTX_START_DEFAULT_ARGS)
 
 #if defined(GUI)
   if (!calibration_needed && !(startOptions & OPENTX_START_NO_SPLASH)) {
-    doSplash();
     AUDIO_HELLO();
+    doSplash();
   }
 #endif
 


### PR DESCRIPTION
This will resolve the recent comments about audio being played out of sequence. 

Whilst Lua still manages to play before the welcome, this is also a OTX behaviour, and I suspect could be because Lua scripts and widgets start before the audio queue. 