### PR TITLE
Companion hardware internal module continued

### DIFF
--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -813,10 +813,11 @@ StringTagMappingTable Boards::getTrimSourcesLookupTable(Board::Type board)
 QList<int> Boards::getSupportedInternalModules(Board::Type board)
 {
   QList<int> modules;
+  modules = {(int)MODULE_TYPE_NONE};
   if (IS_TARANIS_X9DP_2019(board) || IS_TARANIS_X7_ACCESS(board)) {
-    modules = {(int)MODULE_TYPE_ISRM_PXX2};
+    modules.append({(int)MODULE_TYPE_ISRM_PXX2});
   } else if (IS_FLYSKY_NV14(board)) {
-    modules = {(int)MODULE_TYPE_FLYSKY};
+    modules.append({(int)MODULE_TYPE_FLYSKY});
   } else if (IS_FAMILY_HORUS_OR_T16(board) || IS_FAMILY_T12(board)
              || (IS_TARANIS_SMALL(board) && IS_ACCESS_RADIO(board))) {
     modules.append({
@@ -826,7 +827,7 @@ QList<int> Boards::getSupportedInternalModules(Board::Type board)
         (int)MODULE_TYPE_MULTIMODULE,
     });
   } else if (IS_TARANIS(board)) {
-    modules = {(int)MODULE_TYPE_XJT_PXX1};
+    modules.append({(int)MODULE_TYPE_XJT_PXX1});
   }
 
   return modules;

--- a/companion/src/firmwares/boards.h
+++ b/companion/src/firmwares/boards.h
@@ -212,7 +212,6 @@ class Boards
     static QString potTypeToString(int value);
     static QString sliderTypeToString(int value);
     static QString switchTypeToString(int value);
-    static QString intModuleTypeToString(int value);
     static AbstractStaticItemModel * potTypeItemModel();
     static AbstractStaticItemModel * sliderTypeItemModel();
     static AbstractStaticItemModel * switchTypeItemModel();
@@ -221,7 +220,7 @@ class Boards
     static StringTagMappingTable getTrimSourcesLookupTable(Board::Type board);
     static QList<int> getSupportedInternalModules(Board::Type board);
     static int getDefaultInternalModules(Board::Type board);
-  
+
   protected:
 
     Board::Type m_boardType;

--- a/companion/src/firmwares/moduledata.cpp
+++ b/companion/src/firmwares/moduledata.cpp
@@ -381,7 +381,7 @@ bool ModuleData::isProtocolAvailable(int moduleidx, unsigned int protocol, Gener
   Firmware *fw = getCurrentFirmware();
   Board::Type board = fw->getBoard();
 
-  if (moduleidx == 0 && Boards::getCapability(board, Board::HasInternalModuleSupport))
+  if (moduleidx == 0)
     return (int)settings.internalModule == getTypeFromProtocol(protocol);
 
   QString id = fw->getId();

--- a/companion/src/generaledit/generaledit.cpp
+++ b/companion/src/generaledit/generaledit.cpp
@@ -66,8 +66,11 @@ GeneralEdit::GeneralEdit(QWidget * parent, RadioData & radioData, Firmware * fir
   addTab(new GeneralSetupPanel(this, generalSettings, firmware), tr("Setup"));
   addTab(new CustomFunctionsPanel(this, nullptr, generalSettings, firmware, editorItemModels), tr("Global Functions"));
   addTab(new TrainerPanel(this, generalSettings, firmware, editorItemModels), tr("Trainer"));
-  addTab(new HardwarePanel(this, generalSettings, firmware, editorItemModels), tr("Hardware"));
+  auto hwpnl = new HardwarePanel(this, generalSettings, firmware, editorItemModels);
+  addTab(hwpnl, tr("Hardware"));
   addTab(new CalibrationPanel(this, generalSettings, firmware), tr("Calibration"));
+
+  connect(hwpnl, &HardwarePanel::internalModuleChanged, this, [&] { intModChanged = true; });
 
   ui->tabWidget->setCurrentIndex( g.generalEditTab() );
 }
@@ -81,6 +84,8 @@ GeneralEdit::~GeneralEdit()
 void GeneralEdit::closeEvent(QCloseEvent *event)
 {
   g.generalEditTab(ui->tabWidget->currentIndex());
+  if (intModChanged)
+    emit internalModuleChanged(); // for MidiChild to trap
 }
 
 void GeneralEdit::addTab(GenericPanel *panel, QString text)

--- a/companion/src/generaledit/generaledit.h
+++ b/companion/src/generaledit/generaledit.h
@@ -47,6 +47,9 @@ class GeneralEdit : public QDialog
     GeneralEdit(QWidget * parent, RadioData & radioData, Firmware * firmware);
     ~GeneralEdit();
 
+  protected:
+    virtual void closeEvent(QCloseEvent *event) override;
+
   private:
     Ui::GeneralEdit *ui;
     GeneralSettings & generalSettings;
@@ -60,6 +63,7 @@ class GeneralEdit : public QDialog
 
   signals:
     void modified();
+    void internalModuleChanged();
 
   private slots:
     void onTabModified();
@@ -71,6 +75,6 @@ class GeneralEdit : public QDialog
     Firmware * firmware;
     QVector<GenericPanel *> panels;
     void addTab(GenericPanel *panel, QString text);
-    void closeEvent(QCloseEvent *event);
     CompoundItemModelFactory *editorItemModels;
+    bool intModChanged = false;
 };

--- a/companion/src/generaledit/hardware.cpp
+++ b/companion/src/generaledit/hardware.cpp
@@ -132,15 +132,13 @@ HardwarePanel::HardwarePanel(QWidget * parent, GeneralSettings & generalSettings
   }
 
   if (Boards::getCapability(board, Board::HasInternalModuleSupport)) {
+    m_internalModule = generalSettings.internalModule; // to permit undo
     addLabel(tr("Internal module"), row, 0);
-    AutoComboBox *internalModule = new AutoComboBox(this);
+    internalModule = new AutoComboBox(this);
     internalModule->setModel(tabFilteredModels->getItemModel(FIM_INTERNALMODULES));
     internalModule->setField(generalSettings.internalModule, this);
     addParams(row, internalModule);
-    connect(internalModule, &AutoComboBox::currentDataChanged, this, [=] () {
-            QMessageBox::warning(this, CPN_STR_APP_NAME,
-                                 tr("ALERT: Check each model's internal module protocol to ensure it is compatible!"));
-    });
+    connect(internalModule, &AutoComboBox::currentDataChanged, this, &HardwarePanel::on_internalModuleChanged);
   }
 
   if (firmware->getCapability(HasTelemetryBaudrate)) {
@@ -204,6 +202,23 @@ HardwarePanel::HardwarePanel(QWidget * parent, GeneralSettings & generalSettings
 HardwarePanel::~HardwarePanel()
 {
   delete tabFilteredModels;
+}
+
+void HardwarePanel::on_internalModuleChanged()
+{
+  if (QMessageBox::warning(this, CPN_STR_APP_NAME,
+                       tr("Warning: Changing the Internal module may invalidate the internal module protocol of one or more models!"),
+                       QMessageBox::Abort | QMessageBox::Ok, QMessageBox::Abort) != QMessageBox::Ok) {
+
+    generalSettings.internalModule = m_internalModule;
+    internalModule->updateValue();
+  }
+  else {
+    m_internalModule = generalSettings.internalModule;
+
+    QMessageBox::information(this, CPN_STR_APP_NAME,
+                       tr("Important: You are advised to check the internal module protocol for all models."));
+  }
 }
 
 void HardwarePanel::addStick(int index, int & row)

--- a/companion/src/generaledit/hardware.cpp
+++ b/companion/src/generaledit/hardware.cpp
@@ -207,17 +207,15 @@ HardwarePanel::~HardwarePanel()
 void HardwarePanel::on_internalModuleChanged()
 {
   if (QMessageBox::warning(this, CPN_STR_APP_NAME,
-                       tr("Warning: Changing the Internal module may invalidate the internal module protocol of one or more models!"),
-                       QMessageBox::Abort | QMessageBox::Ok, QMessageBox::Abort) != QMessageBox::Ok) {
+                       tr("Warning: Changing the Internal module may invalidate the internal module protocol of the models!"),
+                       QMessageBox::Cancel | QMessageBox::Ok, QMessageBox::Cancel) != QMessageBox::Ok) {
 
     generalSettings.internalModule = m_internalModule;
     internalModule->updateValue();
   }
   else {
     m_internalModule = generalSettings.internalModule;
-
-    QMessageBox::information(this, CPN_STR_APP_NAME,
-                       tr("Important: You are advised to check the internal module protocol for all models."));
+    emit internalModuleChanged();
   }
 }
 

--- a/companion/src/generaledit/hardware.h
+++ b/companion/src/generaledit/hardware.h
@@ -35,6 +35,9 @@ class HardwarePanel : public GeneralPanel
     HardwarePanel(QWidget * parent, GeneralSettings & generalSettings, Firmware * firmware, CompoundItemModelFactory * editorItemModels);
     virtual ~HardwarePanel();
 
+  signals:
+    void internalModuleChanged();
+
   private slots:
     void on_internalModuleChanged();
 

--- a/companion/src/generaledit/hardware.h
+++ b/companion/src/generaledit/hardware.h
@@ -25,6 +25,7 @@
 class CompoundItemModelFactory;
 class FilteredItemModelFactory;
 class QGridLayout;
+class AutoComboBox;
 
 class HardwarePanel : public GeneralPanel
 {
@@ -34,11 +35,16 @@ class HardwarePanel : public GeneralPanel
     HardwarePanel(QWidget * parent, GeneralSettings & generalSettings, Firmware * firmware, CompoundItemModelFactory * editorItemModels);
     virtual ~HardwarePanel();
 
+  private slots:
+    void on_internalModuleChanged();
+
   private:
     Board::Type board;
     CompoundItemModelFactory *editorItemModels;
     FilteredItemModelFactory *tabFilteredModels;
     QGridLayout *grid;
+    AutoComboBox *internalModule;
+    unsigned int m_internalModule = 0;
 
     void addStick(int index, int & row);
     void addPot(int index, int & row);

--- a/companion/src/mainwindow.h
+++ b/companion/src/mainwindow.h
@@ -50,6 +50,7 @@ class MainWindow : public QMainWindow
     void firmwareDownloadCompleted();
     void firmwareChanged();
     void startSync();
+    void onInternalModuleChanged();
 
   protected:
     QString getCompanionUpdateBaseUrl() const;

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1643,44 +1643,32 @@ bool MdiChild::loadBackup()
 #endif
 }
 
-QDialog * MdiChild::getChildDialog(QRegularExpression & regexp)
-{
-  QList<QDialog *>dlgs = findChildren<QDialog *>();
-
-  for (QDialog *dlg : dlgs) {
-    if (dlg->windowTitle().contains(regexp))
-      return dlg;
-  }
-
-  return nullptr;
-}
-
-QDialog * MdiChild::getModelEditDialog(int row)
-{
-  QRegularExpression regexp(QString(tr("^Editing model %1:*")).arg(row + 1), QRegularExpression::CaseInsensitiveOption);  //  to be safe use case insensitive
-
-  return getChildDialog(regexp);
-}
-
-QList<QDialog *> * MdiChild::getChildrenDialogsList(QRegularExpression & regexp)
+QList<QDialog *> * MdiChild::getModelEditDialogsList()
 {
   QList<QDialog *> *ret = new QList<QDialog *>();
 
-  QList<QDialog *>dlgs = findChildren<QDialog *>();
+  QList<QDialog *> dlgs = findChildren<QDialog *>();
 
   for (QDialog *dlg : dlgs) {
-    if (dlg->windowTitle().contains(regexp))
+    ModelEdit * med = dynamic_cast<ModelEdit *>(dlg);
+    if (med)
       ret->append(dlg);
   }
 
   return ret;
 }
 
-QList<QDialog *> * MdiChild::getModelEditDialogsList()
+QDialog * MdiChild::getModelEditDialog(int row)
 {
-  QRegularExpression regexp(QString(tr("^Editing model *")), QRegularExpression::CaseInsensitiveOption);  //  to be safe use case insensitive
+  QList<QDialog *> *dlgs = getModelEditDialogsList();
 
-  return getChildrenDialogsList(regexp);
+  for (QDialog *dlg : *dlgs) {
+    ModelEdit * med = dynamic_cast<ModelEdit *>(dlg);
+    if (med && med->getModelId() == row)
+      return med;
+  }
+
+  return nullptr;
 }
 
 void MdiChild::onInternalModuleChanged()

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -32,6 +32,7 @@
 #include "storage.h"
 #include "radiointerface.h"
 #include "radiodataconversionstate.h"
+#include "filtereditemmodels.h"
 
 #include <algorithm>
 #include <ExportableTableView>
@@ -1095,9 +1096,15 @@ void MdiChild::pasteGeneralData(const QMimeData * mimeData)
 
 void MdiChild::generalEdit()
 {
+  if (getModelEditDialogsList()->count() > 0) {
+    QMessageBox::information(this, CPN_STR_APP_NAME, tr("Unable to Edit Radio Settings whilst models are open for editing."));
+    return;
+  }
+
   GeneralEdit * t = new GeneralEdit(this, radioData, firmware);
   connect(t, &GeneralEdit::modified, this, &MdiChild::setModified);
-  t->show();
+  connect(t, &GeneralEdit::internalModuleChanged, this, &MdiChild::onInternalModuleChanged);  // passed up from HardwarePanel >> GeneralEdit
+  t->exec();
 }
 
 void MdiChild::copyGeneralSettings()
@@ -1263,6 +1270,13 @@ void MdiChild::openModelEditWindow(int row)
 {
   if (row < 0 && (row = getCurrentModel()) < 0)
     return;
+
+  QDialog * med = getModelEditDialog(row);
+  if (med) {
+    med->activateWindow();
+    med->raise();
+    return;
+  }
 
   QApplication::setOverrideCursor(Qt::WaitCursor);
   checkAndInitModel(row);
@@ -1627,4 +1641,75 @@ bool MdiChild::loadBackup()
 #else
   return false;
 #endif
+}
+
+QDialog * MdiChild::getChildDialog(QRegularExpression & regexp)
+{
+  QList<QDialog *>dlgs = findChildren<QDialog *>();
+
+  for (QDialog *dlg : dlgs) {
+    if (dlg->windowTitle().contains(regexp))
+      return dlg;
+  }
+
+  return nullptr;
+}
+
+QDialog * MdiChild::getModelEditDialog(int row)
+{
+  QRegularExpression regexp(QString(tr("^Editing model %1:*")).arg(row + 1), QRegularExpression::CaseInsensitiveOption);  //  to be safe use case insensitive
+
+  return getChildDialog(regexp);
+}
+
+QList<QDialog *> * MdiChild::getChildrenDialogsList(QRegularExpression & regexp)
+{
+  QList<QDialog *> *ret = new QList<QDialog *>();
+
+  QList<QDialog *>dlgs = findChildren<QDialog *>();
+
+  for (QDialog *dlg : dlgs) {
+    if (dlg->windowTitle().contains(regexp))
+      ret->append(dlg);
+  }
+
+  return ret;
+}
+
+QList<QDialog *> * MdiChild::getModelEditDialogsList()
+{
+  QRegularExpression regexp(QString(tr("^Editing model *")), QRegularExpression::CaseInsensitiveOption);  //  to be safe use case insensitive
+
+  return getChildrenDialogsList(regexp);
+}
+
+void MdiChild::onInternalModuleChanged()
+{
+  FilteredItemModel * fim = new FilteredItemModel(ModuleData::protocolItemModel(radioData.generalSettings), 0 + 1/*flag cannot be 0*/);
+
+  int cnt = 0;
+
+  for (unsigned int i = 0; i < radioData.models.size(); i++) {
+    ModuleData & module = radioData.models[i].moduleData[0];
+    bool found = false;
+
+    for (int j = 0; j < fim->rowCount(); j++) {
+      if (fim->data(fim->index(j, 0), AbstractItemModel::IMDR_Id).toInt() == (int)module.protocol) {
+        found = true;
+        break;
+      }
+    }
+
+    if (!found) {
+      module.clear();
+      cnt++;
+    }
+  }
+
+  if (cnt > 0) {
+    QMessageBox::warning(this, CPN_STR_APP_NAME, tr("Internal module protocol changed to <b>OFF</b> for %1 models!").arg(cnt));
+    setModified();
+  }
+
+  delete fim;
 }

--- a/companion/src/mdichild.h
+++ b/companion/src/mdichild.h
@@ -117,6 +117,7 @@ class MdiChild : public QWidget
     void onItemSelected(const QModelIndex &);
     void onCurrentItemChanged(const QModelIndex &, const QModelIndex &);
     void onDataChanged(const QModelIndex & index);
+    void onInternalModuleChanged();
 
     void generalEdit();
     void copyGeneralSettings();
@@ -183,6 +184,10 @@ class MdiChild : public QWidget
     bool convertStorage(Board::Type from, Board::Type to, bool newFile = false);
     void showWarning(const QString & msg);
     int askQuestion(const QString & msg, QMessageBox::StandardButtons buttons = (QMessageBox::Yes | QMessageBox::No), QMessageBox::StandardButton defaultButton = QMessageBox::No);
+    QDialog * getChildDialog(QRegularExpression & regexp);
+    QDialog * getModelEditDialog(int row);
+    QList<QDialog *> * getChildrenDialogsList(QRegularExpression & regexp);
+    QList<QDialog *> * getModelEditDialogsList();
 
     Ui::MdiChild * ui;
     TreeModel * modelsListModel;

--- a/companion/src/modeledit/modeledit.cpp
+++ b/companion/src/modeledit/modeledit.cpp
@@ -49,6 +49,7 @@ ModelEdit::ModelEdit(QWidget * parent, RadioData & radioData, int modelId, Firmw
 
   ui->setupUi(this);
   setWindowIcon(CompanionIcon("edit.png"));
+  setAttribute(Qt::WA_DeleteOnClose);
   restoreGeometry(g.modelEditGeo());
   ui->pushButton->setIcon(CompanionIcon("simulate.png"));
 

--- a/companion/src/modeledit/modeledit.h
+++ b/companion/src/modeledit/modeledit.h
@@ -48,6 +48,8 @@ class ModelEdit : public QDialog
     ModelEdit(QWidget * parent, RadioData & radioData, int modelId, Firmware * firmware);
     ~ModelEdit();
 
+    int getModelId() { return modelId; }
+
   protected:
     void closeEvent(QCloseEvent *event);
 

--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -28,6 +28,7 @@
 #include "multiprotocols.h"
 #include "checklistdialog.h"
 #include "helpers.h"
+#include "moduledata.h"
 
 #include <QDir>
 
@@ -240,6 +241,23 @@ ModulePanel::ModulePanel(QWidget * parent, ModelData & model, ModuleData & modul
   if (panelFilteredItemModels && moduleIdx >= 0) {
     int id = panelFilteredItemModels->registerItemModel(new FilteredItemModel(ModuleData::protocolItemModel(generalSettings), moduleIdx + 1/*flag cannot be 0*/), QString("Module Protocol %1").arg(moduleIdx));
     ui->protocol->setModel(panelFilteredItemModels->getItemModel(id));
+
+    if (ui->protocol->findData(module.protocol) < 0) {
+      QString msg = tr("Warning: The internal module protocol <b>%1</b> is incompatible with the hardware internal module <b>%2</b> and has been set to <b>OFF</b>!");
+      msg = msg.arg(module.protocolToString(module.protocol)).arg(ModuleData::typeToString(generalSettings.internalModule));
+
+      QMessageBox *msgBox = new QMessageBox(this);
+      msgBox->setIcon( QMessageBox::Warning );
+      msgBox->setText(msg);
+      msgBox->addButton( "Ok", QMessageBox::AcceptRole );
+      msgBox->setWindowFlag(Qt::WindowStaysOnTopHint);
+      msgBox->setAttribute(Qt::WA_DeleteOnClose); // delete pointer after close
+      msgBox->setModal(false);
+      msgBox->show();
+
+      module.clear();
+    }
+
     ui->protocol->setField(module.protocol, this);
   }
 


### PR DESCRIPTION
Summary of changes:
- allow user the opportunity cancel hardware internal module update
- after hardware change, check and update all models internal module protocol to OFF if incompatible
- on model edit load, check and update model internal module protocol to OFF if incompatible
- fixed: do not allow radio settings to be edited whilst any models are in edit mode ~~(requires internationalization testing)~~
- fixed: prevent multiple edit instances of same model ~~(requires internationalization testing)~~
- fixed: destroy model edit dialog on close and reduce memory bloat
- fixed: change Edit Radio Settings to modal dialog
