### PR TITLE
fix lua error message

### DIFF
--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -798,7 +798,8 @@ void luaError(lua_State * L, uint8_t error)
     if (!strncmp(msg, ".", 2)) msg += 1;
 #endif
 #if LCD_W == 128
-      msg = strrchr(msg, '/') + 1;
+    const char * tmp = strrchr(msg, '/');
+    if (tmp) msg = tmp + 1;
 #else
     if (!strncmp(msg, "/SCRIPTS/", 9)) msg += 9;
 #endif


### PR DESCRIPTION
Same as https://github.com/opentx/opentx/pull/8760

It's not guaranteed that the error string contains '/'. strrchr will return a null pointer if the character isn't found and the result is that we get only the error title and no message.
The companion will crash if this happens in the sim.
