### PR TITLE
Fix pot and slider warnings in Companion and radios

### DIFF
--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -1467,8 +1467,10 @@ SetupPanel::SetupPanel(QWidget * parent, ModelData & model, GeneralSettings & ge
 
   // Pot warnings
   prevFocus = ui->potWarningMode;
-  if (IS_HORUS_OR_TARANIS(board)) {
-    for (int i = 0; i < getBoardCapability(board, Board::Pots) + getBoardCapability(board, Board::Sliders); i++) {
+  int count = getBoardCapability(board, Board::Pots) + getBoardCapability(board, Board::Sliders);
+
+  if (IS_HORUS_OR_TARANIS(board) && count > 0) {
+    for (int i = 0; i < count; i++) {
       RawSource src(SOURCE_TYPE_STICK, CPN_MAX_STICKS + i);
       QCheckBox * cb = new QCheckBox(this);
       cb->setProperty("index", i);

--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -1775,7 +1775,7 @@ void SetupPanel::updatePotWarnings()
   for (int i = 0; i < potWarningCheckboxes.size(); i++) {
     QCheckBox *checkbox = potWarningCheckboxes[i];
     int index = checkbox->property("index").toInt();
-    checkbox->setChecked(!model->potsWarnEnabled[index]);
+    checkbox->setChecked(model->potsWarnEnabled[index]);
     checkbox->setDisabled(model->potsWarningMode == 0);
   }
   lock = false;
@@ -1785,7 +1785,7 @@ void SetupPanel::potWarningToggled(bool checked)
 {
   if (!lock) {
     int index = sender()->property("index").toInt();
-    model->potsWarnEnabled[index] = !checked;
+    model->potsWarnEnabled[index] = checked;
     updatePotWarnings();
     emit modified();
   }

--- a/companion/src/modeledit/setup.ui
+++ b/companion/src/modeledit/setup.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>1007</width>
+    <width>1024</width>
     <height>435</height>
    </rect>
   </property>
@@ -192,7 +192,7 @@
           </font>
          </property>
          <property name="text">
-          <string></string>
+          <string/>
          </property>
          <property name="alignment">
           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -378,7 +378,7 @@
          <item alignment="Qt::AlignTop">
           <widget class="QLabel" name="label_potWarning">
            <property name="text">
-            <string>Pot Warnings</string>
+            <string>Pot/Slider Warnings</string>
            </property>
           </widget>
          </item>
@@ -548,19 +548,19 @@
        </item>
        <item row="1" column="3">
         <widget class="QSpinBox" name="customThrottleWarningPosition">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimum">
-         <number>-100</number>
-        </property>
-        <property name="maximum">
-         <number>100</number>
-        </property>
-       </widget>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimum">
+          <number>-100</number>
+         </property>
+         <property name="maximum">
+          <number>100</number>
+         </property>
+        </widget>
        </item>
        <item row="2" column="3">
         <widget class="QCheckBox" name="displayText">
@@ -617,7 +617,6 @@
          </item>
         </widget>
        </item>
-
        <item row="2" column="4">
         <widget class="QPushButton" name="editText">
          <property name="sizePolicy">

--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -906,7 +906,7 @@ void menuModelSetup(event_t event)
             }
             else {
               LcdFlags flags = ((menuHorizontalPosition==i+1) && attr) ? BLINK : 0;
-              if ((!attr || menuHorizontalPosition >= 0) && !(g_model.potsWarnEnabled & (1 << i))) {
+              if ((!attr || menuHorizontalPosition >= 0) && (g_model.potsWarnEnabled & (1 << i))) {
                 flags |= INVERS;
               }
 

--- a/radio/src/gui/212x64/model_setup.cpp
+++ b/radio/src/gui/212x64/model_setup.cpp
@@ -405,7 +405,7 @@ void menuModelSetup(event_t event)
     0, // Global functions
 
     0, // ADC Jitter filter
-    
+
     REGISTRATION_ID_ROWS
 
     LABEL(InternalModule),
@@ -822,7 +822,7 @@ void menuModelSetup(event_t event)
               }
 #endif
               LcdFlags flags = ((menuHorizontalPosition==i+1) && attr) ? BLINK : 0;
-              if ((!attr || menuHorizontalPosition >= 0) && !(g_model.potsWarnEnabled & (1 << i))) {
+              if ((!attr || menuHorizontalPosition >= 0) && (g_model.potsWarnEnabled & (1 << i))) {
                 flags |= INVERS;
               }
 

--- a/radio/src/storage/storage_common.cpp
+++ b/radio/src/storage/storage_common.cpp
@@ -243,7 +243,7 @@ void storageFlushCurrentModel()
 
   if (g_model.potsWarnMode == POTS_WARN_AUTO) {
     for (int i=0; i<NUM_POTS+NUM_SLIDERS; i++) {
-      if (!(g_model.potsWarnEnabled & (1 << i))) {
+      if (g_model.potsWarnEnabled & (1 << i)) {
         SAVE_POT_POSITION(i);
       }
     }

--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -796,7 +796,7 @@ void checkSwitches()
           if (!IS_POT_SLIDER_AVAILABLE(POT1+i)) {
             continue;
           }
-          if (!(g_model.potsWarnEnabled & (1 << i))) {
+          if (g_model.potsWarnEnabled & (1 << i)) {
             if (abs(g_model.potsWarnPosition[i] - GET_LOWRES_POT_POSITION(i)) > 1) {
               if (++numWarnings < 6) {
                 lcdDrawTextAtIndex(x, y, STR_VSRCRAW, NUM_STICKS + 1 + i, INVERS);
@@ -887,7 +887,7 @@ void logicalSwitchesTimerTick()
     }
     msg = luaSetStickySwitchBuffer.read();
   }
-  
+
   // Update logical switches
   for (uint8_t fm=0; fm<MAX_FLIGHT_MODES; fm++) {
     for (uint8_t i=0; i<MAX_LOGICAL_SWITCHES; i++) {
@@ -1004,7 +1004,7 @@ void logicalSwitchesReset()
       LS_LAST_VALUE(fm, i) = CS_LAST_VALUE_INIT;
     }
   }
-  
+
   luaSetStickySwitchBuffer.clear();
 }
 


### PR DESCRIPTION
Fixes #1843
Fixes #1730
Fixes #1663
Fixes #1504
Fixes #1050

Summary of changes:
- fix Companion yaml model read and write
- B&W radios treat bit values the same as color to avoid unnecessary complication for Companion and radio conversions
- B&W radios default is therefore off for all pots and sliders
- B&W radios fix runtime warnings check
- all radios fix to save last pot or slider position when checked and mode AUTO on change of model or power off
- all radios do not display Pots Warning in model setup if no pots or sliders supported

Note: this will need a warning for B&W radio users in the release notes!!

Tested on Ubuntu 20.02 with TX16S and X9D+ libsims
