### PR TITLE
Send correct internal CRSF modelid on change for B&W screens

### DIFF
--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -1429,7 +1429,7 @@ void menuModelSetup(event_t event)
                 CHECK_INCDEC_MODELVAR_ZERO(event, g_model.header.modelId[moduleIdx], getMaxRxNum(moduleIdx));
                 if (checkIncDec_Ret) {
                   if (isModuleCrossfire(moduleIdx))
-                    moduleState[EXTERNAL_MODULE].counter = CRSF_FRAME_MODELID;
+                    moduleState[moduleIdx].counter = CRSF_FRAME_MODELID;
                   modelHeaders[g_eeGeneral.currModel].modelId[moduleIdx] = g_model.header.modelId[moduleIdx];
                 }
                 else if (event == EVT_KEY_LONG(KEY_ENTER)) {

--- a/radio/src/gui/212x64/model_setup.cpp
+++ b/radio/src/gui/212x64/model_setup.cpp
@@ -1253,7 +1253,7 @@ void menuModelSetup(event_t event)
                 CHECK_INCDEC_MODELVAR_ZERO(event, g_model.header.modelId[moduleIdx], getMaxRxNum(moduleIdx));
                 if (checkIncDec_Ret) {
                   if (isModuleCrossfire(moduleIdx))
-                    moduleState[EXTERNAL_MODULE].counter = CRSF_FRAME_MODELID;
+                    moduleState[moduleIdx].counter = CRSF_FRAME_MODELID;
                   modelHeaders[g_eeGeneral.currModel].modelId[moduleIdx] = g_model.header.modelId[moduleIdx];
                 }
                 else if (event == EVT_KEY_LONG(KEY_ENTER)) {

--- a/radio/src/pulses/crossfire.cpp
+++ b/radio/src/pulses/crossfire.cpp
@@ -30,7 +30,7 @@
 #endif
 
 
-uint8_t createCrossfireModelIDFrame(uint8_t * frame)
+uint8_t createCrossfireModelIDFrame(uint8_t moduleIdx, uint8_t * frame)
 {
   uint8_t * buf = frame;
   *buf++ = UART_SYNC;                                 /* device address */
@@ -40,7 +40,7 @@ uint8_t createCrossfireModelIDFrame(uint8_t * frame)
   *buf++ = RADIO_ADDRESS;                             /* Origin Address */
   *buf++ = SUBCOMMAND_CRSF;                           /* sub command */
   *buf++ = COMMAND_MODEL_SELECT_ID;                   /* command of set model/receiver id */
-  *buf++ = g_model.header.modelId[EXTERNAL_MODULE];   /* model ID */
+  *buf++ = g_model.header.modelId[moduleIdx];         /* model ID */
   *buf++ = crc8_BA(frame + 2, 6);
   *buf++ = crc8(frame + 2, 7);
   return buf - frame;
@@ -83,7 +83,7 @@ static void setupPulsesCrossfire(uint8_t idx, CrossfirePulsesData* p_data,
 #endif
   {
     if (moduleState[idx].counter == CRSF_FRAME_MODELID) {
-      p_data->length = createCrossfireModelIDFrame(p_data->pulses);
+      p_data->length = createCrossfireModelIDFrame(idx, p_data->pulses);
       moduleState[idx].counter = CRSF_FRAME_MODELID_SENT;
     } else {
       p_data->length = createCrossfireChannelsFrame(

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -322,6 +322,9 @@ void telemetryWakeup()
           if (isModuleCrossfire(EXTERNAL_MODULE)) {
             moduleState[EXTERNAL_MODULE].counter = CRSF_FRAME_MODELID;
           }
+          if (isModuleCrossfire(INTERNAL_MODULE)) {
+            moduleState[INTERNAL_MODULE].counter = CRSF_FRAME_MODELID;
+          }
 #endif
         }
         telemetryState = TELEMETRY_OK;


### PR DESCRIPTION
For internal CRSF modules, the modelid ("Receiver") set in the Model Setup was not properly being sent to the internal module. It always stays modelid 0. 

* The colorlcd variant had the proper code to trigger the send, but the B&W screens would always trigger a send for the EXTERNAL module, which would never fire. This updates the trigger to apply to the correct module. (`model_setup.cpp`)
* The actual send code would always use the EXTERNAL module's `modelId` when generating the CRSF packet. Updated to use the correct module's modelId. (`crossfire.cpp`)
* When there's a telemetry KO -> OK transition, the code would trigger sending the modelId to the EXTERNAL module always. I've changed it to trigger it on either or both modules, whichever are CRSF-type, I'm not 100% sure on this change if that's the right thing to do, but it gets the job done. Feel free to update the bit in temeletry.cpp if this is not appropriate.

Tested on Zorro and T-Pro internal ELRS modules.