### PR TITLE
fix: Make decision to show int MPM spectrum analyser entry settings dependent

### DIFF
--- a/radio/src/gui/colorlcd/radio_tools.cpp
+++ b/radio/src/gui/colorlcd/radio_tools.cpp
@@ -271,7 +271,8 @@ void RadioToolsPage::rebuild(FormWindow * window)
     grid.nextLine();
   }
 #endif
-#if defined(INTERNAL_MODULE_MULTI)
+#if defined(HARDWARE_INTERNAL_MODULE)
+  if (g_eeGeneral.internalModule == MODULE_TYPE_MULTIMODULE)
   {
     auto txt =
         new StaticText(window, grid.getLabelSlot(), "multi", BUTTON_BACKGROUND,

--- a/radio/src/gui/common/stdlcd/radio_tools.cpp
+++ b/radio/src/gui/common/stdlcd/radio_tools.cpp
@@ -118,8 +118,10 @@ void menuRadioTools(event_t event)
 
   if (isPXX2ModuleOptionAvailable(reusableBuffer.hardwareAndSettings.modules[INTERNAL_MODULE].information.modelID, MODULE_OPTION_POWER_METER))
     addRadioModuleTool(index++, STR_POWER_METER_INT, menuRadioPowerMeter, INTERNAL_MODULE);
-#elif defined(INTERNAL_MODULE_MULTI)
-  addRadioModuleTool(index++, STR_SPECTRUM_ANALYSER_INT, menuRadioSpectrumAnalyser, INTERNAL_MODULE);
+#endif
+#if defined(HARDWARE_INTERNAL_MODULE)
+  if (g_eeGeneral.internalModule == MODULE_TYPE_MULTIMODULE)
+    addRadioModuleTool(index++, STR_SPECTRUM_ANALYSER_INT, menuRadioSpectrumAnalyser, INTERNAL_MODULE);
 #endif
 #if defined(PXX2)|| defined(MULTIMODULE)
   if (isPXX2ModuleOptionAvailable(reusableBuffer.hardwareAndSettings.modules[EXTERNAL_MODULE].information.modelID, MODULE_OPTION_SPECTRUM_ANALYSER) || isModuleMultimodule(EXTERNAL_MODULE))


### PR DESCRIPTION
Fixes #1647

Showing of the "(int) Spectrum Analyser" was determined at build time,
dependent on the default internal module, which is wrong post #1117

This now makes it so it is dependent on current internal module setting (if the radio has an internal module) for both colorlcd and B&W radios.

Tested on TX16 and Zorro (ELRS). Tool entry added with MULTI, not added with CRSF. 