### PR TITLE
Make Outputs work with NV14 & two rows

### DIFF
--- a/radio/src/gui/colorlcd/widgets/outputs.cpp
+++ b/radio/src/gui/colorlcd/widgets/outputs.cpp
@@ -43,7 +43,7 @@ class OutputsWidget : public Widget
   {
     if (width() > 300 && height() > 20)
       twoColumns(dc);
-    else if (width() > 150 && height() > 20)
+    else if (width() > 100 && height() > 20)
       oneColumn(dc);
   }
 


### PR DESCRIPTION
This fixes the initally reported problem in issue #1103.
Changed code to allow one column display of outputs already with a width of 100. 

Reason: On the Nirvana the screen width is 320 pixels. Thus the widget width is less than 150 pixels, if you select a two column out layout.
The rendering of the outputs looks good with a width of 100px, so there is no need for the "150" - we can start displaying from 100. Should make no difference to the radios with width 480px.
