### PR TITLE
Warn on connected model (#1466)

### DIFF
--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -42,6 +42,7 @@ constexpr coord_t MODEL_SELECT_CELL_HEIGHT = 92;
 constexpr coord_t MODEL_IMAGE_WIDTH  = MODEL_SELECT_CELL_WIDTH;
 constexpr coord_t MODEL_IMAGE_HEIGHT = 72;
 
+inline tmr10ms_t getTicks() { return g_tmr10ms; }
 
 class ModelButton : public Button
 {
@@ -184,6 +185,8 @@ class ModelCategoryPageBody : public FormWindow
     update();
   }
 
+  
+
   void update(int selected = -1)
   {
     clear();
@@ -214,6 +217,10 @@ class ModelCategoryPageBody : public FormWindow
                 AUDIO_ERROR_MESSAGE(AU_MODEL_STILL_POWERED);
                 if (!confirmationDialog(
                         STR_MODEL_STILL_POWERED, nullptr, false, []() {
+                          tmr10ms_t startTime = getTicks();
+                          while (!TELEMETRY_STREAMING()) {
+                            if (getTicks() - startTime > 150) break;
+                          }
                           return !TELEMETRY_STREAMING() ||
                                  g_eeGeneral.disableRssiPoweroffAlarm;
                         })) {

--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -185,8 +185,6 @@ class ModelCategoryPageBody : public FormWindow
     update();
   }
 
-  
-
   void update(int selected = -1)
   {
     clear();
@@ -219,7 +217,7 @@ class ModelCategoryPageBody : public FormWindow
                         STR_MODEL_STILL_POWERED, nullptr, false, []() {
                           tmr10ms_t startTime = getTicks();
                           while (!TELEMETRY_STREAMING()) {
-                            if (getTicks() - startTime > TELEMETRY_CHECK_DELAY)
+                            if (getTicks() - startTime > TELEMETRY_CHECK_DELAY10ms)
                               break;
                           }
                           return !TELEMETRY_STREAMING() ||

--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -213,6 +213,17 @@ class ModelCategoryPageBody : public FormWindow
               storageCheck(true);
               memcpy(g_eeGeneral.currModelFilename, model->modelFilename,
                      LEN_MODEL_FILENAME);
+              bool modelConnectedConfirmed =
+                  !TELEMETRY_STREAMING() ||
+                  g_eeGeneral.disableRssiPoweroffAlarm;
+              if (!modelConnectedConfirmed) {
+                AUDIO_ERROR_MESSAGE(AU_MODEL_STILL_POWERED);
+                confirmationDialog(
+                    STR_MODEL_STILL_POWERED, nullptr, false, []() {
+                      return !TELEMETRY_STREAMING() ||
+                             g_eeGeneral.disableRssiPoweroffAlarm;
+                    });
+              }
               loadModel(g_eeGeneral.currModelFilename, false);
               storageDirty(EE_GENERAL);
               storageCheck(true);

--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -219,7 +219,8 @@ class ModelCategoryPageBody : public FormWindow
                         STR_MODEL_STILL_POWERED, nullptr, false, []() {
                           tmr10ms_t startTime = getTicks();
                           while (!TELEMETRY_STREAMING()) {
-                            if (getTicks() - startTime > 150) break;
+                            if (getTicks() - startTime > TELEMETRY_CHECK_DELAY)
+                              break;
                           }
                           return !TELEMETRY_STREAMING() ||
                                  g_eeGeneral.disableRssiPoweroffAlarm;

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -2146,7 +2146,7 @@ uint32_t pwrCheck()
             closeCondition = []() {
               tmr10ms_t startTime = getTicks();
               while (!TELEMETRY_STREAMING()) {
-                if (getTicks() - startTime > TELEMETRY_CHECK_DELAY) break;
+                if (getTicks() - startTime > TELEMETRY_CHECK_DELAY10ms) break;
               }
               return !TELEMETRY_STREAMING() || g_eeGeneral.disableRssiPoweroffAlarm;
             };

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -2049,6 +2049,10 @@ uint32_t pwrPressedDuration()
   }
 }
 
+#if defined(COLORLCD)
+inline tmr10ms_t getTicks() { return g_tmr10ms; }
+#endif
+
 uint32_t pwrCheck()
 {
   const char * message = nullptr;
@@ -2139,7 +2143,11 @@ uint32_t pwrCheck()
           }
           else if (!modelConnectedConfirmed) {
             message = STR_MODEL_STILL_POWERED;
-            closeCondition = [](){
+            closeCondition = []() {
+              tmr10ms_t startTime = getTicks();
+              while (!TELEMETRY_STREAMING()) {
+                if (getTicks() - startTime > TELEMETRY_CHECK_DELAY) break;
+              }
               return !TELEMETRY_STREAMING() || g_eeGeneral.disableRssiPoweroffAlarm;
             };
           }

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -471,6 +471,8 @@ void alert(const char * title, const char * msg, uint8_t sound);
 
 #elif defined(COLORLCD)
 
+#define TELEMETRY_CHECK_DELAY 150
+
 bool confirmationDialog(const char *title, const char *msg, bool checkPwr = true, const std::function<bool(void)>& closeCondition = nullptr);
 
 void raiseAlert(const char *title, const char *msg, const char *info,

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -471,7 +471,7 @@ void alert(const char * title, const char * msg, uint8_t sound);
 
 #elif defined(COLORLCD)
 
-#define TELEMETRY_CHECK_DELAY 150
+#define TELEMETRY_CHECK_DELAY10ms 150
 
 bool confirmationDialog(const char *title, const char *msg, bool checkPwr = true, const std::function<bool(void)>& closeCondition = nullptr);
 


### PR DESCRIPTION
Fixes #1466 
This PR adds a warning "Model is still connected" when user attempts to select a new model (on color LCD TXs).

Summary of changes: audio message and confirmation dialog are added.
