### PR TITLE
Companion B&W radios clean up sd card MODELS folder before writing updated models to sd card

### DIFF
--- a/companion/src/storage/categorized.h
+++ b/companion/src/storage/categorized.h
@@ -44,6 +44,7 @@ class CategorizedStorageFormat : public StorageFormat
     virtual bool loadFile(QByteArray & fileData, const QString & fileName) = 0;
     virtual bool writeFile(const QByteArray & fileData, const QString & fileName) = 0;
     virtual bool getFileList(std::list<std::string>& filelist) = 0;
+    virtual bool deleteFile(const QString & fileName) = 0;
 
     virtual bool loadBin(RadioData & radioData);
     virtual bool writeBin(const RadioData & radioData);

--- a/companion/src/storage/etx.h
+++ b/companion/src/storage/etx.h
@@ -47,6 +47,7 @@ class EtxFormat : public CategorizedStorageFormat
     virtual bool loadFile(QByteArray & fileData, const QString & fileName);
     virtual bool writeFile(const QByteArray & fileData, const QString & fileName);
     virtual bool getFileList(std::list<std::string>& filelist);
+    virtual bool deleteFile(const QString & fileName) { return false; }
 
     mz_zip_archive zip_archive;
 };

--- a/companion/src/storage/otx.h
+++ b/companion/src/storage/otx.h
@@ -47,6 +47,7 @@ class OtxFormat : public CategorizedStorageFormat
     virtual bool loadFile(QByteArray & fileData, const QString & fileName);
     virtual bool writeFile(const QByteArray & fileData, const QString & fileName);
     virtual bool getFileList(std::list<std::string>& filelist) { return false; }
+    virtual bool deleteFile(const QString & fileName) { return false; }
 
     mz_zip_archive zip_archive;
 };

--- a/companion/src/storage/sdcard.cpp
+++ b/companion/src/storage/sdcard.cpp
@@ -61,11 +61,24 @@ bool SdcardFormat::getFileList(std::list<std::string>& filelist)
 {
   QDir dir(filename);
   if (!dir.cd("MODELS")) return false;
-  
+
   QStringList ql = dir.entryList();
   for (const auto& str : ql) {
     filelist.push_back("MODELS/" + str.toStdString());
   }
+  return true;
+}
+
+bool SdcardFormat::deleteFile(const QString & filename)
+{
+  QString path = this->filename + "/" + filename;
+
+  if (!QFile::remove(path)) {
+    setError(tr("Error deleting file %1").arg(path));
+    return false;
+  }
+
+  qDebug() << "File" << path << "deleted";
   return true;
 }
 

--- a/companion/src/storage/sdcard.h
+++ b/companion/src/storage/sdcard.h
@@ -42,6 +42,7 @@ class SdcardFormat : public CategorizedStorageFormat
     virtual bool loadFile(QByteArray & fileData, const QString & fileName);
     virtual bool writeFile(const QByteArray & fileData, const QString & fileName);
     virtual bool getFileList(std::list<std::string>& filelist);
+    virtual bool deleteFile(const QString & fileName);
 };
 
 class SdcardStorageFactory : public DefaultStorageFactory<SdcardFormat>


### PR DESCRIPTION
Fixes #1696

Summary of changes:
On B&W radios, before writing models to MODELS folder on sd card:
- delete all modelsxx.yml files
- delete models.yml file if it exists

A bit of translation housekeeping