### PR TITLE
Revert "Potential out of bounds access of flightmode name on main screen (#1333)"

### DIFF
--- a/radio/src/gui/colorlcd/view_main_decoration.cpp
+++ b/radio/src/gui/colorlcd/view_main_decoration.cpp
@@ -328,8 +328,8 @@ void ViewMainDecoration::createFlightMode()
   };
 
   std::function<std::string()> getFM = []() -> std::string {
-      return stringFromNtString(g_model.flightModeData[mixerCurrentFlightMode].name);
-};
+    return g_model.flightModeData[mixerCurrentFlightMode].name;
+  };
 
   flightMode = new DynamicText(this, r, getFM, CENTERED | COLOR_THEME_SECONDARY1);
 }

--- a/radio/src/strhelpers.h
+++ b/radio/src/strhelpers.h
@@ -25,8 +25,6 @@
 #include "definitions.h"
 #include "opentx_types.h"
 
-#include <string>
-
 #define SHOW_TIME  0x1
 #define SHOW_TIMER 0x0
 #define SHOW_TIMER_UPPER_CASE   0x2
@@ -92,8 +90,4 @@ char *getTimerString(int32_t tme, TimerOptions timerOptions = {.options = 0});
 void splitTimer(char *s0, char *s1, char *s2, char *s3, int tme,
                 bool bLowercase = true);
 
-template<size_t N>
-constexpr std::string stringFromNtString(const char (&a)[N]) {
-    return std::string(a, strnlen(a, N));        
-}    
 #endif  // _STRHELPERS_H_


### PR DESCRIPTION
Temporary reversion of EdgeTX/edgetx#1337 as it causes Mac Companion builds to fail when building `libsimulator`

https://github.com/EdgeTX/edgetx/runs/4755792840