### PR TITLE
Eshifri/output direction

### DIFF
--- a/radio/src/gui/128x64/view_statistics.cpp
+++ b/radio/src/gui/128x64/view_statistics.cpp
@@ -182,23 +182,6 @@ void menuStatisticsDebug(event_t event)
   y += FH;
 #endif
 
-#if defined(COPROCESSOR)
-  lcdDrawTextAlignedLeft(y, STR_COPROC_TEMP);
-  if (coprocData.read==0) {
-    lcdDrawText(MENU_DEBUG_COL1_OFS, y, "Co Proc NACK",INVERS);
-  }
-  else if (coprocData.read==0x81) {
-    lcdDrawText(MENU_DEBUG_COL1_OFS, y, "Inst.TinyApp",INVERS);
-  }
-  else if (coprocData.read<3) {
-    lcdDrawText(MENU_DEBUG_COL1_OFS, y, "Upgr.TinyApp",INVERS);
-  }
-  else {
-    drawValueWithUnit(MENU_DEBUG_COL1_OFS, y, coprocData.temp, UNIT_TEMPERATURE, LEFT);
-    drawValueWithUnit(MENU_DEBUG_COL2_OFS, y, coprocData.maxtemp, UNIT_TEMPERATURE, LEFT);
-  }
-  y += FH;
-#endif
 
   lcdDrawTextAlignedLeft(y, "Free Mem");
   lcdDrawNumber(MENU_DEBUG_COL1_OFS, y, availableMemory(), LEFT);

--- a/radio/src/gui/common/stdlcd/radio_version.cpp
+++ b/radio/src/gui/common/stdlcd/radio_version.cpp
@@ -240,14 +240,6 @@ void menuRadioVersion(event_t event)
   lcdDrawText(FW, y, vers_stamp, SMLSIZE);
   y += 5 * (FH - 1);
 
-#if defined(COPROCESSOR)
-  lcdDrawText(FW, y, "COPR\037\033: ", SMLSIZE);
-  if (coprocData.valid == 1)
-    lcdDrawNumber(lcdNextPos, y, coprocData.read, SMLSIZE);
-  else
-    lcdDrawText(lcdNextPos, y, "---", SMLSIZE);
-  y += FH - 1;
-#endif
 
   y += 2;
 

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -151,15 +151,6 @@ void per10ms()
   /* Update global Date/Time every 100 per10ms cycles */
   if (++g_ms100 == 100) {
     g_rtcTime++;   // inc global unix timestamp one second
-#if defined(COPROCESSOR)
-    if (g_rtcTime < 60 || rtc_count<5) {
-      rtcInit();
-      rtc_count++;
-    }
-    else {
-      coprocReadData(true);
-    }
-#endif
     g_ms100 = 0;
   }
 #endif

--- a/radio/src/simu.cpp
+++ b/radio/src/simu.cpp
@@ -470,10 +470,6 @@ void OpenTxSim::updateKeysAndSwitches(bool start)
 long OpenTxSim::onTimeout(FXObject*, FXSelector, void*)
 {
   if (hasFocus()) {
-#if defined(COPROCESSOR)
-    coprocData.temp = 23;
-    coprocData.maxtemp = 28;
-#endif
 
     updateKeysAndSwitches();
 

--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -784,13 +784,6 @@ void disableSpeaker()
 }
 #endif
 
-#if defined(COPROCESSOR)
-CoprocData coprocData;
-
-void coprocReadData(bool)
-{
-}
-#endif
 
 void rtcInit()
 {


### PR DESCRIPTION
This PR implements highlighting of the Min or Max fields in the Otputs and OutputEdit screens.
This is a substitute to arrows on the corresponding OTX screen.

Was inspired by discussion at 
https://www.rcgroups.com/forums/showthread.php?3916381-Official-EdgeTX-Discussion-Thread/page128#post48604759

Fixes ##1385

Summary of changes: Static Text Min and Max changes color based on the changes in the channel output.
