### PR TITLE
Show warning LED with switch and throttle alerts

### DIFF
--- a/radio/src/gui/colorlcd/fullscreen_dialog.cpp
+++ b/radio/src/gui/colorlcd/fullscreen_dialog.cpp
@@ -201,9 +201,11 @@ void raiseAlert(const char * title, const char * msg, const char * action, uint8
 {
   TRACE("raiseAlert('%s')", msg);
   AUDIO_ERROR_MESSAGE(sound);
+  LED_ERROR_BEGIN();
   auto dialog = new FullScreenDialog(WARNING_TYPE_ALERT, title ? title : "",
                                      msg ? msg : "", action ? action : "");
   dialog->runForever();
+  LED_ERROR_END();
 }
 
 // POPUP_CONFIRMATION

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -783,12 +783,14 @@ bool isThrottleWarningAlertNeeded()
 void checkThrottleStick()
 {
   if (isThrottleWarningAlertNeeded()) {
+    LED_ERROR_BEGIN();
     AUDIO_ERROR_MESSAGE(AU_THROTTLE_ALERT);
-    auto dialog = new FullScreenDialog(WARNING_TYPE_ALERT, TR_THROTTLE_UPPERCASE, STR_THROTTLE_NOT_IDLE, STR_PRESS_ANY_KEY_TO_SKIP);
-    dialog->setCloseCondition([]() {
-        return !isThrottleWarningAlertNeeded();
-    });
+    auto dialog =
+        new FullScreenDialog(WARNING_TYPE_ALERT, TR_THROTTLE_UPPERCASE,
+                             STR_THROTTLE_NOT_IDLE, STR_PRESS_ANY_KEY_TO_SKIP);
+    dialog->setCloseCondition([]() { return !isThrottleWarningAlertNeeded(); });
     dialog->runForever();
+    LED_ERROR_END();
   }
 }
 #else

--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -723,8 +723,10 @@ void checkSwitches()
   if (!isSwitchWarningRequired(bad_pots))
     return;
 
+  LED_ERROR_BEGIN();
   auto dialog = new SwitchWarnDialog();
   dialog->runForever();
+  LED_ERROR_END();
 }
 #elif defined(GUI)
 void checkSwitches()


### PR DESCRIPTION
Resolves #470 

Show warning led color (i.e. red) with throttle warning, switch warnings, and alerts generally, e.g. 
- Failsafe not set
- MULTI Low power warning
- RTC low battery warning
- storage conversion warning