### PR TITLE
use yml instead of bin to construct notes file name from model file n…

### DIFF
--- a/radio/src/gui/colorlcd/view_text.cpp
+++ b/radio/src/gui/colorlcd/view_text.cpp
@@ -438,6 +438,12 @@ static void replaceSpaceWithUnderscore(std::string& name)
   } while (index != std::string::npos);
 }
 
+#if defined(SDCARD_YAML)
+#define MODEL_FILE_EXT  YAML_EXT
+#else
+#define MODEL_FILE_EXT  MODELS_EXT
+#endif
+
 bool openNotes(const char buf[], std::string modelNotesName)
 {
   if(isFileAvailable(modelNotesName.c_str())) { 
@@ -466,7 +472,7 @@ void readModelNotes()
 #if !defined(EEPROM) 
   if(!notesFound) {   
     modelNotesName.assign(g_eeGeneral.currModelFilename);
-    size_t index = modelNotesName.find(".yml");
+    size_t index = modelNotesName.find(MODEL_FILE_EXT);
     if(index != std::string::npos)
     {
       modelNotesName.erase(index);

--- a/radio/src/gui/colorlcd/view_text.cpp
+++ b/radio/src/gui/colorlcd/view_text.cpp
@@ -466,7 +466,7 @@ void readModelNotes()
 #if !defined(EEPROM) 
   if(!notesFound) {   
     modelNotesName.assign(g_eeGeneral.currModelFilename);
-    size_t index = modelNotesName.find(".bin");
+    size_t index = modelNotesName.find(".yml");
     if(index != std::string::npos)
     {
       modelNotesName.erase(index);


### PR DESCRIPTION
Fixes #1198 

Summary of changes: when model notes file is named modelX.txt we should assume that the model file has "yml" rather than "bin" extension.
