### PR TITLE
Ensure stock internal module is used as default if defined

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -290,6 +290,10 @@ void generalDefault()
   g_eeGeneral.contrast = LCD_CONTRAST_DEFAULT;
 #endif
 
+#if defined(DEFAULT_INTERNAL_MODULE)
+    g_eeGeneral.internalModule = DEFAULT_INTERNAL_MODULE;
+#endif
+
 #if defined(DEFAULT_POTS_CONFIG)
   g_eeGeneral.potsConfig = DEFAULT_POTS_CONFIG;
 #endif


### PR DESCRIPTION
e.g. where before a complete wipe or unsupported upgrade path failure
failed to enable NV14 internal module by default.

This was tested by attempting to upgrade the NV14 from OpenFlysky OTX 2.1 and also by simply deleting all the yaml configuration files. Prior to this PR, it would result in internalModule being off, now it correctly sets it to Flysky.