### PR TITLE
Fix NV14 touch behavior.

### DIFF
--- a/radio/src/targets/nv14/touch_driver.cpp
+++ b/radio/src/targets/nv14/touch_driver.cpp
@@ -553,5 +553,7 @@ TouchState touchPanelRead()
   TouchState ret = internalTouchState;
   internalTouchState.deltaX = 0;
   internalTouchState.deltaY = 0;
+  if(internalTouchState.event == TE_UP)
+    internalTouchState.event = TE_NONE;
   return ret;
 }


### PR DESCRIPTION
TE_UP needs to be reset to TE_NONE after touch read from MainWindow. If this is not done, the TE_UP event is handled multiple times

Summary of changes:
This fixes the NV14 touch sensitivity problem.

fixes #1245 