### PR TITLE
fix crash on tab group sub page access/exit

### DIFF
--- a/radio/src/gui/colorlcd/tabsgroup.cpp
+++ b/radio/src/gui/colorlcd/tabsgroup.cpp
@@ -76,7 +76,7 @@ bool TabsCarousel::onTouchStart(coord_t x, coord_t y)
   if(sliding)
     sliding = false;
 
-  return true;
+   return Window::onTouchStart(x,y);
 }
 
 bool TabsCarousel::onTouchEnd(coord_t x, coord_t y)
@@ -100,7 +100,6 @@ bool TabsCarousel::onTouchSlide(coord_t x, coord_t y, coord_t startX, coord_t st
   sliding = true;
 
   Window::onTouchSlide(x,y,startX,startY,slideX,slideY);
-  menu->setCurrentTab(currentIndex);
 
   return true;
 }


### PR DESCRIPTION
Fixes crash on tab group sub page access/exit and not working access to top bar elements that are on top of tab bar tab icons
Fixes #1203 
