### PR TITLE
298 keys stuck

### DIFF
--- a/radio/src/gui/colorlcd/tabsgroup.cpp
+++ b/radio/src/gui/colorlcd/tabsgroup.cpp
@@ -73,10 +73,33 @@ void TabsCarousel::paint(BitmapBuffer * dc)
 #if defined(HARDWARE_TOUCH)
 bool TabsCarousel::onTouchEnd(coord_t x, coord_t y)
 {
+  if(sliding)
+  {
+    sliding = false;
+    return true;
+  }
+
   unsigned index = (x - padding_left) / MENU_HEADER_BUTTON_WIDTH;
+
   if (index >= menu->tabs.size()) {
     return false;
   }
+
+  menu->setCurrentTab(index);
+  setCurrentIndex(index);
+  return true;
+}
+
+bool TabsCarousel::onTouchSlide(coord_t x, coord_t y, coord_t startX, coord_t startY, coord_t slideX, coord_t slideY)
+{
+  sliding = true;
+
+  unsigned index = std::max<coord_t>(0,x - padding_left) / MENU_HEADER_BUTTON_WIDTH;
+
+  if (index >= menu->tabs.size()) {
+    index = menu->tabs.size()-1;
+  }
+
   menu->setCurrentTab(index);
   setCurrentIndex(index);
   return true;

--- a/radio/src/gui/colorlcd/tabsgroup.cpp
+++ b/radio/src/gui/colorlcd/tabsgroup.cpp
@@ -71,13 +71,18 @@ void TabsCarousel::paint(BitmapBuffer * dc)
 }
 
 #if defined(HARDWARE_TOUCH)
+bool TabsCarousel::onTouchStart(coord_t x, coord_t y)
+{
+  if(sliding)
+    sliding = false;
+
+  return true;
+}
+
 bool TabsCarousel::onTouchEnd(coord_t x, coord_t y)
 {
   if(sliding)
-  {
-    sliding = false;
     return true;
-  }
 
   unsigned index = (x - padding_left) / MENU_HEADER_BUTTON_WIDTH;
 

--- a/radio/src/gui/colorlcd/tabsgroup.cpp
+++ b/radio/src/gui/colorlcd/tabsgroup.cpp
@@ -99,14 +99,9 @@ bool TabsCarousel::onTouchSlide(coord_t x, coord_t y, coord_t startX, coord_t st
 {
   sliding = true;
 
-  unsigned index = std::max<coord_t>(0,x - padding_left) / MENU_HEADER_BUTTON_WIDTH;
+  Window::onTouchSlide(x,y,startX,startY,slideX,slideY);
+  menu->setCurrentTab(currentIndex);
 
-  if (index >= menu->tabs.size()) {
-    index = menu->tabs.size()-1;
-  }
-
-  menu->setCurrentTab(index);
-  setCurrentIndex(index);
   return true;
 }
 #endif

--- a/radio/src/gui/colorlcd/tabsgroup.h
+++ b/radio/src/gui/colorlcd/tabsgroup.h
@@ -103,12 +103,16 @@ class TabsCarousel: public Window {
 
 #if defined(HARDWARE_TOUCH)
     bool onTouchEnd(coord_t x, coord_t y) override;
+    bool onTouchSlide(coord_t x, coord_t y, coord_t startX, coord_t startY, coord_t slideX, coord_t slideY) override;
 #endif
 
   protected:
     constexpr static uint8_t padding_left = 3;
     TabsGroup * menu;
     uint8_t currentIndex = 0;
+#if defined(HARDWARE_TOUCH)
+    bool sliding = false;
+#endif
 };
 
 class TabsGroupHeader: public FormGroup {

--- a/radio/src/gui/colorlcd/tabsgroup.h
+++ b/radio/src/gui/colorlcd/tabsgroup.h
@@ -102,6 +102,7 @@ class TabsCarousel: public Window {
     void paint(BitmapBuffer * dc) override;
 
 #if defined(HARDWARE_TOUCH)
+    bool onTouchStart(coord_t x, coord_t y) override;
     bool onTouchEnd(coord_t x, coord_t y) override;
     bool onTouchSlide(coord_t x, coord_t y, coord_t startX, coord_t startY, coord_t slideX, coord_t slideY) override;
 #endif


### PR DESCRIPTION
Fixes #298 

Summary of changes:
handle slide events on the tab bar and ignore touch end event with old coordinates when touch ends.
Please check on NV14
