### PR TITLE
Remove calibration check when asserting availability of 6-pos switch positions

### DIFF
--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -333,13 +333,7 @@ bool isSwitchAvailable(int swtch, SwitchContext context)
 #if NUM_XPOTS > 0
   if (swtch >= SWSRC_FIRST_MULTIPOS_SWITCH && swtch <= SWSRC_LAST_MULTIPOS_SWITCH) {
     int index = (swtch - SWSRC_FIRST_MULTIPOS_SWITCH) / XPOTS_MULTIPOS_COUNT;
-    if (IS_POT_MULTIPOS(POT1+index)) {
-      StepsCalibData * calib = (StepsCalibData *) &g_eeGeneral.calib[POT1+index];
-      return (calib->count >= ((swtch - SWSRC_FIRST_MULTIPOS_SWITCH) % XPOTS_MULTIPOS_COUNT));
-    }
-    else {
-      return false;
-    }
+    return IS_POT_MULTIPOS(POT1+index);
   }
 #endif
 


### PR DESCRIPTION
# Description

Currently, if your 6POS is not calibrated correctly, you cannot select anything but the first position in switch select drop-downs, because `isSwitchAvailable()` verifies that the 6POS has the number of calibrated positions before letting you choose these positions, which is an issue in simulation, as you cannot really calibrate the 6POS properly.

Further, I think it might be confusing to not be able to select a switch position just because the calibration is off.

# Proposed change

This PR removes the check for calibrated positions.