### PR TITLE
Fix YAML write issue with mix offset

### DIFF
--- a/radio/src/storage/conversions/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/conversions/yaml/yaml_datastructs_funcs.cpp
@@ -36,7 +36,7 @@ bool w_board(void* user, uint8_t* data, uint32_t bitoffs,
 bool in_write_weight(const YamlNode* node, uint32_t val, yaml_writer_func wf,
                      void* opaque)
 {
-  int32_t sval = yaml_to_signed(val, node->size);
+  int32_t sval = yaml_to_signed(val, node->size <= 11 ? node->size : 11);
   int32_t gvar = (node->size > 8 ? GV1_LARGE : GV1_SMALL);
 
   if (sval >= gvar - 10 && sval <= gvar) {


### PR DESCRIPTION
Fixes #1734

Summary of changes:
- Mix data offset: convert to signed int with maximum 11 bits even if it uses 14 bits.