### PR TITLE
Add support for internal module to Companion

### DIFF
--- a/companion/src/apppreferencesdialog.cpp
+++ b/companion/src/apppreferencesdialog.cpp
@@ -460,6 +460,12 @@ void AppPreferencesDialog::on_clearImageButton_clicked()
 void AppPreferencesDialog::onBaseFirmwareChanged()
 {
   populateFirmwareOptions(getBaseFirmware());
+
+  Firmware *newfw = getFirmwareVariant();
+  Profile & profile = g.currentProfile();
+  profile.defaultInternalModule(Boards::getDefaultInternalModules(newfw->getBoard()));
+  ui->defaultInternalModuleCB->setModel(ModuleData::internalModuleItemModel(newfw->getBoard()));
+  ui->defaultInternalModuleCB->setCurrentIndex(ui->defaultInternalModuleCB->findData(profile.defaultInternalModule()));
 }
 
 Firmware *AppPreferencesDialog::getBaseFirmware() const

--- a/companion/src/apppreferencesdialog.cpp
+++ b/companion/src/apppreferencesdialog.cpp
@@ -28,6 +28,10 @@
 #include "joystick.h"
 #include "joystickdialog.h"
 #endif
+#include "moduledata.h"
+#include "compounditemmodels.h"
+
+#include <QAbstractItemModel>
 
 AppPreferencesDialog::AppPreferencesDialog(QWidget * parent) :
   QDialog(parent),
@@ -97,6 +101,7 @@ void AppPreferencesDialog::accept()
     g.jsSupport(false);
     g.jsCtrl(0);
   }
+  profile.defaultInternalModule(ui->defaultInternalModuleCB->currentData().toInt());
   profile.channelOrder(ui->channelorderCB->currentIndex());
   profile.defaultMode(ui->stickmodeCB->currentIndex());
   profile.renameFwFiles(ui->renameFirmware->isChecked());
@@ -256,6 +261,8 @@ void AppPreferencesDialog::initSettings()
   }
 #endif
   //  Profile Tab Inits
+  ui->defaultInternalModuleCB->setModel(ModuleData::internalModuleItemModel());
+  ui->defaultInternalModuleCB->setCurrentIndex(ui->defaultInternalModuleCB->findData(profile.defaultInternalModule()));
   ui->channelorderCB->setCurrentIndex(profile.channelOrder());
   ui->stickmodeCB->setCurrentIndex(profile.defaultMode());
   ui->renameFirmware->setChecked(profile.renameFwFiles());

--- a/companion/src/apppreferencesdialog.ui
+++ b/companion/src/apppreferencesdialog.ui
@@ -51,178 +51,21 @@
       <attribute name="title">
        <string>Radio Profile</string>
       </attribute>
-      <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0,0,0">
-       <item row="5" column="1">
-        <widget class="QWidget" name="optionsWidget" native="true">
+      <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0,0,0,0">
+       <item row="14" column="0">
+        <widget class="QLabel" name="label_14">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <layout class="QGridLayout" name="optionsLayout">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <property name="horizontalSpacing">
-           <number>5</number>
-          </property>
-          <property name="verticalSpacing">
-           <number>4</number>
-          </property>
-         </layout>
-        </widget>
-       </item>
-       <item row="7" column="0" colspan="4">
-        <widget class="QWidget" name="widget_splashImage" native="true">
-         <layout class="QGridLayout" name="gridLayout_5">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
-          <property name="spacing">
-           <number>6</number>
-          </property>
-          <item row="0" column="0">
-           <widget class="QLabel" name="splashLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="font">
-             <font>
-              <weight>75</weight>
-              <bold>true</bold>
-             </font>
-            </property>
-            <property name="text">
-             <string>Splash Screen</string>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1">
-           <widget class="QLineEdit" name="SplashFileName">
-            <property name="enabled">
-             <bool>true</bool>
-            </property>
-            <property name="readOnly">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="2">
-           <widget class="QPushButton" name="SplashSelect">
-            <property name="text">
-             <string>Select Image</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLabel" name="imageLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>128</width>
-              <height>64</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>212</width>
-              <height>64</height>
-             </size>
-            </property>
-            <property name="frameShape">
-             <enum>QFrame::StyledPanel</enum>
-            </property>
-            <property name="frameShadow">
-             <enum>QFrame::Plain</enum>
-            </property>
-            <property name="lineWidth">
-             <number>1</number>
-            </property>
-            <property name="text">
-             <string/>
-            </property>
-            <property name="scaledContents">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QPushButton" name="clearImageButton">
-            <property name="text">
-             <string>Clear Image</string>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="0" colspan="3">
-           <widget class="Line" name="line_6">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="orientation">
-             <enum>Qt::Horizontal</enum>
-            </property>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="16" column="1">
-        <widget class="QCheckBox" name="burnFirmware">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
          <property name="text">
-          <string>Offer to write FW to Tx after download</string>
+          <string>Default Stick Mode</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="0" colspan="4">
-        <widget class="Line" name="line_8">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="14" column="1">
+       <item row="15" column="2">
         <widget class="QComboBox" name="channelorderCB">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -358,88 +201,27 @@
          </item>
         </widget>
        </item>
-       <item row="2" column="1">
-        <widget class="QComboBox" name="boardCB">
-         <property name="enabled">
-          <bool>true</bool>
+       <item row="10" column="2">
+        <widget class="QLineEdit" name="profilebackupPath">
+         <property name="toolTip">
+          <string>If set it will override the application general setting</string>
+         </property>
+         <property name="readOnly">
+          <bool>false</bool>
          </property>
         </widget>
        </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="label_6">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Build Options</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
-         </property>
-        </widget>
-       </item>
-       <item row="15" column="1">
-        <widget class="QCheckBox" name="renameFirmware">
+       <item row="4" column="2">
+        <widget class="QComboBox" name="langCombo">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="text">
-          <string>Append version number to FW file name</string>
-         </property>
         </widget>
        </item>
-       <item row="9" column="2" colspan="2">
-        <widget class="QPushButton" name="sdPathButton">
-         <property name="text">
-          <string>Select Folder</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_2">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Profile Name</string>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QLineEdit" name="profileNameLE"/>
-       </item>
-       <item row="10" column="0">
-        <widget class="QLabel" name="profilebackupPathLabel">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>The profile specific folder,  if set, will override general Backup folder</string>
-         </property>
-         <property name="text">
-          <string>Backup folder</string>
-         </property>
-        </widget>
-       </item>
-       <item row="12" column="1">
+       <item row="12" column="2">
         <widget class="QLabel" name="lblGeneralSettings">
          <property name="enabled">
           <bool>true</bool>
@@ -455,39 +237,17 @@
          </property>
         </widget>
        </item>
-       <item row="8" column="0" colspan="4">
-        <widget class="QLabel" name="label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
+       <item row="10" column="3" colspan="2">
+        <widget class="QPushButton" name="ProfilebackupPathButton">
+         <property name="toolTip">
+          <string>The profile specific folder,  if set, will override general Backup folder</string>
          </property>
          <property name="text">
-          <string>Other Settings</string>
+          <string>Select Folder</string>
          </property>
         </widget>
        </item>
-       <item row="13" column="0">
-        <widget class="QLabel" name="label_14">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Default Stick Mode</string>
-         </property>
-        </widget>
-       </item>
-       <item row="13" column="1">
+       <item row="14" column="2">
         <widget class="QComboBox" name="stickmodeCB">
          <property name="maximumSize">
           <size>
@@ -541,58 +301,58 @@ Mode 4:
          </item>
         </widget>
        </item>
-       <item row="14" column="0">
-        <widget class="QLabel" name="label_13">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
+       <item row="9" column="2">
+        <widget class="QLineEdit" name="sdPath">
+         <property name="enabled">
+          <bool>true</bool>
          </property>
          <property name="text">
-          <string>Default Channel Order</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="1">
-        <widget class="QCheckBox" name="pbackupEnable">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>if set, will override general backup enable</string>
-         </property>
-         <property name="text">
-          <string>Enable automatic backup before writing firmware</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0" colspan="4">
-        <widget class="Line" name="splashSeparator">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="1">
-        <widget class="QLineEdit" name="profilebackupPath">
-         <property name="toolTip">
-          <string>If set it will override the application general setting</string>
+          <string/>
          </property>
          <property name="readOnly">
           <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <widget class="QLineEdit" name="profileNameLE"/>
+       </item>
+       <item row="2" column="2">
+        <widget class="QComboBox" name="boardCB">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Profile Name</string>
+         </property>
+        </widget>
+       </item>
+       <item row="16" column="2">
+        <widget class="QCheckBox" name="renameFirmware">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Append version number to FW file name</string>
          </property>
         </widget>
        </item>
@@ -612,16 +372,6 @@ Mode 4:
          </property>
         </widget>
        </item>
-       <item row="10" column="2" colspan="2">
-        <widget class="QPushButton" name="ProfilebackupPathButton">
-         <property name="toolTip">
-          <string>The profile specific folder,  if set, will override general Backup folder</string>
-         </property>
-         <property name="text">
-          <string>Select Folder</string>
-         </property>
-        </widget>
-       </item>
        <item row="12" column="0">
         <widget class="QLabel" name="label_4">
          <property name="sizePolicy">
@@ -632,6 +382,136 @@ Mode 4:
          </property>
          <property name="text">
           <string>General Settings</string>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="0">
+        <widget class="QLabel" name="profilebackupPathLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>The profile specific folder,  if set, will override general Backup folder</string>
+         </property>
+         <property name="text">
+          <string>Backup folder</string>
+         </property>
+        </widget>
+       </item>
+       <item row="15" column="0">
+        <widget class="QLabel" name="label_13">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Default Channel Order</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="13" column="0">
+        <widget class="QLabel" name="label_21">
+         <property name="text">
+          <string>Default Int. Module</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0" colspan="5">
+        <widget class="Line" name="line_8">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="17" column="2">
+        <widget class="QCheckBox" name="burnFirmware">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Offer to write FW to Tx after download</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="label_6">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Build Options</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="langLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Menu Language</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="3" colspan="2">
+        <widget class="QPushButton" name="sdPathButton">
+         <property name="text">
+          <string>Select Folder</string>
+         </property>
+        </widget>
+       </item>
+       <item row="18" column="2">
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>5</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="6" column="0" colspan="5">
+        <widget class="Line" name="splashSeparator">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
          </property>
         </widget>
        </item>
@@ -658,57 +538,187 @@ Mode 4:
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="langLabel">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Menu Language</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="1">
-        <widget class="QLineEdit" name="sdPath">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="readOnly">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="17" column="1">
-        <spacer name="verticalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>5</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="4" column="1">
-        <widget class="QComboBox" name="langCombo">
+       <item row="11" column="2">
+        <widget class="QCheckBox" name="pbackupEnable">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
+         <property name="toolTip">
+          <string>if set, will override general backup enable</string>
+         </property>
+         <property name="text">
+          <string>Enable automatic backup before writing firmware</string>
+         </property>
         </widget>
+       </item>
+       <item row="7" column="0" colspan="5">
+        <widget class="QWidget" name="widget_splashImage" native="true">
+         <layout class="QGridLayout" name="gridLayout_5">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <property name="spacing">
+           <number>6</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="splashLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Minimum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="font">
+             <font>
+              <weight>75</weight>
+              <bold>true</bold>
+             </font>
+            </property>
+            <property name="text">
+             <string>Splash Screen</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QLineEdit" name="SplashFileName">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
+           <widget class="QPushButton" name="SplashSelect">
+            <property name="text">
+             <string>Select Image</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLabel" name="imageLabel">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Maximum" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="minimumSize">
+             <size>
+              <width>128</width>
+              <height>64</height>
+             </size>
+            </property>
+            <property name="maximumSize">
+             <size>
+              <width>212</width>
+              <height>64</height>
+             </size>
+            </property>
+            <property name="frameShape">
+             <enum>QFrame::StyledPanel</enum>
+            </property>
+            <property name="frameShadow">
+             <enum>QFrame::Plain</enum>
+            </property>
+            <property name="lineWidth">
+             <number>1</number>
+            </property>
+            <property name="text">
+             <string/>
+            </property>
+            <property name="scaledContents">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QPushButton" name="clearImageButton">
+            <property name="text">
+             <string>Clear Image</string>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0" colspan="3">
+           <widget class="Line" name="line_6">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="5" column="2">
+        <widget class="QWidget" name="optionsWidget" native="true">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <layout class="QGridLayout" name="optionsLayout">
+          <property name="leftMargin">
+           <number>0</number>
+          </property>
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <property name="horizontalSpacing">
+           <number>5</number>
+          </property>
+          <property name="verticalSpacing">
+           <number>4</number>
+          </property>
+         </layout>
+        </widget>
+       </item>
+       <item row="8" column="0" colspan="5">
+        <widget class="QLabel" name="label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Other Settings</string>
+         </property>
+        </widget>
+       </item>
+       <item row="13" column="2">
+        <widget class="QComboBox" name="defaultInternalModuleCB"/>
        </item>
       </layout>
      </widget>

--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -21,6 +21,7 @@
 #include "boards.h"
 #include "macros.h"
 #include "compounditemmodels.h"
+#include "moduledata.h"
 
 // TODO remove all those constants
 // Update: These are now all only used within this class.
@@ -807,4 +808,65 @@ StringTagMappingTable Boards::getTrimSourcesLookupTable(Board::Type board)
                           });
 
   return tbl;
+}
+
+QList<ModuleType> Boards::getSupportedInternalModules(Board::Type board)
+{
+  QList<ModuleType> modules;
+  if (IS_TARANIS_X9DP_2019(board) || IS_TARANIS_X7_ACCESS(board)) {
+    modules = {MODULE_TYPE_ISRM_PXX2};
+  } else if (IS_FLYSKY_NV14(board)) {
+    modules = {MODULE_TYPE_FLYSKY};
+  } else if (IS_FAMILY_HORUS_OR_T16(board) || IS_FAMILY_T12(board)
+             || (IS_TARANIS_SMALL(board) && IS_ACCESS_RADIO(board))) {
+    modules.append({
+        MODULE_TYPE_XJT_PXX1,
+        MODULE_TYPE_ISRM_PXX2,
+        MODULE_TYPE_CROSSFIRE,
+        MODULE_TYPE_MULTIMODULE,
+    });
+  } else if (IS_TARANIS(board)) {
+    modules = {MODULE_TYPE_XJT_PXX1};
+  }
+
+  return modules;
+}
+
+ModuleType Boards::getDefaultInternalModules(Board::Type board)
+{
+  switch(board) {
+  case BOARD_TARANIS_X7:
+  case BOARD_TARANIS_X9D:
+  case BOARD_TARANIS_X9DP:
+  case BOARD_TARANIS_X9E:
+  case BOARD_HORUS_X12S:
+  case BOARD_X10:
+  case BOARD_TARANIS_XLITE:
+    return MODULE_TYPE_XJT_PXX1;
+
+  case BOARD_TARANIS_X7_ACCESS:
+  case BOARD_TARANIS_X9DP_2019:
+  case BOARD_X10_EXPRESS:
+  case BOARD_TARANIS_XLITES:
+  case BOARD_TARANIS_X9LITE:
+  case BOARD_TARANIS_X9LITES:
+    return MODULE_TYPE_ISRM_PXX2;
+
+  case BOARD_JUMPER_T12:
+  case BOARD_JUMPER_T16:
+  case BOARD_RADIOMASTER_TX16S:
+  case BOARD_JUMPER_T18:
+  case BOARD_RADIOMASTER_TX12:
+  case BOARD_RADIOMASTER_T8:
+  case BOARD_JUMPER_TLITE:
+  case BOARD_RADIOMASTER_ZORRO:
+  case BOARD_JUMPER_TPRO:
+    return MODULE_TYPE_MULTIMODULE;
+
+  case BOARD_FLYSKY_NV14:
+    return MODULE_TYPE_FLYSKY;
+
+  default:
+    return MODULE_TYPE_NONE;
+  }
 }

--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -489,6 +489,9 @@ int Boards::getCapability(Board::Type board, Board::Capability capability)
     case HasSDCard:
       return IS_STM32(board);
 
+    case HasInternalModuleSupport:
+      return (IS_STM32(board) && !IS_TARANIS_SMALL(board));
+
     default:
       return 0;
   }

--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -490,7 +490,7 @@ int Boards::getCapability(Board::Type board, Board::Capability capability)
       return IS_STM32(board);
 
     case HasInternalModuleSupport:
-      return (IS_STM32(board) && !IS_TARANIS_SMALL(board));
+      return (IS_STM32(board) && !IS_TARANIS_X9(board));
 
     default:
       return 0;

--- a/companion/src/firmwares/boards.h
+++ b/companion/src/firmwares/boards.h
@@ -20,6 +20,7 @@
 
 #pragma once
 #include "datahelpers.h"
+#include "moduledata.h"
 
 #include <QtCore>
 #include <QObject>
@@ -219,7 +220,9 @@ class Boards
     static AbstractStaticItemModel * intModuleTypeItemModel();
     static StringTagMappingTable getTrimSwitchesLookupTable(Board::Type board);
     static StringTagMappingTable getTrimSourcesLookupTable(Board::Type board);
-
+    static QList<ModuleType> getSupportedInternalModules(Board::Type board);
+    static ModuleType getDefaultInternalModules(Board::Type board);
+  
   protected:
 
     Board::Type m_boardType;
@@ -291,7 +294,12 @@ inline bool IS_FAMILY_T16(Board::Type board)
 
 inline bool IS_FAMILY_T12(Board::Type board)
 {
-  return board == Board::BOARD_JUMPER_T12 || board == Board::BOARD_RADIOMASTER_TX12 || board == Board::BOARD_RADIOMASTER_ZORRO || board == Board::BOARD_RADIOMASTER_T8 || board == Board::BOARD_JUMPER_TLITE;
+  return board == Board::BOARD_JUMPER_T12 ||
+         board == Board::BOARD_RADIOMASTER_TX12 ||
+         board == Board::BOARD_RADIOMASTER_ZORRO ||
+         board == Board::BOARD_RADIOMASTER_T8 ||
+         board == Board::BOARD_JUMPER_TLITE ||
+         board == Board::BOARD_JUMPER_TPRO;
 }
 
 inline bool IS_FLYSKY_NV14(Board::Type board)
@@ -409,10 +417,17 @@ inline bool IS_TARANIS_X9DP_2019(Board::Type board)
   return (board == Board::BOARD_TARANIS_X9DP_2019);
 }
 
+inline bool IS_ACCESS_RADIO(Board::Type board)
+{
+  return IS_TARANIS_XLITES(board) || IS_TARANIS_X9LITE(board) ||
+         board == Board::BOARD_TARANIS_X9DP_2019 ||
+         board == Board::BOARD_X10_EXPRESS || IS_TARANIS_X7_ACCESS(board);
+}
+
 inline bool IS_ACCESS_RADIO(Board::Type board, const QString & id)
 {
-  return (IS_TARANIS_XLITES(board) || IS_TARANIS_X9LITE(board) || board == Board::BOARD_TARANIS_X9DP_2019 || board == Board::BOARD_X10_EXPRESS || IS_TARANIS_X7_ACCESS(board) ||
-          (IS_FAMILY_HORUS_OR_T16(board) && id.contains("internalaccess")));
+  return IS_ACCESS_RADIO(board) ||
+         (IS_FAMILY_HORUS_OR_T16(board) && id.contains("internalaccess"));
 }
 
 inline bool HAS_EEPROM_YAML(Board::Type board)

--- a/companion/src/firmwares/boards.h
+++ b/companion/src/firmwares/boards.h
@@ -147,7 +147,8 @@ namespace Board {
     HasRTC,
     HasColorLcd,
     NumFunctionSwitches,
-    HasSDCard
+    HasSDCard,
+    HasInternalModuleSupport
   };
 
   struct SwitchInfo
@@ -211,9 +212,11 @@ class Boards
     static QString potTypeToString(int value);
     static QString sliderTypeToString(int value);
     static QString switchTypeToString(int value);
+    static QString intModuleTypeToString(int value);
     static AbstractStaticItemModel * potTypeItemModel();
     static AbstractStaticItemModel * sliderTypeItemModel();
     static AbstractStaticItemModel * switchTypeItemModel();
+    static AbstractStaticItemModel * intModuleTypeItemModel();
     static StringTagMappingTable getTrimSwitchesLookupTable(Board::Type board);
     static StringTagMappingTable getTrimSourcesLookupTable(Board::Type board);
 

--- a/companion/src/firmwares/edgetx/yaml_generalsettings.cpp
+++ b/companion/src/firmwares/edgetx/yaml_generalsettings.cpp
@@ -23,6 +23,7 @@
 #include "yaml_trainerdata.h"
 #include "yaml_calibdata.h"
 #include "yaml_switchconfig.h"
+#include "yaml_moduledata.h"
 
 #include "eeprominterface.h"
 #include "edgetxinterface.h"
@@ -74,6 +75,25 @@ const YamlLookupTable antennaModeLut = {
   {  GeneralSettings::ANTENNA_MODE_INTERNAL_EXTERNAL, "MODE_INTERNAL_EXTERNAL"  },
 };
 
+const YamlLookupTable internalModuleLut = {
+  {  MODULE_TYPE_NONE, "TYPE_NONE"  },
+  {  MODULE_TYPE_PPM, "TYPE_PPM"  },
+  {  MODULE_TYPE_XJT_PXX1, "TYPE_XJT_PXX1"  },
+  {  MODULE_TYPE_ISRM_PXX2, "TYPE_ISRM_PXX2"  },
+  {  MODULE_TYPE_DSM2, "TYPE_DSM2"  },
+  {  MODULE_TYPE_CROSSFIRE, "TYPE_CROSSFIRE"  },
+  {  MODULE_TYPE_MULTIMODULE, "TYPE_MULTIMODULE"  },
+  {  MODULE_TYPE_R9M_PXX1, "TYPE_R9M_PXX1"  },
+  {  MODULE_TYPE_R9M_PXX2, "TYPE_R9M_PXX2"  },
+  {  MODULE_TYPE_R9M_LITE_PXX1, "TYPE_R9M_LITE_PXX1"  },
+  {  MODULE_TYPE_R9M_LITE_PXX2, "TYPE_R9M_LITE_PXX2"  },
+  {  MODULE_TYPE_GHOST, "TYPE_GHOST"  },
+  {  MODULE_TYPE_R9M_LITE_PRO_PXX2, "TYPE_R9M_LITE_PRO_PXX2"  },
+  {  MODULE_TYPE_SBUS, "TYPE_SBUS"  },
+  {  MODULE_TYPE_XJT_LITE_PXX2, "TYPE_XJT_LITE_PXX2"  },
+  {  MODULE_TYPE_FLYSKY, "TYPE_FLYSKY"  },
+};
+
 namespace YAML
 {
 
@@ -116,6 +136,7 @@ Node convert<GeneralSettings>::encode(const GeneralSettings& rhs)
   node["adjustRTC"] = (int)rhs.adjustRTC;
   node["inactivityTimer"] = rhs.inactivityTimer;
   node["telemetryBaudrate"] = rhs.telemetryBaudrate;  // TODO: conversion???
+  node["internalModule"] = LookupValue(internalModuleLut, rhs.internalModule);
   node["splashMode"] = rhs.splashMode;                // TODO: B&W only
   node["lightAutoOff"] = rhs.backlightDelay;
   node["templateSetup"] = rhs.templateSetup;
@@ -266,6 +287,13 @@ bool convert<GeneralSettings>::decode(const Node& node, GeneralSettings& rhs)
   node["adjustRTC"] >> rhs.adjustRTC;
   node["inactivityTimer"] >> rhs.inactivityTimer;
   node["telemetryBaudrate"] >> rhs.telemetryBaudrate;  // TODO: conversion???
+
+  if (node["internalModule"]) {
+    node["internalModule"] >> internalModuleLut >> rhs.internalModule;
+  } else {
+    rhs.internalModule = Boards::getDefaultInternalModules(fw->getBoard());
+  }
+
   node["splashMode"] >> rhs.splashMode;                // TODO: B&W only
   node["lightAutoOff"] >> rhs.backlightDelay;
   node["templateSetup"] >> rhs.templateSetup;

--- a/companion/src/firmwares/generalsettings.cpp
+++ b/companion/src/firmwares/generalsettings.cpp
@@ -245,9 +245,8 @@ GeneralSettings::GeneralSettings()
     }
   }
 
-  // TODO: add a preset in the radio profile
-  internalModule = Boards::getDefaultInternalModules(board);
-  
+  internalModule = g.profile[g.sessionId()].defaultInternalModule();
+
   const char * themeName = IS_FLYSKY_NV14(board) ? "FlySky" : "EdgeTX";
   RadioTheme::init(themeName, themeData);
 }

--- a/companion/src/firmwares/generalsettings.cpp
+++ b/companion/src/firmwares/generalsettings.cpp
@@ -245,6 +245,9 @@ GeneralSettings::GeneralSettings()
     }
   }
 
+  // TODO: add a preset in the radio profile
+  internalModule = Boards::getDefaultInternalModules(board);
+  
   const char * themeName = IS_FLYSKY_NV14(board) ? "FlySky" : "EdgeTX";
   RadioTheme::init(themeName, themeData);
 }

--- a/companion/src/firmwares/generalsettings.h
+++ b/companion/src/firmwares/generalsettings.h
@@ -161,6 +161,7 @@ class GeneralSettings {
     int vBatMin;
     int vBatMax;
     int backlightMode;
+    unsigned int internalModule;  // Introducted in EdgeTX 2.6 yaml only
     TrainerData trainer;
     unsigned int view;    // main screen view // TODO enum
     bool disableThrottleWarning;

--- a/companion/src/firmwares/moduledata.cpp
+++ b/companion/src/firmwares/moduledata.cpp
@@ -338,20 +338,20 @@ QString ModuleData::typeToString(int type)
   static const char * strings[] = {
     "OFF",
     "PPM",
-    "FrSky XJT",
+    "XJT",
     "ISRM",
     "DSM2",
-    "TBS Crossfire",
-    "DIY Multiprotocol Module",
-    "FrSky R9M",
-    "FrSky R9M ACCESS",
-    "FrSky R9MLite",
-    "FrSky R9ML ACCESS",
-    "ImmersionRC Ghost",
-    "FrSky R9MLP ACCESS",
-    "SBUS output at VBat",
-    "FrSky XJT Lite",
-    "FlySky"
+    "CRSF",
+    "MULTI",
+    "R9M",
+    "R9M ACCESS",
+    "R9MLite",
+    "R9ML ACCESS",
+    "GHST",
+    "R9MLP ACCESS",
+    "SBUS",
+    "XJT Lite",
+    "FLYSKY"
   };
 
   return CHECK_IN_ARRAY(strings, type);

--- a/companion/src/firmwares/moduledata.cpp
+++ b/companion/src/firmwares/moduledata.cpp
@@ -25,7 +25,6 @@
 #include "radiodataconversionstate.h"
 #include "compounditemmodels.h"
 #include "generalsettings.h"
-#include "datahelpers.h"
 
 #include <QPair>
 #include <QVector>
@@ -359,12 +358,12 @@ QString ModuleData::typeToString(int type)
   return CHECK_IN_ARRAY(strings, type);
 }
 
-AbstractStaticItemModel * ModuleData::internalModuleItemModel()
+AbstractStaticItemModel * ModuleData::internalModuleItemModel(int board)
 {
   AbstractStaticItemModel * mdl = new AbstractStaticItemModel();
   mdl->setName("moduledata.internalmodule");
 
-  auto modules = Boards::getSupportedInternalModules(getCurrentBoard());
+  auto modules = Boards::getSupportedInternalModules(board == Board::BOARD_UNKNOWN ? getCurrentBoard() : (Board::Type)board);
   for(auto mod : modules) {
     mdl->appendToItemList(typeToString(mod), mod);
   }

--- a/companion/src/firmwares/moduledata.cpp
+++ b/companion/src/firmwares/moduledata.cpp
@@ -407,8 +407,9 @@ AbstractStaticItemModel * ModuleData::internalModuleItemModel()
   AbstractStaticItemModel * mdl = new AbstractStaticItemModel();
   mdl->setName("moduledata.internalmodule");
 
-  for (int i = 0; i < MODULE_TYPE_COUNT; i++) {
-    mdl->appendToItemList(typeToString(i), i, isInternalModuleAvailable(i));
+  auto modules = Boards::getSupportedInternalModules(getCurrentBoard());
+  for(auto mod : modules) {
+    mdl->appendToItemList(typeToString(mod), mod);
   }
 
   mdl->loadItemList();

--- a/companion/src/firmwares/moduledata.cpp
+++ b/companion/src/firmwares/moduledata.cpp
@@ -165,8 +165,8 @@ QString ModuleData::protocolToString(unsigned int protocol)
     "LP45", "DSM2", "DSMX",
     "PPM16", "PPMsim",
     "FrSky XJT (D16)", "FrSky XJT (D8)", "FrSky XJT (LR12)", "FrSky DJT",
-    "TBS Crossfire",
-    "DIY Multiprotocol Module",
+    "Crossfire",
+    "Multi",
     "FrSky R9M",
     "FrSky R9M Lite",
     "FrSky R9M Lite Pro",
@@ -177,7 +177,7 @@ QString ModuleData::protocolToString(unsigned int protocol)
     "FrSky ACCESS R9M Lite Pro",
     "FrSky XJT lite (D16)", "FrSky XJT lite (D8)", "FrSky XJT lite (LR12)",
     "AFHDS3",
-    "ImmersionRC Ghost"
+    "Ghost"
   };
 
   return CHECK_IN_ARRAY(strings, protocol);

--- a/companion/src/firmwares/moduledata.cpp
+++ b/companion/src/firmwares/moduledata.cpp
@@ -278,37 +278,39 @@ int ModuleData::getMaxChannelCount()
 //  static
 int ModuleData::getTypeFromProtocol(unsigned int protocol)
 {
+  //  must be kept in sync with opentxeeprom.h ProtocolsConversionTable
+
   const QVector<QPair<int, int>>ProtocolTypeTable = {
 
-                          { PULSES_OFF, MODULE_TYPE_NONE },
-                          { PULSES_PPM, MODULE_TYPE_PPM },
+                          { PULSES_OFF,                 MODULE_TYPE_NONE },
+                          { PULSES_PPM,                 MODULE_TYPE_PPM },
 
-                          { PULSES_PXX_XJT_X16, MODULE_TYPE_XJT_PXX1 },
-                          { PULSES_PXX_XJT_D8, MODULE_TYPE_XJT_PXX1 },
-                          { PULSES_PXX_XJT_LR12, MODULE_TYPE_XJT_PXX1 },
+                          { PULSES_PXX_XJT_X16,         MODULE_TYPE_XJT_PXX1 },
+                          { PULSES_PXX_XJT_D8,          MODULE_TYPE_XJT_PXX1 },
+                          { PULSES_PXX_XJT_LR12,        MODULE_TYPE_XJT_PXX1 },
 
-                          { PULSES_ACCESS_ISRM, MODULE_TYPE_ISRM_PXX2 },
-                          { PULSES_ACCST_ISRM_D16, MODULE_TYPE_ISRM_PXX2 },
+                          { PULSES_ACCESS_ISRM,         MODULE_TYPE_ISRM_PXX2 },
+                          { PULSES_ACCST_ISRM_D16,      MODULE_TYPE_ISRM_PXX2 },
 
-                          { PULSES_LP45, MODULE_TYPE_DSM2 },
-                          { PULSES_DSM2, MODULE_TYPE_DSM2 },
-                          { PULSES_DSMX, MODULE_TYPE_DSM2 },
+                          { PULSES_LP45,                MODULE_TYPE_DSM2 },
+                          { PULSES_DSM2,                MODULE_TYPE_DSM2 },
+                          { PULSES_DSMX,                MODULE_TYPE_DSM2 },
 
-                          { PULSES_CROSSFIRE, MODULE_TYPE_CROSSFIRE },
-                          { PULSES_MULTIMODULE, MODULE_TYPE_MULTIMODULE },
-                          { PULSES_PXX_R9M, MODULE_TYPE_R9M_PXX1 },
-                          { PULSES_ACCESS_R9M, MODULE_TYPE_R9M_PXX2 },
-                          { PULSES_PXX_R9M_LITE, MODULE_TYPE_R9M_LITE_PXX1 },
-                          { PULSES_ACCESS_R9M_LITE, MODULE_TYPE_R9M_LITE_PXX2 },
-                          { PULSES_GHOST, MODULE_TYPE_GHOST },
+                          { PULSES_CROSSFIRE,           MODULE_TYPE_CROSSFIRE },
+                          { PULSES_MULTIMODULE,         MODULE_TYPE_MULTIMODULE },
+                          { PULSES_PXX_R9M,             MODULE_TYPE_R9M_PXX1 },
+                          { PULSES_ACCESS_R9M,          MODULE_TYPE_R9M_PXX2 },
+                          { PULSES_PXX_R9M_LITE,        MODULE_TYPE_R9M_LITE_PXX1 },
+                          { PULSES_ACCESS_R9M_LITE,     MODULE_TYPE_R9M_LITE_PXX2 },
+                          { PULSES_GHOST,               MODULE_TYPE_GHOST },
                           { PULSES_ACCESS_R9M_LITE_PRO, MODULE_TYPE_R9M_LITE_PRO_PXX2 },
-                          { PULSES_SBUS, MODULE_TYPE_SBUS },
+                          { PULSES_SBUS,                MODULE_TYPE_SBUS },
 
-                          { PULSES_XJT_LITE_X16, MODULE_TYPE_XJT_LITE_PXX2 },
-                          { PULSES_XJT_LITE_D8, MODULE_TYPE_XJT_LITE_PXX2 },
-                          { PULSES_XJT_LITE_LR12, MODULE_TYPE_XJT_LITE_PXX2 },
+                          { PULSES_XJT_LITE_X16,        MODULE_TYPE_XJT_LITE_PXX2 },
+                          { PULSES_XJT_LITE_D8,         MODULE_TYPE_XJT_LITE_PXX2 },
+                          { PULSES_XJT_LITE_LR12,       MODULE_TYPE_XJT_LITE_PXX2 },
 
-                          { PULSES_AFHDS3, MODULE_TYPE_FLYSKY }
+                          { PULSES_AFHDS3,              MODULE_TYPE_FLYSKY }
                       };
 
   QPair<int, int>elmt;
@@ -357,51 +359,6 @@ QString ModuleData::typeToString(int type)
   return CHECK_IN_ARRAY(strings, type);
 }
 
-//  static
-bool ModuleData::isInternalModuleAvailable(int moduleType)
-{
-  if (moduleType == MODULE_TYPE_NONE)
-    return true;
-
-  Firmware *fw = getCurrentFirmware();
-  Board::Type board = fw->getBoard();
-  QString id = fw->getId();
-
-  if (!Boards::getCapability(board, Board::HasInternalModuleSupport))
-    return false;
-
-  //===================================
-  //  TODO: this is not finished!!!!!!!
-  //===================================
-
-  switch(moduleType) {
-    case MODULE_TYPE_MULTIMODULE:
-      return id.contains("internalmulti") || IS_RADIOMASTER_TX16S(board) || IS_JUMPER_T18(board) || IS_RADIOMASTER_TX12(board) || IS_JUMPER_TLITE(board);
-      break;
-    case MODULE_TYPE_CROSSFIRE:
-      break;
-    case MODULE_TYPE_XJT_PXX1:
-      if(IS_TARANIS(board))
-        return true;
-      break;
-    case MODULE_TYPE_ISRM_PXX2:
-      if(IS_ACCESS_RADIO(board, id))
-        return true;
-      break;
-    case MODULE_TYPE_PPM:
-      break;
-    case MODULE_TYPE_FLYSKY:
-      if (IS_FLYSKY_NV14(board))
-        return true;
-      break;
-    default:
-      return false;
-  }
-
-  return false;
-}
-
-//  static
 AbstractStaticItemModel * ModuleData::internalModuleItemModel()
 {
   AbstractStaticItemModel * mdl = new AbstractStaticItemModel();

--- a/companion/src/firmwares/moduledata.h
+++ b/companion/src/firmwares/moduledata.h
@@ -249,7 +249,7 @@ class ModuleData {
     static int getTypeFromProtocol(unsigned int protocol);
     static int getSubTypeFromProtocol(unsigned int protocol);
     static QString typeToString(int type);
-    static AbstractStaticItemModel * internalModuleItemModel();
+    static AbstractStaticItemModel * internalModuleItemModel(int board = -1);
     static bool isProtocolAvailable(int moduleidx, unsigned int  protocol, GeneralSettings & settings);
     static AbstractStaticItemModel * protocolItemModel(GeneralSettings & settings);
 };

--- a/companion/src/firmwares/moduledata.h
+++ b/companion/src/firmwares/moduledata.h
@@ -249,7 +249,6 @@ class ModuleData {
     static int getTypeFromProtocol(unsigned int protocol);
     static int getSubTypeFromProtocol(unsigned int protocol);
     static QString typeToString(int type);
-    static bool isInternalModuleAvailable(int type);
     static AbstractStaticItemModel * internalModuleItemModel();
     static bool isProtocolAvailable(int moduleidx, unsigned int  protocol, GeneralSettings & settings);
     static AbstractStaticItemModel * protocolItemModel(GeneralSettings & settings);

--- a/companion/src/firmwares/moduledata.h
+++ b/companion/src/firmwares/moduledata.h
@@ -18,8 +18,7 @@
  * GNU General Public License for more details.
  */
 
-#ifndef MODULEDATA_H
-#define MODULEDATA_H
+#pragma once
 
 #include "constants.h"
 
@@ -27,6 +26,30 @@
 
 class Firmware;
 class RadioDataConversionState;
+class AbstractStaticItemModel;
+class GeneralSettings;
+
+// from radio/src/pulses/module_constants.h
+enum ModuleType {
+  MODULE_TYPE_NONE = 0,
+  MODULE_TYPE_PPM,
+  MODULE_TYPE_XJT_PXX1,
+  MODULE_TYPE_ISRM_PXX2,
+  MODULE_TYPE_DSM2,
+  MODULE_TYPE_CROSSFIRE,
+  MODULE_TYPE_MULTIMODULE,
+  MODULE_TYPE_R9M_PXX1,  // R9M
+  MODULE_TYPE_R9M_PXX2,  // R9M ACCESS
+  MODULE_TYPE_R9M_LITE_PXX1,  //R9MLite
+  MODULE_TYPE_R9M_LITE_PXX2,  //R9MLP
+  MODULE_TYPE_GHOST,     // Replaces MODULE_TYPE_R9M_LITE_PRO_PXX1 which doesn't exist
+  MODULE_TYPE_R9M_LITE_PRO_PXX2,
+  MODULE_TYPE_SBUS,
+  MODULE_TYPE_XJT_LITE_PXX2,
+  MODULE_TYPE_FLYSKY, //no more protocols possible because of 4 bits value
+  MODULE_TYPE_COUNT,
+  MODULE_TYPE_MAX = MODULE_TYPE_COUNT - 1
+};
 
 enum PulsesProtocol {
   PULSES_OFF,
@@ -219,10 +242,15 @@ class ModuleData {
     QString subTypeToString(int type = -1) const;
     QString powerValueToString(Firmware * fw) const;
     static QString indexToString(int index, Firmware * fw);
-    static QString protocolToString(unsigned protocol);
+    static QString protocolToString(unsigned int protocol);
     static QStringList powerValueStrings(enum PulsesProtocol protocol, int subType, Firmware * fw);
     bool hasFailsafes(Firmware * fw) const;
     int getMaxChannelCount();
+    static int getTypeFromProtocol(unsigned int protocol);
+    static int getSubTypeFromProtocol(unsigned int protocol);
+    static QString typeToString(int type);
+    static bool isInternalModuleAvailable(int type);
+    static AbstractStaticItemModel * internalModuleItemModel();
+    static bool isProtocolAvailable(int moduleidx, unsigned int  protocol, GeneralSettings & settings);
+    static AbstractStaticItemModel * protocolItemModel(GeneralSettings & settings);
 };
-
-#endif // MODULEDATA_H

--- a/companion/src/generaledit/hardware.cpp
+++ b/companion/src/generaledit/hardware.cpp
@@ -137,6 +137,10 @@ HardwarePanel::HardwarePanel(QWidget * parent, GeneralSettings & generalSettings
     internalModule->setModel(tabFilteredModels->getItemModel(FIM_INTERNALMODULES));
     internalModule->setField(generalSettings.internalModule, this);
     addParams(row, internalModule);
+    connect(internalModule, &AutoComboBox::currentDataChanged, this, [=] () {
+            QMessageBox::warning(this, CPN_STR_APP_NAME,
+                                 tr("ALERT: Check each model's internal module protocol to ensure it is compatible!"));
+    });
   }
 
   if (firmware->getCapability(HasTelemetryBaudrate)) {

--- a/companion/src/mainwindow.cpp
+++ b/companion/src/mainwindow.cpp
@@ -1626,9 +1626,11 @@ int MainWindow::newProfile(bool loadProfile)
   if (i == MAX_PROFILES)  //Failed to find free slot
     return -1;
 
+  Firmware *newfw = Firmware::getDefaultVariant();
   g.profile[i].init();
-  g.profile[i].name(tr("New Radio"));
-  g.profile[i].fwType(Firmware::getDefaultVariant()->getId());
+  g.profile[i].name("New Radio");
+  g.profile[i].fwType(newfw->getId());
+  g.profile[i].defaultInternalModule(Boards::getDefaultInternalModules(newfw->getBoard()));
 
   if (loadProfile) {
     if (loadProfileId(i))

--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -237,14 +237,12 @@ ModulePanel::ModulePanel(QWidget * parent, ModelData & model, ModuleData & modul
     ui->trainerMode->hide();
   }
 
-  // The protocols available on this board
-  for (unsigned int i = 0; i < PULSES_PROTOCOL_LAST; i++) {
-    if (firmware->isAvailable((PulsesProtocol) i, moduleIdx)) {
-      ui->protocol->addItem(ModuleData::protocolToString(i), i);
-      if (i == module.protocol)
-        ui->protocol->setCurrentIndex(ui->protocol->count() - 1);
-    }
+  if (panelFilteredItemModels && moduleIdx >= 0) {
+    int id = panelFilteredItemModels->registerItemModel(new FilteredItemModel(ModuleData::protocolItemModel(generalSettings), moduleIdx + 1/*flag cannot be 0*/), QString("Module Protocol %1").arg(moduleIdx));
+    ui->protocol->setModel(panelFilteredItemModels->getItemModel(id));
+    ui->protocol->setField(module.protocol, this);
   }
+
   for (int i = 0; i <= MODULE_SUBTYPE_MULTI_LAST; i++) {
     if (i == MODULE_SUBTYPE_MULTI_SCANNER)
       continue;
@@ -266,7 +264,7 @@ ModulePanel::ModulePanel(QWidget * parent, ModelData & model, ModuleData & modul
 
   update();
 
-  connect(ui->protocol, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ModulePanel::onProtocolChanged);
+  connect(ui->protocol, &AutoComboBox::currentDataChanged, this, &ModulePanel::onProtocolChanged);
   connect(ui->multiSubType, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ModulePanel::onSubTypeChanged);
   connect(ui->multiProtocol, static_cast<void(QComboBox::*)(int)>(&QComboBox::currentIndexChanged), this, &ModulePanel::onMultiProtocolChanged);
   connect(this, &ModulePanel::channelsRangeChanged, this, &ModulePanel::setupFailsafes);
@@ -662,8 +660,7 @@ void ModulePanel::update()
 
 void ModulePanel::onProtocolChanged(int index)
 {
-  if (!lock && module.protocol != ui->protocol->itemData(index).toUInt()) {
-    module.protocol = ui->protocol->itemData(index).toInt();
+  if (!lock) {
     module.channelsCount = module.getMaxChannelCount();
     update();
     emit updateItemModels();
@@ -1391,7 +1388,7 @@ SetupPanel::SetupPanel(QWidget * parent, ModelData & model, GeneralSettings & ge
   //  ui->functionSwitchesLayout->hide();
 
   for (int i = firmware->getCapability(NumFirstUsableModule); i < firmware->getCapability(NumModules); i++) {
-    modules[i] = new ModulePanel(this, model, model.moduleData[i], generalSettings, firmware, i);
+    modules[i] = new ModulePanel(this, model, model.moduleData[i], generalSettings, firmware, i, panelFilteredModels);
     ui->modulesLayout->addWidget(modules[i]);
     connect(modules[i], &ModulePanel::modified, this, &SetupPanel::modified);
     connect(modules[i], &ModulePanel::updateItemModels, this, &SetupPanel::onModuleUpdateItemModels);

--- a/companion/src/modeledit/setup_module.ui
+++ b/companion/src/modeledit/setup_module.ui
@@ -805,7 +805,7 @@
          </widget>
         </item>
         <item row="0" column="1">
-         <widget class="QComboBox" name="protocol">
+         <widget class="AutoComboBox" name="protocol">
           <property name="sizePolicy">
            <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
             <horstretch>0</horstretch>

--- a/companion/src/storage/appdata.h
+++ b/companion/src/storage/appdata.h
@@ -380,6 +380,7 @@ class Profile: public CompStoreObj
     PROPERTYSTR(sdPath)
     PROPERTYSTR(pBackupDir)
 
+    PROPERTY (int, defaultInternalModule, 0)
     PROPERTY4(int, channelOrder, "default_channel_order",  0)
     PROPERTY4(int, defaultMode,  "default_mode",           1)
     PROPERTY (int, volumeGain,   10)


### PR DESCRIPTION
Based on ~~main~~ Companion YAML branch ~~as not sure where yaml would be at and it compiles~~.

Things to do:
- [x] finish boards module valid combinations bool ModuleData::isInternalModuleAvailable(int moduleType)
- [ ] on change of internal module type update each model if protocol not supported by module
- [x] yaml for field post merge
- [x] set default internal module where appropriate (conversion from older formats, new file, etc)