### PR TITLE
This adds acoustic and/or haptic feedback for touch events

### DIFF
--- a/radio/src/gui/colorlcd/LvglWrapper.cpp
+++ b/radio/src/gui/colorlcd/LvglWrapper.cpp
@@ -209,8 +209,10 @@ extern "C" void touchDriverRead(lv_indev_drv_t *drv, lv_indev_data_t *data)
     copy_ts_to_indev_data(st, data);
   }
 
-  // Reset inactivity counters
-  if (st.event != TE_NONE) { reset_inactivity(); }
+  if (st.event == TE_UP) {  // on Touch Up
+      reset_inactivity();   // reset activity counter
+      onKeyPress();         // provide acoustic and/or haptic feedback if requested in settings
+  }
   
   backup_touch_data(data);
 #endif


### PR DESCRIPTION
This adds acoustic and/or haptic feedback for touch events depending depending on radio settings.

This addresses issue [#1778](https://github.com/EdgeTX/edgetx/issues/1778)

Select "All" in radio settings/radio setup/Sound/Mode for key and touch acoustic feedback and settings/radio setup/Haptic/Mode for key and touch haptic feedback.

"NoKey" also disables touch feedback.
