### PR TITLE
fixed cosmetic in flight modes

### DIFF
--- a/radio/src/gui/128x64/model_flightmodes.cpp
+++ b/radio/src/gui/128x64/model_flightmodes.cpp
@@ -251,7 +251,7 @@ void menuModelFlightModesAll(event_t event)
 
   if (menuVerticalOffset != MAX_FLIGHT_MODES-(LCD_LINES-2)) return;
 
-  lcdDrawText(LCD_W/2, (LCD_LINES-1)*FH+1, STR_CHECKTRIMS, CENTERED);
+  lcdDrawTextAlignedLeft((LCD_LINES-1)*FH+1, STR_CHECKTRIMS);
   drawFlightMode(OFS_CHECKTRIMS, (LCD_LINES-1)*FH+1, mixerCurrentFlightMode+1);
   if (sub==MAX_FLIGHT_MODES && !trimsCheckTimer) {
     lcdInvertLastLine();


### PR DESCRIPTION
look at the bottom line from flight modes. found this on rm zorro

before:
![before](https://user-images.githubusercontent.com/29702171/156382840-739e546e-6913-4cc3-b5d2-fe4dd5e53c36.png)

after:
![after](https://user-images.githubusercontent.com/29702171/156382865-118d2580-6908-4328-bacd-30d50c90a12a.png)

