### PR TITLE
List ProtocolName next to Mode: MULTI

### DIFF
--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -797,6 +797,13 @@ class ModuleWindow : public FormGroup {
 #endif
 #if defined(MULTIMODULE)
       else if (isModuleMultimodule(moduleIdx)) {
+        MultiModuleStatus &status = getMultiModuleStatus(moduleIdx);
+
+        if (status.protocolName[0] && status.isValid()) {
+             new StaticText(this, grid.getFieldSlot(2, 1), status.protocolName,
+                            0, COLOR_THEME_PRIMARY1);
+        }
+
         Choice * mmSubProto = nullptr;
         grid.nextLine();
         new StaticText(this, grid.getLabelSlot(true), STR_RF_PROTOCOL, 0,


### PR DESCRIPTION
Behaviour with this PR (example with SIYI HM30 that transmits via S.PORT in the protocolName field "HM30\0\0\0"):

![grafik](https://user-images.githubusercontent.com/21011587/155003885-6be09a3f-eab1-453c-a0b2-4ffd02e707cf.png)

![grafik](https://user-images.githubusercontent.com/21011587/155006493-8b04ef2c-312d-4578-b71c-898996066c00.png)

Old behaviour without this PR:

![grafik](https://user-images.githubusercontent.com/21011587/155005131-60bcb8ba-2686-4a18-a49a-61e630091695.png)

For comparison OpenTX 2.3.14:

![grafik](https://user-images.githubusercontent.com/21011587/155004154-a163f9d0-3db9-4733-81f4-374d3ebdfed7.png)

Following function call was missing in EdgeTX:

https://github.com/opentx/opentx/blob/801b28958045d683b8c8058db5c167ae0c39da65/radio/src/gui/480x272/model_setup.cpp#L1080

String extraction:

https://github.com/opentx/opentx/blob/801b28958045d683b8c8058db5c167ae0c39da65/radio/src/gui/480x272/lcd.cpp#L455-L458
