### PR TITLE
Fix wrong x-coordinate for Lua touchState during sliding

### DIFF
--- a/radio/src/lua/widgets.cpp
+++ b/radio/src/lua/widgets.cpp
@@ -27,6 +27,7 @@
 #include "widget.h"
 #include "libopenui_file.h"
 #include "api_colorlcd.h"
+#include "view_main.h"
 
 #define WIDGET_SCRIPTS_MAX_INSTRUCTIONS    (10000/100)
 #define MANUAL_SCRIPTS_MAX_INSTRUCTIONS    (20000/100)
@@ -641,9 +642,10 @@ bool LuaWidget::onTouchSlide(coord_t x, coord_t y, coord_t startX, coord_t start
     eventData* es = findOpenEventSlot(EVT_TOUCH_SLIDE);
 
     if (es) {
+      ViewMain* vm = ViewMain::instance();
       es->event = EVT_TOUCH_SLIDE;
-      es->touchX = x;
-      es->touchY = y;
+      es->touchX = x + vm->getScrollPositionX();
+      es->touchY = y + vm->getScrollPositionY();
       es->startX = startX;
       es->startY = startY;
       es->slideX += slideX;


### PR DESCRIPTION
Fix wrong x-coordinate for Lua touchState during sliding on mainviews other than the first screen

Fix for issue #1348 as discussed on https://github.com/EdgeTX/libopenui/pull/49