### PR TITLE
Preserve last edited line in model pages

### DIFF
--- a/radio/src/gui/colorlcd/model_curves.cpp
+++ b/radio/src/gui/colorlcd/model_curves.cpp
@@ -275,6 +275,9 @@ class CurveButton : public Button {
     uint8_t index;
 };
 
+int ModelCurvesPage::currentCurve = 0;
+coord_t ModelCurvesPage::currentScrollPosition = 0;
+
 ModelCurvesPage::ModelCurvesPage() :
   PageTab(STR_MENUCURVES, ICON_MODEL_CURVES)
 {
@@ -371,6 +374,9 @@ void ModelCurvesPage::build(FormWindow * window, int8_t focusIndex)
         if (focus) {
           txt->setBackgroundColor(COLOR_THEME_FOCUS);
           txt->setTextFlags(COLOR_THEME_PRIMARY2 | CENTERED);
+          currentCurve = index;
+          coord_t tmp = window->getScrollPositionY();
+          if (tmp) currentScrollPosition = tmp;
         } else {
           txt->setBackgroundColor(COLOR_THEME_SECONDARY2);
           txt->setTextFlags(COLOR_THEME_PRIMARY1 | CENTERED);
@@ -409,4 +415,5 @@ void ModelCurvesPage::build(FormWindow * window, int8_t focusIndex)
 #endif
 
   window->setInnerHeight(grid.getWindowHeight());
+  window->setScrollPositionY(currentScrollPosition);
 }

--- a/radio/src/gui/colorlcd/model_curves.h
+++ b/radio/src/gui/colorlcd/model_curves.h
@@ -31,10 +31,13 @@ class ModelCurvesPage: public PageTab {
 
     virtual void build(FormWindow * window) override
     {
-      build(window, 0);
+      build(window, currentCurve);
     }
 
-  protected:
+    static int currentCurve;
+    static coord_t currentScrollPosition;
+
+   protected:
     void build(FormWindow * window, int8_t focusIndex);
     void rebuild(FormWindow * window, int8_t focusIndex);
     void editCurve(FormWindow * window, uint8_t curve);

--- a/radio/src/gui/colorlcd/model_inputs.cpp
+++ b/radio/src/gui/colorlcd/model_inputs.cpp
@@ -480,6 +480,9 @@ class InputLineButton : public CommonInputOrMixButton
   }
 };
 
+int ModelInputsPage::currentInput = 0;
+coord_t ModelInputsPage::currentScrollPosition = 0;
+
 ModelInputsPage::ModelInputsPage():
   PageTab(STR_MENUINPUTS, ICON_MODEL_INPUTS)
 {
@@ -576,6 +579,9 @@ void ModelInputsPage::build(FormWindow *window, int8_t focusIndex)
           if (focus) {
             txt->setBackgroundColor(COLOR_THEME_FOCUS);
             txt->setTextFlags(COLOR_THEME_PRIMARY2 | LEFT);
+            currentInput = input;
+            coord_t tmp = window->getScrollPositionY();
+            if(tmp) currentScrollPosition = tmp;
           } else {
             txt->setBackgroundColor(COLOR_THEME_SECONDARY2);
             txt->setTextFlags(COLOR_THEME_PRIMARY1 | LEFT);
@@ -641,6 +647,7 @@ void ModelInputsPage::build(FormWindow *window, int8_t focusIndex)
   grid.nextLine();
 
   window->setInnerHeight(grid.getWindowHeight());
+  window->setScrollPositionY(currentScrollPosition);
 }
 
 // TODO port: avoid global s_currCh on ARM boards (as done here)...

--- a/radio/src/gui/colorlcd/model_inputs.h
+++ b/radio/src/gui/colorlcd/model_inputs.h
@@ -33,7 +33,10 @@ class ModelInputsPage: public PageTab {
       build(window, 0);
     }
 
-  protected:
+    static int currentInput;
+    static coord_t currentScrollPosition;
+
+   protected:
     void build(FormWindow * window, int8_t focusIndex);
     void rebuild(FormWindow * window, int8_t focusIndex);
     void editInput(FormWindow * window, uint8_t channel, uint8_t index);

--- a/radio/src/gui/colorlcd/model_logical_switches.cpp
+++ b/radio/src/gui/colorlcd/model_logical_switches.cpp
@@ -338,6 +338,9 @@ class LogicalSwitchButton : public Button
   bool active;
 };
 
+int ModelLogicalSwitchesPage::currentLS = 0;
+coord_t ModelLogicalSwitchesPage::currentScrollPosition = 0;
+
 ModelLogicalSwitchesPage::ModelLogicalSwitchesPage():
   PageTab(STR_MENULOGICALSWITCHES, ICON_MODEL_LOGICAL_SWITCHES)
 {
@@ -420,6 +423,9 @@ void ModelLogicalSwitchesPage::build(FormWindow* window, int8_t focusIndex)
         if (focus) {
           txt->setBackgroundColor(COLOR_THEME_FOCUS);
           txt->setTextFlags(COLOR_THEME_PRIMARY2 | CENTERED);
+          currentLS = i;
+          coord_t tmp = window->getScrollPositionY();
+          if(tmp) currentScrollPosition = tmp;
         } else {
           txt->setBackgroundColor(COLOR_THEME_SECONDARY2);
           txt->setTextFlags(COLOR_THEME_PRIMARY1 | CENTERED);
@@ -442,4 +448,5 @@ void ModelLogicalSwitchesPage::build(FormWindow* window, int8_t focusIndex)
   grid.nextLine();
 
   window->setInnerHeight(grid.getWindowHeight());
+  window->setScrollPositionY(currentScrollPosition);
 }

--- a/radio/src/gui/colorlcd/model_logical_switches.h
+++ b/radio/src/gui/colorlcd/model_logical_switches.h
@@ -30,10 +30,13 @@ public:
 
     virtual void build(FormWindow * window) override
     {
-      build(window, 0);
+      build(window, currentLS);
     }
 
-protected:
+    static int currentLS;
+    static coord_t currentScrollPosition;
+
+   protected:
     void build(FormWindow * window, int8_t focusIndex);
     void rebuild(FormWindow * window, int8_t focusIndex);
     void editLogicalSwitch(FormWindow * window, uint8_t lsIndex);

--- a/radio/src/gui/colorlcd/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model_mixes.cpp
@@ -416,6 +416,9 @@ class MixLineTitle : public StaticText
   }
 };
 
+int ModelMixesPage::currentMix;
+coord_t ModelMixesPage::currentScrollPosition;
+
 void ModelMixesPage::build(FormWindow * window, int8_t focusMixIndex)
 {
   FormGridLayout grid;
@@ -507,6 +510,9 @@ void ModelMixesPage::build(FormWindow * window, int8_t focusMixIndex)
           if (focus) {
             txt->setBackgroundColor(COLOR_THEME_FOCUS);
             txt->setTextFlags(COLOR_THEME_PRIMARY2 | CENTERED);
+            currentMix = mixIndex;
+            coord_t tmp = window->getScrollPositionY();
+            if (tmp) currentScrollPosition = tmp;
           } else {
             txt->setBackgroundColor(COLOR_THEME_SECONDARY2);
             txt->setTextFlags(COLOR_THEME_PRIMARY1 | CENTERED);
@@ -576,6 +582,7 @@ void ModelMixesPage::build(FormWindow * window, int8_t focusMixIndex)
   grid.nextLine();
 
   window->setInnerHeight(grid.getWindowHeight());
+  window->setScrollPositionY(currentScrollPosition);
 }
 
 void deleteMix(uint8_t idx)

--- a/radio/src/gui/colorlcd/model_mixes.h
+++ b/radio/src/gui/colorlcd/model_mixes.h
@@ -28,12 +28,15 @@ class ModelMixesPage: public PageTab {
   public:
     ModelMixesPage();
 
-    void build(FormWindow * window) override
+    void build(FormWindow* window) override 
     {
-      build(window, 0);
+       build(window, currentMix); 
     }
 
-  protected:
+    static int currentMix;
+    static coord_t currentScrollPosition;
+
+   protected:
     void build(FormWindow * window, int8_t focusMixIndex);
     void rebuild(FormWindow * window, int8_t focusMixIndex);
     void editMix(FormWindow * window, uint8_t channel, uint8_t mixIndex);

--- a/radio/src/gui/colorlcd/model_outputs.h
+++ b/radio/src/gui/colorlcd/model_outputs.h
@@ -30,10 +30,13 @@ class ModelOutputsPage: public PageTab {
 
     virtual void build(FormWindow * window) override
     {
-      build(window, 0);
+      build(window, currentChannel);
     }
 
-  protected:
+    static int currentChannel;
+    static coord_t currentScrollPosition;
+
+   protected:
     void build(FormWindow * window, int8_t focusChannel);
     void rebuild(FormWindow * window, int8_t focusChannel);
     void editOutput(FormWindow * window, uint8_t channel);

--- a/radio/src/gui/colorlcd/special_functions.cpp
+++ b/radio/src/gui/colorlcd/special_functions.cpp
@@ -601,6 +601,9 @@ class SpecialFunctionButton : public Button
   bool active = false;
 };
 
+int SpecialFunctionsPage::currentFunction = 0;
+coord_t SpecialFunctionsPage::currentScrollPosition = 0;
+
 SpecialFunctionsPage::SpecialFunctionsPage(CustomFunctionData *functions) :
     PageTab(functions == g_model.customFn ? STR_MENUCUSTOMFUNC
                                           : STR_MENUSPECIALFUNCS,
@@ -723,6 +726,9 @@ void SpecialFunctionsPage::build(FormWindow *window, int8_t focusIndex)
         if (focus) {
           txt->setBackgroundColor(COLOR_THEME_FOCUS);
           txt->setTextFlags(COLOR_THEME_PRIMARY2 | CENTERED);
+          currentFunction = i;
+          coord_t tmp = window->getScrollPositionY();
+          if(tmp) currentScrollPosition = tmp;
         } else {
           txt->setBackgroundColor(COLOR_THEME_SECONDARY2);
           txt->setTextFlags(COLOR_THEME_PRIMARY1 | CENTERED);
@@ -750,4 +756,5 @@ void SpecialFunctionsPage::build(FormWindow *window, int8_t focusIndex)
 
   //  window->setLastField();
   window->setInnerHeight(grid.getWindowHeight());
+  window->setScrollPositionY(currentScrollPosition);
 }

--- a/radio/src/gui/colorlcd/special_functions.h
+++ b/radio/src/gui/colorlcd/special_functions.h
@@ -35,7 +35,11 @@ class SpecialFunctionsPage: public PageTab {
       build(window, 0);
     }
 
-  protected:
+    static int currentFunction;
+    static coord_t currentScrollPosition;
+
+
+   protected:
     CustomFunctionData * functions;
     void build(FormWindow * window, int8_t focusSpecialFunctionIndex);
     void rebuild(FormWindow * window, int8_t focusSpecialFunctionIndex);


### PR DESCRIPTION
Fixes I'm sure there was a feature request, but I cannot find it.

Summary of changes:
This PR adds the code to keep the last edited line (channel, mix, input, LS, SF) when switching between the Tabs. (Color LCD TXs.)
This will be especially convenient when combined with switching to Channel Monitor and returning back to the relevant channel/mix.
