### PR TITLE
Set the same highest brown-out threshold level for all T16 family radios

### DIFF
--- a/radio/src/targets/horus/CMakeLists.txt
+++ b/radio/src/targets/horus/CMakeLists.txt
@@ -95,6 +95,10 @@ if (PCB STREQUAL X10)
       set(AUX2_SERIAL ON)
     endif()
     set(INTERNAL_GPS_BAUDRATE "9600" CACHE STRING "Baud rate for internal GPS")    
+    set(FIRMWARE_TARGET_SRC
+    ${FIRMWARE_TARGET_SRC}
+       ../../thirdparty/STM32F4xx_DSP_StdPeriph_Lib_V1.8.0/Libraries/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_flash.c
+      )
   elseif (PCBREV STREQUAL TX16S)
     set(FLAVOUR tx16s)
     set(LUA_EXPORT lua_export_t16)
@@ -130,6 +134,10 @@ if (PCB STREQUAL X10)
       set(AUX2_SERIAL ON)
     endif()
     set(INTERNAL_GPS_BAUDRATE "9600" CACHE STRING "Baud rate for internal GPS")    
+    set(FIRMWARE_TARGET_SRC
+    ${FIRMWARE_TARGET_SRC}
+       ../../thirdparty/STM32F4xx_DSP_StdPeriph_Lib_V1.8.0/Libraries/STM32F4xx_StdPeriph_Driver/src/stm32f4xx_flash.c
+      )
   else()
     set(FLAVOUR x10)
     set(DEFAULT_INTERNAL_MODULE XJT_PXX1 CACHE STRING "Default internal module")

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -159,8 +159,7 @@ void boardInit()
                          BACKLIGHT_RCC_APB2Periph,
                          ENABLE);
 
-#if defined(RADIO_TX16S)
-    
+#if defined(RADIO_FAMILY_T16)
   if (FLASH_OB_GetBOR() != OB_BOR_LEVEL3)
   {
     FLASH_OB_Unlock();


### PR DESCRIPTION
All in T16_FAMILY use the same STM32F429BIT6 and the same MCU supply voltage, so IMHO all benefit from this.