### PR TITLE
Removed the call to update() when widget leaves fullscreen mode

### DIFF
--- a/radio/src/gui/colorlcd/widget.cpp
+++ b/radio/src/gui/colorlcd/widget.cpp
@@ -167,7 +167,7 @@ void Widget::setFullscreen(bool fullscreen)
   if (!fullscreen) {
 
     // Reset all zones in container
-    update();
+    Widget::update();
     setWindowFlags(getWindowFlags() & ~OPAQUE);
 
     // and give up focus


### PR DESCRIPTION
As discussed on Discord with @pfeerick  and @lshems 