### PR TITLE
Fix crash when viewing TXT file longer than 20480 bytes on color LCD TX (#1612)

### DIFF
--- a/radio/src/gui/colorlcd/view_text.cpp
+++ b/radio/src/gui/colorlcd/view_text.cpp
@@ -204,11 +204,9 @@ void ViewTextWindow::sdReadTextFileBlock(const char *filename, int &lines_count)
 
   result = f_open(&file, (TCHAR *)filename, FA_OPEN_EXISTING | FA_READ);
   if (result == FR_OK) {
-    for (int i = 0; i < TEXT_FILE_MAXSIZE &&
-                    f_read(&file, &c, 1, &sz) == FR_OK && sz == 1 &&
+    while(f_read(&file, &c, 1, &sz) == FR_OK && sz == 1 &&
                     (lines_count == 0 ||
-                     current_line - textVerticalOffset < maxScreenLines);
-         i++) {
+                     current_line - textVerticalOffset < maxScreenLines)) {
       if (c == '\n' || line_length >= maxLineLength) {
         ++current_line;
         line_length = 1;
@@ -273,7 +271,8 @@ void ViewTextWindow::drawVerticalScrollbar(BitmapBuffer *dc)
 
   if (readPos < header.getRect().h << 1) readPos = header.getRect().h << 1;
 
-  coord_t yofs = divRoundClosest(body.getRect().h * readPos, maxPos);
+  coord_t yofs = max(divRoundClosest(body.getRect().h * readPos, maxPos),
+                     header.getRect().h + (int)PAGE_LINE_SPACING);
   coord_t yhgt = divRoundClosest(body.getRect().h * body.getRect().h, maxPos);
   if (yhgt < 15) yhgt = 15;
   if (yhgt + yofs > maxPos) yhgt = maxPos - yofs;

--- a/radio/src/gui/colorlcd/view_text.h
+++ b/radio/src/gui/colorlcd/view_text.h
@@ -26,8 +26,6 @@
 #include "page.h"
 #include "static.h"
 
-constexpr uint16_t TEXT_FILE_MAXSIZE = 20480;
-
 class ViewTextWindow : public Page
 {
  public:


### PR DESCRIPTION
Fixes #1612 

Summary of changes: This PR prevents infinite loop when the text file is bigger than the predefined maximum size.
It also removes the upper limit for the TXT file size and improves scroll-bar display.
