### PR TITLE
fix: colorlcd "Global" bg image not being loaded at theme change

### DIFF
--- a/radio/src/gui/colorlcd/theme_manager.cpp
+++ b/radio/src/gui/colorlcd/theme_manager.cpp
@@ -300,7 +300,25 @@ void ThemeFile::applyBackground()
   if (pos != std::string::npos) {
     auto rootDir = backgroundImageFileName.substr(0, pos + 1);
     rootDir = rootDir + "background_" + std::to_string(LCD_W) + "x" + std::to_string(LCD_H) + ".png";
-    instance->setBackgroundImageFileName((char *)rootDir.c_str());
+
+    FIL file;
+    FRESULT result = f_open(&file, rootDir.c_str(), FA_OPEN_EXISTING);
+    if (result == FR_OK) {
+      instance->setBackgroundImageFileName((char *)rootDir.c_str());
+    } else {
+      // TODO: This needs to be made user configurable, not
+      // require the file be deleted to remove global background
+      char fileName[FF_MAX_LFN + 1];
+      fileName[FF_MAX_LFN] = '\0';
+      strncpy(fileName, THEMES_PATH, FF_MAX_LFN);
+      strcat(fileName, "/EdgeTX/background.png");
+      result = f_open(&file, fileName, FA_OPEN_EXISTING);
+      if (result == FR_OK) {
+        instance->setBackgroundImageFileName(fileName);
+      } else {
+        instance->setBackgroundImageFileName("");
+      }
+    }
   } else {
     instance->setBackgroundImageFileName("");
   }


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #1680

Summary of changes:
- Ensures global background image is used if a theme does not provide it's own when a theme is loaded. Thus consistent with power-on behaviour. 
