### PR TITLE
Use static MPM protolist on simu

### DIFF
--- a/radio/src/io/multi_protolist.h
+++ b/radio/src/io/multi_protolist.h
@@ -42,7 +42,8 @@ class MultiRfProtocols
   uint8_t currentProto = 0;
   uint8_t totalProtos = 0;
 
-  MultiRfProtocols(unsigned int moduleIdx) : moduleIdx(moduleIdx) {}
+  MultiRfProtocols(unsigned int moduleIdx);
+  void fillBuiltinProtos();
 
  public:
 


### PR DESCRIPTION
This prevents the MPM protocol scanning to happen in the simulation, which would not work as the FreeRTOS Software Timers are not functional until we start to use FreeRTOS in simulation as well (Posix / Windows port).

Resolves #1793
