### PR TITLE
proposal: Pressing power button should reset backlight timeout

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -2043,6 +2043,9 @@ uint32_t pwrCheck()
     return e_power_off;
   }
   else if (pwrPressed()) {
+#if defined(COLORLCD)
+    resetBacklightTimeout();
+#endif
     if (TELEMETRY_STREAMING()) {
       message = STR_MODEL_STILL_POWERED;
     }

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -2043,9 +2043,10 @@ uint32_t pwrCheck()
     return e_power_off;
   }
   else if (pwrPressed()) {
-#if defined(COLORLCD)
-    resetBacklightTimeout();
-#endif
+    if (g_eeGeneral.backlightMode == e_backlight_mode_keys ||
+        g_eeGeneral.backlightMode == e_backlight_mode_all)
+      resetBacklightTimeout();
+
     if (TELEMETRY_STREAMING()) {
       message = STR_MODEL_STILL_POWERED;
     }


### PR DESCRIPTION
This PR simply resets the backlight timeout on colorlcd radios whenever the power button is pressed. 

Thus instead of the shutdown animation flashing up and the screen turning off immediately if you release the button (if the backlight was in auto off mode), it now stays on for the timeout interval. 