### PR TITLE
Fix Display Function switches names and symbol

### DIFF
--- a/radio/src/gui/128x64/lcd.cpp
+++ b/radio/src/gui/128x64/lcd.cpp
@@ -730,14 +730,40 @@ void drawSource(coord_t x, coord_t y, uint32_t idx, LcdFlags att)
     }
   }
   else if (idx >= MIXSRC_FIRST_SWITCH && idx <= MIXSRC_LAST_SWITCH) {
-    idx = idx-MIXSRC_FIRST_SWITCH;
-    if (ZEXIST(g_eeGeneral.switchNames[idx])) {
-      lcdDrawChar(x, y, '\212', att); //switch symbol
-      lcdDrawSizedText(lcdNextPos, y, g_eeGeneral.switchNames[idx], LEN_SWITCH_NAME, att);
+
+#if defined(FUNCTION_SWITCHES)    
+    if(idx >= MIXSRC_FIRST_FS_SWITCH) {
+      idx = idx-(MIXSRC_FIRST_SWITCH+NUM_REGULAR_SWITCHES);
+      if (ZEXIST(g_model.switchNames[idx])) {
+        lcdDrawChar(x, y, '\214', att); //switch symbol
+        lcdDrawSizedText(lcdNextPos, y, g_model.switchNames[idx], LEN_SWITCH_NAME, att);
+      }
+      else {
+        char s[LEN_SWITCH_NAME] = {'S', 'W'};
+        s[LEN_SWITCH_NAME-1] = '1' + idx;
+        lcdDrawChar(x, y, '\214', att); //switch symbol
+        lcdDrawSizedText(lcdNextPos, y, s, LEN_SWITCH_NAME, att);
+      }
     }
     else {
-      lcdDrawTextAtIndex(x, y, STR_VSRCRAW, idx + MIXSRC_FIRST_SWITCH - MIXSRC_Rud + 1, att);
+      idx = idx-MIXSRC_FIRST_SWITCH;
+      if (ZEXIST(g_eeGeneral.switchNames[idx])) {
+        lcdDrawChar(x, y, '\214', att); //switch symbol
+        lcdDrawSizedText(lcdNextPos, y, g_eeGeneral.switchNames[idx], LEN_SWITCH_NAME, att);
+      }
+      else
+        lcdDrawTextAtIndex(x, y, STR_VSRCRAW, idx + MIXSRC_FIRST_SWITCH - MIXSRC_Rud + 1, att);
     }
+#else
+  idx = idx-MIXSRC_FIRST_SWITCH;
+  if (ZEXIST(g_eeGeneral.switchNames[idx])) {
+    lcdDrawChar(x, y, '\214', att); //switch symbol
+    lcdDrawSizedText(lcdNextPos, y, g_eeGeneral.switchNames[idx], LEN_SWITCH_NAME, att);
+  }
+  else
+    lcdDrawTextAtIndex(x, y, STR_VSRCRAW, idx + MIXSRC_FIRST_SWITCH - MIXSRC_Rud + 1, att);
+#endif
+
   }
   else if (idx < MIXSRC_SW1)
     lcdDrawTextAtIndex(x, y, STR_VSRCRAW, idx-MIXSRC_Rud+1, att);

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -470,13 +470,21 @@ char *getSwitchName(char *dest, swsrc_t idx)
   if (g_eeGeneral.switchNames[swinfo.quot][0] != '\0') {
     dest =
         strAppend(dest, g_eeGeneral.switchNames[swinfo.quot], LEN_SWITCH_NAME);
-  } else {
-#if defined(FUNCTIONS_SWITCHES)
+  } 
+  else {
+#if defined(FUNCTION_SWITCHES) 
     if (swinfo.quot >= NUM_REGULAR_SWITCHES)  {
-      *dest++ = 'W';
-      *dest++ = '1' + swinfo.quot - 4;
+      int fsIdx = swinfo.quot - NUM_REGULAR_SWITCHES;
+      if(ZEXIST(g_model.switchNames[fsIdx])){
+        dest = strAppend(dest, g_model.switchNames[fsIdx], LEN_SWITCH_NAME);
+      }
+      else {
+        *dest++ = 'S';
+        *dest++ = 'W';
+        *dest++ = '1' + swinfo.quot - 4;
+      }
       return dest;
-    }
+    }  
 #endif
     *dest++ = 'S';
     *dest++ = getRawSwitchFromIdx(swinfo.quot);
@@ -503,9 +511,24 @@ char *getSwitchPositionName(char *dest, swsrc_t idx)
   (IDX_TRIMS_IN_STR_VSWITCHES + SWSRC_LAST_TRIM - SWSRC_FIRST_TRIM + 1)
   if (idx <= SWSRC_LAST_SWITCH) {
     div_t swinfo = switchInfo(idx);
-    s = getSwitchName(s, idx);
-    *s++ = (STR_CHAR_UP "-" STR_CHAR_DOWN)[swinfo.rem];
-    *s = '\0';
+    
+#if defined(FUNCTION_SWITCHES)
+    if (idx >= SWSRC_FIRST_FUNCTION_SWITCH && idx <= (SWSRC_FIRST_FUNCTION_SWITCH + NUM_FUNCTIONS_SWITCHES)) {
+      s = getSwitchName(s, idx);
+      *s++ = (STR_CHAR_UP "-" STR_CHAR_DOWN)[swinfo.rem];
+      *s = '\0';
+    } 
+    else {
+      s = getSwitchName(s, idx);
+      *s++ = (STR_CHAR_UP "-" STR_CHAR_DOWN)[swinfo.rem];
+      *s = '\0';
+    }
+#else
+  s = getSwitchName(s, idx);
+  *s++ = (STR_CHAR_UP "-" STR_CHAR_DOWN)[swinfo.rem];
+  *s = '\0';
+#endif
+
   }
 
 #if NUM_XPOTS > 0


### PR DESCRIPTION
Fix display of Function switches names on Inputs, Mixes, Logical SW and Special Functions screens.
Now names are used instead of SWx or Sx when a name is configured in setup screen.
Fix symbol of Function switches.

