### PR TITLE
Listbox multiline selectable

### DIFF
--- a/radio/src/gui/colorlcd/listbox.h
+++ b/radio/src/gui/colorlcd/listbox.h
@@ -131,6 +131,7 @@ class ListBase : public FormField
     int32_t activeIndex = -1;
     std::set<uint32_t> selectedIndexes;
     selecttype_e selectionType = LISTBOX_SINGLE_SELECT;
+    bool waslongpress = false;
 
 #if defined(HARDWARE_TOUCH)
     uint32_t duration10ms;

--- a/radio/src/gui/colorlcd/listbox.h
+++ b/radio/src/gui/colorlcd/listbox.h
@@ -23,6 +23,7 @@
 #include <vector>
 #include <iostream>
 #include <string>
+#include <set>
 #include "bitmapbuffer.h"
 #include "libopenui.h"
 #include "touch.h"
@@ -37,13 +38,24 @@ class ListBase : public FormField
               uint8_t lineHeight = MENUS_LINE_HEIGHT,
               WindowFlags windowFlags = 0, LcdFlags lcdFlags = 0);
 
-    
+    typedef enum {
+      LISTBOX_SINGLE_SELECT,
+      LISTBOX_MULTI_SELECT
+    } selecttype_e;
+
     // draw one line of the list. Default implementation just draws the names.  Oher types of lists
     // can draw anything they want.
     virtual void drawLine(BitmapBuffer *dc, const rect_t &rect, uint32_t index, LcdFlags lcdFlags);
     void paint (BitmapBuffer *dc) override;
 
     virtual void setSelected(int selected);
+    virtual void setFocusLine(int selected);
+    void clearSelection() {selectedIndexes.clear(); invalidate();}
+
+    void setMultiSelectHandler(std::function<void(std::set<uint32_t>)> handler)
+    {
+      _multiSelectHandler = std::move(handler);
+    }
 
     void setLongPressHandler(std::function<void(event_t)> handler)
     {
@@ -53,6 +65,11 @@ class ListBase : public FormField
     void setPressHandler(std::function<void(event_t)> handler)
     {
       pressHandler = std::move(handler);
+    }
+
+    void setSelectionMode(selecttype_e st)
+    {
+      selectionType = st;
     }
 
     void setActiveIndex(int index)
@@ -108,9 +125,12 @@ class ListBase : public FormField
     std::vector<std::string> names;
     std::function<uint32_t()> _getValue;
     std::function<void(uint32_t)> _setValue;
+    std::function<void(std::set<uint32_t>)> _multiSelectHandler = nullptr;
     int lineHeight;
     int32_t selected = -1;
     int32_t activeIndex = -1;
+    std::set<uint32_t> selectedIndexes;
+    selecttype_e selectionType = LISTBOX_SINGLE_SELECT;
 
 #if defined(HARDWARE_TOUCH)
     uint32_t duration10ms;


### PR DESCRIPTION
This pull request allows the listbox to be a multi select widget. For use in model labels. Separated for use in LVGL modifications at @kevinkoenig request.

Sets Mutliselect mode with setSelectionMode(LISTBOX_MULTI_SELECT);

Allows a callback function setMultiSelectHandler() which passes list of selected indexes on change.

When in multiselect mode a dashed outline will show the focus line. Also as indicator when listbox has focus.

![image](https://user-images.githubusercontent.com/281145/152274057-9dfa2fb3-3f26-4695-98de-21b40b3f2efb.png)![image](https://user-images.githubusercontent.com/281145/152274135-f555c0f8-f821-401e-a75e-62cc9f7784fb.png)

