### PR TITLE
Show internal RF module info instead of "No information"

### DIFF
--- a/radio/src/gui/colorlcd/radio_version.cpp
+++ b/radio/src/gui/colorlcd/radio_version.cpp
@@ -23,6 +23,9 @@
 #include "opentx.h"
 #include "options.h"
 #include "libopenui.h"
+#if defined(CROSSFIRE)
+  #include "mixer_scheduler.h"
+#endif
 
 char *getVersion(char *str, PXX2Version version)
 {
@@ -102,14 +105,20 @@ class versionDialog: public Dialog
       if (g_model.moduleData[module].type == MODULE_TYPE_NONE) {
         new StaticText(form, grid->getFieldSlot(1, 0), STR_OFF, 0, COLOR_THEME_PRIMARY1);
       }
-#if defined(HARDWARE_EXTERNAL_ACCESS_MOD)
+#if defined(CROSSFIRE)
+      else if (isModuleCrossfire(module)) {
+          char statusText[64] = "";
+          new StaticText(form, grid->getFieldSlot(2, 0), "CRSF", 0, COLOR_THEME_PRIMARY1);
+          sprintf(statusText,"%d Hz %lu Err", 1000000 / getMixerSchedulerPeriod(), telemetryErrors);
+          new StaticText(form, grid->getFieldSlot(2, 1), statusText, 0, COLOR_THEME_PRIMARY1);
+      }
+#endif
       else if (isModuleMultimodule(module)) {
-        char statusText[64];
+        char statusText[64] = "";
         new StaticText(form, grid->getFieldSlot(2, 0), "Multimodule", 0, COLOR_THEME_PRIMARY1);
         getMultiModuleStatus(module).getStatusString(statusText);
         new StaticText(form, grid->getFieldSlot(2, 1), statusText, 0, COLOR_THEME_PRIMARY1);
       }
-#endif
       else if (!isModulePXX2(module)) {
         new StaticText(form, grid->getFieldSlot(1, 0), STR_NO_INFORMATION, 0, COLOR_THEME_PRIMARY1);
       }


### PR DESCRIPTION
Fixes #1760
Presently tested on a color radio with int. MPM and CRSF.

Old behaviour:
![grafik](https://user-images.githubusercontent.com/21011587/160698273-34b2d3e3-4c42-49c7-8cff-169f67af1299.png)

After this PR with MPM:
![grafik](https://user-images.githubusercontent.com/21011587/160698052-6fc01fa8-1a65-40d8-aaa8-fc74369fee99.png)
