### PR TITLE
force backlight on when displaying full screen dialogs

### DIFF
--- a/radio/src/gui/colorlcd/fullscreen_dialog.cpp
+++ b/radio/src/gui/colorlcd/fullscreen_dialog.cpp
@@ -159,6 +159,8 @@ void FullScreenDialog::runForever()
   running = true;
 
   while (running) {
+    resetBacklightTimeout();
+
     auto check = pwrCheck();
     if (check == e_power_off) {
       boardOff();
@@ -187,6 +189,8 @@ void FullScreenDialog::runForeverNoPwrCheck()
   running = true;
 
   while (running) {
+    resetBacklightTimeout();
+
     checkBacklight();
     WDG_RESET();
 

--- a/radio/src/gui/colorlcd/fullscreen_dialog.cpp
+++ b/radio/src/gui/colorlcd/fullscreen_dialog.cpp
@@ -158,6 +158,10 @@ void FullScreenDialog::runForever()
 {
   running = true;
 
+  MainWindow* mainWin = MainWindow::instance();
+#if defined(HARDWARE_TOUCH)
+  mainWin->setTouchEnabled(true);
+#endif
   while (running) {
     resetBacklightTimeout();
 
@@ -178,7 +182,7 @@ void FullScreenDialog::runForever()
     WDG_RESET();
 
     RTOS_WAIT_MS(1);
-    MainWindow::instance()->run(false);
+    mainWin->run(false);
   }
 
   deleteLater();
@@ -188,6 +192,10 @@ void FullScreenDialog::runForeverNoPwrCheck()
 {
   running = true;
 
+  MainWindow* mainWin = MainWindow::instance();
+#if defined(HARDWARE_TOUCH)
+  mainWin->setTouchEnabled(true);
+#endif
   while (running) {
     resetBacklightTimeout();
 
@@ -195,7 +203,7 @@ void FullScreenDialog::runForeverNoPwrCheck()
     WDG_RESET();
 
     RTOS_WAIT_MS(1);
-    MainWindow::instance()->run(false);
+    mainWin->run(false);
   }
 
   deleteLater();

--- a/radio/src/gui/colorlcd/radio_setup.cpp
+++ b/radio/src/gui/colorlcd/radio_setup.cpp
@@ -560,4 +560,5 @@ void RadioSetupPage::updateBacklightControls()
     backlightOffBright->enable(false);
     break;
   }
+  resetBacklightTimeout();
 }


### PR DESCRIPTION
Fixes #1428

Summary of changes:
when displaying a full screen dialog on color lcd radios, the backlight is forced on and therefore the touch screen is enbaled, if the radio has one.