### PR TITLE
Do not enable DMA1_Stream2 IRQ for FlySky Hall Sticks

### DIFF
--- a/radio/src/targets/horus/flyskyHallStick_driver.cpp
+++ b/radio/src/targets/horus/flyskyHallStick_driver.cpp
@@ -160,13 +160,6 @@ void reset_hall_stick( void )
 
 void flysky_hall_stick_check_init()
 {
-    NVIC_InitTypeDef NVIC_InitStructure;
-    NVIC_InitStructure.NVIC_IRQChannel = FLYSKY_HALL_SERIAL_RX_DMA_Stream_IRQn;
-    NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
-    NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
-    NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-    NVIC_Init(&NVIC_InitStructure);
-
     USART_InitTypeDef USART_InitStructure;
     GPIO_InitTypeDef GPIO_InitStructure;
 
@@ -220,13 +213,6 @@ void flysky_hall_stick_check_init()
 void flysky_hall_stick_init()
 {
   USART_DeInit(FLYSKY_HALL_SERIAL_USART);
-
-  NVIC_InitTypeDef NVIC_InitStructure;
-  NVIC_InitStructure.NVIC_IRQChannel = FLYSKY_HALL_SERIAL_RX_DMA_Stream_IRQn;
-  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
-  NVIC_InitStructure.NVIC_IRQChannelSubPriority = 0;
-  NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
-  NVIC_Init(&NVIC_InitStructure);
 
   USART_InitTypeDef USART_InitStructure;
   GPIO_InitTypeDef GPIO_InitStructure;


### PR DESCRIPTION
As there was no Interrupt-Service-Routine defined for FlySky Hall RX DMA (DMA1_Stream2_IRQHandler, IRQ no 13), should not enable the interrupt.

Tested on RM TX16S with FlySky digital hall sticks.