### PR TITLE
Fix some missing colorlcd gui if GPS on AUX1

### DIFF
--- a/radio/src/gui/colorlcd/radio_setup.cpp
+++ b/radio/src/gui/colorlcd/radio_setup.cpp
@@ -411,7 +411,7 @@ void RadioSetupPage::build(FormWindow * window)
   
 #if defined(INTERNAL_GPS)
   // GPS
-  if (hasSerialMode(UART_MODE_GPS)) {
+  if (hasSerialMode(UART_MODE_GPS) != -1) {
     new Subtitle(window, grid.getLabelSlot(), STR_GPS, 0, COLOR_THEME_PRIMARY1);
     grid.nextLine();
 

--- a/radio/src/gui/colorlcd/view_statistics.cpp
+++ b/radio/src/gui/colorlcd/view_statistics.cpp
@@ -240,7 +240,7 @@ void DebugViewPage::build(FormWindow *window)
 #endif
 
 #if defined(INTERNAL_GPS)
-  if (hasSerialMode(UART_MODE_GPS)) {
+  if (hasSerialMode(UART_MODE_GPS) != -1) {
     new StaticText(window, grid.getLabelSlot(), STR_INT_GPS_LABEL, 0,
                    COLOR_THEME_PRIMARY1);
     new DynamicText(


### PR DESCRIPTION
Version: 2.7.0-RC2
Classification: bug
Severity: minor

Some of the colorlcd GUI for Internal GPS was misusing `hasSerialMode()` expecting it to return a true/false, but it actually returns the port number that is set to the requested mode. Since the port numbers start at 0 for Serial Port AUX1, this means that there was some GUI that was missing if the GPS is attached to AUX1. This simply corrects the comparison to be true of `hasSerialMode(UART_MODE_GPS) != -1`

I've checked all other `hasSerialMode()` calls and they look correct, these are the only two problems.

Summary of changes:
* Radio Setup missing GPS items
* Statistics missing GPS info
