### PR TITLE
Companion add new model actions template and prompt

### DIFF
--- a/companion/src/apppreferencesdialog.cpp
+++ b/companion/src/apppreferencesdialog.cpp
@@ -80,7 +80,7 @@ void AppPreferencesDialog::accept()
   g.promptProfile(ui->chkPromptProfile->isChecked());
   g.simuSW(ui->simuSW->isChecked());
   g.removeModelSlots(ui->opt_removeBlankSlots->isChecked());
-  g.newModelAction(ui->opt_newMdl_useWizard->isChecked() ? AppData::MODEL_ACT_WIZARD : ui->opt_newMdl_useEditor->isChecked() ? AppData::MODEL_ACT_EDITOR : AppData::MODEL_ACT_NONE);
+  g.newModelAction((AppData::NewModelAction)ui->cboNewModelAction->currentIndex());
   g.historySize(ui->historySize->value());
   g.backLight(ui->backLightColor->currentIndex());
   profile.volumeGain(round(ui->volumeGain->value() * 10.0));
@@ -207,9 +207,8 @@ void AppPreferencesDialog::initSettings()
 
   ui->simuSW->setChecked(g.simuSW());
   ui->opt_removeBlankSlots->setChecked(g.removeModelSlots());
-  ui->opt_newMdl_useNone->setChecked(g.newModelAction() == AppData::MODEL_ACT_NONE);
-  ui->opt_newMdl_useWizard->setChecked(g.newModelAction() == AppData::MODEL_ACT_WIZARD);
-  ui->opt_newMdl_useEditor->setChecked(g.newModelAction() == AppData::MODEL_ACT_EDITOR);
+  ui->cboNewModelAction->addItems(AppData::newModelActionsList());
+  ui->cboNewModelAction->setCurrentIndex(g.newModelAction());
   ui->libraryPath->setText(g.libDir());
   ui->ge_lineedit->setText(g.gePath());
 

--- a/companion/src/apppreferencesdialog.ui
+++ b/companion/src/apppreferencesdialog.ui
@@ -45,7 +45,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="profileTab">
       <attribute name="title">
@@ -887,40 +887,6 @@ Mode 4:
            </item>
           </layout>
          </item>
-         <item row="10" column="1">
-          <layout class="QHBoxLayout" name="horizontalLayout_2">
-           <item>
-            <widget class="QRadioButton" name="opt_newMdl_useWizard">
-             <property name="text">
-              <string>Use model wizard</string>
-             </property>
-             <attribute name="buttonGroup">
-              <string notr="true">btnGrp_newModelActions</string>
-             </attribute>
-            </widget>
-           </item>
-           <item>
-            <widget class="QRadioButton" name="opt_newMdl_useEditor">
-             <property name="text">
-              <string>Open model editor</string>
-             </property>
-             <attribute name="buttonGroup">
-              <string notr="true">btnGrp_newModelActions</string>
-             </attribute>
-            </widget>
-           </item>
-           <item>
-            <widget class="QRadioButton" name="opt_newMdl_useNone">
-             <property name="text">
-              <string>Just create the model</string>
-             </property>
-             <attribute name="buttonGroup">
-              <string notr="true">btnGrp_newModelActions</string>
-             </attribute>
-            </widget>
-           </item>
-          </layout>
-         </item>
          <item row="14" column="1">
           <layout class="QHBoxLayout" name="horizontalLayout_8">
            <item>
@@ -1189,6 +1155,9 @@ Mode 4:
             <string>Prompt for radio profile</string>
            </property>
           </widget>
+         </item>
+         <item row="10" column="1">
+          <widget class="QComboBox" name="cboNewModelAction"/>
          </item>
         </layout>
        </item>

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1346,6 +1346,11 @@ void MdiChild::newFile(bool createDefaults)
 
 bool MdiChild::loadFile(const QString & filename, bool resetCurrentFile)
 {
+  if (getStorageType(filename) == STORAGE_TYPE_YML) {
+    newFile(false);
+    resetCurrentFile = false;
+  }
+
   Storage storage(filename);
   if (!storage.load(radioData)) {
     QMessageBox::critical(this, CPN_STR_TTL_ERROR, storage.error());
@@ -1360,6 +1365,10 @@ bool MdiChild::loadFile(const QString & filename, bool resetCurrentFile)
   if (resetCurrentFile) {
     setCurrentFile(filename);
   }
+
+  //  set after successful import
+  if (getStorageType(filename) == STORAGE_TYPE_YML)
+    setModified();
 
   //  For etx files this will never be true as any conversion occurs when parsing file
   if (!Boards::isBoardCompatible(storage.getBoard(), getCurrentBoard())) {

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1761,6 +1761,8 @@ void MdiChild::openModelPrompt(int row)
   msgBox.setWindowTitle(CPN_STR_APP_NAME);
   msgBox.setIcon(QMessageBox::Question);
   msgBox.setText(tr("Add a new model using"));
+  QPushButton *defaultsButton = msgBox.addButton(tr("Defaults"),QMessageBox::ActionRole);
+  QPushButton *editButton = msgBox.addButton(tr("Edit"),QMessageBox::ActionRole);
   QPushButton *wizardButton = msgBox.addButton(tr("Wizard"),QMessageBox::ActionRole);
   QPushButton *templateButton = msgBox.addButton(tr("Template"),QMessageBox::ActionRole);
   QPushButton *cancelButton = msgBox.addButton(QMessageBox::Cancel);
@@ -1768,7 +1770,16 @@ void MdiChild::openModelPrompt(int row)
   msgBox.exec();
 
   if (msgBox.clickedButton() == cancelButton) {
+      if (!deleteModel(row))
+        QMessageBox::critical(this, CPN_STR_APP_NAME, tr("Failed to remove temporary model!"));
       return;
+  }
+  else if (msgBox.clickedButton() == defaultsButton) {
+      //  nothing to do here
+      return;
+  }
+  else if (msgBox.clickedButton() == editButton) {
+      openModelEditWindow(row);
   }
   else if (msgBox.clickedButton() == wizardButton) {
       openModelWizard(row);

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1709,13 +1709,28 @@ void MdiChild::openModelTemplate(int row)
   if (row < 0 && (row = getCurrentModel()) < 0)
     return;
 
-  QString fileName = QFileDialog::getOpenFileName(this, tr("Select a model template file"), QDir::toNativeSeparators(g.profile[g.id()].sdPath() + "/TEMPLATES"), YML_FILES_FILTER);
+  QString filename = QFileDialog::getOpenFileName(this, tr("Select a model template file"), QDir::toNativeSeparators(g.profile[g.id()].sdPath() + "/TEMPLATES"), YML_FILES_FILTER);
 
-  if (fileName.isEmpty())
+  if (filename.isEmpty())
     return;
 
   //  validate like read single model
   //  if okay copy into current model slot
+
+  RadioData data;
+
+  Storage storage(filename);
+  if (!storage.load(data)) {
+    QMessageBox::critical(this, CPN_STR_TTL_ERROR, storage.error());
+    return;
+  }
+
+  QString warning = storage.warning();
+  if (!warning.isEmpty()) {
+    QMessageBox::warning(this, CPN_STR_TTL_WARNING, warning);
+  }
+
+  radioData.models[row] = data.models[0];
 
   openModelEditWindow(row);
 }

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -903,8 +903,14 @@ int MdiChild::newModel(int modelIndex, int categoryIndex)
   setSelectedModel(modelIndex);
   //qDebug() << modelIndex << categoryIndex << isNewModel;
 
-  if (isNewModel && g.newModelAction() == AppData::MODEL_ACT_WIZARD)
-    openModelWizard(modelIndex);
+  if (isNewModel) {
+    if (g.newModelAction() == AppData::MODEL_ACT_WIZARD)
+      openModelWizard(modelIndex);
+    else if (g.newModelAction() == AppData::MODEL_ACT_TEMPLATE)
+      openModelTemplate(modelIndex);
+    else if (g.newModelAction() == AppData::MODEL_ACT_PROMPT)
+      openModelPrompt(modelIndex);
+  }
   else if (g.newModelAction() == AppData::MODEL_ACT_EDITOR)
     openModelEditWindow(modelIndex);
 
@@ -1696,4 +1702,49 @@ void MdiChild::onInternalModuleChanged()
   }
 
   delete fim;
+}
+
+void MdiChild::openModelTemplate(int row)
+{
+  if (row < 0 && (row = getCurrentModel()) < 0)
+    return;
+
+  QString fileName = QFileDialog::getOpenFileName(this, tr("Select a model template file"), QDir::toNativeSeparators(g.profile[g.id()].sdPath() + "/TEMPLATES"), YML_FILES_FILTER);
+
+  if (fileName.isEmpty())
+    return;
+
+  //  validate like read single model
+  //  if okay copy into current model slot
+
+  openModelEditWindow(row);
+}
+
+void MdiChild::openModelPrompt(int row)
+{
+  if (row < 0 && (row = getCurrentModel()) < 0)
+    return;
+
+  QMessageBox msgBox;
+  msgBox.setWindowTitle(CPN_STR_APP_NAME);
+  msgBox.setIcon(QMessageBox::Question);
+  msgBox.setText(tr("Add a new model using"));
+  QPushButton *createButton = msgBox.addButton(tr("Defaults"), QMessageBox::ActionRole);
+  QPushButton *wizardButton = msgBox.addButton(tr("Wizard"),QMessageBox::ActionRole);
+  QPushButton *templateButton = msgBox.addButton(tr("Template"),QMessageBox::ActionRole);
+  QPushButton *cancelButton = msgBox.addButton(QMessageBox::Cancel);
+
+  msgBox.exec();
+
+  if (msgBox.clickedButton() == createButton || msgBox.clickedButton() == cancelButton) {
+      return;
+  }
+  else if (msgBox.clickedButton() == wizardButton) {
+      openModelWizard(row);
+  }
+  else if (msgBox.clickedButton() == templateButton) {
+      openModelTemplate(row);
+  }
+
+  return;
 }

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -910,6 +910,8 @@ int MdiChild::newModel(int modelIndex, int categoryIndex)
       openModelTemplate(modelIndex);
     else if (g.newModelAction() == AppData::MODEL_ACT_PROMPT)
       openModelPrompt(modelIndex);
+    else if (g.newModelAction() == AppData::MODEL_ACT_EDITOR)
+      openModelEditWindow(modelIndex);
   }
   else if (g.newModelAction() == AppData::MODEL_ACT_EDITOR)
     openModelEditWindow(modelIndex);

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1729,14 +1729,13 @@ void MdiChild::openModelPrompt(int row)
   msgBox.setWindowTitle(CPN_STR_APP_NAME);
   msgBox.setIcon(QMessageBox::Question);
   msgBox.setText(tr("Add a new model using"));
-  QPushButton *createButton = msgBox.addButton(tr("Defaults"), QMessageBox::ActionRole);
   QPushButton *wizardButton = msgBox.addButton(tr("Wizard"),QMessageBox::ActionRole);
   QPushButton *templateButton = msgBox.addButton(tr("Template"),QMessageBox::ActionRole);
   QPushButton *cancelButton = msgBox.addButton(QMessageBox::Cancel);
 
   msgBox.exec();
 
-  if (msgBox.clickedButton() == createButton || msgBox.clickedButton() == cancelButton) {
+  if (msgBox.clickedButton() == cancelButton) {
       return;
   }
   else if (msgBox.clickedButton() == wizardButton) {

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1741,6 +1741,14 @@ void MdiChild::openModelTemplate(int row)
 
   radioData.models[row] = data.models[0];
 
+  //  reset module bindings
+  for (int i = 0; i < CPN_MAX_MODULES; i++) {
+    radioData.models[row].moduleData[i].modelId = row + 1;
+  }
+
+  setModified();
+  setSelectedModel(row);
+
   openModelEditWindow(row);
 }
 

--- a/companion/src/mdichild.h
+++ b/companion/src/mdichild.h
@@ -138,6 +138,8 @@ class MdiChild : public QWidget
 
     void openModelWizard(int row = -1);
     void openModelEditWindow(int row = -1);
+    void openModelTemplate(int row = -1);
+    void openModelPrompt(int row = -1);
 
     void setDefault();
     void modelSimulate();

--- a/companion/src/storage/appdata.h
+++ b/companion/src/storage/appdata.h
@@ -451,9 +451,13 @@ class AppData: public CompStoreObj
     enum NewModelAction {
       MODEL_ACT_NONE,
       MODEL_ACT_WIZARD,
-      MODEL_ACT_EDITOR
+      MODEL_ACT_EDITOR,
+      MODEL_ACT_TEMPLATE,
+      MODEL_ACT_PROMPT
     };
     Q_ENUM(NewModelAction)
+
+    static QStringList newModelActionsList() { return { tr("None"), tr("Wizard"), tr("Edit"), tr("Template"), tr("Prompt") } ; }
 
     explicit AppData();
     void init() override;

--- a/companion/src/storage/appdata.h
+++ b/companion/src/storage/appdata.h
@@ -457,7 +457,7 @@ class AppData: public CompStoreObj
     };
     Q_ENUM(NewModelAction)
 
-    static QStringList newModelActionsList() { return { tr("None"), tr("Wizard"), tr("Edit"), tr("Template"), tr("Prompt") } ; }
+    static QStringList newModelActionsList() { return { tr("None"), tr("Wizard"), tr("Editor"), tr("Template"), tr("Prompt") } ; }
 
     explicit AppData();
     void init() override;

--- a/companion/src/storage/yaml.cpp
+++ b/companion/src/storage/yaml.cpp
@@ -19,13 +19,16 @@
  */
 
 #include "yaml.h"
+#include "edgetxinterface.h"
+#include "eeprominterface.h"
+#include "yaml_ops.h"
 
 #include <QFile>
 #include <QDir>
 
-bool YamlFormat::loadFile(QByteArray & filedata, const QString & filename)
+bool YamlFormat::loadFile(QByteArray & filedata)
 {
-  QString path = this->filename + "/" + filename;
+  QString path = filename;
   QFile file(path);
   if (!file.open(QFile::ReadOnly)) {
     setError(tr("Error opening file %1:\n%2.").arg(path).arg(file.errorString()));
@@ -53,14 +56,69 @@ bool YamlFormat::writeFile(const QByteArray & filedata, const QString & filename
 
 bool YamlFormat::load(RadioData & radioData)
 {
-  QByteArray radioSettingsBuffer;
-  if (!loadFile(radioSettingsBuffer, "RADIO/radio.yml")) {
-    setError(tr("Can't extract RADIO/radio.yml"));
+  bool hasCategories = getCurrentFirmware()->getCapability(HasModelCategories);
+  int modelIdx = 0;
+
+  QByteArray data;
+  if (!loadFile(data)) {
+    setError(tr("Cannot read %1").arg(filename));
     return false;
   }
 
-  qDebug() << "Warning: format ignored - under development";
-  return false; // force failure until fully developed
+  std::istringstream data_istream(data.toStdString());
+  YAML::Node node = YAML::Load(data_istream);
+
+  board = getCurrentBoard();
+
+  if (!node.IsMap()) {
+    setError(tr("File %1 is not a valid format").arg(filename));
+    return false;
+  }
+
+  if (node["header"].IsMap()) {
+    qDebug() << "File" << filename << "appears to contain model data";
+
+    if (hasCategories) {
+      CategoryData category(qPrintable(tr("New category")));
+      radioData.categories.push_back(category);
+    }
+
+    radioData.models.resize(1);
+
+    auto& model = radioData.models[modelIdx];
+
+    try {
+      if (!loadModelFromYaml(model, data)) {
+        setError(tr("Cannot load ") + filename);
+        return false;
+      }
+    } catch(const std::runtime_error& e) {
+      setError(tr("Cannot load ") + filename + ":\n" + QString(e.what()));
+      return false;
+    }
+
+    model.category = 0;
+    model.modelIndex = modelIdx;
+    strncpy(model.filename, qPrintable(filename), sizeof(model.filename) - 1);
+    model.used = true;
+
+    strncpy(radioData.generalSettings.currModelFilename, qPrintable(filename), sizeof(radioData.generalSettings.currModelFilename) - 1);
+    radioData.generalSettings.currModelIndex = modelIdx;
+    //  without knowing the radio this model came from the old to new radio conversion can cause more issues than it tries to solve
+    //  so leave fixing incompatibilities to the user
+    radioData.generalSettings.variant = getCurrentBoard();
+
+    setWarning(tr("Please check all radio and model settings as no conversion could be performed."));
+    return true;
+  }
+  else if (node["board"].IsScalar()) {
+    setError(tr("File %1 appears to contain radio settings and importing is unsupported.").arg(filename));
+  }
+  else {
+    setError(tr("Unable to determine content type for file %1").arg(filename));
+  }
+
+  return false;
 }
 
 bool YamlFormat::write(const RadioData & radioData)

--- a/companion/src/storage/yaml.h
+++ b/companion/src/storage/yaml.h
@@ -39,6 +39,6 @@ class YamlFormat : public StorageFormat
     virtual bool write(const RadioData & radioData);
 
   protected:
-    bool loadFile(QByteArray & fileData, const QString & fileName);
+    bool loadFile(QByteArray & fileData);
     bool writeFile(const QByteArray & fileData, const QString & fileName);
 };


### PR DESCRIPTION
Enhancement #1953

Summary of changes:
- change new model actions from series of radio buttons to dropdown list
- add new model actions template and prompt
- selecting template launches the open files dialog in the application sd card/TEMPLATES directory with a yml filter. However, there is no restriction on were you can import a template from. After selecting a model file the edit dialog is opened.

If new action Prompt is selected this dialog is displayed

![Screenshot from 2022-05-16 22-05-27](https://user-images.githubusercontent.com/15316949/168588998-f0c3785a-e742-4405-a51f-a2f00009a6ac.png)

Selecting Cancel will delete the temporary model.

Note: this PR includes PR 1959 as it needs to be able to open individual model files. It has been cherry picked into commits.