### PR TITLE
change source_t from uint8_t to uint16_t for NV14. #806

### DIFF
--- a/radio/src/opentx_types.h
+++ b/radio/src/opentx_types.h
@@ -33,7 +33,7 @@ typedef int16_t safetych_t;
 typedef int16_t gvar_t;
 typedef uint32_t bitfield_channels_t;
 typedef uint16_t FlightModesType;
-#if defined(PCBFRSKY)
+#if defined(PCBFRSKY) || defined(PCBNV14)
 typedef uint16_t source_t;
 #else
 typedef uint8_t source_t;


### PR DESCRIPTION
Fixes #806 

Summary of changes: change data type of source_t from uint8_t to uint16_t. 
One byte is not sufficient any more for all sensor sources.
I do not understand why it works for other targets, but apparently it does.
Most likely, almost everything is considered to be PCBFRSKY. :-)
