### PR TITLE
USB-VCP no OFF if internal RF module is set to CRSF

### DIFF
--- a/companion/src/generaledit/hardware.cpp
+++ b/companion/src/generaledit/hardware.cpp
@@ -82,7 +82,8 @@ public:
 HardwarePanel::HardwarePanel(QWidget * parent, GeneralSettings & generalSettings, Firmware * firmware, CompoundItemModelFactory * sharedItemModels):
   GeneralPanel(parent, generalSettings, firmware),
   board(firmware->getBoard()),
-  editorItemModels(sharedItemModels)
+  editorItemModels(sharedItemModels),
+  serialPortUSBVCP(nullptr)
 {
   editorItemModels->registerItemModel(Boards::potTypeItemModel());
   editorItemModels->registerItemModel(Boards::sliderTypeItemModel());
@@ -226,7 +227,7 @@ HardwarePanel::HardwarePanel(QWidget * parent, GeneralSettings & generalSettings
     addLabel(tr("%1").arg(lbl), row, 0);
     AutoComboBox *serialPortMode = new AutoComboBox(this);
     serialPortMode->setModel(editorItemModels->getItemModel(auxmodelid));
-    serialPortMode->setField(generalSettings.serialPort[GeneralSettings::SP_AUX1]);
+    serialPortMode->setField(generalSettings.serialPort[GeneralSettings::SP_AUX1], this);
     exclGroup->addCombo(serialPortMode);
 
     AutoCheckBox *serialPortPower = new AutoCheckBox(this);
@@ -244,7 +245,7 @@ HardwarePanel::HardwarePanel(QWidget * parent, GeneralSettings & generalSettings
     addLabel(tr("%1").arg(lbl), row, 0);
     AutoComboBox *serialPortMode = new AutoComboBox(this);
     serialPortMode->setModel(editorItemModels->getItemModel(auxmodelid));
-    serialPortMode->setField(generalSettings.serialPort[GeneralSettings::SP_AUX2]);
+    serialPortMode->setField(generalSettings.serialPort[GeneralSettings::SP_AUX2], this);
     exclGroup->addCombo(serialPortMode);
 
     AutoCheckBox *serialPortPower = new AutoCheckBox(this);
@@ -259,11 +260,13 @@ HardwarePanel::HardwarePanel(QWidget * parent, GeneralSettings & generalSettings
 
   if (firmware->getCapability(HasVCPSerialMode)) {
     addLabel(tr("USB-VCP"), row, 0);
-    AutoComboBox *serialPortMode = new AutoComboBox(this);
-    serialPortMode->setModel(editorItemModels->getItemModel(vcpmodelid));
-    serialPortMode->setField(generalSettings.serialPort[GeneralSettings::SP_VCP]);
-    exclGroup->addCombo(serialPortMode);
-    addParams(row, serialPortMode);
+    serialPortUSBVCP = new AutoComboBox(this);
+    serialPortUSBVCP->setModel(editorItemModels->getItemModel(vcpmodelid));
+    serialPortUSBVCP->setField(generalSettings.serialPort[GeneralSettings::SP_VCP], this);
+    exclGroup->addCombo(serialPortUSBVCP);
+    addParams(row, serialPortUSBVCP);
+    connect(this, &HardwarePanel::internalModuleChanged, this, &HardwarePanel::updateSerialPortUSBVCP);
+    updateSerialPortUSBVCP();
   }
 
   if (firmware->getCapability(HasADCJitterFilter)) {
@@ -326,6 +329,7 @@ void HardwarePanel::on_internalModuleChanged()
       generalSettings.internalModuleBaudrate = 0;
       internalModuleBaudRate->setVisible(false);
     }
+
     emit internalModuleChanged();
   }
 }
@@ -421,4 +425,26 @@ void HardwarePanel::addSection(QString text, int & row)
 {
   addLabel(QString("<b>%1</b>").arg(text), row, 0);
   row++;
+}
+
+void HardwarePanel::updateSerialPortUSBVCP()
+{
+  if (!serialPortUSBVCP)
+    return;
+
+  if (m_internalModule == MODULE_TYPE_CROSSFIRE &&
+      generalSettings.serialPort[GeneralSettings::SP_VCP] == GeneralSettings::AUX_SERIAL_OFF) {
+    generalSettings.serialPort[GeneralSettings::SP_VCP] = GeneralSettings::AUX_SERIAL_CLI;
+    serialPortUSBVCP->updateValue();
+  }
+
+  auto view = dynamic_cast<QListView*>(serialPortUSBVCP->view());
+  Q_ASSERT(view);
+
+  for (int i = 0; i < serialPortUSBVCP->count(); i++) {
+    if (m_internalModule == MODULE_TYPE_CROSSFIRE && i == GeneralSettings::AUX_SERIAL_OFF)
+      view->setRowHidden(i, true);
+    else
+      view->setRowHidden(i, false);
+  }
 }

--- a/companion/src/generaledit/hardware.h
+++ b/companion/src/generaledit/hardware.h
@@ -49,6 +49,7 @@ class HardwarePanel : public GeneralPanel
     AutoComboBox *internalModule;
     unsigned int m_internalModule = 0;
     AutoComboBox *internalModuleBaudRate;
+    AutoComboBox *serialPortUSBVCP;
 
     void addStick(int index, int & row);
     void addPot(int index, int & row);
@@ -58,4 +59,6 @@ class HardwarePanel : public GeneralPanel
     void addLine(int & row);
     void addParams(int & row, QWidget * widget1, QWidget * widget2 = nullptr);
     void addSection(QString text, int & row);
+
+    void updateSerialPortUSBVCP();
 };

--- a/radio/src/gui/colorlcd/radio_hardware.cpp
+++ b/radio/src/gui/colorlcd/radio_hardware.cpp
@@ -312,6 +312,11 @@ class InternalModuleWindow : public FormGroup {
             restartModule(INTERNAL_MODULE);
           });
       grid.nextLine();
+      #if defined(USB_SERIAL)
+        // If USB-VCP was off, set it to CLI to enable passthrough flashing
+        if (serialGetMode(SP_VCP) ==  UART_MODE_NONE)
+          serialSetMode(SP_VCP, UART_MODE_CLI);
+      #endif
     }
 #endif
     getParent()->moveWindowsTop(top() + 1, adjustHeight());

--- a/radio/src/gui/common/stdlcd/radio_hardware.cpp
+++ b/radio/src/gui/common/stdlcd/radio_hardware.cpp
@@ -532,6 +532,11 @@ void menuRadioHardware(event_t event)
           memclear(&g_model.moduleData[INTERNAL_MODULE], sizeof(ModuleData));
           storageDirty(EE_MODEL);
           storageDirty(EE_GENERAL);
+        #if defined(CROSSFIRE) && defined(USB_SERIAL)
+          // If USB-VCP was off, set it to CLI to enable passthrough flashing
+          if (isInternalModuleCrossfire() && serialGetMode(SP_VCP) ==  UART_MODE_NONE)
+            serialSetMode(SP_VCP, UART_MODE_CLI);
+        #endif
         }
       } break;
 #endif

--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -382,6 +382,12 @@ int hasSerialMode(int mode)
 
 bool isSerialModeAvailable(uint8_t port_nr, int mode)
 {
+#if defined(USB_SERIAL)
+  // Do not list OFF on VCP if internal RF module is set to CROSSFIRE to allow pass-through flashing
+  if (port_nr == SP_VCP && mode == UART_MODE_NONE && isInternalModuleCrossfire())
+    return false;
+#endif
+  
   if (mode == UART_MODE_NONE)
     return true;
 

--- a/radio/src/storage/storage_common.cpp
+++ b/radio/src/storage/storage_common.cpp
@@ -89,7 +89,7 @@ void postRadioSettingsLoad()
 #if defined(USB_SERIAL)
   // default VCP to CLI if not configured
   // to something else as NONE.
-  if (serialGetMode(SP_VCP) == UART_MODE_NONE) {
+  if (isInternalModuleCrossfire() && serialGetMode(SP_VCP) == UART_MODE_NONE) {
     serialSetMode(SP_VCP, UART_MODE_CLI);
   }
 #endif


### PR DESCRIPTION
Stops listing OFF as an option on USB-VCP menu, if internal RF module is set to CRSF (to allow pass-through flashing). If USB-VCP was set to OFF and internal module is changed to CRSF, changes USB-VCP automatically to CLI.

Tackles #1952 

Tested with TX16S mkII and Zorro.