### PR TITLE
force a valid backlight on setting on color lcd radios

### DIFF
--- a/radio/src/gui/colorlcd/radio_setup.cpp
+++ b/radio/src/gui/colorlcd/radio_setup.cpp
@@ -361,7 +361,7 @@ void RadioSetupPage::build(FormWindow * window)
 
     // Backlight ON bright
     new StaticText(window, grid.getLabelSlot(true), STR_BLONBRIGHTNESS, 0, COLOR_THEME_PRIMARY1);
-    backlightOnBright = new Slider(window, grid.getFieldSlot(), BACKLIGHT_LEVEL_MIN+1, BACKLIGHT_LEVEL_MAX, // ON always has at least some backlight
+    backlightOnBright = new Slider(window, grid.getFieldSlot(), BACKLIGHT_LEVEL_MIN, BACKLIGHT_LEVEL_MAX,
                [=]() -> int32_t {
                  return BACKLIGHT_LEVEL_MAX - g_eeGeneral.backlightBright;
                },

--- a/radio/src/gui/colorlcd/radio_setup.cpp
+++ b/radio/src/gui/colorlcd/radio_setup.cpp
@@ -361,7 +361,7 @@ void RadioSetupPage::build(FormWindow * window)
 
     // Backlight ON bright
     new StaticText(window, grid.getLabelSlot(true), STR_BLONBRIGHTNESS, 0, COLOR_THEME_PRIMARY1);
-    backlightOnBright = new Slider(window, grid.getFieldSlot(), BACKLIGHT_LEVEL_MIN, BACKLIGHT_LEVEL_MAX,
+    backlightOnBright = new Slider(window, grid.getFieldSlot(), BACKLIGHT_LEVEL_MIN+1, BACKLIGHT_LEVEL_MAX, // ON always has at least some backlight
                [=]() -> int32_t {
                  return BACKLIGHT_LEVEL_MAX - g_eeGeneral.backlightBright;
                },

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -568,6 +568,11 @@ void checkBacklight()
       }
       if (backlightOn) {
         currentBacklightBright = requiredBacklightBright;
+#if defined(COLOR_LCD)
+        // force backlight on for color lcd radios
+	if(currentBacklightBright <= BACKLIGHT_LEVEL_MIN)
+          currentBacklightBricht = BACKLIGHT_LEVEL_MIN+1;
+#endif
         BACKLIGHT_ENABLE();
       }
       else {
@@ -1879,6 +1884,10 @@ void opentxInit()
     // no backlight mode off on color lcd radios
     g_eeGeneral.backlightMode = e_backlight_mode_keys;
   }
+  if (g_eeGeneral.backlightBright <= BACKLIGHT_LEVEL_MIN)
+    g_eeGeneral.backlightBright = BACKLIGHT_LEVEL_MIN+5;
+  if (g_eeGeneral.lightAutoOff < 1)
+    g_eeGeneral.lightAutoOff = 1;
 #endif
 
   if (g_eeGeneral.backlightMode != e_backlight_mode_off) {

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -568,10 +568,10 @@ void checkBacklight()
       }
       if (backlightOn) {
         currentBacklightBright = requiredBacklightBright;
-#if defined(COLOR_LCD)
+#if defined(COLORLCD)
         // force backlight on for color lcd radios
-        if(currentBacklightBright > BACLIGHT_LEVEL_MAX - BACKLIGHT_LEVEL_MIN)
-          currentBacklightBricht = BACKLIGHT_LEVEL_MAX - BACKLIGHT_LEVEL_MIN;
+        if(currentBacklightBright > BACKLIGHT_LEVEL_MAX - BACKLIGHT_LEVEL_MIN)
+          currentBacklightBright = BACKLIGHT_LEVEL_MAX - BACKLIGHT_LEVEL_MIN;
 #endif
         BACKLIGHT_ENABLE();
       }

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -570,7 +570,7 @@ void checkBacklight()
         currentBacklightBright = requiredBacklightBright;
 #if defined(COLOR_LCD)
         // force backlight on for color lcd radios
-	if(currentBacklightBright <= BACKLIGHT_LEVEL_MIN)
+        if(currentBacklightBright <= BACKLIGHT_LEVEL_MIN)
           currentBacklightBricht = BACKLIGHT_LEVEL_MIN+1;
 #endif
         BACKLIGHT_ENABLE();

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -570,8 +570,8 @@ void checkBacklight()
         currentBacklightBright = requiredBacklightBright;
 #if defined(COLOR_LCD)
         // force backlight on for color lcd radios
-        if(currentBacklightBright <= BACKLIGHT_LEVEL_MIN)
-          currentBacklightBricht = BACKLIGHT_LEVEL_MIN+1;
+        if(currentBacklightBright > BACLIGHT_LEVEL_MAX - BACKLIGHT_LEVEL_MIN)
+          currentBacklightBricht = BACKLIGHT_LEVEL_MAX - BACKLIGHT_LEVEL_MIN;
 #endif
         BACKLIGHT_ENABLE();
       }
@@ -1888,8 +1888,8 @@ void opentxInit()
     // no backlight mode off on color lcd radios
     g_eeGeneral.backlightMode = e_backlight_mode_keys;
   }
-  if (g_eeGeneral.backlightBright <= BACKLIGHT_LEVEL_MIN)
-    g_eeGeneral.backlightBright = BACKLIGHT_LEVEL_MIN+5;
+  if (g_eeGeneral.backlightBright > BACKLIGHT_LEVEL_MAX - BACKLIGHT_LEVEL_MIN)
+    g_eeGeneral.backlightBright = BACKLIGHT_LEVEL_MAX - BACKLIGHT_LEVEL_MIN;
   if (g_eeGeneral.lightAutoOff < 1)
     g_eeGeneral.lightAutoOff = 1;
 #endif

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -584,7 +584,11 @@ void checkBacklight()
 
 void resetBacklightTimeout()
 {
-  lightOffCounter = ((uint16_t)g_eeGeneral.lightAutoOff*250) << 1;
+  uint16_t autoOff = g_eeGeneral.lightAutoOff;
+#if defined(COLORLCD)
+  autoOff = std::max<uint16_t>(1, autoOff); // prevent the timeout from being 0 seconds on color lcd radios
+#endif
+  lightOffCounter = (autoOff*250) << 1;
 }
 
 #if defined(SPLASH)


### PR DESCRIPTION
Summary of changes:
When configuration is broken it can happen, that on Color LCD radios the backlight is set to off and/or the brightness is set to off and/or the backlight timer is set to 0.
All of those conditions render the radios unusable.
These changes enforce usable backlight settings, even when they are overwritten by functions or lua scripts.
