### PR TITLE
fix TE_SLIDE_END repetition issue, reset tapCount on NV14

### DIFF
--- a/radio/src/targets/horus/tp_gt911.cpp
+++ b/radio/src/targets/horus/tp_gt911.cpp
@@ -793,7 +793,7 @@ struct TouchState touchPanelRead()
           internalTouchState.tapCount = tapCount;
           tapTime = now;
         }
-      } else if (internalTouchState.event != TE_SLIDE_END) {
+      } else {
         internalTouchState.event = TE_NONE;
       }
     }

--- a/radio/src/targets/nv14/touch_driver.cpp
+++ b/radio/src/targets/nv14/touch_driver.cpp
@@ -545,15 +545,15 @@ TouchState touchPanelRead()
       }
       downTime = 0;
     } else {
-      internalTouchState.x = LCD_WIDTH;
-      internalTouchState.y = LCD_HEIGHT;
+      tapCount = 0;
+      internalTouchState.tapCount = 0;
       internalTouchState.event = TE_SLIDE_END;
     }
   }
   TouchState ret = internalTouchState;
   internalTouchState.deltaX = 0;
   internalTouchState.deltaY = 0;
-  if(internalTouchState.event == TE_UP)
+  if(internalTouchState.event == TE_UP || internalTouchState.event == TE_SLIDE_END)
     internalTouchState.event = TE_NONE;
   return ret;
 }


### PR DESCRIPTION
No more continuing TE_SLIDE_END events after sliding with inertia
reset tapCount in NV14 touch driver for TE_SLIE_END events, as this is incompatible with full screen lua events

Needs PR [libopenui#50](https://github.com/EdgeTX/libopenui/pull/50)