### PR TITLE
fix auto power off on cleared warning trigger

### DIFF
--- a/radio/src/gui/colorlcd/fullscreen_dialog.cpp
+++ b/radio/src/gui/colorlcd/fullscreen_dialog.cpp
@@ -201,12 +201,24 @@ void raiseAlert(const char * title, const char * msg, const char * action, uint8
 }
 
 // POPUP_CONFIRMATION
-bool confirmationDialog(const char* title, const char* msg, bool checkPwr)
+bool confirmationDialog(const char* title, const char* msg, bool checkPwr, const std::function<bool(void)>& closeCondition)
 {
   bool confirmed = false;
   auto dialog = new FullScreenDialog(WARNING_TYPE_CONFIRM, title ? title : "",
                                      msg ? msg : "", "",
                                      [&confirmed]() { confirmed = true; });
+  if(closeCondition)
+  {
+    dialog->setCloseCondition([&confirmed,&closeCondition]() {
+      if(closeCondition())
+      {
+        confirmed=true;
+        return true;
+      } else {
+        return false;
+      }});
+  }
+
   if (checkPwr) {
     dialog->runForever();
   } else {

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -471,7 +471,7 @@ void alert(const char * title, const char * msg, uint8_t sound);
 
 #elif defined(COLORLCD)
 
-bool confirmationDialog(const char *title, const char *msg, bool checkPwr = true);
+bool confirmationDialog(const char *title, const char *msg, bool checkPwr = true, const std::function<bool(void)>& closeCondition = nullptr);
 
 void raiseAlert(const char *title, const char *msg, const char *info,
                 uint8_t sound);


### PR DESCRIPTION
Fixes #206 

also adds a close condition callback to the confirmation dialog
