### PR TITLE
Initialize the PWM interrupt count to 0

### DIFF
--- a/radio/src/targets/common/arm/stm32/sticks_pwm_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/sticks_pwm_driver.cpp
@@ -21,7 +21,7 @@
 
 #include "opentx.h"
 
-volatile uint32_t pwm_interrupt_count;
+volatile uint32_t pwm_interrupt_count = 0;
 volatile uint16_t timer_capture_values[NUM_PWMSTICKS];
 
 void sticksPwmInit()


### PR DESCRIPTION
Did not commit directly to main, as I have no PWM gimbal hw to test this.