### PR TITLE
Clear internal RF module settings if radio level setting changed

### DIFF
--- a/radio/src/gui/colorlcd/radio_hardware.cpp
+++ b/radio/src/gui/colorlcd/radio_hardware.cpp
@@ -330,10 +330,17 @@ void RadioHardwarePage::build(FormWindow * window)
 #if defined(HARDWARE_INTERNAL_MODULE)
   new StaticText(window, grid.getLabelSlot(), TR_INTERNAL_MODULE, 0,
                  COLOR_THEME_PRIMARY1);
-  auto internalModule =
-      new Choice(window, grid.getFieldSlot(1, 0), STR_INTERNAL_MODULE_PROTOCOLS,
-                 MODULE_TYPE_NONE, MODULE_TYPE_COUNT - 1,
-                 GET_SET_DEFAULT(g_eeGeneral.internalModule));
+  auto internalModule = new Choice(window, grid.getFieldSlot(1, 0),
+      STR_INTERNAL_MODULE_PROTOCOLS, MODULE_TYPE_NONE, MODULE_TYPE_COUNT - 1,
+      GET_DEFAULT(g_eeGeneral.internalModule),
+      [=](int moduleType) {
+        if (!isInternalModuleAvailable(moduleType)) {
+          memclear(&g_model.moduleData[INTERNAL_MODULE], sizeof(ModuleData));
+        }
+        storageDirty(EE_MODEL);
+        g_eeGeneral.internalModule = moduleType;
+        SET_DIRTY();
+      });
 
   internalModule->setAvailableHandler([](int module){
       return isInternalModuleSupported(module);

--- a/radio/src/gui/colorlcd/radio_hardware.cpp
+++ b/radio/src/gui/colorlcd/radio_hardware.cpp
@@ -336,8 +336,8 @@ void RadioHardwarePage::build(FormWindow * window)
       [=](int moduleType) {
         if (!isInternalModuleAvailable(moduleType)) {
           memclear(&g_model.moduleData[INTERNAL_MODULE], sizeof(ModuleData));
+          storageDirty(EE_MODEL);
         }
-        storageDirty(EE_MODEL);
         g_eeGeneral.internalModule = moduleType;
         SET_DIRTY();
       });

--- a/radio/src/gui/colorlcd/radio_hardware.cpp
+++ b/radio/src/gui/colorlcd/radio_hardware.cpp
@@ -334,7 +334,7 @@ void RadioHardwarePage::build(FormWindow * window)
       STR_INTERNAL_MODULE_PROTOCOLS, MODULE_TYPE_NONE, MODULE_TYPE_COUNT - 1,
       GET_DEFAULT(g_eeGeneral.internalModule),
       [=](int moduleType) {
-        if (!isInternalModuleAvailable(moduleType)) {
+        if (g_model.moduleData[INTERNAL_MODULE].type != moduleType) {
           memclear(&g_model.moduleData[INTERNAL_MODULE], sizeof(ModuleData));
           storageDirty(EE_MODEL);
         }

--- a/radio/src/gui/common/stdlcd/radio_hardware.cpp
+++ b/radio/src/gui/common/stdlcd/radio_hardware.cpp
@@ -529,11 +529,21 @@ void menuRadioHardware(event_t event)
 
 #if !defined(PCBX9D) && !defined(PCBX9DP) && !defined(PCBX9E)
       case ITEM_RADIO_HARDWARE_INTERNAL_MODULE:
-        g_eeGeneral.internalModule =
-            editChoice(HW_SETTINGS_COLUMN2, y, STR_INTERNAL_MODULE,
-                       STR_INTERNAL_MODULE_PROTOCOLS,
-                       g_eeGeneral.internalModule, MODULE_TYPE_NONE,
-                       MODULE_TYPE_MAX, attr, event, isInternalModuleSupported);
+        reusableBuffer.radioHardware.internalModule =
+            g_eeGeneral.internalModule;
+        reusableBuffer.radioHardware.internalModule = editChoice(
+            HW_SETTINGS_COLUMN2, y, STR_INTERNAL_MODULE,
+            STR_INTERNAL_MODULE_PROTOCOLS,
+            reusableBuffer.radioHardware.internalModule, MODULE_TYPE_NONE,
+            MODULE_TYPE_MAX, attr, event, isInternalModuleSupported);
+        if (reusableBuffer.radioHardware.internalModule !=
+            g_model.moduleData[INTERNAL_MODULE].type) {
+          storageDirty(EE_MODEL);
+          g_eeGeneral.internalModule =
+              reusableBuffer.radioHardware.internalModule;
+          memclear(&g_model.moduleData[INTERNAL_MODULE], sizeof(ModuleData));
+          storageDirty(EE_GENERAL);
+        }
         break;
 #endif
 

--- a/radio/src/gui/common/stdlcd/radio_hardware.cpp
+++ b/radio/src/gui/common/stdlcd/radio_hardware.cpp
@@ -528,23 +528,19 @@ void menuRadioHardware(event_t event)
 #endif
 
 #if !defined(PCBX9D) && !defined(PCBX9DP) && !defined(PCBX9E)
-      case ITEM_RADIO_HARDWARE_INTERNAL_MODULE:
-        reusableBuffer.radioHardware.internalModule =
-            g_eeGeneral.internalModule;
-        reusableBuffer.radioHardware.internalModule = editChoice(
-            HW_SETTINGS_COLUMN2, y, STR_INTERNAL_MODULE,
-            STR_INTERNAL_MODULE_PROTOCOLS,
-            reusableBuffer.radioHardware.internalModule, MODULE_TYPE_NONE,
-            MODULE_TYPE_MAX, attr, event, isInternalModuleSupported);
-        if (reusableBuffer.radioHardware.internalModule !=
-            g_model.moduleData[INTERNAL_MODULE].type) {
-          storageDirty(EE_MODEL);
-          g_eeGeneral.internalModule =
-              reusableBuffer.radioHardware.internalModule;
+      case ITEM_RADIO_HARDWARE_INTERNAL_MODULE: {
+        g_eeGeneral.internalModule =
+            editChoice(HW_SETTINGS_COLUMN2, y, STR_INTERNAL_MODULE,
+                       STR_INTERNAL_MODULE_PROTOCOLS,
+                       g_eeGeneral.internalModule, MODULE_TYPE_NONE,
+                       MODULE_TYPE_MAX, attr, event, isInternalModuleSupported);
+        if (g_model.moduleData[INTERNAL_MODULE].type !=
+            g_eeGeneral.internalModule) {
           memclear(&g_model.moduleData[INTERNAL_MODULE], sizeof(ModuleData));
+          storageDirty(EE_MODEL);
           storageDirty(EE_GENERAL);
         }
-        break;
+      } break;
 #endif
 
 #if (defined(CROSSFIRE) || defined(GHOST))

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -1076,6 +1076,7 @@ union ReusableBuffer
 
   struct {
     int8_t antennaMode;
+    int8_t internalModule;
   } radioHardware;
 
   struct {

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -1076,7 +1076,6 @@ union ReusableBuffer
 
   struct {
     int8_t antennaMode;
-    int8_t internalModule;
   } radioHardware;
 
   struct {


### PR DESCRIPTION
Resolves #1299 

Ensures if you change the internal module at the radio level, that the currently active model internal rf settings are cleared, thus inhibited. This is not needed on model load, as there is a model load check which inhibits the dissimilar settings being made active. 


Summary of changes:
- On colorlcd, if you chose an option for the internal protocol other than the current one, the active model level setting is cleared  - so you can view the list and abort or re-select the current internal module without loosing any settings.
- On B&W, as soon as you scroll to see any other internal protocol other than the currently selected one, the active model level setting is cleared. Due to how the menu is displayed, you can't view the list without the setting being cleared. 

Tested on both TX16S and TX12. 