### PR TITLE
Fix UI elements left visible when `FLIGHT_MODES=N`

### DIFF
--- a/radio/src/gui/colorlcd/menu_model.cpp
+++ b/radio/src/gui/colorlcd/menu_model.cpp
@@ -41,7 +41,9 @@ ModelMenu::ModelMenu():
 #if defined(HELI)
   addTab(new ModelHeliPage());
 #endif
+#if defined(FLIGHT_MODES)
   addTab(new ModelFlightModesPage());
+#endif
   addTab(new ModelInputsPage());
   addTab(new ModelMixesPage());
   addTab(new ModelOutputsPage());

--- a/radio/src/gui/colorlcd/model_inputs.cpp
+++ b/radio/src/gui/colorlcd/model_inputs.cpp
@@ -359,6 +359,7 @@ class InputEditWindow : public Page
       updateCurveParamField(line);
       grid.nextLine();
 
+#if defined(FLIGHT_MODES)
       // Flight modes
       new StaticText(window, grid.getLabelSlot(), STR_FLMODE, 0, COLOR_THEME_PRIMARY1);
       for (uint32_t i=0; i<MAX_FLIGHT_MODES; i++) {
@@ -374,6 +375,7 @@ class InputEditWindow : public Page
                        OPAQUE | (bfSingleBitGet(line->flightModes, i) ? 0 : BUTTON_CHECKED));
       }
       grid.nextLine();
+#endif
 
       window->setInnerHeight(grid.getWindowHeight());
     }

--- a/radio/src/gui/colorlcd/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model_mixes.cpp
@@ -167,6 +167,7 @@ class MixEditWindow : public Page
     updateCurveParamField(mix);
     grid.nextLine();
 
+#if defined(FLIGHT_MODES)
     // Flight modes
     new StaticText(window, grid.getLabelSlot(), STR_FLMODE, 0, COLOR_THEME_PRIMARY1);
     for (uint32_t i = 0; i < MAX_FLIGHT_MODES; i++) {
@@ -182,6 +183,7 @@ class MixEditWindow : public Page
           OPAQUE | (bfSingleBitGet(mix->flightModes, i) ? 0 : BUTTON_CHECKED));
     }
     grid.nextLine();
+#endif
 
     // Switch
     new StaticText(window, grid.getLabelSlot(), STR_SWITCH, 0, COLOR_THEME_PRIMARY1);


### PR DESCRIPTION
Fixes where  `FLIGHT_MODES=N` leaves UI elements visible
- model setup tab
- model mixes flight mode controls
- model inputs flight mode controls
