### PR TITLE
fix SF repeat field problem (#1539)

### DIFF
--- a/radio/src/gui/colorlcd/special_functions.cpp
+++ b/radio/src/gui/colorlcd/special_functions.cpp
@@ -346,7 +346,7 @@ class SpecialFunctionEditPage : public Page
           },
           SET_DEFAULT(CFN_PLAY_REPEAT(cfn)));
       repeat->setDisplayHandler(
-          [repeat](BitmapBuffer *dc, LcdFlags flags, int32_t value) {
+          [](BitmapBuffer *dc, LcdFlags flags, int32_t value) {
             if (value == 0)
               dc->drawText(3, 0, "1x", flags);
             else if (value == (int8_t)CFN_PLAY_REPEAT_NOSTART)

--- a/radio/src/gui/colorlcd/special_functions.cpp
+++ b/radio/src/gui/colorlcd/special_functions.cpp
@@ -335,15 +335,21 @@ class SpecialFunctionEditPage : public Page
                    GET_SET_DEFAULT(CFN_ACTIVE(cfn)));
       grid.nextLine();
     } else if (HAS_REPEAT_PARAM(func)) {  // !1x 1x 1s 2s 3s ...
-      new StaticText(specialFunctionOneWindow, grid.getLabelSlot(), STR_REPEAT, 0, COLOR_THEME_PRIMARY1);
+      new StaticText(specialFunctionOneWindow, grid.getLabelSlot(), STR_REPEAT,
+                     0, COLOR_THEME_PRIMARY1);
       auto repeat = new NumberEdit(
           specialFunctionOneWindow, grid.getFieldSlot(2, 1), -1,
-          60 / CFN_PLAY_REPEAT_MUL, GET_SET_DEFAULT(CFN_PLAY_REPEAT(cfn)));
+          60 / CFN_PLAY_REPEAT_MUL,
+          [cfn]() {
+            int32_t value = (int8_t)CFN_PLAY_REPEAT(cfn);
+            return value;
+          },
+          SET_DEFAULT(CFN_PLAY_REPEAT(cfn)));
       repeat->setDisplayHandler(
-          [](BitmapBuffer *dc, LcdFlags flags, int32_t value) {
+          [repeat](BitmapBuffer *dc, LcdFlags flags, int32_t value) {
             if (value == 0)
               dc->drawText(3, 0, "1x", flags);
-            else if (value == CFN_PLAY_REPEAT_NOSTART)
+            else if (value == (int8_t)CFN_PLAY_REPEAT_NOSTART)
               dc->drawText(3, 0, "!1x", flags);
             else
               dc->drawNumber(3, 0, value * CFN_PLAY_REPEAT_MUL, flags, 0,


### PR DESCRIPTION
This PR fixies a jump from !1x to 60s when editing the "repeat" field for SF setup

Fixes #1539 

Summary of changes: convert uint8_t field in the cfn structure to int8_t when providing value to NumberEdit(), since the valid range is [-1, 60].
