### PR TITLE
Make compilation on M1 Macs work

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ if(WIN32)
   list(APPEND CMAKE_PREFIX_PATH "${WIN_EXTRA_LIBS_PATH}" "${WIN_EXTRA_LIBS_PATH}/SDL")  # hints for FindSDL
 endif()
 
-if(APPLE)
+if(CMAKE_HOST_APPLE)
   execute_process(COMMAND xcrun --show-sdk-path
     OUTPUT_VARIABLE SDKROOT
     ERROR_QUIET

--- a/radio/src/storage/yaml/CMakeLists.txt
+++ b/radio/src/storage/yaml/CMakeLists.txt
@@ -66,6 +66,9 @@ get_property(dirs DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR} PROPERTY INCLUDE_DIRECTO
 foreach(dir ${dirs})
   #message(STATUS "dir='${dir}'")
   set(YAML_GEN_ARGS ${YAML_GEN_ARGS} -I${dir})
+
+  # Force to build 32 bit binaries (Fix for Apple Silicon M1 hosts)
+  set(YAML_GEN_ARGS ${YAML_GEN_ARGS} -m32)
 endforeach()
 
 set(YAML_GEN_ARGS ${YAML_GEN_ARGS} -DRTOS_COOS -Wno-inconsistent-missing-override)
@@ -74,7 +77,7 @@ set(YAML_GEN_ARGS ${YAML_GEN_ARGS} -DRTOS_COOS -Wno-inconsistent-missing-overrid
 
 add_custom_target(yaml_data
     WORKING_DIRECTORY ${RADIO_DIRECTORY}/src
-    COMMAND ${PYTHON_EXECUTABLE} ${YAML_GEN} ${YAML_GEN_ARGS} > ${YAML_GEN_OUTPUT}
+    COMMAND ${PYTHON_EXECUTABLE} ${YAML_GEN} ${YAML_GEN_ARGS} ${SYSROOT_ARG} > ${YAML_GEN_OUTPUT}
     DEPENDS ${RADIO_DIRECTORY}/src/datastructs.h
             ${RADIO_DIRECTORY}/src/dataconstants.h
             ${RADIO_DIRECTORY}/src/myeeprom.h


### PR DESCRIPTION
Summary of changes:
Makes EdgeTx (firmware, companion, simulator) build on M1 macs.

In addition to the dependencies described on the Wiki page, a build on a M1 based Mac requires the following to set the CMake environment variable:
export CMAKE_APPLE_SILICON_PROCESSOR=arm
