### PR TITLE
Bump macOS runner version to mac-11

### DIFF
--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -36,7 +36,7 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: macos-10.15
+    runs-on: macos-11
 
     steps:
       - name: Check out the repo

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -39,6 +39,11 @@ jobs:
     runs-on: macos-11
 
     steps:
+      - name: Select XCode version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '11.7'
+
       - name: Check out the repo
         uses: actions/checkout@v2
         with:


### PR DESCRIPTION
Summary of changes:
- `macos-11` runner (`10.15` is deprecated)
- select XCode `11.7`

See [here](https://github.com/actions/virtual-environments/blob/main/images/macos/macos-11-Readme.md) for details on supported tools/versions.