### PR TITLE
No VCP off in menu with iCRSF module

### DIFF
--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -382,6 +382,12 @@ int hasSerialMode(int mode)
 
 bool isSerialModeAvailable(uint8_t port_nr, int mode)
 {
+#if defined(USB_SERIAL)
+  // Do not list OFF on VCP if internal RF module is set to CROSSFIRE to allow pass-through flashing
+  if (port_nr == SP_VCP && mode == UART_MODE_NONE && isInternalModuleCrossfire())
+    return false;
+#endif
+  
   if (mode == UART_MODE_NONE)
     return true;
 


### PR DESCRIPTION
Do not list OFF on VCP menu if internal RF module is set to CRSF to allow pass-through flashing.