### PR TITLE
Fix bash's word-splitting bugs when parsing the result of pwd command

### DIFF
--- a/.github/workflows/linux_cpn.yml
+++ b/.github/workflows/linux_cpn.yml
@@ -48,7 +48,7 @@ jobs:
         shell: bash
         run: |
           mkdir output && \
-          tools/build-companion-nightly.sh $(pwd) $(pwd)/output/
+          tools/build-companion-nightly.sh "$(pwd)" "$(pwd)/output/"
 
       - name: Compose release filename
         # https://stackoverflow.com/questions/58033366/how-to-get-current-branch-within-github-actions

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -92,7 +92,7 @@ jobs:
         shell: bash
         run: |
           mkdir output && \
-          tools/build-companion-nightly.sh $(pwd) $(pwd)/output/
+          tools/build-companion-nightly.sh "$(pwd)" "$(pwd)/output/"
 
       - name: Compose release filename
         # https://stackoverflow.com/questions/58033366/how-to-get-current-branch-within-github-actions

--- a/.github/workflows/win-cpn-32.yml
+++ b/.github/workflows/win-cpn-32.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           mkdir output && \
           CMAKE_PREFIX_PATH=$RUNNER_WORKSPACE/Qt/$QT_VERSION/$MINGW_PATH \
-          tools/build-companion-nightly-win32.sh $(pwd) $(pwd)/output/
+          tools/build-companion-nightly-win32.sh "$(pwd)" "$(pwd)/output/"
       - name: Compose release filename
         # https://stackoverflow.com/questions/58033366/how-to-get-current-branch-within-github-actions
         run: echo "artifact_name=edgetx-cpn-win-32-${GITHUB_REF##*/}" >> $GITHUB_ENV

--- a/.github/workflows/win_cpn.yml
+++ b/.github/workflows/win_cpn.yml
@@ -94,7 +94,7 @@ jobs:
         run: |
           mkdir output && \
           CMAKE_PREFIX_PATH=$RUNNER_WORKSPACE/Qt/$QT_VERSION/$MINGW_PATH \
-          tools/build-companion-nightly.sh $(pwd) $(pwd)/output/
+          tools/build-companion-nightly.sh "$(pwd)" "$(pwd)/output/"
 
       - name: Compose release filename
         # https://stackoverflow.com/questions/58033366/how-to-get-current-branch-within-github-actions

--- a/tools/build-gh.sh
+++ b/tools/build-gh.sh
@@ -46,7 +46,7 @@ if [[ -n ${GCC_ARM} ]] ; then
   export PATH=${GCC_ARM}:$PATH
 fi
 
-: ${SRCDIR:=$(dirname $(pwd)/"$0")/..}
+: ${SRCDIR:=$(dirname "$(pwd)/$0")/..}
 
 : ${BUILD_TYPE:=Release}
 : ${COMMON_OPTIONS:="-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_RULE_MESSAGES=OFF -DDISABLE_COMPANION=YES -Wno-dev "}

--- a/tools/commit-tests.sh
+++ b/tools/commit-tests.sh
@@ -46,7 +46,7 @@ if [[ -n ${GCC_ARM} ]] ; then
   export PATH=${GCC_ARM}:$PATH
 fi
 
-: ${SRCDIR:=$(dirname $(pwd)/"$0")/..}
+: ${SRCDIR:=$(dirname "$(pwd)/$0")/..}
 
 : ${BUILD_TYPE:=Debug}
 : ${COMMON_OPTIONS:="-DCMAKE_BUILD_TYPE=$BUILD_TYPE -Wno-dev "}

--- a/tools/generate-yaml.sh
+++ b/tools/generate-yaml.sh
@@ -10,7 +10,7 @@ if [[ -n ${GCC_ARM} ]] ; then
 fi
 
 : ${FLAVOR:="t12;t8;tlite;tpro;tx12;zorro;tx16s;x12s;nv14;x7;x9d;x9dp;x9e;x9lite;x9lites;xlite;xlites"}
-: ${SRCDIR:=$(dirname $(pwd)/"$0")/..}
+: ${SRCDIR:=$(dirname "$(pwd)/$0")/..}
 
 : ${COMMON_OPTIONS:="-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_RULE_MESSAGES=OFF -DDISABLE_COMPANION=YES -Wno-dev -DYAML_STORAGE=YES "}
 


### PR DESCRIPTION
I wanted to contribute to edgetx somehow and was going over the bash and python files when I spotted a small bash issue which could cause a little bit of trouble in the future, that is if anybody tries to run those from a folder that contains whitespaces.

I'm not familiar enough of edgetx yet to know how likely that is to happen, the github workflows are probably safe but the ones under tools/ seems to be more exposed, in anycase the fix is straightforward and there's no downsides to it.

Please also let me know if you would be interested in PRs porting the python2 scripts to python3, pep8 fixes and fixes to other shellcheck findings. I could contribute more to these areas.

Commit message below:

These invocations will all cause bugs when pwd returns something that
can be interpreted by bash, the most common case being a folder
with whitespaces in its name. In other words these can be triggered by
calling the scripts from any folder that contains whitespaces.

More info on this specific finding by shellcheck:
https://github.com/koalaman/shellcheck/wiki/SC2046

Thank you
