### PR TITLE
add  "Assign bitmap" to image file menu (#1668)

### DIFF
--- a/radio/src/gui/colorlcd/radio_sdmanager.cpp
+++ b/radio/src/gui/colorlcd/radio_sdmanager.cpp
@@ -278,9 +278,13 @@ void RadioSdManagerPage::build(FormWindow * window)
                 MultiFirmwareUpdate(name, EXTERNAL_MODULE, MULTI_TYPE_ELRS);
               });
             }
-            // else if (isExtensionMatching(ext, BITMAPS_EXT)) {
-            //   // TODO
-            // }
+            else if (isExtensionMatching(ext, BITMAPS_EXT)) {
+               menu->addLine(STR_ASSIGN_BITMAP, [=]() {
+                 memcpy(g_model.header.bitmap, name.c_str(),
+                        sizeof(g_model.header.bitmap));
+                 storageDirty(EE_MODEL);
+               });
+            }
             else if (!strcasecmp(ext, TEXT_EXT) || !strcasecmp(ext, LOGS_EXT)) {
               menu->addLine(STR_VIEW_TEXT, [=]() {
                 static char lfn[FF_MAX_LFN + 1];  // TODO optimize that!


### PR DESCRIPTION
Fixes #1668 

Add menu line "Assign Bitmap" to SD manager file menu when image file is selected.
If applied the selected image will be used for current model.