### PR TITLE
Reset sdcard sync local folder and radio on change of profile

### DIFF
--- a/companion/src/mainwindow.cpp
+++ b/companion/src/mainwindow.cpp
@@ -847,6 +847,13 @@ void MainWindow::sdsync()
   static bool showExtraOptions = false;
   QStringList errorMsgs;
 
+  if (syncOpts.sessionId != g.sessionId()) {
+    syncOpts.reset();
+    syncOpts.folderA = QString();
+    syncOpts.folderB = QString();
+    syncOpts.sessionId = g.sessionId();
+  }
+
   if (syncOpts.folderA.isEmpty())
     syncOpts.folderA = g.profile[g.id()].sdPath();
   if (syncOpts.folderB.isEmpty())

--- a/companion/src/process_sync.h
+++ b/companion/src/process_sync.h
@@ -75,6 +75,7 @@ class SyncProcess : public QObject
         int flags;               // SyncOptionFlags
         int dirFilterFlags;      // QDir::Filters
         int logLevel;            // QtMsgType (see ProgressWidget::addMessage())
+        int sessionId;           // Last run radio profile
 
         void reset()
         {
@@ -86,6 +87,7 @@ class SyncProcess : public QObject
           logLevel = QtWarningMsg;
           flags = OPT_RECURSIVE;
           dirFilterFlags = QDir::Dirs | QDir::Files | QDir::NoDotAndDotDot;
+          sessionId = -1;
         }
 
         friend inline QDebug operator<<(QDebug debug, const SyncOptions &o) {


### PR DESCRIPTION
Fixes #1072

Summary:
On change of profile :
- default local folder to current profile
- force re-probe for an attached radio