### PR TITLE
CROSSFIRE_FRAME_PERIODS fix

### DIFF
--- a/radio/src/mixer_scheduler.h
+++ b/radio/src/mixer_scheduler.h
@@ -25,7 +25,7 @@
 #define MIXER_SCHEDULER_DEFAULT_PERIOD_US  4000u // 4ms
 #define MIXER_SCHEDULER_JOYSTICK_PERIOD_US 2000u // 2ms
 
-#define MIN_REFRESH_RATE      1750 /* us */
+#define MIN_REFRESH_RATE       850 /* us */
 #define MAX_REFRESH_RATE     50000 /* us */
 
 #if !defined(SIMU)

--- a/radio/src/telemetry/crossfire.h
+++ b/radio/src/telemetry/crossfire.h
@@ -112,10 +112,11 @@ const uint32_t CROSSFIRE_BAUDRATES[] = {
 };
 const uint8_t CROSSFIRE_FRAME_PERIODS[] = {
   16,
-  4,
-  4,
-  4,
-  4,
+  2,
+  2,
+  2,
+  2,
+  2,
 };
 #if SPORT_MAX_BAUDRATE < 400000
   // index 0 (115200) is the default 0 value


### PR DESCRIPTION
Added missing element in CROSSFIRE_FRAME_PERIODS array, lowered MIN_REFRESH_RATE to 850 us and changed mixer scheduler period to 2ms for baud rates >= 400.000.

Thx to tip from [kobata](https://www.rcgroups.com/forums/member.php?u=906901) at RCGroups: https://www.rcgroups.com/forums/showthread.php?3916381-Official-EdgeTX-Discussion-Thread/page137#post48722019

Needs testing!