### PR TITLE
Companion - Log Viewer - Reorder colors for better reading

### DIFF
--- a/companion/src/logsdialog.cpp
+++ b/companion/src/logsdialog.cpp
@@ -46,16 +46,16 @@ LogsDialog::LogsDialog(QWidget *parent) :
 
   colors.append(Qt::green);
   colors.append(Qt::red);
-  colors.append(Qt::yellow);
   colors.append(Qt::magenta);
   colors.append(Qt::cyan);
-  colors.append(Qt::darkBlue);
+  colors.append(Qt::blue);
+  colors.append(Qt::yellow);
   colors.append(Qt::darkGreen);
   colors.append(Qt::darkRed);
-  colors.append(Qt::darkYellow);
   colors.append(Qt::darkMagenta);
   colors.append(Qt::darkCyan);
-  colors.append(Qt::blue);
+  colors.append(Qt::darkBlue);
+  colors.append(Qt::darkYellow);
   pen.setWidthF(1.0);
 
   // create and prepare a plot title layout element


### PR DESCRIPTION
The companion log viewer lets you view aggregated series on the same graph.

By default, it uses colors in the order of their definition, but yellow is pretty bad to visualize. I just changed the order of the colors and, for me, it was much better to see with the white background of the graph.

Hope you like it. :smile: 
