### PR TITLE
read CPU_UID

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -260,8 +260,11 @@ void memswap(void * a, void * b, uint8_t size)
 #if defined(PXX2)
 void setDefaultOwnerId()
 {
+  uint8_t ch;
   for (uint8_t i = 0; i < PXX2_LEN_REGISTRATION_ID; i++) {
-     g_eeGeneral.ownerRegistrationID[i] = (((uint8_t *)cpu_uid)[4 + i] & 0x3fu);
+    ch = ((uint8_t *)cpu_uid)[4+i]&0x7f;
+    if(ch<0x20 || ch==0x7f) ch='-';
+    g_eeGeneral.ownerRegistrationID[PXX2_LEN_REGISTRATION_ID-1-i] = ch;
   }
 }
 #endif


### PR DESCRIPTION
The CPU_UID data stored from address 0x1FFF7A10 + 4 is on my radio
0x1FFF7A10+4 : 0x06, 0x51, 0x38, 0x31, 0x33, 0x37, 0x30, 0x33

Since the control character 0x06 (ACK) was mixed, I changed it to another character.

Looking at RM0090 39.1, it seems that the characters are stored from the lower byte of the UID, so the character storage order is set so that the upper byte comes first.