### PR TITLE
[companion] fix: only write yaml to radio, not bin

### DIFF
--- a/companion/src/storage/categorized.cpp
+++ b/companion/src/storage/categorized.cpp
@@ -42,15 +42,12 @@ bool CategorizedStorageFormat::load(RadioData & radioData)
 bool CategorizedStorageFormat::write(const RadioData & radioData)
 {
   StorageType st = getStorageType(filename);
-  if (st == STORAGE_TYPE_UNKNOWN) {
-    st = probeFormat();
-  }
   if (st == STORAGE_TYPE_ETX || st == STORAGE_TYPE_YML ||
       st == STORAGE_TYPE_UNKNOWN) {
     return writeYaml(radioData);
-  } else {
-    return writeBin(radioData);
   }
+
+  return false;
 }
 
 StorageType CategorizedStorageFormat::probeFormat()


### PR DESCRIPTION
Fixes #1384

- Fixes issue whereby Companion was writing bin files with yml extension