### PR TITLE
Fix loading data on B&W simulated radios

### DIFF
--- a/companion/src/simulation/simulatorwidget.cpp
+++ b/companion/src/simulation/simulatorwidget.cpp
@@ -294,11 +294,12 @@ bool SimulatorWidget::setRadioData(RadioData * radioData)
 
   saveTempRadioData = (flags & SIMULATOR_FLAGS_STANDALONE);
 
-  if (IS_FAMILY_HORUS_OR_T16(m_board))
-    ret = useTempDataPath(true);
+  // All radios use SD card data path from 2.6.0 on
+  ret = useTempDataPath(true);
 
   if (ret) {
-    if (radioDataPath.isEmpty()) {
+    if (!IS_FAMILY_HORUS_OR_T16(m_board)) {
+      // Save radio/model data to simulator EEPROM for now (YAML does not need this)
       startupData.fill(0, Boards::getEEpromSize(m_board));
       if (firmware->getEEpromInterface()->save((uint8_t *)startupData.data(), *radioData, 0, firmware->getCapability(SimulatorVariant)) <= 0) {
         ret = false;

--- a/radio/src/targets/simu/simufatfs.cpp
+++ b/radio/src/targets/simu/simufatfs.cpp
@@ -124,23 +124,20 @@ bool redirectToSettingsDirectory(const std::string & path)
       * model (*.bin) files in /MODELS directory
   */
   if (!simuSettingsDirectory.empty()) {
-#if defined(COLORLCD)
-    if (path == RADIO_MODELSLIST_PATH || path == RADIO_SETTINGS_PATH
-#if defined(SDCARD_YAML)
-        || path == MODELSLIST_YAML_PATH || path == RADIO_SETTINGS_YAML_PATH
-#endif
-        ) {
+#if defined(SDCARD_RAW) || defined(SDCARD_YAML)
+    if (path == MODELS_PATH || path == RADIO_PATH) return true;
+  #if !defined(EEPROM_RLC)
+    if (path == RADIO_MODELSLIST_PATH || path == RADIO_SETTINGS_PATH)
       return true;
-    }
-#endif
-    if (startsWith(path, "/MODELS")
-        && (endsWith(path, MODELS_EXT)
-#if defined(SDCARD_YAML)
-            || endsWith(path, YAML_EXT)
-#endif
-            )) {
+    if (startsWith(path, MODELS_PATH) && endsWith(path, MODELS_EXT))
       return true;
-    }
+  #endif
+#endif
+#if defined(SDCARD_YAML)
+    if (path == MODELSLIST_YAML_PATH || path == RADIO_SETTINGS_YAML_PATH)
+      return true;
+    if (startsWith(path, MODELS_PATH) && endsWith(path, YAML_EXT)) return true;
+#endif
   }
   return false;
 }


### PR DESCRIPTION
Fixes #1283

Summary of changes:
- Companion / Simulator: use temporary SD card path for non-Horus radios as well.
- Simu plugin: fix simulated SD card path redirection.

Please note that this is a *temporary fix* while waiting for the real solution (#1186).