### PR TITLE
Adds channel outputs to set of logged data

### DIFF
--- a/radio/src/logs.cpp
+++ b/radio/src/logs.cpp
@@ -246,6 +246,10 @@ void writeHeader()
     }
   }
   f_puts("LSW,", &g_oLogFile);
+  
+  for (uint8_t channel = 0; channel < MAX_OUTPUT_CHANNELS; channel++) {
+    f_printf(&g_oLogFile, "CH%d(us),", channel+1);
+  }
 #else
   f_puts("Rud,Ele,Thr,Ail,P1,P2,P3,THR,RUD,ELE,3POS,AIL,GEA,TRN,", &g_oLogFile);
 #endif
@@ -353,6 +357,10 @@ void logsWrite()
         }
       }
       f_printf(&g_oLogFile, "0x%08X%08X,", getLogicalSwitchesStates(32), getLogicalSwitchesStates(0));
+
+      for (uint8_t channel = 0; channel < MAX_OUTPUT_CHANNELS; channel++) {
+        f_printf(&g_oLogFile, "%d,", PPM_CENTER+channelOutputs[channel]/2); // in us
+      }
 #else
       f_printf(&g_oLogFile, "%d,%d,%d,%d,%d,%d,%d,",
           GET_2POS_STATE(THR),

--- a/radio/src/tasks.h
+++ b/radio/src/tasks.h
@@ -36,7 +36,7 @@
 
 #if defined(FREE_RTOS)
 #define MIXER_TASK_PRIO        (tskIDLE_PRIORITY + 4)
-#define AUDIO_TASK_PRIO        (tskIDLE_PRIORITY + 2)
+#define AUDIO_TASK_PRIO        (tskIDLE_PRIORITY + 3) // Note: FreeRTOSConfig.h defines software timers as priority 2
 #define MENUS_TASK_PRIO        (tskIDLE_PRIORITY + 1)
 #define CLI_TASK_PRIO          (tskIDLE_PRIORITY + 1)
 #else


### PR DESCRIPTION
Summary of changes:
- adds logging of channel outputs CH1..CH32 in units of microseconds

Justification of change:
Looking at my logs the other day I noticed stick, switch and pot inputs are logged but no way of telling what the transmitters really sends to the rx (channel outputs). Only the beginning of the processing chain is logged. Example V-Tail. The only thing you see is you commanding left/right rudder. You can't see how this finally ends up commanding two rx outputs to move two servos after all the tx mix/curve/output processing.

Example 1: V-Tail. Compare rudder stick input to actual action of servos
![c1](https://user-images.githubusercontent.com/5615068/177579834-a71ea248-dee2-416f-b99f-1657013d2666.PNG)
![c2](https://user-images.githubusercontent.com/5615068/177579850-c2038de3-e0a8-4537-a8ab-5ea1d0944cb5.PNG)

Example 2: Channel throw limited and delayed by mixer. Servo on channel 5 controlled by switch SA, delayed by 5s by mixer and limited to 80% (1909us) and 50% throw (1244us). 
![c3](https://user-images.githubusercontent.com/5615068/177579914-4e9a1af4-cb5c-4578-8721-5c1f5eacc87f.PNG)

