### PR TITLE
Solve ZORRO and TX12MK2 display cluttered stripes on the screen after…

### DIFF
--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -309,6 +309,10 @@ void boardOff()
   }
 #endif
 
+#if defined(RADIO_ZORRO) || defined(RADIO_TX12MK2)
+  lcdInit(); 
+#endif
+
   lcdOff();
   SysTick->CTRL = 0; // turn off systick
   pwrOff();


### PR DESCRIPTION
Solve ZORRO and TX12MK2 display cluttered stripes on the screen after shutdown.
This problem can be solved by initializing again before turning off the LCD.
![1658527429969](https://user-images.githubusercontent.com/6081642/180574557-e5725800-e1c6-47c1-8512-72d7b849d93e.png)


