### PR TITLE
Introduce FreeRTOS Software timers

### DIFF
--- a/radio/src/FreeRTOSConfig.h
+++ b/radio/src/FreeRTOSConfig.h
@@ -42,7 +42,7 @@
 #define configUSE_APPLICATION_TASK_TAG  0
 #define configUSE_COUNTING_SEMAPHORES   0
 #define configGENERATE_RUN_TIME_STATS   0
-#define configUSE_TIMERS                0
+#define configUSE_TIMERS                1
 
 #if !defined(DEBUG)
   #define configMAX_TASK_NAME_LEN         4
@@ -65,7 +65,7 @@
 /* Software timer definitions. */
 #define configTIMER_TASK_PRIORITY       ( 2 )
 #define configTIMER_QUEUE_LENGTH        10
-#define configTIMER_TASK_STACK_DEPTH    ( configMINIMAL_STACK_SIZE * 2 )
+#define configTIMER_TASK_STACK_DEPTH    ( 512 )
 
 /* Set the following definitions to 1 to include the API function, or zero
 to exclude the API function. */
@@ -73,6 +73,7 @@ to exclude the API function. */
 #define INCLUDE_vTaskSuspend            1
 #define INCLUDE_vTaskDelayUntil         1
 #define INCLUDE_vTaskDelay              1
+#define INCLUDE_xTimerPendFunctionCall  1
 
 #if defined(THREADSAFE_MALLOC)
 #define INCLUDE_xTaskGetSchedulerState  1

--- a/radio/src/cli.cpp
+++ b/radio/src/cli.cpp
@@ -1059,8 +1059,6 @@ static const etx_serial_init spIntmoduleSerialInitParams = {
   .stop_bits = ETX_StopBits_One,
   .word_length = ETX_WordLength_8,
   .rx_enable = true,
-  .on_receive = intmoduleFifoReceive,
-  .on_error = intmoduleFifoError,
 };
 
 static void spInternalModuleSetBaudRate(uint32_t baud)

--- a/radio/src/hal/serial_driver.h
+++ b/radio/src/hal/serial_driver.h
@@ -47,8 +47,6 @@ typedef struct {
   uint8_t word_length;  // = ETX_WordLength_8;
   uint8_t rx_enable;    // = false;
 
-  void (*on_receive)(uint8_t data);  // = nullptr;
-  void (*on_error)();                // = nullptr;
 } etx_serial_init;
 
 struct etx_serial_callbacks_t {

--- a/radio/src/io/frsky_firmware_update.cpp
+++ b/radio/src/io/frsky_firmware_update.cpp
@@ -316,8 +316,6 @@ static const etx_serial_init serialInitParams = {
   .stop_bits = ETX_StopBits_One,
   .word_length = ETX_WordLength_8,
   .rx_enable = true,
-  .on_receive = intmoduleFifoReceive,
-  .on_error = intmoduleFifoError,
 };
 #endif
 

--- a/radio/src/io/frsky_pxx2.h
+++ b/radio/src/io/frsky_pxx2.h
@@ -25,7 +25,7 @@
 #include "../fifo.h"
 #include "../pulses/pxx.h"
 
-class ModuleFifo : public Fifo<uint8_t, PXX2_FRAME_MAXLENGTH> {
+class ModuleFifo : public Fifo<uint8_t, INTMODULE_FIFO_SIZE> {
   public:
     bool getFrame(uint8_t * frame)
     {
@@ -74,7 +74,6 @@ class ModuleFifo : public Fifo<uint8_t, PXX2_FRAME_MAXLENGTH> {
       return ((crc >> 8) == crcLow) && ((crc & 0xFF) == crcHigh);
     }
 
-    uint32_t errors;
 };
 
 #endif

--- a/radio/src/io/frsky_pxx2.h
+++ b/radio/src/io/frsky_pxx2.h
@@ -22,8 +22,10 @@
 #ifndef _IO_PXX2_H_
 #define _IO_PXX2_H_
 
-#include "../fifo.h"
-#include "../pulses/pxx.h"
+#include "fifo.h"
+#include "pulses/pxx.h"
+
+#include "board.h"
 
 class ModuleFifo : public Fifo<uint8_t, INTMODULE_FIFO_SIZE> {
   public:

--- a/radio/src/io/multi_firmware_update.cpp
+++ b/radio/src/io/multi_firmware_update.cpp
@@ -82,8 +82,6 @@ static const etx_serial_init serialInitParams = {
   .stop_bits = ETX_StopBits_One,
   .word_length = ETX_WordLength_8,
   .rx_enable = true,
-  .on_receive = intmoduleFifoReceive,
-  .on_error = intmoduleFifoError,
 };
 
 class MultiInternalUpdateDriver: public MultiFirmwareUpdateDriver

--- a/radio/src/io/multi_firmware_update.cpp
+++ b/radio/src/io/multi_firmware_update.cpp
@@ -608,14 +608,16 @@ bool MultiDeviceFirmwareUpdate::flashFirmware(const char * filename, ProgressHan
   }
 
   std::unique_ptr<MultiFirmwareUpdateDriver> driver;
-  if (module == EXTERNAL_MODULE)
-    driver.reset(new MultiExternalUpdateDriver());
 #if defined(INTERNAL_MODULE_MULTI)
-  else if (module == INTERNAL_MODULE)
+  if (type == MULTI_TYPE_MULTIMODULE && module == INTERNAL_MODULE)
     driver.reset(new MultiInternalUpdateDriver());
 #endif
-  else if (type == MULTI_TYPE_ELRS)
+#if defined(HARDWARE_EXTERNAL_MODULE)
+  if (type == MULTI_TYPE_MULTIMODULE && module == EXTERNAL_MODULE)
+    driver.reset(new MultiExternalUpdateDriver());
+  if (type == MULTI_TYPE_ELRS && module == EXTERNAL_MODULE)
     driver.reset(new MultiExtSportUpdateDriver());
+#endif
 
   pausePulses();
 

--- a/radio/src/io/multi_firmware_update.cpp
+++ b/radio/src/io/multi_firmware_update.cpp
@@ -128,6 +128,7 @@ class MultiInternalUpdateDriver: public MultiFirmwareUpdateDriver
 };
 #endif
 
+#if defined(HARDWARE_EXTERNAL_MODULE)
 class MultiExternalUpdateDriver: public MultiFirmwareUpdateDriver
 {
   public:
@@ -141,15 +142,7 @@ class MultiExternalUpdateDriver: public MultiFirmwareUpdateDriver
 
     void init(bool inverted) override
     {
-#if !defined(EXTMODULE_USART)
-      GPIO_InitTypeDef GPIO_InitStructure;
-      GPIO_InitStructure.GPIO_Pin = EXTMODULE_TX_GPIO_PIN;
-      GPIO_InitStructure.GPIO_Mode = GPIO_Mode_OUT;
-      GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
-      GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_UP;
-      GPIO_InitStructure.GPIO_Speed = GPIO_Speed_2MHz;
-      GPIO_Init(EXTMODULE_TX_GPIO, &GPIO_InitStructure);
-#endif
+      extmoduleInitTxPin();
 
       if (inverted)
         telemetryPortInvertedInit(57600);
@@ -164,9 +157,7 @@ class MultiExternalUpdateDriver: public MultiFirmwareUpdateDriver
 
     void sendByte(uint8_t byte) const override
     {
-#if defined(HARDWARE_EXTERNAL_MODULE)
       extmoduleSendInvertedByte(byte);
-#endif
     }
 
     void clear() const override
@@ -184,6 +175,7 @@ class MultiExternalUpdateDriver: public MultiFirmwareUpdateDriver
       clear();
     }
 };
+#endif
 
 class MultiExtSportUpdateDriver: public MultiFirmwareUpdateDriver
 {

--- a/radio/src/pulses/afhds2.cpp
+++ b/radio/src/pulses/afhds2.cpp
@@ -45,8 +45,6 @@ const etx_serial_init afhds2SerialInitParams = {
     .stop_bits = ETX_StopBits_One,
     .word_length = ETX_WordLength_8,
     .rx_enable = true,
-    .on_receive = intmoduleFifoReceive,
-    .on_error = intmoduleFifoError,
 };
 
 static void* afhds2Init(uint8_t module)

--- a/radio/src/pulses/crossfire.cpp
+++ b/radio/src/pulses/crossfire.cpp
@@ -111,31 +111,12 @@ static void crossfireSetupMixerScheduler(uint8_t module)
 }
 
 #if defined(INTERNAL_MODULE_CRSF)
-static void intmoduleCRSF_rx(uint8_t data)
-{
-  intmoduleFifo.push(data);
-
-#if !defined(SIMU)
-  // wakeup mixer when rx buffer is quarter full (16 bytes)
-  if (intmoduleFifo.size() >= 16) {
-    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-    xTaskNotifyFromISR(mixerTaskId.rtos_handle, 0, eNoAction,
-                       &xHigherPriorityTaskWoken);
-
-    // might effect a context switch on ISR exit
-    portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
-  }
-#endif
-}
-
 static const etx_serial_init intmoduleCrossfireInitParams = {
   .baudrate = 0,
   .parity = ETX_Parity_None,
   .stop_bits = ETX_StopBits_One,
   .word_length = ETX_WordLength_8,
   .rx_enable = true,
-  .on_receive = intmoduleCRSF_rx,
-  .on_error = nullptr,
 };
 
 static void* crossfireInitInternal(uint8_t module)
@@ -145,9 +126,6 @@ static void* crossfireInitInternal(uint8_t module)
   // serial port setup
   etx_serial_init params(intmoduleCrossfireInitParams);
   params.baudrate = INT_CROSSFIRE_BAUDRATE;
-
-  // wakeup mixer when rx buffer is quarter full (16 bytes)
-  params.on_receive = intmoduleCRSF_rx;
 
   intmoduleFifo.clear();
   IntmoduleSerialDriver.init(&params);

--- a/radio/src/pulses/multi.cpp
+++ b/radio/src/pulses/multi.cpp
@@ -60,8 +60,6 @@ etx_serial_init multiSerialInitParams = {
     .stop_bits = ETX_StopBits_Two,
     .word_length = ETX_WordLength_9,
     .rx_enable = true,
-    .on_receive = intmoduleFifoReceive,
-    .on_error = intmoduleFifoError,
 };
 #endif
 

--- a/radio/src/pulses/pulses.cpp
+++ b/radio/src/pulses/pulses.cpp
@@ -101,6 +101,12 @@ void startPulses()
 
 void stopPulses()
 {
+  if (telemetryTimer) {
+    if( xTimerStop( telemetryTimer, 5 / RTOS_MS_PER_TICK ) != pdPASS ) {
+      /* The timer could not be set into the Active state. */
+    }
+  }
+  
   s_pulses_paused = true;
   for (uint8_t i = 0; i < NUM_MODULES; i++)
     moduleState[i].protocol = PROTOCOL_CHANNELS_UNINITIALIZED;

--- a/radio/src/pulses/pulses.h
+++ b/radio/src/pulses/pulses.h
@@ -260,29 +260,8 @@ uint8_t actualAfhdsRunPower(int moduleIndex);
 #endif
 void extramodulePpmStart();
 
-inline void startPulses()
-{
-  s_pulses_paused = false;
-
-#if defined(HARDWARE_INTERNAL_MODULE)
-  setupPulsesInternalModule();
-#endif
-
-#if defined(HARDWARE_EXTERNAL_MODULE)
-  setupPulsesExternalModule();
-#endif
-
-#if defined(HARDWARE_EXTRA_MODULE)
-  extramodulePpmStart();
-#endif
-}
-
-inline void stopPulses()
-{
-  s_pulses_paused = true;
-  for (uint8_t i = 0; i < NUM_MODULES; i++)
-    moduleState[i].protocol = PROTOCOL_CHANNELS_UNINITIALIZED;
-}
+void startPulses();
+void stopPulses();
 
 inline bool pulsesStarted()
 {

--- a/radio/src/pulses/pxx1.cpp
+++ b/radio/src/pulses/pxx1.cpp
@@ -231,8 +231,6 @@ static const etx_serial_init pxx1SerialInit = {
   .stop_bits = ETX_StopBits_One,
   .word_length = ETX_WordLength_8,
   .rx_enable = false,
-  .on_receive = intmoduleFifoReceive,
-  .on_error = intmoduleFifoError,
 };
 
 static void* pxx1InitInternal(uint8_t module)

--- a/radio/src/pulses/pxx1.cpp
+++ b/radio/src/pulses/pxx1.cpp
@@ -291,8 +291,6 @@ static const etx_serial_init pxx1ExtSerialInit = {
   .stop_bits = ETX_StopBits_One,
   .word_length = ETX_WordLength_8,
   .rx_enable = false,
-  .on_receive = extmoduleFifoReceive,
-  .on_error = extmoduleFifoError,
 };
 
 static void* pxx1InitExternal(uint8_t module)

--- a/radio/src/pulses/pxx2.cpp
+++ b/radio/src/pulses/pxx2.cpp
@@ -36,8 +36,6 @@ const etx_serial_init pxx2SerialInitParams = {
     .stop_bits = ETX_StopBits_One,
     .word_length = ETX_WordLength_8,
     .rx_enable = true,
-    .on_receive = intmoduleFifoReceive,
-    .on_error = intmoduleFifoError,
 };
 #endif
 
@@ -717,8 +715,6 @@ static const etx_serial_init pxx2ExtSerialInitParams = {
   .stop_bits = ETX_StopBits_One,
   .word_length = ETX_WordLength_8,
   .rx_enable = true,
-  .on_receive = extmoduleFifoReceive,
-  .on_error = extmoduleFifoError,
 };
 
 static void* pxx2InitLowSpeed(uint8_t module)

--- a/radio/src/serial.cpp
+++ b/radio/src/serial.cpp
@@ -290,8 +290,6 @@ void serialInit(uint8_t port_nr, int mode)
     .stop_bits = ETX_StopBits_One,
     .word_length = ETX_WordLength_8,
     .rx_enable = false,
-    .on_receive = nullptr,
-    .on_error = nullptr,
   };
 
   bool power_required = false;

--- a/radio/src/targets/common/arm/stm32/aux_serial_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/aux_serial_driver.cpp
@@ -52,7 +52,7 @@ static void* aux_serial_init(const SerialState* st, const etx_serial_init* param
 {
   stm32_usart_init(st->usart, params);
   
-  if (params->rx_enable && st->usart->rxDMA && !params->on_receive) {
+  if (params->rx_enable && st->usart->rxDMA) {
     st->rxFifo->clear();
     stm32_usart_init_rx_dma(st->usart, st->rxFifo->buffer(), st->rxFifo->size());
   }

--- a/radio/src/targets/common/arm/stm32/extmodule_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/extmodule_driver.cpp
@@ -144,6 +144,17 @@ void extmoduleSendNextFrameSoftSerial(const void* pulses, uint16_t length, bool 
   stm32_pulse_start_dma_req(&extmoduleTimer, pulses, length, LL_TIM_OCMODE_TOGGLE, 0);
 }
 
+void extmoduleInitTxPin()
+{
+  LL_GPIO_InitTypeDef pinInit;
+  LL_GPIO_StructInit(&pinInit);
+  pinInit.Pin = extmoduleTimer.GPIO_Pin;
+  pinInit.Mode = LL_GPIO_MODE_OUTPUT;
+  pinInit.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
+  pinInit.Pull = LL_GPIO_PULL_UP;
+  LL_GPIO_Init(extmoduleTimer.GPIOx, &pinInit);
+}
+
 // Delay based byte sending @ 57600 bps
 void extmoduleSendInvertedByte(uint8_t byte)
 {

--- a/radio/src/targets/common/arm/stm32/extmodule_driver.h
+++ b/radio/src/targets/common/arm/stm32/extmodule_driver.h
@@ -41,4 +41,5 @@ void extmoduleSendNextFrameSoftSerial(const void* pulses, uint16_t length,
                                       bool polarity = true);
 
 // Bitbang serial
+void extmoduleInitTxPin();
 void extmoduleSendInvertedByte(uint8_t byte);

--- a/radio/src/targets/common/arm/stm32/extmodule_serial_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/extmodule_serial_driver.cpp
@@ -38,19 +38,12 @@ void extmoduleFifoReceive(uint8_t data)
   extmoduleFifo.push(data);
 }
 
-void extmoduleFifoError()
-{
-  extmoduleFifo.errors++;
-}
-
 static const etx_serial_init extmoduleSerialParams = {
   .baudrate = 0,
   .parity = ETX_Parity_None,
   .stop_bits = ETX_StopBits_One,
   .word_length = ETX_WordLength_8,
   .rx_enable = true,
-  .on_receive = extmoduleFifoReceive,
-  .on_error = extmoduleFifoError,
 };
 
 static const LL_GPIO_InitTypeDef extmoduleUSART_PinDef = {
@@ -80,8 +73,8 @@ static void* extmoduleSerialStart(const etx_serial_init* params)
 {
   if (!params) return nullptr;
     
-  extmodule_driver.on_receive = params->on_receive;
-  extmodule_driver.on_error = params->on_error;
+  extmodule_driver.on_receive = extmoduleFifoReceive;
+  extmodule_driver.on_error = nullptr;
 
   // UART config
   stm32_usart_init(&extmoduleUSART, params);

--- a/radio/src/targets/common/arm/stm32/intmodule_serial_driver.h
+++ b/radio/src/targets/common/arm/stm32/intmodule_serial_driver.h
@@ -26,8 +26,4 @@
 
 #define INTMODULE_USART_IRQ_PRIORITY 6
 
-// Callbacks using intmoduleFifo
-void intmoduleFifoReceive(uint8_t data);
-void intmoduleFifoError();
-
 extern const etx_serial_driver_t IntmoduleSerialDriver;

--- a/radio/src/targets/common/arm/stm32/timers_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/timers_driver.cpp
@@ -67,8 +67,7 @@ static void interrupt1ms()
 #endif
 
   // 5ms loop
-  if (pre_scale == 5 || pre_scale == 10)
-  {
+  if (pre_scale == 5 || pre_scale == 10) {
 #if defined(HAPTIC)
     DEBUG_TIMER_START(debugTimerHaptic);
     HAPTIC_HEARTBEAT();
@@ -77,8 +76,7 @@ static void interrupt1ms()
   }
   
   // 10ms loop
-  if (pre_scale == 10)
-	{
+  if (pre_scale == 10) {
     pre_scale = 0;
     DEBUG_TIMER_START(debugTimerPer10ms);
     DEBUG_TIMER_SAMPLE(debugTimerPer10msPeriod);

--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -615,6 +615,7 @@ int32_t getVolume();
 #define VOLUME_LEVEL_DEF               12
 
 // Telemetry driver
+#define INTMODULE_FIFO_SIZE            512
 #define TELEMETRY_FIFO_SIZE            512
 void telemetryPortInit(uint32_t baudrate, uint8_t mode);
 void telemetryPortSetDirectionInput();

--- a/radio/src/targets/nv14/board.h
+++ b/radio/src/targets/nv14/board.h
@@ -478,6 +478,7 @@ int32_t getVolume();
 #define VOLUME_LEVEL_DEF               12
 
 // Telemetry driver
+#define INTMODULE_FIFO_SIZE            512
 #define TELEMETRY_FIFO_SIZE             512
 void telemetryPortInit(uint32_t baudrate, uint8_t mode);
 void telemetryPortSetDirectionOutput();

--- a/radio/src/targets/simu/module_drivers.cpp
+++ b/radio/src/targets/simu/module_drivers.cpp
@@ -48,11 +48,12 @@ void extmoduleSendNextFramePxx1(void const*, unsigned short) {}
 void extmoduleSendNextFrameSoftSerial(void const*, unsigned short, bool) {}
 void extmoduleSendNextFramePpm(void*, unsigned short, unsigned short, bool) {}
 
+#if defined(TRAINER_GPIO)
 void init_trainer_ppm() {}
 void stop_trainer_ppm() {}
-
 void init_trainer_capture() {}
 void stop_trainer_capture() {}
+#endif
 
 void init_trainer_module_cppm() {}
 void stop_trainer_module_cppm() {}

--- a/radio/src/targets/simu/module_drivers.cpp
+++ b/radio/src/targets/simu/module_drivers.cpp
@@ -42,6 +42,7 @@ void extmodulePpmStart(unsigned short, bool) {}
 void extmoduleSerialStart() {}
 void extmodulePxx1SerialStart() {}
 void extmodulePxx1PulsesStart() {}
+void extmoduleInitTxPin() {}
 void extmoduleSendInvertedByte(uint8_t) {}
 void extmoduleSendNextFramePxx1(void const*, unsigned short) {}
 void extmoduleSendNextFrameSoftSerial(void const*, unsigned short, bool) {}

--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -52,7 +52,7 @@ GPIO_TypeDef gpioa, gpiob, gpioc, gpiod, gpioe, gpiof, gpiog, gpioh, gpioi, gpio
 USART_TypeDef Usart0, Usart1, Usart2, Usart3, Usart4;
 ADC_Common_TypeDef adc;
 RTC_TypeDef rtc;
-void GPIO_Init(GPIO_TypeDef* GPIOx, GPIO_InitTypeDef* GPIO_InitStruct) { }
+
 void lcdCopy(void * dest, void * src);
 
 FATFS g_FATFS_Obj;
@@ -802,3 +802,6 @@ struct TouchState getInternalTouchState()
   return simTouchState;
 }
 #endif
+
+void telemetryStart() {}
+void telemetryStop() {}

--- a/radio/src/targets/taranis/board.h
+++ b/radio/src/targets/taranis/board.h
@@ -976,6 +976,8 @@ void setTopBatteryValue(uint32_t volts);
 extern Fifo<uint8_t, TELEMETRY_FIFO_SIZE> telemetryFifo;
 #endif
 
+#define INTMODULE_FIFO_SIZE            128
+
 // Gyro driver
 #define GYRO_VALUES_COUNT               6
 #define GYRO_BUFFER_LENGTH              (GYRO_VALUES_COUNT * sizeof(int16_t))

--- a/radio/src/tasks.cpp
+++ b/radio/src/tasks.cpp
@@ -100,12 +100,6 @@ void execMixerFrequentActions()
 #if defined(BLUETOOTH)
   bluetooth.wakeup();
 #endif
-
-  if (!s_pulses_paused) {
-    DEBUG_TIMER_START(debugTimerTelemetryWakeup);
-    telemetryWakeup();
-    DEBUG_TIMER_STOP(debugTimerTelemetryWakeup);
-  }
 }
 
 TASK_FUNCTION(mixerTask)

--- a/radio/src/telemetry/frsky.h
+++ b/radio/src/telemetry/frsky.h
@@ -283,14 +283,6 @@ void sportProcessTelemetryPacket(uint16_t id, uint8_t subId, uint8_t instance,
                                  uint32_t data, TelemetryUnit unit = UNIT_RAW);
 void sportProcessTelemetryPacketWithoutCrc(uint8_t origin, const uint8_t *packet);
 
-void telemetryWakeup();
-void telemetryReset();
-
-extern uint8_t telemetryProtocol;
-void telemetryInit(uint8_t protocol);
-
-void telemetryInterrupt10ms();
-
 bool pushFrskyTelemetryData(uint8_t data); // returns true when end of frame detected
 void processFrskyTelemetryData(uint8_t data);
 

--- a/radio/src/telemetry/frsky_pxx2.cpp
+++ b/radio/src/telemetry/frsky_pxx2.cpp
@@ -29,6 +29,8 @@
 #include "intmodule_serial_driver.h"
 #endif
 
+static_assert(PXX2_FRAME_MAXLENGTH <= INTMODULE_FIFO_SIZE);
+
 void processGetHardwareInfoFrame(uint8_t module, const uint8_t * frame)
 {
   if (moduleState[module].mode != MODULE_MODE_GET_HARDWARE_INFO) {

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -31,6 +31,9 @@
   #include "libopenui.h"
 #endif
 
+#include <FreeRTOS.h>
+#include <timers.h>
+
 uint8_t telemetryStreaming = 0;
 uint8_t telemetryRxBuffer[TELEMETRY_RX_PACKET_SIZE];   // Receive buffer. 9 bytes (full packet), worst case 18 bytes with byte-stuffing (+1)
 uint8_t telemetryRxBufferCount = 0;
@@ -105,6 +108,45 @@ void telemetryMirrorSend(uint8_t data)
     _sendByte(_ctx, data);
   }
 }
+
+#if !defined(SIMU)
+static TimerHandle_t telemetryTimer = nullptr;
+static StaticTimer_t telemetryTimerBuffer;
+
+static void telemetryTimerCb(TimerHandle_t xTimer)
+{
+  (void)xTimer;
+  if (!s_pulses_paused) {
+    DEBUG_TIMER_START(debugTimerTelemetryWakeup);
+    telemetryWakeup();
+    DEBUG_TIMER_STOP(debugTimerTelemetryWakeup);
+  }
+}
+
+void telemetryStart()
+{
+  if (!telemetryTimer) {
+    telemetryTimer =
+        xTimerCreateStatic("Telem", 4 / RTOS_MS_PER_TICK, pdTRUE, (void*)0,
+                           telemetryTimerCb, &telemetryTimerBuffer);
+  }
+
+  if (telemetryTimer) {
+    if( xTimerStart( telemetryTimer, 0 ) != pdPASS ) {
+      /* The timer could not be set into the Active state. */
+    }
+  }
+}
+
+void telemetryStop()
+{
+  if (telemetryTimer) {
+    if( xTimerStop( telemetryTimer, 5 / RTOS_MS_PER_TICK ) != pdPASS ) {
+      /* The timer could not be set into the Active state. */
+    }
+  }
+}
+#endif
 
 void processTelemetryData(uint8_t data)
 {

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -275,6 +275,9 @@ void telemetryWakeup()
 {
   uint8_t requiredTelemetryProtocol = modelTelemetryProtocol();
 
+  // TODO: needs to be moved to protocol/module init
+  //       as-is, it implies only ONE telemetry protocol
+  //       enabled at the same time
   if (telemetryProtocol != requiredTelemetryProtocol) {
     telemetryInit(requiredTelemetryProtocol);
   }

--- a/radio/src/telemetry/telemetry.h
+++ b/radio/src/telemetry/telemetry.h
@@ -87,6 +87,17 @@ void telemetrySetMirrorCb(void* ctx, void (*fct)(void*, uint8_t));
 // Mirror telemetry byte
 void telemetryMirrorSend(uint8_t data);
 
+void telemetryWakeup();
+void telemetryReset();
+
+extern uint8_t telemetryProtocol;
+void telemetryInit(uint8_t protocol);
+
+void telemetryInterrupt10ms();
+
+void telemetryStart();
+void telemetryStop();
+
 #define TELEMETRY_AVERAGE_COUNT        3
 
 enum {


### PR DESCRIPTION
Software timers are programmable timers and pending routines that are processed in a separate Task (Timer Task aka. Daemon Task).

The goal here is to allow the mixer scheduler to be freed from all none-essential tasks, as well as offering a nice way to schedule recurring tasks without always looking for a timer to hook into, or a task to add the burden to.

This PR starts with the telemetry processing which is moved first to this background task. Mid-term, the telemetry processing should be split into 2 parts with the following periods:
- **10ms**: recurring maintenance (mostly expiration and decay of values).
- **depends on module**: each module should have the chance to schedule its telemetry polling task (if it supports telemetry) with a protocol/module specific period (don't be greedy!).