### PR TITLE
Companion fix custom curve edit default points

### DIFF
--- a/companion/src/firmwares/curvedata.cpp
+++ b/companion/src/firmwares/curvedata.cpp
@@ -36,18 +36,19 @@ void CurveData::clear(int count)
 
 void CurveData::init()
 {
-  float incr = 200.0 / ((float)count - 1.0);
+  memset(points, 0, sizeof(CurvePoint) * CPN_MAX_POINTS);
 
-  //  points[0].x must be -100
+  float incr = 200.0 / (float)(count - 1);
 
-  for (int i = 0; i < count; i++) {
-    if (i < count - 1)
-      points[i].x = -100 + (int)(incr * i);
-    else
-      points[i].x = 100;    // points[count - 1].x must be +100 do not risk a rounding issue using incr
-
+  for (int i = 1; i < (count - 1); i++) {
+    points[i].x = -100 + (int)(incr * (float)i);
     points[i].y = points[i].x;
   }
+
+  points[0].x = -100;
+  points[0].y = -100;
+  points[count - 1].x = 100;
+  points[count - 1].y = 100;
 }
 
 bool CurveData::isEmpty() const

--- a/companion/src/helpers.cpp
+++ b/companion/src/helpers.cpp
@@ -672,6 +672,14 @@ void TableLayout::pushColumnsLeft(int col)
 #endif
 }
 
+void TableLayout::setColumnStretch(int col, int stretch)
+{
+#if defined(TABLE_LAYOUT)
+#else
+  gridWidget->setColumnStretch(col, stretch);
+#endif
+}
+
 QString Helpers::getChecklistsPath()
 {
   return QDir::toNativeSeparators(g.profile[g.id()].sdPath() + "/MODELS/");   // TODO : add sub folder to constants

--- a/companion/src/helpers.h
+++ b/companion/src/helpers.h
@@ -196,6 +196,7 @@ public:
   void setColumnWidth(int col, QString str);
   void pushRowsUp(int row);
   void pushColumnsLeft(int col);
+  void setColumnStretch(int col, int stretch);
 
 private:
 #if defined(TABLE_LAYOUT)

--- a/companion/src/modeledit/curves.cpp
+++ b/companion/src/modeledit/curves.cpp
@@ -62,6 +62,7 @@ CurvesPanel::CurvesPanel(QWidget * parent, ModelData & model, GeneralSettings & 
     connect(image[i], &CurveImageWidget::doubleClicked, this, &CurvesPanel::on_curveImageDoubleClicked);
 
     tableLayout->addWidget(i, col++, image[i]);
+    tableLayout->setColumnStretch(col, 1);
 
     grp[i] = new QWidget(); // layouts are not hideable so use widget as parent for grid
 
@@ -80,6 +81,8 @@ CurvesPanel::CurvesPanel(QWidget * parent, ModelData & model, GeneralSettings & 
     numpoints[i] = new QLabel();
     grid[i]->addWidget(numpoints[i], row, 1);
     points[i] = new QLabel();
+    points[i]->setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Preferred);
+    points[i]->setWordWrap(true);
     grid[i]->addWidget(points[i], row++, 2, Qt::AlignLeft);
 
     grid[i]->addWidget(new QLabel(tr("Smooth:")), row, 0, Qt::AlignLeft);


### PR DESCRIPTION
Fixes #1814
The initialisation algorithm is correct so appears to be caused by Qt's event stack triggering other events in the middle of our update.

Summary of changes:
- change event refreshing to be more granular and add lock checks
- expand curves tab details column and wrap points list (Qt makes it choice about where to break lines thus the unused space)
- housekeeping
