### PR TITLE
fix: Drop the path from nightly release zips

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Zip release file
         uses: montudor/action-zip@v1
         with:
-          args: zip -qq -r ${{ env.release_filename }} ./edgetx-firmware-nightly
+          args: zip -qq -j -r ${{ env.release_filename }} ./edgetx-firmware-nightly
 
       - name: Deploy release
         uses: marvinpinto/action-automatic-releases@latest


### PR DESCRIPTION
Nightly release zips were including a subfolder, as opposed to PR and normal releases. 

Adding the `-j` flag to zip tells it to junk (drop) the paths. 

@CoderElectronics Ari, will Flasher cope with this without any changes? I know Buddy has been updated to accept either, but I would like to make the zips consistent