### PR TITLE
Enable lua `table`  for colorlcd, not just horus style targets

### DIFF
--- a/radio/src/thirdparty/Lua/src/linit.c
+++ b/radio/src/thirdparty/Lua/src/linit.c
@@ -28,7 +28,7 @@
 */
 static const luaL_Reg loadedlibs[] = {
   // {"_G", luaopen_base},
-#if defined(PCBHORUS)
+#if defined(COLORLCD)
   {LUA_LOADLIBNAME, luaopen_package},
 #endif
   // {LUA_COLIBNAME, luaopen_coroutine},
@@ -53,7 +53,7 @@ const luaR_table lua_rotable[] =
   {LUA_STRLIBNAME, strlib, NULL},
   {LUA_MATHLIBNAME, mathlib, mathlib_vals},
   {LUA_BITLIBNAME, bitlib, NULL},
-#if defined(PCBHORUS)
+#if defined(COLORLCD)
   {LUA_TABLIBNAME, tab_funcs, NULL},
 #endif
   {NULL, NULL, NULL}


### PR DESCRIPTION
Resolves #1141 

Summary of changes:
- Enable lua table library for all colorlcd targets, not just Horus-style targets
- Firmware size change: 1397888 => 1402632

Tested with following on both TX16S and NV14 hardware. 
```lua
local toolName = "TNS|Table Sort Test|TNE"

local function run(event)
    local t = {5,4,3,2,1}
    local w, h = 0, 0
    local x, y = 0, 0

    -- Lazy B&W test
    if LCD_H > 64 then
        w, h = lcd.sizeText("M")
    else
        w, h = 8, 8
    end

    lcd.clear()
    
    x = 5
    lcd.drawText(x, h*1, "Unsorted table")
    for k in pairs(t) do
        x = w*k + 5
        lcd.drawText(x, h*2, t[k])
    end

    table.sort(t)

    x = 5
    lcd.drawText(x, h*4, "Sorted table")
    for k in pairs(t) do
        x = w*k + 5
        lcd.drawText(x, h*5, t[k])
    end
    
    return 0
end

return {run=run}
```

Thanks to @JimB40 for the initial skeleton ;)