### PR TITLE
Stuck key test for COLORLCD #1271

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -728,6 +728,7 @@ void checkAll()
 #if defined(COLORLCD)
   if (!waitKeysReleased()) {
     auto dlg = new FullScreenDialog(WARNING_TYPE_ALERT, STR_KEYSTUCK);
+    LED_ERROR_BEGIN();
     AUDIO_ERROR_MESSAGE(AU_ERROR);
     tmr10ms_t tgtime = get_tmr10ms() + 500;
     uint32_t keys = readKeys();
@@ -748,6 +749,7 @@ void checkAll()
       if (tgtime >= get_tmr10ms() && keyDown()) {
         return false;
       } else {
+        LED_ERROR_END();
         return true;
       }
     });

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -726,7 +726,33 @@ void checkAll()
 #endif
 
 #if defined(COLORLCD)
-  #warning "KEYSTUCK Message Not Yet Implemented"
+  if (!waitKeysReleased()) {
+    auto dlg = new FullScreenDialog(WARNING_TYPE_ALERT, STR_KEYSTUCK);
+    AUDIO_ERROR_MESSAGE(AU_ERROR);
+    tmr10ms_t tgtime = get_tmr10ms() + 500;
+    uint32_t keys = readKeys();
+    std::string strKeys("");
+    const char STR_VKEYS[] = TR_VKEYS;
+    const int len = int(LEN_VKEYS[0]);
+    char s[6];
+    s[5] = 0;
+    for (int i = (int)KEY_PGUP; i < (int)TRM_BASE; i++) {
+      if (keys & (1 << i)) {
+        strncpy(s, &STR_VKEYS[i * len], len);
+        strKeys += s;
+      }
+    }
+
+    dlg->setMessage(strKeys.c_str());
+    dlg->setCloseCondition([tgtime]() {
+      if (tgtime >= get_tmr10ms() && keyDown()) {
+        return false;
+      } else {
+        return true;
+      }
+    });
+    dlg->runForever();
+  }
 #else
   if (!waitKeysReleased()) {
     showMessageBox(STR_KEYSTUCK);

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -736,7 +736,7 @@ void checkAll()
     const int len = int(LEN_VKEYS[0]);
     char s[6];
     s[5] = 0;
-    for (int i = (int)KEY_PGUP; i < (int)TRM_BASE; i++) {
+    for (int i = 0; i < (int)TRM_BASE; i++) {
       if (keys & (1 << i)) {
         strncpy(s, &STR_VKEYS[i * len], len);
         strKeys += s;

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -749,11 +749,11 @@ void checkAll()
       if (tgtime >= get_tmr10ms() && keyDown()) {
         return false;
       } else {
-        LED_ERROR_END();
         return true;
       }
     });
     dlg->runForever();
+    LED_ERROR_END();
   }
 #else
   if (!waitKeysReleased()) {


### PR DESCRIPTION
Fixes #1271 

Summary of changes: During the boot check for stuck key and display FullScreenDialog with the warning and the name of the key that causes the problem.
The message is displayed for ~5 seconds and goes away (as for b/w TX) or can be cleared by RTN or ENTER (or touch).
