### PR TITLE
Fix Return behavior on Ghost Menus

### DIFF
--- a/radio/src/gui/colorlcd/radio_ghost_module_config.cpp
+++ b/radio/src/gui/colorlcd/radio_ghost_module_config.cpp
@@ -134,10 +134,24 @@ void RadioGhostModuleConfig::onEvent(event_t event)
       reusableBuffer.ghostMenu.menuAction = GHST_MENU_CTRL_CLOSE;
       moduleState[EXTERNAL_MODULE].counter = GHST_MENU_CONTROL;
       RTOS_WAIT_MS(10);
-      deleteLater();
+      Page::onEvent(event);
       break;
   }
-  Page::onEvent(event);
+}
+
+void RadioGhostModuleConfig::checkEvents()
+{
+  Page::checkEvents();
+
+    if (reusableBuffer.ghostMenu.menuStatus == GHST_MENU_STATUS_UNOPENED) { // Handles situation where module is plugged after tools start
+    reusableBuffer.ghostMenu.buttonAction = GHST_BTN_NONE;
+    reusableBuffer.ghostMenu.menuAction = GHST_MENU_CTRL_OPEN;
+    moduleState[EXTERNAL_MODULE].counter = GHST_MENU_CONTROL;
+  }
+  else if (reusableBuffer.ghostMenu.menuStatus == GHST_MENU_STATUS_CLOSING) {
+          RTOS_WAIT_MS(10);
+          deleteLater();
+  }
 }
 #endif
 

--- a/radio/src/gui/colorlcd/radio_ghost_module_config.cpp
+++ b/radio/src/gui/colorlcd/radio_ghost_module_config.cpp
@@ -143,14 +143,14 @@ void RadioGhostModuleConfig::checkEvents()
 {
   Page::checkEvents();
 
-    if (reusableBuffer.ghostMenu.menuStatus == GHST_MENU_STATUS_UNOPENED) { // Handles situation where module is plugged after tools start
+  if (reusableBuffer.ghostMenu.menuStatus == GHST_MENU_STATUS_UNOPENED) { // Handles situation where module is plugged after tools start
     reusableBuffer.ghostMenu.buttonAction = GHST_BTN_NONE;
     reusableBuffer.ghostMenu.menuAction = GHST_MENU_CTRL_OPEN;
     moduleState[EXTERNAL_MODULE].counter = GHST_MENU_CONTROL;
   }
   else if (reusableBuffer.ghostMenu.menuStatus == GHST_MENU_STATUS_CLOSING) {
-          RTOS_WAIT_MS(10);
-          deleteLater();
+    RTOS_WAIT_MS(10);
+    deleteLater();
   }
 }
 #endif

--- a/radio/src/gui/colorlcd/radio_ghost_module_config.h
+++ b/radio/src/gui/colorlcd/radio_ghost_module_config.h
@@ -30,6 +30,7 @@ class RadioGhostModuleConfig: public Page
 
 #if defined(HARDWARE_KEYS)
     void onEvent(event_t event) override;
+    void checkEvents();
 #endif
 
   protected:


### PR DESCRIPTION
A temporary fix while the Ghost menus are ported to their Lua form, this restores the EdgeTx Ghost Menus to a functioning state. 

Add code to catch the GHST_MENU_STATUS_CLOSING message sent from the Ghost module when the EdgeTx Ghost menu can be close (backing out of the root menu). 
