### PR TITLE
Further tweaks to version string

### DIFF
--- a/radio/src/stamp.cpp
+++ b/radio/src/stamp.cpp
@@ -49,7 +49,7 @@
     const char vers_stamp[]   = "VERS" TAB ": Factory firmware (" GIT_STR ")";
   #else
     #if defined(VERSION_TAG)
-      const char vers_stamp[] = "VERS" TAB ": " VERSION_TAG DISPLAY_VERSION " (" GIT_STR ")";
+      const char vers_stamp[] = "VERS" TAB ": " VERSION_TAG DISPLAY_VERSION;
     #else
       const char vers_stamp[] = "VERS" TAB ": " VERSION "-" VERSION_SUFFIX DISPLAY_VERSION " (" GIT_STR ")";
     #endif

--- a/radio/src/stamp.h.in
+++ b/radio/src/stamp.h.in
@@ -2,9 +2,7 @@
 #define TIME    "@TIME@"
 #define VERSION "@VERSION@"
 #define VERSION_SUFFIX "@VERSION_SUFFIX@"
-#if defined(VERSION_TAG)
-  #define VERSION_TAG "@VERSION_TAG@"
-#endif
+#cmakedefine VERSION_TAG "@VERSION_TAG@"
 #define CODENAME "@CODENAME@"
 
 #define VERSION_MAJOR     @VERSION_MAJOR@

--- a/tools/build-gh.sh
+++ b/tools/build-gh.sh
@@ -58,7 +58,7 @@ elif [[ $gh_type = "pull" ]]; then
   # pull: refs/pull/<pr_number>/merge
   gh_pull_number=PR$(echo "$GITHUB_REF" | awk -F / '{print $3}')
   export EDGETX_VERSION_SUFFIX=$gh_pull_number
-else
+elif [[ $gh_type = "heads" ]]; then
   # heads: refs/heads/<branch_name>
   gh_branch=${GITHUB_REF##*/}
   export EDGETX_VERSION_SUFFIX=$gh_branch


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Further builds on #1850, #1887

Summary of changes:
- uses proper CMake syntax to only define VERSION_TAG when it is passed in (before it was always defined, but as an empty string)
- ensures `build-gh.sh` won't unconditionally set `EDGETX_VERSION_SUFFIX` on selfbuilds
- also omits commit SHA on colorlcd (as I had already done that on B&W)

From the testing I've done so far (by overriding `EDGETX_VERSION_TAG` and `EDGETX_VERSION_SUFFIX` in `build-gh.sh`), I know the whole pipeline from `build-gh.sh` correctly showing the tag, or not showing the tag as required, will just need to do another test build with a tag once this is merged to ensure it is being picked up. 

I was tempted to also have VERSION_SUFFIX only defined on existence, but the code logic atm unconditionally expects it to exist if VERSION_TAG doesn't exist, so I left it. 

@rotorman 