### PR TITLE
fix: Disable LUA GV funcs if `GVARS=NO` build

### DIFF
--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -1487,6 +1487,7 @@ static int luaModelSetOutput(lua_State *L)
   return 0;
 }
 
+#if defined(GVARS)
 /*luadoc
 @function model.getGlobalVariable(index, flight_mode)
 
@@ -1547,6 +1548,7 @@ static int luaModelSetGlobalVariable(lua_State *L)
   }
   return 0;
 }
+#endif
 
 /*luadoc
 @function model.getSensor(sensor)
@@ -1644,8 +1646,10 @@ const luaL_Reg modelLib[] = {
   { "setCurve", luaModelSetCurve },
   { "getOutput", luaModelGetOutput },
   { "setOutput", luaModelSetOutput },
+#if defined (GVARS)
   { "getGlobalVariable", luaModelGetGlobalVariable },
   { "setGlobalVariable", luaModelSetGlobalVariable },
+#endif
   { "getSensor", luaModelGetSensor },
   { "resetSensor", luaModelResetSensor },
   { NULL, NULL }  /* sentinel */


### PR DESCRIPTION
Compile option breakage from #1602

<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #1644

Summary of changes:
- Removes LUA `getGlobalVariable` and `setGlobalVariable` functions if running a `GVARS=NO` firmware build