### PR TITLE
Use theme colours for shutdown animation/screen

### DIFF
--- a/radio/src/gui/colorlcd/draw_functions.cpp
+++ b/radio/src/gui/colorlcd/draw_functions.cpp
@@ -21,6 +21,7 @@
 
 #include "opentx.h"
 #include "lcd.h"
+#include "theme_manager.h"
 
 coord_t drawStringWithIndex(BitmapBuffer * dc, coord_t x, coord_t y, const char * str, int idx, LcdFlags flags, const char * prefix, const char * suffix)
 {
@@ -79,13 +80,24 @@ void drawValueOrGVar(BitmapBuffer* dc, coord_t x, coord_t y, gvar_t value,
 
 void drawSleepBitmap()
 {
+  LcdFlags fgColor;
+  LcdFlags bgColor;
+
+  if (ThemePersistance::instance()->isDefaultTheme()) {
+    fgColor = COLOR2FLAGS(WHITE);
+    bgColor = COLOR2FLAGS(BLACK);
+  } else {
+    fgColor = COLOR_THEME_PRIMARY2;
+    bgColor = COLOR_THEME_SECONDARY1;
+  }
+
   lcd->reset();
-  lcd->clear();
+  lcd->clear(bgColor);
 
   const BitmapBuffer* bitmap = OpenTxTheme::instance()->shutdown;
   if (bitmap) {
-    lcd->drawMask((LCD_W-bitmap->width())/2, (LCD_H-bitmap->height())/2,
-                  bitmap, COLOR2FLAGS(WHITE));
+    lcd->drawMask((LCD_W - bitmap->width()) / 2, (LCD_H - bitmap->height()) / 2,
+                  bitmap, fgColor);
   }
 
   lcdRefresh();
@@ -96,46 +108,53 @@ void drawSleepBitmap()
 void drawShutdownAnimation(uint32_t duration, uint32_t totalDuration,
                            const char* message)
 {
-  if (totalDuration == 0)
-    return;
+  if (totalDuration == 0) return;
 
-  static const BitmapBuffer * shutdown = OpenTxTheme::instance()->shutdown;
+  LcdFlags fgColor;
+  LcdFlags bgColor;
+
+  if (ThemePersistance::instance()->isDefaultTheme()) {
+    fgColor = COLOR2FLAGS(WHITE);
+    bgColor = COLOR2FLAGS(BLACK);
+  } else {
+    fgColor = COLOR_THEME_PRIMARY2;
+    bgColor = COLOR_THEME_SECONDARY1;
+  }
+
+  static const BitmapBuffer* shutdown = OpenTxTheme::instance()->shutdown;
 
   lcd->reset();
-  lcd->clear(COLOR2FLAGS(BLACK));
-  
+  lcd->clear(bgColor);
+
   if (shutdown) {
     lcd->drawMask((LCD_W - shutdown->width()) / 2,
-                  (LCD_H - shutdown->height()) / 2, shutdown,
-                  COLOR2FLAGS(WHITE));
+                  (LCD_H - shutdown->height()) / 2, shutdown, fgColor);
 
     int quarter = duration / (totalDuration / 5);
     if (quarter >= 1)
       lcd->drawBitmapPattern(LCD_W / 2, (LCD_H - SHUTDOWN_CIRCLE_DIAMETER) / 2,
-                             LBM_SHUTDOWN_CIRCLE, COLOR2FLAGS(WHITE), 0,
+                             LBM_SHUTDOWN_CIRCLE, fgColor, 0,
                              SHUTDOWN_CIRCLE_DIAMETER / 2);
     if (quarter >= 2)
-      lcd->drawBitmapPattern(LCD_W / 2, LCD_H / 2, LBM_SHUTDOWN_CIRCLE,
-                             COLOR2FLAGS(WHITE), SHUTDOWN_CIRCLE_DIAMETER / 2,
+      lcd->drawBitmapPattern(LCD_W / 2, LCD_H / 2, LBM_SHUTDOWN_CIRCLE, fgColor,
+                             SHUTDOWN_CIRCLE_DIAMETER / 2,
                              SHUTDOWN_CIRCLE_DIAMETER / 2);
     if (quarter >= 3)
       lcd->drawBitmapPattern((LCD_W - SHUTDOWN_CIRCLE_DIAMETER) / 2, LCD_H / 2,
-                             LBM_SHUTDOWN_CIRCLE, COLOR2FLAGS(WHITE),
+                             LBM_SHUTDOWN_CIRCLE, fgColor,
                              SHUTDOWN_CIRCLE_DIAMETER,
                              SHUTDOWN_CIRCLE_DIAMETER / 2);
     if (quarter >= 4)
-      lcd->drawBitmapPattern((LCD_W - SHUTDOWN_CIRCLE_DIAMETER) / 2,
-                             (LCD_H - SHUTDOWN_CIRCLE_DIAMETER) / 2,
-                             LBM_SHUTDOWN_CIRCLE, COLOR2FLAGS(WHITE),
-                             SHUTDOWN_CIRCLE_DIAMETER * 3 / 2,
-                             SHUTDOWN_CIRCLE_DIAMETER / 2);
+      lcd->drawBitmapPattern(
+          (LCD_W - SHUTDOWN_CIRCLE_DIAMETER) / 2,
+          (LCD_H - SHUTDOWN_CIRCLE_DIAMETER) / 2, LBM_SHUTDOWN_CIRCLE, fgColor,
+          SHUTDOWN_CIRCLE_DIAMETER * 3 / 2, SHUTDOWN_CIRCLE_DIAMETER / 2);
   } else {
-    //lcd->clear();
     int quarter = duration / (totalDuration / 5);
     for (int i = 1; i <= 4; i++) {
       if (quarter >= i) {
         lcd->drawSolidFilledRect(LCD_W / 2 - 70 + 24 * i, LCD_H / 2 - 10, 20,
-                                 20, COLOR2FLAGS(WHITE));
+                                 20, fgColor);
       }
     }
   }

--- a/radio/src/gui/colorlcd/theme_manager.h
+++ b/radio/src/gui/colorlcd/theme_manager.h
@@ -176,6 +176,7 @@ class ThemePersistance
 
     inline int getThemeIndex() {return currentTheme;}
     inline void setThemeIndex(int index) { currentTheme = index;}
+    inline bool isDefaultTheme() { if (currentTheme == 0) return true; else return false; }
 
     inline ThemeFile* getCurrentTheme() 
     { 


### PR DESCRIPTION
Resolves #874

Summary of changes:
- add `isDefaultTheme()` bool to ThemePersistance()
- Use COLOR_THEME_SECONDARY1 as background, COLOR_THEME_PRIMARY2 as foreground colours for shutdown screen (i.e. the same as the top bar background colour and top bar icon colour) unless using default theme. In that case, it uses a black background, and white foreground. 

Based on the results of the poll on Discord, of the ~35 respondents, 31 were in favour, and none not in favour of the shutdown screen being themed. I believe the remain four were basically wondering why I even asked... if not, be warned, I know you you are! 😆 

https://discord.com/channels/839849772864503828/839849772864503832/910109100115902514