### PR TITLE
Companion use default hardware name when name only spaces

### DIFF
--- a/companion/src/firmwares/rawsource.cpp
+++ b/companion/src/firmwares/rawsource.cpp
@@ -176,7 +176,7 @@ QString RawSource::toString(const ModelData * model, const GeneralSettings * con
         else if (isStick(&genAryIdx))
           result = QString(generalSettings->stickName[genAryIdx]);
       }
-      if (result.isEmpty())
+      if (result.trimmed().isEmpty())
         result = Boards::getAnalogInputName(board, index);
       return result;
 
@@ -191,7 +191,7 @@ QString RawSource::toString(const ModelData * model, const GeneralSettings * con
 
     case SOURCE_TYPE_SWITCH:
       if (generalSettings)
-        result = QString(generalSettings->switchName[index]);
+        result = QString(generalSettings->switchName[index]).trimmed();
       if (result.isEmpty())
         result = Boards::getSwitchInfo(board, index).name;
       return result;

--- a/companion/src/firmwares/rawswitch.cpp
+++ b/companion/src/firmwares/rawswitch.cpp
@@ -75,7 +75,7 @@ QString RawSwitch::toString(Board::Type board, const GeneralSettings * const gen
         if (IS_HORUS_OR_TARANIS(board)) {
           qr = div(index-1, 3);
           if (generalSettings)
-            swName = QString(generalSettings->switchName[qr.quot]);
+            swName = QString(generalSettings->switchName[qr.quot]).trimmed();
           if (swName.isEmpty())
             swName = Boards::getSwitchInfo(board, qr.quot).name;
           return swName + directionIndicators.at(qr.rem > -1 && qr.rem < directionIndicators.size() ? qr.rem : 1);


### PR DESCRIPTION
Fixes #1519

