### PR TITLE
Change range units label for NV14

### DIFF
--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -1256,14 +1256,23 @@ class ModuleWindow : public FormGroup {
       par->adjustInnerHeight();
     }
 
+#if defined (PCBNV14)
+#define SIGNAL_POSTFIX 
+#define SIGNAL_MESSAGE "SGNL"
+#else
+#define SIGNAL_POSTFIX  " db"
+#define SIGNAL_MESSAGE  "RSSI"
+#endif
+
     void startRSSIDialog(std::function<void()> closeHandler = nullptr)
     {
       auto rssiDialog = new DynamicMessageDialog(
           parent, "Range Test",
           [=]() {
-            return std::to_string((int)TELEMETRY_RSSI()) + std::string(" db");
+            return std::to_string((int)TELEMETRY_RSSI()) +
+                   std::string(SIGNAL_POSTFIX);
           },
-          "RSSI:", 50,
+          SIGNAL_MESSAGE, 50,
           COLOR_THEME_SECONDARY1 | CENTERED | FONT(BOLD) | FONT(XL));
 
       rssiDialog->setCloseHandler([this, closeHandler]() {


### PR DESCRIPTION
Summary of changes: for NV14 RANGE dynamic dialog actually shows Sgnl rather  than RSSI and it is better (for NV14), since Sgnl is linear rather than logarithmic and thus more sensitive.
This PR changes the name of the telemetry value displayed and removes DB units for NV14.
Other targets are not affected.
