### PR TITLE
Adds audio/haptic feedback for all hard keys except trim switches

### DIFF
--- a/radio/src/audio.cpp
+++ b/radio/src/audio.cpp
@@ -1267,11 +1267,6 @@ void pushPrompt(uint16_t prompt, uint8_t id)
 #endif
 }
 
-void onKeyPress()     // audio/haptic feedback on hard keys moved to keys.cpp
-{                     // audio/haptic feedback on touch in LvglWrapper.cpp
-  return;
-}
-
 void onKeyError()
 {
   audioKeyError();

--- a/radio/src/audio.cpp
+++ b/radio/src/audio.cpp
@@ -1267,8 +1267,8 @@ void pushPrompt(uint16_t prompt, uint8_t id)
 #endif
 }
 
-void onKeyPress()
-{
+void onKeyPress()     // audio/haptic feedback on hard keys moved to keys.cpp
+{                     // audio/haptic feedback on touch in LvglWrapper.cpp
   return;
 }
 

--- a/radio/src/audio.cpp
+++ b/radio/src/audio.cpp
@@ -1267,6 +1267,11 @@ void pushPrompt(uint16_t prompt, uint8_t id)
 #endif
 }
 
+void onKeyPress()
+{
+  return;
+}
+
 void onKeyError()
 {
   audioKeyError();

--- a/radio/src/audio.cpp
+++ b/radio/src/audio.cpp
@@ -1267,11 +1267,6 @@ void pushPrompt(uint16_t prompt, uint8_t id)
 #endif
 }
 
-void onKeyPress()
-{
-  audioKeyPress();
-}
-
 void onKeyError()
 {
   audioKeyError();

--- a/radio/src/gui/colorlcd/LvglWrapper.cpp
+++ b/radio/src/gui/colorlcd/LvglWrapper.cpp
@@ -121,8 +121,18 @@ static void keyboardDriverRead(lv_indev_drv_t *drv, lv_indev_data_t *data)
 {
   data->key = 0;
 
-  if (isEvent()) {
-    event_t evt = getWindowEvent();
+  if (isEvent()) {                            // event waiting
+    event_t evt = getEvent(false);            // get keyEvent for hard keys other than trim switches
+
+    if(evt == EVT_KEY_FIRST(KEY_PGUP) ||      // generate acoustic/haptic feedback if radio settings allow
+       evt == EVT_KEY_FIRST(KEY_PGDN) ||
+       evt == EVT_KEY_FIRST(KEY_ENTER) ||
+       evt == EVT_KEY_FIRST(KEY_MODEL) ||
+       evt == EVT_KEY_FIRST(KEY_EXIT) ||
+       evt == EVT_KEY_FIRST(KEY_TELEM) ||
+       evt == EVT_KEY_FIRST(KEY_RADIO)) {
+      audioKeyPress();
+    }
 
     // no focused item ?
     auto obj = get_focus_obj(keyboardDevice);

--- a/radio/src/gui/colorlcd/LvglWrapper.cpp
+++ b/radio/src/gui/colorlcd/LvglWrapper.cpp
@@ -209,9 +209,9 @@ extern "C" void touchDriverRead(lv_indev_drv_t *drv, lv_indev_data_t *data)
     copy_ts_to_indev_data(st, data);
   }
 
-  if (st.event == TE_UP) {  // on Touch Up
-      reset_inactivity();   // reset activity counter
-      onKeyPress();         // provide acoustic and/or haptic feedback if requested in settings
+  if (st.event == TE_DOWN) { // on first touch (same logic as key down)
+      reset_inactivity();    // reset activity counter
+      audioKeyPress();       // provide acoustic and/or haptic feedback if requested in settings
   }
   
   backup_touch_data(data);

--- a/radio/src/gui/colorlcd/access_settings.cpp
+++ b/radio/src/gui/colorlcd/access_settings.cpp
@@ -117,7 +117,6 @@ bool BindRxChoiceMenu::onTouchEnd(coord_t x, coord_t y)
   //       by clicking outside the menu window and the onCancel
   //       handler is not accessible from here
   moduleState[moduleIdx].mode = MODULE_MODE_NORMAL;
-  onKeyPress();
   deleteLater();
   return true;
 }

--- a/radio/src/gui/colorlcd/color_editor_popup.cpp
+++ b/radio/src/gui/colorlcd/color_editor_popup.cpp
@@ -220,7 +220,6 @@ bool ColorEditorPopup::onTouchEnd(coord_t x, coord_t y)
 {
   TRACE("ColorEditorPopup::onTouchEnd");
   if (!Window::onTouchEnd(x, y) && closeWhenClickOutside) {
-    onKeyPress();
     deleteLater();
   }
   return true;

--- a/radio/src/gui/colorlcd/lcd.cpp
+++ b/radio/src/gui/colorlcd/lcd.cpp
@@ -258,9 +258,3 @@ void lcdFlushed()
   if (refr_disp != nullptr)
     lv_disp_flush_ready(refr_disp);
 }
-
-//TODO: move this somewhere else
-event_t getWindowEvent()
-{
-  return getEvent(false);
-}

--- a/radio/src/gui/colorlcd/radio_theme.cpp
+++ b/radio/src/gui/colorlcd/radio_theme.cpp
@@ -182,7 +182,6 @@ public:
       for (auto i = 0; i < (int) _tabs.size(); i++)
         _tabs[i]->check(i == _activeTab);
       _colorEditor->setColorEditorType(_activeTab == 1 ? HSV_COLOR_EDITOR : RGB_COLOR_EDITOR);
-      onKeyPress();
     }
   }
 

--- a/radio/src/gui/colorlcd/view_main_menu.h
+++ b/radio/src/gui/colorlcd/view_main_menu.h
@@ -36,7 +36,6 @@ class ViewMainMenu : public Window
   bool onTouchStart(coord_t /*x*/, coord_t /*y*/) override { return true; }
   bool onTouchEnd(coord_t x, coord_t y) override
   {
-    onKeyPress();
     deleteLater();
     return true;
   }

--- a/radio/src/keys.cpp
+++ b/radio/src/keys.cpp
@@ -23,6 +23,8 @@
 #include "timers_driver.h"
 #include "opentx_helpers.h"
 
+#include "audio.h"
+
 #define KEY_LONG_DELAY              32  // long key press minimum duration (x10ms), must be less than KEY_REPEAT_DELAY
 #define KEY_REPEAT_DELAY            40  // press longer than this enables repeat (but does not fire it yet)
 #define KEY_REPEAT_TRIGGER          48  // repeat trigger, used in combination with m_state to produce decreasing times between repeat events
@@ -101,6 +103,11 @@ void Key::input(bool val)
       inactivity.counter = 0;
       m_state = KSTATE_RPTDELAY;
       m_cnt = 0;
+
+      if(key() < TRM_BASE) {
+        audioKeyPress();                // provide acoustic and/or haptic feedback if requested in settings
+      }
+      
       break;
 
     case KSTATE_RPTDELAY: // gruvin: delay state before first key repeat

--- a/radio/src/keys.cpp
+++ b/radio/src/keys.cpp
@@ -103,13 +103,6 @@ void Key::input(bool val)
       inactivity.counter = 0;
       m_state = KSTATE_RPTDELAY;
       m_cnt = 0;
-
-      #ifndef BOOT                // if not in bootloader provide acoustic and/or
-        if(key() < TRM_BASE) {    // haptic feedback on hard keys except trim switches
-          audioKeyPress();         
-        }
-      #endif
-      
       break;
 
     case KSTATE_RPTDELAY: // gruvin: delay state before first key repeat

--- a/radio/src/keys.cpp
+++ b/radio/src/keys.cpp
@@ -23,8 +23,6 @@
 #include "timers_driver.h"
 #include "opentx_helpers.h"
 
-#include "audio.h"
-
 #define KEY_LONG_DELAY              32  // long key press minimum duration (x10ms), must be less than KEY_REPEAT_DELAY
 #define KEY_REPEAT_DELAY            40  // press longer than this enables repeat (but does not fire it yet)
 #define KEY_REPEAT_TRIGGER          48  // repeat trigger, used in combination with m_state to produce decreasing times between repeat events

--- a/radio/src/keys.cpp
+++ b/radio/src/keys.cpp
@@ -104,9 +104,11 @@ void Key::input(bool val)
       m_state = KSTATE_RPTDELAY;
       m_cnt = 0;
 
-      if(key() < TRM_BASE) {
-        audioKeyPress();                // provide acoustic and/or haptic feedback if requested in settings
-      }
+      #ifndef BOOT                // if not in bootloader provide acoustic and/or
+        if(key() < TRM_BASE) {    // haptic feedback on hard keys except trim switches
+          audioKeyPress();         
+        }
+      #endif
       
       break;
 

--- a/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
+++ b/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
@@ -27,11 +27,6 @@
 #include "keys.h"
 #include "debug.h"
 
-// to satisfy linker for keys.cpp which is used in firmware too
-void audioKeyPress() {
-  return;
-}
-
 #if defined(PCBXLITE)
   #define BOOTLOADER_KEYS                 0x0F
 #else

--- a/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
+++ b/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
@@ -27,6 +27,11 @@
 #include "keys.h"
 #include "debug.h"
 
+// to satisfy linker for keys.cpp which is used in firmware too
+void audioKeyPress() {
+  return;
+}
+
 #if defined(PCBXLITE)
   #define BOOTLOADER_KEYS                 0x0F
 #else


### PR DESCRIPTION
This addresses https://github.com/EdgeTX/edgetx/issues/2194

Needs EdgeTX/libopenui#59

Changed logic from application decides if feedback has to be given (was inconsistent and inefficient) to key driver detects button down and triggers immediate feedback if radio settings allowed for acoustic and/or haptic feedback (radio settings, radio setup, sound set to All)

With this change all instances of the application calling for feedback were removed in favor of the centralized approach.

This first commit also introduces a dummy function for providing feedback on key presses in boot.cpp because keys.cpp is also used as the bootloader key driver but with no logic to determine if feedback is allowed. Using a define that indicates keys.cpp is compiled for use in the bootloader would make a much nicer and backwards compatible solution.

@pfeerick is there a define I could use to identfiy a bootloader compile?
