### PR TITLE
Add channel bar to Output Edit Screen

### DIFF
--- a/radio/src/gui/colorlcd/model_outputs.cpp
+++ b/radio/src/gui/colorlcd/model_outputs.cpp
@@ -24,9 +24,42 @@
 #include "opentx.h"
 #include "libopenui.h"
 
+#include "channel_bar.h"
 #include "gvar_numberedit.h"
 
 #define SET_DIRTY() storageDirty(EE_MODEL)
+
+#if (LCD_W > LCD_H)
+  #define OUTPUT_EDIT_STATUS_BAR_WIDTH 250
+  #define OUTPUT_EDIT_STATUS_BAR_MARGIN 3
+  #define OUTPUT_EDIT_RIGHT_MARGIN 0
+#else
+  #define OUTPUT_EDIT_STATUS_BAR_WIDTH 180
+  #define OUTPUT_EDIT_STATUS_BAR_MARGIN 0
+  #define OUTPUT_EDIT_RIGHT_MARGIN 3
+#endif
+
+class OutputEditStatusBar : public Window
+{
+ public:
+  OutputEditStatusBar(Window *parent, const rect_t &rect, int8_t channel) :
+      Window(parent, rect), _channel(channel)
+  {
+    channelBar = new ComboChannelBar(this, {OUTPUT_EDIT_STATUS_BAR_MARGIN, 0, rect.w - (OUTPUT_EDIT_STATUS_BAR_MARGIN * 2), rect.h}, channel);
+    channelBar->setLeftMargin(0);
+    channelBar->setTextColor(COLOR_THEME_PRIMARY2);
+    channelBar->setOutputChannelBarLimitColor(COLOR_THEME_EDIT);
+  }
+
+  void paint(BitmapBuffer *dc) override
+  {
+    // dc->clear(COLOR_THEME_SECONDARY2);
+  }
+
+ protected:
+  ComboChannelBar *channelBar;
+  int8_t _channel;
+};
 
 class OutputEditWindow : public Page
 {
@@ -45,6 +78,7 @@ class OutputEditWindow : public Page
   int chanZero = 0;
   StaticText *minText;
   StaticText *maxText;
+  OutputEditStatusBar *statusBar = nullptr;
 
   void checkEvents() override
   {
@@ -74,6 +108,10 @@ class OutputEditWindow : public Page
                     LCD_W - PAGE_TITLE_LEFT, PAGE_LINE_HEIGHT},
                    getSourceString(MIXSRC_CH1 + channel), 0,
                    COLOR_THEME_PRIMARY2);
+
+    statusBar = new OutputEditStatusBar(
+        window, {window->getRect().w - OUTPUT_EDIT_STATUS_BAR_WIDTH - OUTPUT_EDIT_RIGHT_MARGIN, 0, OUTPUT_EDIT_STATUS_BAR_WIDTH, MENU_HEADER_HEIGHT + 3},
+        channel);
   }
 
   void buildBody(FormWindow *window)

--- a/radio/src/gui/colorlcd/model_outputs.cpp
+++ b/radio/src/gui/colorlcd/model_outputs.cpp
@@ -243,6 +243,16 @@ class OutputLineButton : public Button
     dc->drawText(228, FIELD_PADDING_TOP, output->symetrical ? "=" : "\210",
                  textColor);
 
+#if LCD_W > LCD_H
+    char chval[10];
+// #if defined(PPM_UNIT_US)
+    snprintf(chval, sizeof(chval), "%d%s", PPM_CH_CENTER(channel) + channelOutputs[channel] / 2, STR_US);
+// #else
+//   snprintf(chval, sizeof(chval), "%d%s", calcRESXto100(channelOutputs[channel]), "%");
+// #endif
+    dc->drawText(260, FIELD_PADDING_TOP, chval, LEFT | textColor);
+#endif
+
     // second line
     if (output->revert) {
       dc->drawTextAtIndex(4, PAGE_LINE_HEIGHT + FIELD_PADDING_TOP, STR_MMMINV,


### PR DESCRIPTION
Resolves #1385

Summary
- [x] Add channel bar to header of outputs edit page
- [x] Add values of each channel in to the end of row in overview table on wide lcd screens (not enough space on NV14, so no change there). Added commented out code that can show in % instead.
- [ ] ~~Add value of current focused channel of narrow screen radios - I think I just figured out how to track focused channel~~
This can wait until 2.8 along with adding the footer statusbar for mixes and outputs page. 

TX16S:
![snapshot_09](https://user-images.githubusercontent.com/5500713/157560364-43ab8099-0ee5-433e-80f1-6bb5c00b7c37.png)
![snapshot_08](https://user-images.githubusercontent.com/5500713/157560386-b09263af-e004-4ef6-9c00-2f61a3530cfd.png)

NV14:
![snapshot_07](https://user-images.githubusercontent.com/5500713/157560442-cdafea8e-600f-45af-a73e-09916ec0ae1a.png)
![snapshot_06](https://user-images.githubusercontent.com/5500713/157560452-5f2f08a0-ce27-434d-a993-069731a2d7c5.png)

