### PR TITLE
Support GVars in calculated telemetry sources

### DIFF
--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -414,6 +414,7 @@ PACK(struct TelemetrySensor {
     void init(const char *label, uint8_t unit=UNIT_RAW, uint8_t prec=0);
     void init(uint16_t id);
     bool isAvailable() const;
+    bool isOfflineFresh() const;
     int32_t getValue(int32_t value, uint8_t unit, uint8_t prec) const;
     bool isConfigurable() const;
     bool isPrecConfigurable() const;

--- a/radio/src/gui/128x64/model_telemetry_sensor.cpp
+++ b/radio/src/gui/128x64/model_telemetry_sensor.cpp
@@ -263,15 +263,46 @@ void menuModelSensor(event_t event)
       {
         drawStringWithIndex(0, y, STR_SOURCE, k-SENSOR_FIELD_PARAM1+1);
         int8_t * source = &sensor->calc.sources[k-SENSOR_FIELD_PARAM1];
+        uint8_t delta = GV_GET_GV1_VALUE(-MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS);
         if (attr) {
-          *source = checkIncDec(event, *source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS, EE_MODEL|NO_INCDEC_MARKS, isSensorAvailable);
+#if defined(GVARS)
+          if (event == EVT_KEY_LONG(KEY_ENTER)) {
+            *source = (GV_IS_GV_VALUE(*source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS) ? 0 : delta);
+            s_editMode = !s_editMode;
+          }
+          if(GV_IS_GV_VALUE(*source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS)) {
+            int8_t idx = (int16_t)GV_INDEX_CALC_DELTA(*source, delta);
+            CHECK_INCDEC_MODELVAR(event, idx, -MAX_GVARS, MAX_GVARS-1);
+            if (idx < 0) {
+              *source = (int8_t)GV_CALC_VALUE_IDX_NEG(idx, delta);
+            }
+            else {
+              *source = (int8_t)GV_CALC_VALUE_IDX_POS(idx, delta);
+            }
+          } else {
+#endif
+            *source = checkIncDec(event, *source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS, EE_MODEL|NO_INCDEC_MARKS, isSensorAvailable);
+            }
+#if defined(GVARS)
         }
-        if (*source < 0) {
-          lcdDrawChar(SENSOR_2ND_COLUMN, y, '-', attr);
-          drawSource(lcdNextPos, y, MIXSRC_FIRST_TELEM+3*(-1-*source), attr);
-        }
-        else {
-          drawSource(SENSOR_2ND_COLUMN, y, *source ? MIXSRC_FIRST_TELEM+3*(*source-1) : 0, attr);
+        if(GV_IS_GV_VALUE(*source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS)) {
+          int8_t gvindex = GV_INDEX_CALC_DELTA(*source, delta);
+          if(gvindex<0 && sensor->formula == TELEM_FORMULA_MULTIPLY) {
+            lcdDrawChar(SENSOR_2ND_COLUMN, y, '/', attr);
+            drawGVarName(lcdNextPos, y, -gvindex-1, attr);
+          } else {
+            drawGVarName(SENSOR_2ND_COLUMN, y, gvindex, attr);
+          }
+        } else
+#endif
+        {
+          if (*source < 0) {
+            lcdDrawChar(SENSOR_2ND_COLUMN, y, '-', attr);
+            drawSource(lcdNextPos, y, MIXSRC_FIRST_TELEM+3*(-1-*source), attr);
+          }
+          else {
+            drawSource(SENSOR_2ND_COLUMN, y, *source ? MIXSRC_FIRST_TELEM+3*(*source-1) : 0, attr);
+          }
         }
         break;
       }

--- a/radio/src/gui/212x64/model_telemetry_sensor.cpp
+++ b/radio/src/gui/212x64/model_telemetry_sensor.cpp
@@ -277,15 +277,46 @@ void menuModelSensor(event_t event)
       {
         drawStringWithIndex(0, y, STR_SOURCE, k-SENSOR_FIELD_PARAM1+1);
         int8_t * source = &sensor->calc.sources[k-SENSOR_FIELD_PARAM1];
+        uint8_t delta = GV_GET_GV1_VALUE(-MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS);
         if (attr) {
+#if defined(GVARS)
+          if (event == EVT_KEY_LONG(KEY_ENTER)) {
+            *source = (GV_IS_GV_VALUE(*source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS) ? 0 : delta);
+            s_editMode = !s_editMode;
+          }
+          if(GV_IS_GV_VALUE(*source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS)) {
+            int8_t idx = (int16_t)GV_INDEX_CALC_DELTA(*source, delta);
+            CHECK_INCDEC_MODELVAR(event, idx, -MAX_GVARS, MAX_GVARS-1);
+            if (idx < 0) {
+              *source = (int8_t)GV_CALC_VALUE_IDX_NEG(idx, delta);
+            }
+            else {
+              *source = (int8_t)GV_CALC_VALUE_IDX_POS(idx, delta);
+            }
+          } else {
+#endif
           *source = checkIncDec(event, *source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS, EE_MODEL|NO_INCDEC_MARKS, isSensorAvailable);
         }
-        if (*source < 0) {
-          lcdDrawChar(SENSOR_2ND_COLUMN, y, '-', attr);
-          drawSource(lcdNextPos, y, MIXSRC_FIRST_TELEM+3*(-1-*source), attr);
+#if defined(GVARS)
         }
-        else {
-          drawSource(SENSOR_2ND_COLUMN, y, *source ? MIXSRC_FIRST_TELEM+3*(*source-1) : 0, attr);
+        if(GV_IS_GV_VALUE(*source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS)) {
+          int8_t gvindex = GV_INDEX_CALC_DELTA(*source, delta);
+          if(gvindex<0 && sensor->formula == TELEM_FORMULA_MULTIPLY) {
+            lcdDrawChar(SENSOR_2ND_COLUMN, y, '/', attr);
+            drawGVarName(lcdNextPos, y, -gvindex-1, attr);
+          } else {
+            drawGVarName(SENSOR_2ND_COLUMN, y, gvindex, attr);
+          }
+        } else
+#endif
+        {
+          if (*source < 0) {
+            lcdDrawChar(SENSOR_2ND_COLUMN, y, '-', attr);
+            drawSource(lcdNextPos, y, MIXSRC_FIRST_TELEM+3*(-1-*source), attr);
+          }
+          else {
+            drawSource(SENSOR_2ND_COLUMN, y, *source ? MIXSRC_FIRST_TELEM+3*(*source-1) : 0, attr);
+          }
         }
         break;
       }

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -453,8 +453,10 @@ void telemetryInterrupt10ms()
 #if !defined(SIMU)
     telemetryData.rssi.reset();
 #endif
-    for (auto & telemetryItem: telemetryItems) {
-      if (telemetryItem.isAvailable()) {
+    for (int i=0; i<MAX_TELEMETRY_SENSORS; i++) {
+      const TelemetrySensor & sensor = g_model.telemetrySensors[i];
+      TelemetryItem & telemetryItem = telemetryItems[i];
+      if (telemetryItem.isAvailable() && !sensor.isOfflineFresh()) {
         telemetryItem.setOld();
       }
     }

--- a/radio/src/telemetry/telemetry_sensors.cpp
+++ b/radio/src/telemetry/telemetry_sensors.cpp
@@ -405,6 +405,41 @@ void TelemetryItem::eval(const TelemetrySensor & sensor)
       }
       for (int i=0; i<maxitems; i++) {
         int8_t source = sensor.calc.sources[i];
+#if defined(GVARS)
+        if (GV_IS_GV_VALUE(source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS)) {
+          int32_t gvarvalue;
+          {
+            int8_t min = -MAX_TELEMETRY_SENSORS;
+            gvarvalue = getGVarValue(GV_INDEX_CALCULATION(source, MAX_TELEMETRY_SENSORS), mixerCurrentFlightMode);
+          }
+
+          if (sensor.formula == TELEM_FORMULA_MULTIPLY) {
+            if (source>0) {
+              //divide, actually
+              int32_t divisor = convertTelemetryValue(-gvarvalue, sensor.unit, 0, sensor.unit, 0);
+              if (divisor!=0) {
+                value = convertTelemetryValue(value, sensor.unit, mulprec, sensor.unit, mulprec+sensor.prec)/divisor;
+              } else {
+                value = 0;
+              }
+            } else {
+              value *= convertTelemetryValue(gvarvalue, sensor.unit, 0, sensor.unit, 0);
+              mulprec += sensor.prec;
+            }
+          }
+          else {
+            if (sensor.formula == TELEM_FORMULA_MIN)
+              value = (count==1 ? gvarvalue : min<int32_t>(value, gvarvalue));
+            else if (sensor.formula == TELEM_FORMULA_MAX)
+              value = (count==1 ? gvarvalue : max<int32_t>(value, gvarvalue));
+            else
+              value += gvarvalue;
+          }
+          count += 1;
+
+          continue;
+        }
+#endif
         if (source) {
           unsigned int index = abs(source)-1;
           TelemetrySensor & telemetrySensor = g_model.telemetrySensors[index];
@@ -631,6 +666,25 @@ void TelemetrySensor::init(uint16_t id)
 bool TelemetrySensor::isAvailable() const
 {
   return ZLEN(label) > 0;
+}
+
+bool TelemetrySensor::isOfflineFresh() const
+{
+  if(type == TELEM_TYPE_CALCULATED && formula <= TELEM_FORMULA_MULTIPLY) {
+    int32_t maxitems = 4;
+    if(formula == TELEM_FORMULA_MULTIPLY) {
+      maxitems = 2;
+    }
+    for(int i=0; i<maxitems; i++) {
+      int8_t source = calc.sources[i];
+      if(source && !GV_IS_GV_VALUE(source, -MAX_TELEMETRY_SENSORS, MAX_TELEMETRY_SENSORS)) {
+        return false;
+      }
+    }
+    return true;
+  } else {
+    return false;
+  }
 }
 
 PACK(typedef struct {


### PR DESCRIPTION
Fixes #2092

Summary of changes:

Allows calculated telemetry sources (specifically `add`, `average`, `min`, `max` and `multiply`) to use GVars as sources.
The multiply source can also divide by GVars, not just multiply.

This is useful for scaling telemetry values in ways that `ratio` does not support due to limited precision.
Additionally, GVars may be dynamically changed, further expanding the scaling capabilities.

Example:
Auto-detecting the number of cells and scaling a voltage sensor (VFAS, blheli32 telemetry) to produce average cell voltage.

Current state:
Missing gui for colorlcd.
Gui works on simulated X9LITE.
Tested and works on real X9D+.

See also:
https://github.com/opentx/opentx/issues/8436
https://github.com/opentx/opentx/issues/6293
https://github.com/opentx/opentx/pull/3593
