### PR TITLE
Stop Companion crashing due to malformed theme.yml files

### DIFF
--- a/companion/src/modeledit/colorcustomscreens.cpp
+++ b/companion/src/modeledit/colorcustomscreens.cpp
@@ -81,18 +81,24 @@ UserInterfacePanel::UserInterfacePanel(QWidget * parent, ModelData & model, Gene
 
     if (QFile(selThemeDetails).exists()) {
 
-      YAML::Node node = YAML::LoadFile(selThemeDetails.toStdString());
-      if (node["summary"]) {
-        const auto &summary = node["summary"];
-        if (summary.IsMap()) {
-          if (summary["name"].IsScalar())
-            themeName = summary["name"].as<std::string>();
-          if (summary["author"].IsScalar())
-            themeAuthor = summary["author"].as<std::string>();
-          if (summary["info"].IsScalar())
-            themeInfo = summary["info"].as<std::string>();
+      try {
+        YAML::Node node = YAML::LoadFile(selThemeDetails.toStdString());
+
+        if (node["summary"]) {
+          const auto &summary = node["summary"];
+          if (summary.IsMap()) {
+            if (summary["name"].IsScalar())
+              themeName = summary["name"].as<std::string>();
+            if (summary["author"].IsScalar())
+              themeAuthor = summary["author"].as<std::string>();
+            if (summary["info"].IsScalar())
+              themeInfo = summary["info"].as<std::string>();
+          }
         }
+      } catch(const std::runtime_error& e) {
+          QMessageBox::warning(this, CPN_STR_APP_NAME, tr("Cannot load %1").arg(selThemeDetails) + ":\n" + QString(e.what()));
       }
+
     }
   }
 


### PR DESCRIPTION
Fixes #1961
Fixes #1517

Summary of changes:
- trap and report YAML parsing errors when processing theme.yml files
- continuing loading model

Example
![Screenshot from 2022-05-16 22-27-33](https://user-images.githubusercontent.com/15316949/168593356-0bbd628d-f025-4f7d-9c26-76cb9381df16.png)
