### PR TITLE
Fix outputs  max/min without GVARS ver.2 #1254

### DIFF
--- a/radio/src/gui/colorlcd/gvar_numberedit.h
+++ b/radio/src/gui/colorlcd/gvar_numberedit.h
@@ -29,9 +29,7 @@
 
 constexpr coord_t GVAR_BUTTON_WIDTH = 30;
 
-#if !defined(GVARS)
-typedef NumberEdit GVarNumberEdit;
-#else
+
 class GVarNumberEdit : public FormGroup
 {
  public:
@@ -128,7 +126,7 @@ class GVarNumberEdit : public FormGroup
       result->setSuffix(suffix);
       field = result;
     }
-
+#if defined(GVARS)
     // The GVAR button
     new TextButton(
         this, {width() - GVAR_BUTTON_WIDTH, 0, GVAR_BUTTON_WIDTH, height()},
@@ -138,8 +136,9 @@ class GVarNumberEdit : public FormGroup
           return 0;
         },
         BUTTON_BACKGROUND | OPAQUE | FORM_DETACHED);
+#endif        
   }
 };
-#endif
+
 
 #endif // _GVAR_NUMBEREDIT_H_

--- a/radio/src/gui/colorlcd/model_outputs.cpp
+++ b/radio/src/gui/colorlcd/model_outputs.cpp
@@ -79,11 +79,7 @@ class OutputEditWindow : public Page {
                      COLOR_THEME_PRIMARY1);
       new GVarNumberEdit(window, grid.getFieldSlot(), -limit, 0,
                          GET_SET_DEFAULT(output->min), 0, PREC1
-#if defined(GVARS)
-                         , -LIMIT_STD_MAX
-#endif
-                         );
-
+                         , -LIMIT_STD_MAX);
       grid.nextLine();
 
       // Max
@@ -91,10 +87,7 @@ class OutputEditWindow : public Page {
                      COLOR_THEME_PRIMARY1);
       new GVarNumberEdit(window, grid.getFieldSlot(), 0, +limit,
                          GET_SET_DEFAULT(output->max), 0, PREC1
-#if defined(GVARS)
-                         , +LIMIT_STD_MAX
-#endif
-                         );
+                         , +LIMIT_STD_MAX);
       grid.nextLine();
 
       // Direction


### PR DESCRIPTION
Fixes #1254

Summary of changes: second variant of the fix. Alternative to PR 1255. Please select. :-)
Get rid of the typedef in gvars_numberedit.h.