### PR TITLE
fix: some radio settings were overwritten or not applied

### DIFF
--- a/radio/src/storage/sdcard_yaml.cpp
+++ b/radio/src/storage/sdcard_yaml.cpp
@@ -129,15 +129,12 @@ const char * loadRadioSettings()
 #endif
     }
 
-#if defined(DEFAULT_INTERNAL_MODULE)
-    g_eeGeneral.internalModule = DEFAULT_INTERNAL_MODULE;
-#endif
-    
     const char* error = loadRadioSettingsYaml();
     if (!error) {
       g_eeGeneral.chkSum = evalChkSum();
     }
-
+    postRadioSettingsLoad();
+    
     return error;
 }
 

--- a/radio/src/storage/storage_common.cpp
+++ b/radio/src/storage/storage_common.cpp
@@ -93,6 +93,11 @@ void postRadioSettingsLoad()
     serialSetMode(SP_VCP, UART_MODE_CLI);
   }
 #endif
+#if defined(DEFAULT_INTERNAL_MODULE)
+  if (!g_eeGeneral.internalModule) {
+    g_eeGeneral.internalModule = DEFAULT_INTERNAL_MODULE;
+  }
+#endif
 }
 
 #if defined(EXTERNAL_ANTENNA) && defined(INTERNAL_MODULE_PXX1)


### PR DESCRIPTION
- fix default VCP configuration (was not applied)
- fix internal module configuration (was always overwritten with default module)