### PR TITLE
Use correct path for model name audio - space vs underscore

### DIFF
--- a/radio/src/audio.cpp
+++ b/radio/src/audio.cpp
@@ -302,14 +302,19 @@ void referenceSystemAudioFiles()
 
 const char * const suffixes[] = { "-off", "-on" };
 
-char * getModelAudioPath(char * path)
+char *getModelAudioPath(char *path)
 {
   strcpy(path, SOUNDS_PATH "/");
-  strncpy(path+SOUNDS_PATH_LNG_OFS, currentLanguagePack->id, 2);
-  char * result = strcat_currentmodelname(path+sizeof(SOUNDS_PATH), 0);
-  *result++ = '/';
-  *result = '\0';
-  return result;
+  strncpy(path + SOUNDS_PATH_LNG_OFS, currentLanguagePack->id, 2);
+  char *buf = strcat_currentmodelname(path + sizeof(SOUNDS_PATH), ' ');
+
+  if (!isFileAvailable(path)) {
+    buf = strcat_currentmodelname(path + sizeof(SOUNDS_PATH), 0);
+  }
+
+  *buf++ = '/';
+  *buf = '\0';
+  return buf;
 }
 
 void getFlightmodeAudioFile(char * filename, int index, unsigned int event)
@@ -478,8 +483,8 @@ void playModelEvent(uint8_t category, uint8_t index, event_t event)
 
 void playModelName()
 {
-  char filename[AUDIO_FILENAME_MAXLEN+1];
-  char * str = getModelAudioPath(filename);
+  char filename[AUDIO_FILENAME_MAXLEN + 1];
+  char *str = getModelAudioPath(filename);
   strcpy(str, "name.wav");
   audioQueue.playFile(filename);
 }

--- a/radio/src/gui/212x64/model_select.cpp
+++ b/radio/src/gui/212x64/model_select.cpp
@@ -65,7 +65,7 @@ void onModelSelectMenu(const char * result)
   }
   else if (result == STR_DELETE_MODEL) {
     char * nametmp =  reusableBuffer.modelsel.mainname;
-    strcat_modelname (nametmp, sub);
+    strcat_modelname (nametmp, sub, 0);
     POPUP_CONFIRMATION(STR_DELETEMODEL, nullptr);
     SET_WARNING_INFO(nametmp, sizeof(g_model.header.name), 0);
   }
@@ -115,7 +115,7 @@ void menuModelSelect(event_t event)
       case EVT_KEY_LONG(KEY_EXIT):
         if (s_copyMode && s_copyTgtOfs == 0 && g_eeGeneral.currModel != sub && modelExists(sub)) {
           char * nametmp =  reusableBuffer.modelsel.mainname;
-          strcat_modelname (nametmp, sub);
+          strcat_modelname (nametmp, sub, 0);
           POPUP_CONFIRMATION(STR_DELETEMODEL, nullptr);
           SET_WARNING_INFO(nametmp, sizeof(g_model.header.name), 0);
           killEvents(event);

--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -539,13 +539,12 @@ class ModelCategoryPageBody : public FormWindow
     memcpy(g_eeGeneral.currModelFilename, btn->modelFilename(),
            LEN_MODEL_FILENAME);
 
-    loadModel(g_eeGeneral.currModelFilename, false);
+    loadModel(g_eeGeneral.currModelFilename, true);
     storageDirty(EE_GENERAL);
     storageCheck(true);
 
     modelslist.setCurrentModel(btn->getModelCell());
     modelslist.setCurrentCategory(category);
-    checkAll();
 
     // Exit to main view
     auto w = Layer::back();

--- a/radio/src/gui/colorlcd/theme_manager.cpp
+++ b/radio/src/gui/colorlcd/theme_manager.cpp
@@ -299,24 +299,17 @@ void ThemeFile::applyBackground()
   auto pos = backgroundImageFileName.rfind('/');
   if (pos != std::string::npos) {
     auto rootDir = backgroundImageFileName.substr(0, pos + 1);
-    rootDir = rootDir + "background_" + std::to_string(LCD_W) + "x" + std::to_string(LCD_H) + ".png";
+    rootDir = rootDir + "background_" + std::to_string(LCD_W) + "x" +
+              std::to_string(LCD_H) + ".png";
 
-    FIL file;
-    FRESULT result = f_open(&file, rootDir.c_str(), FA_OPEN_EXISTING);
-    if (result == FR_OK) {
+    if (isFileAvailable(rootDir.c_str())) {
       instance->setBackgroundImageFileName((char *)rootDir.c_str());
-      f_close(&file);
     } else {
       // TODO: This needs to be made user configurable, not
       // require the file be deleted to remove global background
-      char fileName[FF_MAX_LFN + 1];
-      fileName[FF_MAX_LFN] = '\0';
-      strncpy(fileName, THEMES_PATH, FF_MAX_LFN);
-      strcat(fileName, "/EdgeTX/background.png");
-      result = f_open(&file, fileName, FA_OPEN_EXISTING);
-      if (result == FR_OK) {
-        instance->setBackgroundImageFileName(fileName);
-        f_close(&file);
+      std::string fileName = THEMES_PATH PATH_SEPARATOR "EdgeTX/background.png";
+      if (isFileAvailable(fileName.c_str())) {
+        instance->setBackgroundImageFileName(fileName.c_str());
       } else {
         instance->setBackgroundImageFileName("");
       }

--- a/radio/src/gui/common/stdlcd/model_notes.cpp
+++ b/radio/src/gui/common/stdlcd/model_notes.cpp
@@ -25,8 +25,14 @@ void menuModelNotes(event_t event)
 {
   if (event == EVT_ENTRY) {
     strcpy(reusableBuffer.viewText.filename, MODELS_PATH "/");
-    char *buf = strcat_currentmodelname(&reusableBuffer.viewText.filename[sizeof(MODELS_PATH)], 0);
+    char *buf = strcat_currentmodelname(
+        &reusableBuffer.viewText.filename[sizeof(MODELS_PATH)], ' ');
     strcpy(buf, TEXT_EXT);
+    if (!isFileAvailable(reusableBuffer.viewText.filename)) {
+      buf = strcat_currentmodelname(
+          &reusableBuffer.viewText.filename[sizeof(MODELS_PATH)], 0);
+      strcpy(buf, TEXT_EXT);
+    }
   }
 
   menuTextView(event);

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -1072,12 +1072,12 @@ char * strcat_zchar(char *dest, const char *name, uint8_t size, const char space
 
 #if !defined(STORAGE_MODELSLIST)
 
-#define strcat_modelname(dest, idx)                                     \
-  strcat_zchar(dest, modelHeaders[idx].name, LEN_MODEL_NAME, 0, STR_MODEL, \
+#define strcat_modelname(dest, idx, spaceSym)                                     \
+  strcat_zchar(dest, modelHeaders[idx].name, LEN_MODEL_NAME, spaceSym, STR_MODEL, \
                PSIZE(TR_MODEL), idx + 1)
 
-#define strcat_currentmodelname(dest, foo)      \
-  strcat_modelname(dest, g_eeGeneral.currModel)
+#define strcat_currentmodelname(dest, spaceSym)      \
+  strcat_modelname(dest, g_eeGeneral.currModel, spaceSym)
 
 #else
 

--- a/radio/src/storage/eeprom_raw.cpp
+++ b/radio/src/storage/eeprom_raw.cpp
@@ -450,7 +450,7 @@ const char * eeBackupModel(uint8_t i_fileSrc)
   }
 
   buf[sizeof(MODELS_PATH)-1] = '/';
-  strcpy(strcat_modelname(&buf[sizeof(MODELS_PATH)], i_fileSrc), STR_MODELS_EXT);
+  strcpy(strcat_modelname(&buf[sizeof(MODELS_PATH)], i_fileSrc, 0), STR_MODELS_EXT);
 
   FRESULT result = f_open(&archiveFile, buf, FA_CREATE_ALWAYS | FA_WRITE);
   if (result != FR_OK) {


### PR DESCRIPTION
With model dependent sound files, it was expected to have `_` in the name in place of spaces.

i.e. with a model name of `Model Name`, it should look like
`/SOUNDS/language/model_name/`

So to play the model name in English, it would like:
`/SOUNDS/en/model_name/name.wav`

However, after #645, it was looking for looking for a space, like like in the name:
`/SOUNDS/en/model name/name.wav`

It now looks for `_` instead of whitespace first (i.e. backwards compatible), and then 
checks for model name with whitespace. So both forms are now accepted.

Also, trigger postModelLoad() alarms when changing model to trigger
for checks and playing model name there. 

The second commit cleans up the file check in `theme_manager.cpp`
to also use `isFileAvailable` size it's nicer to use ;)

The third finally teaches B&W about underscore vs spaces generally in relation
to the model name, which means model notes can have a space or underscore
also, which was a leftover that not resolved in #645.

Tests (model notes viewable, model audio - `name.wav` plays, with `Model A` and `Model_B`)
- [X] simu - X9D+2019, TX16S
- [x] TX16S hardware
- [x] TPro hardware
- [x] X9D+2019 hardware

It would appear that on the radio the name is not case sensitive. I have a feeling `simu` was case senstive. 

<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #2169

