### PR TITLE
Changes VCP to USB-VCP in the UI

### DIFF
--- a/radio/src/targets/common/arm/stm32/usbd_cdc.cpp
+++ b/radio/src/targets/common/arm/stm32/usbd_cdc.cpp
@@ -309,7 +309,7 @@ static const etx_serial_driver_t usbSerialDriver = {
 };
 
 const etx_serial_port_t UsbSerialPort = {
-  "VCP",
+  "USB-VCP",
   &usbSerialDriver,
   nullptr,
 };

--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -747,7 +747,7 @@ void rtcSetTime(const struct gtm * t)
 }
 
 #if defined(USB_SERIAL)
-const etx_serial_port_t UsbSerialPort = { "VCP", nullptr, nullptr };
+const etx_serial_port_t UsbSerialPort = { "USB-VCP", nullptr, nullptr };
 #endif
 
 #if defined(AUX_SERIAL)


### PR DESCRIPTION
Inspired by @jmxp69 video: https://youtu.be/Yt79wxH4anM?t=3823 (at 1h 3min 43 sec).
Small change in label text hopefully making the "USB Virtual COM Port" (USB-VCP) more intuitive.

Old label "VCP":

![grafik](https://user-images.githubusercontent.com/21011587/163804536-4d63af78-7b0b-4533-9a22-9dd50eec010d.png)

New "USB-VCP":

![grafik](https://user-images.githubusercontent.com/21011587/163804589-a47ce68b-01fc-4ed9-a770-686760a7d771.png)


