### PR TITLE
fix: Trainer Slave not recognized in Master for ACCESS radios

### DIFF
--- a/radio/src/targets/taranis/board.h
+++ b/radio/src/targets/taranis/board.h
@@ -151,7 +151,7 @@ void extmoduleSendInvertedByte(uint8_t byte);
 
 #if defined(TRAINER_DETECT_GPIO)
   // Trainer detect is a switch on the jack
-  #define TRAINER_CONNECTED()           (GPIO_ReadInputDataBit(TRAINER_DETECT_GPIO, TRAINER_DETECT_GPIO_PIN) == Bit_RESET)
+  #define TRAINER_CONNECTED()           (GPIO_ReadInputDataBit(TRAINER_DETECT_GPIO, TRAINER_DETECT_GPIO_PIN) == TRAINER_DETECT_GPIO_PIN_VALUE)
 #elif defined(PCBXLITES)
   // Trainer is on the same connector than Headphones
   enum JackState

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -1585,6 +1585,7 @@
 #if defined(PCBX9LITE)
   #define TRAINER_DETECT_GPIO           GPIOD
   #define TRAINER_DETECT_GPIO_PIN       GPIO_Pin_11 // PD.11
+  #define TRAINER_DETECT_GPIO_PIN_VALUE Bit_SET
 #endif
   #define TRAINER_TIMER                 TIM4
   #define TRAINER_GPIO_AF               GPIO_AF_TIM4 // TIM4_CH1 (Out) + TIM4_CH2 (In)
@@ -1619,6 +1620,11 @@
   #define TRAINER_OUT_GPIO_PinSource    GPIO_PinSource9
   #define TRAINER_DETECT_GPIO           GPIOA
   #define TRAINER_DETECT_GPIO_PIN       GPIO_Pin_8  // PA.08
+#if defined(RADIO_X9DP2019) || defined(RADIO_X7ACCESS)
+  #define TRAINER_DETECT_GPIO_PIN_VALUE Bit_SET
+#else
+  #define TRAINER_DETECT_GPIO_PIN_VALUE Bit_RESET
+#endif
   #define TRAINER_TIMER                 TIM3
   #define TRAINER_TIMER_IRQn            TIM3_IRQn
   #define TRAINER_GPIO_AF               GPIO_AF_TIM3


### PR DESCRIPTION
Fixes #1587

Where Trainer Slave not recognized in Master due to trainer detect pin being inverted on ACCESS radios. 

Import of:
- https://github.com/opentx/opentx/pull/8811
- https://github.com/opentx/opentx/commit/2241c3f4ce3b0c6cd3fd41a45770c09ce3e75a7e

Currently untested. Needs testing on:
- [x] X9 Lite
- [x] X9D+2019 (previously not working RM WT01 to link slave transmitter worked simply by loading PR firmware)
- [ ] X7 ACCESS would be nice to have also