### PR TITLE
Fix double "Failsafe not set" with MPM

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -664,6 +664,10 @@ static void checkRTCBattery()
 static void checkFailsafe()
 {
   for (int i=0; i<NUM_MODULES; i++) {
+#if defined(MULTIMODULE)
+    // use delayed check for MPM
+    if (isModuleMultimodule(i)) break;
+#endif
     if (isModuleFailsafeAvailable(i)) {
       ModuleData & moduleData = g_model.moduleData[i];
       if (moduleData.failsafeMode == FAILSAFE_NOT_SET) {


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

This bug has been mentioned a few times, but doesn't seem to have been dignified with an actual issue. 

Summary of changes:
- MPM has a delayed failsafe check, which is monitored by `checkFailsafeMulti()`. Only use this, and thus prevent STR_NO_FAILSAFE alert being shown twice. 

Has been tested on TX16S with both internal MPM and external MPM, with modules that have failsafe not set, failsafe set, and no failsafe on protocol with no incorrect behaviours. 
