### PR TITLE
Fix data type for Windows compilation

### DIFF
--- a/radio/src/gui/colorlcd/layouts/sliders.cpp
+++ b/radio/src/gui/colorlcd/layouts/sliders.cpp
@@ -31,7 +31,7 @@ enum slider_type {
 static void slider_self_size(lv_event_t* e)
 {
   lv_point_t* s = (lv_point_t*)lv_event_get_param(e);
-  slider_type t = (slider_type)(long)lv_event_get_user_data(e);
+  slider_type t = (slider_type)(intptr_t)lv_event_get_user_data(e);
   switch(t) {
   case SLIDER_VERT:
     s->y = VERTICAL_SLIDERS_HEIGHT;

--- a/radio/src/gui/colorlcd/layouts/trims.cpp
+++ b/radio/src/gui/colorlcd/layouts/trims.cpp
@@ -32,7 +32,7 @@ enum trim_type {
 static void trim_self_size(lv_event_t* e)
 {
   lv_point_t* s = (lv_point_t*)lv_event_get_param(e);
-  trim_type t = (trim_type)(long)lv_event_get_user_data(e);
+  trim_type t = (trim_type)(intptr_t)lv_event_get_user_data(e);
   switch(t) {
   case TRIM_VERT:
     s->y = VERTICAL_SLIDERS_HEIGHT;


### PR DESCRIPTION

Summary of changes: long type has different length on Linux and Windows.
intptr_t is the proper data type here.
Without this change Windows simulator library build fails.
