### PR TITLE
Show mix and output bars on the mixes and output pages.

### DIFF
--- a/radio/src/gui/colorlcd/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model_mixes.cpp
@@ -416,6 +416,7 @@ class MixLineTitle : public StaticText
   }
 };
 
+#include "channel_bar.h"
 void ModelMixesPage::build(FormWindow * window, int8_t focusMixIndex)
 {
   FormGridLayout grid;
@@ -430,6 +431,7 @@ void ModelMixesPage::build(FormWindow * window, int8_t focusMixIndex)
 
   int mixIndex = 0;
   MixData * mix = g_model.mixData;
+
   for (uint8_t ch = 0; ch < MAX_OUTPUT_CHANNELS; ch++) {
 
     bool skip_mix = (ch == 0 && is_memclear(mix, sizeof(MixData)));
@@ -440,7 +442,6 @@ void ModelMixesPage::build(FormWindow * window, int8_t focusMixIndex)
       auto txt = new MixLineTitle(window, grid.getLabelSlot(),
                                   getSourceString(MIXSRC_CH1 + ch),
                                   BUTTON_BACKGROUND, COLOR_THEME_PRIMARY1 | CENTERED);
-
       uint8_t count = 0;
       while (mixIndex < MAX_MIXERS && mix->destCh == ch && !skip_mix) {
 
@@ -529,6 +530,13 @@ void ModelMixesPage::build(FormWindow * window, int8_t focusMixIndex)
 
         skip_mix = (ch == 0 && is_memclear(mix, sizeof(MixData)));
       }
+
+      grid.spacer();
+      rect_t rect = grid.getCenteredSlot();
+      rect.h -= 2;
+      new MixerChannelBar(window, rect, ch);
+      grid.spacer(PAGE_PADDING + 2);
+
 
       h = grid.getWindowHeight() - h + 1;
       txt->setHeight(h);

--- a/radio/src/gui/colorlcd/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model_mixes.cpp
@@ -416,7 +416,6 @@ class MixLineTitle : public StaticText
   }
 };
 
-#include "channel_bar.h"
 void ModelMixesPage::build(FormWindow * window, int8_t focusMixIndex)
 {
   FormGridLayout grid;

--- a/radio/src/gui/colorlcd/model_outputs.cpp
+++ b/radio/src/gui/colorlcd/model_outputs.cpp
@@ -380,7 +380,19 @@ void ModelOutputsPage::build(FormWindow *window, int8_t focusChannel)
     }
 
     txt->setHeight(button->height());
-    grid.spacer(button->height() + 5);
+    grid.spacer(button->height() + 1);
+
+    for (int mixIndex = 0; mixIndex < MAX_MIXERS; mixIndex++) {
+      MixData &mix = g_model.mixData[mixIndex];
+      if (mix.destCh == ch) {
+        rect_t rect = grid.getCenteredSlot();
+        rect.h -= 2;
+        new OutputChannelBar(window, rect, ch);
+        grid.spacer(PAGE_PADDING * 2 - 2);
+        break;
+      }
+    }
+    grid.spacer(4);
   }
 
   grid.nextLine();


### PR DESCRIPTION
This is inspired by discussion from 
https://www.rcgroups.com/forums/showpost.php?p=48884147&postcount=2203
https://www.rcgroups.com/forums/showthread.php?3916381-Official-EdgeTX-Discussion-Thread/page147

Summary of changes:
On the mixes screen mix bar is displayed below every mix.
On the outputs screen output bar is displayed under every active (associated with mix)  output.

It might be helpful to be able to see all channels affected by a certain input.
I think it is more useful for mixes than for outputs, hence two separate commits, so outputs screen changes may be dropped.

![screenshot_tx16s_22-03-20_10-07-08](https://user-images.githubusercontent.com/46511024/159174137-aa09a84f-95bc-44eb-91ba-74f9d211df6d.png)
![screenshot_tx16s_22-03-20_10-09-51](https://user-images.githubusercontent.com/46511024/159174168-eeb72659-1782-408f-89d3-b2c99761e4df.png)

