### PR TITLE
Fix crash in category Clear (#1897)

### DIFF
--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -740,7 +740,6 @@ class CategoryEditPage : public PageTab
             category->name[0] = ' '; category->name[1] = '\0';            
           }
           modelslist.save();
-          update();
         });
 
         // Details
@@ -749,7 +748,7 @@ class CategoryEditPage : public PageTab
         new StaticText(window, grid.getFieldSlot(3,1), cnt);
 
         if(category->empty()) {
-          new TextButton(window, grid.getFieldSlot(3,2),TR_DELETE, [=]() -> uint8_t {
+          new TextButton(window, grid.getFieldSlot(3,2),STR_DELETE, [=]() -> uint8_t {
             new ConfirmDialog(window, STR_DELETE_CATEGORY,
               std::string(category->name, sizeof(category->name)).c_str(),
               [=] {
@@ -762,7 +761,7 @@ class CategoryEditPage : public PageTab
           } else {
 #ifdef CATEGORIES_SHOW_DELETE_NON_EMPTY
           new TextButton(window, grid.getFieldSlot(3,2),STR_DELETE, [=]() -> uint8_t {
-            new MessageDialog(window, STR_DELETE_CATEGORY, TR_CAT_NOT_EMPTY);
+            new MessageDialog(window, STR_DELETE_CATEGORY, STR_CAT_NOT_EMPTY);
             return 0;
           });
 #endif

--- a/radio/src/storage/modelslist.cpp
+++ b/radio/src/storage/modelslist.cpp
@@ -187,6 +187,7 @@ bool ModelCell::fetchRfData()
 
 ModelsCategory::ModelsCategory(const char * name)
 {
+  memset(this->name, 0, sizeof(this->name));
   strncpy(this->name, name, sizeof(this->name));
 }
 
@@ -194,7 +195,8 @@ ModelsCategory::ModelsCategory(const char * name, uint8_t len)
 {
   if (len > sizeof(this->name)-1)
       len = sizeof(this->name)-1;
-
+      
+  memset(this->name, 0, sizeof(this->name));
   memcpy(this->name, name, len);
   this->name[len] = '\0';
 }


### PR DESCRIPTION
Fixes #1897 

Summary of changes: Removed a call to update() in the changeHandler() of TextEdit.
One cannot call update()/rebuild() from TextEdit.changeHandler().
The reason is long press on ENTER sends two signals: KEY_ENTER and LONG_PRESS.
Both call changeHandler(). The first call causes update() and the screen is build().
So when te second call to changeHandler() comes the corresponding TextEdit is already deleted.
