### PR TITLE
fix: Ext mod XJT opts on 128x64 B&W altering int mod settings

### DIFF
--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -995,9 +995,9 @@ void menuModelSetup(event_t event)
                 if (isModuleXJT(moduleIdx)) {
                   g_model.moduleData[moduleIdx].subType = checkIncDec(event, g_model.moduleData[moduleIdx].subType, 0, MODULE_SUBTYPE_PXX1_LAST, EE_MODEL, isRfProtocolAvailable);
                   if (checkIncDec_Ret) {
-                    g_model.moduleData[0].type = MODULE_TYPE_XJT_PXX1;
-                    g_model.moduleData[0].channelsStart = 0;
-                    g_model.moduleData[0].channelsCount = defaultModuleChannels_M8(moduleIdx);
+                    g_model.moduleData[moduleIdx].type = MODULE_TYPE_XJT_PXX1;
+                    g_model.moduleData[moduleIdx].channelsStart = 0;
+                    g_model.moduleData[moduleIdx].channelsCount = defaultModuleChannels_M8(moduleIdx);
                   }
                 }
                 else if (isModuleISRM(moduleIdx)) {


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes issues where the wrong moduleData index is being written to when editing XJT module settings on 128x64 radios.