### PR TITLE
NV14 Ghost and Tools config entry

### DIFF
--- a/radio/src/gui/colorlcd/radio_tools.cpp
+++ b/radio/src/gui/colorlcd/radio_tools.cpp
@@ -294,7 +294,6 @@ void RadioToolsPage::rebuild(FormWindow * window)
 #endif
 
 #if defined(GHOST)
-#if 0
   if (isModuleGhost(EXTERNAL_MODULE)) {
     auto txt = new StaticText(window, grid.getLabelSlot(), "ghost",
                               BUTTON_BACKGROUND, CENTERED);
@@ -318,7 +317,6 @@ void RadioToolsPage::rebuild(FormWindow * window)
     });
     grid.nextLine();
   }
-#endif
 #endif
 
   window->setInnerHeight(grid.getWindowHeight());

--- a/radio/src/targets/nv14/CMakeLists.txt
+++ b/radio/src/targets/nv14/CMakeLists.txt
@@ -2,6 +2,7 @@ option(DISK_CACHE "Enable SD card disk cache" ON)
 option(UNEXPECTED_SHUTDOWN "Enable the Unexpected Shutdown screen" ON)
 option(MULTIMODULE "DIY Multiprotocol TX Module (https://github.com/pascallanger/DIY-Multiprotocol-TX-Module)" ON)
 option(AFHDS2 "Support for AFHDS2" ON)
+option(GHOST "Ghost TX Module" ON)
 option(PXX1 "PXX1 protocol support" ON)
 option(PXX2 "PXX2 protocol support" OFF)
 


### PR DESCRIPTION
Summary of changes:
- enable GHOST on NV14 so is the same as horus colorlcd targets
- re-enabled GHOST tools config entry, for further testing, until Lua alternative available (#577)