### PR TITLE
Fallback to model file scanning if models.yml cannot be read

### DIFF
--- a/companion/src/firmwares/edgetx/edgetxinterface.cpp
+++ b/companion/src/firmwares/edgetx/edgetxinterface.cpp
@@ -111,13 +111,25 @@ bool writeModelsListToYaml(const std::vector<CategoryData>& categories,
 {
   YAML::Node node;
   std::vector<CategoryData> cats = categories;
+  std::vector<EtxModelMetadata> files = { modelFiles.begin(), modelFiles.end() };
+
+  std::stable_sort(files.begin(), files.end(),
+                   [](const EtxModelMetadata &a, const EtxModelMetadata &b) {
+                     return a.category < b.category;
+                   });
+
+  int catIdx = 0;
+  for (const auto& cat : cats) {
+    node[catIdx++][cat.name] = YAML::Node();
+  }
+
   for (const auto& modelFile: modelFiles) {
 
     YAML::Node cat_attrs;
     cat_attrs["filename"] = modelFile.filename;
     cat_attrs["name"] = modelFile.name;
 
-    auto catIdx = modelFile.category;
+    catIdx = modelFile.category;
     if (catIdx >= (int)cats.size()) {
       catIdx = 0;
       if (cats.size() == 0) {

--- a/companion/src/firmwares/edgetx/edgetxinterface.cpp
+++ b/companion/src/firmwares/edgetx/edgetxinterface.cpp
@@ -51,34 +51,27 @@ bool loadModelsListFromYaml(std::vector<CategoryData>& categories,
   if (data.size() == 0)
     return true;
 
-  try {
-    YAML::Node node = loadYamlFromByteArray(data);
-    if (!node.IsSequence()) return false;
+  YAML::Node node = loadYamlFromByteArray(data);
+  if (!node.IsSequence()) return false;
 
-    int modelIdx = 0;
-    for (const auto& cat : node) {
+  int modelIdx = 0;
+  for (const auto& cat : node) {
+    if (!cat.IsMap()) continue;
 
-      if (!cat.IsMap()) continue;
+    for (const auto& cat_map : cat) {
+      categories.push_back(cat_map.first.Scalar().c_str());
 
-      for (const auto& cat_map : cat) {
-        categories.push_back(cat_map.first.Scalar().c_str());
+      const auto& models = cat_map.second;
+      if (!models.IsSequence()) continue;
 
-        const auto& models = cat_map.second;
-        if (!models.IsSequence()) continue;
-
-        for (const auto& model : models) {
-          std::string filename, name;
-          model["filename"] >> filename;
-          model["name"] >> name;
-          modelFiles.push_back(
-              {filename, name, (int)categories.size() - 1, modelIdx++});
-        }
+      for (const auto& model : models) {
+        std::string filename, name;
+        model["filename"] >> filename;
+        model["name"] >> name;
+        modelFiles.push_back(
+            {filename, name, (int)categories.size() - 1, modelIdx++});
       }
     }
-
-  } catch (const std::runtime_error& e) {
-    qDebug() << "YAML::ParserException: " << e.what();
-    return false;
   }
 
   return true;

--- a/companion/src/firmwares/edgetx/edgetxinterface.cpp
+++ b/companion/src/firmwares/edgetx/edgetxinterface.cpp
@@ -110,18 +110,23 @@ bool writeModelsListToYaml(const std::vector<CategoryData>& categories,
                            QByteArray& data)
 {
   YAML::Node node;
+  std::vector<CategoryData> cats = categories;
   for (const auto& modelFile: modelFiles) {
 
     YAML::Node cat_attrs;
     cat_attrs["filename"] = modelFile.filename;
     cat_attrs["name"] = modelFile.name;
 
-    if (modelFile.category >= (int)categories.size()) {
-      return false;
+    auto catIdx = modelFile.category;
+    if (catIdx >= (int)cats.size()) {
+      catIdx = 0;
+      if (cats.size() == 0) {
+        cats.push_back("Models");
+      }
     }
 
-    const std::string cat_name = categories[modelFile.category].name;
-    node[modelFile.category][cat_name].push_back(cat_attrs);
+    const std::string cat_name = cats[catIdx].name;
+    node[catIdx][cat_name].push_back(cat_attrs);
   }
 
   writeYamlToByteArray(node, data);

--- a/companion/src/modelslist.cpp
+++ b/companion/src/modelslist.cpp
@@ -689,6 +689,7 @@ void TreeModel::refresh()
             defaultCategoryItem = rootItem->appendChild(0, -1);
             /*: Translators do NOT use accent for this, this is the default category name on Horus. */
             defaultCategoryItem->setData(0, tr("Models"));
+            radioData->categories.push_back(qPrintable(tr("Models")));
           }
           categoryItem = defaultCategoryItem;
         }

--- a/companion/src/radiointerface.cpp
+++ b/companion/src/radiointerface.cpp
@@ -211,7 +211,11 @@ bool readSettingsSDCard(const QString & filename, ProgressWidget * progress)
   RadioData radioData;
   Storage inputStorage(radioPath);
   if (!inputStorage.load(radioData)) {
-    QMessageBox::critical(progress, CPN_STR_TTL_ERROR, QCoreApplication::translate("RadioInterface", "Failed to read Models and Settings from") % radioPath);
+    QString errorMsg = inputStorage.error();
+    if (errorMsg.isEmpty()) {
+      errorMsg = QCoreApplication::translate("RadioInterface", "Failed to read Models and Settings from") % radioPath;
+    }
+    QMessageBox::critical(progress, CPN_STR_TTL_ERROR, errorMsg);
     return false;
   }
   Storage outputStorage(filename);

--- a/companion/src/radiointerface.cpp
+++ b/companion/src/radiointerface.cpp
@@ -220,7 +220,7 @@ bool readSettingsSDCard(const QString & filename, ProgressWidget * progress)
   }
   Storage outputStorage(filename);
   if (!outputStorage.write(radioData)) {
-    QMessageBox::critical(progress, CPN_STR_TTL_ERROR, QCoreApplication::translate("RadioInterface", "Failed to write Models and Setting file") % filename);
+    QMessageBox::critical(progress, CPN_STR_TTL_ERROR, QCoreApplication::translate("RadioInterface", "Failed to write Models and Setting file") % " " % filename);
     return false;
   }
 

--- a/companion/src/storage/categorized.cpp
+++ b/companion/src/storage/categorized.cpp
@@ -307,6 +307,8 @@ bool CategorizedStorageFormat::loadYaml(RadioData & radioData)
   }
 
   int modelIdx = 0;
+  bool hasCategories = getCurrentFirmware()->getCapability(HasModelCategories);
+
   radioData.models.resize(modelFiles.size());
   for (const auto& mc : modelFiles) {
     qDebug() << "Filename: " << mc.filename.c_str() << " / Category: " << mc.category;
@@ -321,7 +323,7 @@ bool CategorizedStorageFormat::loadYaml(RadioData & radioData)
     // Please note:
     //  ModelData() use memset to clear everything to 0
     //
-    auto& model = radioData.models[modelIdx++];
+    auto& model = radioData.models[modelIdx];
 
     try {
       if (!loadModelFromYaml(model,modelBuffer)) {
@@ -334,10 +336,17 @@ bool CategorizedStorageFormat::loadYaml(RadioData & radioData)
     }
 
     model.category = mc.category;
-    model.modelIndex = mc.modelIdx;
+    model.modelIndex = modelIdx;
     strncpy(model.filename, mc.filename.c_str(), sizeof(model.filename)-1);
 
+    if (hasCategories && !strncmp(radioData.generalSettings.currModelFilename,
+                                  model.filename, sizeof(model.filename))) {
+      radioData.generalSettings.currModelIndex = modelIdx;
+      qDebug() << "currModelIndex =" << modelIdx;
+    }
+
     model.used = true;
+    modelIdx++;
   }
 
   return true;


### PR DESCRIPTION
Changes:
- properly catch YAML load exception
- fall back to scanning the `/MODELS` directory in case `models.yml` cannot be loaded.