### PR TITLE
[B&W] Don't add entries for non-existant rows

### DIFF
--- a/radio/src/gui/common/stdlcd/radio_hardware.cpp
+++ b/radio/src/gui/common/stdlcd/radio_hardware.cpp
@@ -127,7 +127,7 @@ enum {
   ITEM_RADIO_HARDWARE_SPORT_UPDATE_POWER,
 #endif
   ITEM_RADIO_HARDWARE_DEBUG,
-#if defined(EEPROM_RLC)
+#if defined(EEPROM)
   ITEM_RADIO_BACKUP_EEPROM,
   ITEM_RADIO_FACTORY_RESET,
 #endif
@@ -249,7 +249,7 @@ enum {
   #define SPORT_POWER_ROWS
 #endif
 
-#if defined(EEPROM_RLC)
+#if defined(EEPROM)
 void onFactoryResetConfirm(const char * result)
 {
   if (result == STR_OK) {

--- a/radio/src/gui/common/stdlcd/radio_hardware.cpp
+++ b/radio/src/gui/common/stdlcd/radio_hardware.cpp
@@ -221,6 +221,12 @@ enum {
   #define TX_CAPACITY_MEASUREMENT_ROWS
 #endif
 
+#if !defined(PCBX9D) && !defined(PCBX9DP) && !defined(PCBX9E)
+  #define INTERNAL_MODULE_ROWS   0,
+#else
+  #define INTERNAL_MODULE_ROWS
+#endif
+
 #if (defined(CROSSFIRE) || defined(GHOST))
   #define MAX_BAUD_ROWS                  0,
 #else
@@ -292,6 +298,7 @@ void menuRadioHardware(event_t event)
     0 /* battery calib */,
     RTC_ROW
     TX_CAPACITY_MEASUREMENT_ROWS
+    INTERNAL_MODULE_ROWS
     MAX_BAUD_ROWS
     SERIAL_SAMPLE_MODE_ROWS
     BLUETOOTH_ROWS


### PR DESCRIPTION
Remove blanks lines for BACKUP_EEPROM & FACTORY_RESET, which are later disabled. 

Used to be this pre-yaml:
![image](https://user-images.githubusercontent.com/5500713/144012171-0deb5b3d-fa04-4761-ba5d-a0fd8b971535.png)

which became this:
![image](https://user-images.githubusercontent.com/5500713/144012355-6f9cc89f-029c-40e4-92e1-8d7b217d721a.png)

and will now be:
![image](https://user-images.githubusercontent.com/5500713/144012626-fb8f5895-606b-4883-ad3e-2981cc296cb2.png)
