### PR TITLE
feat(radio): add longer versions of SF names

### DIFF
--- a/radio/src/cfn_sort.cpp
+++ b/radio/src/cfn_sort.cpp
@@ -80,7 +80,7 @@ Functions cfn_sorted[] = {
   /* Hrát zvuk */ FUNC_PLAY_SOUND,
   /* Hudba */ FUNC_BACKGND_MUSIC,
   /* Hudba pauza */ FUNC_BACKGND_MUSIC_PAUSE,
-  /* Insta-Trim */ FUNC_INSTANT_TRIM,
+  /* Instantní trim */ FUNC_INSTANT_TRIM,
 #if OLED_SCREEN
   /* Jas */ FUNC_BACKLIGHT,
 #endif
@@ -90,9 +90,9 @@ Functions cfn_sorted[] = {
 #endif
   /* Loguj na SD */ FUNC_LOGS,
   /* Lua Skript */ FUNC_PLAY_SCRIPT,
-  /* ModuleBind */ FUNC_BIND,
+  /* Modul bind */ FUNC_BIND,
   /* Nastav */ FUNC_ADJUST_GVAR,
-  /* Nastavit Failsafe */ FUNC_SET_FAILSAFE,
+  /* Nastavit failsafe */ FUNC_SET_FAILSAFE,
 #if defined(KEYS_LOCK_KEY1) && defined(KEYS_LOCK_KEY2)
   /* No Keys */ FUNC_DISABLE_KEYS,
 #endif
@@ -124,11 +124,11 @@ Functions cfn_sorted[] = {
 #endif
   /* Baggrund musik */ FUNC_BACKGND_MUSIC,
   /* Baggrund musik || */ FUNC_BACKGND_MUSIC_PAUSE,
+  /* Fast trim */ FUNC_INSTANT_TRIM,
   /* Højdemåler */ FUNC_VARIO,
 #if defined(COLORLCD)
   /* Ikke berøringsaktiv */ FUNC_DISABLE_TOUCH,
 #endif
-  /* Inst. Trim */ FUNC_INSTANT_TRIM,
   /* Juster */ FUNC_ADJUST_GVAR,
 #if defined(VIDEO_SWITCH)
   /* LCD til Video */ FUNC_LCD_TO_VIDEO,
@@ -172,7 +172,7 @@ Functions cfn_sorted[] = {
 #if OLED_SCREEN
   /* Helligkeit */ FUNC_BACKLIGHT,
 #endif
-  /* Inst. Trim */ FUNC_INSTANT_TRIM,
+  /* Instant Trim */ FUNC_INSTANT_TRIM,
 #if defined(COLORLCD)
   /* Kein Touch */ FUNC_DISABLE_TOUCH,
 #endif
@@ -188,17 +188,17 @@ Functions cfn_sorted[] = {
   /* LS setzen */ FUNC_PUSH_CUST_SWITCH,
 #endif
   /* Lua-Skript */ FUNC_PLAY_SCRIPT,
-  /* ModuleBind */ FUNC_BIND,
+  /* Module Bind */ FUNC_BIND,
 #if defined(KEYS_LOCK_KEY1) && defined(KEYS_LOCK_KEY2)
   /* No Keys */ FUNC_DISABLE_KEYS,
 #endif
-  /* RacingMode */ FUNC_RACING_MODE,
-  /* RangeCheck */ FUNC_RANGECHECK,
+  /* Racing Mode */ FUNC_RACING_MODE,
+  /* Range Check */ FUNC_RANGECHECK,
   /* RGB LED */ FUNC_RGB_LED,
   /* Rücksetz. */ FUNC_RESET,
   /* Screenshot */ FUNC_SCREENSHOT,
   /* SD-Aufz. */ FUNC_LOGS,
-  /* SetFailsafe */ FUNC_SET_FAILSAFE,
+  /* Set Failsafe */ FUNC_SET_FAILSAFE,
   /* Setze */ FUNC_SET_TIMER,
   /* Spiel Töne */ FUNC_PLAY_SOUND,
   /* StartMusik */ FUNC_BACKGND_MUSIC,
@@ -224,7 +224,7 @@ Functions cfn_sorted[] = {
   /* Entrenador */ FUNC_TRAINER,
   /* Failsafe */ FUNC_SET_FAILSAFE,
   /* Haptic */ FUNC_HAPTIC,
-  /* Inst. Trim */ FUNC_INSTANT_TRIM,
+  /* Instant Trim */ FUNC_INSTANT_TRIM,
 #if defined(VIDEO_SWITCH)
   /* LCD to Video */ FUNC_LCD_TO_VIDEO,
 #endif
@@ -244,7 +244,7 @@ Functions cfn_sorted[] = {
 #if defined(FUNCTION_SWITCHES)
   /* Push CS */ FUNC_PUSH_CUST_SWITCH,
 #endif
-  /* RacingMode */ FUNC_RACING_MODE,
+  /* Racing Mode */ FUNC_RACING_MODE,
   /* Reset */ FUNC_RESET,
   /* RGB leds */ FUNC_RGB_LED,
   /* SD Logs */ FUNC_LOGS,
@@ -264,7 +264,7 @@ Functions cfn_sorted[] = {
   /* BgMusic */ FUNC_BACKGND_MUSIC,
   /* BgMusic || */ FUNC_BACKGND_MUSIC_PAUSE,
   /* Haptic */ FUNC_HAPTIC,
-  /* Inst. Trim */ FUNC_INSTANT_TRIM,
+  /* Instant Trim */ FUNC_INSTANT_TRIM,
 #if OLED_SCREEN
   /* Kirkkaus */ FUNC_BACKLIGHT,
 #endif
@@ -272,7 +272,7 @@ Functions cfn_sorted[] = {
   /* LCD to Video */ FUNC_LCD_TO_VIDEO,
 #endif
   /* Lua Script */ FUNC_PLAY_SCRIPT,
-  /* ModuleBind */ FUNC_BIND,
+  /* Module Bind */ FUNC_BIND,
 #if defined(KEYS_LOCK_KEY1) && defined(KEYS_LOCK_KEY2)
   /* No Keys */ FUNC_DISABLE_KEYS,
 #endif
@@ -285,15 +285,15 @@ Functions cfn_sorted[] = {
 #if defined(FUNCTION_SWITCHES)
   /* Push CS */ FUNC_PUSH_CUST_SWITCH,
 #endif
-  /* RacingMode */ FUNC_RACING_MODE,
-  /* RangeCheck */ FUNC_RANGECHECK,
+  /* Racing Mode */ FUNC_RACING_MODE,
+  /* Range Check */ FUNC_RANGECHECK,
   /* Reset */ FUNC_RESET,
   /* RGB leds */ FUNC_RGB_LED,
   /* Safety */ FUNC_OVERRIDE_CHANNEL,
   /* Screenshot */ FUNC_SCREENSHOT,
   /* SD Logs */ FUNC_LOGS,
   /* Set */ FUNC_SET_TIMER,
-  /* SetFailsafe */ FUNC_SET_FAILSAFE,
+  /* Set Failsafe */ FUNC_SET_FAILSAFE,
   /* Set Main Screen */ FUNC_SET_SCREEN,
 #if defined(DEBUG)
   /* Test */ FUNC_TEST,
@@ -308,7 +308,7 @@ Functions cfn_sorted[] = {
   /* Définir Écran Princ. */ FUNC_SET_SCREEN,
   /* Désact. Ampli Audio */ FUNC_DISABLE_AUDIO_AMP,
   /* Écolage */ FUNC_TRAINER,
-  /* Inst. Trim */ FUNC_INSTANT_TRIM,
+  /* Instant Trim */ FUNC_INSTANT_TRIM,
   /* Jouer fichier */ FUNC_PLAY_TRACK,
   /* Jouer son */ FUNC_PLAY_SOUND,
 #if defined(VIDEO_SWITCH)
@@ -401,7 +401,7 @@ Functions cfn_sorted[] = {
   /* Disab. touch */ FUNC_DISABLE_TOUCH,
 #endif
   /* Ignora */ FUNC_OVERRIDE_CHANNEL,
-  /* Inst. Trim */ FUNC_INSTANT_TRIM,
+  /* Instant Trim */ FUNC_INSTANT_TRIM,
 #if defined(VIDEO_SWITCH)
   /* LCD su video */ FUNC_LCD_TO_VIDEO,
 #endif
@@ -421,7 +421,7 @@ Functions cfn_sorted[] = {
 #if defined(FUNCTION_SWITCHES)
   /* Premi CS */ FUNC_PUSH_CUST_SWITCH,
 #endif
-  /* RangeCheck */ FUNC_RANGECHECK,
+  /* Range Check */ FUNC_RANGECHECK,
   /* Regola */ FUNC_ADJUST_GVAR,
 #if !OLED_SCREEN
   /* Retroillum. */ FUNC_BACKLIGHT,
@@ -429,7 +429,7 @@ Functions cfn_sorted[] = {
   /* Screenshot */ FUNC_SCREENSHOT,
   /* Script Lua */ FUNC_PLAY_SCRIPT,
   /* Set */ FUNC_SET_TIMER,
-  /* SetFailsafe */ FUNC_SET_FAILSAFE,
+  /* Set Failsafe */ FUNC_SET_FAILSAFE,
   /* Setta Schermo Princ. */ FUNC_SET_SCREEN,
   /* Suona */ FUNC_PLAY_SOUND,
   /* Suona Traccia */ FUNC_PLAY_TRACK,
@@ -543,12 +543,12 @@ Functions cfn_sorted[] = {
 #if OLED_SCREEN
   /* Helderheid */ FUNC_BACKLIGHT,
 #endif
-  /* Inst. Trim */ FUNC_INSTANT_TRIM,
+  /* Instant Trim */ FUNC_INSTANT_TRIM,
 #if defined(VIDEO_SWITCH)
   /* LCD to Video */ FUNC_LCD_TO_VIDEO,
 #endif
   /* Lua Script */ FUNC_PLAY_SCRIPT,
-  /* ModuleBind */ FUNC_BIND,
+  /* Module Bind */ FUNC_BIND,
 #if defined(KEYS_LOCK_KEY1) && defined(KEYS_LOCK_KEY2)
   /* No Keys */ FUNC_DISABLE_KEYS,
 #endif
@@ -561,14 +561,14 @@ Functions cfn_sorted[] = {
 #if defined(FUNCTION_SWITCHES)
   /* Push CS */ FUNC_PUSH_CUST_SWITCH,
 #endif
-  /* RacingMode */ FUNC_RACING_MODE,
-  /* RangeCheck */ FUNC_RANGECHECK,
+  /* Racing Mode */ FUNC_RACING_MODE,
+  /* Range Check */ FUNC_RANGECHECK,
   /* Reset */ FUNC_RESET,
   /* RGB leds */ FUNC_RGB_LED,
   /* Schermafdr */ FUNC_SCREENSHOT,
   /* SD Logs */ FUNC_LOGS,
   /* Set */ FUNC_SET_TIMER,
-  /* SetFailsafe */ FUNC_SET_FAILSAFE,
+  /* Set Failsafe */ FUNC_SET_FAILSAFE,
   /* Set Main Screen */ FUNC_SET_SCREEN,
 #if defined(DEBUG)
   /* Test */ FUNC_TEST,
@@ -591,7 +591,7 @@ Functions cfn_sorted[] = {
   /* LCD to Video */ FUNC_LCD_TO_VIDEO,
 #endif
   /* Logi->SD */ FUNC_LOGS,
-  /* ModuleBind */ FUNC_BIND,
+  /* Module Bind */ FUNC_BIND,
   /* Muz. tła */ FUNC_BACKGND_MUSIC,
   /* Muz. tła || */ FUNC_BACKGND_MUSIC_PAUSE,
 #if defined(KEYS_LOCK_KEY1) && defined(KEYS_LOCK_KEY2)
@@ -606,12 +606,12 @@ Functions cfn_sorted[] = {
 #if defined(FUNCTION_SWITCHES)
   /* Push CS */ FUNC_PUSH_CUST_SWITCH,
 #endif
-  /* RacingMode */ FUNC_RACING_MODE,
-  /* RangeCheck */ FUNC_RANGECHECK,
+  /* Racing Mode */ FUNC_RACING_MODE,
+  /* Range Check */ FUNC_RANGECHECK,
   /* Resetuj */ FUNC_RESET,
   /* RGB ledy */ FUNC_RGB_LED,
+  /* Set Failsafe */ FUNC_SET_FAILSAFE,
   /* Set Main Screen */ FUNC_SET_SCREEN,
-  /* SetFailsafe */ FUNC_SET_FAILSAFE,
   /* SkryptyLua */ FUNC_PLAY_SCRIPT,
 #if defined(DEBUG)
   /* Test */ FUNC_TEST,
@@ -654,7 +654,7 @@ Functions cfn_sorted[] = {
 #if defined(FUNCTION_SWITCHES)
   /* Push CS */ FUNC_PUSH_CUST_SWITCH,
 #endif
-  /* RangeCheck */ FUNC_RANGECHECK,
+  /* Range Check */ FUNC_RANGECHECK,
   /* Rep Valor */ FUNC_PLAY_VALUE,
   /* Reset */ FUNC_RESET,
   /* Script Lua */ FUNC_PLAY_SCRIPT,
@@ -865,12 +865,12 @@ Functions cfn_sorted[] = {
   /* Brightness */ FUNC_BACKLIGHT,
 #endif
   /* Haptic */ FUNC_HAPTIC,
-  /* Inst. Trim */ FUNC_INSTANT_TRIM,
+  /* Instant Trim */ FUNC_INSTANT_TRIM,
 #if defined(VIDEO_SWITCH)
   /* LCD to Video */ FUNC_LCD_TO_VIDEO,
 #endif
   /* Lua Script */ FUNC_PLAY_SCRIPT,
-  /* ModuleBind */ FUNC_BIND,
+  /* Module Bind */ FUNC_BIND,
 #if defined(KEYS_LOCK_KEY1) && defined(KEYS_LOCK_KEY2)
   /* No Keys */ FUNC_DISABLE_KEYS,
 #endif
@@ -884,14 +884,14 @@ Functions cfn_sorted[] = {
 #if defined(FUNCTION_SWITCHES)
   /* Push CS */ FUNC_PUSH_CUST_SWITCH,
 #endif
-  /* RacingMode */ FUNC_RACING_MODE,
-  /* RangeCheck */ FUNC_RANGECHECK,
+  /* Racing Mode */ FUNC_RACING_MODE,
+  /* Range Check */ FUNC_RANGECHECK,
   /* Reset */ FUNC_RESET,
   /* RGB leds */ FUNC_RGB_LED,
   /* Screenshot */ FUNC_SCREENSHOT,
   /* SD Logs */ FUNC_LOGS,
   /* Set */ FUNC_SET_TIMER,
-  /* SetFailsafe */ FUNC_SET_FAILSAFE,
+  /* Set Failsafe */ FUNC_SET_FAILSAFE,
   /* Set Main Screen */ FUNC_SET_SCREEN,
 #if defined(DEBUG)
   /* Test */ FUNC_TEST,

--- a/radio/src/translations/i18n/cz.h
+++ b/radio/src/translations/i18n/cz.h
@@ -216,13 +216,13 @@
 #define TR_CSWSTAY                     "Edge"
 
 #define TR_SF_TRAINER                  "Trenér"
-#define TR_SF_INST_TRIM                "Insta-Trim"
+#define TR_SF_INST_TRIM                "Instantní trim"
 #define TR_SF_RESET                    "Reset"
 #define TR_SF_SET_TIMER                "Změna"
 #define TR_SF_VOLUME                   "Hlasitost"
-#define TR_SF_FAILSAFE                 "Nastavit Failsafe"
+#define TR_SF_FAILSAFE                 "Nastavit failsafe"
 #define TR_SF_RANGE_CHECK              "Kontrola dosahu"
-#define TR_SF_MOD_BIND                 "ModuleBind"
+#define TR_SF_MOD_BIND                 "Modul bind"
 #define TR_SF_RGBLEDS                  "RGB světlo"
 
 #define TR_SOUND                       TR_BW_COL("\204\205Zvuk", "Hrát zvuk")

--- a/radio/src/translations/i18n/da.h
+++ b/radio/src/translations/i18n/da.h
@@ -216,7 +216,7 @@
 #define TR_CSWSTAY                     "Edge"
 
 #define TR_SF_TRAINER                  "Træner"
-#define TR_SF_INST_TRIM                "Inst. Trim"
+#define TR_SF_INST_TRIM                "Fast trim"
 #define TR_SF_RESET                    "Nulstil"
 #define TR_SF_SET_TIMER                "Sæt"
 #define TR_SF_VOLUME                   "Lydstyrke"
@@ -240,7 +240,7 @@
 #define TR_SF_SAFETY                   TR("Overs.", "Overskriv")
 
 #define TR_SF_SCREENSHOT               "Skærm klip"
-#define TR_SF_RACING_MODE              "Ræs tilstand"
+#define TR_SF_RACING_MODE              TR("Ræs til.", "Ræs tilstand")
 #define TR_SF_DISABLE_TOUCH            "Ikke berøringsaktiv"
 #define TR_SF_DISABLE_KEYS             "No Keys"
 #define TR_SF_DISABLE_AUDIO_AMP        TR("Sluk audio amp", "Sluk audio amplifier")

--- a/radio/src/translations/i18n/de.h
+++ b/radio/src/translations/i18n/de.h
@@ -217,13 +217,13 @@
 #define TR_CSWSTAY                     "Puls"  // Edge = einstellbarer Impuls
 
 #define TR_SF_TRAINER                  "Lehrer"
-#define TR_SF_INST_TRIM                "Inst. Trim"
+#define TR_SF_INST_TRIM                "Instant Trim"
 #define TR_SF_RESET                    "Rücksetz."
 #define TR_SF_SET_TIMER                "Setze"
 #define TR_SF_VOLUME                   "Lautstr."
-#define TR_SF_FAILSAFE                 "SetFailsafe"
-#define TR_SF_RANGE_CHECK              "RangeCheck"
-#define TR_SF_MOD_BIND                 "ModuleBind"
+#define TR_SF_FAILSAFE                 "Set Failsafe"
+#define TR_SF_RANGE_CHECK              "Range Check"
+#define TR_SF_MOD_BIND                 "Module Bind"
 #define TR_SF_RGBLEDS                  "RGB LED"
 
 #define TR_SOUND                       "Spiel Töne"
@@ -241,7 +241,7 @@
 #define TR_SF_SAFETY                   TR("Übersch.", "Überschreibe")
 
 #define TR_SF_SCREENSHOT               "Screenshot"
-#define TR_SF_RACING_MODE              "RacingMode"
+#define TR_SF_RACING_MODE              "Racing Mode"
 #define TR_SF_DISABLE_TOUCH            "Kein Touch"
 #define TR_SF_DISABLE_KEYS             "No Keys"
 #define TR_SF_DISABLE_AUDIO_AMP        "Audio Verst. Aus"

--- a/radio/src/translations/i18n/en.h
+++ b/radio/src/translations/i18n/en.h
@@ -214,13 +214,13 @@
 #define TR_CSWSTAY                     "Edge"
 
 #define TR_SF_TRAINER                  "Trainer"
-#define TR_SF_INST_TRIM                "Inst. Trim"
+#define TR_SF_INST_TRIM                "Instant Trim"
 #define TR_SF_RESET                    "Reset"
 #define TR_SF_SET_TIMER                "Set"
 #define TR_SF_VOLUME                   "Volume"
-#define TR_SF_FAILSAFE                 "SetFailsafe"
-#define TR_SF_RANGE_CHECK              "RangeCheck"
-#define TR_SF_MOD_BIND                 "ModuleBind"
+#define TR_SF_FAILSAFE                 "Set Failsafe"
+#define TR_SF_RANGE_CHECK              "Range Check"
+#define TR_SF_MOD_BIND                 "Module Bind"
 #define TR_SF_RGBLEDS                  "RGB leds"
 
 #define TR_SOUND                       "Play Sound"
@@ -239,7 +239,7 @@
 #define TR_SF_SAFETY                   TR("Overr.", "Override")
 
 #define TR_SF_SCREENSHOT               "Screenshot"
-#define TR_SF_RACING_MODE              "RacingMode"
+#define TR_SF_RACING_MODE              "Racing Mode"
 #define TR_SF_DISABLE_TOUCH            "No Touch"
 #define TR_SF_DISABLE_KEYS             "No Keys"
 #define TR_SF_DISABLE_AUDIO_AMP        "Audio Amp Off"

--- a/radio/src/translations/i18n/es.h
+++ b/radio/src/translations/i18n/es.h
@@ -214,7 +214,7 @@
 #define TR_CSWSTAY             TR("Bord", "Borde")
 
 #define TR_SF_TRAINER                  "Entrenador"
-#define TR_SF_INST_TRIM                "Inst. Trim"
+#define TR_SF_INST_TRIM                "Instant Trim"
 #define TR_SF_RESET                    "Reset"
 #define TR_SF_SET_TIMER                "Ajuste"
 #define TR_SF_VOLUME                   "Volumen"
@@ -237,9 +237,9 @@
 #define TR_SF_TEST                     "Test"
 #define TR_SF_SAFETY                   "Seguro"
 
-#define TR_SF_SCREENSHOT      "Captura"
-#define TR_SF_RACING_MODE     "RacingMode"
-#define TR_SF_DISABLE_TOUCH   "No Touch"
+#define TR_SF_SCREENSHOT               "Captura"
+#define TR_SF_RACING_MODE              "Racing Mode"
+#define TR_SF_DISABLE_TOUCH            "No Touch"
 #define TR_SF_DISABLE_KEYS             "No Keys"
 #define TR_SF_DISABLE_AUDIO_AMP        "Audio Amp Off"
 #define TR_SF_SET_SCREEN      TR_BW_COL("Ajus. pantalla", "Set Main Screen")

--- a/radio/src/translations/i18n/fi.h
+++ b/radio/src/translations/i18n/fi.h
@@ -215,13 +215,13 @@
 #define TR_CSWSTAY                     "Edge"
 
 #define TR_SF_TRAINER                  "Trainer"
-#define TR_SF_INST_TRIM                "Inst. Trim"
+#define TR_SF_INST_TRIM                "Instant Trim"
 #define TR_SF_RESET                    "Reset"
 #define TR_SF_SET_TIMER                "Set"
 #define TR_SF_VOLUME                   "Volume"
-#define TR_SF_FAILSAFE                 "SetFailsafe"
-#define TR_SF_RANGE_CHECK              "RangeCheck"
-#define TR_SF_MOD_BIND                 "ModuleBind"
+#define TR_SF_FAILSAFE                 "Set Failsafe"
+#define TR_SF_RANGE_CHECK              "Range Check"
+#define TR_SF_MOD_BIND                 "Module Bind"
 #define TR_SF_RGBLEDS                  "RGB leds"
 
 #define TR_SOUND                       "Play Sound"
@@ -239,7 +239,7 @@
 #define TR_SF_SAFETY                   "Safety"
 
 #define TR_SF_SCREENSHOT               "Screenshot"
-#define TR_SF_RACING_MODE              "RacingMode"
+#define TR_SF_RACING_MODE              "Racing Mode"
 #define TR_SF_DISABLE_TOUCH            "No Touch"
 #define TR_SF_DISABLE_KEYS             "No Keys"
 #define TR_SF_DISABLE_AUDIO_AMP        "Audio Amp Off"

--- a/radio/src/translations/i18n/fr.h
+++ b/radio/src/translations/i18n/fr.h
@@ -218,7 +218,7 @@
 #define TR_CSWSTAY                     "Edge"
 
 #define TR_SF_TRAINER                  "Écolage"
-#define TR_SF_INST_TRIM                "Inst. Trim"
+#define TR_SF_INST_TRIM                "Instant Trim"
 #define TR_SF_RESET                    "Remise à 0"
 #define TR_SF_SET_TIMER                "Déf."
 #define TR_SF_VOLUME                   "Volume"

--- a/radio/src/translations/i18n/it.h
+++ b/radio/src/translations/i18n/it.h
@@ -214,12 +214,12 @@
 #define TR_CSWSTAY                      "Edge"
 
 #define TR_SF_TRAINER                  "Maestro"
-#define TR_SF_INST_TRIM                "Inst. Trim"
+#define TR_SF_INST_TRIM                "Instant Trim"
 #define TR_SF_RESET                    "Azzera"
 #define TR_SF_SET_TIMER                "Set"
 #define TR_SF_VOLUME                   "Volume"
-#define TR_SF_FAILSAFE                 "SetFailsafe"
-#define TR_SF_RANGE_CHECK              "RangeCheck"
+#define TR_SF_FAILSAFE                 "Set Failsafe"
+#define TR_SF_RANGE_CHECK              "Range Check"
 #define TR_SF_MOD_BIND                 "BindModulo"
 #define TR_SF_RGBLEDS                  "Leds RGB"
 

--- a/radio/src/translations/i18n/nl.h
+++ b/radio/src/translations/i18n/nl.h
@@ -215,13 +215,13 @@
 #define TR_CSWSTAY             "Edge"
 
 #define TR_SF_TRAINER          "Trainer"
-#define TR_SF_INST_TRIM        "Inst. Trim"
+#define TR_SF_INST_TRIM        "Instant Trim"
 #define TR_SF_RESET            "Reset"
 #define TR_SF_SET_TIMER        "Set"
 #define TR_SF_VOLUME           "Volume"
-#define TR_SF_FAILSAFE         "SetFailsafe"
-#define TR_SF_RANGE_CHECK      "RangeCheck"
-#define TR_SF_MOD_BIND         "ModuleBind"
+#define TR_SF_FAILSAFE         "Set Failsafe"
+#define TR_SF_RANGE_CHECK      "Range Check"
+#define TR_SF_MOD_BIND         "Module Bind"
 #define TR_SF_RGBLEDS          "RGB leds"
 
 #define TR_SOUND               "Geluid"
@@ -238,12 +238,12 @@
 #define TR_SF_TEST             "Test"
 #define TR_SF_SAFETY           TR("Overr.","Override")
 
-#define TR_SF_SCREENSHOT      "Schermafdr"
-#define TR_SF_RACING_MODE     "RacingMode"
-#define TR_SF_DISABLE_TOUCH   "No Touch"
+#define TR_SF_SCREENSHOT               "Schermafdr"
+#define TR_SF_RACING_MODE              "Racing Mode"
+#define TR_SF_DISABLE_TOUCH            "No Touch"
 #define TR_SF_DISABLE_KEYS             "No Keys"
 #define TR_SF_DISABLE_AUDIO_AMP        "Audio Amp Off"
-#define TR_SF_SET_SCREEN      TR_BW_COL("Set Screen", "Set Main Screen")
+#define TR_SF_SET_SCREEN               TR_BW_COL("Set Screen", "Set Main Screen")
 #define TR_SF_PUSH_CUST_SWITCH         "Push CS"
 #define TR_SF_LCD_TO_VIDEO             "LCD to Video"
 

--- a/radio/src/translations/i18n/pl.h
+++ b/radio/src/translations/i18n/pl.h
@@ -218,9 +218,9 @@
 #define TR_SF_RESET           "Resetuj"
 #define TR_SF_SET_TIMER       "Ustaw"
 #define TR_SF_VOLUME          "Głośność"
-#define TR_SF_FAILSAFE        "SetFailsafe"
-#define TR_SF_RANGE_CHECK     "RangeCheck"
-#define TR_SF_MOD_BIND        "ModuleBind"
+#define TR_SF_FAILSAFE        "Set Failsafe"
+#define TR_SF_RANGE_CHECK     "Range Check"
+#define TR_SF_MOD_BIND        "Module Bind"
 #define TR_SF_RGBLEDS         "RGB ledy"
 
 #define TR_SOUND              "GrajDźwięk"
@@ -237,9 +237,9 @@
 #define TR_SF_TEST            "Test"
 #define TR_SF_SAFETY          TR("Bezp.","Bezpiecz")
 
-#define TR_SF_SCREENSHOT      "Zrzut Ekra"
-#define TR_SF_RACING_MODE     "RacingMode"
-#define TR_SF_DISABLE_TOUCH   "No Touch"
+#define TR_SF_SCREENSHOT        "Zrzut Ekra"
+#define TR_SF_RACING_MODE       "Racing Mode"
+#define TR_SF_DISABLE_TOUCH     "No Touch"
 #define TR_SF_DISABLE_KEYS    "No Keys"
 #define TR_SF_DISABLE_AUDIO_AMP TR("Wycisz wzm.", "Wycisz wzmacniacz audio")
 #define TR_SF_SET_SCREEN      TR_BW_COL("Ustaw ekran", "Set Main Screen")

--- a/radio/src/translations/i18n/pt.h
+++ b/radio/src/translations/i18n/pt.h
@@ -219,7 +219,7 @@
 #define TR_SF_SET_TIMER                "Definir"
 #define TR_SF_VOLUME                   "Volume"
 #define TR_SF_FAILSAFE                 "DefFailsafe"
-#define TR_SF_RANGE_CHECK              "RangeCheck"
+#define TR_SF_RANGE_CHECK              "Range Check"
 #define TR_SF_MOD_BIND                 "BindMódulo"
 #define TR_SF_RGBLEDS                  "Leds RGB"
 


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Summary of changes:
- Building on from #2144, add some more spaces since variable lengths strings now an option. 
- Also means translators can translate the previously untranslated modes.
