### PR TITLE
Fixed support for Radiomaster TX12 additional switches (SI and SJ)

### DIFF
--- a/radio/src/gui/128x64/radio_diagkeys.cpp
+++ b/radio/src/gui/128x64/radio_diagkeys.cpp
@@ -72,7 +72,7 @@ void menuRadioDiagKeys(event_t event)
 #elif (NUM_SWITCHES > 6)
     if (i < NUM_SWITCHES) {
       if (SWITCH_EXISTS(i)) {
-        y = (i > 4) ? FH*(i-4) : MENU_HEADER_HEIGHT + FH*i;
+        y = (i > 4) ? FH*(i-4)+1 : MENU_HEADER_HEIGHT + FH*i + 1;
         getvalue_t val = getValue(MIXSRC_FIRST_SWITCH+i);
         getvalue_t sw = ((val < 0) ? 3*i+1 : ((val == 0) ? 3*i+2 : 3*i+3));
         drawSwitch(i > 4 ? 11*FW-5: 8*FW-9, y, sw, 0, false);
@@ -101,8 +101,8 @@ void menuRadioDiagKeys(event_t event)
 #endif
 
 #if defined(ROTARY_ENCODER_NAVIGATION)
-  coord_t y = LCD_H - FH - 1;
-  lcdDrawText(0, y, STR_ROTARY_ENCODER);
-  lcdDrawNumber(5*FW+FWNUM+2, y, rotencValue / ROTARY_ENCODER_GRANULARITY, RIGHT);
+  coord_t y = LCD_H - FH + 1;
+  lcdDrawText(8*FW-9, y, STR_ROTARY_ENCODER);
+  lcdDrawNumber(12*FW+FWNUM+2, y, rotencValue / ROTARY_ENCODER_GRANULARITY, RIGHT);
 #endif
 }

--- a/radio/src/gui/common/stdlcd/radio_hardware.cpp
+++ b/radio/src/gui/common/stdlcd/radio_hardware.cpp
@@ -210,7 +210,8 @@ enum {
 #elif defined(RADIO_ZORRO)
   #define SWITCH_TYPE_MAX(sw)            ((MIXSRC_SB - MIXSRC_FIRST_SWITCH == sw || MIXSRC_SC - MIXSRC_FIRST_SWITCH == sw) ? SWITCH_3POS : SWITCH_2POS)
 #elif defined(RADIO_TX12) || defined(RADIO_T8)
-  #define SWITCH_TYPE_MAX(sw)            ((MIXSRC_SA - MIXSRC_FIRST_SWITCH == sw || MIXSRC_SD - MIXSRC_FIRST_SWITCH == sw) ? SWITCH_2POS : SWITCH_3POS)
+  #define SWITCH_TYPE_MAX(sw)             ((MIXSRC_SA - MIXSRC_FIRST_SWITCH == sw || MIXSRC_SD - MIXSRC_FIRST_SWITCH == sw || \
+                                            MIXSRC_SI - MIXSRC_FIRST_SWITCH == sw || MIXSRC_SJ - MIXSRC_FIRST_SWITCH) ? SWITCH_2POS : SWITCH_3POS)
 #elif defined(RADIO_T12)
   #define SWITCH_TYPE_MAX(sw)            ((MIXSRC_SG - MIXSRC_FIRST_SWITCH == sw || MIXSRC_SH - MIXSRC_FIRST_SWITCH == sw) ? SWITCH_2POS : SWITCH_3POS)
 #else

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -455,6 +455,11 @@ char getRawSwitchFromIdx(int idx)
   #endif
     else
       return 'A' + idx;
+#elif defined(RADIO_TX12) || defined(RADIO_T8)
+    if (idx < 6)
+        return 'A' + idx;
+    else
+        return 'A' + idx + 2;
 #else
     return 'A' + idx;
 #endif

--- a/radio/src/targets/taranis/keys_driver.cpp
+++ b/radio/src/targets/taranis/keys_driver.cpp
@@ -252,6 +252,8 @@ uint32_t switchState(uint8_t index)
     ADD_2POS_CASE(D);
     ADD_3POS_CASE(E, 4);
     ADD_3POS_CASE(F, 5);
+    ADD_2POS_CASE(I);
+    ADD_2POS_CASE(J);
 #elif defined(RADIO_T8)
     ADD_2POS_CASE(D);
 #elif defined(RADIO_TLITE)


### PR DESCRIPTION
Two connectors are present on TX12 main board (near top of internal TX module) and are mapped as SI (2) and SJ (1), but were not read out by the firmware.

![image](https://user-images.githubusercontent.com/5657414/147564814-c6473162-4e9b-4716-9567-5c59a85f03a9.png)


With this update they might be used for some further hacking of the radio (ex. adding additional 2-pos switches, adding detector of external module insertion etc.).

Resubmitted PR #1302 

Summary of changes:

- Add readout of SI and SJ switches in switchState
