### PR TITLE
Rotary encoder movement not to close throttle warning

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -836,7 +836,7 @@ void checkThrottleStick()
   bool refresh = false;
 #endif
 
-  while (!getEvent()) {
+  while (!keyDown()) {
     if (!isThrottleWarningAlertNeeded()) {
       return;
     }


### PR DESCRIPTION
Fixes #1407

Summary of changes:
Checking only key presses for closing throttle warning instead of any event.
This replicates the behavior for switch warning.
