### PR TITLE
Fix selection of the first line after deleting input.

### DIFF
--- a/radio/src/gui/colorlcd/model_inputs.cpp
+++ b/radio/src/gui/colorlcd/model_inputs.cpp
@@ -569,7 +569,7 @@ void ModelInputsPage::build(FormWindow *window, int8_t focusIndex)
           });
           menu->addLine(STR_DELETE, [=]() {
             deleteExpo(inputIndex);
-            rebuild(window, -1);
+            rebuild(window, inputIndex);
           });
           return 0;
         });
@@ -620,7 +620,7 @@ void ModelInputsPage::build(FormWindow *window, int8_t focusIndex)
                                                         : s_copySrcIdx);
                 s_copyMode = 0;
               }
-              rebuild(window, -1);
+              rebuild(window, inputIndex);
               return 0;
             });
           }


### PR DESCRIPTION
This PR fixies the issue mentioned by @JimB40 in #1745 

Summary of changes: Keep focus on the input close to the deleted one.
