### PR TITLE
On CRSF CRC error, search for second packet embedded in the failed one

### DIFF
--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -117,11 +117,6 @@ void processCrossfireTelemetryFrame(uint8_t module)
   uint8_t * rxBuffer = getTelemetryRxBuffer(module);
   uint8_t &rxBufferCount = getTelemetryRxBufferCount(module);
 
-  if (!checkCrossfireTelemetryFrameCRC(module)) {
-    TRACE("[XF] CRC error");
-    return;
-  }
-
   if (telemetryState == TELEMETRY_INIT &&
       moduleState[module].counter != CRSF_FRAME_MODELID_SENT) {
     moduleState[module].counter = CRSF_FRAME_MODELID;
@@ -256,10 +251,47 @@ void processCrossfireTelemetryFrame(uint8_t module)
   }
 }
 
+bool crossfireLenIsSane(uint8_t len)
+{
+  // packet len must be at least 3 bytes (type+payload+crc) and 2 bytes < MAX (hdr+len)
+  return (len > 2 && len < TELEMETRY_RX_PACKET_SIZE-1);
+}
+
+void crossfireTelemetrySeekStart(uint8_t *rxBuffer, uint8_t &rxBufferCount)
+{
+  // Bad telemetry packets frequently are just truncated packets, with the start
+  // of a new packet contained in the data. This causes multiple packet drops as
+  // the parser tries to resync.
+  // Search through the rxBuffer for a sync byte, shift the contents if found
+  // and reduce rxBufferCount
+  for (uint8_t idx=1; idx<rxBufferCount; ++idx) {
+    uint8_t data = rxBuffer[idx];
+    if (data == RADIO_ADDRESS || data == UART_SYNC) {
+      uint8_t remain = rxBufferCount - idx;
+      // If there's at least 2 bytes, check the length for validity too
+      if (remain > 1 && !crossfireLenIsSane(rxBuffer[idx+1]))
+        continue;
+
+      //TRACE("Found 0x%02x with %u remain", data, remain);
+      // copy the data to the front of the buffer
+      for (uint8_t src=idx; src<rxBufferCount; ++src) {
+        rxBuffer[src-idx] = rxBuffer[src];
+      }
+
+      rxBufferCount = remain;
+      return;
+    } // if found sync
+  }
+
+  // Not found, clear the buffer
+  rxBufferCount = 0;
+}
+
 void processCrossfireTelemetryData(uint8_t data, uint8_t module)
 {
   uint8_t * rxBuffer = getTelemetryRxBuffer(module);
   uint8_t &rxBufferCount = getTelemetryRxBufferCount(module);
+
 #if defined(AUX_SERIAL)
   if (g_eeGeneral.auxSerialMode == UART_MODE_TELEMETRY_MIRROR) {
     auxSerialPutc(data);
@@ -277,7 +309,7 @@ void processCrossfireTelemetryData(uint8_t data, uint8_t module)
     return;
   }
 
-  if (rxBufferCount == 1 && (data < 2 || data > TELEMETRY_RX_PACKET_SIZE-2)) {
+  if (rxBufferCount == 1 && !crossfireLenIsSane(data)) {
     TRACE("[XF] length 0x%02X error", data);
     rxBufferCount = 0;
     return;
@@ -291,9 +323,9 @@ void processCrossfireTelemetryData(uint8_t data, uint8_t module)
     rxBufferCount = 0;
   }
 
-  if (rxBufferCount > 4) {
-    uint8_t length = rxBuffer[1];
-    if (length + 2 == rxBufferCount) {
+  // rxBuffer[1] holds the packet length-2, check if the whole packet was received
+  while (rxBufferCount > 4 && (rxBuffer[1]+2) == rxBufferCount) {
+    if (checkCrossfireTelemetryFrameCRC(module)) {
 #if defined(BLUETOOTH)
       if (g_eeGeneral.bluetoothMode == BLUETOOTH_TELEMETRY &&
           bluetooth.state == BLUETOOTH_STATE_CONNECTED) {
@@ -302,6 +334,10 @@ void processCrossfireTelemetryData(uint8_t data, uint8_t module)
 #endif
       processCrossfireTelemetryFrame(module);
       rxBufferCount = 0;
+    }
+    else {
+      TRACE("[XF] CRC error ");
+      crossfireTelemetrySeekStart(rxBuffer, rxBufferCount); // adjusts rxBufferCount
     }
   }
 }


### PR DESCRIPTION
When the CRSF telemetry parser gets a CRC error, I've found that the only case that causes these is missing bytes in the CRSF telemetry stream. This leads to not only the bad packet being dropped, but also the following packet will be dropped as well, because some of that packet's bytes were used to fill the previous packet's LEN.  A single lost byte causes **at least** two lost packets every time. There can be more lost due to the parser trying to pick up mid-packet and misinterpreting a payload byte as a packet start.

Here's the issue in action, where I've added some extra debug logging. The `*` asterisk indicates a CRSF packet passing CRC, and the `^` is a UART error (green underline). The lines starting with the little `ox` are me printing the bytes that are "out of band" following an error. Note that all the errors here have 4 bytes shifted, but that's just coincidence. I've seen 1-12 bytes from the next packet present in the CRC failed packet.
![image](https://user-images.githubusercontent.com/677183/151864406-cdfb6191-4d08-462c-bf84-3426a819dcdd.png)

The first packet dump is missing 4 bytes, and fills those bytes with the first 4 bytes of the next incoming telemetry packet (orange underline). This PR searches the CRC-failed packet for a valid beginning of another packet which must meet the same criteria the parser expects
* Must start with `RADIO_ADDRESS` or `UART_SYNC`
* Must have a valid LEN field

If this criteria is met, those bytes are shifted to the front of the buffer and the buffer length is set to match the number of bytes moved. This procedure means that up to LEN-2 bytes can be lost and the following packet will still be processed properly.

### Code Moved
The CRC check was moved from `processCrossfireTelemetryFrame()` to the caller `processCrossfireTelemetryData()` so the parser can cleanly handle the shift or buffer clear.

The bluetooth sender would previously send packets prior to CRC checking them, but this was moved so it only sends the packet to bluetooth if the CRC passes to prevent sending known bad data to clients.

### Missing Bytes?
Yeah this is the real problem here. Why are there missing bytes in the CRSF telemetry stream? Bytes are frequently missing at all megabaud speeds, and very very rarely on 400kbps. 100% of the errors I encountered were `USART_FLAG_ORE` UART overrun.

To eliminate all the callback code called from the ISR as a candidate for what was taking too long, I removed the callbacks so the ISR only read the byte and status and returned. In this layout I still received the same number of `USART_FLAG_ORE` errors. It seems that something is masking interrupts for too long, or with a higher priority than the internal UART ISR prio. I tried upping the internal module IRQ prio by one notch but it made no difference, so it is either interrupts off, a timer ISR, or possibly an EXTI.
```
diff --git a/radio/src/targets/common/arm/stm32/intmodule_serial_driver.cpp b/radio/src/targets/common/arm/stm32/intmodule_serial_driver.cpp
index e57bd10cf..856e09a3e 100755
--- a/radio/src/targets/common/arm/stm32/intmodule_serial_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/intmodule_serial_driver.cpp
@@ -143,7 +143,7 @@ void intmoduleSerialStart(const etx_serial_init* params)

   if (params->rx_enable) {
     USART_ITConfig(INTMODULE_USART, USART_IT_RXNE, ENABLE);
-    NVIC_SetPriority(INTMODULE_USART_IRQn, 6);
+    NVIC_SetPriority(INTMODULE_USART_IRQn, 5);
     NVIC_EnableIRQ(INTMODULE_USART_IRQn);
   }
 }
```

I'd love to be able to figure out how to eliminate the "Telemetry Lost" which ExpressLRS sometimes gets which is always following a `USART_FLAG_ORE` error event. This PR does reduce those by having a more robust recovery where less data is lost, but it isn't perfect and if the root cause can be eliminated then this code can probably be removed. Any assistance in figuring this out would be appreciated, as it does appear to be solely on the EdgeTX side (OpenTX as well). If you note in the image above, each orange has 4 bytes missing, but there are only 2 overrun events before them, indicating multiple bytes are lost per USART error ISR.

### Tested
All tests performed using RadioMaster Zorro with internal ELRS module (DupleTX). It does not appear to me more frequent at higher bauds, even 921600 gets roughly as many as 5.25M, but 400k does appear to have significantly fewer. OneBit sampling obviously makes no difference.