### PR TITLE
Fix YAML for all GVAR adjustements custom functions

### DIFF
--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -749,6 +749,7 @@ PACK(struct StepsCalibData {
 #endif
 
 PACK(struct CalibData {
+  CUST_IDX(calib, r_calib, w_calib);
   int16_t mid;
   int16_t spanNeg;
   int16_t spanPos;
@@ -837,7 +838,7 @@ PACK(struct RadioData {
   // Real attributes
   NOBACKUP(uint8_t version);
   NOBACKUP(uint16_t variant SKIP);
-  CalibData calib[NUM_STICKS + STORAGE_NUM_POTS + STORAGE_NUM_SLIDERS + STORAGE_NUM_MOUSE_ANALOGS];
+  CalibData calib[NUM_STICKS + STORAGE_NUM_POTS + STORAGE_NUM_SLIDERS + STORAGE_NUM_MOUSE_ANALOGS] NO_IDX;
   NOBACKUP(uint16_t chkSum SKIP);
   N_HORUS_FIELD(int8_t currModel);
   N_HORUS_FIELD(uint8_t contrast);

--- a/radio/src/storage/conversions/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/conversions/yaml/yaml_datastructs_funcs.cpp
@@ -724,21 +724,20 @@ const char* _func_failsafe_lookup[] = {
 };
 
 // used in read routine as well
+extern const char* _func_sound_lookup[];
 const char* _func_sound_lookup[] = {
   "Bp1","Bp2","Bp3","Wrn1","Wrn2",
   "Chee","Rata","Tick","Sirn","Ring",
   "SciF","Robt","Chrp","Tada","Crck","Alrm"
 };
+extern const uint8_t _func_sound_lookup_size = 16;
 
 // force external linkage
-extern const uint8_t _func_sound_lookup_size = sizeof(_func_sound_lookup);
-
 extern const char* _adjust_gvar_mode_lookup[];
 const char* _adjust_gvar_mode_lookup[] = {
   "Cst", "Src", "GVar", "IncDec"
 };
-
-extern const uint8_t _adjust_gvar_mode_lookup_size = sizeof(_adjust_gvar_mode_lookup);
+extern const uint8_t _adjust_gvar_mode_lookup_size = 4;
   
 bool w_customFn(void* user, uint8_t* data, uint32_t bitoffs,
                 yaml_writer_func wf, void* opaque)
@@ -827,10 +826,15 @@ bool w_customFn(void* user, uint8_t* data, uint32_t bitoffs,
     break;
 
   case FUNC_ADJUST_GVAR:
+    str = yaml_unsigned2str(CFN_GVAR_INDEX(cfn)); // GVAR index
+    if (!wf(opaque, str, strlen(str))) return false;
+    if (!wf(opaque,",",1)) return false;
+
     // output CFN_GVAR_MODE
     str = _adjust_gvar_mode_lookup[CFN_GVAR_MODE(cfn)];
     if (!wf(opaque, str, strlen(str))) return false;
     if (!wf(opaque,",",1)) return false;    
+
     // output param
     switch(CFN_GVAR_MODE(cfn)) {
     case FUNC_ADJUST_GVAR_CONSTANT:

--- a/radio/src/storage/conversions/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/conversions/yaml/yaml_datastructs_funcs.cpp
@@ -262,6 +262,18 @@ uint8_t select_sensor_cfg(void* user, uint8_t* data, uint32_t bitoffs)
     return 5;
 }
 
+#define r_calib nullptr
+
+static bool w_calib(void* user, yaml_writer_func wf, void* opaque)
+{
+  auto tw = reinterpret_cast<YamlTreeWalker*>(user);
+  uint16_t idx = tw->getElmts();
+
+  const char* str =
+      yaml_output_enum(idx + MIXSRC_Rud, enum_MixSources);
+  return str ? wf(opaque, str, strlen(str)) : true;
+}
+
 bool sw_write(void* user, yaml_writer_func wf, void* opaque)
 {
   auto tw = reinterpret_cast<YamlTreeWalker*>(user);

--- a/radio/src/storage/conversions/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/conversions/yaml/yaml_datastructs_funcs.cpp
@@ -811,6 +811,9 @@ bool w_customFn(void* user, uint8_t* data, uint32_t bitoffs,
     // Tmr1,Tmr2,Tmr3
     str = _func_reset_param_lookup[CFN_TIMER_INDEX(cfn)];
     if (!wf(opaque, str, strlen(str))) return false;
+    if (!wf(opaque,",",1)) return false;
+    str = yaml_unsigned2str(CFN_PARAM(cfn));
+    if (!wf(opaque, str, strlen(str))) return false;
     break;
 
   case FUNC_SET_FAILSAFE:

--- a/radio/src/storage/conversions/yaml/yaml_datastructs_nv14.cpp
+++ b/radio/src/storage/conversions/yaml/yaml_datastructs_nv14.cpp
@@ -286,7 +286,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/conversions/yaml/yaml_datastructs_t12.cpp
+++ b/radio/src/storage/conversions/yaml/yaml_datastructs_t12.cpp
@@ -276,7 +276,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/conversions/yaml/yaml_datastructs_t8.cpp
+++ b/radio/src/storage/conversions/yaml/yaml_datastructs_t8.cpp
@@ -276,7 +276,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/conversions/yaml/yaml_datastructs_tlite.cpp
+++ b/radio/src/storage/conversions/yaml/yaml_datastructs_tlite.cpp
@@ -276,7 +276,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/conversions/yaml/yaml_datastructs_tx12.cpp
+++ b/radio/src/storage/conversions/yaml/yaml_datastructs_tx12.cpp
@@ -276,7 +276,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/conversions/yaml/yaml_datastructs_x10.cpp
+++ b/radio/src/storage/conversions/yaml/yaml_datastructs_x10.cpp
@@ -307,7 +307,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/conversions/yaml/yaml_datastructs_x12s.cpp
+++ b/radio/src/storage/conversions/yaml/yaml_datastructs_x12s.cpp
@@ -307,7 +307,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/conversions/yaml/yaml_datastructs_x7.cpp
+++ b/radio/src/storage/conversions/yaml/yaml_datastructs_x7.cpp
@@ -276,7 +276,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/conversions/yaml/yaml_datastructs_x9d.cpp
+++ b/radio/src/storage/conversions/yaml/yaml_datastructs_x9d.cpp
@@ -283,7 +283,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/conversions/yaml/yaml_datastructs_x9e.cpp
+++ b/radio/src/storage/conversions/yaml/yaml_datastructs_x9e.cpp
@@ -322,7 +322,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/conversions/yaml/yaml_datastructs_x9lite.cpp
+++ b/radio/src/storage/conversions/yaml/yaml_datastructs_x9lite.cpp
@@ -263,7 +263,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/conversions/yaml/yaml_datastructs_x9lites.cpp
+++ b/radio/src/storage/conversions/yaml/yaml_datastructs_x9lites.cpp
@@ -271,7 +271,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/conversions/yaml/yaml_datastructs_xlite.cpp
+++ b/radio/src/storage/conversions/yaml/yaml_datastructs_xlite.cpp
@@ -268,7 +268,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/conversions/yaml/yaml_datastructs_xlites.cpp
+++ b/radio/src/storage/conversions/yaml/yaml_datastructs_xlites.cpp
@@ -270,7 +270,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
@@ -1150,7 +1150,20 @@ static void r_customFn(void* user, uint8_t* data, uint32_t bitoffs,
         && val[2] == 'r'
         && val[3] >= '1'
         && val[3] <= '3') {
+
       CFN_TIMER_INDEX(cfn) = val[3] - '1';
+
+      val += 4; val_len -= 4;
+      if (val_len == 0 || val[0] != ',') return;
+      val++; val_len--;
+
+      CFN_PARAM(cfn) = yaml_str2uint_ref(val, val_len);
+      if (val_len == 0 || val[0] != ',') return;
+      val++; val_len--;
+
+      eat_comma = false;
+    } else {
+      return;
     }
     break;
 
@@ -1330,6 +1343,9 @@ static bool w_customFn(void* user, uint8_t* data, uint32_t bitoffs,
   case FUNC_SET_TIMER:
     // Tmr1,Tmr2,Tmr3
     str = yaml_conv_220::_func_reset_param_lookup[CFN_TIMER_INDEX(cfn)];
+    if (!wf(opaque, str, strlen(str))) return false;
+    if (!wf(opaque,",",1)) return false;
+    str = yaml_unsigned2str(CFN_PARAM(cfn));
     if (!wf(opaque, str, strlen(str))) return false;
     break;
 

--- a/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
@@ -1174,7 +1174,16 @@ static void r_customFn(void* user, uint8_t* data, uint32_t bitoffs,
     CFN_PARAM(cfn) = yaml_str2uint(val, l_sep);
     break;
 
-  case FUNC_ADJUST_GVAR:
+  case FUNC_ADJUST_GVAR: {
+
+    CFN_GVAR_INDEX(cfn) = yaml_str2int_ref(val, l_sep);
+    if (val_len == 0 || val[0] != ',') return;
+    val++; val_len--;
+
+    // find "," and cut val_len
+    sep = (const char *)memchr(val, ',', val_len);
+    l_sep = sep ? sep - val : val_len;
+
     // parse CFN_GVAR_MODE
     for (int i=0; i < yaml_conv_220::_adjust_gvar_mode_lookup_size; i++) {
       if (!strncmp(yaml_conv_220::_adjust_gvar_mode_lookup[i],val,l_sep)) {
@@ -1182,12 +1191,14 @@ static void r_customFn(void* user, uint8_t* data, uint32_t bitoffs,
         break;
       }
     }
+
     val += l_sep; val_len -= l_sep;
     if (val_len == 0 || val[0] != ',') return;
     val++; val_len--;
     // find "," and cut val_len
     sep = (const char *)memchr(val, ',', val_len);
     l_sep = sep ? sep - val : val_len;
+
     // output param
     switch(CFN_GVAR_MODE(cfn)) {
     case FUNC_ADJUST_GVAR_CONSTANT:
@@ -1203,7 +1214,9 @@ static void r_customFn(void* user, uint8_t* data, uint32_t bitoffs,
         CFN_PARAM(cfn) = gvar - MIXSRC_FIRST_GVAR;
       }
     } break;
-    } break;
+    }
+
+  } break;
 
   default:
     eat_comma = false;
@@ -1333,10 +1346,15 @@ static bool w_customFn(void* user, uint8_t* data, uint32_t bitoffs,
     break;
 
   case FUNC_ADJUST_GVAR:
+    str = yaml_unsigned2str(CFN_GVAR_INDEX(cfn)); // GVAR index
+    if (!wf(opaque, str, strlen(str))) return false;
+    if (!wf(opaque,",",1)) return false;
+
     // output CFN_GVAR_MODE
     str = yaml_conv_220::_adjust_gvar_mode_lookup[CFN_GVAR_MODE(cfn)];
     if (!wf(opaque, str, strlen(str))) return false;
     if (!wf(opaque,",",1)) return false;    
+
     // output param
     switch(CFN_GVAR_MODE(cfn)) {
     case FUNC_ADJUST_GVAR_CONSTANT:
@@ -1351,6 +1369,7 @@ static bool w_customFn(void* user, uint8_t* data, uint32_t bitoffs,
       if (!w_mixSrcRaw(nullptr, CFN_PARAM(cfn) + MIXSRC_FIRST_GVAR, wf, opaque)) return false;
       break;
     }
+    break;
 
   default:
     add_comma = false;

--- a/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
@@ -451,6 +451,26 @@ static uint8_t select_sensor_cfg(void* user, uint8_t* data, uint32_t bitoffs)
   return yaml_conv_220::select_sensor_cfg(user, data, bitoffs);
 }
 
+static uint32_t r_calib(void* user, const char* val, uint8_t val_len)
+{
+  (void)user;
+
+  uint32_t sw = yaml_parse_enum(enum_MixSources, val, val_len);
+  if (sw >= MIXSRC_Rud) return sw - MIXSRC_Rud;
+
+  return (uint32_t)yaml_str2int(val, val_len);
+}
+
+static bool w_calib(void* user, yaml_writer_func wf, void* opaque)
+{
+  auto tw = reinterpret_cast<YamlTreeWalker*>(user);
+  uint16_t idx = tw->getElmts();
+
+  const char* str =
+      yaml_output_enum(idx + MIXSRC_Rud, enum_MixSources);
+  return str ? wf(opaque, str, strlen(str)) : true;
+}
+
 static uint32_t sw_read(void* user, const char* val, uint8_t val_len)
 {
   (void)user;

--- a/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
@@ -286,7 +286,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/yaml/yaml_datastructs_t12.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t12.cpp
@@ -276,7 +276,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/yaml/yaml_datastructs_t8.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t8.cpp
@@ -276,7 +276,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/yaml/yaml_datastructs_tlite.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tlite.cpp
@@ -276,7 +276,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/yaml/yaml_datastructs_tx12.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tx12.cpp
@@ -276,7 +276,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/yaml/yaml_datastructs_x10.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x10.cpp
@@ -309,7 +309,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
@@ -307,7 +307,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/yaml/yaml_datastructs_x7.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x7.cpp
@@ -276,7 +276,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
@@ -283,7 +283,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
@@ -322,7 +322,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/yaml/yaml_datastructs_x9lite.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9lite.cpp
@@ -263,7 +263,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/yaml/yaml_datastructs_x9lites.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9lites.cpp
@@ -271,7 +271,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/yaml/yaml_datastructs_xlite.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_xlite.cpp
@@ -268,7 +268,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
@@ -270,7 +270,7 @@ const struct YamlIdStr enum_TelemetrySensorType[] = {
 //
 
 static const struct YamlNode struct_CalibData[] = {
-  YAML_IDX,
+  YAML_IDX_CUST("calib",r_calib,w_calib),
   YAML_SIGNED( "mid", 16 ),
   YAML_SIGNED( "spanNeg", 16 ),
   YAML_SIGNED( "spanPos", 16 ),

--- a/radio/src/storage/yaml/yaml_defs.h
+++ b/radio/src/storage/yaml/yaml_defs.h
@@ -52,6 +52,10 @@
   int _dummy_##tag[0] _yaml_attribute("raw:YAML_ARRAY(" _yaml_note( \
       #tag) ", 0, 4, " _yaml_note(elmt_type) ", " _yaml_note(fcn) ")")
 
+#define CUST_IDX(tag, read, write)                                     \
+  int _dummy_##tag[0] _yaml_attribute("raw:YAML_IDX_CUST(" _yaml_note( \
+      #tag) "," _yaml_note(read) "," _yaml_note(write) ")")
+
 #else
 
 #define ENUM(label)
@@ -64,6 +68,7 @@
 #define ARRAY(elmt_size, elmt_type, fcn)
 #define CUST_ATTR(tag, read, write)
 #define CUST_ARRAY(tag, elmt_type, fcn)
+#define CUST_IDX(tag, read, write)
 
 #endif
 

--- a/radio/src/tests/conversions.cpp
+++ b/radio/src/tests/conversions.cpp
@@ -289,13 +289,13 @@ TEST(Conversions, ConversionX10From23)
 
   EXPECT_EQ(221, g_eeGeneral.version);
 
-  EXPECT_EQ(100, g_eeGeneral.calib[9].spanNeg);
-  EXPECT_EQ(500, g_eeGeneral.calib[9].mid);
-  EXPECT_EQ(900, g_eeGeneral.calib[9].spanPos);
+  EXPECT_EQ(100, g_eeGeneral.calib[CALIBRATED_SLIDER_REAR_LEFT].spanNeg);
+  EXPECT_EQ(500, g_eeGeneral.calib[CALIBRATED_SLIDER_REAR_LEFT].mid);
+  EXPECT_EQ(900, g_eeGeneral.calib[CALIBRATED_SLIDER_REAR_LEFT].spanPos);
 
-  EXPECT_EQ(200, g_eeGeneral.calib[10].spanNeg);
-  EXPECT_EQ(400, g_eeGeneral.calib[10].mid);
-  EXPECT_EQ(600, g_eeGeneral.calib[10].spanPos);
+  EXPECT_EQ(200, g_eeGeneral.calib[CALIBRATED_SLIDER_REAR_RIGHT].spanNeg);
+  EXPECT_EQ(400, g_eeGeneral.calib[CALIBRATED_SLIDER_REAR_RIGHT].mid);
+  EXPECT_EQ(600, g_eeGeneral.calib[CALIBRATED_SLIDER_REAR_RIGHT].spanPos);
 
   EXPECT_EQ(-23, g_eeGeneral.vBatMin);
   EXPECT_EQ(8, g_eeGeneral.speakerVolume);


### PR DESCRIPTION
Fixes #1158

Summary of changes:
- added GVAR index to the parameters
- fixed lookup table sizes (prevent memory access violation)
- fixed `SET_TIMER` duration (#1130)
- use symbolic names for calibration data (#1083)