### PR TITLE
Companion re-enable custom screens with sd card themes

### DIFF
--- a/companion/src/modeledit/modeledit.cpp
+++ b/companion/src/modeledit/modeledit.cpp
@@ -106,12 +106,11 @@ ModelEdit::ModelEdit(QWidget * parent, RadioData & radioData, int modelId, Firmw
     s1.report("Telemetry");
   }
 
-  //  temporary hide
-  /*if (Boards::getCapability(firmware->getBoard(), Board::HasColorLcd)) {
+  if (Boards::getCapability(firmware->getBoard(), Board::HasColorLcd)) {
     addTab(new ColorCustomScreensPanel(this, model, generalSettings, firmware, sharedItemModels), tr("Custom Screens"));
     s1.report("ColorLcd Custom Screens");
   }
-  else */if (firmware->getCapability(TelemetryCustomScreens)) {
+  else if (firmware->getCapability(TelemetryCustomScreens)) {
     addTab(new TelemetryCustomScreensPanel(this, model, generalSettings, firmware, sharedItemModels), tr("Custom Screens"));
     s1.report("Telemetry Custom Screens");
   }


### PR DESCRIPTION
Summary of changes:
- re-enable custom screens disabled in yaml PR
- change themes to use sd card

Note: if the profile sd card is not a copy of the radio sd card then Companion has the potential to display the incorrect theme.

Future enhancement is for read models and settings from radio to also copy the /THEMES/selectedtheme.txt file to the etx file.