### PR TITLE
With software controllable serial port power pins, keep power delivery off in bootloader

### DIFF
--- a/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
+++ b/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
@@ -219,6 +219,17 @@ int main()
   pwrInit();
   keysInit();
 
+#if defined(SWSERIALPOWER)
+  #if defined(AUX_SERIAL)
+    void set_aux_pwr(uint8_t on);
+    set_aux_pwr(0);
+  #endif
+  #if defined(AUX2_SERIAL)
+    void set_aux2_pwr(uint8_t on);
+    set_aux2_pwr(0);
+  #endif
+#endif
+
   // wait a bit for the inputs to stabilize...
   if (!WAS_RESET_BY_WATCHDOG_OR_SOFTWARE()) {
     for (uint32_t i = 0; i < 150000; i++) {


### PR DESCRIPTION
Forces software controllable serial port power delivery pins off during bootloader.

Tested with TX16S mkII. W/o this change, AUX1 power remains on, AUX2 off. With this change, during init of the code, briefly AUX1 is powered up, then very early in bootloader main(), serial power is turned off again.
I have no good idea yet how to eliminate the small ca. 900ms long glitch before the bootloader main() runs. Stems likely from the underlying implementation of StdPeriphLibs.

I made this PR against SerPWR branch, due to missing SWSERIALPOWER in the main branch yet.