### PR TITLE
Make list of supported internal module configurable per cmake option

### DIFF
--- a/radio/src/targets/common/arm/CMakeLists.txt
+++ b/radio/src/targets/common/arm/CMakeLists.txt
@@ -30,8 +30,10 @@ set_property(CACHE DEFAULT_INTERNAL_MODULE PROPERTY STRINGS ${INTERNAL_MODULES})
 
 # define variables for internal modules
 foreach(module ${INTERNAL_MODULES})
-  message("-- Adding support for ${module} as internal module")
   set(INTERNAL_MODULE_${module} ON CACHE BOOL "Support for ${module} internal module")
+  if (INTERNAL_MODULE_${module})
+    message("-- Adding support for ${module} as internal module")
+  endif()
 endforeach()
 
 if(INTERNAL_MODULE_PXX1)

--- a/radio/src/targets/horus/CMakeLists.txt
+++ b/radio/src/targets/horus/CMakeLists.txt
@@ -49,7 +49,7 @@ endif()
 add_definitions(-DPCBFRSKY)
 
 # defines existing internal modules
-set(INTERNAL_MODULES PXX1 PXX2 MULTI CRSF)
+set(INTERNAL_MODULES PXX1;PXX2;MULTI;CRSF CACHE STRING "Internal modules")
 
 # VCP CLI
 set(ENABLE_SERIAL_PASSTHROUGH ON CACHE BOOL "Enable serial passthrough")

--- a/radio/src/targets/nv14/CMakeLists.txt
+++ b/radio/src/targets/nv14/CMakeLists.txt
@@ -50,7 +50,7 @@ add_definitions(-DBATTERY_CHARGE)  # -DSOFTWARE_VOLUME
 add_definitions(-DINTERNAL_MODULE_AFHDS2A)
 
 # defines existing internal modules
-set(INTERNAL_MODULES AFHDS2A)
+set(INTERNAL_MODULES AFHDS2A CACHE STRING "Internal modules")
 set(DEFAULT_INTERNAL_MODULE FLYSKY CACHE STRING "Default internal module")
 
 set(TARGET_SRC

--- a/radio/src/targets/taranis/CMakeLists.txt
+++ b/radio/src/targets/taranis/CMakeLists.txt
@@ -357,10 +357,10 @@ if(INTERNAL_MODULE_SERIAL)
 
   if("${PCBREV}" STREQUAL 2019 OR "${PCBREV}" STREQUAL ACCESS)
     # defines existing internal modules
-    set(INTERNAL_MODULES PXX2)
+    set(INTERNAL_MODULES PXX2 CACHE STRING "Internal modules")
   else()
     # defines existing internal modules
-    set(INTERNAL_MODULES PXX1 PXX2 MULTI CRSF)
+    set(INTERNAL_MODULES PXX1;PXX2;MULTI;CRSF CACHE STRING "Internal modules")
   endif()
 
   add_definitions(-DINTERNAL_MODULE_SERIAL)


### PR DESCRIPTION
Resolves #1159

This allows for configuring the available internal modules via cmake as follows:
```
cmake -DPCB=X7 -DPCBREV=T12 -DINTERNAL_MODULES="PXX1;PXX2" -DGHOST=OFF -DAFHDS3=OFF -DCROSSFIRE=OFF ...
```

Please note that `-DCROSSFIRE` will disable the CRSF on the external module interface. Without removing CRSF from the internal modules, it would automatically activate support for CRSF, and thus override `-DCROSSFIRE`.