### PR TITLE
About screen cosmetics / translation

### DIFF
--- a/radio/src/gui/128x64/view_about.cpp
+++ b/radio/src/gui/128x64/view_about.cpp
@@ -38,8 +38,7 @@ void menuAboutView(event_t event)
       break;
   }
 
-  lcdDrawText(2, 0, STR_ABOUTUS, DBLSIZE|INVERS);
-  lcdDrawSolidHorizontalLine(0, 16, LCD_W-17);
+  lcdDrawText(1, 0, STR_ABOUTUS, DBLSIZE|INVERS);
 
   lcdDrawText(ABOUT_INDENT, 22, ABOUT_VERSION_1, SMLSIZE);
   lcdDrawText(ABOUT_INDENT, 30, ABOUT_VERSION_2, SMLSIZE);

--- a/radio/src/translations/de.h.txt
+++ b/radio/src/translations/de.h.txt
@@ -1120,7 +1120,7 @@
 #define TR_LSW_DESCRIPTIONS            { "Vergleich oder Funktion", "Erste Variable", "Zweite Variable/Konstante", "Zweite Variable/Konstante", "Weitere UND Bedingung für Freigabe des Log Schalters", "ON-Zeit des Log Schalters wenn Bedingung ok", "Mindestdauer der Bedingung damit Log Schalter ON geht" }
 
 //Taranis About screen
-#define TR_ABOUTUS                     "Über OpenTx"
+#define TR_ABOUTUS                     TR(" Info ", "Info")
 
 #define TR_CHR_SHORT  				  's' // Taste short
 #define TR_CHR_LONG   			      'l' // Taste long


### PR DESCRIPTION
this will fix the about screen headline and german translation.

before:
![screen-2022-03-26-213852](https://user-images.githubusercontent.com/29702171/160256328-41abc71d-ee52-44c6-850b-b55c6794840a.png)

after:
![screen-2022-03-26-213508](https://user-images.githubusercontent.com/29702171/160256186-6f4ba0c9-aa6b-40ef-b390-a1b2b7f42e28.png)
