### PR TITLE
Add switches definitions for NV14 #1301

### DIFF
--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -217,6 +217,11 @@ void getSwitchesPosition(bool startup)
   CHECK_3POS(1, SW_SB);
   CHECK_2POS(SW_SC);
   CHECK_2POS(SW_SD);
+#elif defined(PCBNV14)
+  CHECK_2POS(SW_SA);
+  CHECK_3POS(0, SW_SB);
+  CHECK_2POS(SW_SC);
+  CHECK_2POS(SW_SD);
 #else
   CHECK_3POS(0, SW_SA);
   CHECK_3POS(1, SW_SB);
@@ -267,6 +272,11 @@ void getSwitchesPosition(bool startup)
   #if defined(HARDWARE_SWITCH_H)
     CHECK_2POS(SW_SH);
   #endif
+#elif defined(PCBNV14)
+  CHECK_2POS(SW_SE);
+  CHECK_3POS(1, SW_SF);
+  CHECK_3POS(2, SW_SG);
+  CHECK_2POS(SW_SH);
 #else
   CHECK_3POS(3, SW_SD);
   CHECK_3POS(4, SW_SE);


### PR DESCRIPTION
Fixes #1301 

Summary of changes: add definitions for NV14 switches for CF support
