### PR TITLE
Disable RTC VBat bridge after first run

### DIFF
--- a/radio/src/targets/common/arm/stm32/stm32_hal_adc.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_hal_adc.cpp
@@ -449,6 +449,7 @@ static void stm32_hal_adc_wait_completion()
 #if defined(ADC_EXT) && !defined(ADC_EXT_DMA_Stream)
   if (isVBatBridgeEnabled()) {
     rtcBatteryVoltage = ADC_EXT->DR;
+    disableVBatBridge();
   }
 #endif
 #endif


### PR DESCRIPTION
Checked with in-circuit-debugger on physical RM TX16S, only after this fix, _isVBatBridgeEnabled()_ returns false, otherwise VBat bridge remained active.