### PR TITLE
chore: Remove "OFF" from protocol lists (#2186)

### DIFF
--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -966,30 +966,50 @@ void menuModelSetup(event_t event)
       case ITEM_MODEL_SETUP_EXTERNAL_MODULE_TYPE:
 #endif
         lcdDrawTextAlignedLeft(y, INDENT TR_MODE);
-        lcdDrawTextAtIndex(MODEL_SETUP_2ND_COLUMN, y,moduleIdx == EXTERNAL_MODULE ? STR_EXTERNAL_MODULE_PROTOCOLS : STR_INTERNAL_MODULE_PROTOCOLS,moduleIdx == EXTERNAL_MODULE ? reusableBuffer.moduleSetup.newType: g_model.moduleData[moduleIdx].type,menuHorizontalPosition == 0 ? attr : 0);
+        lcdDrawTextAtIndex(
+            MODEL_SETUP_2ND_COLUMN, y,
+            moduleIdx == EXTERNAL_MODULE ? STR_EXTERNAL_MODULE_PROTOCOLS
+                                         : STR_INTERNAL_MODULE_PROTOCOLS,
+            moduleIdx == EXTERNAL_MODULE ? reusableBuffer.moduleSetup.newType
+                                         : g_model.moduleData[moduleIdx].type,
+            menuHorizontalPosition == 0 ? attr : 0);
         if (isModuleXJT(moduleIdx))
-          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_XJT_ACCST_RF_PROTOCOLS, 1+g_model.moduleData[moduleIdx].subType, menuHorizontalPosition==1 ? attr : 0);
+          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_XJT_ACCST_RF_PROTOCOLS,
+                             g_model.moduleData[moduleIdx].subType,
+                             menuHorizontalPosition == 1 ? attr : 0);
         else if (isModuleISRM(moduleIdx))
-          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_ISRM_RF_PROTOCOLS, g_model.moduleData[INTERNAL_MODULE].subType, menuHorizontalPosition==1 ? attr : 0);
+          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_ISRM_RF_PROTOCOLS,
+                             g_model.moduleData[INTERNAL_MODULE].subType,
+                             menuHorizontalPosition == 1 ? attr : 0);
         else if (isModuleDSM2(moduleIdx))
-          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_DSM_PROTOCOLS, g_model.moduleData[moduleIdx].subType, menuHorizontalPosition==1 ? attr : 0);
+          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_DSM_PROTOCOLS,
+                             g_model.moduleData[moduleIdx].subType,
+                             menuHorizontalPosition == 1 ? attr : 0);
         else if (isModuleR9MNonAccess(moduleIdx))
-          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_R9M_REGION, g_model.moduleData[moduleIdx].subType, (menuHorizontalPosition==1 ? attr : 0));
-        else if (moduleIdx == INTERNAL_MODULE && isModuleCrossfire(INTERNAL_MODULE))
-          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_CRSF_BAUDRATE, CROSSFIRE_STORE_TO_INDEX(g_eeGeneral.internalModuleBaudrate),0);
+          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_R9M_REGION,
+                             g_model.moduleData[moduleIdx].subType,
+                             (menuHorizontalPosition == 1 ? attr : 0));
+        else if (moduleIdx == INTERNAL_MODULE &&
+                 isModuleCrossfire(INTERNAL_MODULE))
+          lcdDrawTextAtIndex(
+              lcdNextPos + 3, y, STR_CRSF_BAUDRATE,
+              CROSSFIRE_STORE_TO_INDEX(g_eeGeneral.internalModuleBaudrate), 0);
 
-        if (attr && menuHorizontalPosition == 0  && moduleIdx == EXTERNAL_MODULE) {
+        if (attr && menuHorizontalPosition == 0 &&
+            moduleIdx == EXTERNAL_MODULE) {
           if (s_editMode > 0) {
             g_model.moduleData[moduleIdx].type = MODULE_TYPE_NONE;
-          }
-          else if (reusableBuffer.moduleSetup.newType != reusableBuffer.moduleSetup.previousType) {
-            g_model.moduleData[moduleIdx].type = reusableBuffer.moduleSetup.newType;
-            reusableBuffer.moduleSetup.previousType = reusableBuffer.moduleSetup.newType;
+          } else if (reusableBuffer.moduleSetup.newType !=
+                     reusableBuffer.moduleSetup.previousType) {
+            g_model.moduleData[moduleIdx].type =
+                reusableBuffer.moduleSetup.newType;
+            reusableBuffer.moduleSetup.previousType =
+                reusableBuffer.moduleSetup.newType;
             setModuleType(moduleIdx, g_model.moduleData[moduleIdx].type);
             storageDirty(EE_MODEL);
-          }
-          else if (g_model.moduleData[moduleIdx].type == MODULE_TYPE_NONE) {
-            g_model.moduleData[moduleIdx].type = reusableBuffer.moduleSetup.newType;
+          } else if (g_model.moduleData[moduleIdx].type == MODULE_TYPE_NONE) {
+            g_model.moduleData[moduleIdx].type =
+                reusableBuffer.moduleSetup.newType;
           }
         }
         if (attr) {
@@ -998,73 +1018,84 @@ void menuModelSetup(event_t event)
               case 0:
 #if defined(HARDWARE_INTERNAL_MODULE)
                 if (moduleIdx == INTERNAL_MODULE) {
-                  uint8_t moduleType = checkIncDec(event, g_model.moduleData[moduleIdx].type, MODULE_TYPE_NONE, MODULE_TYPE_MAX, EE_MODEL,
-                                                   isInternalModuleAvailable);
+                  uint8_t moduleType =
+                      checkIncDec(event, g_model.moduleData[moduleIdx].type,
+                                  MODULE_TYPE_NONE, MODULE_TYPE_MAX, EE_MODEL,
+                                  isInternalModuleAvailable);
                   if (checkIncDec_Ret) {
                     setModuleType(moduleIdx, moduleType);
                   }
-                }
-                else
+                } else
 #endif
-                  reusableBuffer.moduleSetup.newType = checkIncDec(event, reusableBuffer.moduleSetup.newType, MODULE_TYPE_NONE, MODULE_TYPE_MAX, 0,
-                                                                   isExternalModuleAvailable);
+                  reusableBuffer.moduleSetup.newType =
+                      checkIncDec(event, reusableBuffer.moduleSetup.newType,
+                                  MODULE_TYPE_NONE, MODULE_TYPE_MAX, 0,
+                                  isExternalModuleAvailable);
                 break;
 
               case 1:
                 if (isModuleXJT(moduleIdx)) {
-                  g_model.moduleData[moduleIdx].subType = checkIncDec(event, g_model.moduleData[moduleIdx].subType, 0, MODULE_SUBTYPE_PXX1_LAST, EE_MODEL, isRfProtocolAvailable);
+                  g_model.moduleData[moduleIdx].subType =
+                      checkIncDec(event, g_model.moduleData[moduleIdx].subType,
+                                  0, MODULE_SUBTYPE_PXX1_LAST, EE_MODEL,
+                                  isRfProtocolAvailable);
                   if (checkIncDec_Ret) {
-                    if (isModuleXJTLite(moduleIdx))
-                      g_model.moduleData[moduleIdx].type = MODULE_TYPE_XJT_LITE_PXX2;
-                    else
-                      g_model.moduleData[moduleIdx].type = MODULE_TYPE_XJT_PXX1;
                     g_model.moduleData[moduleIdx].channelsStart = 0;
-                    g_model.moduleData[moduleIdx].channelsCount = defaultModuleChannels_M8(moduleIdx);
+                    g_model.moduleData[moduleIdx].channelsCount =
+                        defaultModuleChannels_M8(moduleIdx);
                   }
-                }
-                else if (isModuleISRM(moduleIdx)) {
-                  g_model.moduleData[moduleIdx].subType = checkIncDec(event, g_model.moduleData[moduleIdx].subType, 0, MODULE_SUBTYPE_ISRM_PXX2_ACCST_D16, EE_MODEL, isRfProtocolAvailable);
-                }
-                else if (isModuleDSM2(moduleIdx)) {
-                  CHECK_INCDEC_MODELVAR(event, g_model.moduleData[moduleIdx].subType, DSM2_PROTO_LP45, DSM2_PROTO_DSMX);
-                }
-                else if (isModuleR9MNonAccess(moduleIdx)) {
-                  g_model.moduleData[moduleIdx].subType = checkIncDec(event,
-                                                                      g_model.moduleData[moduleIdx].subType,
-                                                                      MODULE_SUBTYPE_R9M_FCC,
-                                                                      MODULE_SUBTYPE_R9M_LAST,
-                                                                      EE_MODEL);
+                } else if (isModuleISRM(moduleIdx)) {
+                  g_model.moduleData[moduleIdx].subType =
+                      checkIncDec(event, g_model.moduleData[moduleIdx].subType,
+                                  0, MODULE_SUBTYPE_ISRM_PXX2_ACCST_D16,
+                                  EE_MODEL, isRfProtocolAvailable);
+                } else if (isModuleDSM2(moduleIdx)) {
+                  CHECK_INCDEC_MODELVAR(event,
+                                        g_model.moduleData[moduleIdx].subType,
+                                        DSM2_PROTO_LP45, DSM2_PROTO_DSMX);
+                } else if (isModuleR9MNonAccess(moduleIdx)) {
+                  g_model.moduleData[moduleIdx].subType =
+                      checkIncDec(event, g_model.moduleData[moduleIdx].subType,
+                                  MODULE_SUBTYPE_R9M_FCC,
+                                  MODULE_SUBTYPE_R9M_LAST, EE_MODEL);
                   if (checkIncDec_Ret) {
                     g_model.moduleData[moduleIdx].pxx.power = 0;
                     g_model.moduleData[moduleIdx].channelsStart = 0;
-                    g_model.moduleData[moduleIdx].channelsCount = defaultModuleChannels_M8(moduleIdx);
+                    g_model.moduleData[moduleIdx].channelsCount =
+                        defaultModuleChannels_M8(moduleIdx);
                   }
-                }
-                else {
-                  CHECK_INCDEC_MODELVAR(event, g_model.moduleData[moduleIdx].subType, 0, MODULE_SUBTYPE_PXX1_LAST);
+                } else {
+                  CHECK_INCDEC_MODELVAR(event,
+                                        g_model.moduleData[moduleIdx].subType,
+                                        0, MODULE_SUBTYPE_PXX1_LAST);
                 }
 
                 if (checkIncDec_Ret) {
                   g_model.moduleData[moduleIdx].channelsStart = 0;
-                  g_model.moduleData[moduleIdx].channelsCount = defaultModuleChannels_M8(moduleIdx);
+                  g_model.moduleData[moduleIdx].channelsCount =
+                      defaultModuleChannels_M8(moduleIdx);
                 }
             }
           }
 #if POPUP_LEVEL > 1
           else if (old_editMode > 0) {
             if (isModuleR9MNonAccess(moduleIdx)) {
-              if (g_model.moduleData[moduleIdx].subType > MODULE_SUBTYPE_R9M_EU) {
+              if (g_model.moduleData[moduleIdx].subType >
+                  MODULE_SUBTYPE_R9M_EU) {
                 POPUP_WARNING(STR_MODULE_PROTOCOL_FLEX_WARN_LINE1);
-                SET_WARNING_INFO(STR_MODULE_PROTOCOL_WARN_LINE2, sizeof(TR_MODULE_PROTOCOL_WARN_LINE2) - 1, 0);
+                SET_WARNING_INFO(STR_MODULE_PROTOCOL_WARN_LINE2,
+                                 sizeof(TR_MODULE_PROTOCOL_WARN_LINE2) - 1, 0);
               }
 #if POPUP_LEVEL >= 3
-              else if (g_model.moduleData[moduleIdx].subType == MODULE_SUBTYPE_R9M_EU) {
+              else if (g_model.moduleData[moduleIdx].subType ==
+                       MODULE_SUBTYPE_R9M_EU) {
                 POPUP_WARNING(STR_MODULE_PROTOCOL_EU_WARN_LINE1);
-                SET_WARNING_INFO(STR_MODULE_PROTOCOL_WARN_LINE2, sizeof(TR_MODULE_PROTOCOL_WARN_LINE2) - 1, 0);
-              }
-              else {
+                SET_WARNING_INFO(STR_MODULE_PROTOCOL_WARN_LINE2,
+                                 sizeof(TR_MODULE_PROTOCOL_WARN_LINE2) - 1, 0);
+              } else {
                 POPUP_WARNING(STR_MODULE_PROTOCOL_FCC_WARN_LINE1);
-                SET_WARNING_INFO(STR_MODULE_PROTOCOL_WARN_LINE2, sizeof(TR_MODULE_PROTOCOL_WARN_LINE2) - 1, 0);
+                SET_WARNING_INFO(STR_MODULE_PROTOCOL_WARN_LINE2,
+                                 sizeof(TR_MODULE_PROTOCOL_WARN_LINE2) - 1, 0);
               }
 #endif
             }

--- a/radio/src/gui/212x64/model_setup.cpp
+++ b/radio/src/gui/212x64/model_setup.cpp
@@ -266,12 +266,7 @@ void editTimerCountdown(int timerIdx, coord_t y, LcdFlags attr, event_t event)
 #define IF_INTERNAL_MODULE_ON(x)          (IS_INTERNAL_MODULE_ENABLED() ? (uint8_t)(x) : HIDDEN_ROW)
 #define IF_EXTERNAL_MODULE_ON(x)          (IS_EXTERNAL_MODULE_ENABLED() ? (uint8_t)(x) : HIDDEN_ROW)
 
-#if defined(INTERNAL_MODULE_PXX1)
 #define INTERNAL_MODULE_TYPE_ROWS         ((isModuleXJT(INTERNAL_MODULE) || isModulePXX2(INTERNAL_MODULE)) ? (uint8_t)1 : (uint8_t)0) // Module type + RF protocols
-#else
-#define INTERNAL_MODULE_TYPE_ROWS         (0) // Module type + RF protocols
-#endif
-
 #define TRAINER_CHANNELS_ROW              (IS_SLAVE_TRAINER() ? (uint8_t)1 : HIDDEN_ROW)
 #define TRAINER_PPM_PARAMS_ROW            (g_model.trainerData.mode == TRAINER_MODE_SLAVE ? (uint8_t)2 : HIDDEN_ROW)
 #define TRAINER_BLUETOOTH_M_ROW           ((bluetooth.distantAddr[0] == '\0' || bluetooth.state == BLUETOOTH_STATE_CONNECTED) ? (uint8_t)0 : (uint8_t)1)
@@ -882,51 +877,52 @@ void menuModelSetup(event_t event)
       case ITEM_MODEL_SETUP_INTERNAL_MODULE_TYPE:
       {
         lcdDrawTextAlignedLeft(y, INDENT TR_MODE);
-#if defined(INTERNAL_MODULE_PXX1)
-        lcdDrawTextAtIndex(MODEL_SETUP_2ND_COLUMN, y, STR_INTERNAL_MODULE_PROTOCOLS, g_model.moduleData[INTERNAL_MODULE].type, menuHorizontalPosition==0 ? attr : 0);
+        lcdDrawTextAtIndex(MODEL_SETUP_2ND_COLUMN, y,
+                           STR_INTERNAL_MODULE_PROTOCOLS,
+                           g_model.moduleData[INTERNAL_MODULE].type,
+                           menuHorizontalPosition == 0 ? attr : 0);
         if (isModuleXJT(INTERNAL_MODULE))
-          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_XJT_ACCST_RF_PROTOCOLS, 1 + g_model.moduleData[INTERNAL_MODULE].subType, menuHorizontalPosition==1 ? attr : 0);
+          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_XJT_ACCST_RF_PROTOCOLS,
+                             g_model.moduleData[INTERNAL_MODULE].subType,
+                             menuHorizontalPosition == 1 ? attr : 0);
         else if (isModuleISRM(INTERNAL_MODULE))
-          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_ISRM_RF_PROTOCOLS, 1 + g_model.moduleData[INTERNAL_MODULE].subType, menuHorizontalPosition==1 ? attr : 0);
+          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_ISRM_RF_PROTOCOLS,
+                             g_model.moduleData[INTERNAL_MODULE].subType,
+                             menuHorizontalPosition == 1 ? attr : 0);
         else if (isModuleCrossfire(INTERNAL_MODULE))
-          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_CRSF_BAUDRATE, CROSSFIRE_STORE_TO_INDEX(g_eeGeneral.internalModuleBaudrate),0);
+          lcdDrawTextAtIndex(
+              lcdNextPos + 3, y, STR_CRSF_BAUDRATE,
+              CROSSFIRE_STORE_TO_INDEX(g_eeGeneral.internalModuleBaudrate), 0);
         if (attr) {
           if (menuHorizontalPosition == 0) {
-            uint8_t moduleType = checkIncDec(event, g_model.moduleData[INTERNAL_MODULE].type, MODULE_TYPE_NONE, MODULE_TYPE_MAX, EE_MODEL, isInternalModuleAvailable);
+            uint8_t moduleType =
+                checkIncDec(event, g_model.moduleData[INTERNAL_MODULE].type,
+                            MODULE_TYPE_NONE, MODULE_TYPE_MAX, EE_MODEL,
+                            isInternalModuleAvailable);
             if (checkIncDec_Ret) {
               setModuleType(INTERNAL_MODULE, moduleType);
             }
-          }
-          else if (isModuleXJT(INTERNAL_MODULE)) {
-            g_model.moduleData[INTERNAL_MODULE].subType = checkIncDec(event, g_model.moduleData[INTERNAL_MODULE].subType, 0, MODULE_SUBTYPE_PXX1_LAST, EE_MODEL, isRfProtocolAvailable);
+          } else if (isModuleXJT(INTERNAL_MODULE)) {
+            g_model.moduleData[INTERNAL_MODULE].subType = checkIncDec(
+                event, g_model.moduleData[INTERNAL_MODULE].subType, 0,
+                MODULE_SUBTYPE_PXX1_LAST, EE_MODEL, isRfProtocolAvailable);
             if (checkIncDec_Ret) {
-              g_model.moduleData[0].type = MODULE_TYPE_XJT_PXX1;
-              g_model.moduleData[0].channelsStart = 0;
-              g_model.moduleData[0].channelsCount = defaultModuleChannels_M8(INTERNAL_MODULE);
+              g_model.moduleData[INTERNAL_MODULE].channelsStart = 0;
+              g_model.moduleData[INTERNAL_MODULE].channelsCount =
+                  defaultModuleChannels_M8(INTERNAL_MODULE);
             }
-          }
-          else if (isModulePXX2(INTERNAL_MODULE)) {
-            g_model.moduleData[INTERNAL_MODULE].subType = checkIncDec(event, g_model.moduleData[INTERNAL_MODULE].subType, 0, MODULE_SUBTYPE_ISRM_PXX2_ACCST_D16, EE_MODEL, isRfProtocolAvailable);
-          }
-        }
-#else
-        uint8_t index = 0;
-        if (g_model.moduleData[INTERNAL_MODULE].type == MODULE_TYPE_ISRM_PXX2) {
-          index = 1 + g_model.moduleData[INTERNAL_MODULE].subType;
-        }
-        lcdDrawTextAtIndex(MODEL_SETUP_2ND_COLUMN, y, STR_ISRM_RF_PROTOCOLS, index, attr);
-        if (attr) {
-          index = checkIncDec(event, index, 0, MODULE_SUBTYPE_ISRM_PXX2_ACCST_D16 + 1 /* because of --- */, EE_MODEL);
-          if (checkIncDec_Ret) {
-            memclear(&g_model.moduleData[INTERNAL_MODULE], sizeof(ModuleData));
-            if (index > 0) {
-              g_model.moduleData[INTERNAL_MODULE].type = MODULE_TYPE_ISRM_PXX2;
-              g_model.moduleData[INTERNAL_MODULE].subType = index - 1;
-              g_model.moduleData[INTERNAL_MODULE].channelsCount = defaultModuleChannels_M8(INTERNAL_MODULE);
+          } else if (isModuleISRM(INTERNAL_MODULE)) {
+            g_model.moduleData[INTERNAL_MODULE].subType =
+                checkIncDec(event, g_model.moduleData[INTERNAL_MODULE].subType,
+                            0, MODULE_SUBTYPE_ISRM_PXX2_ACCST_D16, EE_MODEL,
+                            isRfProtocolAvailable);
+            if (checkIncDec_Ret) {
+              g_model.moduleData[INTERNAL_MODULE].channelsStart = 0;
+              g_model.moduleData[INTERNAL_MODULE].channelsCount =
+                  defaultModuleChannels_M8(INTERNAL_MODULE);
             }
           }
         }
-#endif
         break;
       }
 
@@ -938,7 +934,7 @@ void menuModelSetup(event_t event)
         lcdDrawTextAlignedLeft(y, INDENT TR_MODE);
         lcdDrawTextAtIndex(MODEL_SETUP_2ND_COLUMN, y, STR_EXTERNAL_MODULE_PROTOCOLS, reusableBuffer.moduleSetup.newType, menuHorizontalPosition==0 ? attr : 0);
         if (isModuleXJT(EXTERNAL_MODULE))
-          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_XJT_ACCST_RF_PROTOCOLS, 1+g_model.moduleData[EXTERNAL_MODULE].subType, menuHorizontalPosition==1 ? attr : 0);
+          lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_XJT_ACCST_RF_PROTOCOLS, g_model.moduleData[EXTERNAL_MODULE].subType, menuHorizontalPosition==1 ? attr : 0);
         else if (isModuleDSM2(EXTERNAL_MODULE))
           lcdDrawTextAtIndex(lcdNextPos + 3, y, STR_DSM_PROTOCOLS, g_model.moduleData[EXTERNAL_MODULE].subType, menuHorizontalPosition==1 ? attr : 0);
         else if (isModuleR9MNonAccess(EXTERNAL_MODULE))

--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -637,7 +637,7 @@ class ModuleWindow : public FormGroup {
       if (isModuleXJT(moduleIdx)) {
         rfChoice = new Choice(
             this, grid.getFieldSlot(2, 1), STR_XJT_ACCST_RF_PROTOCOLS,
-            MODULE_SUBTYPE_PXX1_OFF, MODULE_SUBTYPE_PXX1_LAST,
+            0, MODULE_SUBTYPE_PXX1_LAST,
             GET_DEFAULT(g_model.moduleData[moduleIdx].subType),
             [=](int32_t newValue) {
               g_model.moduleData[moduleIdx].subType = newValue;

--- a/radio/src/translations/untranslated.h
+++ b/radio/src/translations/untranslated.h
@@ -157,15 +157,10 @@
 #define TR_INTERNAL_MODULE_PROTOCOLS   TR_EXTERNAL_MODULE_PROTOCOLS
 
 #define LEN_XJT_ACCST_RF_PROTOCOLS     "\004"
-#define TR_XJT_ACCST_RF_PROTOCOLS      "OFF\0""D16\0""D8\0 ""LR12"
+#define TR_XJT_ACCST_RF_PROTOCOLS      "D16\0""D8\0 ""LR12"
 
-#if defined(COLORLCD)
 #define LEN_ISRM_RF_PROTOCOLS          "\006"
 #define TR_ISRM_RF_PROTOCOLS           "ACCESS""D16\0  ""LR12"
-#else
-#define LEN_ISRM_RF_PROTOCOLS          "\006"
-#define TR_ISRM_RF_PROTOCOLS           "OFF\0  ""ACCESS""D16\0  ""LR12"
-#endif
 
 #define LEN_R9M_PXX2_RF_PROTOCOLS      "\006"
 #define TR_R9M_PXX2_RF_PROTOCOLS       "ACCESS""FCC\0  ""EU\0   ""Flex"


### PR DESCRIPTION
* chore: Remove "OFF" from protocol lists

* Fix subType setting for X9D+2019

* fix: Chan start and count for ISRM, dup type set
Channel start and count wasn't being updated for ISRM.
Also remove duplicate modulke type setting, which was the
cause of an earlier bug that was worked around on 128x64

* fix(colorlcd): Shorter ACCST opts string crash

* chore: Formatting only