### PR TITLE
Fix bit mask generation

### DIFF
--- a/radio/src/storage/yaml/yaml_bits.cpp
+++ b/radio/src/storage/yaml/yaml_bits.cpp
@@ -23,12 +23,18 @@
 #include "yaml_bits.h"
 #include "yaml_parser.h"
 
-#define MASK_LOWER(bits) ((1 << (bits)) - 1)
+#include <limits.h>     /* CHAR_BIT */
+
+#define BIT_MASK(__TYPE__, __ONE_COUNT__) \
+    ((__TYPE__) (-((__ONE_COUNT__) != 0))) \
+    & (((__TYPE__) -1) >> ((sizeof(__TYPE__) * CHAR_BIT) - (__ONE_COUNT__)))
+
+#define MASK_LOWER(bits) BIT_MASK(uint32_t, bits)
 #define MASK_UPPER(bits) (0xFF << bits)
 
 void yaml_put_bits(uint8_t* dst, uint32_t i, uint32_t bit_ofs, uint32_t bits)
 {
-    i &= ((1UL << bits) - 1);
+    i &= MASK_LOWER(bits);
 
     if (bit_ofs) {
 


### PR DESCRIPTION
Avoids overflowing when the bit mask should be 32bits long.

Resolves #1351