### PR TITLE
Fixed build error, when building with -DMULTIMODULE=NO.

### DIFF
--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -166,12 +166,14 @@ void processTelemetryData(uint8_t data)
   }
 #endif
 
+#if defined(MULTIMODULE)
   if (telemetryProtocol == PROTOCOL_TELEMETRY_SPEKTRUM ||
       telemetryProtocol == PROTOCOL_TELEMETRY_DSMP) {
     processSpektrumTelemetryData(EXTERNAL_MODULE, data, telemetryRxBuffer,
                                  telemetryRxBufferCount);
     return;
   }
+#endif
 
 #if defined(MULTIMODULE)
   if (telemetryProtocol == PROTOCOL_TELEMETRY_FLYSKY_IBUS) {


### PR DESCRIPTION
Calling any spektrum (and multi module) functions when MULTIMODULE is
_not_ defined, breaks the build.

This patch fixes an above-mentioned case, where
processSpektrumTelemetryData was being called from telemetry.cpp
without checking whether MULTIMODULE was defined.
