### PR TITLE
Update settings version on conversion

### DIFF
--- a/radio/src/storage/conversions/conversions_220_221.cpp
+++ b/radio/src/storage/conversions/conversions_220_221.cpp
@@ -174,6 +174,10 @@ const char* convertRadioData_220_to_221()
 
   const char* error = nullptr;
   uint16_t read = eeLoadGeneralSettingsData(data, size);
+
+  auto& settings = *reinterpret_cast<bin_storage_220::RadioData*>(data);
+  settings.version = 221;
+
   if (read == size) {
     error = writeFileYaml(RADIO_SETTINGS_YAML_PATH,
                           yaml_conv_220::get_radiodata_nodes(), data);


### PR DESCRIPTION
Fixes #1503, #1366

When updating from 220 to 221 of config format for radio data, the settings version flag was not being updated, meaning the version remained 220, instead of being incremented to 221. 

Whilst this will probably be causing other issues, this was most noticeable in that caused the power-on delay to be locked to 2 seconds on B&W radios with momentary power-on buttons, due to a version mismatch check present there, if the radio had done the conversion. 