### PR TITLE
Ghost MSP support

### DIFF
--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -489,10 +489,6 @@ PACK(struct ModuleData {
       int8_t refreshRate;  // definition as framelength for ppm (* 5 + 225 = time in 1/10 ms)
     } sbus);
     NOBACKUP(struct {
-      uint8_t raw12bits:1;
-      uint8_t spare1:7;
-    } ghost);
-    NOBACKUP(struct {
       uint8_t receivers:7; // 4 bits spare
       uint8_t racingMode:1;
       char receiverName[PXX2_MAX_RECEIVERS_PER_MODULE][PXX2_LEN_RX_NAME];
@@ -532,6 +528,10 @@ PACK(struct ModuleData {
         rx_freq[1] = value >> 8;
       }
     } afhds3));
+    NOBACKUP(struct {
+      uint8_t raw12bits:1;
+      uint8_t spare1:7 SKIP;
+    } ghost);
   } NAME(mod) FUNC(select_mod_type);
 
   // Helper functions to set both of the rfProto protocol at the same time

--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -489,6 +489,10 @@ PACK(struct ModuleData {
       int8_t refreshRate;  // definition as framelength for ppm (* 5 + 225 = time in 1/10 ms)
     } sbus);
     NOBACKUP(struct {
+      uint8_t raw12bits:1;
+      uint8_t spare1:7;
+    } ghost);
+    NOBACKUP(struct {
       uint8_t receivers:7; // 4 bits spare
       uint8_t racingMode:1;
       char receiverName[PXX2_MAX_RECEIVERS_PER_MODULE][PXX2_LEN_RX_NAME];

--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -1651,6 +1651,10 @@ void menuModelSetup(event_t event)
           lcdDrawTextAlignedLeft(y, STR_WARN_BATTVOLTAGE);
           putsVolts(lcdLastRightPos, y, getBatteryVoltage(), attr | PREC2 | LEFT);
         }
+        else if (isModuleGhost(moduleIdx)) {
+          auto & module = g_model.moduleData[moduleIdx];
+          module.ghost.raw12bits = editCheckBox(module.ghost.raw12bits , MODEL_SETUP_2ND_COLUMN, y, INDENT "Raw 12 bits", attr, event);
+        }
         break;
       }
 

--- a/radio/src/gui/212x64/model_setup.cpp
+++ b/radio/src/gui/212x64/model_setup.cpp
@@ -1431,6 +1431,10 @@ void menuModelSetup(event_t event)
          lcdDrawTextAlignedLeft(y, STR_WARN_BATTVOLTAGE);
          putsVolts(lcdLastRightPos, y, getBatteryVoltage(), attr | PREC2 | LEFT);
        }
+       else if (isModuleGhost(moduleIdx)) {
+         auto & module = g_model.moduleData[moduleIdx];
+         module.ghost.raw12bits = editCheckBox(module.ghost.raw12bits , MODEL_SETUP_2ND_COLUMN, y, INDENT "Raw 12 bits", attr, event);
+       }
      }
      break;
 

--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -1255,6 +1255,11 @@ class ModuleWindow : public FormGroup {
         grid.nextLine();
       }
 
+      if (isModuleGhost(moduleIdx)) {
+          new StaticText(this, grid.getLabelSlot(true), "Raw 12 bits", 0, COLOR_THEME_PRIMARY1);
+          new CheckBox(this, grid.getFieldSlot(), GET_SET_DEFAULT(g_model.moduleData[moduleIdx].ghost.raw12bits));
+      }
+
       auto par = getParent();
       par->moveWindowsTop(top() + 1, adjustHeight());
       par->adjustInnerHeight();

--- a/radio/src/gui/gui_common.h
+++ b/radio/src/gui/gui_common.h
@@ -361,6 +361,8 @@ inline uint8_t MODULE_OPTION_ROW(uint8_t moduleIdx) {
     return TITLE_ROW;
   if(isModuleAFHDS3(moduleIdx))
     return HIDDEN_ROW;
+  if(isModuleGhost(moduleIdx))
+    return 0;
   return MULTIMODULE_OPTIONS_ROW(moduleIdx);
 }
 

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -812,6 +812,113 @@ static int luaCrossfireTelemetryPush(lua_State * L)
 }
 #endif
 
+#if defined(GHOST)
+/*luadoc
+@function ghostTelemetryPop()
+
+Pops a received Ghost Telemetry packet from the queue.
+
+@retval nil queue does not contain any (or enough) bytes to form a whole packet
+
+@retval multiple returns 2 values:
+ * type (number)
+ * packet (table) data bytes
+
+@status current Introduced in 2.7.0
+*/
+static int luaGhostTelemetryPop(lua_State * L)
+{
+  if (!luaInputTelemetryFifo) {
+    luaInputTelemetryFifo = new Fifo<uint8_t, LUA_TELEMETRY_INPUT_FIFO_SIZE>();
+    if (!luaInputTelemetryFifo) {
+      return 0;
+    }
+  }
+
+  uint8_t length = 0, data = 0;
+  if (luaInputTelemetryFifo->probe(length) && luaInputTelemetryFifo->size() >= uint32_t(length)) {
+    // length value includes type(1B), payload, crc(1B)
+    luaInputTelemetryFifo->pop(length);
+    luaInputTelemetryFifo->pop(data); // type
+    lua_pushnumber(L, data);          // return type
+    lua_newtable(L);
+    for (uint8_t i=0; i<length-2; i++) {
+      luaInputTelemetryFifo->pop(data);
+      lua_pushinteger(L, i+1);
+      lua_pushinteger(L, data);
+      lua_settable(L, -3);
+    }
+    return 2;
+  }
+
+  return 0;
+}
+
+/*luadoc
+@function ghostTelemetryPush()
+
+This functions allows for sending telemetry data toward the Ghost link.
+
+When called without parameters, it will only return the status of the output buffer without sending anything.
+
+@param command command
+
+@param data table of data bytes
+
+@retval boolean  data queued in output buffer or not.
+
+@retval nil      incorrect telemetry protocol.
+
+@status current Introduced in 2.7.0
+*/
+static int luaGhostTelemetryPush(lua_State * L)
+{
+  bool sport = (telemetryProtocol == PROTOCOL_TELEMETRY_GHOST);
+
+  if (!sport) {
+    lua_pushnil(L);
+    return 1;
+  }
+
+  if (lua_gettop(L) == 0) {
+    lua_pushboolean(L, outputTelemetryBuffer.isAvailable());
+  }
+  else if (lua_gettop(L) > TELEMETRY_OUTPUT_BUFFER_SIZE ) {
+    lua_pushboolean(L, false);
+    return 1;
+  }
+  else if (outputTelemetryBuffer.isAvailable()) {
+    uint8_t type = luaL_checkunsigned(L, 1);
+    luaL_checktype(L, 2, LUA_TTABLE);
+    uint8_t length = luaL_len(L, 2);              // payload length
+
+    if( length > 10 ) {                           // max 10B payload
+      lua_pushboolean(L, false);
+      return 1;
+    }
+
+    // Ghost frames are fixed 14B
+    outputTelemetryBuffer.pushByte(getGhostModuleAddr());         // addr (1B)
+    outputTelemetryBuffer.pushByte(12);           // len = payload length(10B) + type(1B) + crc(1B)
+    outputTelemetryBuffer.pushByte(type);         // type (1B)
+    for (int i=0; i<length; i++) {                // data, max 10B
+      lua_rawgeti(L, 2, i+1);
+      outputTelemetryBuffer.pushByte(luaL_checkunsigned(L, -1));
+    }
+    for (int i=0; i<10-length; i++) {             // fill zeroes to frame size
+      outputTelemetryBuffer.pushByte(0);
+    }
+    outputTelemetryBuffer.pushByte(crc8(outputTelemetryBuffer.data + 2, 11 ));  // Start at type, CRC over type (1B) + payload (10B)
+    outputTelemetryBuffer.setDestination(TELEMETRY_ENDPOINT_SPORT);
+    lua_pushboolean(L, true);
+  }
+  else {
+    lua_pushboolean(L, false);
+  }
+  return 1;
+}
+#endif
+
 /*luadoc
 @function getFieldInfo(source)
 
@@ -2292,6 +2399,10 @@ const luaL_Reg opentxLib[] = {
 #if defined(CROSSFIRE)
   { "crossfireTelemetryPop", luaCrossfireTelemetryPop },
   { "crossfireTelemetryPush", luaCrossfireTelemetryPush },
+#endif
+#if defined(GHOST)
+  { "ghostTelemetryPop", luaGhostTelemetryPop },
+  { "ghostTelemetryPush", luaGhostTelemetryPush },
 #endif
 #if defined(MULTIMODULE)
   { "multiBuffer", luaMultiBuffer },

--- a/radio/src/pulses/ghost.cpp
+++ b/radio/src/pulses/ghost.cpp
@@ -24,59 +24,73 @@
 uint8_t createGhostMenuControlFrame(uint8_t * frame, int16_t * pulses)
 {
   uint8_t * buf = frame;
-#if SPORT_MAX_BAUDRATE < 400000
-  *buf++ = g_eeGeneral.telemetryBaudrate == GHST_TELEMETRY_RATE_400K ? GHST_ADDR_MODULE_SYM : GHST_ADDR_MODULE_ASYM;
-#else
-  *buf++ = GHST_ADDR_MODULE_SYM;
-#endif
 
-  *buf++ = GHST_UL_RC_CHANS_SIZE;
-  uint8_t * crc_start = buf;
-  *buf++ = GHST_UL_MENU_CTRL;
+  *buf++ = getGhostModuleAddr();            // addr
+  *buf++ = GHST_UL_RC_CHANS_SIZE;           // length
+  const uint8_t * crc_start = buf;
+  *buf++ = GHST_UL_MENU_CTRL;               // type
+
+  // payload
   *buf++ = reusableBuffer.ghostMenu.buttonAction; // Joystick states, Up, Down, Left, Right, Press
   *buf++ = reusableBuffer.ghostMenu.menuAction;   // menu control, open, close, etc.
-
-  for (uint8_t i = 0; i < 8; i++)
+  for (uint8_t i = 0; i < 8; i++) {
     *buf++ = 0;   // padding to make this the same size as the pulses packet
+  }
 
+  // crc
   *buf++ = crc8(crc_start, GHST_UL_RC_CHANS_SIZE - 1);
 
   return buf - frame;
 }
 
 // Range for pulses (channels output) is [-1024:+1024]
-uint8_t createGhostChannelsFrame(uint8_t * frame, int16_t * pulses)
+uint8_t createGhostChannelsFrame(uint8_t * frame, int16_t * pulses, bool raw12bits)
 {
-  static uint8_t lastGhostFrameId = GHST_UL_RC_CHANS_HS4_5TO8;
+  static uint8_t lastGhostFrameId = 0;
   uint8_t ghostUpper4Offset = 0;
 
   switch (lastGhostFrameId) {
     case GHST_UL_RC_CHANS_HS4_5TO8:
-      ghostUpper4Offset = 0;
-      break;
-    case GHST_UL_RC_CHANS_HS4_9TO12:
+    case GHST_UL_RC_CHANS_HS4_12_5TO8:
+      lastGhostFrameId = raw12bits ? GHST_UL_RC_CHANS_HS4_12_9TO12 : GHST_UL_RC_CHANS_HS4_9TO12;
       ghostUpper4Offset = 4;
-      break;
-    case GHST_UL_RC_CHANS_HS4_13TO16:
+    break;
+
+    case GHST_UL_RC_CHANS_HS4_9TO12:
+    case GHST_UL_RC_CHANS_HS4_12_9TO12:
+      lastGhostFrameId = raw12bits ? GHST_UL_RC_CHANS_HS4_12_13TO16 : GHST_UL_RC_CHANS_HS4_13TO16;
       ghostUpper4Offset = 8;
       break;
+
+    case GHST_UL_RC_CHANS_HS4_13TO16:
+    case GHST_UL_RC_CHANS_HS4_12_13TO16:
+      lastGhostFrameId = raw12bits ? GHST_UL_RC_CHANS_HS4_12_5TO8 : GHST_UL_RC_CHANS_HS4_5TO8;
+      ghostUpper4Offset = 0;
+      break;
+
+    default:  // We don't have known previous state so init
+      lastGhostFrameId = raw12bits ? GHST_UL_RC_CHANS_HS4_12_5TO8 : GHST_UL_RC_CHANS_HS4_5TO8;
+      ghostUpper4Offset = 0;
+    break;
   }
 
   uint8_t * buf = frame;
-#if SPORT_MAX_BAUDRATE < 400000
-  *buf++ = g_eeGeneral.telemetryBaudrate == GHST_TELEMETRY_RATE_400K ? GHST_ADDR_MODULE_SYM : GHST_ADDR_MODULE_ASYM;
-#else
-  *buf++ = GHST_ADDR_MODULE_SYM;
-#endif
-  *buf++ = GHST_UL_RC_CHANS_SIZE;
+  *buf++ = getGhostModuleAddr();            // addr
+  *buf++ = GHST_UL_RC_CHANS_SIZE;           // len
   uint8_t * crc_start = buf;
-  *buf++ = lastGhostFrameId;
+  *buf++ = lastGhostFrameId;                // type
 
+  // payload
   // first 4 high speed, 12 bit channels (11 relevant bits with openTx)
   uint32_t bits = 0;
   uint8_t bitsavailable = 0;
   for (int i = 0; i < 4; i++) {
-    uint32_t value = limit(0, GHST_RC_CTR_VAL_12BIT + (((pulses[i] + 2 * PPM_CH_CENTER(i) - 2 * PPM_CENTER) << 3) / 5), 2 * GHST_RC_CTR_VAL_12BIT);
+    uint32_t value;
+    if(raw12bits) {
+      value = limit(0, (1024 + (pulses[i] + 2 * PPM_CH_CENTER(i) - 2 * PPM_CENTER)) << 1, 0xFFF);
+    } else {
+      value = limit(0, GHST_RC_CTR_VAL_12BIT + (((pulses[i] + 2 * PPM_CH_CENTER(i) - 2 * PPM_CENTER) << 3) / 5), 2 * GHST_RC_CTR_VAL_12BIT);
+    }
     bits |= value << bitsavailable;
     bitsavailable += GHST_CH_BITS_12;
     while (bitsavailable >= 8) {
@@ -89,22 +103,17 @@ uint8_t createGhostChannelsFrame(uint8_t * frame, int16_t * pulses)
   // second 4 lower speed, 8 bit channels
   for (int i = 4; i < 8; ++i) {
     uint8_t channelIndex = i + ghostUpper4Offset;
-    *buf++ = limit(0, GHST_RC_CTR_VAL_8BIT + (((pulses[channelIndex] + 2 * PPM_CH_CENTER(channelIndex) - 2 * PPM_CENTER) >> 1) / 5), 2 * GHST_RC_CTR_VAL_8BIT);
+    uint8_t value;
+    if(raw12bits) {
+      value = limit(0, 128 + ((pulses[channelIndex] + 2 * PPM_CH_CENTER(channelIndex) - 2 * PPM_CENTER) >> 3), 0xFF);
+    } else {
+      value = limit(0, GHST_RC_CTR_VAL_8BIT + (((pulses[channelIndex] + 2 * PPM_CH_CENTER(channelIndex) - 2 * PPM_CENTER) >> 1) / 5), 2 * GHST_RC_CTR_VAL_8BIT);
+    }
+    *buf++ = value;
   }
 
+  // crc
   *buf++ = crc8(crc_start, GHST_UL_RC_CHANS_SIZE - 1);
-
-  switch (lastGhostFrameId) {
-    case GHST_UL_RC_CHANS_HS4_5TO8:
-      lastGhostFrameId = GHST_UL_RC_CHANS_HS4_9TO12;
-      break;
-    case GHST_UL_RC_CHANS_HS4_9TO12:
-      lastGhostFrameId = GHST_UL_RC_CHANS_HS4_13TO16;
-      break;
-    case GHST_UL_RC_CHANS_HS4_13TO16:
-      lastGhostFrameId = GHST_UL_RC_CHANS_HS4_5TO8;
-      break;
-  }
 
   return buf - frame;
 }
@@ -113,11 +122,12 @@ void setupPulsesGhost()
 {
   if (telemetryProtocol == PROTOCOL_TELEMETRY_GHOST) {
     uint8_t * pulses = extmodulePulsesData.ghost.pulses;
-    if (moduleState[EXTERNAL_MODULE].counter == GHST_MENU_CONTROL)
-      extmodulePulsesData.ghost.length = createGhostMenuControlFrame(pulses, &channelOutputs[g_model.moduleData[EXTERNAL_MODULE].channelsStart]);
-    else
-      extmodulePulsesData.ghost.length = createGhostChannelsFrame(pulses, &channelOutputs[g_model.moduleData[EXTERNAL_MODULE].channelsStart]);
-
+    auto & module = g_model.moduleData[EXTERNAL_MODULE];
+    if (moduleState[EXTERNAL_MODULE].counter == GHST_MENU_CONTROL) {
+        extmodulePulsesData.ghost.length = createGhostMenuControlFrame(pulses, &channelOutputs[module.channelsStart]);
+    } else {
+        extmodulePulsesData.ghost.length = createGhostChannelsFrame(pulses, &channelOutputs[module.channelsStart], module.ghost.raw12bits);
+    }
     moduleState[EXTERNAL_MODULE].counter = GHST_FRAME_CHANNEL;
   }
 }

--- a/radio/src/pulses/ghost.cpp
+++ b/radio/src/pulses/ghost.cpp
@@ -121,12 +121,21 @@ uint8_t createGhostChannelsFrame(uint8_t * frame, int16_t * pulses, bool raw12bi
 void setupPulsesGhost()
 {
   if (telemetryProtocol == PROTOCOL_TELEMETRY_GHOST) {
-    uint8_t * pulses = extmodulePulsesData.ghost.pulses;
-    auto & module = g_model.moduleData[EXTERNAL_MODULE];
+
+    auto &module = g_model.moduleData[EXTERNAL_MODULE];
+    auto *p_data = &extmodulePulsesData.ghost;
+
+    #if defined(LUA)
+    if (outputTelemetryBuffer.destination == TELEMETRY_ENDPOINT_SPORT) {
+      memcpy(p_data->pulses, outputTelemetryBuffer.data, outputTelemetryBuffer.size);
+      p_data->length = outputTelemetryBuffer.size;
+      outputTelemetryBuffer.reset();
+    } else
+    #endif
     if (moduleState[EXTERNAL_MODULE].counter == GHST_MENU_CONTROL) {
-        extmodulePulsesData.ghost.length = createGhostMenuControlFrame(pulses, &channelOutputs[module.channelsStart]);
+        p_data->length = createGhostMenuControlFrame(p_data->pulses, &channelOutputs[module.channelsStart]);
     } else {
-        extmodulePulsesData.ghost.length = createGhostChannelsFrame(pulses, &channelOutputs[module.channelsStart], module.ghost.raw12bits);
+        p_data->length = createGhostChannelsFrame(p_data->pulses, &channelOutputs[module.channelsStart], module.ghost.raw12bits);
     }
     moduleState[EXTERNAL_MODULE].counter = GHST_FRAME_CHANNEL;
   }

--- a/radio/src/storage/conversions/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/conversions/yaml/yaml_datastructs_funcs.cpp
@@ -204,7 +204,7 @@ bool w_zov_color(void* user, uint8_t* data, uint32_t bitoffs,
 }
 #endif
 
-uint8_t select_mod_type(void* user, uint8_t* data, uint32_t bitoffs)
+static uint8_t select_mod_type(void* user, uint8_t* data, uint32_t bitoffs)
 {
     data += bitoffs >> 3UL;
     data -= offsetof(ModuleData, ppm);

--- a/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
@@ -39,7 +39,6 @@ namespace yaml_conv_220 {
   bool w_vbat_max(const YamlNode* node, uint32_t val, yaml_writer_func wf, void* opaque);
 
   uint8_t select_zov(void* user, uint8_t* data, uint32_t bitoffs);
-  uint8_t select_mod_type(void* user, uint8_t* data, uint32_t bitoffs);
   uint8_t select_script_input(void* user, uint8_t* data, uint32_t bitoffs);
   uint8_t select_id1(void* user, uint8_t* data, uint32_t bitoffs);
   uint8_t select_id2(void* user, uint8_t* data, uint32_t bitoffs);
@@ -433,7 +432,38 @@ bool w_zov_color(void* user, uint8_t* data, uint32_t bitoffs,
 
 static uint8_t select_mod_type(void* user, uint8_t* data, uint32_t bitoffs)
 {
-  return yaml_conv_220::select_mod_type(user, data, bitoffs);
+  data += bitoffs >> 3UL;
+  data -= offsetof(ModuleData, ppm);
+
+  ModuleData* mod_data = reinterpret_cast<ModuleData*>(data);
+  switch (mod_data->type) {
+    case MODULE_TYPE_NONE:
+    case MODULE_TYPE_PPM:
+    case MODULE_TYPE_DSM2:
+    case MODULE_TYPE_CROSSFIRE:
+      return 1;
+    case MODULE_TYPE_MULTIMODULE:
+      return 2;
+    case MODULE_TYPE_XJT_PXX1:
+    case MODULE_TYPE_R9M_PXX1:
+    case MODULE_TYPE_R9M_LITE_PXX1:
+      return 3;
+    case MODULE_TYPE_SBUS:
+      return 4;
+    case MODULE_TYPE_ISRM_PXX2:
+    case MODULE_TYPE_R9M_PXX2:
+    case MODULE_TYPE_R9M_LITE_PXX2:
+    case MODULE_TYPE_R9M_LITE_PRO_PXX2:
+    case MODULE_TYPE_XJT_LITE_PXX2:
+      return 5;
+    case MODULE_TYPE_FLYSKY:
+      if (mod_data->subType == FLYSKY_SUBTYPE_AFHDS2A) return 6;
+      if (mod_data->subType == FLYSKY_SUBTYPE_AFHDS3) return 7;
+      break;
+    case MODULE_TYPE_GHOST:
+      return 8;
+  }
+  return 0;
 }
 
 static uint8_t select_script_input(void* user, uint8_t* data, uint32_t bitoffs)

--- a/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
@@ -664,6 +664,11 @@ static const struct YamlNode struct_anonymous_11[] = {
   YAML_UNSIGNED( "reserved", 6 ),
   YAML_END
 };
+static const struct YamlNode struct_anonymous_12[] = {
+  YAML_UNSIGNED( "raw12bits", 1 ),
+  YAML_PADDING( 7 ),
+  YAML_END
+};
 static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_ARRAY("raw", 8, 25, struct_unsigned_8, NULL),
   YAML_STRUCT("ppm", 16, struct_anonymous_5, NULL),
@@ -673,6 +678,7 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_STRUCT("pxx2", 200, struct_anonymous_9, NULL),
   YAML_STRUCT("flysky", 56, struct_anonymous_10, NULL),
   YAML_STRUCT("afhds3", 64, struct_anonymous_11, NULL),
+  YAML_STRUCT("ghost", 8, struct_anonymous_12, NULL),
   YAML_END
 };
 static const struct YamlNode struct_ModuleData[] = {
@@ -720,61 +726,61 @@ static const struct YamlNode struct_string_32[] = {
   YAML_STRING("val", 4),
   YAML_END
 };
-static const struct YamlNode union_anonymous_12_elmts[] = {
+static const struct YamlNode union_anonymous_13_elmts[] = {
   YAML_UNSIGNED( "id", 16 ),
   YAML_UNSIGNED( "persistentValue", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_14[] = {
+static const struct YamlNode struct_anonymous_15[] = {
   YAML_UNSIGNED( "physID", 5 ),
   YAML_UNSIGNED( "rxIndex", 3 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_13_elmts[] = {
-  YAML_STRUCT("frskyInstance", 8, struct_anonymous_14, NULL),
+static const struct YamlNode union_anonymous_14_elmts[] = {
+  YAML_STRUCT("frskyInstance", 8, struct_anonymous_15, NULL),
   YAML_UNSIGNED( "instance", 8 ),
   YAML_ENUM("formula", 8, enum_TelemetrySensorFormula),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_16[] = {
+static const struct YamlNode struct_anonymous_17[] = {
   YAML_UNSIGNED( "ratio", 16 ),
   YAML_SIGNED( "offset", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_17[] = {
+static const struct YamlNode struct_anonymous_18[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_UNSIGNED( "index", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_18[] = {
+static const struct YamlNode struct_anonymous_19[] = {
   YAML_ARRAY("sources", 8, 4, struct_signed_8, NULL),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_19[] = {
+static const struct YamlNode struct_anonymous_20[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_PADDING( 24 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_20[] = {
+static const struct YamlNode struct_anonymous_21[] = {
   YAML_UNSIGNED( "gps", 8 ),
   YAML_UNSIGNED( "alt", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_15_elmts[] = {
-  YAML_STRUCT("custom", 32, struct_anonymous_16, NULL),
-  YAML_STRUCT("cell", 32, struct_anonymous_17, NULL),
-  YAML_STRUCT("calc", 32, struct_anonymous_18, NULL),
-  YAML_STRUCT("consumption", 32, struct_anonymous_19, NULL),
-  YAML_STRUCT("dist", 32, struct_anonymous_20, NULL),
+static const struct YamlNode union_anonymous_16_elmts[] = {
+  YAML_STRUCT("custom", 32, struct_anonymous_17, NULL),
+  YAML_STRUCT("cell", 32, struct_anonymous_18, NULL),
+  YAML_STRUCT("calc", 32, struct_anonymous_19, NULL),
+  YAML_STRUCT("consumption", 32, struct_anonymous_20, NULL),
+  YAML_STRUCT("dist", 32, struct_anonymous_21, NULL),
   YAML_UNSIGNED( "param", 32 ),
   YAML_END
 };
 static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_IDX,
-  YAML_UNION("id1", 16, union_anonymous_12_elmts, select_id1),
-  YAML_UNION("id2", 8, union_anonymous_13_elmts, select_id2),
+  YAML_UNION("id1", 16, union_anonymous_13_elmts, select_id1),
+  YAML_UNION("id2", 8, union_anonymous_14_elmts, select_id2),
   YAML_STRING("label", 4),
   YAML_UNSIGNED( "subId", 8 ),
   YAML_ENUM("type", 1, enum_TelemetrySensorType),
@@ -787,7 +793,7 @@ static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_UNSIGNED( "persistent", 1 ),
   YAML_UNSIGNED( "onlyPositive", 1 ),
   YAML_PADDING( 1 ),
-  YAML_UNION("cfg", 32, union_anonymous_15_elmts, select_sensor_cfg),
+  YAML_UNION("cfg", 32, union_anonymous_16_elmts, select_sensor_cfg),
   YAML_END
 };
 static const struct YamlNode struct_WidgetPersistentData[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_t12.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t12.cpp
@@ -630,6 +630,11 @@ static const struct YamlNode struct_anonymous_11[] = {
   YAML_UNSIGNED( "reserved", 6 ),
   YAML_END
 };
+static const struct YamlNode struct_anonymous_12[] = {
+  YAML_UNSIGNED( "raw12bits", 1 ),
+  YAML_PADDING( 7 ),
+  YAML_END
+};
 static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_ARRAY("raw", 8, 25, struct_unsigned_8, NULL),
   YAML_STRUCT("ppm", 16, struct_anonymous_5, NULL),
@@ -639,6 +644,7 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_STRUCT("pxx2", 200, struct_anonymous_9, NULL),
   YAML_STRUCT("flysky", 56, struct_anonymous_10, NULL),
   YAML_STRUCT("afhds3", 64, struct_anonymous_11, NULL),
+  YAML_STRUCT("ghost", 8, struct_anonymous_12, NULL),
   YAML_END
 };
 static const struct YamlNode struct_ModuleData[] = {
@@ -681,61 +687,61 @@ static const struct YamlNode struct_ScriptData[] = {
   YAML_ARRAY("inputs", 16, 6, union_ScriptDataInput, NULL),
   YAML_END
 };
-static const struct YamlNode union_anonymous_12_elmts[] = {
+static const struct YamlNode union_anonymous_13_elmts[] = {
   YAML_UNSIGNED( "id", 16 ),
   YAML_UNSIGNED( "persistentValue", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_14[] = {
+static const struct YamlNode struct_anonymous_15[] = {
   YAML_UNSIGNED( "physID", 5 ),
   YAML_UNSIGNED( "rxIndex", 3 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_13_elmts[] = {
-  YAML_STRUCT("frskyInstance", 8, struct_anonymous_14, NULL),
+static const struct YamlNode union_anonymous_14_elmts[] = {
+  YAML_STRUCT("frskyInstance", 8, struct_anonymous_15, NULL),
   YAML_UNSIGNED( "instance", 8 ),
   YAML_ENUM("formula", 8, enum_TelemetrySensorFormula),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_16[] = {
+static const struct YamlNode struct_anonymous_17[] = {
   YAML_UNSIGNED( "ratio", 16 ),
   YAML_SIGNED( "offset", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_17[] = {
+static const struct YamlNode struct_anonymous_18[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_UNSIGNED( "index", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_18[] = {
+static const struct YamlNode struct_anonymous_19[] = {
   YAML_ARRAY("sources", 8, 4, struct_signed_8, NULL),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_19[] = {
+static const struct YamlNode struct_anonymous_20[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_PADDING( 24 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_20[] = {
+static const struct YamlNode struct_anonymous_21[] = {
   YAML_UNSIGNED( "gps", 8 ),
   YAML_UNSIGNED( "alt", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_15_elmts[] = {
-  YAML_STRUCT("custom", 32, struct_anonymous_16, NULL),
-  YAML_STRUCT("cell", 32, struct_anonymous_17, NULL),
-  YAML_STRUCT("calc", 32, struct_anonymous_18, NULL),
-  YAML_STRUCT("consumption", 32, struct_anonymous_19, NULL),
-  YAML_STRUCT("dist", 32, struct_anonymous_20, NULL),
+static const struct YamlNode union_anonymous_16_elmts[] = {
+  YAML_STRUCT("custom", 32, struct_anonymous_17, NULL),
+  YAML_STRUCT("cell", 32, struct_anonymous_18, NULL),
+  YAML_STRUCT("calc", 32, struct_anonymous_19, NULL),
+  YAML_STRUCT("consumption", 32, struct_anonymous_20, NULL),
+  YAML_STRUCT("dist", 32, struct_anonymous_21, NULL),
   YAML_UNSIGNED( "param", 32 ),
   YAML_END
 };
 static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_IDX,
-  YAML_UNION("id1", 16, union_anonymous_12_elmts, select_id1),
-  YAML_UNION("id2", 8, union_anonymous_13_elmts, select_id2),
+  YAML_UNION("id1", 16, union_anonymous_13_elmts, select_id1),
+  YAML_UNION("id2", 8, union_anonymous_14_elmts, select_id2),
   YAML_STRING("label", 4),
   YAML_UNSIGNED( "subId", 8 ),
   YAML_ENUM("type", 1, enum_TelemetrySensorType),
@@ -748,7 +754,7 @@ static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_UNSIGNED( "persistent", 1 ),
   YAML_UNSIGNED( "onlyPositive", 1 ),
   YAML_PADDING( 1 ),
-  YAML_UNION("cfg", 32, union_anonymous_15_elmts, select_sensor_cfg),
+  YAML_UNION("cfg", 32, union_anonymous_16_elmts, select_sensor_cfg),
   YAML_END
 };
 static const struct YamlNode struct_FrSkyBarData[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_t8.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t8.cpp
@@ -630,6 +630,11 @@ static const struct YamlNode struct_anonymous_11[] = {
   YAML_UNSIGNED( "reserved", 6 ),
   YAML_END
 };
+static const struct YamlNode struct_anonymous_12[] = {
+  YAML_UNSIGNED( "raw12bits", 1 ),
+  YAML_PADDING( 7 ),
+  YAML_END
+};
 static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_ARRAY("raw", 8, 25, struct_unsigned_8, NULL),
   YAML_STRUCT("ppm", 16, struct_anonymous_5, NULL),
@@ -639,6 +644,7 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_STRUCT("pxx2", 200, struct_anonymous_9, NULL),
   YAML_STRUCT("flysky", 56, struct_anonymous_10, NULL),
   YAML_STRUCT("afhds3", 64, struct_anonymous_11, NULL),
+  YAML_STRUCT("ghost", 8, struct_anonymous_12, NULL),
   YAML_END
 };
 static const struct YamlNode struct_ModuleData[] = {
@@ -681,61 +687,61 @@ static const struct YamlNode struct_ScriptData[] = {
   YAML_ARRAY("inputs", 16, 6, union_ScriptDataInput, NULL),
   YAML_END
 };
-static const struct YamlNode union_anonymous_12_elmts[] = {
+static const struct YamlNode union_anonymous_13_elmts[] = {
   YAML_UNSIGNED( "id", 16 ),
   YAML_UNSIGNED( "persistentValue", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_14[] = {
+static const struct YamlNode struct_anonymous_15[] = {
   YAML_UNSIGNED( "physID", 5 ),
   YAML_UNSIGNED( "rxIndex", 3 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_13_elmts[] = {
-  YAML_STRUCT("frskyInstance", 8, struct_anonymous_14, NULL),
+static const struct YamlNode union_anonymous_14_elmts[] = {
+  YAML_STRUCT("frskyInstance", 8, struct_anonymous_15, NULL),
   YAML_UNSIGNED( "instance", 8 ),
   YAML_ENUM("formula", 8, enum_TelemetrySensorFormula),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_16[] = {
+static const struct YamlNode struct_anonymous_17[] = {
   YAML_UNSIGNED( "ratio", 16 ),
   YAML_SIGNED( "offset", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_17[] = {
+static const struct YamlNode struct_anonymous_18[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_UNSIGNED( "index", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_18[] = {
+static const struct YamlNode struct_anonymous_19[] = {
   YAML_ARRAY("sources", 8, 4, struct_signed_8, NULL),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_19[] = {
+static const struct YamlNode struct_anonymous_20[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_PADDING( 24 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_20[] = {
+static const struct YamlNode struct_anonymous_21[] = {
   YAML_UNSIGNED( "gps", 8 ),
   YAML_UNSIGNED( "alt", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_15_elmts[] = {
-  YAML_STRUCT("custom", 32, struct_anonymous_16, NULL),
-  YAML_STRUCT("cell", 32, struct_anonymous_17, NULL),
-  YAML_STRUCT("calc", 32, struct_anonymous_18, NULL),
-  YAML_STRUCT("consumption", 32, struct_anonymous_19, NULL),
-  YAML_STRUCT("dist", 32, struct_anonymous_20, NULL),
+static const struct YamlNode union_anonymous_16_elmts[] = {
+  YAML_STRUCT("custom", 32, struct_anonymous_17, NULL),
+  YAML_STRUCT("cell", 32, struct_anonymous_18, NULL),
+  YAML_STRUCT("calc", 32, struct_anonymous_19, NULL),
+  YAML_STRUCT("consumption", 32, struct_anonymous_20, NULL),
+  YAML_STRUCT("dist", 32, struct_anonymous_21, NULL),
   YAML_UNSIGNED( "param", 32 ),
   YAML_END
 };
 static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_IDX,
-  YAML_UNION("id1", 16, union_anonymous_12_elmts, select_id1),
-  YAML_UNION("id2", 8, union_anonymous_13_elmts, select_id2),
+  YAML_UNION("id1", 16, union_anonymous_13_elmts, select_id1),
+  YAML_UNION("id2", 8, union_anonymous_14_elmts, select_id2),
   YAML_STRING("label", 4),
   YAML_UNSIGNED( "subId", 8 ),
   YAML_ENUM("type", 1, enum_TelemetrySensorType),
@@ -748,7 +754,7 @@ static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_UNSIGNED( "persistent", 1 ),
   YAML_UNSIGNED( "onlyPositive", 1 ),
   YAML_PADDING( 1 ),
-  YAML_UNION("cfg", 32, union_anonymous_15_elmts, select_sensor_cfg),
+  YAML_UNION("cfg", 32, union_anonymous_16_elmts, select_sensor_cfg),
   YAML_END
 };
 static const struct YamlNode struct_FrSkyBarData[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_tlite.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tlite.cpp
@@ -630,6 +630,11 @@ static const struct YamlNode struct_anonymous_11[] = {
   YAML_UNSIGNED( "reserved", 6 ),
   YAML_END
 };
+static const struct YamlNode struct_anonymous_12[] = {
+  YAML_UNSIGNED( "raw12bits", 1 ),
+  YAML_PADDING( 7 ),
+  YAML_END
+};
 static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_ARRAY("raw", 8, 25, struct_unsigned_8, NULL),
   YAML_STRUCT("ppm", 16, struct_anonymous_5, NULL),
@@ -639,6 +644,7 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_STRUCT("pxx2", 200, struct_anonymous_9, NULL),
   YAML_STRUCT("flysky", 56, struct_anonymous_10, NULL),
   YAML_STRUCT("afhds3", 64, struct_anonymous_11, NULL),
+  YAML_STRUCT("ghost", 8, struct_anonymous_12, NULL),
   YAML_END
 };
 static const struct YamlNode struct_ModuleData[] = {
@@ -681,61 +687,61 @@ static const struct YamlNode struct_ScriptData[] = {
   YAML_ARRAY("inputs", 16, 6, union_ScriptDataInput, NULL),
   YAML_END
 };
-static const struct YamlNode union_anonymous_12_elmts[] = {
+static const struct YamlNode union_anonymous_13_elmts[] = {
   YAML_UNSIGNED( "id", 16 ),
   YAML_UNSIGNED( "persistentValue", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_14[] = {
+static const struct YamlNode struct_anonymous_15[] = {
   YAML_UNSIGNED( "physID", 5 ),
   YAML_UNSIGNED( "rxIndex", 3 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_13_elmts[] = {
-  YAML_STRUCT("frskyInstance", 8, struct_anonymous_14, NULL),
+static const struct YamlNode union_anonymous_14_elmts[] = {
+  YAML_STRUCT("frskyInstance", 8, struct_anonymous_15, NULL),
   YAML_UNSIGNED( "instance", 8 ),
   YAML_ENUM("formula", 8, enum_TelemetrySensorFormula),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_16[] = {
+static const struct YamlNode struct_anonymous_17[] = {
   YAML_UNSIGNED( "ratio", 16 ),
   YAML_SIGNED( "offset", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_17[] = {
+static const struct YamlNode struct_anonymous_18[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_UNSIGNED( "index", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_18[] = {
+static const struct YamlNode struct_anonymous_19[] = {
   YAML_ARRAY("sources", 8, 4, struct_signed_8, NULL),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_19[] = {
+static const struct YamlNode struct_anonymous_20[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_PADDING( 24 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_20[] = {
+static const struct YamlNode struct_anonymous_21[] = {
   YAML_UNSIGNED( "gps", 8 ),
   YAML_UNSIGNED( "alt", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_15_elmts[] = {
-  YAML_STRUCT("custom", 32, struct_anonymous_16, NULL),
-  YAML_STRUCT("cell", 32, struct_anonymous_17, NULL),
-  YAML_STRUCT("calc", 32, struct_anonymous_18, NULL),
-  YAML_STRUCT("consumption", 32, struct_anonymous_19, NULL),
-  YAML_STRUCT("dist", 32, struct_anonymous_20, NULL),
+static const struct YamlNode union_anonymous_16_elmts[] = {
+  YAML_STRUCT("custom", 32, struct_anonymous_17, NULL),
+  YAML_STRUCT("cell", 32, struct_anonymous_18, NULL),
+  YAML_STRUCT("calc", 32, struct_anonymous_19, NULL),
+  YAML_STRUCT("consumption", 32, struct_anonymous_20, NULL),
+  YAML_STRUCT("dist", 32, struct_anonymous_21, NULL),
   YAML_UNSIGNED( "param", 32 ),
   YAML_END
 };
 static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_IDX,
-  YAML_UNION("id1", 16, union_anonymous_12_elmts, select_id1),
-  YAML_UNION("id2", 8, union_anonymous_13_elmts, select_id2),
+  YAML_UNION("id1", 16, union_anonymous_13_elmts, select_id1),
+  YAML_UNION("id2", 8, union_anonymous_14_elmts, select_id2),
   YAML_STRING("label", 4),
   YAML_UNSIGNED( "subId", 8 ),
   YAML_ENUM("type", 1, enum_TelemetrySensorType),
@@ -748,7 +754,7 @@ static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_UNSIGNED( "persistent", 1 ),
   YAML_UNSIGNED( "onlyPositive", 1 ),
   YAML_PADDING( 1 ),
-  YAML_UNION("cfg", 32, union_anonymous_15_elmts, select_sensor_cfg),
+  YAML_UNION("cfg", 32, union_anonymous_16_elmts, select_sensor_cfg),
   YAML_END
 };
 static const struct YamlNode struct_FrSkyBarData[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_tpro.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tpro.cpp
@@ -636,6 +636,11 @@ static const struct YamlNode struct_anonymous_11[] = {
   YAML_UNSIGNED( "reserved", 6 ),
   YAML_END
 };
+static const struct YamlNode struct_anonymous_12[] = {
+  YAML_UNSIGNED( "raw12bits", 1 ),
+  YAML_PADDING( 7 ),
+  YAML_END
+};
 static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_ARRAY("raw", 8, 25, struct_unsigned_8, NULL),
   YAML_STRUCT("ppm", 16, struct_anonymous_5, NULL),
@@ -645,6 +650,7 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_STRUCT("pxx2", 200, struct_anonymous_9, NULL),
   YAML_STRUCT("flysky", 56, struct_anonymous_10, NULL),
   YAML_STRUCT("afhds3", 64, struct_anonymous_11, NULL),
+  YAML_STRUCT("ghost", 8, struct_anonymous_12, NULL),
   YAML_END
 };
 static const struct YamlNode struct_ModuleData[] = {
@@ -687,61 +693,61 @@ static const struct YamlNode struct_ScriptData[] = {
   YAML_ARRAY("inputs", 16, 6, union_ScriptDataInput, NULL),
   YAML_END
 };
-static const struct YamlNode union_anonymous_12_elmts[] = {
+static const struct YamlNode union_anonymous_13_elmts[] = {
   YAML_UNSIGNED( "id", 16 ),
   YAML_UNSIGNED( "persistentValue", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_14[] = {
+static const struct YamlNode struct_anonymous_15[] = {
   YAML_UNSIGNED( "physID", 5 ),
   YAML_UNSIGNED( "rxIndex", 3 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_13_elmts[] = {
-  YAML_STRUCT("frskyInstance", 8, struct_anonymous_14, NULL),
+static const struct YamlNode union_anonymous_14_elmts[] = {
+  YAML_STRUCT("frskyInstance", 8, struct_anonymous_15, NULL),
   YAML_UNSIGNED( "instance", 8 ),
   YAML_ENUM("formula", 8, enum_TelemetrySensorFormula),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_16[] = {
+static const struct YamlNode struct_anonymous_17[] = {
   YAML_UNSIGNED( "ratio", 16 ),
   YAML_SIGNED( "offset", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_17[] = {
+static const struct YamlNode struct_anonymous_18[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_UNSIGNED( "index", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_18[] = {
+static const struct YamlNode struct_anonymous_19[] = {
   YAML_ARRAY("sources", 8, 4, struct_signed_8, NULL),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_19[] = {
+static const struct YamlNode struct_anonymous_20[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_PADDING( 24 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_20[] = {
+static const struct YamlNode struct_anonymous_21[] = {
   YAML_UNSIGNED( "gps", 8 ),
   YAML_UNSIGNED( "alt", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_15_elmts[] = {
-  YAML_STRUCT("custom", 32, struct_anonymous_16, NULL),
-  YAML_STRUCT("cell", 32, struct_anonymous_17, NULL),
-  YAML_STRUCT("calc", 32, struct_anonymous_18, NULL),
-  YAML_STRUCT("consumption", 32, struct_anonymous_19, NULL),
-  YAML_STRUCT("dist", 32, struct_anonymous_20, NULL),
+static const struct YamlNode union_anonymous_16_elmts[] = {
+  YAML_STRUCT("custom", 32, struct_anonymous_17, NULL),
+  YAML_STRUCT("cell", 32, struct_anonymous_18, NULL),
+  YAML_STRUCT("calc", 32, struct_anonymous_19, NULL),
+  YAML_STRUCT("consumption", 32, struct_anonymous_20, NULL),
+  YAML_STRUCT("dist", 32, struct_anonymous_21, NULL),
   YAML_UNSIGNED( "param", 32 ),
   YAML_END
 };
 static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_IDX,
-  YAML_UNION("id1", 16, union_anonymous_12_elmts, select_id1),
-  YAML_UNION("id2", 8, union_anonymous_13_elmts, select_id2),
+  YAML_UNION("id1", 16, union_anonymous_13_elmts, select_id1),
+  YAML_UNION("id2", 8, union_anonymous_14_elmts, select_id2),
   YAML_STRING("label", 4),
   YAML_UNSIGNED( "subId", 8 ),
   YAML_ENUM("type", 1, enum_TelemetrySensorType),
@@ -754,7 +760,7 @@ static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_UNSIGNED( "persistent", 1 ),
   YAML_UNSIGNED( "onlyPositive", 1 ),
   YAML_PADDING( 1 ),
-  YAML_UNION("cfg", 32, union_anonymous_15_elmts, select_sensor_cfg),
+  YAML_UNION("cfg", 32, union_anonymous_16_elmts, select_sensor_cfg),
   YAML_END
 };
 static const struct YamlNode struct_FrSkyBarData[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_tx12.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tx12.cpp
@@ -630,6 +630,11 @@ static const struct YamlNode struct_anonymous_11[] = {
   YAML_UNSIGNED( "reserved", 6 ),
   YAML_END
 };
+static const struct YamlNode struct_anonymous_12[] = {
+  YAML_UNSIGNED( "raw12bits", 1 ),
+  YAML_PADDING( 7 ),
+  YAML_END
+};
 static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_ARRAY("raw", 8, 25, struct_unsigned_8, NULL),
   YAML_STRUCT("ppm", 16, struct_anonymous_5, NULL),
@@ -639,6 +644,7 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_STRUCT("pxx2", 200, struct_anonymous_9, NULL),
   YAML_STRUCT("flysky", 56, struct_anonymous_10, NULL),
   YAML_STRUCT("afhds3", 64, struct_anonymous_11, NULL),
+  YAML_STRUCT("ghost", 8, struct_anonymous_12, NULL),
   YAML_END
 };
 static const struct YamlNode struct_ModuleData[] = {
@@ -681,61 +687,61 @@ static const struct YamlNode struct_ScriptData[] = {
   YAML_ARRAY("inputs", 16, 6, union_ScriptDataInput, NULL),
   YAML_END
 };
-static const struct YamlNode union_anonymous_12_elmts[] = {
+static const struct YamlNode union_anonymous_13_elmts[] = {
   YAML_UNSIGNED( "id", 16 ),
   YAML_UNSIGNED( "persistentValue", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_14[] = {
+static const struct YamlNode struct_anonymous_15[] = {
   YAML_UNSIGNED( "physID", 5 ),
   YAML_UNSIGNED( "rxIndex", 3 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_13_elmts[] = {
-  YAML_STRUCT("frskyInstance", 8, struct_anonymous_14, NULL),
+static const struct YamlNode union_anonymous_14_elmts[] = {
+  YAML_STRUCT("frskyInstance", 8, struct_anonymous_15, NULL),
   YAML_UNSIGNED( "instance", 8 ),
   YAML_ENUM("formula", 8, enum_TelemetrySensorFormula),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_16[] = {
+static const struct YamlNode struct_anonymous_17[] = {
   YAML_UNSIGNED( "ratio", 16 ),
   YAML_SIGNED( "offset", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_17[] = {
+static const struct YamlNode struct_anonymous_18[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_UNSIGNED( "index", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_18[] = {
+static const struct YamlNode struct_anonymous_19[] = {
   YAML_ARRAY("sources", 8, 4, struct_signed_8, NULL),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_19[] = {
+static const struct YamlNode struct_anonymous_20[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_PADDING( 24 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_20[] = {
+static const struct YamlNode struct_anonymous_21[] = {
   YAML_UNSIGNED( "gps", 8 ),
   YAML_UNSIGNED( "alt", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_15_elmts[] = {
-  YAML_STRUCT("custom", 32, struct_anonymous_16, NULL),
-  YAML_STRUCT("cell", 32, struct_anonymous_17, NULL),
-  YAML_STRUCT("calc", 32, struct_anonymous_18, NULL),
-  YAML_STRUCT("consumption", 32, struct_anonymous_19, NULL),
-  YAML_STRUCT("dist", 32, struct_anonymous_20, NULL),
+static const struct YamlNode union_anonymous_16_elmts[] = {
+  YAML_STRUCT("custom", 32, struct_anonymous_17, NULL),
+  YAML_STRUCT("cell", 32, struct_anonymous_18, NULL),
+  YAML_STRUCT("calc", 32, struct_anonymous_19, NULL),
+  YAML_STRUCT("consumption", 32, struct_anonymous_20, NULL),
+  YAML_STRUCT("dist", 32, struct_anonymous_21, NULL),
   YAML_UNSIGNED( "param", 32 ),
   YAML_END
 };
 static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_IDX,
-  YAML_UNION("id1", 16, union_anonymous_12_elmts, select_id1),
-  YAML_UNION("id2", 8, union_anonymous_13_elmts, select_id2),
+  YAML_UNION("id1", 16, union_anonymous_13_elmts, select_id1),
+  YAML_UNION("id2", 8, union_anonymous_14_elmts, select_id2),
   YAML_STRING("label", 4),
   YAML_UNSIGNED( "subId", 8 ),
   YAML_ENUM("type", 1, enum_TelemetrySensorType),
@@ -748,7 +754,7 @@ static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_UNSIGNED( "persistent", 1 ),
   YAML_UNSIGNED( "onlyPositive", 1 ),
   YAML_PADDING( 1 ),
-  YAML_UNION("cfg", 32, union_anonymous_15_elmts, select_sensor_cfg),
+  YAML_UNION("cfg", 32, union_anonymous_16_elmts, select_sensor_cfg),
   YAML_END
 };
 static const struct YamlNode struct_FrSkyBarData[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_x10.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x10.cpp
@@ -685,6 +685,11 @@ static const struct YamlNode struct_anonymous_11[] = {
   YAML_UNSIGNED( "reserved", 6 ),
   YAML_END
 };
+static const struct YamlNode struct_anonymous_12[] = {
+  YAML_UNSIGNED( "raw12bits", 1 ),
+  YAML_PADDING( 7 ),
+  YAML_END
+};
 static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_ARRAY("raw", 8, 25, struct_unsigned_8, NULL),
   YAML_STRUCT("ppm", 16, struct_anonymous_5, NULL),
@@ -694,6 +699,7 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_STRUCT("pxx2", 200, struct_anonymous_9, NULL),
   YAML_STRUCT("flysky", 56, struct_anonymous_10, NULL),
   YAML_STRUCT("afhds3", 64, struct_anonymous_11, NULL),
+  YAML_STRUCT("ghost", 8, struct_anonymous_12, NULL),
   YAML_END
 };
 static const struct YamlNode struct_ModuleData[] = {
@@ -741,61 +747,61 @@ static const struct YamlNode struct_string_32[] = {
   YAML_STRING("val", 4),
   YAML_END
 };
-static const struct YamlNode union_anonymous_12_elmts[] = {
+static const struct YamlNode union_anonymous_13_elmts[] = {
   YAML_UNSIGNED( "id", 16 ),
   YAML_UNSIGNED( "persistentValue", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_14[] = {
+static const struct YamlNode struct_anonymous_15[] = {
   YAML_UNSIGNED( "physID", 5 ),
   YAML_UNSIGNED( "rxIndex", 3 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_13_elmts[] = {
-  YAML_STRUCT("frskyInstance", 8, struct_anonymous_14, NULL),
+static const struct YamlNode union_anonymous_14_elmts[] = {
+  YAML_STRUCT("frskyInstance", 8, struct_anonymous_15, NULL),
   YAML_UNSIGNED( "instance", 8 ),
   YAML_ENUM("formula", 8, enum_TelemetrySensorFormula),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_16[] = {
+static const struct YamlNode struct_anonymous_17[] = {
   YAML_UNSIGNED( "ratio", 16 ),
   YAML_SIGNED( "offset", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_17[] = {
+static const struct YamlNode struct_anonymous_18[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_UNSIGNED( "index", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_18[] = {
+static const struct YamlNode struct_anonymous_19[] = {
   YAML_ARRAY("sources", 8, 4, struct_signed_8, NULL),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_19[] = {
+static const struct YamlNode struct_anonymous_20[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_PADDING( 24 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_20[] = {
+static const struct YamlNode struct_anonymous_21[] = {
   YAML_UNSIGNED( "gps", 8 ),
   YAML_UNSIGNED( "alt", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_15_elmts[] = {
-  YAML_STRUCT("custom", 32, struct_anonymous_16, NULL),
-  YAML_STRUCT("cell", 32, struct_anonymous_17, NULL),
-  YAML_STRUCT("calc", 32, struct_anonymous_18, NULL),
-  YAML_STRUCT("consumption", 32, struct_anonymous_19, NULL),
-  YAML_STRUCT("dist", 32, struct_anonymous_20, NULL),
+static const struct YamlNode union_anonymous_16_elmts[] = {
+  YAML_STRUCT("custom", 32, struct_anonymous_17, NULL),
+  YAML_STRUCT("cell", 32, struct_anonymous_18, NULL),
+  YAML_STRUCT("calc", 32, struct_anonymous_19, NULL),
+  YAML_STRUCT("consumption", 32, struct_anonymous_20, NULL),
+  YAML_STRUCT("dist", 32, struct_anonymous_21, NULL),
   YAML_UNSIGNED( "param", 32 ),
   YAML_END
 };
 static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_IDX,
-  YAML_UNION("id1", 16, union_anonymous_12_elmts, select_id1),
-  YAML_UNION("id2", 8, union_anonymous_13_elmts, select_id2),
+  YAML_UNION("id1", 16, union_anonymous_13_elmts, select_id1),
+  YAML_UNION("id2", 8, union_anonymous_14_elmts, select_id2),
   YAML_STRING("label", 4),
   YAML_UNSIGNED( "subId", 8 ),
   YAML_ENUM("type", 1, enum_TelemetrySensorType),
@@ -808,7 +814,7 @@ static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_UNSIGNED( "persistent", 1 ),
   YAML_UNSIGNED( "onlyPositive", 1 ),
   YAML_PADDING( 1 ),
-  YAML_UNION("cfg", 32, union_anonymous_15_elmts, select_sensor_cfg),
+  YAML_UNION("cfg", 32, union_anonymous_16_elmts, select_sensor_cfg),
   YAML_END
 };
 static const struct YamlNode struct_WidgetPersistentData[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
@@ -683,6 +683,11 @@ static const struct YamlNode struct_anonymous_11[] = {
   YAML_UNSIGNED( "reserved", 6 ),
   YAML_END
 };
+static const struct YamlNode struct_anonymous_12[] = {
+  YAML_UNSIGNED( "raw12bits", 1 ),
+  YAML_PADDING( 7 ),
+  YAML_END
+};
 static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_ARRAY("raw", 8, 25, struct_unsigned_8, NULL),
   YAML_STRUCT("ppm", 16, struct_anonymous_5, NULL),
@@ -692,6 +697,7 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_STRUCT("pxx2", 200, struct_anonymous_9, NULL),
   YAML_STRUCT("flysky", 56, struct_anonymous_10, NULL),
   YAML_STRUCT("afhds3", 64, struct_anonymous_11, NULL),
+  YAML_STRUCT("ghost", 8, struct_anonymous_12, NULL),
   YAML_END
 };
 static const struct YamlNode struct_ModuleData[] = {
@@ -739,61 +745,61 @@ static const struct YamlNode struct_string_32[] = {
   YAML_STRING("val", 4),
   YAML_END
 };
-static const struct YamlNode union_anonymous_12_elmts[] = {
+static const struct YamlNode union_anonymous_13_elmts[] = {
   YAML_UNSIGNED( "id", 16 ),
   YAML_UNSIGNED( "persistentValue", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_14[] = {
+static const struct YamlNode struct_anonymous_15[] = {
   YAML_UNSIGNED( "physID", 5 ),
   YAML_UNSIGNED( "rxIndex", 3 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_13_elmts[] = {
-  YAML_STRUCT("frskyInstance", 8, struct_anonymous_14, NULL),
+static const struct YamlNode union_anonymous_14_elmts[] = {
+  YAML_STRUCT("frskyInstance", 8, struct_anonymous_15, NULL),
   YAML_UNSIGNED( "instance", 8 ),
   YAML_ENUM("formula", 8, enum_TelemetrySensorFormula),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_16[] = {
+static const struct YamlNode struct_anonymous_17[] = {
   YAML_UNSIGNED( "ratio", 16 ),
   YAML_SIGNED( "offset", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_17[] = {
+static const struct YamlNode struct_anonymous_18[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_UNSIGNED( "index", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_18[] = {
+static const struct YamlNode struct_anonymous_19[] = {
   YAML_ARRAY("sources", 8, 4, struct_signed_8, NULL),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_19[] = {
+static const struct YamlNode struct_anonymous_20[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_PADDING( 24 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_20[] = {
+static const struct YamlNode struct_anonymous_21[] = {
   YAML_UNSIGNED( "gps", 8 ),
   YAML_UNSIGNED( "alt", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_15_elmts[] = {
-  YAML_STRUCT("custom", 32, struct_anonymous_16, NULL),
-  YAML_STRUCT("cell", 32, struct_anonymous_17, NULL),
-  YAML_STRUCT("calc", 32, struct_anonymous_18, NULL),
-  YAML_STRUCT("consumption", 32, struct_anonymous_19, NULL),
-  YAML_STRUCT("dist", 32, struct_anonymous_20, NULL),
+static const struct YamlNode union_anonymous_16_elmts[] = {
+  YAML_STRUCT("custom", 32, struct_anonymous_17, NULL),
+  YAML_STRUCT("cell", 32, struct_anonymous_18, NULL),
+  YAML_STRUCT("calc", 32, struct_anonymous_19, NULL),
+  YAML_STRUCT("consumption", 32, struct_anonymous_20, NULL),
+  YAML_STRUCT("dist", 32, struct_anonymous_21, NULL),
   YAML_UNSIGNED( "param", 32 ),
   YAML_END
 };
 static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_IDX,
-  YAML_UNION("id1", 16, union_anonymous_12_elmts, select_id1),
-  YAML_UNION("id2", 8, union_anonymous_13_elmts, select_id2),
+  YAML_UNION("id1", 16, union_anonymous_13_elmts, select_id1),
+  YAML_UNION("id2", 8, union_anonymous_14_elmts, select_id2),
   YAML_STRING("label", 4),
   YAML_UNSIGNED( "subId", 8 ),
   YAML_ENUM("type", 1, enum_TelemetrySensorType),
@@ -806,7 +812,7 @@ static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_UNSIGNED( "persistent", 1 ),
   YAML_UNSIGNED( "onlyPositive", 1 ),
   YAML_PADDING( 1 ),
-  YAML_UNION("cfg", 32, union_anonymous_15_elmts, select_sensor_cfg),
+  YAML_UNION("cfg", 32, union_anonymous_16_elmts, select_sensor_cfg),
   YAML_END
 };
 static const struct YamlNode struct_WidgetPersistentData[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_x7.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x7.cpp
@@ -630,6 +630,11 @@ static const struct YamlNode struct_anonymous_11[] = {
   YAML_UNSIGNED( "reserved", 6 ),
   YAML_END
 };
+static const struct YamlNode struct_anonymous_12[] = {
+  YAML_UNSIGNED( "raw12bits", 1 ),
+  YAML_PADDING( 7 ),
+  YAML_END
+};
 static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_ARRAY("raw", 8, 25, struct_unsigned_8, NULL),
   YAML_STRUCT("ppm", 16, struct_anonymous_5, NULL),
@@ -639,6 +644,7 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_STRUCT("pxx2", 200, struct_anonymous_9, NULL),
   YAML_STRUCT("flysky", 56, struct_anonymous_10, NULL),
   YAML_STRUCT("afhds3", 64, struct_anonymous_11, NULL),
+  YAML_STRUCT("ghost", 8, struct_anonymous_12, NULL),
   YAML_END
 };
 static const struct YamlNode struct_ModuleData[] = {
@@ -681,61 +687,61 @@ static const struct YamlNode struct_ScriptData[] = {
   YAML_ARRAY("inputs", 16, 6, union_ScriptDataInput, NULL),
   YAML_END
 };
-static const struct YamlNode union_anonymous_12_elmts[] = {
+static const struct YamlNode union_anonymous_13_elmts[] = {
   YAML_UNSIGNED( "id", 16 ),
   YAML_UNSIGNED( "persistentValue", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_14[] = {
+static const struct YamlNode struct_anonymous_15[] = {
   YAML_UNSIGNED( "physID", 5 ),
   YAML_UNSIGNED( "rxIndex", 3 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_13_elmts[] = {
-  YAML_STRUCT("frskyInstance", 8, struct_anonymous_14, NULL),
+static const struct YamlNode union_anonymous_14_elmts[] = {
+  YAML_STRUCT("frskyInstance", 8, struct_anonymous_15, NULL),
   YAML_UNSIGNED( "instance", 8 ),
   YAML_ENUM("formula", 8, enum_TelemetrySensorFormula),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_16[] = {
+static const struct YamlNode struct_anonymous_17[] = {
   YAML_UNSIGNED( "ratio", 16 ),
   YAML_SIGNED( "offset", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_17[] = {
+static const struct YamlNode struct_anonymous_18[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_UNSIGNED( "index", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_18[] = {
+static const struct YamlNode struct_anonymous_19[] = {
   YAML_ARRAY("sources", 8, 4, struct_signed_8, NULL),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_19[] = {
+static const struct YamlNode struct_anonymous_20[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_PADDING( 24 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_20[] = {
+static const struct YamlNode struct_anonymous_21[] = {
   YAML_UNSIGNED( "gps", 8 ),
   YAML_UNSIGNED( "alt", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_15_elmts[] = {
-  YAML_STRUCT("custom", 32, struct_anonymous_16, NULL),
-  YAML_STRUCT("cell", 32, struct_anonymous_17, NULL),
-  YAML_STRUCT("calc", 32, struct_anonymous_18, NULL),
-  YAML_STRUCT("consumption", 32, struct_anonymous_19, NULL),
-  YAML_STRUCT("dist", 32, struct_anonymous_20, NULL),
+static const struct YamlNode union_anonymous_16_elmts[] = {
+  YAML_STRUCT("custom", 32, struct_anonymous_17, NULL),
+  YAML_STRUCT("cell", 32, struct_anonymous_18, NULL),
+  YAML_STRUCT("calc", 32, struct_anonymous_19, NULL),
+  YAML_STRUCT("consumption", 32, struct_anonymous_20, NULL),
+  YAML_STRUCT("dist", 32, struct_anonymous_21, NULL),
   YAML_UNSIGNED( "param", 32 ),
   YAML_END
 };
 static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_IDX,
-  YAML_UNION("id1", 16, union_anonymous_12_elmts, select_id1),
-  YAML_UNION("id2", 8, union_anonymous_13_elmts, select_id2),
+  YAML_UNION("id1", 16, union_anonymous_13_elmts, select_id1),
+  YAML_UNION("id2", 8, union_anonymous_14_elmts, select_id2),
   YAML_STRING("label", 4),
   YAML_UNSIGNED( "subId", 8 ),
   YAML_ENUM("type", 1, enum_TelemetrySensorType),
@@ -748,7 +754,7 @@ static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_UNSIGNED( "persistent", 1 ),
   YAML_UNSIGNED( "onlyPositive", 1 ),
   YAML_PADDING( 1 ),
-  YAML_UNION("cfg", 32, union_anonymous_15_elmts, select_sensor_cfg),
+  YAML_UNION("cfg", 32, union_anonymous_16_elmts, select_sensor_cfg),
   YAML_END
 };
 static const struct YamlNode struct_FrSkyBarData[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
@@ -638,6 +638,11 @@ static const struct YamlNode struct_anonymous_11[] = {
   YAML_UNSIGNED( "reserved", 6 ),
   YAML_END
 };
+static const struct YamlNode struct_anonymous_12[] = {
+  YAML_UNSIGNED( "raw12bits", 1 ),
+  YAML_PADDING( 7 ),
+  YAML_END
+};
 static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_ARRAY("raw", 8, 25, struct_unsigned_8, NULL),
   YAML_STRUCT("ppm", 16, struct_anonymous_5, NULL),
@@ -647,6 +652,7 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_STRUCT("pxx2", 200, struct_anonymous_9, NULL),
   YAML_STRUCT("flysky", 56, struct_anonymous_10, NULL),
   YAML_STRUCT("afhds3", 64, struct_anonymous_11, NULL),
+  YAML_STRUCT("ghost", 8, struct_anonymous_12, NULL),
   YAML_END
 };
 static const struct YamlNode struct_ModuleData[] = {
@@ -694,61 +700,61 @@ static const struct YamlNode struct_string_32[] = {
   YAML_STRING("val", 4),
   YAML_END
 };
-static const struct YamlNode union_anonymous_12_elmts[] = {
+static const struct YamlNode union_anonymous_13_elmts[] = {
   YAML_UNSIGNED( "id", 16 ),
   YAML_UNSIGNED( "persistentValue", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_14[] = {
+static const struct YamlNode struct_anonymous_15[] = {
   YAML_UNSIGNED( "physID", 5 ),
   YAML_UNSIGNED( "rxIndex", 3 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_13_elmts[] = {
-  YAML_STRUCT("frskyInstance", 8, struct_anonymous_14, NULL),
+static const struct YamlNode union_anonymous_14_elmts[] = {
+  YAML_STRUCT("frskyInstance", 8, struct_anonymous_15, NULL),
   YAML_UNSIGNED( "instance", 8 ),
   YAML_ENUM("formula", 8, enum_TelemetrySensorFormula),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_16[] = {
+static const struct YamlNode struct_anonymous_17[] = {
   YAML_UNSIGNED( "ratio", 16 ),
   YAML_SIGNED( "offset", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_17[] = {
+static const struct YamlNode struct_anonymous_18[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_UNSIGNED( "index", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_18[] = {
+static const struct YamlNode struct_anonymous_19[] = {
   YAML_ARRAY("sources", 8, 4, struct_signed_8, NULL),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_19[] = {
+static const struct YamlNode struct_anonymous_20[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_PADDING( 24 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_20[] = {
+static const struct YamlNode struct_anonymous_21[] = {
   YAML_UNSIGNED( "gps", 8 ),
   YAML_UNSIGNED( "alt", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_15_elmts[] = {
-  YAML_STRUCT("custom", 32, struct_anonymous_16, NULL),
-  YAML_STRUCT("cell", 32, struct_anonymous_17, NULL),
-  YAML_STRUCT("calc", 32, struct_anonymous_18, NULL),
-  YAML_STRUCT("consumption", 32, struct_anonymous_19, NULL),
-  YAML_STRUCT("dist", 32, struct_anonymous_20, NULL),
+static const struct YamlNode union_anonymous_16_elmts[] = {
+  YAML_STRUCT("custom", 32, struct_anonymous_17, NULL),
+  YAML_STRUCT("cell", 32, struct_anonymous_18, NULL),
+  YAML_STRUCT("calc", 32, struct_anonymous_19, NULL),
+  YAML_STRUCT("consumption", 32, struct_anonymous_20, NULL),
+  YAML_STRUCT("dist", 32, struct_anonymous_21, NULL),
   YAML_UNSIGNED( "param", 32 ),
   YAML_END
 };
 static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_IDX,
-  YAML_UNION("id1", 16, union_anonymous_12_elmts, select_id1),
-  YAML_UNION("id2", 8, union_anonymous_13_elmts, select_id2),
+  YAML_UNION("id1", 16, union_anonymous_13_elmts, select_id1),
+  YAML_UNION("id2", 8, union_anonymous_14_elmts, select_id2),
   YAML_STRING("label", 4),
   YAML_UNSIGNED( "subId", 8 ),
   YAML_ENUM("type", 1, enum_TelemetrySensorType),
@@ -761,7 +767,7 @@ static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_UNSIGNED( "persistent", 1 ),
   YAML_UNSIGNED( "onlyPositive", 1 ),
   YAML_PADDING( 1 ),
-  YAML_UNION("cfg", 32, union_anonymous_15_elmts, select_sensor_cfg),
+  YAML_UNION("cfg", 32, union_anonymous_16_elmts, select_sensor_cfg),
   YAML_END
 };
 static const struct YamlNode struct_FrSkyBarData[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
@@ -677,6 +677,11 @@ static const struct YamlNode struct_anonymous_11[] = {
   YAML_UNSIGNED( "reserved", 6 ),
   YAML_END
 };
+static const struct YamlNode struct_anonymous_12[] = {
+  YAML_UNSIGNED( "raw12bits", 1 ),
+  YAML_PADDING( 7 ),
+  YAML_END
+};
 static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_ARRAY("raw", 8, 25, struct_unsigned_8, NULL),
   YAML_STRUCT("ppm", 16, struct_anonymous_5, NULL),
@@ -686,6 +691,7 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_STRUCT("pxx2", 200, struct_anonymous_9, NULL),
   YAML_STRUCT("flysky", 56, struct_anonymous_10, NULL),
   YAML_STRUCT("afhds3", 64, struct_anonymous_11, NULL),
+  YAML_STRUCT("ghost", 8, struct_anonymous_12, NULL),
   YAML_END
 };
 static const struct YamlNode struct_ModuleData[] = {
@@ -733,61 +739,61 @@ static const struct YamlNode struct_string_32[] = {
   YAML_STRING("val", 4),
   YAML_END
 };
-static const struct YamlNode union_anonymous_12_elmts[] = {
+static const struct YamlNode union_anonymous_13_elmts[] = {
   YAML_UNSIGNED( "id", 16 ),
   YAML_UNSIGNED( "persistentValue", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_14[] = {
+static const struct YamlNode struct_anonymous_15[] = {
   YAML_UNSIGNED( "physID", 5 ),
   YAML_UNSIGNED( "rxIndex", 3 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_13_elmts[] = {
-  YAML_STRUCT("frskyInstance", 8, struct_anonymous_14, NULL),
+static const struct YamlNode union_anonymous_14_elmts[] = {
+  YAML_STRUCT("frskyInstance", 8, struct_anonymous_15, NULL),
   YAML_UNSIGNED( "instance", 8 ),
   YAML_ENUM("formula", 8, enum_TelemetrySensorFormula),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_16[] = {
+static const struct YamlNode struct_anonymous_17[] = {
   YAML_UNSIGNED( "ratio", 16 ),
   YAML_SIGNED( "offset", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_17[] = {
+static const struct YamlNode struct_anonymous_18[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_UNSIGNED( "index", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_18[] = {
+static const struct YamlNode struct_anonymous_19[] = {
   YAML_ARRAY("sources", 8, 4, struct_signed_8, NULL),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_19[] = {
+static const struct YamlNode struct_anonymous_20[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_PADDING( 24 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_20[] = {
+static const struct YamlNode struct_anonymous_21[] = {
   YAML_UNSIGNED( "gps", 8 ),
   YAML_UNSIGNED( "alt", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_15_elmts[] = {
-  YAML_STRUCT("custom", 32, struct_anonymous_16, NULL),
-  YAML_STRUCT("cell", 32, struct_anonymous_17, NULL),
-  YAML_STRUCT("calc", 32, struct_anonymous_18, NULL),
-  YAML_STRUCT("consumption", 32, struct_anonymous_19, NULL),
-  YAML_STRUCT("dist", 32, struct_anonymous_20, NULL),
+static const struct YamlNode union_anonymous_16_elmts[] = {
+  YAML_STRUCT("custom", 32, struct_anonymous_17, NULL),
+  YAML_STRUCT("cell", 32, struct_anonymous_18, NULL),
+  YAML_STRUCT("calc", 32, struct_anonymous_19, NULL),
+  YAML_STRUCT("consumption", 32, struct_anonymous_20, NULL),
+  YAML_STRUCT("dist", 32, struct_anonymous_21, NULL),
   YAML_UNSIGNED( "param", 32 ),
   YAML_END
 };
 static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_IDX,
-  YAML_UNION("id1", 16, union_anonymous_12_elmts, select_id1),
-  YAML_UNION("id2", 8, union_anonymous_13_elmts, select_id2),
+  YAML_UNION("id1", 16, union_anonymous_13_elmts, select_id1),
+  YAML_UNION("id2", 8, union_anonymous_14_elmts, select_id2),
   YAML_STRING("label", 4),
   YAML_UNSIGNED( "subId", 8 ),
   YAML_ENUM("type", 1, enum_TelemetrySensorType),
@@ -800,7 +806,7 @@ static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_UNSIGNED( "persistent", 1 ),
   YAML_UNSIGNED( "onlyPositive", 1 ),
   YAML_PADDING( 1 ),
-  YAML_UNION("cfg", 32, union_anonymous_15_elmts, select_sensor_cfg),
+  YAML_UNION("cfg", 32, union_anonymous_16_elmts, select_sensor_cfg),
   YAML_END
 };
 static const struct YamlNode struct_FrSkyBarData[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_x9lite.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9lite.cpp
@@ -615,6 +615,11 @@ static const struct YamlNode struct_anonymous_11[] = {
   YAML_UNSIGNED( "reserved", 6 ),
   YAML_END
 };
+static const struct YamlNode struct_anonymous_12[] = {
+  YAML_UNSIGNED( "raw12bits", 1 ),
+  YAML_PADDING( 7 ),
+  YAML_END
+};
 static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_ARRAY("raw", 8, 25, struct_unsigned_8, NULL),
   YAML_STRUCT("ppm", 16, struct_anonymous_5, NULL),
@@ -624,6 +629,7 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_STRUCT("pxx2", 200, struct_anonymous_9, NULL),
   YAML_STRUCT("flysky", 56, struct_anonymous_10, NULL),
   YAML_STRUCT("afhds3", 64, struct_anonymous_11, NULL),
+  YAML_STRUCT("ghost", 8, struct_anonymous_12, NULL),
   YAML_END
 };
 static const struct YamlNode struct_ModuleData[] = {
@@ -666,61 +672,61 @@ static const struct YamlNode struct_ScriptData[] = {
   YAML_ARRAY("inputs", 16, 6, union_ScriptDataInput, NULL),
   YAML_END
 };
-static const struct YamlNode union_anonymous_12_elmts[] = {
+static const struct YamlNode union_anonymous_13_elmts[] = {
   YAML_UNSIGNED( "id", 16 ),
   YAML_UNSIGNED( "persistentValue", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_14[] = {
+static const struct YamlNode struct_anonymous_15[] = {
   YAML_UNSIGNED( "physID", 5 ),
   YAML_UNSIGNED( "rxIndex", 3 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_13_elmts[] = {
-  YAML_STRUCT("frskyInstance", 8, struct_anonymous_14, NULL),
+static const struct YamlNode union_anonymous_14_elmts[] = {
+  YAML_STRUCT("frskyInstance", 8, struct_anonymous_15, NULL),
   YAML_UNSIGNED( "instance", 8 ),
   YAML_ENUM("formula", 8, enum_TelemetrySensorFormula),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_16[] = {
+static const struct YamlNode struct_anonymous_17[] = {
   YAML_UNSIGNED( "ratio", 16 ),
   YAML_SIGNED( "offset", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_17[] = {
+static const struct YamlNode struct_anonymous_18[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_UNSIGNED( "index", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_18[] = {
+static const struct YamlNode struct_anonymous_19[] = {
   YAML_ARRAY("sources", 8, 4, struct_signed_8, NULL),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_19[] = {
+static const struct YamlNode struct_anonymous_20[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_PADDING( 24 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_20[] = {
+static const struct YamlNode struct_anonymous_21[] = {
   YAML_UNSIGNED( "gps", 8 ),
   YAML_UNSIGNED( "alt", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_15_elmts[] = {
-  YAML_STRUCT("custom", 32, struct_anonymous_16, NULL),
-  YAML_STRUCT("cell", 32, struct_anonymous_17, NULL),
-  YAML_STRUCT("calc", 32, struct_anonymous_18, NULL),
-  YAML_STRUCT("consumption", 32, struct_anonymous_19, NULL),
-  YAML_STRUCT("dist", 32, struct_anonymous_20, NULL),
+static const struct YamlNode union_anonymous_16_elmts[] = {
+  YAML_STRUCT("custom", 32, struct_anonymous_17, NULL),
+  YAML_STRUCT("cell", 32, struct_anonymous_18, NULL),
+  YAML_STRUCT("calc", 32, struct_anonymous_19, NULL),
+  YAML_STRUCT("consumption", 32, struct_anonymous_20, NULL),
+  YAML_STRUCT("dist", 32, struct_anonymous_21, NULL),
   YAML_UNSIGNED( "param", 32 ),
   YAML_END
 };
 static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_IDX,
-  YAML_UNION("id1", 16, union_anonymous_12_elmts, select_id1),
-  YAML_UNION("id2", 8, union_anonymous_13_elmts, select_id2),
+  YAML_UNION("id1", 16, union_anonymous_13_elmts, select_id1),
+  YAML_UNION("id2", 8, union_anonymous_14_elmts, select_id2),
   YAML_STRING("label", 4),
   YAML_UNSIGNED( "subId", 8 ),
   YAML_ENUM("type", 1, enum_TelemetrySensorType),
@@ -733,7 +739,7 @@ static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_UNSIGNED( "persistent", 1 ),
   YAML_UNSIGNED( "onlyPositive", 1 ),
   YAML_PADDING( 1 ),
-  YAML_UNION("cfg", 32, union_anonymous_15_elmts, select_sensor_cfg),
+  YAML_UNION("cfg", 32, union_anonymous_16_elmts, select_sensor_cfg),
   YAML_END
 };
 static const struct YamlNode struct_FrSkyBarData[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_x9lites.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9lites.cpp
@@ -625,6 +625,11 @@ static const struct YamlNode struct_anonymous_11[] = {
   YAML_UNSIGNED( "reserved", 6 ),
   YAML_END
 };
+static const struct YamlNode struct_anonymous_12[] = {
+  YAML_UNSIGNED( "raw12bits", 1 ),
+  YAML_PADDING( 7 ),
+  YAML_END
+};
 static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_ARRAY("raw", 8, 25, struct_unsigned_8, NULL),
   YAML_STRUCT("ppm", 16, struct_anonymous_5, NULL),
@@ -634,6 +639,7 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_STRUCT("pxx2", 200, struct_anonymous_9, NULL),
   YAML_STRUCT("flysky", 56, struct_anonymous_10, NULL),
   YAML_STRUCT("afhds3", 64, struct_anonymous_11, NULL),
+  YAML_STRUCT("ghost", 8, struct_anonymous_12, NULL),
   YAML_END
 };
 static const struct YamlNode struct_ModuleData[] = {
@@ -676,61 +682,61 @@ static const struct YamlNode struct_ScriptData[] = {
   YAML_ARRAY("inputs", 16, 6, union_ScriptDataInput, NULL),
   YAML_END
 };
-static const struct YamlNode union_anonymous_12_elmts[] = {
+static const struct YamlNode union_anonymous_13_elmts[] = {
   YAML_UNSIGNED( "id", 16 ),
   YAML_UNSIGNED( "persistentValue", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_14[] = {
+static const struct YamlNode struct_anonymous_15[] = {
   YAML_UNSIGNED( "physID", 5 ),
   YAML_UNSIGNED( "rxIndex", 3 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_13_elmts[] = {
-  YAML_STRUCT("frskyInstance", 8, struct_anonymous_14, NULL),
+static const struct YamlNode union_anonymous_14_elmts[] = {
+  YAML_STRUCT("frskyInstance", 8, struct_anonymous_15, NULL),
   YAML_UNSIGNED( "instance", 8 ),
   YAML_ENUM("formula", 8, enum_TelemetrySensorFormula),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_16[] = {
+static const struct YamlNode struct_anonymous_17[] = {
   YAML_UNSIGNED( "ratio", 16 ),
   YAML_SIGNED( "offset", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_17[] = {
+static const struct YamlNode struct_anonymous_18[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_UNSIGNED( "index", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_18[] = {
+static const struct YamlNode struct_anonymous_19[] = {
   YAML_ARRAY("sources", 8, 4, struct_signed_8, NULL),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_19[] = {
+static const struct YamlNode struct_anonymous_20[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_PADDING( 24 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_20[] = {
+static const struct YamlNode struct_anonymous_21[] = {
   YAML_UNSIGNED( "gps", 8 ),
   YAML_UNSIGNED( "alt", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_15_elmts[] = {
-  YAML_STRUCT("custom", 32, struct_anonymous_16, NULL),
-  YAML_STRUCT("cell", 32, struct_anonymous_17, NULL),
-  YAML_STRUCT("calc", 32, struct_anonymous_18, NULL),
-  YAML_STRUCT("consumption", 32, struct_anonymous_19, NULL),
-  YAML_STRUCT("dist", 32, struct_anonymous_20, NULL),
+static const struct YamlNode union_anonymous_16_elmts[] = {
+  YAML_STRUCT("custom", 32, struct_anonymous_17, NULL),
+  YAML_STRUCT("cell", 32, struct_anonymous_18, NULL),
+  YAML_STRUCT("calc", 32, struct_anonymous_19, NULL),
+  YAML_STRUCT("consumption", 32, struct_anonymous_20, NULL),
+  YAML_STRUCT("dist", 32, struct_anonymous_21, NULL),
   YAML_UNSIGNED( "param", 32 ),
   YAML_END
 };
 static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_IDX,
-  YAML_UNION("id1", 16, union_anonymous_12_elmts, select_id1),
-  YAML_UNION("id2", 8, union_anonymous_13_elmts, select_id2),
+  YAML_UNION("id1", 16, union_anonymous_13_elmts, select_id1),
+  YAML_UNION("id2", 8, union_anonymous_14_elmts, select_id2),
   YAML_STRING("label", 4),
   YAML_UNSIGNED( "subId", 8 ),
   YAML_ENUM("type", 1, enum_TelemetrySensorType),
@@ -743,7 +749,7 @@ static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_UNSIGNED( "persistent", 1 ),
   YAML_UNSIGNED( "onlyPositive", 1 ),
   YAML_PADDING( 1 ),
-  YAML_UNION("cfg", 32, union_anonymous_15_elmts, select_sensor_cfg),
+  YAML_UNION("cfg", 32, union_anonymous_16_elmts, select_sensor_cfg),
   YAML_END
 };
 static const struct YamlNode struct_FrSkyBarData[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_xlite.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_xlite.cpp
@@ -622,6 +622,11 @@ static const struct YamlNode struct_anonymous_11[] = {
   YAML_UNSIGNED( "reserved", 6 ),
   YAML_END
 };
+static const struct YamlNode struct_anonymous_12[] = {
+  YAML_UNSIGNED( "raw12bits", 1 ),
+  YAML_PADDING( 7 ),
+  YAML_END
+};
 static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_ARRAY("raw", 8, 25, struct_unsigned_8, NULL),
   YAML_STRUCT("ppm", 16, struct_anonymous_5, NULL),
@@ -631,6 +636,7 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_STRUCT("pxx2", 200, struct_anonymous_9, NULL),
   YAML_STRUCT("flysky", 56, struct_anonymous_10, NULL),
   YAML_STRUCT("afhds3", 64, struct_anonymous_11, NULL),
+  YAML_STRUCT("ghost", 8, struct_anonymous_12, NULL),
   YAML_END
 };
 static const struct YamlNode struct_ModuleData[] = {
@@ -673,61 +679,61 @@ static const struct YamlNode struct_ScriptData[] = {
   YAML_ARRAY("inputs", 16, 6, union_ScriptDataInput, NULL),
   YAML_END
 };
-static const struct YamlNode union_anonymous_12_elmts[] = {
+static const struct YamlNode union_anonymous_13_elmts[] = {
   YAML_UNSIGNED( "id", 16 ),
   YAML_UNSIGNED( "persistentValue", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_14[] = {
+static const struct YamlNode struct_anonymous_15[] = {
   YAML_UNSIGNED( "physID", 5 ),
   YAML_UNSIGNED( "rxIndex", 3 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_13_elmts[] = {
-  YAML_STRUCT("frskyInstance", 8, struct_anonymous_14, NULL),
+static const struct YamlNode union_anonymous_14_elmts[] = {
+  YAML_STRUCT("frskyInstance", 8, struct_anonymous_15, NULL),
   YAML_UNSIGNED( "instance", 8 ),
   YAML_ENUM("formula", 8, enum_TelemetrySensorFormula),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_16[] = {
+static const struct YamlNode struct_anonymous_17[] = {
   YAML_UNSIGNED( "ratio", 16 ),
   YAML_SIGNED( "offset", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_17[] = {
+static const struct YamlNode struct_anonymous_18[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_UNSIGNED( "index", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_18[] = {
+static const struct YamlNode struct_anonymous_19[] = {
   YAML_ARRAY("sources", 8, 4, struct_signed_8, NULL),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_19[] = {
+static const struct YamlNode struct_anonymous_20[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_PADDING( 24 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_20[] = {
+static const struct YamlNode struct_anonymous_21[] = {
   YAML_UNSIGNED( "gps", 8 ),
   YAML_UNSIGNED( "alt", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_15_elmts[] = {
-  YAML_STRUCT("custom", 32, struct_anonymous_16, NULL),
-  YAML_STRUCT("cell", 32, struct_anonymous_17, NULL),
-  YAML_STRUCT("calc", 32, struct_anonymous_18, NULL),
-  YAML_STRUCT("consumption", 32, struct_anonymous_19, NULL),
-  YAML_STRUCT("dist", 32, struct_anonymous_20, NULL),
+static const struct YamlNode union_anonymous_16_elmts[] = {
+  YAML_STRUCT("custom", 32, struct_anonymous_17, NULL),
+  YAML_STRUCT("cell", 32, struct_anonymous_18, NULL),
+  YAML_STRUCT("calc", 32, struct_anonymous_19, NULL),
+  YAML_STRUCT("consumption", 32, struct_anonymous_20, NULL),
+  YAML_STRUCT("dist", 32, struct_anonymous_21, NULL),
   YAML_UNSIGNED( "param", 32 ),
   YAML_END
 };
 static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_IDX,
-  YAML_UNION("id1", 16, union_anonymous_12_elmts, select_id1),
-  YAML_UNION("id2", 8, union_anonymous_13_elmts, select_id2),
+  YAML_UNION("id1", 16, union_anonymous_13_elmts, select_id1),
+  YAML_UNION("id2", 8, union_anonymous_14_elmts, select_id2),
   YAML_STRING("label", 4),
   YAML_UNSIGNED( "subId", 8 ),
   YAML_ENUM("type", 1, enum_TelemetrySensorType),
@@ -740,7 +746,7 @@ static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_UNSIGNED( "persistent", 1 ),
   YAML_UNSIGNED( "onlyPositive", 1 ),
   YAML_PADDING( 1 ),
-  YAML_UNION("cfg", 32, union_anonymous_15_elmts, select_sensor_cfg),
+  YAML_UNION("cfg", 32, union_anonymous_16_elmts, select_sensor_cfg),
   YAML_END
 };
 static const struct YamlNode struct_FrSkyBarData[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
@@ -626,6 +626,11 @@ static const struct YamlNode struct_anonymous_11[] = {
   YAML_UNSIGNED( "reserved", 6 ),
   YAML_END
 };
+static const struct YamlNode struct_anonymous_12[] = {
+  YAML_UNSIGNED( "raw12bits", 1 ),
+  YAML_PADDING( 7 ),
+  YAML_END
+};
 static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_ARRAY("raw", 8, 25, struct_unsigned_8, NULL),
   YAML_STRUCT("ppm", 16, struct_anonymous_5, NULL),
@@ -635,6 +640,7 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_STRUCT("pxx2", 200, struct_anonymous_9, NULL),
   YAML_STRUCT("flysky", 56, struct_anonymous_10, NULL),
   YAML_STRUCT("afhds3", 64, struct_anonymous_11, NULL),
+  YAML_STRUCT("ghost", 8, struct_anonymous_12, NULL),
   YAML_END
 };
 static const struct YamlNode struct_ModuleData[] = {
@@ -677,61 +683,61 @@ static const struct YamlNode struct_ScriptData[] = {
   YAML_ARRAY("inputs", 16, 6, union_ScriptDataInput, NULL),
   YAML_END
 };
-static const struct YamlNode union_anonymous_12_elmts[] = {
+static const struct YamlNode union_anonymous_13_elmts[] = {
   YAML_UNSIGNED( "id", 16 ),
   YAML_UNSIGNED( "persistentValue", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_14[] = {
+static const struct YamlNode struct_anonymous_15[] = {
   YAML_UNSIGNED( "physID", 5 ),
   YAML_UNSIGNED( "rxIndex", 3 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_13_elmts[] = {
-  YAML_STRUCT("frskyInstance", 8, struct_anonymous_14, NULL),
+static const struct YamlNode union_anonymous_14_elmts[] = {
+  YAML_STRUCT("frskyInstance", 8, struct_anonymous_15, NULL),
   YAML_UNSIGNED( "instance", 8 ),
   YAML_ENUM("formula", 8, enum_TelemetrySensorFormula),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_16[] = {
+static const struct YamlNode struct_anonymous_17[] = {
   YAML_UNSIGNED( "ratio", 16 ),
   YAML_SIGNED( "offset", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_17[] = {
+static const struct YamlNode struct_anonymous_18[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_UNSIGNED( "index", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_18[] = {
+static const struct YamlNode struct_anonymous_19[] = {
   YAML_ARRAY("sources", 8, 4, struct_signed_8, NULL),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_19[] = {
+static const struct YamlNode struct_anonymous_20[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_PADDING( 24 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_20[] = {
+static const struct YamlNode struct_anonymous_21[] = {
   YAML_UNSIGNED( "gps", 8 ),
   YAML_UNSIGNED( "alt", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_15_elmts[] = {
-  YAML_STRUCT("custom", 32, struct_anonymous_16, NULL),
-  YAML_STRUCT("cell", 32, struct_anonymous_17, NULL),
-  YAML_STRUCT("calc", 32, struct_anonymous_18, NULL),
-  YAML_STRUCT("consumption", 32, struct_anonymous_19, NULL),
-  YAML_STRUCT("dist", 32, struct_anonymous_20, NULL),
+static const struct YamlNode union_anonymous_16_elmts[] = {
+  YAML_STRUCT("custom", 32, struct_anonymous_17, NULL),
+  YAML_STRUCT("cell", 32, struct_anonymous_18, NULL),
+  YAML_STRUCT("calc", 32, struct_anonymous_19, NULL),
+  YAML_STRUCT("consumption", 32, struct_anonymous_20, NULL),
+  YAML_STRUCT("dist", 32, struct_anonymous_21, NULL),
   YAML_UNSIGNED( "param", 32 ),
   YAML_END
 };
 static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_IDX,
-  YAML_UNION("id1", 16, union_anonymous_12_elmts, select_id1),
-  YAML_UNION("id2", 8, union_anonymous_13_elmts, select_id2),
+  YAML_UNION("id1", 16, union_anonymous_13_elmts, select_id1),
+  YAML_UNION("id2", 8, union_anonymous_14_elmts, select_id2),
   YAML_STRING("label", 4),
   YAML_UNSIGNED( "subId", 8 ),
   YAML_ENUM("type", 1, enum_TelemetrySensorType),
@@ -744,7 +750,7 @@ static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_UNSIGNED( "persistent", 1 ),
   YAML_UNSIGNED( "onlyPositive", 1 ),
   YAML_PADDING( 1 ),
-  YAML_UNION("cfg", 32, union_anonymous_15_elmts, select_sensor_cfg),
+  YAML_UNION("cfg", 32, union_anonymous_16_elmts, select_sensor_cfg),
   YAML_END
 };
 static const struct YamlNode struct_FrSkyBarData[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_zorro.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_zorro.cpp
@@ -630,6 +630,11 @@ static const struct YamlNode struct_anonymous_11[] = {
   YAML_UNSIGNED( "reserved", 6 ),
   YAML_END
 };
+static const struct YamlNode struct_anonymous_12[] = {
+  YAML_UNSIGNED( "raw12bits", 1 ),
+  YAML_PADDING( 7 ),
+  YAML_END
+};
 static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_ARRAY("raw", 8, 25, struct_unsigned_8, NULL),
   YAML_STRUCT("ppm", 16, struct_anonymous_5, NULL),
@@ -639,6 +644,7 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
   YAML_STRUCT("pxx2", 200, struct_anonymous_9, NULL),
   YAML_STRUCT("flysky", 56, struct_anonymous_10, NULL),
   YAML_STRUCT("afhds3", 64, struct_anonymous_11, NULL),
+  YAML_STRUCT("ghost", 8, struct_anonymous_12, NULL),
   YAML_END
 };
 static const struct YamlNode struct_ModuleData[] = {
@@ -681,61 +687,61 @@ static const struct YamlNode struct_ScriptData[] = {
   YAML_ARRAY("inputs", 16, 6, union_ScriptDataInput, NULL),
   YAML_END
 };
-static const struct YamlNode union_anonymous_12_elmts[] = {
+static const struct YamlNode union_anonymous_13_elmts[] = {
   YAML_UNSIGNED( "id", 16 ),
   YAML_UNSIGNED( "persistentValue", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_14[] = {
+static const struct YamlNode struct_anonymous_15[] = {
   YAML_UNSIGNED( "physID", 5 ),
   YAML_UNSIGNED( "rxIndex", 3 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_13_elmts[] = {
-  YAML_STRUCT("frskyInstance", 8, struct_anonymous_14, NULL),
+static const struct YamlNode union_anonymous_14_elmts[] = {
+  YAML_STRUCT("frskyInstance", 8, struct_anonymous_15, NULL),
   YAML_UNSIGNED( "instance", 8 ),
   YAML_ENUM("formula", 8, enum_TelemetrySensorFormula),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_16[] = {
+static const struct YamlNode struct_anonymous_17[] = {
   YAML_UNSIGNED( "ratio", 16 ),
   YAML_SIGNED( "offset", 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_17[] = {
+static const struct YamlNode struct_anonymous_18[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_UNSIGNED( "index", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_18[] = {
+static const struct YamlNode struct_anonymous_19[] = {
   YAML_ARRAY("sources", 8, 4, struct_signed_8, NULL),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_19[] = {
+static const struct YamlNode struct_anonymous_20[] = {
   YAML_UNSIGNED( "source", 8 ),
   YAML_PADDING( 24 ),
   YAML_END
 };
-static const struct YamlNode struct_anonymous_20[] = {
+static const struct YamlNode struct_anonymous_21[] = {
   YAML_UNSIGNED( "gps", 8 ),
   YAML_UNSIGNED( "alt", 8 ),
   YAML_PADDING( 16 ),
   YAML_END
 };
-static const struct YamlNode union_anonymous_15_elmts[] = {
-  YAML_STRUCT("custom", 32, struct_anonymous_16, NULL),
-  YAML_STRUCT("cell", 32, struct_anonymous_17, NULL),
-  YAML_STRUCT("calc", 32, struct_anonymous_18, NULL),
-  YAML_STRUCT("consumption", 32, struct_anonymous_19, NULL),
-  YAML_STRUCT("dist", 32, struct_anonymous_20, NULL),
+static const struct YamlNode union_anonymous_16_elmts[] = {
+  YAML_STRUCT("custom", 32, struct_anonymous_17, NULL),
+  YAML_STRUCT("cell", 32, struct_anonymous_18, NULL),
+  YAML_STRUCT("calc", 32, struct_anonymous_19, NULL),
+  YAML_STRUCT("consumption", 32, struct_anonymous_20, NULL),
+  YAML_STRUCT("dist", 32, struct_anonymous_21, NULL),
   YAML_UNSIGNED( "param", 32 ),
   YAML_END
 };
 static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_IDX,
-  YAML_UNION("id1", 16, union_anonymous_12_elmts, select_id1),
-  YAML_UNION("id2", 8, union_anonymous_13_elmts, select_id2),
+  YAML_UNION("id1", 16, union_anonymous_13_elmts, select_id1),
+  YAML_UNION("id2", 8, union_anonymous_14_elmts, select_id2),
   YAML_STRING("label", 4),
   YAML_UNSIGNED( "subId", 8 ),
   YAML_ENUM("type", 1, enum_TelemetrySensorType),
@@ -748,7 +754,7 @@ static const struct YamlNode struct_TelemetrySensor[] = {
   YAML_UNSIGNED( "persistent", 1 ),
   YAML_UNSIGNED( "onlyPositive", 1 ),
   YAML_PADDING( 1 ),
-  YAML_UNION("cfg", 32, union_anonymous_15_elmts, select_sensor_cfg),
+  YAML_UNION("cfg", 32, union_anonymous_16_elmts, select_sensor_cfg),
   YAML_END
 };
 static const struct YamlNode struct_FrSkyBarData[] = {

--- a/radio/src/telemetry/ghost.cpp
+++ b/radio/src/telemetry/ghost.cpp
@@ -302,6 +302,20 @@ void processGhostTelemetryFrame()
       processGhostTelemetryValue(GHOST_ID_GPS_SATS, telemetryRxBuffer[7]);   
       break; 
     }
+    case GHST_DL_MAGBARO: {
+      // Not implemented yet
+      break;
+    }
+#if defined(LUA)
+    default:
+      if (luaInputTelemetryFifo && luaInputTelemetryFifo->hasSpace(telemetryRxBufferCount-2) ) {
+        for (uint8_t i=1; i<telemetryRxBufferCount-1; i++) {
+          // destination address and CRC are skipped
+          luaInputTelemetryFifo->push(telemetryRxBuffer[i]);
+        }
+      }
+      break;
+#endif
   }
 }
 

--- a/radio/src/telemetry/ghost.cpp
+++ b/radio/src/telemetry/ghost.cpp
@@ -88,6 +88,14 @@ const GhostSensor ghostSensors[] = {
   {0x00,                     NULL,                  UNIT_RAW,               0},
 };
 
+uint8_t getGhostModuleAddr() {
+#if SPORT_MAX_BAUDRATE < 400000
+  return g_eeGeneral.telemetryBaudrate == GHST_TELEMETRY_RATE_400K ? GHST_ADDR_MODULE_SYM : GHST_ADDR_MODULE_ASYM;
+#else
+  return GHST_ADDR_MODULE_SYM;
+#endif
+}
+
 const GhostSensor *getGhostSensor(uint8_t id)
 {
   for (const GhostSensor * sensor = ghostSensors; sensor->id; sensor++) {

--- a/radio/src/telemetry/ghost.h
+++ b/radio/src/telemetry/ghost.h
@@ -30,17 +30,21 @@
 #define GHST_ADDR_MODULE_ASYM           0x88    // asymmetrical, 400k pulses, 115k telemetry
 #define GHST_ADDR_FC                    0x82
 #define GHST_ADDR_GOGGLES               0x83    // phase 2
-#define GHST_ADDR_5G_TXCTRL             0x84	// phase 3
+#define GHST_ADDR_5G_TXCTRL             0x84    // phase 3
 #define GHST_ADDR_5G_TWRSCAN            0x85
 #define GHST_ADDR_5G_RLY                0x86
 
-#define GHST_UL_RC_CHANS_HS4_5TO8	0x10	// High Speed 4 channel (12 bits), plus CH5-8 (8 bits)
-#define GHST_UL_RC_CHANS_HS4_9TO12	0x11	// High Speed 4 channel (12 bits), plus CH9-12 (8 bits)
-#define GHST_UL_RC_CHANS_HS4_13TO16	0x12	// High Speed 4 channel (12 bits), plus CH13-16 (8 bits)
-#define GHST_UL_RC_CHANS_SIZE           12      // 1 (type) + 10 (data) + 1 (crc)
+#define GHST_UL_RC_CHANS_HS4_5TO8       0x10  // High Speed 4 channel (12 bit legacy), plus CH5-8 (8 bits)
+#define GHST_UL_RC_CHANS_HS4_9TO12      0x11  // High Speed 4 channel (12 bit legacy), plus CH9-12 (8 bits)
+#define GHST_UL_RC_CHANS_HS4_13TO16     0x12  // High Speed 4 channel (12 bit legacy), plus CH13-16 (8 bits)
+#define GHST_UL_RC_CHANS_SIZE           12    // 1 (type) + 10 (data) + 1 (crc)
 #define GHST_UL_MENU_CTRL               0x13
 
-#define GHST_DL_OPENTX_SYNC		0x20
+#define GHST_UL_RC_CHANS_HS4_12_5TO8    0x30  // High Speed 4 channel (12 bit raw), plus CH5-8 (8 bit raw)
+#define GHST_UL_RC_CHANS_HS4_12_9TO12   0x31  // High Speed 4 channel (12 bit raw), plus CH9-12 (8 bit raw)
+#define GHST_UL_RC_CHANS_HS4_12_13TO16  0x32  // High Speed 4 channel (12 bit raw), plus CH13-16 (8 bit raw)
+
+#define GHST_DL_OPENTX_SYNC             0x20
 #define GHST_DL_LINK_STAT               0x21
 #define GHST_DL_VTX_STAT                0x22
 #define GHST_DL_PACK_STAT               0x23
@@ -48,8 +52,8 @@
 #define GHST_DL_GPS_PRIMARY             0x25
 #define GHST_DL_GPS_SECONDARY           0x26
 
-#define GHST_RC_CTR_VAL_12BIT		0x7C0   // 0x3e0 << 1
-#define GHST_RC_CTR_VAL_8BIT		0x7C
+#define GHST_RC_CTR_VAL_12BIT           0x7C0   // 0x3e0 << 1
+#define GHST_RC_CTR_VAL_8BIT            0x7C
 
 #define GHST_CH_BITS_12                 12
 #define GHST_CH_BITS_8                  8
@@ -101,6 +105,7 @@ enum GhstVtxBand
 
 void processGhostTelemetryData(uint8_t data);
 void ghostSetDefault(int index, uint8_t id, uint8_t subId);
+uint8_t getGhostModuleAddr();
 
 #if SPORT_MAX_BAUDRATE < 400000
 // For radios which can't support telemetry at high rates, offer baud rate choices

--- a/radio/src/telemetry/ghost.h
+++ b/radio/src/telemetry/ghost.h
@@ -51,6 +51,8 @@
 #define GHST_DL_MENU_DESC               0x24
 #define GHST_DL_GPS_PRIMARY             0x25
 #define GHST_DL_GPS_SECONDARY           0x26
+#define GHST_DL_MAGBARO                 0x27
+#define GHST_DL_MSP_RESP                0x28
 
 #define GHST_RC_CTR_VAL_12BIT           0x7C0   // 0x3e0 << 1
 #define GHST_RC_CTR_VAL_8BIT            0x7C


### PR DESCRIPTION
Add support for MSP with Ghost protocol.

`luaGhostTelemetryPush` and `luaGhostTelemetryPop` similar to CRSF version.

Need new Ghost FW v1.0.6.0+

New features:

- Betaflight LUA Scripts will work https://github.com/betaflight/betaflight-tx-lua-scripts/pull/419
- We can create LUA script for Ghost setup later

BF: https://github.com/betaflight/betaflight/pull/11242

Agreed with @raphaelcoeffic to put it to ETX 2.7.

Merge after https://github.com/EdgeTX/edgetx/pull/1233

FYI: @tonycake @TheIsotopes