### PR TITLE
Load radio settings before power on delay is evaluated

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1748,8 +1748,14 @@ void opentxInit()
   menuHandlers[1] = menuModelSelect;
 #endif
 
-#if defined(EEPROM)
+#if defined(STARTUP_ANIMATION)
+  lcdRefreshWait();
+  lcdClear();
+  lcdRefresh();
+  lcdRefreshWait();
+
   bool radioSettingsValid = storageReadRadioSettings(false);
+  (void)radioSettingsValid;
 #endif
 
   BACKLIGHT_ENABLE(); // we start the backlight during the startup animation

--- a/radio/src/storage/sdcard_common.h
+++ b/radio/src/storage/sdcard_common.h
@@ -76,6 +76,8 @@ uint8_t findEmptyModel(uint8_t id, bool down);
 
 #endif
 
+bool storageReadRadioSettings(bool checks);
+
 const char * loadRadioSettings();
 const char * writeGeneralSettings();
 

--- a/radio/src/storage/sdcard_yaml.cpp
+++ b/radio/src/storage/sdcard_yaml.cpp
@@ -475,3 +475,9 @@ const char * restoreModel(uint8_t idx, char *model_name)
 }
 
 #endif
+
+bool storageReadRadioSettings(bool checks)
+{
+  if (!sdMounted()) sdInit();
+  return loadRadioSettingsYaml() == nullptr;
+}


### PR DESCRIPTION
This PR reads the radio settings early enough so that the power on delay can be properly evaluated. However, this introduces an additional delay (mount SD card + read settings) which is quite noticeable.

A better implementation should use settings in EEPROM / FLASH to get rid of this delay. Similar techniques could be used for some settings which are needed early on color radios.

Resolves #1366
