### PR TITLE
More global variables - issue #388

### DIFF
--- a/radio/src/dataconstants.h
+++ b/radio/src/dataconstants.h
@@ -388,8 +388,11 @@ enum PotsWarnMode {
 #define RESERVE_RANGE_FOR_GVARS        10
 // even we do not spend space in EEPROM for 10 GVARS, we reserve the space inside the range of values, like offset, weight, etc.
 
+#if defined(PCBHORUS) && defined(PCBX10)
 #define MAX_GVARS                      16
-
+#else
+#define MAX_GVARS                      9
+#endif
 enum SwitchSources {
   SWSRC_NONE = 0,
 

--- a/radio/src/dataconstants.h
+++ b/radio/src/dataconstants.h
@@ -388,7 +388,7 @@ enum PotsWarnMode {
 #define RESERVE_RANGE_FOR_GVARS        10
 // even we do not spend space in EEPROM for 10 GVARS, we reserve the space inside the range of values, like offset, weight, etc.
 
-#define MAX_GVARS                    9
+#define MAX_GVARS                      16
 
 enum SwitchSources {
   SWSRC_NONE = 0,

--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -79,7 +79,11 @@ static inline void check_struct()
   CHKSIZE(ExpoData, 17);
   CHKSIZE(LimitData, 13);
   CHKSIZE(CustomFunctionData, 9);
+#if defined(PCBHORUS) && defined(PCBX10)
   CHKSIZE(FlightModeData, 58);
+#else
+  CHKSIZE(FlightModeData, 44);
+#endif
   CHKSIZE(TimerData, 16);
   CHKSIZE(SwashRingData, 8);
   CHKSIZE(ModelHeader, 31);

--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -79,7 +79,7 @@ static inline void check_struct()
   CHKSIZE(ExpoData, 17);
   CHKSIZE(LimitData, 13);
   CHKSIZE(CustomFunctionData, 9);
-  CHKSIZE(FlightModeData, 44);
+  CHKSIZE(FlightModeData, 58);
   CHKSIZE(TimerData, 16);
   CHKSIZE(SwashRingData, 8);
   CHKSIZE(ModelHeader, 31);
@@ -133,7 +133,7 @@ static inline void check_struct()
 #elif defined(PCBHORUS)
   #if defined(PCBX10)
     CHKSIZE(RadioData, 921);
-    CHKSIZE(ModelData, 11022);
+    CHKSIZE(ModelData, 11197);
   #else
     CHKSIZE(RadioData, 903);
     CHKSIZE(ModelData, 11020);

--- a/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
@@ -123,7 +123,11 @@ static inline void check_yaml_funcs()
 
 #if defined(PCBHORUS)
   static_assert(offsetof(FlightModeData, gvars) == 26,"");
+#if defined(PCBHORUS) && defined(PCBX10)
   check_size<FlightModeData, 58>();
+#else
+  check_size<FlightModeData, 44>();
+#endif
   check_size<CustomFunctionData, 9>();
 #elif defined(PCBNV14)
   static_assert(offsetof(FlightModeData, gvars) == 22,"");

--- a/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
@@ -114,7 +114,13 @@ static inline void check_yaml_funcs()
 {
   static_assert(offsetof(ModuleData, ppm) == 4,"");
   check_size<ModuleData, 29>();
+
+#if defined(PCBHORUS) && defined(PCBX10)
   static_assert(MAX_GVARS == 16,"");
+#else
+  static_assert(MAX_GVARS == 9,"");
+#endif
+
 #if defined(PCBHORUS)
   static_assert(offsetof(FlightModeData, gvars) == 26,"");
   check_size<FlightModeData, 58>();

--- a/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
@@ -114,10 +114,10 @@ static inline void check_yaml_funcs()
 {
   static_assert(offsetof(ModuleData, ppm) == 4,"");
   check_size<ModuleData, 29>();
-  static_assert(MAX_GVARS == 9,"");
+  static_assert(MAX_GVARS == 16,"");
 #if defined(PCBHORUS)
   static_assert(offsetof(FlightModeData, gvars) == 26,"");
-  check_size<FlightModeData, 44>();
+  check_size<FlightModeData, 58>();
   check_size<CustomFunctionData, 9>();
 #elif defined(PCBNV14)
   static_assert(offsetof(FlightModeData, gvars) == 22,"");


### PR DESCRIPTION
I changed MAX_GVARS to 16. This caused some size checks and asserts to fail, so I changed those as well. I do not know what consequences this may have - does it corrupt model files or the EEPROM?
Therefore: DO NOT load this on your transmitter at this time!!