### PR TITLE
Companion save individual models

### DIFF
--- a/companion/src/mdichild.h
+++ b/companion/src/mdichild.h
@@ -59,6 +59,7 @@ class MdiChild : public QWidget
       ACT_MDL_DUP,
       ACT_MDL_INS,
       ACT_MDL_MOV,
+      ACT_MDL_SAV,
       ACT_MDL_RTR,  // ResToRe backup
       ACT_MDL_WIZ,
       ACT_MDL_DFT,  // set as DeFaulT
@@ -132,6 +133,7 @@ class MdiChild : public QWidget
     void categoryAdd();
     void modelAdd();
     void modelEdit();
+    void modelSave();
     void wizardEdit();
     void modelDuplicate();
     void onModelMoveToCategory();
@@ -175,6 +177,9 @@ class MdiChild : public QWidget
     void moveModelsToCategory(const QVector<int> models, const int toCategoryId);
     void moveSelectedModelsToCat(const int toCategoryId);
     unsigned countUsedModels(const int categoryId = -1);
+    unsigned saveModels(const QVector<int> modelIndices);
+    bool saveModel(const int modelIndex);
+    void saveSelectedModels();
 
     void clearCutList();
     void removeModelFromCutList(const int modelIndex);

--- a/companion/src/storage/storage.cpp
+++ b/companion/src/storage/storage.cpp
@@ -121,6 +121,20 @@ bool Storage::write(const RadioData & radioData)
   return ret;
 }
 
+bool Storage::writeModel(const RadioData & radioData, const int modelIndex)
+{
+  bool ret = false;
+  foreach(StorageFactory * factory, registeredStorageFactories) {
+    if (factory->probe(filename)) {
+      StorageFormat * format = factory->instance(filename);
+      ret = format->writeModel(radioData, modelIndex);
+      delete format;
+      break;
+    }
+  }
+  return ret;
+}
+
 bool convertEEprom(const QString & sourceEEprom, const QString & destinationEEprom, const QString & firmwareFilename)
 {
   FirmwareInterface firmware(firmwareFilename);

--- a/companion/src/storage/storage.h
+++ b/companion/src/storage/storage.h
@@ -57,6 +57,7 @@ class StorageFormat
     virtual ~StorageFormat() {}
     virtual bool load(RadioData & radioData) = 0;
     virtual bool write(const RadioData & radioData) = 0;
+    virtual bool writeModel(const RadioData & radioData, const int modelIndex) { return false; }
 
     QString error() {
       return _error;
@@ -157,6 +158,7 @@ class Storage : public StorageFormat
 
     virtual bool load(RadioData & radioData);
     virtual bool write(const RadioData & radioData);
+    virtual bool writeModel(const RadioData & radioData, const int modelIndex);
 };
 
 void registerStorageFactories();

--- a/companion/src/storage/yaml.cpp
+++ b/companion/src/storage/yaml.cpp
@@ -40,9 +40,9 @@ bool YamlFormat::loadFile(QByteArray & filedata)
   return true;
 }
 
-bool YamlFormat::writeFile(const QByteArray & filedata, const QString & filename)
+bool YamlFormat::writeFile(const QByteArray & filedata)
 {
-  QString path = this->filename + "/" + filename;
+  QString path = filename;
   QFile file(path);
   if (!file.open(QFile::WriteOnly)) {
     setError(tr("Error opening file %1 in write mode:\n%2.").arg(path).arg(file.errorString()));
@@ -121,21 +121,16 @@ bool YamlFormat::load(RadioData & radioData)
   return false;
 }
 
-bool YamlFormat::write(const RadioData & radioData)
+bool YamlFormat::writeModel(const RadioData & radioData, const int modelIndex)
 {
-  /*  Need this test in case of a new sdcard
-  Board::Type board = getCurrentBoard();
-  if (!HAS_EEPROM_YAML(board)) {
-    qDebug() << "Board does not support YAML format";
+  if (modelIndex < 0 || modelIndex >= (int)radioData.models.size() || radioData.models[modelIndex].isEmpty())
     return false;
-  }
 
-  // ensure directories exist on sd card
-  QDir dir(filename);
-  dir.mkdir("RADIO");
-  dir.mkdir("MODELS");
-  */
+  QByteArray modelData;
+  writeModelToYaml(radioData.models[modelIndex], modelData);
 
-  qDebug() << "Warning: format ignored - under development";
-  return false; // force failure until fully developed
+  if (!writeFile(modelData))
+    return false;
+
+  return true;
 }

--- a/companion/src/storage/yaml.h
+++ b/companion/src/storage/yaml.h
@@ -36,9 +36,10 @@ class YamlFormat : public StorageFormat
 
     virtual QString name() { return "yml"; }
     virtual bool load(RadioData & radioData);
-    virtual bool write(const RadioData & radioData);
+    virtual bool write(const RadioData & radioData) { return false; }
+    virtual bool writeModel(const RadioData & radioData, const int modelIndex) override;
 
   protected:
     bool loadFile(QByteArray & fileData);
-    bool writeFile(const QByteArray & fileData, const QString & fileName);
+    bool writeFile(const QByteArray & fileData);
 };


### PR DESCRIPTION
Fixes #1965

Summary of changes:
- add save model(s) to models and settings menus and toolbars
- new storage functions to support single model write
- modified yml storage format write functions
- default save directory is application sd card TEMPLATES
- model name used as default file name

Note: builds upon PR 1959 and 1963 which have been cherry picked into this PR