### PR TITLE
Companion fix otx and etx read and write for max telemetry baudrate

### DIFF
--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -493,6 +493,13 @@ int Boards::getCapability(Board::Type board, Board::Capability capability)
     case HasInternalModuleSupport:
       return (IS_STM32(board) && !IS_TARANIS_X9(board));
 
+    case SportMaxBaudRate:
+      if (IS_FAMILY_T16(board) || IS_FLYSKY_NV14(board) || IS_TARANIS_X7_ACCESS(board) ||
+         (IS_TARANIS(board) && !IS_TARANIS_XLITE(board) && !IS_TARANIS_X7(board) && !IS_TARANIS_X9LITE(board)))
+        return 400000;  //  400K and higher
+      else
+        return 250000;  //  less than 400K
+
     default:
       return 0;
   }

--- a/companion/src/firmwares/boards.h
+++ b/companion/src/firmwares/boards.h
@@ -148,7 +148,8 @@ namespace Board {
     HasColorLcd,
     NumFunctionSwitches,
     HasSDCard,
-    HasInternalModuleSupport
+    HasInternalModuleSupport,
+    SportMaxBaudRate
   };
 
   struct SwitchInfo

--- a/companion/src/firmwares/edgetx/yaml_generalsettings.cpp
+++ b/companion/src/firmwares/edgetx/yaml_generalsettings.cpp
@@ -94,6 +94,32 @@ const YamlLookupTable internalModuleLut = {
   {  MODULE_TYPE_FLYSKY, "TYPE_FLYSKY"  },
 };
 
+struct YamlTelemetryBaudrate {
+  unsigned int value;
+
+  YamlTelemetryBaudrate() = default;
+
+  YamlTelemetryBaudrate(const unsigned int * telemetryBaudrate)
+  {
+    if (Boards::getCapability(getCurrentFirmware()->getBoard(), Board::SportMaxBaudRate) < 400000) {
+      value = *telemetryBaudrate;
+    }
+    else {
+      value = (*telemetryBaudrate + telemetryBaudratesList.size() - 1) % telemetryBaudratesList.size();
+    }
+  }
+
+  void toCpn(unsigned int * telemetryBaudrate, unsigned int variant)
+  {
+    if (Boards::getCapability((Board::Type)variant, Board::SportMaxBaudRate) < 400000) {
+      *telemetryBaudrate = value;
+    }
+    else {
+      *telemetryBaudrate = (value + 1) % telemetryBaudratesList.size();
+    }
+  }
+};
+
 namespace YAML
 {
 
@@ -135,7 +161,10 @@ Node convert<GeneralSettings>::encode(const GeneralSettings& rhs)
   node["timezone"] = rhs.timezone;
   node["adjustRTC"] = (int)rhs.adjustRTC;
   node["inactivityTimer"] = rhs.inactivityTimer;
-  node["telemetryBaudrate"] = rhs.telemetryBaudrate;  // TODO: conversion???
+
+  YamlTelemetryBaudrate telemetryBaudrate(&rhs.telemetryBaudrate);
+  node["telemetryBaudrate"] = telemetryBaudrate.value;
+
   node["internalModule"] = LookupValue(internalModuleLut, rhs.internalModule);
   node["splashMode"] = rhs.splashMode;                // TODO: B&W only
   node["lightAutoOff"] = rhs.backlightDelay;
@@ -289,7 +318,10 @@ bool convert<GeneralSettings>::decode(const Node& node, GeneralSettings& rhs)
   node["timezone"] >> rhs.timezone;
   node["adjustRTC"] >> rhs.adjustRTC;
   node["inactivityTimer"] >> rhs.inactivityTimer;
-  node["telemetryBaudrate"] >> rhs.telemetryBaudrate;  // TODO: conversion???
+
+  YamlTelemetryBaudrate telemetryBaudrate;
+  node["telemetryBaudrate"] >> telemetryBaudrate.value;
+  telemetryBaudrate.toCpn(&rhs.telemetryBaudrate, rhs.variant);
 
   if (node["internalModule"]) {
     node["internalModule"] >> internalModuleLut >> rhs.internalModule;

--- a/companion/src/firmwares/generalsettings.cpp
+++ b/companion/src/firmwares/generalsettings.cpp
@@ -488,14 +488,7 @@ QString GeneralSettings::auxSerialModeToString(int value)
 //  static
 QString GeneralSettings::telemetryBaudrateToString(int value)
 {
-  switch(value) {
-    case 0:
-      return "400000";
-    case 1:
-      return "115200";
-    default:
-      return CPN_STR_UNKNOWN_ITEM;
-  }
+  return telemetryBaudratesList.value(value, CPN_STR_UNKNOWN_ITEM);
 }
 
 //  static
@@ -572,7 +565,7 @@ AbstractStaticItemModel * GeneralSettings::telemetryBaudrateItemModel()
   AbstractStaticItemModel * mdl = new AbstractStaticItemModel();
   mdl->setName(AIM_GS_TELEMETRYBAUDRATE);
 
-  for (int i = 0; i <= 1; i++) {
+  for (int i = 0; i < telemetryBaudratesList.size(); i++) {
     mdl->appendToItemList(telemetryBaudrateToString(i), i);
   }
 

--- a/companion/src/firmwares/generalsettings.h
+++ b/companion/src/firmwares/generalsettings.h
@@ -43,6 +43,8 @@ constexpr char AIM_GS_TELEMETRYBAUDRATE[]  {"gs.telemetrybaudrate"};
 constexpr char AIM_TRAINERMIX_MODE[]       {"trainermix.mode"};
 constexpr char AIM_TRAINERMIX_SRC[]        {"trainermix.src"};
 
+static const QStringList telemetryBaudratesList({ "115K", "400K", "921K", "1.87M", "3.75M", "5.25M" });
+
 enum UartModes {
   UART_MODE_NONE,
   UART_MODE_TELEMETRY_MIRROR,

--- a/companion/src/firmwares/opentx/opentxeeprom.cpp
+++ b/companion/src/firmwares/opentx/opentxeeprom.cpp
@@ -3317,6 +3317,9 @@ void OpenTxGeneralData::beforeExport()
   }
 
   chkSum = sum;
+
+  if (Boards::getCapability((Board::Type)generalData.variant, Board::SportMaxBaudRate) >= 400000)
+    generalData.telemetryBaudrate = (generalData.telemetryBaudrate + telemetryBaudratesList.size() - 1) % telemetryBaudratesList.size();
 }
 
 void OpenTxGeneralData::afterImport()
@@ -3327,5 +3330,8 @@ void OpenTxGeneralData::afterImport()
       RadioTheme::init(themeName, generalData.themeData);
     }
   }
+
+  if (Boards::getCapability((Board::Type)generalData.variant, Board::SportMaxBaudRate) >= 400000)
+    generalData.telemetryBaudrate = (generalData.telemetryBaudrate + 1) % telemetryBaudratesList.size();
 }
 


### PR DESCRIPTION
Fixes #1566

Summary of changes:
Radio specific mapping of radio field enum to display value.
New board capability SportMaxBaudRate which influences the mapping between companion and radios. (Please double check this list! It is based on radio target hals and CMakelists.txt)
Changes required to yaml read/write and otx eeprom import/export (pre-yaml issue).

Tested a number of radio simulators. However there are a lot of radios.

This is another one of those legacy fields with twister logic that keeps coming back to haunt us Boooooo