### PR TITLE
Fixed support for Radiomaster TX12 additional switches (SI and SJ)

### DIFF
--- a/radio/src/targets/taranis/keys_driver.cpp
+++ b/radio/src/targets/taranis/keys_driver.cpp
@@ -245,6 +245,8 @@ uint32_t switchState(uint8_t index)
     ADD_2POS_CASE(D);
     ADD_3POS_CASE(E, 4);
     ADD_3POS_CASE(F, 5);
+    ADD_2POS_CASE(I);
+    ADD_2POS_CASE(J);
 #elif defined(RADIO_T8)
     ADD_2POS_CASE(D);
 #elif defined(RADIO_TLITE)


### PR DESCRIPTION
Two connectors are present on TX12 main board (near top of internal TX module) and are mapped as SI and SJ, but were not read out by the firmware.
With this update they might be used for some further hacking of the radio (ex. adding additional 2-pos switches, adding detector of external module insertion etc.).

Summary of changes:

- Add readout of SI and SJ switches in switchState
