### PR TITLE
NV14: Corrects negative altitude when the real value is over 300 meters...

### DIFF
--- a/radio/src/telemetry/flysky_nv14.cpp
+++ b/radio/src/telemetry/flysky_nv14.cpp
@@ -89,7 +89,7 @@ extern uint32_t NV14internalModuleFwVersion;
 
 extern int32_t getALT(uint32_t value);
 
-signed short CalculateAltitude(unsigned int pressure)
+int32_t CalculateAltitude(unsigned int pressure)
 {
   int32_t alt = getALT(pressure);
   return alt;


### PR DESCRIPTION
Corrects negative altitude when the real value is over 300 meters above the ground

problem video:
https://www.youtube.com/watch?v=HgxIYUSzpnM

discussion of the problem:
https://github.com/EdgeTX/edgetx/issues/1971