### PR TITLE
Fix handling default values of VALUE inputs of mixer scripts

### DIFF
--- a/radio/src/gui/colorlcd/model_mixer_scripts.cpp
+++ b/radio/src/gui/colorlcd/model_mixer_scripts.cpp
@@ -111,9 +111,9 @@ class ScriptEditWindow : public Page {
           ScriptInput& si = sio.inputs[i];
           new StaticText(window, grid.getLabelSlot(true), si.name, 0, COLOR_THEME_PRIMARY1);
           grid.nextLine();
-          if (si.type == INPUT_TYPE_VALUE) {                    
-              (new NumberEdit(gInputs, inputsGrid.getSlot(), si.min, si.max,
-                             GET_SET_WITH_OFFSET(sd->inputs[i].value, si.def)))->setDefault(si.def);
+          if (si.type == INPUT_TYPE_VALUE) {
+            (new NumberEdit(gInputs, inputsGrid.getSlot(), si.min, si.max,
+                            GET_SET_WITH_OFFSET(sd->inputs[i].value, si.def)))->setDefault(si.def);
           } else {
             new SourceChoice(gInputs, inputsGrid.getSlot(), 0,
                              MIXSRC_LAST_TELEM,

--- a/radio/src/gui/colorlcd/model_mixer_scripts.cpp
+++ b/radio/src/gui/colorlcd/model_mixer_scripts.cpp
@@ -111,10 +111,11 @@ class ScriptEditWindow : public Page {
           ScriptInput& si = sio.inputs[i];
           new StaticText(window, grid.getLabelSlot(true), si.name, 0, COLOR_THEME_PRIMARY1);
           grid.nextLine();
-          if (si.type == INPUT_TYPE_VALUE) {
-            new NumberEdit(gInputs, inputsGrid.getSlot(), si.min - si.def,
-                           si.max - si.def,
-                           GET_SET_WITH_OFFSET(sd->inputs[i].value, si.def));
+          if (si.type == INPUT_TYPE_VALUE) {              
+              (new NumberEdit(gInputs, inputsGrid.getSlot(), si.min, si.max,
+                           GET_SET_WITH_OFFSET(sd->inputs[i].value, 0)))->setDefault(si.def);
+              sd->inputs[i].value = si.def;
+              
           } else {
             new SourceChoice(gInputs, inputsGrid.getSlot(), 0,
                              MIXSRC_LAST_TELEM,

--- a/radio/src/gui/colorlcd/model_mixer_scripts.cpp
+++ b/radio/src/gui/colorlcd/model_mixer_scripts.cpp
@@ -111,11 +111,9 @@ class ScriptEditWindow : public Page {
           ScriptInput& si = sio.inputs[i];
           new StaticText(window, grid.getLabelSlot(true), si.name, 0, COLOR_THEME_PRIMARY1);
           grid.nextLine();
-          if (si.type == INPUT_TYPE_VALUE) {              
+          if (si.type == INPUT_TYPE_VALUE) {                    
               (new NumberEdit(gInputs, inputsGrid.getSlot(), si.min, si.max,
-                           GET_SET_WITH_OFFSET(sd->inputs[i].value, 0)))->setDefault(si.def);
-              sd->inputs[i].value = si.def;
-              
+                             GET_SET_WITH_OFFSET(sd->inputs[i].value, si.def)))->setDefault(si.def);
           } else {
             new SourceChoice(gInputs, inputsGrid.getSlot(), 0,
                              MIXSRC_LAST_TELEM,

--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -1119,12 +1119,13 @@ static bool resumeLua(bool init, bool allowLcdUsage)
           ScriptData & sd = g_model.scriptsData[ref - SCRIPT_MIX_FIRST];
           ScriptInputsOutputs * sio = & scriptInputsOutputs[ref - SCRIPT_MIX_FIRST];
           inputsCount = sio -> inputsCount;
-         
+
           for (int j = 0; j < inputsCount; j++) {
-            if (sio -> inputs[j].type == INPUT_TYPE_SOURCE)
+            if (sio->inputs[j].type == INPUT_TYPE_SOURCE)
               luaGetValueAndPush(lsScripts, sd.inputs[j].source);
             else
-            lua_pushinteger(lsScripts, sd.inputs[j].value + sio->inputs[j].def);
+              lua_pushinteger(lsScripts,
+                              sd.inputs[j].value + sio->inputs[j].def);
           }
         } else
 #endif

--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -1124,7 +1124,7 @@ static bool resumeLua(bool init, bool allowLcdUsage)
             if (sio -> inputs[j].type == INPUT_TYPE_SOURCE)
               luaGetValueAndPush(lsScripts, sd.inputs[j].source);
             else
-              lua_pushinteger(lsScripts, sd.inputs[j].value + sio -> inputs[j].def);
+            lua_pushinteger(lsScripts, sd.inputs[j].value);
           }
         } else
 #endif

--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -1124,7 +1124,7 @@ static bool resumeLua(bool init, bool allowLcdUsage)
             if (sio -> inputs[j].type == INPUT_TYPE_SOURCE)
               luaGetValueAndPush(lsScripts, sd.inputs[j].source);
             else
-            lua_pushinteger(lsScripts, sd.inputs[j].value);
+            lua_pushinteger(lsScripts, sd.inputs[j].value + sio->inputs[j].def);
           }
         } else
 #endif

--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -908,26 +908,22 @@ void logicalSwitchesTimerTick()
         ls_sticky_struct & lastValue = (ls_sticky_struct &)LS_LAST_VALUE(fm, i);
         bool before = lastValue.last & 0x01;
         if (lastValue.state) {
-            if (ls->v2 != SWSRC_NONE) {
-                bool now = getSwitch(ls->v2);
-                if (now != before) {
-                  lastValue.last ^= 1;
-                  if (!before) {
-                    lastValue.state = 0;
-                  }
-                }
+          bool now = getSwitch(ls->v2);
+          if (now != before) {
+            lastValue.last ^= 1;
+            if (!before) {
+              lastValue.state = 0;
             }
+          }
         }
         else {
-            if (ls->v1 != SWSRC_NONE) {
-                bool now = getSwitch(ls->v1);
-                if (before != now) {
-                  lastValue.last ^= 1;
-                  if (!before) {
-                    lastValue.state = 1;
-                  }
-                }
+          bool now = getSwitch(ls->v1);
+          if (before != now) {
+            lastValue.last ^= 1;
+            if (!before) {
+              lastValue.state = 1;
             }
+          }
         }
       }
       else if (ls->func == LS_FUNC_EDGE) {

--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -908,22 +908,26 @@ void logicalSwitchesTimerTick()
         ls_sticky_struct & lastValue = (ls_sticky_struct &)LS_LAST_VALUE(fm, i);
         bool before = lastValue.last & 0x01;
         if (lastValue.state) {
-          bool now = getSwitch(ls->v2);
-          if (now != before) {
-            lastValue.last ^= 1;
-            if (!before) {
-              lastValue.state = 0;
+            if (ls->v2 != SWSRC_NONE) {
+                bool now = getSwitch(ls->v2);
+                if (now != before) {
+                  lastValue.last ^= 1;
+                  if (!before) {
+                    lastValue.state = 0;
+                  }
+                }
             }
-          }
         }
         else {
-          bool now = getSwitch(ls->v1);
-          if (before != now) {
-            lastValue.last ^= 1;
-            if (!before) {
-              lastValue.state = 1;
+            if (ls->v1 != SWSRC_NONE) {
+                bool now = getSwitch(ls->v1);
+                if (before != now) {
+                  lastValue.last ^= 1;
+                  if (!before) {
+                    lastValue.state = 1;
+                  }
+                }
             }
-          }
         }
       }
       else if (ls->func == LS_FUNC_EDGE) {


### PR DESCRIPTION
The default values of VALUE inputs in the input table of a mixer script were used as a offset, not as a default value.
