### PR TITLE
handle text fields in log

### DIFF
--- a/radio/src/logs.cpp
+++ b/radio/src/logs.cpp
@@ -325,6 +325,9 @@ void logsWrite()
             else if (sensor.unit == UNIT_DATETIME) {
               f_printf(&g_oLogFile, "%4d-%02d-%02d %02d:%02d:%02d,", telemetryItem.datetime.year, telemetryItem.datetime.month, telemetryItem.datetime.day, telemetryItem.datetime.hour, telemetryItem.datetime.min, telemetryItem.datetime.sec);
             }
+            else if (sensor.unit == UNIT_TEXT) {
+              f_printf(&g_oLogFile, "\"%s\",", telemetryItem.text);
+            }
             else if (sensor.prec == 2) {
               div_t qr = div((int)telemetryItem.value, 100);
               if (telemetryItem.value < 0) f_printf(&g_oLogFile, "-");


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #1991

Summary of changes:
Write the "text" field for telemetry sensors that are text type.  Previously, the logic was falling through to write the sensor.value, which is 0.