### PR TITLE
Remove reference to EEPROM / EEPR in radio version screen

### DIFF
--- a/radio/src/gui/colorlcd/radio_version.cpp
+++ b/radio/src/gui/colorlcd/radio_version.cpp
@@ -234,8 +234,8 @@ void RadioVersionPage::build(FormWindow * window)
   new StaticText(window, grid.getLineSlot(), time_stamp, 0, COLOR_THEME_PRIMARY1);
   grid.nextLine();
 
-  // EEprom version
-  new StaticText(window, grid.getLineSlot(), eeprom_stamp, 0, COLOR_THEME_PRIMARY1);
+  // Configuration version
+  new StaticText(window, grid.getLineSlot(), cfgv_stamp, 0, COLOR_THEME_PRIMARY1);
   grid.nextLine();
 
   // Firmware options

--- a/radio/src/gui/colorlcd/radio_version.cpp
+++ b/radio/src/gui/colorlcd/radio_version.cpp
@@ -24,13 +24,14 @@
 #include "options.h"
 #include "libopenui.h"
 
-char * getVersion(char * str, PXX2Version version)
+char *getVersion(char *str, PXX2Version version)
 {
-  if (version.major == 0xFF && version.minor == 0x0F && version.revision == 0x0F) {
+  if (version.major == 0xFF && version.minor == 0x0F &&
+      version.revision == 0x0F) {
     return strAppend(str, "---", 4);
-  }
-  else {
-    sprintf(str, "%u.%u.%u", (1 + version.major) % 0xFF, version.minor, version.revision);
+  } else {
+    sprintf(str, "%u.%u.%u", (1 + version.major) % 0xFF, version.minor,
+            version.revision);
     return str;
   }
 }
@@ -250,16 +251,21 @@ void RadioVersionPage::build(FormWindow * window)
 
 #if defined(AFHDS2)
   new StaticText(window, grid.getLabelSlot(), "RF FW:");
-  sprintf(reusableBuffer.moduleSetup.msg, "%d.%d.%d", (int)((NV14internalModuleFwVersion >> 16) & 0xFF), (int)((NV14internalModuleFwVersion >> 8) & 0xFF), (int)(NV14internalModuleFwVersion & 0xFF));
+  sprintf(reusableBuffer.moduleSetup.msg, "%d.%d.%d",
+          (int)((NV14internalModuleFwVersion >> 16) & 0xFF),
+          (int)((NV14internalModuleFwVersion >> 8) & 0xFF),
+          (int)(NV14internalModuleFwVersion & 0xFF));
   new StaticText(window, grid.getFieldSlot(), reusableBuffer.moduleSetup.msg);
   grid.nextLine();
 #endif
+
 #if defined(PXX2)
   // Module and receivers versions
-  auto moduleVersions = new TextButton(window, grid.getLineSlot(), STR_MODULES_RX_VERSION);
+  auto moduleVersions =
+      new TextButton(window, grid.getLineSlot(), STR_MODULES_RX_VERSION);
   moduleVersions->setPressHandler([=]() -> uint8_t {
-      new versionDialog(window, {50, 30, LCD_W - 100, 0});
-      return 0;
+    new versionDialog(window, {50, 30, LCD_W - 100, 0});
+    return 0;
   });
 #endif
 }

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -704,7 +704,7 @@ extern const char fw_stamp[];
 extern const char vers_stamp[];
 extern const char date_stamp[];
 extern const char time_stamp[];
-extern const char eeprom_stamp[];
+extern const char cfgv_stamp[];
 #else
 extern const char vers_stamp[];
 #endif

--- a/radio/src/stamp.cpp
+++ b/radio/src/stamp.cpp
@@ -25,7 +25,7 @@
 #define STR2(s) #s
 #define DEFNUMSTR(s)  STR2(s)
 
-#define EEPROM_STR DEFNUMSTR(EEPROM_VER);
+#define CFGV_STR DEFNUMSTR(EEPROM_VER);
 
 #define TAB "\037\033"
 
@@ -52,15 +52,15 @@
 #endif
   const char date_stamp[]  =   "DATE" TAB ": " DATE;
   const char time_stamp[]  =   "TIME" TAB ": " TIME;
-  const char eeprom_stamp[]  = "EEPR" TAB ": " EEPROM_STR;
+  const char cfgv_stamp[]  = "CFGV" TAB ": " CFGV_STR;
 #elif defined(BOARD_NAME)
-  const char vers_stamp[]  = "FW" TAB ": edgetx-" BOARD_NAME "\036VERS" TAB ": " VERSION DISPLAY_VERSION " (" GIT_STR ")" "\036DATE" TAB ": " DATE " " TIME "\036EEPR" TAB ": " EEPROM_STR;
+  const char vers_stamp[]  = "FW" TAB ": edgetx-" BOARD_NAME "\036VERS" TAB ": " VERSION DISPLAY_VERSION " (" GIT_STR ")" "\036DATE" TAB ": " DATE " " TIME "\036CFGV" TAB ": " CFGV_STR;
 #elif defined(RADIOMASTER_RELEASE)
-  const char vers_stamp[]  = "FW" TAB ": edgetx-" FLAVOUR    "\036VERS" TAB ": RM Factory (" GIT_STR ")" "\036BUILT BY : EdgeTX" "\036DATE" TAB ": " DATE " " TIME "\036EEPR" TAB ": " EEPROM_STR;
+  const char vers_stamp[]  = "FW" TAB ": edgetx-" FLAVOUR    "\036VERS" TAB ": RM Factory (" GIT_STR ")" "\036BUILT BY : EdgeTX" "\036DATE" TAB ": " DATE " " TIME "\036CFGV" TAB ": " CFGV_STR;
 #elif defined(JUMPER_RELEASE)
-  const char vers_stamp[]  = "FW" TAB ": edgetx-" FLAVOUR    "\036VERS" TAB ": Factory (" GIT_STR ")" "\036BUILT BY : EdgeTX" "\036DATE" TAB ": " DATE " " TIME "\036EEPR" TAB ": " EEPROM_STR;
+  const char vers_stamp[]  = "FW" TAB ": edgetx-" FLAVOUR    "\036VERS" TAB ": Factory (" GIT_STR ")" "\036BUILT BY : EdgeTX" "\036DATE" TAB ": " DATE " " TIME "\036CFGV" TAB ": " CFGV_STR;
 #else
-  const char vers_stamp[]  = "FW" TAB ": edgetx-" FLAVOUR    "\036VERS" TAB ": " VERSION DISPLAY_VERSION " (" GIT_STR ")" "\036DATE" TAB ": " DATE " " TIME "\036EEPR" TAB ": " EEPROM_STR;
+  const char vers_stamp[]  = "FW" TAB ": edgetx-" FLAVOUR    "\036VERS" TAB ": " VERSION DISPLAY_VERSION " (" GIT_STR ")" "\036DATE" TAB ": " DATE " " TIME "\036CFGV" TAB ": " CFGV_STR;
 #endif
 
 /**


### PR DESCRIPTION
Resolves #1081

Summary of changes:
- EEPR => CFGV
- eeprom_stamp => cfgv_stamp
- updated strings correspondingly
- some auto formatting

![snapshot_02](https://user-images.githubusercontent.com/5500713/147842309-672fbf98-42fb-42c8-a797-95e934b5f3d2.png)

