### PR TITLE
Fixed ZORRO's date and time reset issue #1588

### DIFF
--- a/radio/src/targets/taranis/CMakeLists.txt
+++ b/radio/src/targets/taranis/CMakeLists.txt
@@ -193,6 +193,7 @@ elseif(PCB STREQUAL X7)
     set(FIRMWARE_TARGET_SRC
       ${FIRMWARE_TARGET_SRC}
       startup_stm32f40_41xxx.s
+      ../../thirdparty/STM32F4xx_DSP_StdPeriph_Lib_V1.8.0/Libraries/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_flash.c
       )
     add_definitions(-DSTM32F40_41xxx)
     set(ROTARY_ENCODER YES)

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -135,6 +135,17 @@ void boardInit()
   bluetoothInit(BLUETOOTH_DEFAULT_BAUDRATE, true);
 #endif
 
+#if defined (RADIO_ZORRO)
+    
+  if (FLASH_OB_GetBOR() != OB_BOR_LEVEL3)
+  {
+    FLASH_OB_Unlock();
+    FLASH_OB_BORConfig(OB_BOR_LEVEL3);
+    FLASH_OB_Launch();
+    FLASH_OB_Lock();
+  }
+#endif
+
   pwrInit();
 
 #if defined(AUTOUPDATE)


### PR DESCRIPTION
Fixed ZORRO's date and time reset issue https://github.com/EdgeTX/edgetx/issues/1588

Added judgment on BOR LEVEL to fix the date and time reset issue in a simple way, for Zorro already owned by the user, updating the firmware is the most convenient way.

I have used various destructive tests, none of which will cause the date and time to reset.

So I think, TX16S and other radios, sometimes directly unplugging the battery or some unconventional operations, will cause the firmware to be damaged and unable to boot, which is also related to this BOR LEVEL.