### PR TITLE
YAML Trainer data: iterate through nodes rather than assuming their presence

### DIFF
--- a/companion/src/firmwares/edgetx/yaml_trainerdata.cpp
+++ b/companion/src/firmwares/edgetx/yaml_trainerdata.cpp
@@ -61,19 +61,8 @@ Node convert<TrainerData>::encode(const TrainerData& rhs)
 
 bool convert<TrainerData>::decode(const Node& node, TrainerData& rhs)
 {
-  if (node["calib"]) {
-    const Node& calib = node["calib"];
-    for (int i = 0; i < 4; i++) {
-      calib[std::to_string(i)]["val"] >> rhs.calib[i];
-    }
-  }
-
-  if (node["mix"]) {
-    const Node& mix = node["mix"];
-    for (int i = 0; i < 4; i++) {
-      mix[std::to_string(i)] >> rhs.mix[i];
-    }
-  }
+  node["calib"] >> rhs.calib;
+  node["mix"] >> rhs.mix;
   return true;
 }
 


### PR DESCRIPTION
Resolves #1349

Fixes reading this:
```yaml
trainer: 
   calib: 
      2:
         val: -512
      3:
         val: -3
   mix: 
      0:
         srcChn: 3
         mode: ADD
         studWeight: 100
      1:
         srcChn: 1
         mode: ADD
         studWeight: 100
      2:
         srcChn: 2
         mode: ADD
         studWeight: 100
      3:
         srcChn: 0
         mode: ADD
         studWeight: 100
```