### PR TITLE
`LUA=N` compile fixes and radio hardware tab bottom padding (for touch)

### DIFF
--- a/radio/src/cli.cpp
+++ b/radio/src/cli.cpp
@@ -28,7 +28,7 @@
 #include <ctype.h>
 #include <malloc.h>
 #include <new>
-
+#include <stdarg.h>
 #include "cli.h"
 
 #if defined(INTMODULE_USART)

--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -165,12 +165,14 @@ class SelectTemplate : public TemplatePage
             // Dismiss template pages
             deleteLater();
             templateFolderPage->deleteLater();
+#if defined(LUA)
             // If there is a wizard Lua script, fire it up
             snprintf(buffer, LEN_BUFFER, "%s%c%s%s", path, '/', name.c_str(), SCRIPT_EXT);
             if (f_stat(buffer, 0) == FR_OK) {
               luaExec(buffer);
               StandaloneLuaWindow::instance()->attach(focusWindow);
             }
+#endif
             return 0;
           });
         tb->setFocusHandler([=](bool active) {
@@ -269,6 +271,10 @@ class SelectTemplateFolder : public TemplatePage
       directories.sort(compare_nocase);
 
       for (auto name: directories) {
+#if not defined(LUA)
+        // Don't show wizards dir if no lua
+        if (!strcasecmp(name.c_str(), "WIZARD") == 0) {
+#endif
         auto tfb = new TemplateButton(&body, grid.getLabelSlot(), name,
             [=]() -> uint8_t {
             snprintf(path, LEN_PATH, "%s%c%s", TEMPLATES_PATH, '/', name.c_str());
@@ -285,6 +291,9 @@ class SelectTemplateFolder : public TemplatePage
         grid.spacer(tfb->height() + 5);
       }
       body.setInnerHeight(grid.getWindowHeight());
+#if not defined(LUA)
+      }
+#endif
     }
     
     f_closedir(&dir);

--- a/radio/src/gui/colorlcd/radio_hardware.cpp
+++ b/radio/src/gui/colorlcd/radio_hardware.cpp
@@ -265,9 +265,9 @@ class InternalModuleWindow : public FormGroup {
 #endif
     clear();
 
-    new StaticText(this, grid.getLabelSlot(), TR_INTERNAL_MODULE, 0,
+    new StaticText(this, grid.getLabelSlot(true), TR_INTERNAL_MODULE, 0,
                    COLOR_THEME_PRIMARY1);
-    auto internalModule = new Choice(this, grid.getFieldSlot(1, 0),STR_INTERNAL_MODULE_PROTOCOLS, MODULE_TYPE_NONE, MODULE_TYPE_COUNT - 1,
+    auto internalModule = new Choice(this, grid.getFieldSlot(),STR_INTERNAL_MODULE_PROTOCOLS, MODULE_TYPE_NONE, MODULE_TYPE_COUNT - 1,
                                      GET_DEFAULT(g_eeGeneral.internalModule),
                                      [=](int moduleType) {
                                        if (g_model.moduleData[INTERNAL_MODULE].type != moduleType) {
@@ -281,12 +281,12 @@ class InternalModuleWindow : public FormGroup {
     internalModule->setAvailableHandler([](int module){
       return isInternalModuleSupported(module);
     });
+    grid.nextLine();
 
 #if defined(CROSSFIRE)
     if (isInternalModuleCrossfire()) {
-      grid.nextLine();
-      new StaticText(this, grid.getLabelSlot(), STR_BAUDRATE, 0,COLOR_THEME_PRIMARY1);
-      new Choice(this, grid.getFieldSlot(1, 0), STR_CRSF_BAUDRATE, 0,CROSSFIRE_MAX_INTERNAL_BAUDRATE,
+      new StaticText(this, grid.getLabelSlot(true), STR_BAUDRATE, 0,COLOR_THEME_PRIMARY1);
+      new Choice(this, grid.getFieldSlot(), STR_CRSF_BAUDRATE, 0,CROSSFIRE_MAX_INTERNAL_BAUDRATE,
           [=]() -> int {
             return CROSSFIRE_STORE_TO_INDEX(g_eeGeneral.internalModuleBaudrate);
           },
@@ -297,10 +297,8 @@ class InternalModuleWindow : public FormGroup {
           });
       grid.nextLine();
     }
-    auto par = getParent();
-    par->moveWindowsTop(top() + 1, adjustHeight());
-    par->adjustInnerHeight();
 #endif
+    getParent()->moveWindowsTop(top() + 1, adjustHeight());
   }
 
   void checkEvents() override
@@ -481,7 +479,7 @@ void RadioHardwarePage::build(FormWindow * window)
 
 // extra bottom padding if touchscreen
 #if defined HARDWARE_TOUCH
-  grid.nextLine();
+  new StaticText(window, grid.getLabelSlot());
 #endif
 
   window->setInnerHeight(grid.getWindowHeight());


### PR DESCRIPTION
Fixes #1751

Summary of changes:
- adds padding back again at the bottom of the radio hardware tab. Is an incomplete solution, as the real problem apperas to something in InternalModuleWindow not updating height properly. 
- Also resolves compile failures on NV14 if compiled with `LUA=N`, and generally removes some new UI LUA stuff if not valid

