### PR TITLE
Add a DEBUG_BLUETOOTH option to clean up console

### DIFF
--- a/radio/src/bluetooth.cpp
+++ b/radio/src/bluetooth.cpp
@@ -57,12 +57,12 @@ Bluetooth bluetooth;
 void Bluetooth::write(const uint8_t * data, uint8_t length)
 {
   if (btTxFifo.hasSpace(length)) {
-    BLUETOOTH_TRACE("BT>");
+    BLUETOOTH_TRACE_VERBOSE("BT>");
     for (int i = 0; i < length; i++) {
-      BLUETOOTH_TRACE(" %02X", data[i]);
+      BLUETOOTH_TRACE_VERBOSE(" %02X", data[i]);
       btTxFifo.push(data[i]);
     }
-    BLUETOOTH_TRACE(CRLF);
+    BLUETOOTH_TRACE_VERBOSE(CRLF);
   }
   else {
     BLUETOOTH_TRACE("[BT] TX fifo full!" CRLF);
@@ -95,7 +95,7 @@ char * Bluetooth::readline(bool error_reset)
       return nullptr;
     }
 
-    BLUETOOTH_TRACE("%02X ", byte);
+    BLUETOOTH_TRACE_VERBOSE("%02X ", byte);
 
 #if 0
     if (error_reset && byte == 'R' && bufferIndex == 4 && memcmp(buffer, "ERRO", 4)) {

--- a/radio/src/bluetooth.h
+++ b/radio/src/bluetooth.h
@@ -56,8 +56,11 @@ enum BluetoothStates {
     f_printf(&g_bluetoothFile, __VA_ARGS__); \
     TRACE_NOCRLF(__VA_ARGS__);
 #else
-  #define BLUETOOTH_TRACE(...)  \
-    TRACE_NOCRLF(__VA_ARGS__);
+#if defined(DEBUG_BLUETOOTH)
+  #define BLUETOOTH_TRACE(...)  TRACE_NOCRLF(__VA_ARGS__);
+#else
+  #define BLUETOOTH_TRACE(...)
+#endif
 #endif
 
 class Bluetooth

--- a/radio/src/bluetooth.h
+++ b/radio/src/bluetooth.h
@@ -58,8 +58,16 @@ enum BluetoothStates {
 #else
 #if defined(DEBUG_BLUETOOTH)
   #define BLUETOOTH_TRACE(...)  TRACE_NOCRLF(__VA_ARGS__);
+  #define BLUETOOTH_TRACE_TIMESTAMP(f_, ...)  debugPrintf((TRACE_TIME_FORMAT f_), TRACE_TIME_VALUE, ##__VA_ARGS__)
+#if defined(DEBUG_BLUETOOTH_VERBOSE)
+  #define BLUETOOTH_TRACE_VERBOSE(...) TRACE_NOCRLF(__VA_ARGS__);
+#else
+  #define BLUETOOTH_TRACE_VERBOSE(...)
+#endif
 #else
   #define BLUETOOTH_TRACE(...)
+  #define BLUETOOTH_TIMESTAMP(f_, ...)
+  #define BLUETOOTH_TRACE_VERBOSE(...)
 #endif
 #endif
 

--- a/radio/src/targets/common/arm/CMakeLists.txt
+++ b/radio/src/targets/common/arm/CMakeLists.txt
@@ -141,7 +141,11 @@ if(DEBUG_LATENCY STREQUAL END_TO_END)
 endif()
 
 if(DEBUG_BLUETOOTH)
- add_definitions(-DDEBUG_BLUETOOTH)
+  add_definitions(-DDEBUG_BLUETOOTH)
+  option(DEBUG_BLUETOOTH_VERBOSE "Debug Bluetooth Verbose" OFF)
+  if(DEBUG_BLUETOOTH_VERBOSE)
+    add_definitions(-DDEBUG_BLUETOOTH_VERBOSE)
+  endif()
 endif()
 
 if(CLI)

--- a/radio/src/targets/common/arm/CMakeLists.txt
+++ b/radio/src/targets/common/arm/CMakeLists.txt
@@ -23,6 +23,7 @@ option(DEBUG_LATENCY "Debug latency" OFF)
 option(DEBUG_USB_INTERRUPTS "Count individual USB interrupts" OFF)
 option(DEBUG_TASKS "Task switching statistics" OFF)
 option(DEBUG_TIMERS "Time critical parts of the code" OFF)
+option(DEBUG_BLUETOOTH "Debug Bluetooth" OFF)
 
 # option to select the default internal module
 #set(DEFAULT_INTERNAL_MODULE NONE CACHE STRING "Default internal module")
@@ -137,6 +138,10 @@ endif()
 if(DEBUG_LATENCY STREQUAL END_TO_END)
   add_definitions(-DDEBUG_LATENCY)
   add_definitions(-DDEBUG_LATENCY_END_TO_END)
+endif()
+
+if(DEBUG_BLUETOOTH)
+ add_definitions(-DDEBUG_BLUETOOTH)
 endif()
 
 if(CLI)

--- a/radio/src/targets/common/arm/stm32/bluetooth_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/bluetooth_driver.cpp
@@ -123,7 +123,7 @@ extern "C" void BT_USART_IRQHandler(void)
     USART_ClearITPendingBit(BT_USART, USART_IT_RXNE);
     uint8_t byte = USART_ReceiveData(BT_USART);
     btRxFifo.push(byte);
-    BLUETOOTH_TRACE("BT %02X", byte);
+    BLUETOOTH_TRACE_VERBOSE("BT %02X" CRLF, byte);
 #if defined(BLUETOOTH_PROBE)
     if (!btChipPresent) {
       // This is to differentiate X7 and X7S and X-Lite with/without BT

--- a/radio/src/targets/common/arm/stm32/bluetooth_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/bluetooth_driver.cpp
@@ -123,7 +123,7 @@ extern "C" void BT_USART_IRQHandler(void)
     USART_ClearITPendingBit(BT_USART, USART_IT_RXNE);
     uint8_t byte = USART_ReceiveData(BT_USART);
     btRxFifo.push(byte);
-    TRACE("BT %02X", byte);
+    BLUETOOTH_TRACE("BT %02X", byte);
 #if defined(BLUETOOTH_PROBE)
     if (!btChipPresent) {
       // This is to differentiate X7 and X7S and X-Lite with/without BT


### PR DESCRIPTION
Bluetooth prints a ridiculous amount of data with or without debug turned on. It's currently writing every byte received. Fills the console so quick you can't see anything else happening.

This pull request only prints that data if specifically requested via a cmake option.

Printing of every byte is completely removed.