### PR TITLE
Find libclang on systems that use `/usr/lib64`

### DIFF
--- a/radio/util/find_clang.py
+++ b/radio/util/find_clang.py
@@ -67,7 +67,8 @@ def findLibClang():
             "/usr/lib/llvm-6.0/lib",
             "/usr/lib/llvm-3.8/lib",
             "/usr/local/lib",
-            "/usr/lib"
+            "/usr/lib",
+            "/usr/lib64"
         ]
         libSuffix = ".so"
     elif sys.platform == "win32" or sys.platform == "msys":


### PR DESCRIPTION
Fix issue 1889 - find libclang on openSUSE and other systems that use /usr/lib64.


<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #1889

Summary of changes:
