### PR TITLE
Remove CFGV as no longer needed

### DIFF
--- a/radio/src/fw_version.h
+++ b/radio/src/fw_version.h
@@ -27,7 +27,6 @@ extern const char fw_stamp[];
 extern const char vers_stamp[];
 extern const char date_stamp[];
 extern const char time_stamp[];
-extern const char cfgv_stamp[];
 #else
 extern const char vers_stamp[];
 #endif

--- a/radio/src/gui/colorlcd/radio_version.cpp
+++ b/radio/src/gui/colorlcd/radio_version.cpp
@@ -272,7 +272,6 @@ void RadioVersionPage::build(FormWindow * window)
   version += vers_stamp + nl;
   version += date_stamp + nl;
   version += time_stamp + nl;
-  version += cfgv_stamp + nl;
   version += "OPTS: ";
 
   for (uint8_t i = 0; options[i]; i++) {

--- a/radio/src/stamp.cpp
+++ b/radio/src/stamp.cpp
@@ -28,8 +28,6 @@
 #define STR2(s) #s
 #define DEFNUMSTR(s)  STR2(s)
 
-#define CFGV_STR DEFNUMSTR(EEPROM_VER);
-
 #define TAB "\037\033"
 
 #if defined(FRSKY_RELEASE)
@@ -59,18 +57,17 @@
   #endif
   const char date_stamp[]   = "DATE" TAB ": " DATE;
   const char time_stamp[]   = "TIME" TAB ": " TIME;
-  const char cfgv_stamp[]   = "CFGV" TAB ": " CFGV_STR;
 #elif defined(BOARD_NAME)
-  const char vers_stamp[]   = "FW" TAB ": edgetx-" BOARD_NAME "\036VERS" TAB ": " VERSION DISPLAY_VERSION " (" GIT_STR ")" "\036DATE" TAB ": " DATE " " TIME "\036CFGV" TAB ": " CFGV_STR;
+  const char vers_stamp[]   = "FW" TAB ": edgetx-" BOARD_NAME "\036VERS" TAB ": " VERSION DISPLAY_VERSION " (" GIT_STR ")" "\036DATE" TAB ": " DATE " " TIME;
 #elif defined(RADIOMASTER_RELEASE)
-  const char vers_stamp[]   = "FW" TAB ": edgetx-" FLAVOUR    "\036VERS" TAB ": RM Factory (" GIT_STR ")" "\036BUILT BY : EdgeTX" "\036DATE" TAB ": " DATE " " TIME "\036CFGV" TAB ": " CFGV_STR;
+  const char vers_stamp[]   = "FW" TAB ": edgetx-" FLAVOUR    "\036VERS" TAB ": RM Factory (" GIT_STR ")" "\036BUILT BY : EdgeTX" "\036DATE" TAB ": " DATE " " TIME;
 #elif defined(JUMPER_RELEASE)
-  const char vers_stamp[]   = "FW" TAB ": edgetx-" FLAVOUR    "\036VERS" TAB ": Factory (" GIT_STR ")" "\036BUILT BY : EdgeTX" "\036DATE" TAB ": " DATE " " TIME "\036CFGV" TAB ": " CFGV_STR;
+  const char vers_stamp[]   = "FW" TAB ": edgetx-" FLAVOUR    "\036VERS" TAB ": Factory (" GIT_STR ")" "\036BUILT BY : EdgeTX" "\036DATE" TAB ": " DATE " " TIME;
 #else
   #if defined(VERSION_TAG)
-    const char vers_stamp[]   = "FW" TAB ": edgetx-" FLAVOUR    "\036VERS" TAB ": " VERSION_TAG DISPLAY_VERSION "\036NAME" ": " CODENAME "\036DATE" TAB ": " DATE " " TIME "\036CFGV" TAB ": " CFGV_STR;
+    const char vers_stamp[]   = "FW" TAB ": edgetx-" FLAVOUR    "\036VERS" TAB ": " VERSION_TAG DISPLAY_VERSION "\036NAME" ": " CODENAME "\036DATE" TAB ": " DATE " " TIME;
   #else
-    const char vers_stamp[]   = "FW" TAB ": edgetx-" FLAVOUR    "\036VERS" TAB ": " VERSION "-" VERSION_SUFFIX DISPLAY_VERSION "\036GIT#" TAB ": " GIT_STR "\036DATE" TAB ": " DATE " " TIME "\036CFGV" TAB ": " CFGV_STR;
+    const char vers_stamp[]   = "FW" TAB ": edgetx-" FLAVOUR    "\036VERS" TAB ": " VERSION "-" VERSION_SUFFIX DISPLAY_VERSION "\036GIT#" TAB ": " GIT_STR "\036DATE" TAB ": " DATE " " TIME;
   #endif
 #endif
 


### PR DESCRIPTION
Remove CFGV as no longer needed

Since it related to the EEPROM config value,
which is no longer relevant.

Additionally, this (CFGV) broke after ee0c371 :laughing:

Elaboration: This (CFGV, previously EPRV) is no longer relevant since now the config version is the semver saved in the file, which will be the same as the running ETX version since it is updated automatically. 

<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #

Summary of changes:
