### PR TITLE
Fix ISRM/ACCST translation alignment

### DIFF
--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -988,30 +988,50 @@ void menuModelSetup(event_t event)
       case ITEM_MODEL_SETUP_EXTERNAL_MODULE_TYPE:
 #endif
         lcdDrawTextAlignedLeft(y, INDENT TR_MODE);
-        lcdDrawTextAtIndex(MODEL_SETUP_2ND_COLUMN, y,moduleIdx == EXTERNAL_MODULE ? STR_EXTERNAL_MODULE_PROTOCOLS : STR_INTERNAL_MODULE_PROTOCOLS,moduleIdx == EXTERNAL_MODULE ? reusableBuffer.moduleSetup.newType: g_model.moduleData[moduleIdx].type,menuHorizontalPosition == 0 ? attr : 0);
+        lcdDrawTextAtIndex(
+            MODEL_SETUP_2ND_COLUMN, y,
+            moduleIdx == EXTERNAL_MODULE ? STR_EXTERNAL_MODULE_PROTOCOLS
+                                         : STR_INTERNAL_MODULE_PROTOCOLS,
+            moduleIdx == EXTERNAL_MODULE ? reusableBuffer.moduleSetup.newType
+                                         : g_model.moduleData[moduleIdx].type,
+            menuHorizontalPosition == 0 ? attr : 0);
         if (isModuleXJT(moduleIdx))
-          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_XJT_ACCST_RF_PROTOCOLS, g_model.moduleData[moduleIdx].subType, menuHorizontalPosition==1 ? attr : 0);
+          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_XJT_ACCST_RF_PROTOCOLS,
+                             g_model.moduleData[moduleIdx].subType,
+                             menuHorizontalPosition == 1 ? attr : 0);
         else if (isModuleISRM(moduleIdx))
-          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_ISRM_RF_PROTOCOLS, g_model.moduleData[INTERNAL_MODULE].subType, menuHorizontalPosition==1 ? attr : 0);
+          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_ISRM_RF_PROTOCOLS,
+                             g_model.moduleData[INTERNAL_MODULE].subType,
+                             menuHorizontalPosition == 1 ? attr : 0);
         else if (isModuleDSM2(moduleIdx))
-          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_DSM_PROTOCOLS, g_model.moduleData[moduleIdx].subType, menuHorizontalPosition==1 ? attr : 0);
+          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_DSM_PROTOCOLS,
+                             g_model.moduleData[moduleIdx].subType,
+                             menuHorizontalPosition == 1 ? attr : 0);
         else if (isModuleR9MNonAccess(moduleIdx))
-          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_R9M_REGION, g_model.moduleData[moduleIdx].subType, (menuHorizontalPosition==1 ? attr : 0));
-        else if (moduleIdx == INTERNAL_MODULE && isModuleCrossfire(INTERNAL_MODULE))
-          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_CRSF_BAUDRATE, CROSSFIRE_STORE_TO_INDEX(g_eeGeneral.internalModuleBaudrate),0);
+          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_R9M_REGION,
+                             g_model.moduleData[moduleIdx].subType,
+                             (menuHorizontalPosition == 1 ? attr : 0));
+        else if (moduleIdx == INTERNAL_MODULE &&
+                 isModuleCrossfire(INTERNAL_MODULE))
+          lcdDrawTextAtIndex(
+              lcdNextPos + 3, y, STR_CRSF_BAUDRATE,
+              CROSSFIRE_STORE_TO_INDEX(g_eeGeneral.internalModuleBaudrate), 0);
 
-        if (attr && menuHorizontalPosition == 0  && moduleIdx == EXTERNAL_MODULE) {
+        if (attr && menuHorizontalPosition == 0 &&
+            moduleIdx == EXTERNAL_MODULE) {
           if (s_editMode > 0) {
             g_model.moduleData[moduleIdx].type = MODULE_TYPE_NONE;
-          }
-          else if (reusableBuffer.moduleSetup.newType != reusableBuffer.moduleSetup.previousType) {
-            g_model.moduleData[moduleIdx].type = reusableBuffer.moduleSetup.newType;
-            reusableBuffer.moduleSetup.previousType = reusableBuffer.moduleSetup.newType;
+          } else if (reusableBuffer.moduleSetup.newType !=
+                     reusableBuffer.moduleSetup.previousType) {
+            g_model.moduleData[moduleIdx].type =
+                reusableBuffer.moduleSetup.newType;
+            reusableBuffer.moduleSetup.previousType =
+                reusableBuffer.moduleSetup.newType;
             setModuleType(moduleIdx, g_model.moduleData[moduleIdx].type);
             storageDirty(EE_MODEL);
-          }
-          else if (g_model.moduleData[moduleIdx].type == MODULE_TYPE_NONE) {
-            g_model.moduleData[moduleIdx].type = reusableBuffer.moduleSetup.newType;
+          } else if (g_model.moduleData[moduleIdx].type == MODULE_TYPE_NONE) {
+            g_model.moduleData[moduleIdx].type =
+                reusableBuffer.moduleSetup.newType;
           }
         }
         if (attr) {
@@ -1020,69 +1040,84 @@ void menuModelSetup(event_t event)
               case 0:
 #if defined(HARDWARE_INTERNAL_MODULE)
                 if (moduleIdx == INTERNAL_MODULE) {
-                  uint8_t moduleType = checkIncDec(event, g_model.moduleData[moduleIdx].type, MODULE_TYPE_NONE, MODULE_TYPE_MAX, EE_MODEL,
-                                                   isInternalModuleAvailable);
+                  uint8_t moduleType =
+                      checkIncDec(event, g_model.moduleData[moduleIdx].type,
+                                  MODULE_TYPE_NONE, MODULE_TYPE_MAX, EE_MODEL,
+                                  isInternalModuleAvailable);
                   if (checkIncDec_Ret) {
                     setModuleType(moduleIdx, moduleType);
                   }
-                }
-                else
+                } else
 #endif
-                  reusableBuffer.moduleSetup.newType = checkIncDec(event, reusableBuffer.moduleSetup.newType, MODULE_TYPE_NONE, MODULE_TYPE_MAX, 0,
-                                                                   isExternalModuleAvailable);
+                  reusableBuffer.moduleSetup.newType =
+                      checkIncDec(event, reusableBuffer.moduleSetup.newType,
+                                  MODULE_TYPE_NONE, MODULE_TYPE_MAX, 0,
+                                  isExternalModuleAvailable);
                 break;
 
               case 1:
                 if (isModuleXJT(moduleIdx)) {
-                  g_model.moduleData[moduleIdx].subType = checkIncDec(event, g_model.moduleData[moduleIdx].subType, 0, MODULE_SUBTYPE_PXX1_LAST, EE_MODEL, isRfProtocolAvailable);
+                  g_model.moduleData[moduleIdx].subType =
+                      checkIncDec(event, g_model.moduleData[moduleIdx].subType,
+                                  0, MODULE_SUBTYPE_PXX1_LAST, EE_MODEL,
+                                  isRfProtocolAvailable);
                   if (checkIncDec_Ret) {
                     g_model.moduleData[moduleIdx].channelsStart = 0;
-                    g_model.moduleData[moduleIdx].channelsCount = defaultModuleChannels_M8(moduleIdx);
+                    g_model.moduleData[moduleIdx].channelsCount =
+                        defaultModuleChannels_M8(moduleIdx);
                   }
-                }
-                else if (isModuleISRM(moduleIdx)) {
-                  g_model.moduleData[moduleIdx].subType = checkIncDec(event, g_model.moduleData[moduleIdx].subType, 0, MODULE_SUBTYPE_ISRM_PXX2_ACCST_D16, EE_MODEL, isRfProtocolAvailable);
-                }
-                else if (isModuleDSM2(moduleIdx)) {
-                  CHECK_INCDEC_MODELVAR(event, g_model.moduleData[moduleIdx].subType, DSM2_PROTO_LP45, DSM2_PROTO_DSMX);
-                }
-                else if (isModuleR9MNonAccess(moduleIdx)) {
-                  g_model.moduleData[moduleIdx].subType = checkIncDec(event,
-                                                                      g_model.moduleData[moduleIdx].subType,
-                                                                      MODULE_SUBTYPE_R9M_FCC,
-                                                                      MODULE_SUBTYPE_R9M_LAST,
-                                                                      EE_MODEL);
+                } else if (isModuleISRM(moduleIdx)) {
+                  g_model.moduleData[moduleIdx].subType =
+                      checkIncDec(event, g_model.moduleData[moduleIdx].subType,
+                                  0, MODULE_SUBTYPE_ISRM_PXX2_ACCST_D16,
+                                  EE_MODEL, isRfProtocolAvailable);
+                } else if (isModuleDSM2(moduleIdx)) {
+                  CHECK_INCDEC_MODELVAR(event,
+                                        g_model.moduleData[moduleIdx].subType,
+                                        DSM2_PROTO_LP45, DSM2_PROTO_DSMX);
+                } else if (isModuleR9MNonAccess(moduleIdx)) {
+                  g_model.moduleData[moduleIdx].subType =
+                      checkIncDec(event, g_model.moduleData[moduleIdx].subType,
+                                  MODULE_SUBTYPE_R9M_FCC,
+                                  MODULE_SUBTYPE_R9M_LAST, EE_MODEL);
                   if (checkIncDec_Ret) {
                     g_model.moduleData[moduleIdx].pxx.power = 0;
                     g_model.moduleData[moduleIdx].channelsStart = 0;
-                    g_model.moduleData[moduleIdx].channelsCount = defaultModuleChannels_M8(moduleIdx);
+                    g_model.moduleData[moduleIdx].channelsCount =
+                        defaultModuleChannels_M8(moduleIdx);
                   }
-                }
-                else {
-                  CHECK_INCDEC_MODELVAR(event, g_model.moduleData[moduleIdx].subType, 0, MODULE_SUBTYPE_PXX1_LAST);
+                } else {
+                  CHECK_INCDEC_MODELVAR(event,
+                                        g_model.moduleData[moduleIdx].subType,
+                                        0, MODULE_SUBTYPE_PXX1_LAST);
                 }
 
                 if (checkIncDec_Ret) {
                   g_model.moduleData[moduleIdx].channelsStart = 0;
-                  g_model.moduleData[moduleIdx].channelsCount = defaultModuleChannels_M8(moduleIdx);
+                  g_model.moduleData[moduleIdx].channelsCount =
+                      defaultModuleChannels_M8(moduleIdx);
                 }
             }
           }
 #if POPUP_LEVEL > 1
           else if (old_editMode > 0) {
             if (isModuleR9MNonAccess(moduleIdx)) {
-              if (g_model.moduleData[moduleIdx].subType > MODULE_SUBTYPE_R9M_EU) {
+              if (g_model.moduleData[moduleIdx].subType >
+                  MODULE_SUBTYPE_R9M_EU) {
                 POPUP_WARNING(STR_MODULE_PROTOCOL_FLEX_WARN_LINE1);
-                SET_WARNING_INFO(STR_MODULE_PROTOCOL_WARN_LINE2, sizeof(TR_MODULE_PROTOCOL_WARN_LINE2) - 1, 0);
+                SET_WARNING_INFO(STR_MODULE_PROTOCOL_WARN_LINE2,
+                                 sizeof(TR_MODULE_PROTOCOL_WARN_LINE2) - 1, 0);
               }
 #if POPUP_LEVEL >= 3
-              else if (g_model.moduleData[moduleIdx].subType == MODULE_SUBTYPE_R9M_EU) {
+              else if (g_model.moduleData[moduleIdx].subType ==
+                       MODULE_SUBTYPE_R9M_EU) {
                 POPUP_WARNING(STR_MODULE_PROTOCOL_EU_WARN_LINE1);
-                SET_WARNING_INFO(STR_MODULE_PROTOCOL_WARN_LINE2, sizeof(TR_MODULE_PROTOCOL_WARN_LINE2) - 1, 0);
-              }
-              else {
+                SET_WARNING_INFO(STR_MODULE_PROTOCOL_WARN_LINE2,
+                                 sizeof(TR_MODULE_PROTOCOL_WARN_LINE2) - 1, 0);
+              } else {
                 POPUP_WARNING(STR_MODULE_PROTOCOL_FCC_WARN_LINE1);
-                SET_WARNING_INFO(STR_MODULE_PROTOCOL_WARN_LINE2, sizeof(TR_MODULE_PROTOCOL_WARN_LINE2) - 1, 0);
+                SET_WARNING_INFO(STR_MODULE_PROTOCOL_WARN_LINE2,
+                                 sizeof(TR_MODULE_PROTOCOL_WARN_LINE2) - 1, 0);
               }
 #endif
             }

--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -990,7 +990,7 @@ void menuModelSetup(event_t event)
         lcdDrawTextAlignedLeft(y, INDENT TR_MODE);
         lcdDrawTextAtIndex(MODEL_SETUP_2ND_COLUMN, y,moduleIdx == EXTERNAL_MODULE ? STR_EXTERNAL_MODULE_PROTOCOLS : STR_INTERNAL_MODULE_PROTOCOLS,moduleIdx == EXTERNAL_MODULE ? reusableBuffer.moduleSetup.newType: g_model.moduleData[moduleIdx].type,menuHorizontalPosition == 0 ? attr : 0);
         if (isModuleXJT(moduleIdx))
-          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_XJT_ACCST_RF_PROTOCOLS, 1+g_model.moduleData[moduleIdx].subType, menuHorizontalPosition==1 ? attr : 0);
+          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_XJT_ACCST_RF_PROTOCOLS, g_model.moduleData[moduleIdx].subType, menuHorizontalPosition==1 ? attr : 0);
         else if (isModuleISRM(moduleIdx))
           lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_ISRM_RF_PROTOCOLS, g_model.moduleData[INTERNAL_MODULE].subType, menuHorizontalPosition==1 ? attr : 0);
         else if (isModuleDSM2(moduleIdx))

--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -1036,10 +1036,6 @@ void menuModelSetup(event_t event)
                 if (isModuleXJT(moduleIdx)) {
                   g_model.moduleData[moduleIdx].subType = checkIncDec(event, g_model.moduleData[moduleIdx].subType, 0, MODULE_SUBTYPE_PXX1_LAST, EE_MODEL, isRfProtocolAvailable);
                   if (checkIncDec_Ret) {
-                    if (isModuleXJTLite(moduleIdx))
-                      g_model.moduleData[moduleIdx].type = MODULE_TYPE_XJT_LITE_PXX2;
-                    else
-                      g_model.moduleData[moduleIdx].type = MODULE_TYPE_XJT_PXX1;
                     g_model.moduleData[moduleIdx].channelsStart = 0;
                     g_model.moduleData[moduleIdx].channelsCount = defaultModuleChannels_M8(moduleIdx);
                   }

--- a/radio/src/gui/212x64/model_setup.cpp
+++ b/radio/src/gui/212x64/model_setup.cpp
@@ -912,12 +912,11 @@ void menuModelSetup(event_t event)
       case ITEM_MODEL_SETUP_INTERNAL_MODULE_TYPE:
       {
         lcdDrawTextAlignedLeft(y, INDENT TR_MODE);
-#if defined(INTERNAL_MODULE_PXX1)
         lcdDrawTextAtIndex(MODEL_SETUP_2ND_COLUMN, y, STR_INTERNAL_MODULE_PROTOCOLS, g_model.moduleData[INTERNAL_MODULE].type, menuHorizontalPosition==0 ? attr : 0);
         if (isModuleXJT(INTERNAL_MODULE))
-          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_XJT_ACCST_RF_PROTOCOLS, 1 + g_model.moduleData[INTERNAL_MODULE].subType, menuHorizontalPosition==1 ? attr : 0);
+          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_XJT_ACCST_RF_PROTOCOLS, g_model.moduleData[INTERNAL_MODULE].subType, menuHorizontalPosition==1 ? attr : 0);
         else if (isModuleISRM(INTERNAL_MODULE))
-          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_ISRM_RF_PROTOCOLS, 1 + g_model.moduleData[INTERNAL_MODULE].subType, menuHorizontalPosition==1 ? attr : 0);
+          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_ISRM_RF_PROTOCOLS, g_model.moduleData[INTERNAL_MODULE].subType, menuHorizontalPosition==1 ? attr : 0);
         else if (isModuleCrossfire(INTERNAL_MODULE))
           lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_CRSF_BAUDRATE, CROSSFIRE_STORE_TO_INDEX(g_eeGeneral.internalModuleBaudrate),0);
         if (attr) {
@@ -930,33 +929,15 @@ void menuModelSetup(event_t event)
           else if (isModuleXJT(INTERNAL_MODULE)) {
             g_model.moduleData[INTERNAL_MODULE].subType = checkIncDec(event, g_model.moduleData[INTERNAL_MODULE].subType, 0, MODULE_SUBTYPE_PXX1_LAST, EE_MODEL, isRfProtocolAvailable);
             if (checkIncDec_Ret) {
-              g_model.moduleData[0].type = MODULE_TYPE_XJT_PXX1;
-              g_model.moduleData[0].channelsStart = 0;
-              g_model.moduleData[0].channelsCount = defaultModuleChannels_M8(INTERNAL_MODULE);
+              g_model.moduleData[INTERNAL_MODULE].type = MODULE_TYPE_XJT_PXX1;
+              g_model.moduleData[INTERNAL_MODULE].channelsStart = 0;
+              g_model.moduleData[INTERNAL_MODULE].channelsCount = defaultModuleChannels_M8(INTERNAL_MODULE);
             }
           }
           else if (isModulePXX2(INTERNAL_MODULE)) {
             g_model.moduleData[INTERNAL_MODULE].subType = checkIncDec(event, g_model.moduleData[INTERNAL_MODULE].subType, 0, MODULE_SUBTYPE_ISRM_PXX2_ACCST_D16, EE_MODEL, isRfProtocolAvailable);
           }
         }
-#else
-        uint8_t index = 0;
-        if (g_model.moduleData[INTERNAL_MODULE].type == MODULE_TYPE_ISRM_PXX2) {
-          index = 1 + g_model.moduleData[INTERNAL_MODULE].subType;
-        }
-        lcdDrawTextAtIndex(MODEL_SETUP_2ND_COLUMN, y, STR_ISRM_RF_PROTOCOLS, index, attr);
-        if (attr) {
-          index = checkIncDec(event, index, 0, MODULE_SUBTYPE_ISRM_PXX2_ACCST_D16 + 1 /* because of --- */, EE_MODEL);
-          if (checkIncDec_Ret) {
-            memclear(&g_model.moduleData[INTERNAL_MODULE], sizeof(ModuleData));
-            if (index > 0) {
-              g_model.moduleData[INTERNAL_MODULE].type = MODULE_TYPE_ISRM_PXX2;
-              g_model.moduleData[INTERNAL_MODULE].subType = index - 1;
-              g_model.moduleData[INTERNAL_MODULE].channelsCount = defaultModuleChannels_M8(INTERNAL_MODULE);
-            }
-          }
-        }
-#endif
         break;
       }
 
@@ -968,7 +949,7 @@ void menuModelSetup(event_t event)
         lcdDrawTextAlignedLeft(y, INDENT TR_MODE);
         lcdDrawTextAtIndex(MODEL_SETUP_2ND_COLUMN, y, STR_EXTERNAL_MODULE_PROTOCOLS, reusableBuffer.moduleSetup.newType, menuHorizontalPosition==0 ? attr : 0);
         if (isModuleXJT(EXTERNAL_MODULE))
-          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_XJT_ACCST_RF_PROTOCOLS, 1+g_model.moduleData[EXTERNAL_MODULE].subType, menuHorizontalPosition==1 ? attr : 0);
+          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_XJT_ACCST_RF_PROTOCOLS, g_model.moduleData[EXTERNAL_MODULE].subType, menuHorizontalPosition==1 ? attr : 0);
         else if (isModuleDSM2(EXTERNAL_MODULE))
           lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_DSM_PROTOCOLS, g_model.moduleData[EXTERNAL_MODULE].subType, menuHorizontalPosition==1 ? attr : 0);
         else if (isModuleR9MNonAccess(EXTERNAL_MODULE))

--- a/radio/src/gui/212x64/model_setup.cpp
+++ b/radio/src/gui/212x64/model_setup.cpp
@@ -924,13 +924,16 @@ void menuModelSetup(event_t event)
           else if (isModuleXJT(INTERNAL_MODULE)) {
             g_model.moduleData[INTERNAL_MODULE].subType = checkIncDec(event, g_model.moduleData[INTERNAL_MODULE].subType, 0, MODULE_SUBTYPE_PXX1_LAST, EE_MODEL, isRfProtocolAvailable);
             if (checkIncDec_Ret) {
-              g_model.moduleData[INTERNAL_MODULE].type = MODULE_TYPE_XJT_PXX1;
               g_model.moduleData[INTERNAL_MODULE].channelsStart = 0;
               g_model.moduleData[INTERNAL_MODULE].channelsCount = defaultModuleChannels_M8(INTERNAL_MODULE);
             }
           }
-          else if (isModulePXX2(INTERNAL_MODULE)) {
+          else if (isModuleISRM(INTERNAL_MODULE)) {
             g_model.moduleData[INTERNAL_MODULE].subType = checkIncDec(event, g_model.moduleData[INTERNAL_MODULE].subType, 0, MODULE_SUBTYPE_ISRM_PXX2_ACCST_D16, EE_MODEL, isRfProtocolAvailable);
+            if (checkIncDec_Ret) {
+              g_model.moduleData[INTERNAL_MODULE].channelsStart = 0;
+              g_model.moduleData[INTERNAL_MODULE].channelsCount = defaultModuleChannels_M8(INTERNAL_MODULE);
+            }
           }
         }
         break;

--- a/radio/src/gui/212x64/model_setup.cpp
+++ b/radio/src/gui/212x64/model_setup.cpp
@@ -282,12 +282,7 @@ void editTimerCountdown(int timerIdx, coord_t y, LcdFlags attr, event_t event)
 #define IF_INTERNAL_MODULE_ON(x)          (IS_INTERNAL_MODULE_ENABLED() ? (uint8_t)(x) : HIDDEN_ROW)
 #define IF_EXTERNAL_MODULE_ON(x)          (IS_EXTERNAL_MODULE_ENABLED() ? (uint8_t)(x) : HIDDEN_ROW)
 
-#if defined(INTERNAL_MODULE_PXX1)
 #define INTERNAL_MODULE_TYPE_ROWS         ((isModuleXJT(INTERNAL_MODULE) || isModulePXX2(INTERNAL_MODULE)) ? (uint8_t)1 : (uint8_t)0) // Module type + RF protocols
-#else
-#define INTERNAL_MODULE_TYPE_ROWS         (0) // Module type + RF protocols
-#endif
-
 #define TRAINER_CHANNELS_ROW              (IS_SLAVE_TRAINER() ? (uint8_t)1 : HIDDEN_ROW)
 #define TRAINER_PPM_PARAMS_ROW            (g_model.trainerData.mode == TRAINER_MODE_SLAVE ? (uint8_t)2 : HIDDEN_ROW)
 #define TRAINER_BLUETOOTH_M_ROW           ((bluetooth.distantAddr[0] == '\0' || bluetooth.state == BLUETOOTH_STATE_CONNECTED) ? (uint8_t)0 : (uint8_t)1)

--- a/radio/src/gui/212x64/model_setup.cpp
+++ b/radio/src/gui/212x64/model_setup.cpp
@@ -907,32 +907,49 @@ void menuModelSetup(event_t event)
       case ITEM_MODEL_SETUP_INTERNAL_MODULE_TYPE:
       {
         lcdDrawTextAlignedLeft(y, INDENT TR_MODE);
-        lcdDrawTextAtIndex(MODEL_SETUP_2ND_COLUMN, y, STR_INTERNAL_MODULE_PROTOCOLS, g_model.moduleData[INTERNAL_MODULE].type, menuHorizontalPosition==0 ? attr : 0);
+        lcdDrawTextAtIndex(MODEL_SETUP_2ND_COLUMN, y,
+                           STR_INTERNAL_MODULE_PROTOCOLS,
+                           g_model.moduleData[INTERNAL_MODULE].type,
+                           menuHorizontalPosition == 0 ? attr : 0);
         if (isModuleXJT(INTERNAL_MODULE))
-          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_XJT_ACCST_RF_PROTOCOLS, g_model.moduleData[INTERNAL_MODULE].subType, menuHorizontalPosition==1 ? attr : 0);
+          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_XJT_ACCST_RF_PROTOCOLS,
+                             g_model.moduleData[INTERNAL_MODULE].subType,
+                             menuHorizontalPosition == 1 ? attr : 0);
         else if (isModuleISRM(INTERNAL_MODULE))
-          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_ISRM_RF_PROTOCOLS, g_model.moduleData[INTERNAL_MODULE].subType, menuHorizontalPosition==1 ? attr : 0);
+          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_ISRM_RF_PROTOCOLS,
+                             g_model.moduleData[INTERNAL_MODULE].subType,
+                             menuHorizontalPosition == 1 ? attr : 0);
         else if (isModuleCrossfire(INTERNAL_MODULE))
-          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_CRSF_BAUDRATE, CROSSFIRE_STORE_TO_INDEX(g_eeGeneral.internalModuleBaudrate),0);
+          lcdDrawTextAtIndex(
+              lcdNextPos + 3, y, STR_CRSF_BAUDRATE,
+              CROSSFIRE_STORE_TO_INDEX(g_eeGeneral.internalModuleBaudrate), 0);
         if (attr) {
           if (menuHorizontalPosition == 0) {
-            uint8_t moduleType = checkIncDec(event, g_model.moduleData[INTERNAL_MODULE].type, MODULE_TYPE_NONE, MODULE_TYPE_MAX, EE_MODEL, isInternalModuleAvailable);
+            uint8_t moduleType =
+                checkIncDec(event, g_model.moduleData[INTERNAL_MODULE].type,
+                            MODULE_TYPE_NONE, MODULE_TYPE_MAX, EE_MODEL,
+                            isInternalModuleAvailable);
             if (checkIncDec_Ret) {
               setModuleType(INTERNAL_MODULE, moduleType);
             }
-          }
-          else if (isModuleXJT(INTERNAL_MODULE)) {
-            g_model.moduleData[INTERNAL_MODULE].subType = checkIncDec(event, g_model.moduleData[INTERNAL_MODULE].subType, 0, MODULE_SUBTYPE_PXX1_LAST, EE_MODEL, isRfProtocolAvailable);
+          } else if (isModuleXJT(INTERNAL_MODULE)) {
+            g_model.moduleData[INTERNAL_MODULE].subType = checkIncDec(
+                event, g_model.moduleData[INTERNAL_MODULE].subType, 0,
+                MODULE_SUBTYPE_PXX1_LAST, EE_MODEL, isRfProtocolAvailable);
             if (checkIncDec_Ret) {
               g_model.moduleData[INTERNAL_MODULE].channelsStart = 0;
-              g_model.moduleData[INTERNAL_MODULE].channelsCount = defaultModuleChannels_M8(INTERNAL_MODULE);
+              g_model.moduleData[INTERNAL_MODULE].channelsCount =
+                  defaultModuleChannels_M8(INTERNAL_MODULE);
             }
-          }
-          else if (isModuleISRM(INTERNAL_MODULE)) {
-            g_model.moduleData[INTERNAL_MODULE].subType = checkIncDec(event, g_model.moduleData[INTERNAL_MODULE].subType, 0, MODULE_SUBTYPE_ISRM_PXX2_ACCST_D16, EE_MODEL, isRfProtocolAvailable);
+          } else if (isModuleISRM(INTERNAL_MODULE)) {
+            g_model.moduleData[INTERNAL_MODULE].subType =
+                checkIncDec(event, g_model.moduleData[INTERNAL_MODULE].subType,
+                            0, MODULE_SUBTYPE_ISRM_PXX2_ACCST_D16, EE_MODEL,
+                            isRfProtocolAvailable);
             if (checkIncDec_Ret) {
               g_model.moduleData[INTERNAL_MODULE].channelsStart = 0;
-              g_model.moduleData[INTERNAL_MODULE].channelsCount = defaultModuleChannels_M8(INTERNAL_MODULE);
+              g_model.moduleData[INTERNAL_MODULE].channelsCount =
+                  defaultModuleChannels_M8(INTERNAL_MODULE);
             }
           }
         }

--- a/radio/src/gui/colorlcd/module_setup.cpp
+++ b/radio/src/gui/colorlcd/module_setup.cpp
@@ -469,7 +469,7 @@ void ModuleSubTypeChoice::update()
 
   if (isModuleXJT(moduleIdx)) {
 
-    setMin(MODULE_SUBTYPE_PXX1_OFF);
+    setMin(MODULE_SUBTYPE_PXX1_ACCST_D16);
     setMax(MODULE_SUBTYPE_PXX1_LAST);
     setValues(STR_XJT_ACCST_RF_PROTOCOLS);
     setGetValueHandler(GET_DEFAULT(md->subType));
@@ -479,8 +479,7 @@ void ModuleSubTypeChoice::update()
       md->channelsCount = defaultModuleChannels_M8(moduleIdx);
       SET_DIRTY();
     });
-    setAvailableHandler(
-        [](int index) { return index != MODULE_SUBTYPE_PXX1_OFF; });
+    setAvailableHandler(nullptr);
   }
   else if (isModuleDSM2(moduleIdx)) {
     setMin(DSM2_PROTO_LP45);

--- a/radio/src/gui/colorlcd/module_setup.cpp
+++ b/radio/src/gui/colorlcd/module_setup.cpp
@@ -468,7 +468,6 @@ void ModuleSubTypeChoice::update()
   ModuleData* md = &g_model.moduleData[moduleIdx];
 
   if (isModuleXJT(moduleIdx)) {
-
     setMin(MODULE_SUBTYPE_PXX1_ACCST_D16);
     setMax(MODULE_SUBTYPE_PXX1_LAST);
     setValues(STR_XJT_ACCST_RF_PROTOCOLS);

--- a/radio/src/translations/untranslated.h
+++ b/radio/src/translations/untranslated.h
@@ -142,12 +142,8 @@
 #define TR_INTERNAL_MODULE_PROTOCOLS   TR_EXTERNAL_MODULE_PROTOCOLS
 
 #define TR_FLYSKY_PROTOCOLS            "AFHDS3","AFHDS2A"
-#define TR_XJT_ACCST_RF_PROTOCOLS      "OFF","D16","D8","LR12"
-#if defined(COLORLCD)
+#define TR_XJT_ACCST_RF_PROTOCOLS      "D16","D8","LR12"
 #define TR_ISRM_RF_PROTOCOLS           "ACCESS","D16","LR12"
-#else
-#define TR_ISRM_RF_PROTOCOLS           "OFF","ACCESS","D16","LR12"
-#endif
 #define TR_R9M_PXX2_RF_PROTOCOLS       "ACCESS","FCC","EU","Flex"
 #define TR_SPORT_MODES                 "S.PORT","F.PORT","FBUS(FPORT2)"
 #define TR_R9M_REGION                  "FCC","EU","868MHz","915MHz"


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Puts to rest the issue that started with #2079, and I then fixed and broke with 28ba80f28819c2df6140a210dd5d613b95e0b68a and 5752cf4061b85660d64b222b694d7120c409ec1e.

Essentially, the `STR_XJT_ACCST_RF_PROTOCOLS` and `STR_ISRM_RF_PROTOCOLS` should only list the protocols, and not also have "OFF" as the first entry. It seems this was done solely for 212x64 handling with ISRM radios, rather than use the same two column interface used for all other radios. 

This has been hardware tested on X9D+ (XJT), X9D+2019 (ISRM), Zorro (XJT Lite module), and TX16S (XJT module), and simu tested against X7, X7-ACCESS, X10 and X10-ACCESS (as well as TX16S, X9D+2019 and TX12 at various points). 

Last commit is automatic formatting only.

