### PR TITLE
Use "cpn-win-64"

### DIFF
--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -98,7 +98,7 @@ jobs:
 
       - name: Compose release filename
         # https://stackoverflow.com/questions/58033366/how-to-get-current-branch-within-github-actions
-        run: echo "artifact_name=edgetx-cpn-win-${GITHUB_REF##*/}" >> $GITHUB_ENV
+        run: echo "artifact_name=edgetx-cpn-win-64-${GITHUB_REF##*/}" >> $GITHUB_ENV
 
       - name: Archive production artifacts
         uses: actions/upload-artifact@v2


### PR DESCRIPTION
To clear some confusion by users, change the Windows Companion installer package filename from `cpn-win-*` to `cpn-win-64-*` in order to more clearly denote that this is a 64-bit Windows version.