### PR TITLE
Radio hardware: layout improvements

### DIFF
--- a/radio/src/gui/colorlcd/CMakeLists.txt
+++ b/radio/src/gui/colorlcd/CMakeLists.txt
@@ -74,6 +74,9 @@ set(GUI_SRC
   radio_tools.cpp
   radio_trainer.cpp
   radio_version.cpp
+  hw_intmodule.cpp
+  hw_inputs.cpp
+  hw_serial.cpp
   radio_hardware.cpp
   radio_diagkeys.cpp
   radio_diaganas.cpp

--- a/radio/src/gui/colorlcd/hw_inputs.cpp
+++ b/radio/src/gui/colorlcd/hw_inputs.cpp
@@ -1,0 +1,225 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "hw_inputs.h"
+#include "opentx.h"
+
+#define SET_DIRTY() storageDirty(EE_GENERAL)
+
+struct HWInputEdit : public RadioTextEdit {
+  HWInputEdit(Window* parent, char* name, size_t len) :
+      RadioTextEdit(parent, rect_t{}, name, len)
+  {
+    setWidth(LV_DPI_DEF / 2);
+  }
+};
+
+static const lv_coord_t col_two_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(2),
+                                         LV_GRID_TEMPLATE_LAST};
+
+static const lv_coord_t row_dsc[] = {LV_GRID_CONTENT, LV_GRID_TEMPLATE_LAST};
+
+HWSticks::HWSticks(Window* parent) : FormGroup(parent, rect_t{})
+{
+  FlexGridLayout grid(col_two_dsc, row_dsc, 2);
+  setFlexLayout();
+
+  for (int i = 0; i < NUM_STICKS; i++) {
+    auto line = newLine(&grid);
+    new StaticText(line, rect_t{}, STR_VSRCRAW[i + 1], 0, COLOR_THEME_PRIMARY1);
+    new HWInputEdit(line, g_eeGeneral.anaNames[i], LEN_ANA_NAME);
+  }
+
+#if defined(STICK_DEAD_ZONE)
+  auto line = newLine(&grid);
+  new StaticText(line, rect_t{}, STR_DEAD_ZONE, 0, COLOR_THEME_PRIMARY1);
+  auto dz = new Choice(line, rect_t{}, 0, 7,
+                       GET_SET_DEFAULT(g_eeGeneral.stickDeadZone));
+  dz->setTextHandler([](uint8_t value) {
+    return std::to_string(value ? 2 << (value - 1) : 0);
+  });
+#endif
+}
+
+HWPots::HWPots(Window* parent) : FormGroup(parent, rect_t{})
+{
+  FlexGridLayout grid(col_two_dsc, row_dsc, 2);
+  setFlexLayout();
+
+  for (int i = 0; i < NUM_POTS; i++) {
+    // Display EX3 & EX4 (= last two pots) only when FlySky gimbals are present
+#if !defined(SIMU) && defined(RADIO_FAMILY_T16)
+    if (!globalData.flyskygimbals && (i >= (NUM_POTS - 2))) continue;
+#endif
+    auto line = newLine(&grid);
+    new StaticText(line, rect_t{}, STR_VSRCRAW[i + NUM_STICKS + 1], 0,
+                   COLOR_THEME_PRIMARY1);
+
+    auto box = new FormGroup(line, rect_t{});
+    box->setFlexLayout(LV_FLEX_FLOW_ROW, lv_dpx(4));
+
+    auto box_obj = box->getLvObj();
+    lv_obj_set_style_flex_cross_place(box_obj, LV_FLEX_ALIGN_CENTER, 0);
+
+    new HWInputEdit(box, g_eeGeneral.anaNames[i + NUM_STICKS], LEN_ANA_NAME);
+    new Choice(
+        box, rect_t{}, STR_POTTYPES, POT_NONE, POT_WITHOUT_DETENT,
+        [=]() -> int {
+          return bfGet<uint32_t>(g_eeGeneral.potsConfig, 2 * i, 2);
+        },
+        [=](int newValue) {
+          g_eeGeneral.potsConfig =
+              bfSet<uint32_t>(g_eeGeneral.potsConfig, newValue, 2 * i, 2);
+          SET_DIRTY();
+        });
+  }
+}
+
+HWSliders::HWSliders(Window* parent) : FormGroup(parent, rect_t{})
+{
+  FlexGridLayout grid(col_two_dsc, row_dsc, 2);
+  setFlexLayout();
+
+#if (NUM_SLIDERS > 0)
+  for (int i = 0; i < NUM_SLIDERS; i++) {
+    const int idx = i + NUM_STICKS + NUM_POTS;
+
+    auto line = newLine(&grid);
+    new StaticText(line, rect_t{}, STR_VSRCRAW[idx + 1], 0,
+                   COLOR_THEME_PRIMARY1);
+
+    auto box = new FormGroup(line, rect_t{});
+    box->setFlexLayout(LV_FLEX_FLOW_ROW, lv_dpx(4));
+
+    auto box_obj = box->getLvObj();
+    lv_obj_set_style_flex_cross_place(box_obj, LV_FLEX_ALIGN_CENTER, 0);
+
+    new HWInputEdit(box, g_eeGeneral.anaNames[idx], LEN_ANA_NAME);
+    new Choice(
+        box, rect_t{}, STR_SLIDERTYPES, SLIDER_NONE, SLIDER_WITH_DETENT,
+        [=]() -> int {
+          uint8_t mask = (0x01 << i);
+          return (g_eeGeneral.slidersConfig & mask) >> i;
+        },
+        [=](int newValue) {
+          uint8_t mask = (0x01 << i);
+          g_eeGeneral.slidersConfig &= ~mask;
+          g_eeGeneral.slidersConfig |= (newValue << i);
+          SET_DIRTY();
+        });
+  }
+#endif
+}
+
+class SwitchDynamicLabel : public StaticText
+{
+ public:
+  SwitchDynamicLabel(Window* parent, uint8_t index) :
+      StaticText(parent, rect_t{}, "", 0, COLOR_THEME_PRIMARY1),
+      index(index)
+  {
+    checkEvents();
+  }
+
+  std::string label()
+  {
+    std::string str(STR_VSRCRAW[index + MIXSRC_FIRST_SWITCH - MIXSRC_Rud + 1]);
+    return str + getSwitchPositionSymbol(lastpos);
+  }
+
+  uint8_t position()
+  {
+    auto value = getValue(MIXSRC_FIRST_SWITCH + index);
+    if (value > 0)
+      return 2;
+    else if (value < 0)
+      return 0;
+    else
+      return 1;
+  }
+
+  void checkEvents() override
+  {
+    uint8_t newpos = position();
+    if (newpos != lastpos) {
+      lastpos = newpos;
+      setText(label());
+    }
+  }
+
+ protected:
+  uint8_t index;
+  uint8_t lastpos = 0xff;
+};
+
+#if defined(PCBHORUS)
+#define SWITCH_TYPE_MAX(sw)                  \
+  ((MIXSRC_SF - MIXSRC_FIRST_SWITCH == sw || \
+    MIXSRC_SH - MIXSRC_FIRST_SWITCH == sw)   \
+       ? SWITCH_2POS                         \
+       : SWITCH_3POS)
+#else
+#define SWITCH_TYPE_MAX(sw) (SWITCH_3POS)
+#endif
+
+HWSwitches::HWSwitches(Window* parent) : FormGroup(parent, rect_t{})
+{
+  FlexGridLayout grid(col_two_dsc, row_dsc, 2);
+  setFlexLayout();
+
+  for (int i = 0; i < NUM_SWITCHES; i++) {
+    auto line = newLine(&grid);
+    new SwitchDynamicLabel(line, i);
+
+    auto box = new FormGroup(line, rect_t{});
+    box->setFlexLayout(LV_FLEX_FLOW_ROW, lv_dpx(4));
+
+    auto box_obj = box->getLvObj();
+    lv_obj_set_style_flex_cross_place(box_obj, LV_FLEX_ALIGN_CENTER, 0);
+
+    new HWInputEdit(box, g_eeGeneral.switchNames[i], LEN_SWITCH_NAME);
+    new Choice(
+        box, rect_t{}, STR_SWTYPES, SWITCH_NONE, SWITCH_TYPE_MAX(i),
+        [=]() -> int { return SWITCH_CONFIG(i); },
+        [=](int newValue) {
+          swconfig_t mask = (swconfig_t)0x03 << (2 * i);
+          g_eeGeneral.switchConfig = (g_eeGeneral.switchConfig & ~mask) |
+                                     ((swconfig_t(newValue) & 0x03) << (2 * i));
+          SET_DIRTY();
+        });
+  }
+}
+
+template <class T>
+HWInputDialog<T>::HWInputDialog(const char* title) :
+    Dialog(Layer::back(), std::string(), rect_t{})
+{
+  setCloseWhenClickOutside(true);
+  if (title) content->setTitle(title);
+  new T(&content->form);
+  content->setWidth(LCD_W * 0.8);
+  content->updateSize();
+}
+
+template struct HWInputDialog<HWSticks>;
+template struct HWInputDialog<HWPots>;
+template struct HWInputDialog<HWSliders>;
+template struct HWInputDialog<HWSwitches>;

--- a/radio/src/gui/colorlcd/hw_inputs.h
+++ b/radio/src/gui/colorlcd/hw_inputs.h
@@ -1,0 +1,57 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include "form.h"
+#include "dialog.h"
+#include "button.h"
+
+struct HWSticks : public FormGroup {
+  HWSticks(Window* parent);
+};
+
+struct HWPots : public FormGroup {
+  HWPots(Window* parent);
+};
+
+struct HWSliders : public FormGroup {
+  HWSliders(Window* parent);
+};
+
+struct HWSwitches : public FormGroup {
+  HWSwitches(Window* parent);
+};
+
+template<class T>
+struct HWInputDialog : public Dialog
+{
+  HWInputDialog(const char* title = nullptr);
+};
+
+template <class T>
+TextButton* makeHWInputButton(Window* parent, const char* title)
+{
+  return new TextButton(parent, rect_t{}, title, [=]() {
+    new HWInputDialog<T>(title);
+    return 0;
+  });
+}

--- a/radio/src/gui/colorlcd/hw_intmodule.cpp
+++ b/radio/src/gui/colorlcd/hw_intmodule.cpp
@@ -24,8 +24,8 @@
 
 #define SET_DIRTY() storageDirty(EE_GENERAL)
 
-static const lv_coord_t col_two_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(2),
-                                         LV_GRID_TEMPLATE_LAST};
+static const lv_coord_t col_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(3),
+                                     LV_GRID_TEMPLATE_LAST};
 
 static const lv_coord_t row_dsc[] = {LV_GRID_CONTENT, LV_GRID_TEMPLATE_LAST};
 
@@ -34,13 +34,17 @@ InternalModuleWindow::InternalModuleWindow(Window *parent, const rect_t &rect) :
     lastModule(g_eeGeneral.internalModule)
 {
   setFlexLayout();
-  FlexGridLayout grid(col_two_dsc, row_dsc, 2);
-  lv_obj_set_style_pad_left(lvobj, lv_dpx(8), 0);
 
+  FlexGridLayout grid(col_dsc, row_dsc, 2);
   auto line = newLine(&grid);
-  new StaticText(line, rect_t{}, TR_INTERNAL_MODULE, 0, COLOR_THEME_PRIMARY1);
+
+  new StaticText(line, rect_t{}, STR_MODE, 0, COLOR_THEME_PRIMARY1);
+
+  auto box = new FormGroup(line, rect_t{});
+  box->setFlexLayout(LV_FLEX_FLOW_ROW, lv_dpx(8));
+
   auto internalModule = new Choice(
-      line, rect_t{}, STR_INTERNAL_MODULE_PROTOCOLS, MODULE_TYPE_NONE,
+      box, rect_t{}, STR_INTERNAL_MODULE_PROTOCOLS, MODULE_TYPE_NONE,
       MODULE_TYPE_COUNT - 1, GET_DEFAULT(g_eeGeneral.internalModule),
       [=](int type) { return setModuleType(type); });
 
@@ -48,11 +52,14 @@ InternalModuleWindow::InternalModuleWindow(Window *parent, const rect_t &rect) :
       [](int module) { return isInternalModuleSupported(module); });
 
 #if defined(CROSSFIRE)
-  line = newLine(&grid);
-  br_line = line->getLvObj();
+  box = new FormGroup(box, rect_t{});
+  box->setFlexLayout(LV_FLEX_FLOW_ROW, lv_dpx(8));
 
-  new StaticText(line, rect_t{}, STR_BAUDRATE, 0, COLOR_THEME_PRIMARY1);
-  new Choice(line, rect_t{}, STR_CRSF_BAUDRATE, 0,
+  br_box = box->getLvObj();
+  lv_obj_set_style_flex_cross_place(br_box, LV_FLEX_ALIGN_CENTER, 0);
+
+  new StaticText(box, rect_t{}, STR_BAUDRATE, 0, COLOR_THEME_PRIMARY1);
+  new Choice(box, rect_t{}, STR_CRSF_BAUDRATE, 0,
              CROSSFIRE_MAX_INTERNAL_BAUDRATE, getBaudrate, setBaudrate);
 
   updateBaudrateLine();
@@ -86,9 +93,9 @@ void InternalModuleWindow::updateBaudrateLine()
 {
 #if defined(CROSSFIRE)
   if (isInternalModuleCrossfire()) {
-    lv_obj_clear_flag(br_line, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_clear_flag(br_box, LV_OBJ_FLAG_HIDDEN);
   } else {
-    lv_obj_add_flag(br_line, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(br_box, LV_OBJ_FLAG_HIDDEN);
   }
 #endif
 }

--- a/radio/src/gui/colorlcd/hw_intmodule.cpp
+++ b/radio/src/gui/colorlcd/hw_intmodule.cpp
@@ -1,0 +1,94 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "hw_intmodule.h"
+#include "opentx.h"
+
+#define SET_DIRTY() storageDirty(EE_GENERAL)
+
+static const lv_coord_t col_two_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(2),
+                                         LV_GRID_TEMPLATE_LAST};
+
+static const lv_coord_t row_dsc[] = {LV_GRID_CONTENT, LV_GRID_TEMPLATE_LAST};
+
+InternalModuleWindow::InternalModuleWindow(Window *parent, const rect_t &rect) :
+    FormGroup(parent, rect, FORWARD_SCROLL),
+    lastModule(g_eeGeneral.internalModule)
+{
+  setFlexLayout();
+  FlexGridLayout grid(col_two_dsc, row_dsc, 2);
+  lv_obj_set_style_pad_left(lvobj, lv_dpx(8), 0);
+
+  auto line = newLine(&grid);
+  new StaticText(line, rect_t{}, TR_INTERNAL_MODULE, 0, COLOR_THEME_PRIMARY1);
+  auto internalModule = new Choice(
+      line, rect_t{}, STR_INTERNAL_MODULE_PROTOCOLS, MODULE_TYPE_NONE,
+      MODULE_TYPE_COUNT - 1, GET_DEFAULT(g_eeGeneral.internalModule),
+      [=](int type) { return setModuleType(type); });
+
+  internalModule->setAvailableHandler(
+      [](int module) { return isInternalModuleSupported(module); });
+
+#if defined(CROSSFIRE)
+  line = newLine(&grid);
+  br_line = line->getLvObj();
+
+  new StaticText(line, rect_t{}, STR_BAUDRATE, 0, COLOR_THEME_PRIMARY1);
+  new Choice(line, rect_t{}, STR_CRSF_BAUDRATE, 0,
+             CROSSFIRE_MAX_INTERNAL_BAUDRATE, getBaudrate, setBaudrate);
+
+  updateBaudrateLine();
+#endif
+}
+
+void InternalModuleWindow::setModuleType(int moduleType)
+{
+  if (g_model.moduleData[INTERNAL_MODULE].type != moduleType) {
+    memclear(&g_model.moduleData[INTERNAL_MODULE], sizeof(ModuleData));
+    storageDirty(EE_MODEL);
+  }
+  g_eeGeneral.internalModule = moduleType;
+  updateBaudrateLine();
+  SET_DIRTY();
+}
+
+int InternalModuleWindow::getBaudrate()
+{
+  return CROSSFIRE_STORE_TO_INDEX(g_eeGeneral.internalModuleBaudrate);
+}
+
+void InternalModuleWindow::setBaudrate(int val)
+{
+  g_eeGeneral.internalModuleBaudrate = CROSSFIRE_INDEX_TO_STORE(val);
+  restartModule(INTERNAL_MODULE);
+  SET_DIRTY();
+}
+
+void InternalModuleWindow::updateBaudrateLine()
+{
+#if defined(CROSSFIRE)
+  if (isInternalModuleCrossfire()) {
+    lv_obj_clear_flag(br_line, LV_OBJ_FLAG_HIDDEN);
+  } else {
+    lv_obj_add_flag(br_line, LV_OBJ_FLAG_HIDDEN);
+  }
+#endif
+}

--- a/radio/src/gui/colorlcd/hw_intmodule.h
+++ b/radio/src/gui/colorlcd/hw_intmodule.h
@@ -30,7 +30,7 @@ class InternalModuleWindow : public FormGroup
 
  protected:
   uint8_t lastModule = 0;
-  lv_obj_t* br_line = nullptr;
+  lv_obj_t* br_box = nullptr;
 
   static int getBaudrate();
   static void setBaudrate(int val);

--- a/radio/src/gui/colorlcd/hw_intmodule.h
+++ b/radio/src/gui/colorlcd/hw_intmodule.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include "form.h"
+
+class InternalModuleWindow : public FormGroup
+{
+ public:
+  InternalModuleWindow(Window *parent, const rect_t &rect);
+
+ protected:
+  uint8_t lastModule = 0;
+  lv_obj_t* br_line = nullptr;
+
+  static int getBaudrate();
+  static void setBaudrate(int val);
+
+  void setModuleType(int moduleType);
+  void updateBaudrateLine();
+};

--- a/radio/src/gui/colorlcd/hw_serial.cpp
+++ b/radio/src/gui/colorlcd/hw_serial.cpp
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "hw_serial.h"
+#include "opentx.h"
+
+#define SET_DIRTY() storageDirty(EE_GENERAL)
+
+static const lv_coord_t col_two_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(2),
+                                         LV_GRID_TEMPLATE_LAST};
+
+static const lv_coord_t row_dsc[] = {LV_GRID_CONTENT, LV_GRID_TEMPLATE_LAST};
+
+SerialConfigWindow::SerialConfigWindow(Window *parent, const rect_t &rect) :
+    FormGroup(parent, rect, FORWARD_SCROLL)
+{
+  setFlexLayout();
+  FlexGridLayout grid(col_two_dsc, row_dsc, 2);
+  lv_obj_set_style_pad_left(lvobj, lv_dpx(8), 0);
+
+  bool display_ttl_warning = false;
+  for (uint8_t port_nr = 0; port_nr < MAX_SERIAL_PORTS; port_nr++) {
+    auto port = serialGetPort(port_nr);
+    if (!port || !port->name) continue;
+
+    display_ttl_warning = true;
+    auto line = newLine(&grid);
+    new StaticText(line, rect_t{}, port->name, 0, COLOR_THEME_PRIMARY1);
+    auto aux = new Choice(
+        line, rect_t{}, STR_AUX_SERIAL_MODES, 0, UART_MODE_MAX,
+        [=]() { return serialGetMode(port_nr); },
+        [=](int value) {
+          serialSetMode(port_nr, value);
+          serialInit(port_nr, value);
+          SET_DIRTY();
+        });
+    aux->setAvailableHandler(
+        [=](int value) { return isSerialModeAvailable(port_nr, value); });
+
+#if defined(SWSERIALPOWER)
+    if (port_nr < SP_VCP) {
+      line = newLine(&grid);
+      new StaticText(line, rect_t{}, STR_AUX_SERIAL_PORT_POWER, 0,
+                     COLOR_THEME_PRIMARY1);
+      new CheckBox(
+          line, rect_t{}, [=] { return serialGetPower(port_nr); },
+          [=](int8_t newValue) {
+            serialSetPower(port_nr, (bool)newValue);
+            SET_DIRTY();
+          });
+    }
+#endif
+  }
+
+  if (display_ttl_warning) {
+    grid.setColSpan(2);
+    auto line = newLine(&grid);
+    new StaticText(line, rect_t{}, STR_TTL_WARNING, 0, COLOR_THEME_WARNING);
+  }
+}

--- a/radio/src/gui/colorlcd/hw_serial.cpp
+++ b/radio/src/gui/colorlcd/hw_serial.cpp
@@ -24,7 +24,7 @@
 
 #define SET_DIRTY() storageDirty(EE_GENERAL)
 
-static const lv_coord_t col_two_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(2),
+static const lv_coord_t col_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(3),
                                          LV_GRID_TEMPLATE_LAST};
 
 static const lv_coord_t row_dsc[] = {LV_GRID_CONTENT, LV_GRID_TEMPLATE_LAST};
@@ -33,19 +33,24 @@ SerialConfigWindow::SerialConfigWindow(Window *parent, const rect_t &rect) :
     FormGroup(parent, rect, FORWARD_SCROLL)
 {
   setFlexLayout();
-  FlexGridLayout grid(col_two_dsc, row_dsc, 2);
-  lv_obj_set_style_pad_left(lvobj, lv_dpx(8), 0);
+  FlexGridLayout grid(col_dsc, row_dsc, 2);
 
   bool display_ttl_warning = false;
   for (uint8_t port_nr = 0; port_nr < MAX_SERIAL_PORTS; port_nr++) {
     auto port = serialGetPort(port_nr);
     if (!port || !port->name) continue;
 
-    display_ttl_warning = true;
+    if (port_nr != SP_VCP) display_ttl_warning = true;
+
     auto line = newLine(&grid);
     new StaticText(line, rect_t{}, port->name, 0, COLOR_THEME_PRIMARY1);
+
+    auto box = new FormGroup(line, rect_t{});
+    box->setFlexLayout(LV_FLEX_FLOW_ROW, lv_dpx(8));
+    lv_obj_set_style_flex_cross_place(box->getLvObj(), LV_FLEX_ALIGN_CENTER, 0);
+    
     auto aux = new Choice(
-        line, rect_t{}, STR_AUX_SERIAL_MODES, 0, UART_MODE_MAX,
+        box, rect_t{}, STR_AUX_SERIAL_MODES, 0, UART_MODE_MAX,
         [=]() { return serialGetMode(port_nr); },
         [=](int value) {
           serialSetMode(port_nr, value);
@@ -55,19 +60,16 @@ SerialConfigWindow::SerialConfigWindow(Window *parent, const rect_t &rect) :
     aux->setAvailableHandler(
         [=](int value) { return isSerialModeAvailable(port_nr, value); });
 
-#if defined(SWSERIALPOWER)
-    if (port_nr < SP_VCP) {
-      line = newLine(&grid);
-      new StaticText(line, rect_t{}, STR_AUX_SERIAL_PORT_POWER, 0,
+    if (port->set_pwr != nullptr) {
+      new StaticText(box, rect_t{}, STR_AUX_SERIAL_PORT_POWER, 0,
                      COLOR_THEME_PRIMARY1);
       new CheckBox(
-          line, rect_t{}, [=] { return serialGetPower(port_nr); },
+          box, rect_t{}, [=] { return serialGetPower(port_nr); },
           [=](int8_t newValue) {
             serialSetPower(port_nr, (bool)newValue);
             SET_DIRTY();
           });
     }
-#endif
   }
 
   if (display_ttl_warning) {

--- a/radio/src/gui/colorlcd/hw_serial.h
+++ b/radio/src/gui/colorlcd/hw_serial.h
@@ -1,0 +1,30 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include "form.h"
+
+class SerialConfigWindow : public FormGroup
+{
+ public:
+  SerialConfigWindow(Window *parent, const rect_t &rect);
+};

--- a/radio/src/gui/colorlcd/model_curves.cpp
+++ b/radio/src/gui/colorlcd/model_curves.cpp
@@ -323,6 +323,7 @@ void ModelCurvesPage::build(FormWindow * window, int8_t focusIndex)
   FormGridLayout grid;
   grid.spacer(PAGE_PADDING);
   grid.setLabelWidth(66);
+  window->padAll(0);
 
   for (uint8_t index = 0; index < MAX_CURVES; index++) {
 

--- a/radio/src/gui/colorlcd/model_flightmodes.cpp
+++ b/radio/src/gui/colorlcd/model_flightmodes.cpp
@@ -311,16 +311,15 @@ static const lv_coord_t fmt_row_dsc[] = {LV_GRID_CONTENT,
 void ModelFlightModesPage::build(FormWindow * window)
 {
   window->setFlexLayout();
+  window->padRow(lv_dpx(8));
+  
   lv_obj_t* obj = window->getLvObj();
   lv_obj_set_style_flex_cross_place(obj, LV_FLEX_ALIGN_CENTER, 0);
 
   FlexGridLayout grid(fmt_col_dsc, fmt_row_dsc, 0);
   auto fm_box = window->newLine(&grid);
-
-  obj = fm_box->getLvObj();
-  lv_obj_set_style_pad_all(obj, 8, 0);
-  lv_obj_set_style_pad_row(obj, 2, 0);
-  lv_obj_set_style_pad_column(obj, 2, 0);
+  fm_box->padRow(lv_dpx(2));
+  fm_box->padColumn(lv_dpx(2));
   
   for (int i = 0; i < MAX_FLIGHT_MODES; i++) {
     new FlightModeBtn(fm_box, i);

--- a/radio/src/gui/colorlcd/model_flightmodes.cpp
+++ b/radio/src/gui/colorlcd/model_flightmodes.cpp
@@ -42,8 +42,8 @@ static const lv_coord_t line_col_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1),
 static const lv_coord_t line_row_dsc[] = {LV_GRID_CONTENT,
                                           LV_GRID_TEMPLATE_LAST};
 
-static const lv_coord_t trims_col_dsc[] = {LV_GRID_FR(2), LV_GRID_FR(2),
-                                           LV_GRID_TEMPLATE_LAST};
+// static const lv_coord_t trims_col_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1),
+//                                            LV_GRID_TEMPLATE_LAST};
 
 static const lv_coord_t trims_row_dsc[] = {LV_GRID_CONTENT,
                                            LV_GRID_CONTENT,
@@ -93,26 +93,23 @@ static std::string getFMTrimStr(uint8_t mode)
 
 struct FMTrimSettings : public Dialog {
   FMTrimSettings(Window* parent, FlightModeData* p_fm) :
-      Dialog(parent->getFullScreenWindow(), STR_TRIMS, rect_t{})
+    Dialog(parent->getFullScreenWindow(), STR_TRIMS, rect_t{})
   {
-    auto lv_content = content->getLvObj();
-    lv_obj_set_flex_flow(lv_content, LV_FLEX_FLOW_COLUMN);
-
     setCloseWhenClickOutside(true);
-
     auto form = &content->form;
-    form->setFlexLayout();
 
-    FlexGridLayout trim_grid(trims_col_dsc, trims_row_dsc);
+    FlexGridLayout trim_grid(line_col_dsc, trims_row_dsc);
     auto line = form->newLine(&trim_grid);
 
     for (int t = 0; t < NUM_TRIMS; t++) {
-      auto trim_obj = window_create(line->getLvObj());
-      auto trim = new FormGroup::Line(line, trim_obj);
-      lv_obj_set_layout(trim_obj, LV_LAYOUT_FLEX);
-      lv_obj_set_style_pad_column(trim_obj, 4, 0);
-      lv_obj_set_style_pad_bottom(trim_obj, 8, 0);
+
+      auto trim = new FormGroup(line, rect_t{});
+      trim->setFlexLayout(LV_FLEX_FLOW_ROW, lv_dpx(8));
+
+      auto trim_obj = trim->getLvObj();
+      lv_obj_set_style_pad_column(trim_obj, lv_dpx(8), 0);
       lv_obj_set_style_flex_cross_place(trim_obj, LV_FLEX_ALIGN_CENTER, 0);
+      lv_obj_set_style_grid_cell_x_align(trim_obj, LV_GRID_ALIGN_STRETCH, 0);
 
       trim_t* tr = &p_fm->trim[t];
       auto btn = new TextButton(
@@ -144,25 +141,19 @@ struct FMTrimSettings : public Dialog {
 
     content->setWidth(LCD_W * 0.8);
     content->updateSize();
-    // form->setFocus();
   }
 };
 
 FlightModeEdit::FlightModeEdit(uint8_t index) :
     Page(ICON_MODEL_FLIGHT_MODES)
 {
-  std::string title =
-      std::string(TR_MENUFLIGHTMODE) + " " + std::to_string(index);
-  new StaticText(&header,
-                 {PAGE_TITLE_LEFT, PAGE_TITLE_TOP, LCD_W - PAGE_TITLE_LEFT,
-                  PAGE_LINE_HEIGHT},
-                 title, 0, COLOR_THEME_PRIMARY2);
+  std::string title = std::string(TR_MENUFLIGHTMODE)
+    + " " + std::to_string(index);
+  header.setTitle(title);
 
-  auto form = new FormWindow(&body, rect_t{0, 0, body.width(), body.height()},
-                             NO_FOCUS /*| FORM_FORWARD_FOCUS*/);
-
-  form->setFlexLayout();
   FlexGridLayout grid(line_col_dsc, line_row_dsc, 2);
+  auto form = new FormWindow(&body, rect_t{});
+  form->setFlexLayout();
 
   FlightModeData* p_fm = &g_model.flightModeData[index];
   
@@ -198,8 +189,6 @@ FlightModeEdit::FlightModeEdit(uint8_t index) :
     new FMTrimSettings(this, p_fm);
     return 0;
   });
-
-  // form->setFocus();
 }
 
 class FlightModeBtn: public Button

--- a/radio/src/gui/colorlcd/model_gvars.cpp
+++ b/radio/src/gui/colorlcd/model_gvars.cpp
@@ -357,6 +357,7 @@ void ModelGVarsPage::build(FormWindow * window)
   FormGridLayout grid;
   grid.spacer(PAGE_PADDING);
   grid.setLabelWidth(70);
+  window->padAll(0);
 
   for (uint8_t index = 0; index < MAX_GVARS; index++) {
     Button * button = new GVarButton(window, grid.getLineSlot(), index);

--- a/radio/src/gui/colorlcd/model_inputs.cpp
+++ b/radio/src/gui/colorlcd/model_inputs.cpp
@@ -460,11 +460,12 @@ void ModelInputsPage::pasteInputAfter(uint8_t dst_idx)
 
 void ModelInputsPage::build(FormWindow *window)
 {
-  window->setFlexLayout(LV_FLEX_FLOW_COLUMN, 8);
-  lv_obj_set_style_pad_all(window->getLvObj(), 8, 0);
+  window->setFlexLayout();
+  window->padRow(lv_dpx(8));
   
   form = new FormGroup(window, rect_t{});
-  form->setFlexLayout(LV_FLEX_FLOW_COLUMN, 8);
+  form->setFlexLayout();
+  form->padRow(lv_dpx(8));
 
   auto form_obj = form->getLvObj();
   lv_obj_set_width(form_obj, lv_pct(100));

--- a/radio/src/gui/colorlcd/model_logical_switches.cpp
+++ b/radio/src/gui/colorlcd/model_logical_switches.cpp
@@ -370,6 +370,7 @@ void ModelLogicalSwitchesPage::build(FormWindow* window, int8_t focusIndex)
   FormGridLayout grid;
   grid.spacer(PAGE_PADDING);
   grid.setLabelWidth(66);
+  window->padAll(0);
 
   for (uint8_t i = 0; i < MAX_LOGICAL_SWITCHES; i++) {
     LogicalSwitchData* ls = lswAddress(i);

--- a/radio/src/gui/colorlcd/model_mixer_scripts.cpp
+++ b/radio/src/gui/colorlcd/model_mixer_scripts.cpp
@@ -236,6 +236,7 @@ void ModelMixerScriptsPage::build(FormWindow * window, int8_t focusIdx)
   FormGridLayout grid;
   grid.spacer(PAGE_PADDING);
   grid.setLabelWidth(66);
+  window->padAll(0);
 
   int8_t scriptIdx = 0;
   for (int8_t idx = 0; idx < MAX_SCRIPTS; idx++) {

--- a/radio/src/gui/colorlcd/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model_mixes.cpp
@@ -533,11 +533,12 @@ void ModelMixesPage::pasteMixAfter(uint8_t dst_idx)
 
 void ModelMixesPage::build(FormWindow * window)
 {
-  window->setFlexLayout(LV_FLEX_FLOW_COLUMN, 8);
-  lv_obj_set_style_pad_all(window->getLvObj(), 8, 0);
+  window->setFlexLayout();
+  window->padRow(lv_dpx(8));
   
   form = new FormGroup(window, rect_t{});
-  form->setFlexLayout(LV_FLEX_FLOW_COLUMN, 8);
+  form->setFlexLayout();
+  form->padRow(lv_dpx(8));
 
   auto form_obj = form->getLvObj();
   lv_obj_set_width(form_obj, lv_pct(100));

--- a/radio/src/gui/colorlcd/model_outputs.cpp
+++ b/radio/src/gui/colorlcd/model_outputs.cpp
@@ -147,15 +147,14 @@ ModelOutputsPage::ModelOutputsPage() :
 
 void ModelOutputsPage::build(FormWindow *window)
 {
-  window->setFlexLayout(LV_FLEX_FLOW_COLUMN, 8);
-  lv_obj_set_style_pad_all(window->getLvObj(), 8, 0);
+  window->setFlexLayout();
+  window->padRow(lv_dpx(8));
 
   auto form = new FormGroup(window, rect_t{});
-  form->setFlexLayout(LV_FLEX_FLOW_ROW_WRAP, lv_dpx(8));
+  form->setFlexLayout(LV_FLEX_FLOW_ROW_WRAP, lv_dpx(16));
+  form->padRow(lv_dpx(8));
 
   auto form_obj = form->getLvObj();
-  lv_obj_set_style_pad_all(form_obj, lv_dpx(8), 0);
-  lv_obj_set_style_pad_row(form_obj, lv_dpx(8), 0);
   lv_obj_set_style_flex_cross_place(form_obj, LV_FLEX_ALIGN_CENTER, 0);
 
   // auto btn =
@@ -167,6 +166,7 @@ void ModelOutputsPage::build(FormWindow *window)
 
   auto box = new FormGroup(form, rect_t{});
   box->setFlexLayout(LV_FLEX_FLOW_ROW, lv_dpx(8));
+
   auto box_obj = box->getLvObj();
   lv_obj_set_width(box_obj, LV_SIZE_CONTENT);
   lv_obj_set_style_flex_cross_place(box_obj, LV_FLEX_ALIGN_CENTER, 0);
@@ -183,7 +183,7 @@ void ModelOutputsPage::build(FormWindow *window)
     btn->setPressHandler([=]() -> uint8_t {
       Menu *menu = new Menu(window);
       menu->addLine(STR_EDIT, [=]() {
-        editOutput(btn, ch);
+        editOutput(ch);
       });
       menu->addLine(STR_RESET, [=]() {
         output->min = 0;
@@ -211,11 +211,7 @@ void ModelOutputsPage::build(FormWindow *window)
   }
 }
 
-void ModelOutputsPage::editOutput(OutputLineButton *btn, uint8_t channel)
+void ModelOutputsPage::editOutput(uint8_t channel)
 {
-  // auto btn_obj = btn->getLvObj();
-  // Window *edit = 
   new OutputEditWindow(channel);
-  // edit->setCloseHandler(
-  //     [=]() { lv_event_send(btn_obj, LV_EVENT_VALUE_CHANGED, nullptr); });
 }

--- a/radio/src/gui/colorlcd/model_outputs.h
+++ b/radio/src/gui/colorlcd/model_outputs.h
@@ -24,8 +24,6 @@
 
 #include "tabsgroup.h"
 
-class OutputLineButton;
-
 class ModelOutputsPage : public PageTab
 {
  public:
@@ -33,7 +31,7 @@ class ModelOutputsPage : public PageTab
   void build(FormWindow* window) override;
 
  protected:
-  void editOutput(OutputLineButton* btn, uint8_t channel);
+  void editOutput(uint8_t channel);
 };
 
 #endif // _MODEL_OUTPUTS_H_

--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -263,8 +263,9 @@ void ModelSetupPage::build(FormWindow * window)
   // Timer buttons
   form = new FormGroup(window, rect_t{});
   form->setFlexLayout(LV_FLEX_FLOW_ROW_WRAP, lv_dpx(8));
-  lv_obj_set_style_pad_all(form->getLvObj(), lv_dpx(8), 0);
-  
+  lv_obj_set_style_flex_main_place(form->getLvObj(), LV_FLEX_ALIGN_SPACE_EVENLY, 0);
+  form->padAll(lv_dpx(8));
+
   new SubScreenButton(form, TR_TIMER "1",
                       []() { new TimerWindow(0); });
   new SubScreenButton(form, TR_TIMER "2",
@@ -274,7 +275,8 @@ void ModelSetupPage::build(FormWindow * window)
 
   form = new FormGroup(window, rect_t{});
   form->setFlexLayout(LV_FLEX_FLOW_ROW_WRAP, lv_dpx(8));
-  lv_obj_set_style_pad_all(form->getLvObj(), lv_dpx(8), 0);
+  lv_obj_set_style_flex_main_place(form->getLvObj(), LV_FLEX_ALIGN_SPACE_EVENLY, 0);
+  form->padAll(lv_dpx(8));
 
   new SubScreenButton(form, STR_PREFLIGHT,
                       []() { new PreflightChecks(); });

--- a/radio/src/gui/colorlcd/model_telemetry.cpp
+++ b/radio/src/gui/colorlcd/model_telemetry.cpp
@@ -457,6 +457,7 @@ void ModelTelemetryPage::build(FormWindow * window, int8_t focusSensorIndex)
 {
   FormGridLayout grid;
   grid.spacer(PAGE_PADDING);
+  window->padAll(0);
 
   this->window = window;
 

--- a/radio/src/gui/colorlcd/radio_diaganas.cpp
+++ b/radio/src/gui/colorlcd/radio_diaganas.cpp
@@ -523,20 +523,28 @@ class AnaMinMaxViewWindow: public Window {
 
 void AnaCalibratedViewPage::build(FormWindow *window)
 {
-    new AnaCalibratedViewWindow(window, {10, 10, window->width() - 10, window->height() - 10});
+  window->padAll(0);
+  new AnaCalibratedViewWindow(
+      window, {10, 10, window->width() - 10, window->height() - 10});
 }
 
 void AnaFilteredDevViewPage::build(FormWindow *window)
 {
-    new AnaFilteredDevViewWindow(window, {10, 10, window->width() - 10, window->height() - 10});
+  window->padAll(0);
+  new AnaFilteredDevViewWindow(
+      window, {10, 10, window->width() - 10, window->height() - 10});
 }
 
 void AnaUnfilteredRawViewPage::build(FormWindow *window)
 {
-    new AnaUnfilteredRawViewWindow(window, {10, 10, window->width() - 10, window->height() - 10});
+  window->padAll(0);
+  new AnaUnfilteredRawViewWindow(
+      window, {10, 10, window->width() - 10, window->height() - 10});
 }
 
 void AnaMinMaxViewPage::build(FormWindow *window)
 {
-    new AnaMinMaxViewWindow(window, {10, 10, window->width() - 10, window->height() - 10});
+  window->padAll(0);
+  new AnaMinMaxViewWindow(
+      window, {10, 10, window->width() - 10, window->height() - 10});
 }

--- a/radio/src/gui/colorlcd/radio_hardware.cpp
+++ b/radio/src/gui/colorlcd/radio_hardware.cpp
@@ -165,43 +165,11 @@ void RadioHardwarePage::build(FormWindow * window)
   FlexGridLayout grid(col_three_dsc, row_dsc, 2);
   lv_obj_set_style_pad_all(window->getLvObj(), lv_dpx(8), 0);
 
-  // Calibration
-  new Subtitle(window, rect_t{}, STR_INPUTS, 0, COLOR_THEME_PRIMARY1 | FONT(BOLD));
-
-  auto line = window->newLine(&grid);
-  grid.nextCell();
-
-  auto calib = new TextButton(line, rect_t{}, STR_CALIBRATION);
-  calib->setPressHandler([=]() -> uint8_t {
-      new RadioCalibrationPage();
-      return 0;
-  });
-
-  // Sticks
-  // new Subtitle(window, rect_t{}, STR_STICKS, 0, COLOR_THEME_PRIMARY1);
-  // new HWSticks(window);
-  makeHWInputButton<HWSticks>(window, STR_STICKS);
-
-  // Pots
-  // new Subtitle(window, rect_t{}, STR_POTS, 0, COLOR_THEME_PRIMARY1);
-  // new HWPots(window);
-  makeHWInputButton<HWPots>(window, STR_POTS);
-
-  // Sliders
-#if (NUM_SLIDERS > 0)
-  // new Subtitle(window, rect_t{}, STR_SLIDERS, 0, COLOR_THEME_PRIMARY1);
-  // new HWSliders(window);
-  makeHWInputButton<HWSliders>(window, STR_SLIDERS);
-#endif
-
-  // Switches
-  // new Subtitle(window, rect_t{}, STR_SWITCHES, 0, COLOR_THEME_PRIMARY1);
-  // new HWSwitches(window);
-  makeHWInputButton<HWSwitches>(window, STR_SWITCHES);
-  
   // Bat calibration
   // TODO: sub-title?
-  line = window->newLine(&grid);
+  // TODO: add battery range before
+  //
+  auto line = window->newLine(&grid);
   new StaticText(line, rect_t{}, STR_BATT_CALIB, 0, COLOR_THEME_PRIMARY1);
   auto batCal =
       new NumberEdit(line, rect_t{}, -127, 127,
@@ -241,15 +209,46 @@ void RadioHardwarePage::build(FormWindow * window)
   new StaticText(line, rect_t{}, STR_JITTER_FILTER, 0, COLOR_THEME_PRIMARY1);
   new CheckBox(line, rect_t{}, GET_SET_INVERTED(g_eeGeneral.noJitterFilter));
 
+  // Calibration
+  new Subtitle(window, rect_t{}, STR_INPUTS, 0, COLOR_THEME_PRIMARY1);
+
+  auto box = new FormGroup(window, rect_t{});
+  box->setFlexLayout(LV_FLEX_FLOW_ROW_WRAP, lv_dpx(8));
+  lv_obj_set_style_pad_all(box->getLvObj(), lv_dpx(8), 0);
+
+  auto calib = new TextButton(box, rect_t{}, STR_CALIBRATION);
+  calib->setPressHandler([=]() -> uint8_t {
+      new RadioCalibrationPage();
+      return 0;
+  });
+
+  // Sticks
+  makeHWInputButton<HWSticks>(box, STR_STICKS);
+
+  // Pots
+  makeHWInputButton<HWPots>(box, STR_POTS);
+
+  // Sliders
+#if (NUM_SLIDERS > 0)
+  makeHWInputButton<HWSliders>(box, STR_SLIDERS);
+#endif
+
+  // Switches
+  makeHWInputButton<HWSwitches>(box, STR_SWITCHES);
+  
   // Debugs
-  line = window->newLine(&grid);
-  new StaticText(line, rect_t{}, STR_DEBUG, 0, COLOR_THEME_PRIMARY1 | FONT(BOLD));
-  new TextButton(line, rect_t{}, STR_ANALOGS_BTN, [=]() -> uint8_t {
+  new Subtitle(window, rect_t{}, STR_DEBUG, 0, COLOR_THEME_PRIMARY1);
+
+  box = new FormGroup(window, rect_t{});
+  box->setFlexLayout(LV_FLEX_FLOW_ROW_WRAP, lv_dpx(8));
+  lv_obj_set_style_pad_all(box->getLvObj(), lv_dpx(8), 0);
+
+  new TextButton(box, rect_t{}, STR_ANALOGS_BTN, [=]() -> uint8_t {
     new RadioAnalogsDiagsViewPageGroup();
     return 0;
   });
 
-  new TextButton(line, rect_t{}, STR_KEYS_BTN, [=]() -> uint8_t {
+  new TextButton(box, rect_t{}, STR_KEYS_BTN, [=]() -> uint8_t {
     new RadioKeyDiagsPage();
     return 0;
   });

--- a/radio/src/gui/colorlcd/radio_hardware.cpp
+++ b/radio/src/gui/colorlcd/radio_hardware.cpp
@@ -27,70 +27,16 @@
 #include "libopenui.h"
 #include "hal/adc_driver.h"
 #include "aux_serial_driver.h"
+#include "hw_intmodule.h"
+#include "hw_serial.h"
+#include "hw_inputs.h"
 
 #define SET_DIRTY() storageDirty(EE_GENERAL)
 
-static const lv_coord_t col_two_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1),
-                                     LV_GRID_TEMPLATE_LAST};
-static const lv_coord_t col_three_dsc[] = {LV_GRID_FR(2), LV_GRID_FR(1), LV_GRID_FR(1),
+static const lv_coord_t col_three_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1),
                                      LV_GRID_TEMPLATE_LAST};
 static const lv_coord_t row_dsc[] = {LV_GRID_CONTENT, LV_GRID_CONTENT,
                                      LV_GRID_TEMPLATE_LAST};
-
-#if defined(PCBHORUS)
-#define SWITCH_TYPE_MAX(sw)            ((MIXSRC_SF-MIXSRC_FIRST_SWITCH == sw || MIXSRC_SH-MIXSRC_FIRST_SWITCH == sw) ? SWITCH_2POS : SWITCH_3POS)
-#else
-#define SWITCH_TYPE_MAX(sw)            (SWITCH_3POS)
-#endif
-
-class SwitchDynamicLabel: public StaticText {
-  public:
-    SwitchDynamicLabel(Window * parent, const rect_t & rect, uint8_t index):
-      StaticText(parent, rect, "", 0, COLOR_THEME_PRIMARY1),
-      index(index)
-    {
-      update();
-    }
-
-    std::string label()
-    {
-      static const char* switchPositions[] = {
-         STR_CHAR_UP,
-         "-",
-         STR_CHAR_DOWN
-      };
-      return TEXT_AT_INDEX(STR_VSRCRAW, (index + MIXSRC_FIRST_SWITCH - MIXSRC_Rud + 1)) + std::string(switchPositions[lastpos]);
-    }
-
-    void update()
-    {
-      uint8_t newpos = position();
-      if (newpos != lastpos) {
-        lastpos = newpos;
-        setText(label());
-      }
-    }
-
-    uint8_t position()
-    {
-      auto value = getValue(MIXSRC_FIRST_SWITCH + index);
-      if (value > 0)
-        return 2;
-      else if (value < 0)
-        return 0;
-      else
-        return 1;
-    }
-
-    void checkEvents() override
-    {
-      update();
-    }
-
-  protected:
-    uint8_t index;
-    uint8_t lastpos = 0xff;
-};
 
 RadioHardwarePage::RadioHardwarePage():
   PageTab(STR_HARDWARE, ICON_RADIO_HARDWARE)
@@ -98,12 +44,11 @@ RadioHardwarePage::RadioHardwarePage():
 }
 
 #if defined(BLUETOOTH)
-
 class ModeChoice : public Choice
 {
  public:
-  ModeChoice(Window *parent, const rect_t &rect, const char **values,
-             int vmin, int vmax, std::function<int()> getValue,
+  ModeChoice(Window *parent, const rect_t &rect, const char **values, int vmin,
+             int vmax, std::function<int()> getValue,
              std::function<void(int)> setValue = nullptr,
              bool *menuOpen = nullptr) :
       Choice(parent, rect, values, vmin, vmax, getValue, setValue),
@@ -124,439 +69,188 @@ class ModeChoice : public Choice
 
 class BluetoothConfigWindow : public FormGroup
 {
-  public:
-    BluetoothConfigWindow(Window * parent, const rect_t &rect) :
-      FormGroup(parent, rect, FORWARD_SCROLL // | FORM_FORWARD_FOCUS
-                )
-    {
-      update();
-    }
-
-    void checkEvents() override
-    {
-      FormGroup::checkEvents();
-      if (!rte) return;
-      if (bluetooth.state != lastbluetoothstate) {
-        lastbluetoothstate = bluetooth.state;
-        if (!(modechoiceopen || rte->hasFocus())) update();
-      }
-    }
-
-    void update()
-    {
-      clear();
-
-      setFlexLayout();
-      FlexGridLayout grid(col_three_dsc, row_dsc, 2);
-
-      auto line = newLine(&grid);
-
-      auto label = new StaticText(line, rect_t{}, STR_MODE, 0,
-                     COLOR_THEME_PRIMARY1);
-      lv_obj_set_style_pad_left(label->getLvObj(), lv_dpx(8), LV_PART_MAIN);
-      modechoiceopen = false;
-      btMode = new ModeChoice(
-          line, rect_t{}, STR_BLUETOOTH_MODES, BLUETOOTH_OFF,
-          BLUETOOTH_TRAINER, GET_DEFAULT(g_eeGeneral.bluetoothMode),
-          [=](int32_t newValue) {
-            g_eeGeneral.bluetoothMode = newValue;
-            update();
-            SET_DIRTY();
-            // btMode->setFocus(SET_FOCUS_DEFAULT);
-            modechoiceopen = false;
-          },
-          &modechoiceopen);
-      line = newLine(&grid);
-
-      if (g_eeGeneral.bluetoothMode != BLUETOOTH_OFF) {
-        // Pin code (displayed for information only, not editable)
-        if (g_eeGeneral.bluetoothMode == BLUETOOTH_TELEMETRY) {
-          label = new StaticText(line, rect_t{}, STR_BLUETOOTH_PIN_CODE, 0, COLOR_THEME_PRIMARY1);
-          lv_obj_set_style_pad_left(label->getLvObj(), lv_dpx(8), LV_PART_MAIN);
-          new StaticText(line, rect_t{}, "000000", 0, COLOR_THEME_PRIMARY1);
-          line = newLine(&grid);
-        }
-
-        // Local MAC
-        label = new StaticText(line, rect_t{}, STR_BLUETOOTH_LOCAL_ADDR, 0, COLOR_THEME_PRIMARY1);
-        lv_obj_set_style_pad_left(label->getLvObj(), lv_dpx(8), LV_PART_MAIN);
-        new StaticText(line, rect_t{}, bluetooth.localAddr[0] == '\0' ? "---" : bluetooth.localAddr, 0, COLOR_THEME_PRIMARY1);
-        line = newLine(&grid);
-
-        // Remote MAC
-        label = new StaticText(line, rect_t{}, STR_BLUETOOTH_DIST_ADDR, 0, COLOR_THEME_PRIMARY1);
-        lv_obj_set_style_pad_left(label->getLvObj(), lv_dpx(8), LV_PART_MAIN);
-        new StaticText(line, rect_t{}, bluetooth.distantAddr[0] == '\0' ? "---" : bluetooth.distantAddr, 0, COLOR_THEME_PRIMARY1);
-        line = newLine(&grid);
-
-        // BT radio name
-        label = new StaticText(line, rect_t{}, STR_NAME, 0, COLOR_THEME_PRIMARY1);
-        lv_obj_set_style_pad_left(label->getLvObj(), lv_dpx(8), LV_PART_MAIN);
-        rte = new RadioTextEdit(line, rect_t{}, g_eeGeneral.bluetoothName, LEN_BLUETOOTH_NAME);
-        line = newLine(&grid);
-      }
-
-      getParent()->moveWindowsTop(top() + 1, adjustHeight());
-    }
-
-   protected:
-    Choice *btMode = nullptr;
-    RadioTextEdit *rte = nullptr;
-
-   private:
-    bool modechoiceopen = false;
-    uint8_t lastbluetoothstate = BLUETOOTH_STATE_OFF;
-};
-#endif
-
-class SerialConfigWindow : public FormGroup
-{
  public:
-  SerialConfigWindow(Window *parent, const rect_t &rect) :
-      FormGroup(parent, rect, FORWARD_SCROLL // | FORM_FORWARD_FOCUS
-                )
+  BluetoothConfigWindow(Window *parent, const rect_t &rect) :
+      FormGroup(parent, rect, FORWARD_SCROLL)
   {
     update();
-  }
-
-  void update()
-  {
-    clear();
-
-    setFlexLayout();
-    FlexGridLayout grid(col_two_dsc, row_dsc, 2);
-
-    auto line = newLine(&grid);
-
-    bool display_ttl_warning = false;
-    for (uint8_t port_nr = 0; port_nr < MAX_SERIAL_PORTS; port_nr++) {
-      auto port = serialGetPort(port_nr);
-      if (!port || !port->name) continue;
-
-      display_ttl_warning = true;
-      auto label = new StaticText(line, rect_t{}, port->name, 0,
-                     COLOR_THEME_PRIMARY1);
-      lv_obj_set_style_pad_left(label->getLvObj(), lv_dpx(8), LV_PART_MAIN);
-      auto aux = new Choice(
-          line, rect_t{}, STR_AUX_SERIAL_MODES, 0,
-          UART_MODE_MAX, [=]() { return serialGetMode(port_nr); },
-          [=](int value) {
-            serialSetMode(port_nr, value);
-            serialInit(port_nr, value);
-            SET_DIRTY();
-          });
-      aux->setAvailableHandler(
-          [=](int value) { return isSerialModeAvailable(port_nr, value); });
-      line = newLine(&grid);
-
-#if defined(SWSERIALPOWER)
-      if (port_nr < SP_VCP)
-      {
-          auto label = new StaticText(line, rect_t{}, STR_AUX_SERIAL_PORT_POWER, 0, COLOR_THEME_PRIMARY1);
-          lv_obj_set_style_pad_left(label->getLvObj(), lv_dpx(8), LV_PART_MAIN);
-          new CheckBox(
-              line, rect_t{},
-                [=] { return serialGetPower(port_nr); },
-                [=](int8_t newValue) {
-                   serialSetPower(port_nr, (bool)newValue);
-                   SET_DIRTY();
-                }
-          );
-          line = newLine(&grid);
-      }
-#endif
-    }
-
-    if (display_ttl_warning) {
-      grid.setColSpan(2);
-      auto label = new StaticText(line, rect_t{}, STR_TTL_WARNING, 0,
-                     COLOR_THEME_WARNING);
-      lv_obj_set_style_pad_left(label->getLvObj(), lv_dpx(8), LV_PART_MAIN);
-      grid.setColSpan(1);
-      line = newLine(&grid);
-    }
-
-    getParent()->moveWindowsTop(top() + 1, adjustHeight());
-  }
-};
-
-class InternalModuleWindow : public FormGroup {
- public:
-  InternalModuleWindow(Window *parent, const rect_t &rect) :
-    FormGroup(parent, rect, FORWARD_SCROLL),
-    lastModule(g_eeGeneral.internalModule)
-  {
-    update();
-  }
-
-  void update()
-  {
-    clear();
-
-    setFlexLayout();
-    FlexGridLayout grid(col_two_dsc, row_dsc, 2);
-
-    auto line = newLine(&grid);
-
-    auto label = new StaticText(line, rect_t{}, TR_INTERNAL_MODULE, 0,
-                   COLOR_THEME_PRIMARY1);
-    lv_obj_set_style_pad_left(label->getLvObj(), lv_dpx(8), LV_PART_MAIN);
-    auto internalModule = new Choice(line, rect_t{},STR_INTERNAL_MODULE_PROTOCOLS, MODULE_TYPE_NONE, MODULE_TYPE_COUNT - 1,
-                                     GET_DEFAULT(g_eeGeneral.internalModule),
-                                     [=](int moduleType) {
-                                       if (g_model.moduleData[INTERNAL_MODULE].type != moduleType) {
-                                         memclear(&g_model.moduleData[INTERNAL_MODULE], sizeof(ModuleData));
-                                         storageDirty(EE_MODEL);
-                                       }
-                                       g_eeGeneral.internalModule = moduleType;
-                                       SET_DIRTY();
-                                     });
-
-    internalModule->setAvailableHandler([](int module){
-      return isInternalModuleSupported(module);
-    });
-    line = newLine(&grid);
-
-#if defined(CROSSFIRE)
-    if (isInternalModuleCrossfire()) {
-      auto label = new StaticText(line, rect_t{}, STR_BAUDRATE, 0,COLOR_THEME_PRIMARY1);
-      lv_obj_set_style_pad_left(label->getLvObj(), lv_dpx(8), LV_PART_MAIN);
-      new Choice(line, rect_t{}, STR_CRSF_BAUDRATE, 0,CROSSFIRE_MAX_INTERNAL_BAUDRATE,
-          [=]() -> int {
-            return CROSSFIRE_STORE_TO_INDEX(g_eeGeneral.internalModuleBaudrate);
-          },
-          [=](int newValue) {
-            g_eeGeneral.internalModuleBaudrate = CROSSFIRE_INDEX_TO_STORE(newValue);
-            SET_DIRTY();
-            restartModule(INTERNAL_MODULE);
-          });
-      line = newLine(&grid);
-    }
-#endif
-    getParent()->moveWindowsTop(top() + 1, adjustHeight());
   }
 
   void checkEvents() override
   {
-    if (g_eeGeneral.internalModule != lastModule) {
-      lastModule = g_eeGeneral.internalModule;
-      update();
-    }
-
     FormGroup::checkEvents();
+    if (!rte) return;
+    if (bluetooth.state != lastbluetoothstate) {
+      lastbluetoothstate = bluetooth.state;
+      if (!(modechoiceopen || rte->hasFocus())) update();
+    }
+  }
+
+  void update()
+  {
+    clear();
+
+    setFlexLayout();
+    FlexGridLayout grid(col_three_dsc, row_dsc, 2);
+    lv_obj_set_style_pad_left(lvobj, lv_dpx(8), 0);
+
+    auto line = newLine(&grid);
+    new StaticText(line, rect_t{}, STR_MODE, 0, COLOR_THEME_PRIMARY1);
+
+    modechoiceopen = false;
+    btMode = new ModeChoice(
+        line, rect_t{}, STR_BLUETOOTH_MODES, BLUETOOTH_OFF, BLUETOOTH_TRAINER,
+        GET_DEFAULT(g_eeGeneral.bluetoothMode),
+        [=](int32_t newValue) {
+          g_eeGeneral.bluetoothMode = newValue;
+          update();
+          modechoiceopen = false;
+          SET_DIRTY();
+        },
+        &modechoiceopen);
+
+    line = newLine(&grid);
+    if (g_eeGeneral.bluetoothMode != BLUETOOTH_OFF) {
+      // Pin code (displayed for information only, not editable)
+      if (g_eeGeneral.bluetoothMode == BLUETOOTH_TELEMETRY) {
+        label = new StaticText(line, rect_t{}, STR_BLUETOOTH_PIN_CODE, 0,
+                               COLOR_THEME_PRIMARY1);
+        lv_obj_set_style_pad_left(label->getLvObj(), lv_dpx(8), LV_PART_MAIN);
+        new StaticText(line, rect_t{}, "000000", 0, COLOR_THEME_PRIMARY1);
+        line = newLine(&grid);
+      }
+
+      // Local MAC
+      label = new StaticText(line, rect_t{}, STR_BLUETOOTH_LOCAL_ADDR, 0,
+                             COLOR_THEME_PRIMARY1);
+      lv_obj_set_style_pad_left(label->getLvObj(), lv_dpx(8), LV_PART_MAIN);
+      new StaticText(
+          line, rect_t{},
+          bluetooth.localAddr[0] == '\0' ? "---" : bluetooth.localAddr, 0,
+          COLOR_THEME_PRIMARY1);
+      line = newLine(&grid);
+
+      // Remote MAC
+      label = new StaticText(line, rect_t{}, STR_BLUETOOTH_DIST_ADDR, 0,
+                             COLOR_THEME_PRIMARY1);
+      lv_obj_set_style_pad_left(label->getLvObj(), lv_dpx(8), LV_PART_MAIN);
+      new StaticText(
+          line, rect_t{},
+          bluetooth.distantAddr[0] == '\0' ? "---" : bluetooth.distantAddr, 0,
+          COLOR_THEME_PRIMARY1);
+      line = newLine(&grid);
+
+      // BT radio name
+      label = new StaticText(line, rect_t{}, STR_NAME, 0, COLOR_THEME_PRIMARY1);
+      lv_obj_set_style_pad_left(label->getLvObj(), lv_dpx(8), LV_PART_MAIN);
+      rte = new RadioTextEdit(line, rect_t{}, g_eeGeneral.bluetoothName,
+                              LEN_BLUETOOTH_NAME);
+      line = newLine(&grid);
+    }
   }
 
  protected:
-  uint8_t lastModule = 0;
+  Choice *btMode = nullptr;
+  RadioTextEdit *rte = nullptr;
+
+ private:
+  bool modechoiceopen = false;
+  uint8_t lastbluetoothstate = BLUETOOTH_STATE_OFF;
 };
+#endif
 
 void RadioHardwarePage::build(FormWindow * window)
 {
   window->setFlexLayout();
   FlexGridLayout grid(col_three_dsc, row_dsc, 2);
-
-  auto line = window->newLine(&grid);
+  lv_obj_set_style_pad_all(window->getLvObj(), lv_dpx(8), 0);
 
   // Calibration
-  new StaticText(line, rect_t{}, STR_INPUTS, 0, COLOR_THEME_PRIMARY1 | FONT(BOLD));
+  new Subtitle(window, rect_t{}, STR_INPUTS, 0, COLOR_THEME_PRIMARY1 | FONT(BOLD));
+
+  auto line = window->newLine(&grid);
+  grid.nextCell();
+
   auto calib = new TextButton(line, rect_t{}, STR_CALIBRATION);
   calib->setPressHandler([=]() -> uint8_t {
-      // auto calibrationPage = 
       new RadioCalibrationPage();
-      // calibrationPage->setCloseHandler([=]() {
-      //     calib->setFocus(SET_FOCUS_DEFAULT);
-      // });
       return 0;
   });
-  line = window->newLine(&grid);
 
   // Sticks
-  new Subtitle(line, rect_t{}, STR_STICKS, 0, COLOR_THEME_PRIMARY1);
-  line = window->newLine(&grid);
-  for (int i = 0; i < NUM_STICKS; i++) {
-    auto label = new StaticText(line, rect_t{}, TEXT_AT_INDEX(STR_VSRCRAW, (i + 1)), 0, COLOR_THEME_PRIMARY1);
-    lv_obj_set_style_pad_left(label->getLvObj(), lv_dpx(8), LV_PART_MAIN);
-    auto textEdit = new RadioTextEdit(line, rect_t{}, g_eeGeneral.anaNames[i], LEN_ANA_NAME);
-    lv_obj_set_style_grid_cell_x_align(textEdit->getLvObj(), LV_GRID_ALIGN_STRETCH, 0);
-    line = window->newLine(&grid);
-  }
-
-#if defined(STICK_DEAD_ZONE)
-  auto text = new StaticText(line, rect_t{}, STR_DEAD_ZONE);
-  lv_obj_set_style_pad_left(text->getLvObj(), lv_dpx(8), LV_PART_MAIN);
-  auto choice =
-      new Choice(line, rect_t{}, 0, 7,
-                 GET_DEFAULT(g_eeGeneral.stickDeadZone), [=](uint8_t newValue) {
-                   g_eeGeneral.stickDeadZone = newValue;
-                   SET_DIRTY();
-                 });
-  choice->setTextHandler([](uint8_t value) {
-    return std::to_string(value ? 2 << (value - 1) : 0);
-  });
-  line = window->newLine(&grid);
-#endif
+  // new Subtitle(window, rect_t{}, STR_STICKS, 0, COLOR_THEME_PRIMARY1);
+  // new HWSticks(window);
+  makeHWInputButton<HWSticks>(window, STR_STICKS);
 
   // Pots
-  new Subtitle(line, rect_t{}, STR_POTS, 0, COLOR_THEME_PRIMARY1);
-  line = window->newLine(&grid);
-  for (int i = 0; i < NUM_POTS; i++) {
-    // Display EX3 & EX4 (= last two pots) only when FlySky gimbals are present
-#if !defined(SIMU) && defined(RADIO_FAMILY_T16)
-      if (!globalData.flyskygimbals && (i >= (NUM_POTS - 2)))
-        continue;
-#endif
-
-    auto label = new StaticText(line, rect_t{}, TEXT_AT_INDEX(STR_VSRCRAW, (i + NUM_STICKS + 1)), 0, COLOR_THEME_PRIMARY1);
-    lv_obj_set_style_pad_left(label->getLvObj(), lv_dpx(8), LV_PART_MAIN);
-
-    auto textEdit = new RadioTextEdit(line, rect_t{}, g_eeGeneral.anaNames[i + NUM_STICKS], LEN_ANA_NAME);
-    lv_obj_set_style_grid_cell_x_align(textEdit->getLvObj(), LV_GRID_ALIGN_STRETCH, 0);
-    new Choice(line, rect_t{}, STR_POTTYPES, POT_NONE, POT_WITHOUT_DETENT,
-               [=]() -> int {
-                   return bfGet<uint32_t>(g_eeGeneral.potsConfig, 2*i, 2);
-               },
-               [=](int newValue) {
-                   g_eeGeneral.potsConfig = bfSet<uint32_t>(g_eeGeneral.potsConfig, newValue, 2*i, 2);
-                   SET_DIRTY();
-               });
-    line = window->newLine(&grid);
-  }
+  // new Subtitle(window, rect_t{}, STR_POTS, 0, COLOR_THEME_PRIMARY1);
+  // new HWPots(window);
+  makeHWInputButton<HWPots>(window, STR_POTS);
 
   // Sliders
 #if (NUM_SLIDERS > 0)
-  new Subtitle(line, rect_t{}, STR_SLIDERS, 0, COLOR_THEME_PRIMARY1);
-  line = window->newLine(&grid);
-  for (int i = 0; i < NUM_SLIDERS; i++) {
-    const int idx = i + NUM_STICKS + NUM_POTS;
-    auto label  = new StaticText(line, rect_t{}, TEXT_AT_INDEX(STR_VSRCRAW, idx + 1), 0, COLOR_THEME_PRIMARY1);
-    lv_obj_set_style_pad_left(label->getLvObj(), lv_dpx(8), LV_PART_MAIN);
-    auto textEdit = new RadioTextEdit(line, rect_t{}, g_eeGeneral.anaNames[idx], LEN_ANA_NAME);
-    lv_obj_set_style_grid_cell_x_align(textEdit->getLvObj(), LV_GRID_ALIGN_STRETCH, 0);
-    new Choice(
-        window, rect_t{}, STR_SLIDERTYPES, SLIDER_NONE,
-        SLIDER_WITH_DETENT,
-        [=]() -> int {
-          uint8_t mask = (0x01 << i);
-          return (g_eeGeneral.slidersConfig & mask) >> i;
-        },
-        [=](int newValue) {
-          uint8_t mask = (0x01 << i);
-          g_eeGeneral.slidersConfig &= ~mask;
-          g_eeGeneral.slidersConfig |= (newValue << i);
-          SET_DIRTY();
-        });
-    line = window->newLine(&grid);
-  }
+  // new Subtitle(window, rect_t{}, STR_SLIDERS, 0, COLOR_THEME_PRIMARY1);
+  // new HWSliders(window);
+  makeHWInputButton<HWSliders>(window, STR_SLIDERS);
 #endif
 
   // Switches
-  new Subtitle(line, rect_t{}, STR_SWITCHES, 0, COLOR_THEME_PRIMARY1);
-  line = window->newLine(&grid);
-  for (int i = 0; i < NUM_SWITCHES; i++) {
-    auto label = new SwitchDynamicLabel(line, rect_t{}, i);
-    lv_obj_set_style_pad_left(label->getLvObj(), lv_dpx(8), LV_PART_MAIN);
-    auto textEdit = new RadioTextEdit(line, rect_t{}, g_eeGeneral.switchNames[i], LEN_SWITCH_NAME);
-    lv_obj_set_style_grid_cell_x_align(textEdit->getLvObj(), LV_GRID_ALIGN_STRETCH, 0);
-    new Choice(line, rect_t{}, STR_SWTYPES, SWITCH_NONE, SWITCH_TYPE_MAX(i),
-               [=]() -> int {
-                   return SWITCH_CONFIG(i);
-               },
-               [=](int newValue) {
-                   swconfig_t mask = (swconfig_t) 0x03 << (2 * i);
-                   g_eeGeneral.switchConfig = (g_eeGeneral.switchConfig & ~mask) | ((swconfig_t(newValue) & 0x03) << (2 * i));
-                   SET_DIRTY();
-               });
-    line = window->newLine(&grid);
-  }
-
+  // new Subtitle(window, rect_t{}, STR_SWITCHES, 0, COLOR_THEME_PRIMARY1);
+  // new HWSwitches(window);
+  makeHWInputButton<HWSwitches>(window, STR_SWITCHES);
+  
   // Bat calibration
+  // TODO: sub-title?
+  line = window->newLine(&grid);
   new StaticText(line, rect_t{}, STR_BATT_CALIB, 0, COLOR_THEME_PRIMARY1);
-  auto batCal = new NumberEdit(line, rect_t{}, -127, 127, GET_SET_DEFAULT(g_eeGeneral.txVoltageCalibration));
+  auto batCal =
+      new NumberEdit(line, rect_t{}, -127, 127,
+                     GET_SET_DEFAULT(g_eeGeneral.txVoltageCalibration));
   batCal->setDisplayHandler([](int32_t value) {
-      return formatNumberAsString(getBatteryVoltage(), PREC2, 0, nullptr, "V");
+    return formatNumberAsString(getBatteryVoltage(), PREC2, 0, nullptr, "V");
   });
   batCal->setWindowFlags(REFRESH_ALWAYS);
-  line = window->newLine(&grid);
 
   // RTC Batt display
+  line = window->newLine(&grid);
   new StaticText(line, rect_t{}, STR_RTC_BATT, 0, COLOR_THEME_PRIMARY1);
   new DynamicNumber<uint16_t>(line, rect_t{}, [] {
       return getRTCBatteryVoltage();
   }, COLOR_THEME_PRIMARY1 | PREC2, nullptr, "V");
-  line = window->newLine(&grid);
 
   // RTC Batt check enable
+  line = window->newLine(&grid);
   new StaticText(line, rect_t{}, STR_RTC_CHECK, 0, COLOR_THEME_PRIMARY1);
   new CheckBox(line, rect_t{}, GET_SET_INVERTED(g_eeGeneral.disableRtcWarning ));
-  line = window->newLine(&grid);
 
 #if defined(HARDWARE_INTERNAL_MODULE)
-  new Subtitle(line, rect_t{}, TR_INTERNALRF, 0, COLOR_THEME_PRIMARY1);
-  line = window->newLine(&grid);
-  lv_obj_set_style_pad_left(line->getLvObj(), 0, LV_PART_MAIN);
-  lv_obj_set_style_pad_right(line->getLvObj(), 0, LV_PART_MAIN);
-  // Date and Time
-  grid.setColSpan(2);
-  new InternalModuleWindow(line, rect_t{});
-  grid.setColSpan(1);
-  line = window->newLine(&grid);
+  new Subtitle(window, rect_t{}, TR_INTERNALRF, 0, COLOR_THEME_PRIMARY1);
+  new InternalModuleWindow(window, rect_t{});
 #endif
 
 #if defined(BLUETOOTH)
-  // Bluetooth mode
-  {
-    new Subtitle(line, rect_t{}, STR_BLUETOOTH, 0, COLOR_THEME_PRIMARY1);
-    line = window->newLine(&grid);
-    lv_obj_set_style_pad_left(line->getLvObj(), 0, LV_PART_MAIN);
-    lv_obj_set_style_pad_right(line->getLvObj(), 0, LV_PART_MAIN);
-    grid.setColSpan(2);
-    new BluetoothConfigWindow(line, rect_t{});
-    grid.setColSpan(1);
-    line = window->newLine(&grid);
-  }
+  new Subtitle(window, rect_t{}, STR_BLUETOOTH, 0, COLOR_THEME_PRIMARY1);
+  new BluetoothConfigWindow(window, rect_t{});
 #endif
 
-  new Subtitle(line, rect_t{}, STR_AUX_SERIAL_MODE, 0,
-               COLOR_THEME_PRIMARY1);
-  line = window->newLine(&grid);
-  lv_obj_set_style_pad_left(line->getLvObj(), 0, LV_PART_MAIN);
-  lv_obj_set_style_pad_right(line->getLvObj(), 0, LV_PART_MAIN);
-  grid.setColSpan(2);
-  new SerialConfigWindow(line, rect_t{});
-  grid.setColSpan(1);
-  line = window->newLine(&grid);
+  new Subtitle(window, rect_t{}, STR_AUX_SERIAL_MODE, 0, COLOR_THEME_PRIMARY1);
+  new SerialConfigWindow(window, rect_t{});
 
   // ADC filter
+  line = window->newLine(&grid);
   new StaticText(line, rect_t{}, STR_JITTER_FILTER, 0, COLOR_THEME_PRIMARY1);
   new CheckBox(line, rect_t{}, GET_SET_INVERTED(g_eeGeneral.noJitterFilter));
-  line = window->newLine(&grid);
 
   // Debugs
+  line = window->newLine(&grid);
   new StaticText(line, rect_t{}, STR_DEBUG, 0, COLOR_THEME_PRIMARY1 | FONT(BOLD));
-  auto debugAnas = new TextButton(line, rect_t{}, STR_ANALOGS_BTN);
-  debugAnas->setPressHandler([=]() -> uint8_t {
-      // auto debugAnalogsPage = 
-      new RadioAnalogsDiagsViewPageGroup();
-      // debugAnalogsPage->setCloseHandler([=]() {
-      //     calib->setFocus(SET_FOCUS_DEFAULT);
-      // });
-      return 0;
-  });
-
-  auto debugKeys = new TextButton(line, rect_t{}, STR_KEYS_BTN);
-  debugKeys->setPressHandler([=]() -> uint8_t {
-    // auto debugKeysPage = 
-    new RadioKeyDiagsPage();
-    // debugKeysPage->setCloseHandler([=]() {
-    //     calib->setFocus(SET_FOCUS_DEFAULT);
-    // });
+  new TextButton(line, rect_t{}, STR_ANALOGS_BTN, [=]() -> uint8_t {
+    new RadioAnalogsDiagsViewPageGroup();
     return 0;
   });
-  line = window->newLine(&grid);
 
-// extra bottom padding if touchscreen
-#if defined HARDWARE_TOUCH
-  new StaticText(line, rect_t{});
-#endif
-
+  new TextButton(line, rect_t{}, STR_KEYS_BTN, [=]() -> uint8_t {
+    new RadioKeyDiagsPage();
+    return 0;
+  });
 }

--- a/radio/src/gui/colorlcd/radio_hardware.cpp
+++ b/radio/src/gui/colorlcd/radio_hardware.cpp
@@ -165,11 +165,41 @@ void RadioHardwarePage::build(FormWindow * window)
   FlexGridLayout grid(col_three_dsc, row_dsc, 2);
   lv_obj_set_style_pad_all(window->getLvObj(), lv_dpx(8), 0);
 
-  // Bat calibration
   // TODO: sub-title?
-  // TODO: add battery range before
-  //
+
+  // Batt meter range - Range 3.0v to 16v
   auto line = window->newLine(&grid);
+  new StaticText(line, rect_t{}, STR_BATTERY_RANGE, 0, COLOR_THEME_PRIMARY1);
+
+  auto box = new FormGroup(line, rect_t{});
+  box->setFlexLayout(LV_FLEX_FLOW_ROW, lv_dpx(4));
+
+  auto batMin =
+      new NumberEdit(box, rect_t{}, -60 + 90, g_eeGeneral.vBatMax + 29 + 90,
+                     GET_SET_WITH_OFFSET(g_eeGeneral.vBatMin, 90), 0, PREC1);
+  batMin->setSuffix("V");
+  new StaticText(box, rect_t{}, "-");
+  auto batMax =
+      new NumberEdit(box, rect_t{}, g_eeGeneral.vBatMin - 29 + 120, 40 + 120,
+                     GET_SET_WITH_OFFSET(g_eeGeneral.vBatMax, 120), 0, PREC1);
+  batMax->setSuffix("V");
+
+  batMin->setSetValueHandler([=](int32_t newValue) {
+    g_eeGeneral.vBatMin = newValue - 90;
+    SET_DIRTY();
+    batMax->setMin(g_eeGeneral.vBatMin - 29 + 120);
+    batMax->invalidate();
+  });
+
+  batMax->setSetValueHandler([=](int32_t newValue) {
+    g_eeGeneral.vBatMax = newValue - 120;
+    SET_DIRTY();
+    batMin->setMax(g_eeGeneral.vBatMax + 29 + 90);
+    batMin->invalidate();
+  });
+
+  // Bat calibration
+  line = window->newLine(&grid);
   new StaticText(line, rect_t{}, STR_BATT_CALIB, 0, COLOR_THEME_PRIMARY1);
   auto batCal =
       new NumberEdit(line, rect_t{}, -127, 127,
@@ -212,7 +242,7 @@ void RadioHardwarePage::build(FormWindow * window)
   // Calibration
   new Subtitle(window, rect_t{}, STR_INPUTS, 0, COLOR_THEME_PRIMARY1);
 
-  auto box = new FormGroup(window, rect_t{});
+  box = new FormGroup(window, rect_t{});
   box->setFlexLayout(LV_FLEX_FLOW_ROW_WRAP, lv_dpx(8));
   lv_obj_set_style_pad_all(box->getLvObj(), lv_dpx(8), 0);
 

--- a/radio/src/gui/colorlcd/radio_hardware.cpp
+++ b/radio/src/gui/colorlcd/radio_hardware.cpp
@@ -244,42 +244,51 @@ void RadioHardwarePage::build(FormWindow * window)
 
   box = new FormGroup(window, rect_t{});
   box->setFlexLayout(LV_FLEX_FLOW_ROW_WRAP, lv_dpx(8));
-  lv_obj_set_style_pad_all(box->getLvObj(), lv_dpx(8), 0);
+  box->padRow(lv_dpx(8));
+  box->padAll(lv_dpx(8));
 
   auto calib = new TextButton(box, rect_t{}, STR_CALIBRATION);
   calib->setPressHandler([=]() -> uint8_t {
       new RadioCalibrationPage();
       return 0;
   });
+  lv_obj_set_style_min_width(calib->getLvObj(), LV_DPI_DEF, 0);
 
   // Sticks
-  makeHWInputButton<HWSticks>(box, STR_STICKS);
+  auto btn = makeHWInputButton<HWSticks>(box, STR_STICKS);
+  lv_obj_set_style_min_width(btn->getLvObj(), LV_DPI_DEF, 0);
 
   // Pots
-  makeHWInputButton<HWPots>(box, STR_POTS);
+  btn = makeHWInputButton<HWPots>(box, STR_POTS);
+  lv_obj_set_style_min_width(btn->getLvObj(), LV_DPI_DEF, 0);
 
   // Sliders
 #if (NUM_SLIDERS > 0)
-  makeHWInputButton<HWSliders>(box, STR_SLIDERS);
+  btn = makeHWInputButton<HWSliders>(box, STR_SLIDERS);
+  lv_obj_set_style_min_width(btn->getLvObj(), LV_DPI_DEF, 0);
 #endif
 
   // Switches
-  makeHWInputButton<HWSwitches>(box, STR_SWITCHES);
+  btn = makeHWInputButton<HWSwitches>(box, STR_SWITCHES);
+  lv_obj_set_style_min_width(btn->getLvObj(), LV_DPI_DEF, 0);
   
   // Debugs
   new Subtitle(window, rect_t{}, STR_DEBUG, 0, COLOR_THEME_PRIMARY1);
 
   box = new FormGroup(window, rect_t{});
   box->setFlexLayout(LV_FLEX_FLOW_ROW_WRAP, lv_dpx(8));
-  lv_obj_set_style_pad_all(box->getLvObj(), lv_dpx(8), 0);
+  box->padRow(lv_dpx(8));
+  box->padAll(lv_dpx(8));
 
-  new TextButton(box, rect_t{}, STR_ANALOGS_BTN, [=]() -> uint8_t {
+  btn = new TextButton(box, rect_t{}, STR_ANALOGS_BTN, [=]() -> uint8_t {
     new RadioAnalogsDiagsViewPageGroup();
     return 0;
   });
+  lv_obj_set_style_min_width(btn->getLvObj(), LV_DPI_DEF, 0);
 
-  new TextButton(box, rect_t{}, STR_KEYS_BTN, [=]() -> uint8_t {
+  btn = new TextButton(box, rect_t{}, STR_KEYS_BTN, [=]() -> uint8_t {
     new RadioKeyDiagsPage();
     return 0;
   });
+  lv_obj_set_style_min_width(btn->getLvObj(), LV_DPI_DEF, 0);
 }

--- a/radio/src/gui/colorlcd/radio_hardware.cpp
+++ b/radio/src/gui/colorlcd/radio_hardware.cpp
@@ -248,9 +248,10 @@ void RadioHardwarePage::build(FormWindow * window)
 
   box = new FormGroup(window, rect_t{});
   box->setFlexLayout(LV_FLEX_FLOW_ROW_WRAP, lv_dpx(8));
+  lv_obj_set_style_flex_main_place(box->getLvObj(), LV_FLEX_ALIGN_SPACE_EVENLY, 0);
   box->padRow(lv_dpx(8));
   box->padAll(lv_dpx(8));
-
+  
   auto calib = new TextButton(box, rect_t{}, STR_CALIBRATION);
   calib->setPressHandler([=]() -> uint8_t {
       new RadioCalibrationPage();
@@ -281,6 +282,7 @@ void RadioHardwarePage::build(FormWindow * window)
 
   box = new FormGroup(window, rect_t{});
   box->setFlexLayout(LV_FLEX_FLOW_ROW_WRAP, lv_dpx(8));
+  lv_obj_set_style_flex_main_place(box->getLvObj(), LV_FLEX_ALIGN_SPACE_EVENLY, 0);
   box->padRow(lv_dpx(8));
   box->padAll(lv_dpx(8));
 

--- a/radio/src/gui/colorlcd/radio_hardware.cpp
+++ b/radio/src/gui/colorlcd/radio_hardware.cpp
@@ -113,16 +113,16 @@ class BluetoothConfigWindow : public FormGroup
       // Pin code (displayed for information only, not editable)
       if (g_eeGeneral.bluetoothMode == BLUETOOTH_TELEMETRY) {
         line = newLine(&grid);
-        label = new StaticText(line, rect_t{}, STR_BLUETOOTH_PIN_CODE, 0,
-                               COLOR_THEME_PRIMARY1);
+        auto label = new StaticText(line, rect_t{}, STR_BLUETOOTH_PIN_CODE, 0,
+                                    COLOR_THEME_PRIMARY1);
         lv_obj_set_style_pad_left(label->getLvObj(), lv_dpx(8), LV_PART_MAIN);
         new StaticText(line, rect_t{}, "000000", 0, COLOR_THEME_PRIMARY1);
       }
 
       // Local MAC
       line = newLine(&grid);
-      label = new StaticText(line, rect_t{}, STR_BLUETOOTH_LOCAL_ADDR, 0,
-                             COLOR_THEME_PRIMARY1);
+      auto label = new StaticText(line, rect_t{}, STR_BLUETOOTH_LOCAL_ADDR, 0,
+                                  COLOR_THEME_PRIMARY1);
       lv_obj_set_style_pad_left(label->getLvObj(), lv_dpx(8), LV_PART_MAIN);
       new StaticText(
           line, rect_t{},

--- a/radio/src/gui/colorlcd/radio_sdmanager.cpp
+++ b/radio/src/gui/colorlcd/radio_sdmanager.cpp
@@ -154,6 +154,8 @@ static const lv_coord_t row_dsc[] = {LV_GRID_FR(2), LV_GRID_FR(1), LV_GRID_TEMPL
 void RadioSdManagerPage::build(FormWindow * window)
 {
   FlexGridLayout grid(col_dsc, row_dsc, 0);
+  window->padAll(0);
+  
   FormGroup* form = new FormGroup(window, rect_t{});
   form->setWidth(window->width());
   form->setHeight(window->height());

--- a/radio/src/gui/colorlcd/radio_setup.cpp
+++ b/radio/src/gui/colorlcd/radio_setup.cpp
@@ -195,10 +195,11 @@ class WindowButtonGroup : public FormGroup
     padRow(lv_dpx(8));
 
     for (auto& entry : pages) {
-      new TextButton(this, rect_t{}, entry.first, [&, entry]() {
+      auto btn = new TextButton(this, rect_t{}, entry.first, [&, entry]() {
         entry.second();
         return 0;
       });
+      lv_obj_set_style_min_width(btn->getLvObj(), LV_DPI_DEF, 0);
     }
   }
 

--- a/radio/src/gui/colorlcd/radio_setup.cpp
+++ b/radio/src/gui/colorlcd/radio_setup.cpp
@@ -192,6 +192,7 @@ class WindowButtonGroup : public FormGroup
       pages(pages)
   {
     setFlexLayout(LV_FLEX_FLOW_ROW_WRAP, lv_dpx(8));
+    lv_obj_set_style_flex_main_place(lvobj, LV_FLEX_ALIGN_SPACE_EVENLY, 0);
     padRow(lv_dpx(8));
 
     for (auto& entry : pages) {

--- a/radio/src/gui/colorlcd/radio_setup.cpp
+++ b/radio/src/gui/colorlcd/radio_setup.cpp
@@ -605,25 +605,6 @@ void RadioSetupPage::build(FormWindow * window)
   new DateTimeWindow(line, rect_t{});
   grid.setColSpan(1);
 
-  // Batt meter range - Range 3.0v to 16v
-  line = window->newLine(&grid);
-  new StaticText(line, rect_t{}, STR_BATTERY_RANGE, 0, COLOR_THEME_PRIMARY1);
-  auto batMinEdit = new NumberEdit(line, rect_t{}, -60 + 90, g_eeGeneral.vBatMax + 29 + 90, GET_SET_WITH_OFFSET(g_eeGeneral.vBatMin, 90), 0, PREC1);
-  batMinEdit->setSuffix("V");
-  auto batMaxEdit = new NumberEdit(line, rect_t{}, g_eeGeneral.vBatMin - 29 + 120, 40 + 120, GET_SET_WITH_OFFSET(g_eeGeneral.vBatMax, 120), 0, PREC1);
-  batMaxEdit->setSuffix("V");
-  batMinEdit->setSetValueHandler([=](int32_t newValue) {
-    g_eeGeneral.vBatMin= newValue - 90;
-    SET_DIRTY();
-    batMaxEdit->setMin(g_eeGeneral.vBatMin - 29 + 120);
-    batMaxEdit->invalidate();
-  });
-  batMaxEdit->setSetValueHandler([=](int32_t newValue) {
-    g_eeGeneral.vBatMax= newValue - 120;
-    SET_DIRTY();
-    batMinEdit->setMax(g_eeGeneral.vBatMax + 29 + 90);
-    batMinEdit->invalidate();
-  });
   line = window->newLine(&grid);
 
   std::vector<std::pair<const char*, std::function<void()> >> windows;

--- a/radio/src/gui/colorlcd/radio_theme.cpp
+++ b/radio/src/gui/colorlcd/radio_theme.cpp
@@ -528,6 +528,7 @@ void ThemeSetupPage::setupListbox(FormWindow *window, rect_t r, ThemePersistance
 
 void ThemeSetupPage::build(FormWindow *window)
 {
+  window->padAll(0);
   pageWindow = window;
 
   auto tp = ThemePersistance::instance();

--- a/radio/src/gui/colorlcd/radio_tools.cpp
+++ b/radio/src/gui/colorlcd/radio_tools.cpp
@@ -238,10 +238,8 @@ void RadioToolsPage::rebuild(FormWindow * window)
 
   tools.sort(tool_compare_nocase);
 
-  window->setFlexLayout(LV_FLEX_FLOW_ROW_WRAP, 8);
-  lv_obj_t* w_obj = window->getLvObj();
-  lv_obj_set_style_pad_row(w_obj, 8, 0);
-  lv_obj_set_style_pad_all(w_obj, 8, 0);
+  window->setFlexLayout(LV_FLEX_FLOW_ROW_WRAP, lv_dpx(8));
+  window->padRow(lv_dpx(8));
   
   for (const auto& tool : tools) {
     new ToolButton(window, tool);

--- a/radio/src/gui/colorlcd/special_functions.cpp
+++ b/radio/src/gui/colorlcd/special_functions.cpp
@@ -634,6 +634,7 @@ void SpecialFunctionsPage::build(FormWindow *window, int8_t focusIndex)
   FormGridLayout grid;
   grid.spacer(PAGE_PADDING);
   grid.setLabelWidth(66);
+  window->padAll(0);
 
   // Window::clearFocus();
 

--- a/radio/src/gui/colorlcd/tabsgroup.cpp
+++ b/radio/src/gui/colorlcd/tabsgroup.cpp
@@ -223,6 +223,8 @@ void TabsGroup::setVisibleTab(PageTab* tab)
 
     rect_t r = rect_t{0, 0, body.width(), body.height()};
     auto form = new FormWindow(&body, r, NO_FOCUS);
+
+    form->padAll(lv_dpx(8));
     tab->build(form);
 
     header.setTitle(tab->title.c_str());

--- a/radio/src/gui/colorlcd/view_channels.cpp
+++ b/radio/src/gui/colorlcd/view_channels.cpp
@@ -66,6 +66,7 @@ class ChannelsViewFooter: public Window {
 void ChannelsViewPage::build(FormWindow * window)
 {
   constexpr coord_t hmargin = 5;
+  window->padAll(0);
 
   // Channels bars
   for (uint8_t chan = pageIndex * 8; chan < 8 + pageIndex * 8; chan++) {

--- a/radio/src/gui/colorlcd/view_logical_switches.cpp
+++ b/radio/src/gui/colorlcd/view_logical_switches.cpp
@@ -64,6 +64,7 @@ void LogicalSwitchesViewPage::build(FormWindow * window)
   FormGridLayout grid;
   grid.spacer(PAGE_PADDING);
   grid.setLabelWidth(8);
+  window->padAll(0);
 
   // Footer
   footer = new LogicalSwitchDisplayFooter(

--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -759,14 +759,26 @@ const etx_serial_port_t UsbSerialPort = { "USB-VCP", nullptr, nullptr };
 #endif
 
 #if defined(AUX_SERIAL)
-const etx_serial_port_t auxSerialPort = { "AUX1", nullptr, nullptr };
+#if defined(AUX_SERIAL_PWR_GPIO)
+  static void _fake_pwr_aux(uint8_t) {}
+  #define AUX_SERIAL_PWR _fake_pwr_aux
+#else
+  #define AUX_SERIAL_PWR nullptr
+#endif
+const etx_serial_port_t auxSerialPort = { "AUX1", nullptr, AUX_SERIAL_PWR };
 #define AUX_SERIAL_PORT &auxSerialPort
 #else
 #define AUX_SERIAL_PORT nullptr
 #endif
 
 #if defined(AUX2_SERIAL)
-const etx_serial_port_t aux2SerialPort = { "AUX2", nullptr, nullptr };
+#if defined(AUX_SERIAL_PWR_GPIO)
+  static void _fake_pwr_aux2(uint8_t) {}
+  #define AUX2_SERIAL_PWR _fake_pwr_aux2
+#else
+  #define AUX2_SERIAL_PWR nullptr
+#endif
+const etx_serial_port_t aux2SerialPort = { "AUX2", nullptr, AUX2_SERIAL_PWR };
 #define AUX2_SERIAL_PORT &aux2SerialPort
 #else
 #define AUX2_SERIAL_PORT nullptr


### PR DESCRIPTION
Changes:
- use unified border on all page tabs
- dialog auto-layout improved
- moved sticks/pots/sliders/switches hardware settings to pop-ups

<img width="483" alt="Screenshot 2022-06-14 at 11 21 49" src="https://user-images.githubusercontent.com/1050031/173543163-89eca214-d529-44a5-a89a-574c8e1b8a93.png">

<img width="480" alt="Screenshot 2022-06-14 at 09 49 25" src="https://user-images.githubusercontent.com/1050031/173523035-750d79de-880a-4edd-bac5-c2189c455cca.png">

<img width="479" alt="Screenshot 2022-06-14 at 11 22 39" src="https://user-images.githubusercontent.com/1050031/173543347-30af37e4-23eb-45bf-a344-4c52a5e482d7.png">

<img width="482" alt="Screenshot 2022-06-14 at 11 23 06" src="https://user-images.githubusercontent.com/1050031/173543409-88155f80-9c49-4d7e-8d7f-57908959e379.png">

<img width="320" alt="Screenshot 2022-06-14 at 11 23 28" src="https://user-images.githubusercontent.com/1050031/173543486-ebd4ccfb-3d54-4d23-b275-682501d7c1e0.png">

