### PR TITLE
Add a "No SD card" screen on boot

### DIFF
--- a/radio/src/gui/common/stdlcd/draw_functions.cpp
+++ b/radio/src/gui/common/stdlcd/draw_functions.cpp
@@ -575,3 +575,37 @@ void drawSourceValue(coord_t x, coord_t y, source_t source, LcdFlags flags)
   getvalue_t value = getValue(source);
   drawSourceCustomValue(x, y, source, value, flags);
 }
+
+void drawFatalErrorScreen(const char * message)
+{
+  lcdClear();
+  lcdDrawText((LCD_W - getTextWidth(message, 0, DBLSIZE)) / 2,
+              LCD_H/2 - FH, message, DBLSIZE);
+  WDG_RESET();
+  lcdRefresh();
+  lcdRefreshWait();
+}
+
+void runFatalErrorScreen(const char * message)
+{
+  while (true) {
+    backlightEnable();
+    drawFatalErrorScreen(message);
+
+    uint8_t refresh = false;
+    while (true) {
+      uint32_t pwr_check = pwrCheck();
+      if (pwr_check == e_power_off) {
+        boardOff();
+        return;  // only happens in SIMU, required for proper shutdown
+      }
+      else if (pwr_check == e_power_press) {
+        refresh = true;
+      }
+      else if (pwr_check == e_power_on && refresh) {
+        break;
+      }
+      WDG_RESET();
+    }
+  }
+}

--- a/radio/src/gui/common/stdlcd/draw_functions.h
+++ b/radio/src/gui/common/stdlcd/draw_functions.h
@@ -44,6 +44,8 @@ void drawFlightMode(coord_t x, coord_t y, int8_t idx, LcdFlags att = 0);
 void drawStartupAnimation(uint32_t duration, uint32_t totalDuration);
 void drawShutdownAnimation(uint32_t duration, uint32_t totalDuration, const char * message);
 void drawSleepBitmap();
+void drawFatalErrorScreen(const char * message);
+void runFatalErrorScreen(const char * message);
 
 void lcdDrawMMM(coord_t x, coord_t y, LcdFlags flags=0);
 void drawTrimMode(coord_t x, coord_t y, uint8_t flightMode, uint8_t idx, LcdFlags att=0);

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1832,6 +1832,13 @@ void opentxInit()
     if (!sdMounted())
       sdInit();
 
+#if !defined(COLORLCD)
+    if (!sdMounted()) {
+      g_eeGeneral.pwrOffSpeed = 2;
+      runFatalErrorScreen(STR_NO_SDCARD);
+    }
+#endif
+    
 #if defined(AUTOUPDATE)
     sportStopSendByteLoop();
     if (f_stat(AUTOUPDATE_FILENAME, nullptr) == FR_OK) {
@@ -2013,12 +2020,12 @@ int main()
   }
 #endif
 
-#if !defined(EEPROM)
-  if (!SD_CARD_PRESENT() && !UNEXPECTED_SHUTDOWN()) {
-    // TODO: b/w SD card fatal screen
 #if defined(COLORLCD)
+  // SD_CARD_PRESENT() does not work properly on most
+  // B&W targets, so that we need to delay the detection
+  // until the SD card is mounted (requires RTOS scheduler running)
+  if (!SD_CARD_PRESENT() && !UNEXPECTED_SHUTDOWN()) {
     runFatalErrorScreen(STR_NO_SDCARD);
-#endif
   }
 #endif
 


### PR DESCRIPTION
Summary of changes:
- when a B&W radio is started without a mountable SD card, the following screen is displayed:

![IMG_9221](https://user-images.githubusercontent.com/1050031/149660218-4679b098-e312-4522-b2cd-44882b0c22b5.png)

