### PR TITLE
Long timer announce minutes only (#1869)

### DIFF
--- a/radio/src/audio.h
+++ b/radio/src/audio.h
@@ -618,8 +618,8 @@ void playModelName();
 #define PLAY_DURATION_ATT        , uint8_t flags
 #define PLAY_TIME                1
 #define PLAY_LONG_TIMER          2
-#define LONG_TIMER_DURATUON      (10 * 60)  // 10 minutes
-#define IS_PLAY_TIME()           (flags&PLAY_TIME)
+#define LONG_TIMER_DURATION      (10 * 60)  // 10 minutes
+#define IS_PLAY_TIME()           (flags & PLAY_TIME)
 #define IS_PLAY_LONG_TIMER()     (flags & PLAY_LONG_TIMER)
 #define IS_PLAYING(id)           audioQueue.isPlaying((id))
 #define PLAY_VALUE(v, id)        playValue((v), (id))

--- a/radio/src/audio.h
+++ b/radio/src/audio.h
@@ -617,7 +617,10 @@ void playModelName();
 #define PLAY_DURATION(d, att)    playDuration((d), (att), id)
 #define PLAY_DURATION_ATT        , uint8_t flags
 #define PLAY_TIME                1
+#define PLAY_LONG_TIMER          2
+#define LONG_TIMER_DURATUON      (10 * 60)  // 10 minutes
 #define IS_PLAY_TIME()           (flags&PLAY_TIME)
+#define IS_PLAY_LONG_TIMER()     (flags & PLAY_LONG_TIMER)
 #define IS_PLAYING(id)           audioQueue.isPlaying((id))
 #define PLAY_VALUE(v, id)        playValue((v), (id))
 #define PLAY_FILE(f, flags, id)  audioQueue.playFile((f), (flags), (id))

--- a/radio/src/functions.cpp
+++ b/radio/src/functions.cpp
@@ -76,15 +76,15 @@ PLAY_FUNCTION(playValue, source_t idx)
   }
   else if (idx >= MIXSRC_FIRST_TIMER && idx <= MIXSRC_LAST_TIMER) {
     int flag = 0;
-    if (val > LONG_TIMER_DURATION)  flag = PLAY_LONG_TIMER;
+    if (val > LONG_TIMER_DURATION || -val > LONG_TIMER_DURATION) {
+      flag = PLAY_LONG_TIMER;
+    }
     PLAY_DURATION(val, flag);
   } else if (idx == MIXSRC_TX_TIME) {
-    PLAY_DURATION(val*60, PLAY_TIME);
-  }
-  else if (idx == MIXSRC_TX_VOLTAGE) {
+    PLAY_DURATION(val * 60, PLAY_TIME);
+  } else if (idx == MIXSRC_TX_VOLTAGE) {
     PLAY_NUMBER(val, UNIT_VOLTS, PREC1);
-  }
-  else {
+  } else {
     if (idx <= MIXSRC_LAST_CH) {
       val = calcRESXto100(val);
     }

--- a/radio/src/functions.cpp
+++ b/radio/src/functions.cpp
@@ -75,9 +75,10 @@ PLAY_FUNCTION(playValue, source_t idx)
     PLAY_NUMBER(val, telemetrySensor.unit == UNIT_CELLS ? UNIT_VOLTS : telemetrySensor.unit, attr);
   }
   else if (idx >= MIXSRC_FIRST_TIMER && idx <= MIXSRC_LAST_TIMER) {
-    PLAY_DURATION(val, 0);
-  }
-  else if (idx == MIXSRC_TX_TIME) {
+    int flag = 0;
+    if (val > LONG_TIMER_DURATUON)  flag = PLAY_LONG_TIMER;
+    PLAY_DURATION(val, flag);
+  } else if (idx == MIXSRC_TX_TIME) {
     PLAY_DURATION(val*60, PLAY_TIME);
   }
   else if (idx == MIXSRC_TX_VOLTAGE) {

--- a/radio/src/functions.cpp
+++ b/radio/src/functions.cpp
@@ -76,7 +76,7 @@ PLAY_FUNCTION(playValue, source_t idx)
   }
   else if (idx >= MIXSRC_FIRST_TIMER && idx <= MIXSRC_LAST_TIMER) {
     int flag = 0;
-    if (val > LONG_TIMER_DURATUON)  flag = PLAY_LONG_TIMER;
+    if (val > LONG_TIMER_DURATION)  flag = PLAY_LONG_TIMER;
     PLAY_DURATION(val, flag);
   } else if (idx == MIXSRC_TX_TIME) {
     PLAY_DURATION(val*60, PLAY_TIME);

--- a/radio/src/translations/tts_cn.cpp
+++ b/radio/src/translations/tts_cn.cpp
@@ -104,22 +104,28 @@ I18N_PLAY_FUNCTION(cn, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
-  uint8_t tmp = seconds / 3600;
-  seconds %= 3600;
-  if (tmp > 0 || IS_PLAY_TIME()) {
-    PLAY_NUMBER(tmp, UNIT_HOURS, 0);
-  }
+  uint8_t tmp;
+  if (IS_PLAY_LONG_TIMER()) {
+    tmp = seconds / 60;
+    if (seconds % 60 >= 30) tmp += 1;
+    if (tmp > 0) PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
+  } else {
+    tmp = seconds / 3600;
+    seconds %= 3600;
+    if (tmp > 0 || IS_PLAY_TIME()) {
+      PLAY_NUMBER(tmp, UNIT_HOURS, 0);
+    }
 
-  tmp = seconds / 60;
-  seconds %= 60;
-  if (tmp > 0) {
-    PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
-    if (seconds > 0)
-      PUSH_NUMBER_PROMPT(CN_PROMPT_AND);
-  }
+    tmp = seconds / 60;
+    seconds %= 60;
+    if (tmp > 0) {
+      PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
+      if (seconds > 0) PUSH_NUMBER_PROMPT(CN_PROMPT_AND);
+    }
 
-  if (seconds > 0) {
-    PLAY_NUMBER(seconds, UNIT_SECONDS, 0);
+    if (seconds > 0) {
+      PLAY_NUMBER(seconds, UNIT_SECONDS, 0);
+    }
   }
 }
 

--- a/radio/src/translations/tts_cz.cpp
+++ b/radio/src/translations/tts_cz.cpp
@@ -163,20 +163,27 @@ I18N_PLAY_FUNCTION(cz, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
-  uint8_t tmp = seconds / 3600;
-  seconds %= 3600;
-  if (tmp > 0 || IS_PLAY_TIME()) {
-    PLAY_NUMBER(tmp, UNIT_HOURS, FEMALE);
-  }
+  uint8_t tmp;
+  if (IS_PLAY_LONG_TIMER()) {
+    tmp = seconds / 60;
+    if (seconds % 60 >= 30) tmp += 1;
+    if (tmp > 0) PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
+  } else {
+    tmp = seconds / 3600;
+    seconds %= 3600;
+    if (tmp > 0 || IS_PLAY_TIME()) {
+      PLAY_NUMBER(tmp, UNIT_HOURS, FEMALE);
+    }
 
-  tmp = seconds / 60;
-  seconds %= 60;
-  if (tmp > 0) {
-    PLAY_NUMBER(tmp, UNIT_MINUTES, FEMALE);
-  }
+    tmp = seconds / 60;
+    seconds %= 60;
+    if (tmp > 0) {
+      PLAY_NUMBER(tmp, UNIT_MINUTES, FEMALE);
+    }
 
-  if (seconds > 0) {
-    PLAY_NUMBER(seconds, UNIT_SECONDS, FEMALE);
+    if (seconds > 0) {
+      PLAY_NUMBER(seconds, UNIT_SECONDS, FEMALE);
+    }
   }
 }
 

--- a/radio/src/translations/tts_de.cpp
+++ b/radio/src/translations/tts_de.cpp
@@ -161,48 +161,55 @@ I18N_PLAY_FUNCTION(de, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
-  uint8_t tmp = seconds / 3600;
-  seconds %= 3600;
-
-  if (tmp > 0 || IS_PLAY_TIME()) {
-    if (tmp > 1) {
-      PLAY_NUMBER(tmp, 0, 0);
-      PUSH_NUMBER_PROMPT(DE_PROMPT_STUNDEN);
-    }
-    else {
-      PUSH_NUMBER_PROMPT(DE_PROMPT_EINE);
-      PUSH_NUMBER_PROMPT(DE_PROMPT_STUNDE);
-    }
-    if (seconds > 0) {
-      PUSH_NUMBER_PROMPT(DE_PROMPT_UND);
-    }
+  uint8_t tmp;
+ if (IS_PLAY_LONG_TIMER())
+  {
+    tmp = seconds / 60;
+    if (seconds % 60 >= 30) tmp += 1;
+    if (tmp > 0) PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
   }
+  else
+  {
+    tmp = seconds / 3600;
+    seconds %= 3600;
 
-  tmp = seconds / 60;
-  seconds %= 60;
+    if (tmp > 0 || IS_PLAY_TIME()) {
+      if (tmp > 1) {
+        PLAY_NUMBER(tmp, 0, 0);
+        PUSH_NUMBER_PROMPT(DE_PROMPT_STUNDEN);
+      } else {
+        PUSH_NUMBER_PROMPT(DE_PROMPT_EINE);
+        PUSH_NUMBER_PROMPT(DE_PROMPT_STUNDE);
+      }
+      if (seconds > 0) {
+        PUSH_NUMBER_PROMPT(DE_PROMPT_UND);
+      }
+    }
 
-  if (tmp > 0) {
-    if (tmp > 1) {
-      PLAY_NUMBER(tmp, 0, 0);
-      PUSH_NUMBER_PROMPT(DE_PROMPT_MINUTEN);
+    tmp = seconds / 60;
+    seconds %= 60;
+
+    if (tmp > 0) {
+      if (tmp > 1) {
+        PLAY_NUMBER(tmp, 0, 0);
+        PUSH_NUMBER_PROMPT(DE_PROMPT_MINUTEN);
+      } else {
+        PUSH_NUMBER_PROMPT(DE_PROMPT_EINE);
+        PUSH_NUMBER_PROMPT(DE_PROMPT_MINUTE);
+      }
+      if (seconds > 0) {
+        PUSH_NUMBER_PROMPT(DE_PROMPT_UND);
+      }
     }
-    else {
-      PUSH_NUMBER_PROMPT(DE_PROMPT_EINE);
-      PUSH_NUMBER_PROMPT(DE_PROMPT_MINUTE);
-    }
-    if (seconds > 0) {
-      PUSH_NUMBER_PROMPT(DE_PROMPT_UND);
-    }
-  }
-  
-  if (seconds > 1) {
-    PLAY_NUMBER(seconds, 0, 0);
-    PUSH_NUMBER_PROMPT(DE_PROMPT_SEKUNDEN);
-  }
-  else {
-    if (seconds == 1) {
-      PUSH_NUMBER_PROMPT(DE_PROMPT_EINE);
-      PUSH_NUMBER_PROMPT(DE_PROMPT_SEKUNDE);
+
+    if (seconds > 1) {
+      PLAY_NUMBER(seconds, 0, 0);
+      PUSH_NUMBER_PROMPT(DE_PROMPT_SEKUNDEN);
+    } else {
+      if (seconds == 1) {
+        PUSH_NUMBER_PROMPT(DE_PROMPT_EINE);
+        PUSH_NUMBER_PROMPT(DE_PROMPT_SEKUNDE);
+      }
     }
   }
 }

--- a/radio/src/translations/tts_en.cpp
+++ b/radio/src/translations/tts_en.cpp
@@ -104,22 +104,28 @@ I18N_PLAY_FUNCTION(en, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
-  uint8_t tmp = seconds / 3600;
-  seconds %= 3600;
-  if (tmp > 0 || IS_PLAY_TIME()) {
-    PLAY_NUMBER(tmp, UNIT_HOURS, 0);
-  }
+  uint8_t tmp;
+  if (IS_PLAY_LONG_TIMER()) {
+    tmp = seconds / 60;
+    if (seconds % 60 >= 30) tmp += 1;
+    if (tmp > 0) PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
+  } else {
+    tmp = seconds / 3600;
+    seconds %= 3600;
+    if (tmp > 0 || IS_PLAY_TIME()) {
+      PLAY_NUMBER(tmp, UNIT_HOURS, 0);
+    }
 
-  tmp = seconds / 60;
-  seconds %= 60;
-  if (tmp > 0) {
-    PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
-    if (seconds > 0)
-      PUSH_NUMBER_PROMPT(EN_PROMPT_AND);
-  }
+    tmp = seconds / 60;
+    seconds %= 60;
+    if (tmp > 0) {
+      PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
+      if (seconds > 0) PUSH_NUMBER_PROMPT(EN_PROMPT_AND);
+    }
 
-  if (seconds > 0) {
-    PLAY_NUMBER(seconds, UNIT_SECONDS, 0);
+    if (seconds > 0) {
+      PLAY_NUMBER(seconds, UNIT_SECONDS, 0);
+    }
   }
 }
 

--- a/radio/src/translations/tts_es.cpp
+++ b/radio/src/translations/tts_es.cpp
@@ -153,40 +153,44 @@ I18N_PLAY_FUNCTION(es, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
-  uint8_t tmp = seconds / 3600;
-  seconds %= 3600;
-  if (tmp > 0 || IS_PLAY_TIME()) {
-    if (tmp > 1) {
-      PLAY_NUMBER(tmp, 0, 0);
-      PUSH_UNIT_PROMPT(UNIT_HOURS, 1);
+  uint8_t tmp;
+  if (IS_PLAY_LONG_TIMER()) {
+    tmp = seconds / 60;
+    if (seconds % 60 >= 30) tmp += 1;
+    if (tmp > 0) PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
+  } else {
+    tmp = seconds / 3600;
+    seconds %= 3600;
+    if (tmp > 0 || IS_PLAY_TIME()) {
+      if (tmp > 1) {
+        PLAY_NUMBER(tmp, 0, 0);
+        PUSH_UNIT_PROMPT(UNIT_HOURS, 1);
+      } else {
+        PUSH_NUMBER_PROMPT(ES_PROMPT_UNA);
+        PUSH_UNIT_PROMPT(UNIT_HOURS, 0);
+      }
     }
-    else {
-      PUSH_NUMBER_PROMPT(ES_PROMPT_UNA);
-      PUSH_UNIT_PROMPT(UNIT_HOURS, 0);
-    }
-  }
 
-  tmp = seconds / 60;
-  seconds %= 60;
-  if (tmp > 0 ) {
-    if (tmp != 1) {
-      PLAY_NUMBER(tmp, 0, 0);
-      PUSH_UNIT_PROMPT(UNIT_MINUTES, 1);
+    tmp = seconds / 60;
+    seconds %= 60;
+    if (tmp > 0) {
+      if (tmp != 1) {
+        PLAY_NUMBER(tmp, 0, 0);
+        PUSH_UNIT_PROMPT(UNIT_MINUTES, 1);
+      } else {
+        PUSH_NUMBER_PROMPT(ES_PROMPT_UN);
+        PUSH_UNIT_PROMPT(UNIT_MINUTES, 0);
+      }
     }
-    else {
-      PUSH_NUMBER_PROMPT(ES_PROMPT_UN);
-      PUSH_UNIT_PROMPT(UNIT_MINUTES, 0);
-    }
-  }
 
-  if (seconds > 0) {
-    if (seconds != 1) {
-      PLAY_NUMBER(seconds, 0, 0);
-      PUSH_UNIT_PROMPT(UNIT_SECONDS, 1);
-    }
-    else {
-      PUSH_NUMBER_PROMPT(ES_PROMPT_UN);
-      PUSH_UNIT_PROMPT(UNIT_SECONDS, 0);
+    if (seconds > 0) {
+      if (seconds != 1) {
+        PLAY_NUMBER(seconds, 0, 0);
+        PUSH_UNIT_PROMPT(UNIT_SECONDS, 1);
+      } else {
+        PUSH_NUMBER_PROMPT(ES_PROMPT_UN);
+        PUSH_UNIT_PROMPT(UNIT_SECONDS, 0);
+      }
     }
   }
 }

--- a/radio/src/translations/tts_fr.cpp
+++ b/radio/src/translations/tts_fr.cpp
@@ -135,33 +135,36 @@ I18N_PLAY_FUNCTION(fr, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
-  uint8_t tmp = seconds / 3600;
-  seconds %= 3600;
-  if (IS_PLAY_TIME() && tmp==0) {
-    PUSH_NUMBER_PROMPT(FR_PROMPT_MINUIT);
-  }
-  else if (IS_PLAY_TIME() && tmp==12) {
-    PUSH_NUMBER_PROMPT(FR_PROMPT_MIDI);
-  }
-  else if (tmp > 0) {
-    PLAY_NUMBER(tmp, UNIT_HOURS, FEMININ);
-  }
-
-  tmp = seconds / 60;
-  seconds %= 60;
-  if (tmp > 0) {
-    if (IS_PLAY_TIME()) {
-      PLAY_NUMBER(tmp, 0, tmp==1 ? FEMININ : 0);
+  uint8_t tmp;
+  if (IS_PLAY_LONG_TIMER()) {
+    tmp = seconds / 60;
+    if (seconds % 60 >= 30) tmp += 1;
+    if (tmp > 0) PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
+  } else {
+    tmp = seconds / 3600;
+    seconds %= 3600;
+    if (IS_PLAY_TIME() && tmp == 0) {
+      PUSH_NUMBER_PROMPT(FR_PROMPT_MINUIT);
+    } else if (IS_PLAY_TIME() && tmp == 12) {
+      PUSH_NUMBER_PROMPT(FR_PROMPT_MIDI);
+    } else if (tmp > 0) {
+      PLAY_NUMBER(tmp, UNIT_HOURS, FEMININ);
     }
-    else {
-      PLAY_NUMBER(tmp, UNIT_MINUTES, FEMININ);
-      if (seconds > 0)
-        PUSH_NUMBER_PROMPT(FR_PROMPT_ET);
-    }
-  }
 
-  if (!IS_PLAY_TIME() && seconds > 0) {
-    PLAY_NUMBER(seconds, UNIT_SECONDS, FEMININ);
+    tmp = seconds / 60;
+    seconds %= 60;
+    if (tmp > 0) {
+      if (IS_PLAY_TIME()) {
+        PLAY_NUMBER(tmp, 0, tmp == 1 ? FEMININ : 0);
+      } else {
+        PLAY_NUMBER(tmp, UNIT_MINUTES, FEMININ);
+        if (seconds > 0) PUSH_NUMBER_PROMPT(FR_PROMPT_ET);
+      }
+    }
+
+    if (!IS_PLAY_TIME() && seconds > 0) {
+      PLAY_NUMBER(seconds, UNIT_SECONDS, FEMININ);
+    }
   }
 }
 

--- a/radio/src/translations/tts_hu.cpp
+++ b/radio/src/translations/tts_hu.cpp
@@ -104,23 +104,30 @@ I18N_PLAY_FUNCTION(hu, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
-  uint8_t tmp = seconds / 3600;
-  seconds %= 3600;
-  if (tmp > 0 || IS_PLAY_TIME()) {
-    PLAY_NUMBER(tmp, UNIT_HOURS, 0);
-  }
+  uint8_t tmp;
+  if (IS_PLAY_LONG_TIMER()) {
+    tmp = seconds / 60;
+    if (seconds % 60 >= 30) tmp += 1;
+    if (tmp > 0) PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
+  } else {
+    tmp = seconds / 3600;
+    seconds %= 3600;
+    if (tmp > 0 || IS_PLAY_TIME()) {
+      PLAY_NUMBER(tmp, UNIT_HOURS, 0);
+    }
 
-  tmp = seconds / 60;
-  seconds %= 60;
-  if (tmp > 0) {
-    PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
-    // This is not necessary in the Hungarian
-	//if (seconds > 0)
-      //PUSH_NUMBER_PROMPT(HU_PROMPT_AND);
-  }
+    tmp = seconds / 60;
+    seconds %= 60;
+    if (tmp > 0) {
+      PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
+      // This is not necessary in the Hungarian
+      // if (seconds > 0)
+      // PUSH_NUMBER_PROMPT(HU_PROMPT_AND);
+    }
 
-  if (seconds > 0) {
-    PLAY_NUMBER(seconds, UNIT_SECONDS, 0);
+    if (seconds > 0) {
+      PLAY_NUMBER(seconds, UNIT_SECONDS, 0);
+    }
   }
 }
 

--- a/radio/src/translations/tts_it.cpp
+++ b/radio/src/translations/tts_it.cpp
@@ -154,22 +154,28 @@ I18N_PLAY_FUNCTION(it, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
-  uint8_t tmp = seconds / 3600;
-  seconds %= 3600;
-  if (tmp > 0 || IS_PLAY_TIME()) {
-    PLAY_NUMBER(tmp, UNIT_HOURS, 0);
-  }
+  uint8_t tmp;
+  if (IS_PLAY_LONG_TIMER()) {
+    tmp = seconds / 60;
+    if (seconds % 60 >= 30) tmp += 1;
+    if (tmp > 0) PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
+  } else {
+    tmp = seconds / 3600;
+    seconds %= 3600;
+    if (tmp > 0 || IS_PLAY_TIME()) {
+      PLAY_NUMBER(tmp, UNIT_HOURS, 0);
+    }
 
-  tmp = seconds / 60;
-  seconds %= 60;
-  if (tmp > 0) {
-    PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
-    if (seconds > 0)
-      PUSH_NUMBER_PROMPT(IT_PROMPT_E);
-  }
+    tmp = seconds / 60;
+    seconds %= 60;
+    if (tmp > 0) {
+      PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
+      if (seconds > 0) PUSH_NUMBER_PROMPT(IT_PROMPT_E);
+    }
 
-  if (seconds > 0) {
-    PLAY_NUMBER(seconds, UNIT_SECONDS, 0);
+    if (seconds > 0) {
+      PLAY_NUMBER(seconds, UNIT_SECONDS, 0);
+    }
   }
 }
 

--- a/radio/src/translations/tts_nl.cpp
+++ b/radio/src/translations/tts_nl.cpp
@@ -106,22 +106,28 @@ I18N_PLAY_FUNCTION(nl, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
-  uint8_t tmp = seconds / 3600;
-  seconds %= 3600;
-  if (tmp > 0 || IS_PLAY_TIME()) {
-    PLAY_NUMBER(tmp, UNIT_HOURS, 0);
-  }
+  uint8_t tmp;
+  if (IS_PLAY_LONG_TIMER()) {
+    tmp = seconds / 60;
+    if (seconds % 60 >= 30) tmp += 1;
+    if (tmp > 0) PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
+  } else {
+    tmp = seconds / 3600;
+    seconds %= 3600;
+    if (tmp > 0 || IS_PLAY_TIME()) {
+      PLAY_NUMBER(tmp, UNIT_HOURS, 0);
+    }
 
-  tmp = seconds / 60;
-  seconds %= 60;
-  if (tmp > 0) {
-    PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
-    if (seconds > 0)
-      PUSH_NUMBER_PROMPT(NL_PROMPT_AND);
-  }
+    tmp = seconds / 60;
+    seconds %= 60;
+    if (tmp > 0) {
+      PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
+      if (seconds > 0) PUSH_NUMBER_PROMPT(NL_PROMPT_AND);
+    }
 
-  if (seconds > 0) {
-    PLAY_NUMBER(seconds, UNIT_SECONDS, 0);
+    if (seconds > 0) {
+      PLAY_NUMBER(seconds, UNIT_SECONDS, 0);
+    }
   }
 }
 

--- a/radio/src/translations/tts_pl.cpp
+++ b/radio/src/translations/tts_pl.cpp
@@ -211,20 +211,27 @@ I18N_PLAY_FUNCTION(pl, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
-  uint8_t tmp = seconds / 3600;
-  seconds %= 3600;
-  if (tmp > 0 || IS_PLAY_TIME()) {
-    PLAY_NUMBER(tmp, UNIT_HOURS, ZENSKI);
-  }
+  uint8_t tmp;
+  if (IS_PLAY_LONG_TIMER()) {
+    tmp = seconds / 60;
+    if (seconds % 60 >= 30) tmp += 1;
+    if (tmp > 0) PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
+  } else {
+    tmp = seconds / 3600;
+    seconds %= 3600;
+    if (tmp > 0 || IS_PLAY_TIME()) {
+      PLAY_NUMBER(tmp, UNIT_HOURS, ZENSKI);
+    }
 
-  tmp = seconds / 60;
-  seconds %= 60;
-  if (tmp > 0) {
-    PLAY_NUMBER(tmp, UNIT_MINUTES, ZENSKI);
-  }
+    tmp = seconds / 60;
+    seconds %= 60;
+    if (tmp > 0) {
+      PLAY_NUMBER(tmp, UNIT_MINUTES, ZENSKI);
+    }
 
-  if (seconds > 0) {
-    PLAY_NUMBER(seconds, UNIT_SECONDS, ZENSKI);
+    if (seconds > 0) {
+      PLAY_NUMBER(seconds, UNIT_SECONDS, ZENSKI);
+    }
   }
 }
 

--- a/radio/src/translations/tts_pt.cpp
+++ b/radio/src/translations/tts_pt.cpp
@@ -139,41 +139,48 @@ I18N_PLAY_FUNCTION(pt, playDuration, int seconds PLAY_DURATION_ATT)
   }
 
   uint8_t ore = 0;
-  uint8_t tmp = seconds / 3600;
-  seconds %= 3600;
-  if (tmp > 0 || IS_PLAY_TIME()) {
-    ore=tmp;
-    if (tmp > 2) {
-      PLAY_NUMBER(tmp, 0, 0);
-      PUSH_UNIT_PROMPT(UNIT_HOURS, 1);
-    } else if (tmp==2) {
-      PUSH_NUMBER_PROMPT(PT_PROMPT_DUAS);
-      PUSH_UNIT_PROMPT(UNIT_HOURS, 1);
-      } else if (tmp==1) {
-      PUSH_NUMBER_PROMPT(PT_PROMPT_UMA);
-      PUSH_UNIT_PROMPT(UNIT_HOURS, 0);
-    }
-  }
-
-  tmp = seconds / 60;
-  seconds %= 60;
-  if (tmp > 0 || ore >0) {
-    if (tmp != 1) {
-      PLAY_NUMBER(tmp, 0, 0);
-      PUSH_UNIT_PROMPT(UNIT_MINUTES, 1);
-    } else {
-      PUSH_NUMBER_PROMPT(PT_PROMPT_NUMBERS_BASE+1);
-      PUSH_UNIT_PROMPT(UNIT_MINUTES, 0);
-    }
-    PUSH_NUMBER_PROMPT(PT_PROMPT_E);
-  }
-
-  if (seconds != 1) {
-    PLAY_NUMBER(seconds, 0, 0);
-    PUSH_UNIT_PROMPT(UNIT_SECONDS, 1);
+  uint8_t tmp;
+  if (IS_PLAY_LONG_TIMER()) {
+    tmp = seconds / 60;
+    if (seconds % 60 >= 30) tmp += 1;
+    if (tmp > 0) PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
   } else {
-    PUSH_NUMBER_PROMPT(PT_PROMPT_NUMBERS_BASE+1);
-    PUSH_UNIT_PROMPT(UNIT_SECONDS, 0);
+    tmp = seconds / 3600;
+    seconds %= 3600;
+    if (tmp > 0 || IS_PLAY_TIME()) {
+      ore = tmp;
+      if (tmp > 2) {
+        PLAY_NUMBER(tmp, 0, 0);
+        PUSH_UNIT_PROMPT(UNIT_HOURS, 1);
+      } else if (tmp == 2) {
+        PUSH_NUMBER_PROMPT(PT_PROMPT_DUAS);
+        PUSH_UNIT_PROMPT(UNIT_HOURS, 1);
+      } else if (tmp == 1) {
+        PUSH_NUMBER_PROMPT(PT_PROMPT_UMA);
+        PUSH_UNIT_PROMPT(UNIT_HOURS, 0);
+      }
+    }
+
+    tmp = seconds / 60;
+    seconds %= 60;
+    if (tmp > 0 || ore > 0) {
+      if (tmp != 1) {
+        PLAY_NUMBER(tmp, 0, 0);
+        PUSH_UNIT_PROMPT(UNIT_MINUTES, 1);
+      } else {
+        PUSH_NUMBER_PROMPT(PT_PROMPT_NUMBERS_BASE + 1);
+        PUSH_UNIT_PROMPT(UNIT_MINUTES, 0);
+      }
+      PUSH_NUMBER_PROMPT(PT_PROMPT_E);
+    }
+
+    if (seconds != 1) {
+      PLAY_NUMBER(seconds, 0, 0);
+      PUSH_UNIT_PROMPT(UNIT_SECONDS, 1);
+    } else {
+      PUSH_NUMBER_PROMPT(PT_PROMPT_NUMBERS_BASE + 1);
+      PUSH_UNIT_PROMPT(UNIT_SECONDS, 0);
+    }
   }
 }
 

--- a/radio/src/translations/tts_ru.cpp
+++ b/radio/src/translations/tts_ru.cpp
@@ -163,21 +163,27 @@ I18N_PLAY_FUNCTION(ru, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
-  uint8_t tmp = seconds / 3600;
-  seconds %= 3600;
-  if (tmp > 0 || IS_PLAY_TIME()) {
-    PLAY_NUMBER(tmp, UNIT_HOURS, 0);
-  }
+  uint8_t tmp;
+  if (IS_PLAY_LONG_TIMER()) {
+    tmp = seconds / 60;
+    if (seconds % 60 >= 30) tmp += 1;
+    if (tmp > 0) PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
+  } else {
+    tmp = seconds / 3600;
+    seconds %= 3600;
+    if (tmp > 0 || IS_PLAY_TIME()) {
+      PLAY_NUMBER(tmp, UNIT_HOURS, 0);
+    }
 
-  tmp = seconds / 60;
-  seconds %= 60;
-  if (tmp > 0) {
-    PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
-    if (seconds > 0)
-      PUSH_NUMBER_PROMPT(RU_PROMPT_AND);
-  }
-  if (seconds > 0) {
-    PLAY_NUMBER(seconds, UNIT_SECONDS, 0);
+    tmp = seconds / 60;
+    seconds %= 60;
+    if (tmp > 0) {
+      PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
+      if (seconds > 0) PUSH_NUMBER_PROMPT(RU_PROMPT_AND);
+    }
+    if (seconds > 0) {
+      PLAY_NUMBER(seconds, UNIT_SECONDS, 0);
+    }
   }
 }
 

--- a/radio/src/translations/tts_se.cpp
+++ b/radio/src/translations/tts_se.cpp
@@ -99,22 +99,28 @@ I18N_PLAY_FUNCTION(se, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
-  uint8_t tmp = seconds / 3600;
-  seconds %= 3600;
-  if (tmp > 0 || IS_PLAY_TIME()) {
-    PLAY_NUMBER(tmp, UNIT_HOURS, 0);
-  }
+  uint8_t tmp;
+  if (IS_PLAY_LONG_TIMER()) {
+    tmp = seconds / 60;
+    if (seconds % 60 >= 30) tmp += 1;
+    if (tmp > 0) PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
+  } else {
+    tmp = seconds / 3600;
+    seconds %= 3600;
+    if (tmp > 0 || IS_PLAY_TIME()) {
+      PLAY_NUMBER(tmp, UNIT_HOURS, 0);
+    }
 
-  tmp = seconds / 60;
-  seconds %= 60;
-  if (tmp > 0) {
-    PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
-    if (seconds > 0)
-      PUSH_NUMBER_PROMPT(SE_PROMPT_AND);
-  }
+    tmp = seconds / 60;
+    seconds %= 60;
+    if (tmp > 0) {
+      PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
+      if (seconds > 0) PUSH_NUMBER_PROMPT(SE_PROMPT_AND);
+    }
 
-  if (seconds > 0) {
-    PLAY_NUMBER(seconds, UNIT_SECONDS, 0);
+    if (seconds > 0) {
+      PLAY_NUMBER(seconds, UNIT_SECONDS, 0);
+    }
   }
 }
 

--- a/radio/src/translations/tts_sk.cpp
+++ b/radio/src/translations/tts_sk.cpp
@@ -161,20 +161,27 @@ I18N_PLAY_FUNCTION(sk, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
-  uint8_t tmp = seconds / 3600;
-  seconds %= 3600;
-  if (tmp > 0 || IS_PLAY_TIME()) {
-    PLAY_NUMBER(tmp, UNIT_HOURS, ZENSKY);
-  }
+  uint8_t tmp;
+  if (IS_PLAY_LONG_TIMER()) {
+    tmp = seconds / 60;
+    if (seconds % 60 >= 30) tmp += 1;
+    if (tmp > 0) PLAY_NUMBER(tmp, UNIT_MINUTES, 0);
+  } else {
+    tmp = seconds / 3600;
+    seconds %= 3600;
+    if (tmp > 0 || IS_PLAY_TIME()) {
+      PLAY_NUMBER(tmp, UNIT_HOURS, ZENSKY);
+    }
 
-  tmp = seconds / 60;
-  seconds %= 60;
-  if (tmp > 0) {
-    PLAY_NUMBER(tmp, UNIT_MINUTES, ZENSKY);
-  }
+    tmp = seconds / 60;
+    seconds %= 60;
+    if (tmp > 0) {
+      PLAY_NUMBER(tmp, UNIT_MINUTES, ZENSKY);
+    }
 
-  if (seconds > 0) {
-    PLAY_NUMBER(seconds, UNIT_SECONDS, ZENSKY);
+    if (seconds > 0) {
+      PLAY_NUMBER(seconds, UNIT_SECONDS, ZENSKY);
+    }
   }
 }
 


### PR DESCRIPTION
Closes #1869

Summary of changes: 
- timer values longer than 10 minutes will announce time in minutes only (no seconds, no hours). 
- when timer value less than 10 minutes seconds will be announced as well 
