### PR TITLE
Make Ghost menu work with NV14 joystick trims

### DIFF
--- a/radio/src/gui/colorlcd/radio_ghost_module_config.cpp
+++ b/radio/src/gui/colorlcd/radio_ghost_module_config.cpp
@@ -34,17 +34,17 @@ class GhostModuleConfigWindow: public Window
 
     void paint(BitmapBuffer * dc) override
     {
-    	#if defined (PCBNV14)
-    	constexpr coord_t xOffset = 20;
+#if defined(PCBNV14)
+      constexpr coord_t xOffset = 20;
       constexpr coord_t xOffset2 = 140;
       constexpr coord_t yOffset = 20;
       constexpr coord_t lineSpacing = 25;
-      #else
+#else
       constexpr coord_t xOffset = 140;
       constexpr coord_t xOffset2 = 260;
       constexpr coord_t yOffset = 20;
       constexpr coord_t lineSpacing = 25;
-      #endif
+#endif
 
       for (uint8_t line = 0; line < GHST_MENU_LINES; line++) {
         if (reusableBuffer.ghostMenu.line[line].splitLine) {
@@ -91,9 +91,9 @@ RadioGhostModuleConfig::RadioGhostModuleConfig(uint8_t moduleIdx) :
   buildHeader(&header);
   buildBody(&body);
   setFocus(SET_FOCUS_DEFAULT);
-  #if defined (PCBNV14)
-  setTrimsAsButtons(true); // Use NV14 trim joysticks to operate menu
-  #endif
+#if defined(PCBNV14)
+  setTrimsAsButtons(true);  // Use NV14 trim joysticks to operate menu
+#endif
 }
 
 void RadioGhostModuleConfig::buildHeader(Window * window)
@@ -111,9 +111,9 @@ void RadioGhostModuleConfig::onEvent(event_t event)
 {
   switch (event) {
 #if defined(ROTARY_ENCODER_NAVIGATION)
-      case EVT_ROTARY_LEFT:
+    case EVT_ROTARY_LEFT:
 #else
-      case EVT_KEY_BREAK(KEY_UP):
+    case EVT_KEY_BREAK(KEY_UP):
 #endif
       reusableBuffer.ghostMenu.buttonAction = GHST_BTN_JOYUP;
       reusableBuffer.ghostMenu.menuAction = GHST_MENU_CTRL_NONE;
@@ -121,9 +121,9 @@ void RadioGhostModuleConfig::onEvent(event_t event)
       break;
 
 #if defined(ROTARY_ENCODER_NAVIGATION)
-      case EVT_ROTARY_RIGHT:
+    case EVT_ROTARY_RIGHT:
 #else
-      case EVT_KEY_BREAK(KEY_DOWN):
+    case EVT_KEY_BREAK(KEY_DOWN):
 #endif
       reusableBuffer.ghostMenu.buttonAction = GHST_BTN_JOYDOWN;
       reusableBuffer.ghostMenu.menuAction = GHST_MENU_CTRL_NONE;
@@ -149,9 +149,9 @@ void RadioGhostModuleConfig::onEvent(event_t event)
       moduleState[EXTERNAL_MODULE].counter = GHST_MENU_CONTROL;
       RTOS_WAIT_MS(10);
       Page::onEvent(event);
-      #if defined (PCBNV14)
-      setTrimsAsButtons(false); // switch NV14 trims back to normal
-      #endif
+#if defined(PCBNV14)
+      setTrimsAsButtons(false);  // switch NV14 trims back to normal
+#endif
       break;
   }
 }
@@ -168,9 +168,9 @@ void RadioGhostModuleConfig::checkEvents()
   else if (reusableBuffer.ghostMenu.menuStatus == GHST_MENU_STATUS_CLOSING) {
     RTOS_WAIT_MS(10);
     deleteLater();
-    #if defined (PCBNV14)
-    setTrimsAsButtons(false); // switch NV14 trims back to normal
-    #endif
+#if defined(PCBNV14)
+    setTrimsAsButtons(false);  // switch NV14 trims back to normal
+#endif
   }
 }
 #endif

--- a/radio/src/gui/colorlcd/radio_ghost_module_config.cpp
+++ b/radio/src/gui/colorlcd/radio_ghost_module_config.cpp
@@ -34,10 +34,17 @@ class GhostModuleConfigWindow: public Window
 
     void paint(BitmapBuffer * dc) override
     {
+    	#if defined (PCBNV14)
+    	constexpr coord_t xOffset = 20;
+      constexpr coord_t xOffset2 = 140;
+      constexpr coord_t yOffset = 20;
+      constexpr coord_t lineSpacing = 25;
+      #else
       constexpr coord_t xOffset = 140;
       constexpr coord_t xOffset2 = 260;
       constexpr coord_t yOffset = 20;
       constexpr coord_t lineSpacing = 25;
+      #endif
 
       for (uint8_t line = 0; line < GHST_MENU_LINES; line++) {
         if (reusableBuffer.ghostMenu.line[line].splitLine) {
@@ -84,6 +91,9 @@ RadioGhostModuleConfig::RadioGhostModuleConfig(uint8_t moduleIdx) :
   buildHeader(&header);
   buildBody(&body);
   setFocus(SET_FOCUS_DEFAULT);
+  #if defined (PCBNV14)
+  setTrimsAsButtons(true); // Use NV14 trim joysticks to operate menu
+  #endif
 }
 
 void RadioGhostModuleConfig::buildHeader(Window * window)
@@ -101,20 +111,24 @@ void RadioGhostModuleConfig::onEvent(event_t event)
 {
   switch (event) {
 #if defined(ROTARY_ENCODER_NAVIGATION)
-    case EVT_ROTARY_LEFT:
+      case EVT_ROTARY_LEFT:
+#else
+      case EVT_KEY_BREAK(KEY_UP):
+#endif
       reusableBuffer.ghostMenu.buttonAction = GHST_BTN_JOYUP;
       reusableBuffer.ghostMenu.menuAction = GHST_MENU_CTRL_NONE;
       moduleState[EXTERNAL_MODULE].counter = GHST_MENU_CONTROL;
       break;
-#endif
 
 #if defined(ROTARY_ENCODER_NAVIGATION)
-    case EVT_ROTARY_RIGHT:
+      case EVT_ROTARY_RIGHT:
+#else
+      case EVT_KEY_BREAK(KEY_DOWN):
+#endif
       reusableBuffer.ghostMenu.buttonAction = GHST_BTN_JOYDOWN;
       reusableBuffer.ghostMenu.menuAction = GHST_MENU_CTRL_NONE;
       moduleState[EXTERNAL_MODULE].counter = GHST_MENU_CONTROL;
       break;
-#endif
 
     case EVT_KEY_FIRST(KEY_ENTER):
       reusableBuffer.ghostMenu.buttonAction = GHST_BTN_JOYPRESS;
@@ -135,6 +149,9 @@ void RadioGhostModuleConfig::onEvent(event_t event)
       moduleState[EXTERNAL_MODULE].counter = GHST_MENU_CONTROL;
       RTOS_WAIT_MS(10);
       Page::onEvent(event);
+      #if defined (PCBNV14)
+      setTrimsAsButtons(false); // switch NV14 trims back to normal
+      #endif
       break;
   }
 }
@@ -151,6 +168,9 @@ void RadioGhostModuleConfig::checkEvents()
   else if (reusableBuffer.ghostMenu.menuStatus == GHST_MENU_STATUS_CLOSING) {
     RTOS_WAIT_MS(10);
     deleteLater();
+    #if defined (PCBNV14)
+    setTrimsAsButtons(false); // switch NV14 trims back to normal
+    #endif
   }
 }
 #endif

--- a/radio/src/gui/colorlcd/radio_ghost_module_config.cpp
+++ b/radio/src/gui/colorlcd/radio_ghost_module_config.cpp
@@ -34,17 +34,15 @@ class GhostModuleConfigWindow: public Window
 
     void paint(BitmapBuffer * dc) override
     {
-#if defined(PCBNV14)
+#if LCD_H > LCD_W
       constexpr coord_t xOffset = 20;
       constexpr coord_t xOffset2 = 140;
-      constexpr coord_t yOffset = 20;
-      constexpr coord_t lineSpacing = 25;
 #else
       constexpr coord_t xOffset = 140;
       constexpr coord_t xOffset2 = 260;
+#endif
       constexpr coord_t yOffset = 20;
       constexpr coord_t lineSpacing = 25;
-#endif
 
       for (uint8_t line = 0; line < GHST_MENU_LINES; line++) {
         if (reusableBuffer.ghostMenu.line[line].splitLine) {
@@ -91,8 +89,8 @@ RadioGhostModuleConfig::RadioGhostModuleConfig(uint8_t moduleIdx) :
   buildHeader(&header);
   buildBody(&body);
   setFocus(SET_FOCUS_DEFAULT);
-#if defined(PCBNV14)
-  setTrimsAsButtons(true);  // Use NV14 trim joysticks to operate menu
+#if defined(TRIMS_EMULATE_BUTTONS)
+  setTrimsAsButtons(true);  // Use trim joysticks to operate menu (e.g. on NV14)
 #endif
 }
 
@@ -149,8 +147,8 @@ void RadioGhostModuleConfig::onEvent(event_t event)
       moduleState[EXTERNAL_MODULE].counter = GHST_MENU_CONTROL;
       RTOS_WAIT_MS(10);
       Page::onEvent(event);
-#if defined(PCBNV14)
-      setTrimsAsButtons(false);  // switch NV14 trims back to normal
+#if defined(TRIMS_EMULATE_BUTTONS)
+      setTrimsAsButtons(false);  // switch trims back to normal
 #endif
       break;
   }
@@ -168,8 +166,8 @@ void RadioGhostModuleConfig::checkEvents()
   else if (reusableBuffer.ghostMenu.menuStatus == GHST_MENU_STATUS_CLOSING) {
     RTOS_WAIT_MS(10);
     deleteLater();
-#if defined(PCBNV14)
-    setTrimsAsButtons(false);  // switch NV14 trims back to normal
+#if defined(TRIMS_EMULATE_BUTTONS)
+    setTrimsAsButtons(false);  // switch trims back to normal
 #endif
   }
 }

--- a/radio/src/targets/nv14/board.h
+++ b/radio/src/targets/nv14/board.h
@@ -244,6 +244,8 @@ uint8_t keyState(uint8_t index);
 uint32_t switchState(uint8_t index);
 uint32_t readKeys();
 uint32_t readTrims();
+void setTrimsAsButtons(bool);
+bool getTrimsAsButtons();
 #define NUM_TRIMS                       NUM_STICKS
 #define NUM_TRIMS_KEYS                  (NUM_TRIMS * 2)
 #define TRIMS_PRESSED()                 (readTrims())

--- a/radio/src/targets/nv14/board.h
+++ b/radio/src/targets/nv14/board.h
@@ -246,6 +246,7 @@ uint32_t readKeys();
 uint32_t readTrims();
 void setTrimsAsButtons(bool);
 bool getTrimsAsButtons();
+#define TRIMS_EMULATE_BUTTONS
 #define NUM_TRIMS                       NUM_STICKS
 #define NUM_TRIMS_KEYS                  (NUM_TRIMS * 2)
 #define TRIMS_PRESSED()                 (readTrims())

--- a/radio/src/targets/nv14/keys_driver.cpp
+++ b/radio/src/targets/nv14/keys_driver.cpp
@@ -22,17 +22,27 @@
 #include "opentx.h"
 #include "hal/adc_driver.h"
 
+bool trimsAsButtons=false;
+
+void setTrimsAsButtons(bool val)
+{
+	trimsAsButtons=val;
+}
+
+bool getTrimsAsButtons()
+{
+	bool lua=false;
+	#if defined(LUA)
+    lua=isLuaStandaloneRunning();
+  #endif
+  return (trimsAsButtons || lua);
+}
+
 uint32_t readKeys()
 {
   uint32_t result = 0;
-  bool getKeys = true;
-#if defined(LUA)
-  if (!isLuaStandaloneRunning()) {
-    getKeys = false;
-  }
-#endif
 
-  if (getKeys) {
+  if (getTrimsAsButtons()) {
     if (TRIMS_GPIO_REG_LHL & TRIMS_GPIO_PIN_LHL)
        result |= 1 << KEY_RADIO;
      if (TRIMS_GPIO_REG_LHR & TRIMS_GPIO_PIN_LHR)
@@ -64,13 +74,7 @@ uint32_t readTrims()
 {
   uint32_t result = 0;
 
-  bool getTrim = true;
-#if defined(LUA)
-  if (isLuaStandaloneRunning()) {
-    getTrim = false;
-  }
-#endif
-  if(!getTrim) return result;
+  if(getTrimsAsButtons() /*!getTrim*/) return result;
   if (TRIMS_GPIO_REG_LHL & TRIMS_GPIO_PIN_LHL)
     result |= 1 << (TRM_LH_DWN - TRM_BASE);
   if (TRIMS_GPIO_REG_LHR & TRIMS_GPIO_PIN_LHR)
@@ -178,4 +182,5 @@ void keysInit()
 
   GPIO_InitStructure.GPIO_Pin = KEYS_GPIOJ_PINS;
   GPIO_Init(GPIOJ, &GPIO_InitStructure);
+  setTrimsAsButtons(false);
 }

--- a/radio/src/targets/nv14/keys_driver.cpp
+++ b/radio/src/targets/nv14/keys_driver.cpp
@@ -22,19 +22,16 @@
 #include "opentx.h"
 #include "hal/adc_driver.h"
 
-bool trimsAsButtons=false;
+bool trimsAsButtons = false;
 
-void setTrimsAsButtons(bool val)
-{
-	trimsAsButtons=val;
-}
+void setTrimsAsButtons(bool val) { trimsAsButtons = val; }
 
 bool getTrimsAsButtons()
 {
-	bool lua=false;
-	#if defined(LUA)
-    lua=isLuaStandaloneRunning();
-  #endif
+  bool lua = false;
+#if defined(LUA)
+  lua = isLuaStandaloneRunning();
+#endif
   return (trimsAsButtons || lua);
 }
 
@@ -74,7 +71,7 @@ uint32_t readTrims()
 {
   uint32_t result = 0;
 
-  if(getTrimsAsButtons() /*!getTrim*/) return result;
+  if(getTrimsAsButtons()) return result;
   if (TRIMS_GPIO_REG_LHL & TRIMS_GPIO_PIN_LHL)
     result |= 1 << (TRM_LH_DWN - TRM_BASE);
   if (TRIMS_GPIO_REG_LHR & TRIMS_GPIO_PIN_LHR)

--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -560,6 +560,19 @@ bool trimDown(uint8_t idx)
   return readTrims() & (1 << idx);
 }
 
+bool trimsAsButtons = false;
+
+void setTrimsAsButtons(bool val) { trimsAsButtons = val; }
+
+bool getTrimsAsButtons()
+{
+  bool lua = false;
+#if defined(LUA)
+  lua = isLuaStandaloneRunning();
+#endif
+  return (trimsAsButtons || lua);
+}
+
 uint32_t readKeys()
 {
   uint32_t result = 0;

--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -560,6 +560,7 @@ bool trimDown(uint8_t idx)
   return readTrims() & (1 << idx);
 }
 
+#if defined(TRIMS_EMULATE_BUTTONS)
 bool trimsAsButtons = false;
 
 void setTrimsAsButtons(bool val) { trimsAsButtons = val; }
@@ -572,6 +573,7 @@ bool getTrimsAsButtons()
 #endif
   return (trimsAsButtons || lua);
 }
+#endif
 
 uint32_t readKeys()
 {


### PR DESCRIPTION
Enabled the ghost menu to work with the NV14 joystick trims like in lua (for non-touch luas). 
Changed layout to work with NV14.
Cleaned the code tn the NV14 key_driver.cpp
