### PR TITLE
fix: Radio Settings/SYS module version info lockup

### DIFF
--- a/radio/src/gui/colorlcd/radio_version.cpp
+++ b/radio/src/gui/colorlcd/radio_version.cpp
@@ -173,6 +173,16 @@ class versionDialog: public Dialog
       Dialog::checkEvents();
     }
 
+#if defined(HARDWARE_KEYS)
+    void onEvent(event_t event) override
+    {
+      if (event == EVT_KEY_BREAK(KEY_EXIT) ||
+          event == EVT_KEY_BREAK(KEY_ENTER)) {
+        deleteLater();
+      }
+    }
+#endif
+
   protected:
     rect_t rect;
     TextButton * exitButton;


### PR DESCRIPTION
Fix issue where going SYS>VERSION>Modules / RX version , pressing  "PAGE>" or "PAGE<" while info screen being shown, and then press enter/RTN to EXIT, could result on EM immediatly, when leaving the radio settings, or shortly afterwards. 

<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #1582, #1878, #1901

Summary of changes:
