### PR TITLE
Show module info for MPM and CRSF

### DIFF
--- a/radio/src/gui/colorlcd/radio_version.cpp
+++ b/radio/src/gui/colorlcd/radio_version.cpp
@@ -113,12 +113,14 @@ class versionDialog: public Dialog
           new StaticText(form, grid->getFieldSlot(2, 1), statusText, 0, COLOR_THEME_PRIMARY1);
       }
 #endif
+#if defined(MULTIMODULE)
       else if (isModuleMultimodule(module)) {
         char statusText[64] = "";
         new StaticText(form, grid->getFieldSlot(2, 0), "Multimodule", 0, COLOR_THEME_PRIMARY1);
         getMultiModuleStatus(module).getStatusString(statusText);
         new StaticText(form, grid->getFieldSlot(2, 1), statusText, 0, COLOR_THEME_PRIMARY1);
       }
+#endif
       else if (!isModulePXX2(module)) {
         new StaticText(form, grid->getFieldSlot(1, 0), STR_NO_INFORMATION, 0, COLOR_THEME_PRIMARY1);
       }

--- a/radio/src/gui/common/stdlcd/radio_version.cpp
+++ b/radio/src/gui/common/stdlcd/radio_version.cpp
@@ -21,6 +21,9 @@
 
 #include "opentx.h"
 #include "options.h"
+#if defined(CROSSFIRE)
+  #include "mixer_scheduler.h"
+#endif
 
 // TODO duplicated code
 #if defined(ROTARY_ENCODER_NAVIGATION)
@@ -134,6 +137,22 @@ void menuRadioModulesVersion(event_t event)
           y += FH;
           continue;
         }
+        if (isModuleMultimodule(module)) {
+          char statusText[64] = "";
+          getMultiModuleStatus(module).getStatusString(statusText);
+          lcdDrawText(COLUMN2_X, y, statusText);
+          y += FH;
+          continue;
+        }
+#if defined(CROSSFIRE)
+        if (isModuleCrossfire(module)) {
+          char statusText[64] = "";
+          sprintf(statusText,"%d Hz %lu Err", 1000000 / getMixerSchedulerPeriod(), telemetryErrors);
+          lcdDrawText(COLUMN2_X, y, statusText);
+          y += FH;
+          continue;
+        }
+#endif
         if (!isModulePXX2(INTERNAL_MODULE)) {
           lcdDrawText(COLUMN2_X, y, STR_NO_INFORMATION);
           y += FH;

--- a/radio/src/gui/common/stdlcd/radio_version.cpp
+++ b/radio/src/gui/common/stdlcd/radio_version.cpp
@@ -131,47 +131,38 @@ void menuRadioModulesVersion(event_t event)
     // Module model
     if (y >= MENU_BODY_TOP && y < MENU_BODY_BOTTOM) {
       lcdDrawText(INDENT_WIDTH, y, STR_MODULE);
-      if (module == INTERNAL_MODULE) {
-        if (!IS_INTERNAL_MODULE_ON()) {
-          lcdDrawText(COLUMN2_X, y, STR_OFF);
-          y += FH;
-          continue;
-        }
-        if (isModuleMultimodule(module)) {
-          char statusText[64] = "";
-          getMultiModuleStatus(module).getStatusString(statusText);
-          lcdDrawText(COLUMN2_X, y, statusText);
-          y += FH;
-          continue;
-        }
-#if defined(CROSSFIRE)
-        if (isModuleCrossfire(module)) {
-          char statusText[64] = "";
-          sprintf(statusText,"%d Hz %lu Err", 1000000 / getMixerSchedulerPeriod(), telemetryErrors);
-          lcdDrawText(COLUMN2_X, y, statusText);
-          y += FH;
-          continue;
-        }
+      if ((module == INTERNAL_MODULE && !IS_INTERNAL_MODULE_ON()) ||
+          (module == EXTERNAL_MODULE && !IS_EXTERNAL_MODULE_ON())) {
+        lcdDrawText(COLUMN2_X, y, STR_OFF);
+        y += FH;
+        continue;
+      }
+#if defined(MULTIMODULE)
+      if (isModuleMultimodule(module)) {
+        char statusText[64] = "";
+        getMultiModuleStatus(module).getStatusString(statusText);
+        lcdDrawText(COLUMN2_X, y, statusText);
+        y += FH;
+        continue;
+      }
 #endif
-        if (!isModulePXX2(INTERNAL_MODULE)) {
-          lcdDrawText(COLUMN2_X, y, STR_NO_INFORMATION);
-          y += FH;
-          continue;
-        }
+#if defined(CROSSFIRE)
+      if (isModuleCrossfire(module)) {
+        char statusText[64] = "";
+        sprintf(statusText, "%d Hz %lu Err",
+                1000000 / getMixerSchedulerPeriod(), telemetryErrors);
+        lcdDrawText(COLUMN2_X, y, statusText);
+        y += FH;
+        continue;
       }
-      else if (module == EXTERNAL_MODULE) {
-        if (!IS_EXTERNAL_MODULE_ON()) {
-          lcdDrawText(COLUMN2_X, y, STR_OFF);
-          y += FH;
-          continue;
-        }
-        if (!isModulePXX2(EXTERNAL_MODULE)) {
-          lcdDrawText(COLUMN2_X, y, STR_NO_INFORMATION);
-          y += FH;
-          continue;
-        }
+#endif
+      if (!isModulePXX2(module)) {
+        lcdDrawText(COLUMN2_X, y, STR_NO_INFORMATION);
+        y += FH;
+        continue;
       }
-      uint8_t modelId = reusableBuffer.hardwareAndSettings.modules[module].information.modelID;
+      uint8_t modelId = reusableBuffer.hardwareAndSettings.modules[module]
+                            .information.modelID;
       lcdDrawText(COLUMN2_X, y, getPXX2ModuleName(modelId));
     }
     y += FH;


### PR DESCRIPTION
This PR complements #1761 by displaying the module info also on black and white targets.
Tested with 4-in-1 and ELRS Zorros.

Old behaviour:
![grafik](https://user-images.githubusercontent.com/21011587/160868778-d561d28a-2f06-4058-b4b2-6ff5928f9992.png)

With this PR on 4-in-1 Zorro:
![grafik](https://user-images.githubusercontent.com/21011587/160868530-4aac3c4f-dc1f-46fa-8b9e-1f10a4fab4ac.png)

And on ExpressLRS Zorro:
![grafik](https://user-images.githubusercontent.com/21011587/160868600-83e1e47b-092e-4902-bd46-f9a8339ff7b4.png)
