### PR TITLE
Jump from mixes/outputs to channel monitor

### DIFF
--- a/radio/src/gui/colorlcd/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model_mixes.cpp
@@ -29,7 +29,7 @@
 #include "model_curves.h"
 #include "dataconstants.h"
 #include "channel_bar.h"
-#include "view_channels.h"
+
 
 #define SET_DIRTY()     storageDirty(EE_MODEL)
 #define PASTE_BEFORE    -2

--- a/radio/src/gui/colorlcd/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model_mixes.cpp
@@ -29,7 +29,7 @@
 #include "model_curves.h"
 #include "dataconstants.h"
 #include "channel_bar.h"
-
+#include "view_channels.h"
 
 #define SET_DIRTY()     storageDirty(EE_MODEL)
 #define PASTE_BEFORE    -2
@@ -416,6 +416,7 @@ class MixLineTitle : public StaticText
   }
 };
 
+
 void ModelMixesPage::build(FormWindow * window, int8_t focusMixIndex)
 {
   FormGridLayout grid;
@@ -427,6 +428,16 @@ void ModelMixesPage::build(FormWindow * window, int8_t focusMixIndex)
     mixerSetupMultiBitmap,
     mixerSetupReplaceBitmap
   };
+
+  new TextButton(
+      window, grid.getFieldSlot(2, 0), "Open Channel Monitor",
+      [=]() {
+        pushEvent(EVT_KEY_LONG(KEY_TELEM));
+        return 0;
+      },
+      0, COLOR_THEME_PRIMARY1);
+
+  grid.nextLine();
 
   int mixIndex = 0;
   MixData * mix = g_model.mixData;

--- a/radio/src/gui/colorlcd/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model_mixes.cpp
@@ -430,7 +430,7 @@ void ModelMixesPage::build(FormWindow * window, int8_t focusMixIndex)
   };
 
   new TextButton(
-      window, grid.getFieldSlot(2, 0), "Open Channel Monitor",
+      window, grid.getFieldSlot(2, 0), STR_OPEN_CHANNEL_MONITORS,
       [=]() {
         pushEvent(EVT_KEY_LONG(KEY_TELEM));
         return 0;

--- a/radio/src/gui/colorlcd/model_outputs.cpp
+++ b/radio/src/gui/colorlcd/model_outputs.cpp
@@ -25,7 +25,6 @@
 #include "gvar_numberedit.h"
 #include "libopenui.h"
 #include "opentx.h"
-#include "view_channels.h"
 
 #define SET_DIRTY() storageDirty(EE_MODEL)
 

--- a/radio/src/gui/colorlcd/model_outputs.cpp
+++ b/radio/src/gui/colorlcd/model_outputs.cpp
@@ -314,9 +314,8 @@ void ModelOutputsPage::build(FormWindow *window, int8_t focusChannel)
   grid.spacer(PAGE_PADDING);
   grid.setLabelWidth(66);
 
-
   new TextButton(
-      window, grid.getFieldSlot(2, 0), "Open Channel Monitor",
+      window, grid.getFieldSlot(2, 0), STR_OPEN_CHANNEL_MONITORS,
       [=]() {
         pushEvent(EVT_KEY_LONG(KEY_TELEM));
         return 0;

--- a/radio/src/gui/colorlcd/model_outputs.cpp
+++ b/radio/src/gui/colorlcd/model_outputs.cpp
@@ -21,11 +21,11 @@
 
 #include "model_outputs.h"
 
-#include "opentx.h"
-#include "libopenui.h"
-
 #include "channel_bar.h"
 #include "gvar_numberedit.h"
+#include "libopenui.h"
+#include "opentx.h"
+#include "view_channels.h"
 
 #define SET_DIRTY() storageDirty(EE_MODEL)
 
@@ -294,6 +294,7 @@ class OutputLineButton : public Button
   int value = 0;
 };
 
+
 ModelOutputsPage::ModelOutputsPage() :
     PageTab(STR_MENULIMITS, ICON_MODEL_OUTPUTS)
 {
@@ -307,14 +308,24 @@ void ModelOutputsPage::rebuild(FormWindow *window, int8_t focusChannel)
   window->setScrollPositionY(scrollPosition);
 }
 
+
 void ModelOutputsPage::build(FormWindow *window, int8_t focusChannel)
 {
   FormGridLayout grid;
   grid.spacer(PAGE_PADDING);
   grid.setLabelWidth(66);
 
+
   new TextButton(
-      window, grid.getLineSlot(), STR_ADD_ALL_TRIMS_TO_SUBTRIMS,
+      window, grid.getFieldSlot(2, 0), "Open Channel Monitor",
+      [=]() {
+        pushEvent(EVT_KEY_LONG(KEY_TELEM));
+        return 0;
+      },
+      0, COLOR_THEME_PRIMARY1);
+
+  new TextButton(
+      window, grid.getFieldSlot(2, 1), STR_ADD_ALL_TRIMS_TO_SUBTRIMS,
       [=]() {
         moveTrimsToOffsets();  // if highlighted and menu pressed - move trims
                                // to offsets

--- a/radio/src/gui/colorlcd/tabsgroup.cpp
+++ b/radio/src/gui/colorlcd/tabsgroup.cpp
@@ -20,8 +20,14 @@
  */
 
 #include "tabsgroup.h"
+
 #include "mainwindow.h"
+#include "view_channels.h"
 #include "view_main.h"
+#include "model_outputs.h"
+#include "model_mixes.h"
+#include "static.h"
+#include "menu_model.h"
 
 #if defined(HARDWARE_TOUCH)
 #include "keyboard_base.h"
@@ -31,13 +37,15 @@
 
 #include <algorithm>
 
+int calledFromMix = 0;
+static int retTab = 0;
+
 TabsGroupHeader::TabsGroupHeader(TabsGroup * parent, uint8_t icon):
   FormGroup(parent, { 0, 0, LCD_W, MENU_BODY_TOP }, OPAQUE),
 #if defined(HARDWARE_TOUCH)
   back(this, { 0, 0, MENU_HEADER_BACK_BUTTON_WIDTH, MENU_HEADER_BACK_BUTTON_HEIGHT },
-       [=]() -> uint8_t {
-         parent->deleteLater();
-         ViewMain::instance()->setFocus((SET_FOCUS_DEFAULT));
+       [=]() -> uint8_t {         
+         pushEvent(EVT_KEY_FIRST(KEY_EXIT));
          return 1;
        }, NO_FOCUS | FORM_NO_BORDER),
 #endif
@@ -46,7 +54,7 @@ TabsGroupHeader::TabsGroupHeader(TabsGroup * parent, uint8_t icon):
 {
 }
 
-void TabsGroupHeader::paint(BitmapBuffer * dc)
+void TabsGroupHeader::paint(BitmapBuffer* dc)
 {
   OpenTxTheme::instance()->drawPageHeaderBackground(dc, icon, title);
 }
@@ -217,10 +225,30 @@ void TabsGroup::onEvent(event_t event)
   }
   else if (event == EVT_KEY_FIRST(KEY_EXIT)) {
     killEvents(event);
-    ViewMain::instance()->setFocus(SET_FOCUS_DEFAULT);
+    if (!calledFromMix) {
+      ViewMain::instance()->setFocus(SET_FOCUS_DEFAULT);  
+    }
+    else {
+      auto menu = new ModelMenu();
+      menu->setCurrentTab(retTab);
+      calledFromMix = 0;
+      //TRACE("currentTab=%d  %s", retTab, typeid(*currentTab).name());
+    }
     deleteLater();
-  }
-  else if (parent) {
+    calledFromMix = 0;
+    
+  } else if (event == EVT_KEY_LONG(KEY_TELEM)) {
+    //TRACE("currentTab %s", typeid(*currentTab).name());
+    if (typeid(*currentTab) == typeid(ModelOutputsPage) ||
+        typeid(*currentTab) == typeid(ModelMixesPage)) {
+      killEvents(event);
+      calledFromMix = 1;
+      retTab = header.carousel.getCurrentIndex();
+      TRACE("currentTab=%d  %s", calledFromMix, typeid(*currentTab).name());
+      new ChannelsViewMenu();
+      deleteLater();
+    }
+  } else if (parent) {
     parent->onEvent(event);
   }
 }

--- a/radio/src/translations.cpp
+++ b/radio/src/translations.cpp
@@ -715,6 +715,7 @@ const char STR_PRESET[] = TR_PRESET;
 const char STR_CLEAR[] = TR_CLEAR;
 const char STR_RESET[] = TR_RESET;
 const char STR_ADD_ALL_TRIMS_TO_SUBTRIMS[] = TR_ADD_ALL_TRIMS_TO_SUBTRIMS;
+const char STR_OPEN_CHANNEL_MONITORS[] = TR_OPEN_CHANNEL_MONITORS;
 const char STR_COUNT[] = TR_COUNT;
 const char STR_PT[] = TR_PT;
 const char STR_PTS[] = TR_PTS;

--- a/radio/src/translations.h
+++ b/radio/src/translations.h
@@ -1059,6 +1059,7 @@ extern const char STR_PRESET[];
 extern const char STR_CLEAR[];
 extern const char STR_RESET[];
 extern const char STR_ADD_ALL_TRIMS_TO_SUBTRIMS[];
+extern const char STR_OPEN_CHANNEL_MONITORS[];
 extern const char STR_COUNT[];
 extern const char STR_PT[];
 extern const char STR_PTS[];

--- a/radio/src/translations/cn.h.txt
+++ b/radio/src/translations/cn.h.txt
@@ -1312,7 +1312,14 @@
 
 #define TR_USE_THEME_COLOR            "使用主题颜色"
 
+#if LCD_W > LCD_H
 #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS  "将所有微调导入中点偏移值"
+  #define TR_OPEN_CHANNEL_MONITORS        "Open Channel Monitor" 
+#else
+  #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Trms->SubTrms"
+  #define TR_OPEN_CHANNEL_MONITORS        "Chan. Mon." 
+#endif
+
 #define TR_DUPLICATE                  "复制"
 #define TR_ACTIVATE                   "启用"
 #define TR_RED                        "红"

--- a/radio/src/translations/cz.h.txt
+++ b/radio/src/translations/cz.h.txt
@@ -1365,7 +1365,14 @@
 
 #define TR_USE_THEME_COLOR              "Use theme color"
 
-#define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Add all Trims to Subtrims"
+#if LCD_W > LCD_H
+  #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Add all Trims to Subtrims"
+  #define TR_OPEN_CHANNEL_MONITORS        "Open Channel Monitor" 
+#else
+  #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Trms->SubTrms"
+  #define TR_OPEN_CHANNEL_MONITORS        "Chan. Mon." 
+#endif
+
 #define TR_DUPLICATE                    "Duplicate"
 #define TR_ACTIVATE                     "Set Active"
 #define TR_RED                          "Red"

--- a/radio/src/translations/de.h.txt
+++ b/radio/src/translations/de.h.txt
@@ -1372,7 +1372,14 @@
 
 #define TR_USE_THEME_COLOR              "Use theme color"
 
-#define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Add all Trims to Subtrims"
+#if LCD_W > LCD_H
+  #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Add all Trims to Subtrims"
+  #define TR_OPEN_CHANNEL_MONITORS        "Open Channel Monitor" 
+#else
+  #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Trms->SubTrms"
+  #define TR_OPEN_CHANNEL_MONITORS        "Chan. Mon." 
+#endif
+
 #define TR_DUPLICATE                    "Duplicate"
 #define TR_ACTIVATE                     "Set Active"
 #define TR_RED                          "Red"

--- a/radio/src/translations/en.h.txt
+++ b/radio/src/translations/en.h.txt
@@ -1367,7 +1367,14 @@
 
 #define TR_USE_THEME_COLOR              "Use theme color"
 
-#define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Add all Trims to Subtrims"
+#if LCD_W > LCD_H
+  #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Add all Trims to Subtrims"
+  #define TR_OPEN_CHANNEL_MONITORS        "Open Channel Monitor" 
+#else
+  #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Trms->SubTrms"
+  #define TR_OPEN_CHANNEL_MONITORS        "Chan. Mon." 
+#endif
+
 #define TR_DUPLICATE                    "Duplicate"
 #define TR_ACTIVATE                     "Set Active"
 #define TR_RED                          "Red"

--- a/radio/src/translations/es.h.txt
+++ b/radio/src/translations/es.h.txt
@@ -1370,7 +1370,14 @@
 
 #define TR_USE_THEME_COLOR              "Use theme color"
 
-#define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Add all Trims to Subtrims"
+#if LCD_W > LCD_H
+  #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Add all Trims to Subtrims"
+  #define TR_OPEN_CHANNEL_MONITORS        "Open Channel Monitor" 
+#else
+  #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Trms->SubTrms"
+  #define TR_OPEN_CHANNEL_MONITORS        "Chan. Mon." 
+#endif
+
 #define TR_DUPLICATE                    "Duplicate"
 #define TR_ACTIVATE                     "Set Active"
 #define TR_RED                          "Red"

--- a/radio/src/translations/fi.h.txt
+++ b/radio/src/translations/fi.h.txt
@@ -1376,7 +1376,14 @@
 
 #define TR_USE_THEME_COLOR              "Use theme color"
 
-#define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Add all Trims to Subtrims"
+#if LCD_W > LCD_H
+  #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Add all Trims to Subtrims"
+  #define TR_OPEN_CHANNEL_MONITORS        "Open Channel Monitor" 
+#else
+  #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Trms->SubTrms"
+  #define TR_OPEN_CHANNEL_MONITORS        "Chan. Mon." 
+#endif
+
 #define TR_DUPLICATE                    "Duplicate"
 #define TR_ACTIVATE                     "Set Active"
 #define TR_RED                          "Red"

--- a/radio/src/translations/fr.h.txt
+++ b/radio/src/translations/fr.h.txt
@@ -1394,7 +1394,14 @@
 
 #define TR_USE_THEME_COLOR              "Use theme color"
 
-#define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Add all Trims to Subtrims"
+#if LCD_W > LCD_H
+  #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Add all Trims to Subtrims"
+  #define TR_OPEN_CHANNEL_MONITORS        "Open Channel Monitor" 
+#else
+  #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Trms->SubTrms"
+  #define TR_OPEN_CHANNEL_MONITORS        "Chan. Mon." 
+#endif
+
 #define TR_DUPLICATE                    "Duplicate"
 #define TR_ACTIVATE                     "Set Active"
 #define TR_RED                          "Red"

--- a/radio/src/translations/it.h.txt
+++ b/radio/src/translations/it.h.txt
@@ -1390,7 +1390,14 @@
 
 #define TR_USE_THEME_COLOR              "Use theme color"
 
-#define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Add all Trims to Subtrims"
+#if LCD_W > LCD_H
+  #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Add all Trims to Subtrims"
+  #define TR_OPEN_CHANNEL_MONITORS        "Open Channel Monitor" 
+#else
+  #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Trms->SubTrms"
+  #define TR_OPEN_CHANNEL_MONITORS        "Chan. Mon." 
+#endif
+
 #define TR_DUPLICATE                    "Duplicate"
 #define TR_ACTIVATE                     "Set Active"
 #define TR_RED                          "Red"

--- a/radio/src/translations/nl.h.txt
+++ b/radio/src/translations/nl.h.txt
@@ -1381,7 +1381,14 @@
 
 #define TR_USE_THEME_COLOR              "Use theme color"
 
-#define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Add all Trims to Subtrims"
+#if LCD_W > LCD_H
+  #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Add all Trims to Subtrims"
+  #define TR_OPEN_CHANNEL_MONITORS        "Open Channel Monitor" 
+#else
+  #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Trms->SubTrms"
+  #define TR_OPEN_CHANNEL_MONITORS        "Chan. Mon." 
+#endif
+
 #define TR_DUPLICATE                    "Duplicate"
 #define TR_ACTIVATE                     "Set Active"
 #define TR_RED                          "Red"

--- a/radio/src/translations/pl.h.txt
+++ b/radio/src/translations/pl.h.txt
@@ -1386,7 +1386,14 @@
 
 #define TR_USE_THEME_COLOR              "Use theme color"
 
-#define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Add all Trims to Subtrims"
+#if LCD_W > LCD_H
+  #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Add all Trims to Subtrims"
+  #define TR_OPEN_CHANNEL_MONITORS        "Open Channel Monitor" 
+#else
+  #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Trms->SubTrms"
+  #define TR_OPEN_CHANNEL_MONITORS        "Chan. Mon." 
+#endif
+
 #define TR_DUPLICATE                    "Duplicate"
 #define TR_ACTIVATE                     "Set Active"
 #define TR_RED                          "Red"

--- a/radio/src/translations/pt.h.txt
+++ b/radio/src/translations/pt.h.txt
@@ -1392,7 +1392,14 @@
 
 #define TR_USE_THEME_COLOR              "Use theme color"
 
-#define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Add all Trims to Subtrims"
+#if LCD_W > LCD_H
+  #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Add all Trims to Subtrims"
+  #define TR_OPEN_CHANNEL_MONITORS        "Open Channel Monitor" 
+#else
+  #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Trms->SubTrms"
+  #define TR_OPEN_CHANNEL_MONITORS        "Chan. Mon." 
+#endif
+
 #define TR_DUPLICATE                    "Duplicate"
 #define TR_ACTIVATE                     "Set Active"
 #define TR_RED                          "Red"

--- a/radio/src/translations/se.h.txt
+++ b/radio/src/translations/se.h.txt
@@ -1394,7 +1394,14 @@
 
 #define TR_USE_THEME_COLOR              "Use theme color"
 
-#define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Add all Trims to Subtrims"
+#if LCD_W > LCD_H
+  #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Add all Trims to Subtrims"
+  #define TR_OPEN_CHANNEL_MONITORS        "Open Channel Monitor" 
+#else
+  #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Trms->SubTrms"
+  #define TR_OPEN_CHANNEL_MONITORS        "Chan. Mon." 
+#endif
+
 #define TR_DUPLICATE                    "Duplicate"
 #define TR_ACTIVATE                     "Set Active"
 #define TR_RED                          "Red"

--- a/radio/src/translations/tw.h.txt
+++ b/radio/src/translations/tw.h.txt
@@ -1304,7 +1304,14 @@
 
 #define TR_USE_THEME_COLOR            "使用主題顏色"
 
-#define TR_ADD_ALL_TRIMS_TO_SUBTRIMS  "将將所有微調導入中點偏移值"
+#if LCD_W > LCD_H
+  #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS  "将將所有微調導入中點偏移值"
+  #define TR_OPEN_CHANNEL_MONITORS        "Open Channel Monitor" 
+#else
+  #define TR_ADD_ALL_TRIMS_TO_SUBTRIMS    "Trms->SubTrms"
+  #define TR_OPEN_CHANNEL_MONITORS        "Chan. Mon." 
+#endif
+
 #define TR_DUPLICATE                  "複製"
 #define TR_ACTIVATE                   "啟用"
 #define TR_RED                        "紅"


### PR DESCRIPTION
This is the alternative to PR #1713 

This PR implements a jump from mexes and outputs screens to the channel monitor and back.
Screen buttons are added; long press on TELEM performs the same action.

The implementation is kind of a hack, but it works.
