### PR TITLE
Fixing cross-usage of union reusableBuffer

### DIFF
--- a/radio/src/gui/colorlcd/radio_tools.h
+++ b/radio/src/gui/colorlcd/radio_tools.h
@@ -31,7 +31,8 @@ class RadioToolsPage : public PageTab
   void checkEvents() override;
 
  protected:
-  static void rebuild(FormWindow* window);
+  void rebuild(FormWindow* window);
   FormWindow* window = nullptr;
   uint8_t waiting = 0;
+  uint8_t linesCount = 0;
 };

--- a/radio/src/gui/common/stdlcd/radio_tools.cpp
+++ b/radio/src/gui/common/stdlcd/radio_tools.cpp
@@ -113,10 +113,10 @@ void menuRadioTools(event_t event)
 #endif
 
 #if defined(INTERNAL_MODULE_PXX2)
-  if (isPXX2ModuleOptionAvailable(reusableBuffer.hardwareAndSettings.modules[INTERNAL_MODULE].information.modelID, MODULE_OPTION_SPECTRUM_ANALYSER))
+  if (isPXX2ModuleOptionAvailable(reusableBuffer.radioTools.modules[INTERNAL_MODULE].information.modelID, MODULE_OPTION_SPECTRUM_ANALYSER))
     addRadioModuleTool(index++, STR_SPECTRUM_ANALYSER_INT, menuRadioSpectrumAnalyser, INTERNAL_MODULE);
 
-  if (isPXX2ModuleOptionAvailable(reusableBuffer.hardwareAndSettings.modules[INTERNAL_MODULE].information.modelID, MODULE_OPTION_POWER_METER))
+  if (isPXX2ModuleOptionAvailable(reusableBuffer.radioTools.modules[INTERNAL_MODULE].information.modelID, MODULE_OPTION_POWER_METER))
     addRadioModuleTool(index++, STR_POWER_METER_INT, menuRadioPowerMeter, INTERNAL_MODULE);
 #endif
 #if defined(HARDWARE_INTERNAL_MODULE) && defined(MULTIMODULE)
@@ -124,11 +124,11 @@ void menuRadioTools(event_t event)
     addRadioModuleTool(index++, STR_SPECTRUM_ANALYSER_INT, menuRadioSpectrumAnalyser, INTERNAL_MODULE);
 #endif
 #if defined(PXX2) || defined(MULTIMODULE)
-  if (isPXX2ModuleOptionAvailable(reusableBuffer.hardwareAndSettings.modules[EXTERNAL_MODULE].information.modelID, MODULE_OPTION_SPECTRUM_ANALYSER) || isModuleMultimodule(EXTERNAL_MODULE))
+  if (isPXX2ModuleOptionAvailable(reusableBuffer.radioTools.modules[EXTERNAL_MODULE].information.modelID, MODULE_OPTION_SPECTRUM_ANALYSER) || isModuleMultimodule(EXTERNAL_MODULE))
     addRadioModuleTool(index++, STR_SPECTRUM_ANALYSER_EXT, menuRadioSpectrumAnalyser, EXTERNAL_MODULE);
 #endif
 #if defined(PXX2)
-  if (isPXX2ModuleOptionAvailable(reusableBuffer.hardwareAndSettings.modules[EXTERNAL_MODULE].information.modelID, MODULE_OPTION_POWER_METER))
+  if (isPXX2ModuleOptionAvailable(reusableBuffer.radioTools.modules[EXTERNAL_MODULE].information.modelID, MODULE_OPTION_POWER_METER))
     addRadioModuleTool(index++, STR_POWER_METER_EXT, menuRadioPowerMeter, EXTERNAL_MODULE);
 #endif
 

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -970,13 +970,14 @@ union ReusableBuffer
     char id[27];
   } version;
 
-  // moduleOptions, receiverOptions, radioVersion
-  PXX2HardwareAndSettings hardwareAndSettings;
+  PXX2HardwareAndSettings hardwareAndSettings; // radio_version
 
   struct {
     ModuleInformation modules[NUM_MODULES];
-    uint8_t linesCount;
     char msg[64];
+#if !defined(COLORLCD)
+    uint8_t linesCount;
+#endif
   } radioTools;
 
   struct {

--- a/radio/src/pulses/pxx2.h
+++ b/radio/src/pulses/pxx2.h
@@ -418,6 +418,7 @@ struct PXX2HardwareAndSettings {
   ReceiverSettings receiverSettings;  // when dealing with receiver settings, we
                                       // also need module settings
   char msg[64];
+  uint8_t linesCount;
 };
 
 PXX2ModuleSetup& getPXX2ModuleSetupBuffer();

--- a/radio/src/pulses/pxx2.h
+++ b/radio/src/pulses/pxx2.h
@@ -418,7 +418,6 @@ struct PXX2HardwareAndSettings {
   ReceiverSettings receiverSettings;  // when dealing with receiver settings, we
                                       // also need module settings
   char msg[64];
-  uint8_t linesCount;
 };
 
 PXX2ModuleSetup& getPXX2ModuleSetupBuffer();


### PR DESCRIPTION
In my understanding the different union members of resusableBuffer should be dedicated to exactly one(!) menu-page. The _normal_ pattern should be to use a different union-member in different menu-pages. That should be safe, because two pages can't be active at the same time.
But the other way round, using two different union members in the same(!) page is false. 
Just spotted this in `*/radio_tool.cpp` and this should fix it.
