### PR TITLE
Fixes issue #1966

### DIFF
--- a/radio/src/functions.cpp
+++ b/radio/src/functions.cpp
@@ -350,7 +350,7 @@ void evalFunctions(const CustomFunctionData * functions, CustomFunctionsContext 
           case FUNC_LOGS:
             if (CFN_PARAM(cfn)) {
               newActiveFunctions |= (1u << FUNCTION_LOGS);
-              logDelay = CFN_PARAM(cfn);
+              logDelay100ms = CFN_PARAM(cfn);                   // logging period is 0..25.5s in 100ms increments
             }
             break;
 #endif

--- a/radio/src/main.cpp
+++ b/radio/src/main.cpp
@@ -484,6 +484,10 @@ void guiMain(event_t evt)
 }
 #endif
 
+#if !defined(SIMU)
+  void initLoggingTimer();
+#endif
+
 void perMain()
 {
   DEBUG_TIMER_START(debugTimerPerMain1);
@@ -493,7 +497,12 @@ void perMain()
 
   if (!usbPlugged() || (getSelectedUsbMode() == USB_UNSELECTED_MODE)) {
     checkEeprom();
-    logsWrite();
+    
+    #if !defined(SIMU)     // use FreeRTOS software timer if radio firmware
+      initLoggingTimer();  // initialize software timer for logging
+    #else
+      logsWrite();         // call logsWrite the old way for simu
+    #endif
   }
 
   handleUsbConnection();

--- a/radio/src/sdcard.h
+++ b/radio/src/sdcard.h
@@ -110,7 +110,7 @@ const char RADIO_SETTINGS_YAML_PATH[] = RADIO_PATH PATH_SEPARATOR "radio.yml";
   filename[sizeof(path)+sizeof(var)] = '\0'; \
   strcat(&filename[sizeof(path)], ext)
 
-extern uint8_t logDelay;
+extern uint8_t logDelay100ms;
 void logsInit();
 void logsClose();
 void logsWrite();


### PR DESCRIPTION
Fixes https://github.com/EdgeTX/edgetx/issues/1966

Summary of changes
- simulator: allow for one get_tmr10ms() tick (10ms) deviation
- radio: switched to FreeRTOS software timer at user requested period
- code cleanup:
  log.cpp: made variable lastLogTime static
  log.cpp: deleted unused variable g_logError
  functions.cpp, logs.cpp, sdcard.h: renamed variable logDelay to logDelay100ms to show it is scaled to 100ms increments
