### PR TITLE
feat(cpn): Initial TX12MK2 support

### DIFF
--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -95,6 +95,8 @@ uint32_t Boards::getFourCC(Type board)
       return 0x3878746F;
     case BOARD_RADIOMASTER_TX12:
       return 0x4178746F;
+    case BOARD_RADIOMASTER_TX12_MK2:
+      return 0x4878746F;
     case BOARD_RADIOMASTER_ZORRO:
       return 0x4778746F;
     case BOARD_RADIOMASTER_T8:
@@ -129,6 +131,7 @@ int Boards::getEEpromSize(Board::Type board)
     case BOARD_JUMPER_TLITE:
     case BOARD_JUMPER_TPRO:
     case BOARD_RADIOMASTER_TX12:
+    case BOARD_RADIOMASTER_TX12_MK2:
     case BOARD_RADIOMASTER_T8:
     case BOARD_RADIOMASTER_ZORRO:
       return EESIZE_TARANIS;
@@ -170,6 +173,7 @@ int Boards::getFlashSize(Type board)
     case BOARD_JUMPER_TLITE:
     case BOARD_JUMPER_TPRO:
     case BOARD_RADIOMASTER_TX12:
+    case BOARD_RADIOMASTER_TX12_MK2:
     case BOARD_RADIOMASTER_ZORRO:
     case BOARD_RADIOMASTER_T8:
       return FSIZE_TARANIS;
@@ -252,6 +256,18 @@ SwitchInfo Boards::getSwitchInfo(Board::Type board, int index)
       {SWITCH_3POS,     "SF"},
       {SWITCH_2POS,     "SI"},
       {SWITCH_2POS,     "SJ"}
+    };
+    if (index < DIM(switches))
+      return switches[index];
+  }
+  else if (IS_RADIOMASTER_TX12_MK2(board)) {
+    const Board::SwitchInfo switches[] = {
+      {SWITCH_TOGGLE,   "SA"},
+      {SWITCH_3POS,     "SB"},
+      {SWITCH_3POS,     "SC"},
+      {SWITCH_TOGGLE,   "SD"},
+      {SWITCH_3POS,     "SE"},
+      {SWITCH_3POS,     "SF"}
     };
     if (index < DIM(switches))
       return switches[index];
@@ -440,6 +456,8 @@ int Boards::getCapability(Board::Type board, Board::Capability capability)
         return 4;
       else if (board == BOARD_FLYSKY_NV14)
         return 8;
+      else if (board == BOARD_RADIOMASTER_TX12_MK2)
+        return 6;
       else if (IS_FAMILY_T12(board))
         return 8;
       else if (IS_TARANIS_XLITE(board))
@@ -665,6 +683,8 @@ QString Boards::getBoardName(Board::Type board)
       return "Radiomaster TX16S";
     case BOARD_RADIOMASTER_TX12:
       return "Radiomaster TX12";
+    case BOARD_RADIOMASTER_TX12_MK2:
+      return "Radiomaster TX12 Mark II";
     case BOARD_RADIOMASTER_ZORRO:
       return "Radiomaster Zorro";
     case BOARD_RADIOMASTER_T8:
@@ -885,6 +905,7 @@ int Boards::getDefaultInternalModules(Board::Type board)
 
   case BOARD_RADIOMASTER_ZORRO:
   case BOARD_BETAFPV_LR3PRO:
+  case BOARD_RADIOMASTER_TX12_MK2:
     return (int)MODULE_TYPE_CROSSFIRE;
 
   case BOARD_FLYSKY_NV14:

--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -560,6 +560,10 @@ StringTagMappingTable Boards::getAnalogNamesLookupTable(Board::Type board)
 
   if (IS_SKY9X(board)) {
     tbl.insert(tbl.end(), {"P1", "P2", "P3"});
+  } else if (IS_TARANIS_X9LITE(board)) {
+    tbl.insert(tbl.end(), {
+                              {"S1", "POT1"},
+                          });
   } else if (IS_TARANIS_X9E(board)) {
     tbl.insert(tbl.end(), {
                               {"F1", "POT1"},
@@ -578,7 +582,12 @@ StringTagMappingTable Boards::getAnalogNamesLookupTable(Board::Type board)
                               {"GyrX", "GYRO1"},
                               {"GyrY", "GYRO2"},
                           });
-  } else if (IS_TARANIS(board)) {
+  } else if ((IS_TARANIS_SMALL(board) && !IS_JUMPER_TLITE(board)) || IS_FLYSKY_NV14(board)) {
+    tbl.insert(tbl.end(), {
+                              {"S1", "POT1"},
+                              {"S2", "POT2"},
+                          });
+  } else if (IS_TARANIS_X9(board)) {
     tbl.insert(tbl.end(), {
                               {"S1", "POT1"},
                               {"S2", "POT2"},
@@ -597,11 +606,6 @@ StringTagMappingTable Boards::getAnalogNamesLookupTable(Board::Type board)
                               {"RS", "RS"},
                               {"JSx", "MOUSE1"},
                               {"JSy", "MOUSE2"},
-                          });
-  } else if (IS_FLYSKY_NV14(board)) {
-    tbl.insert(tbl.end(), {
-                              {"S1", "POT1"},
-                              {"S2", "POT2"},
                           });
   } else if (IS_HORUS_X10(board) || IS_FAMILY_T16(board)) {
     tbl.insert(tbl.end(), {

--- a/companion/src/firmwares/boards.h
+++ b/companion/src/firmwares/boards.h
@@ -60,6 +60,7 @@ namespace Board {
     BOARD_RADIOMASTER_TX16S,
     BOARD_JUMPER_T18,
     BOARD_RADIOMASTER_TX12,
+    BOARD_RADIOMASTER_TX12_MK2,
     BOARD_RADIOMASTER_T8,
     BOARD_JUMPER_TLITE,
     BOARD_FLYSKY_NV14,
@@ -283,6 +284,11 @@ inline bool IS_RADIOMASTER_TX12(Board::Type board)
   return board == Board::BOARD_RADIOMASTER_TX12;
 }
 
+inline bool IS_RADIOMASTER_TX12_MK2(Board::Type board)
+{
+  return board == Board::BOARD_RADIOMASTER_TX12_MK2;
+}
+
 inline bool IS_RADIOMASTER_ZORRO(Board::Type board)
 {
   return board == Board::BOARD_RADIOMASTER_ZORRO;
@@ -303,6 +309,7 @@ inline bool IS_FAMILY_T12(Board::Type board)
 {
   return board == Board::BOARD_JUMPER_T12 ||
          board == Board::BOARD_RADIOMASTER_TX12 ||
+         board == Board::BOARD_RADIOMASTER_TX12_MK2 ||
          board == Board::BOARD_RADIOMASTER_ZORRO ||
          board == Board::BOARD_RADIOMASTER_T8 ||
          board == Board::BOARD_JUMPER_TLITE ||

--- a/companion/src/firmwares/opentx/opentxeeprom.h
+++ b/companion/src/firmwares/opentx/opentxeeprom.h
@@ -42,6 +42,7 @@
 #define RADIOMASTER_T8_VARIANT         0x4004
 #define RADIOMASTER_ZORRO_VARIANT      0x4006
 #define JUMPER_TPRO_VARIANT            0x4005
+#define RADIOMASTER_TX12_MK2_VARIANT   0x4008
 
 class OpenTxGeneralData: public TransformedField {
   public:

--- a/companion/src/firmwares/opentx/opentxinterface.cpp
+++ b/companion/src/firmwares/opentx/opentxinterface.cpp
@@ -1461,7 +1461,7 @@ void registerOpenTxFirmwares()
   registerOpenTxFirmware(firmware);
   addOpenTxRfOptions(firmware, FLEX);
 
-  /* Radiomaster TX12 board */
+  /* Radiomaster TX12 Mark II board */
   firmware = new OpenTxFirmware(FIRMWAREID("tx12mk2"), QCoreApplication::translate("Firmware", "Radiomaster TX12 Mark II"), BOARD_RADIOMASTER_TX12_MK2);
   addOpenTxCommonOptions(firmware);
   firmware->addOption("noheli", Firmware::tr("Disable HELI menu and cyclic mix support"));

--- a/companion/src/firmwares/opentx/opentxinterface.cpp
+++ b/companion/src/firmwares/opentx/opentxinterface.cpp
@@ -72,6 +72,8 @@ const char * OpenTxEepromInterface::getName()
       return "EdgeTX for Radiomaster TX16S";
     case BOARD_RADIOMASTER_TX12:
       return "EdgeTX for Radiomaster TX12";
+    case BOARD_RADIOMASTER_TX12_MK2:
+      return "EdgeTX for Radiomaster TX12 Mark II";
     case BOARD_RADIOMASTER_ZORRO:
       return "EdgeTX for Radiomaster Zorro";
     case BOARD_RADIOMASTER_T8:
@@ -359,6 +361,9 @@ int OpenTxEepromInterface::save(uint8_t * eeprom, const RadioData & radioData, u
   }
   else if (IS_RADIOMASTER_TX12(board)) {
     variant |= RADIOMASTER_TX12_VARIANT;
+  }
+  else if (IS_RADIOMASTER_TX12_MK2(board)) {
+    variant |= RADIOMASTER_TX12_MK2_VARIANT;
   }
   else if (IS_RADIOMASTER_ZORRO(board)) {
     variant |= RADIOMASTER_ZORRO_VARIANT;
@@ -753,12 +758,12 @@ int OpenTxFirmware::getCapability(::Capability capability)
     case HasAuxSerialMode:
       return (IS_FAMILY_HORUS_OR_T16(board) && !IS_FLYSKY_NV14(board)) ||
              (IS_TARANIS_X9(board) && !IS_TARANIS_X9DP_2019(board)) ||
-             IS_RADIOMASTER_ZORRO(board);
+             IS_RADIOMASTER_ZORRO(board) || IS_RADIOMASTER_TX12_MK2(board);
     case HasAux2SerialMode:
       return IS_FAMILY_T16(board);
     case HasVCPSerialMode:
       return IS_FAMILY_HORUS_OR_T16(board) || IS_RADIOMASTER_ZORRO(board) ||
-             IS_JUMPER_TPRO(board);
+             IS_JUMPER_TPRO(board) || IS_RADIOMASTER_TX12_MK2(board);
     case HasBluetooth:
       return (IS_FAMILY_HORUS_OR_T16(board) || IS_TARANIS_X7(board) || IS_TARANIS_XLITE(board)|| IS_TARANIS_X9E(board) || IS_TARANIS_X9DP_2019(board) || IS_FLYSKY_NV14(board)) ? true : false;
     case HasAntennaChoice:
@@ -777,8 +782,8 @@ int OpenTxFirmware::getCapability(::Capability capability)
       return (IS_TARANIS_X9E(board) || IS_TARANIS_X9DP_2019(board) ||
               IS_TARANIS_X7(board) || IS_JUMPER_TPRO(board) ||
               IS_TARANIS_X9LITE(board) || IS_RADIOMASTER_TX12(board) ||
-              IS_RADIOMASTER_ZORRO(board) || IS_RADIOMASTER_TX16S(board) ||
-              IS_JUMPER_T18(board));
+              IS_RADIOMASTER_TX12_MK2(board) || IS_RADIOMASTER_ZORRO(board) || 
+              IS_RADIOMASTER_TX16S(board) || IS_JUMPER_T18(board));
     case HasSoftwareSerialPower:
       return IS_RADIOMASTER_TX16S(board);
     default:
@@ -827,6 +832,8 @@ bool OpenTxFirmware::isAvailable(PulsesProtocol proto, int port)
             return IS_ACCESS_RADIO(board, id);
           case PULSES_MULTIMODULE:
             return id.contains("internalmulti") || IS_RADIOMASTER_TX16S(board) || IS_JUMPER_T18(board) || IS_RADIOMASTER_TX12(board) || IS_JUMPER_TLITE(board) || IS_BETAFPV_LR3PRO(board);
+          case PULSES_CROSSFIRE:
+            IS_RADIOMASTER_TX12_MK2(board);
           case PULSES_AFHDS3:
             return IS_FLYSKY_NV14(board);
           default:
@@ -1073,6 +1080,11 @@ bool OpenTxEepromInterface::checkVariant(unsigned int version, unsigned int vari
   }
   else if (IS_RADIOMASTER_TX12(board)) {
     if (variant != RADIOMASTER_TX12_VARIANT) {
+      variantError = true;
+    }
+  }
+  else if (IS_RADIOMASTER_TX12_MK2(board)) {
+    if (variant != RADIOMASTER_TX12_MK2_VARIANT) {
       variantError = true;
     }
   }
@@ -1441,6 +1453,16 @@ void registerOpenTxFirmwares()
 
   /* Radiomaster TX12 board */
   firmware = new OpenTxFirmware(FIRMWAREID("tx12"), QCoreApplication::translate("Firmware", "Radiomaster TX12"), BOARD_RADIOMASTER_TX12);
+  addOpenTxCommonOptions(firmware);
+  firmware->addOption("noheli", Firmware::tr("Disable HELI menu and cyclic mix support"));
+  firmware->addOption("nogvars", Firmware::tr("Disable Global variables"));
+  firmware->addOption("lua", Firmware::tr("Enable Lua custom scripts screen"));
+  addOpenTxFontOptions(firmware);
+  registerOpenTxFirmware(firmware);
+  addOpenTxRfOptions(firmware, FLEX);
+
+  /* Radiomaster TX12 board */
+  firmware = new OpenTxFirmware(FIRMWAREID("tx12mk2"), QCoreApplication::translate("Firmware", "Radiomaster TX12 Mark II"), BOARD_RADIOMASTER_TX12_MK2);
   addOpenTxCommonOptions(firmware);
   firmware->addOption("noheli", Firmware::tr("Disable HELI menu and cyclic mix support"));
   firmware->addOption("nogvars", Firmware::tr("Disable Global variables"));

--- a/companion/src/firmwares/opentx/opentxinterface.cpp
+++ b/companion/src/firmwares/opentx/opentxinterface.cpp
@@ -782,7 +782,7 @@ int OpenTxFirmware::getCapability(::Capability capability)
       return (IS_TARANIS_X9E(board) || IS_TARANIS_X9DP_2019(board) ||
               IS_TARANIS_X7(board) || IS_JUMPER_TPRO(board) ||
               IS_TARANIS_X9LITE(board) || IS_RADIOMASTER_TX12(board) ||
-              IS_RADIOMASTER_TX12_MK2(board) || IS_RADIOMASTER_ZORRO(board) || 
+              IS_RADIOMASTER_TX12_MK2(board) || IS_RADIOMASTER_ZORRO(board) ||
               IS_RADIOMASTER_TX16S(board) || IS_JUMPER_T18(board));
     case HasSoftwareSerialPower:
       return IS_RADIOMASTER_TX16S(board);
@@ -833,7 +833,7 @@ bool OpenTxFirmware::isAvailable(PulsesProtocol proto, int port)
           case PULSES_MULTIMODULE:
             return id.contains("internalmulti") || IS_RADIOMASTER_TX16S(board) || IS_JUMPER_T18(board) || IS_RADIOMASTER_TX12(board) || IS_JUMPER_TLITE(board) || IS_BETAFPV_LR3PRO(board);
           case PULSES_CROSSFIRE:
-            IS_RADIOMASTER_TX12_MK2(board);
+            return IS_RADIOMASTER_TX12_MK2(board);
           case PULSES_AFHDS3:
             return IS_FLYSKY_NV14(board);
           default:

--- a/companion/src/simulation/simulatorwidget.cpp
+++ b/companion/src/simulation/simulatorwidget.cpp
@@ -104,6 +104,7 @@ SimulatorWidget::SimulatorWidget(QWidget * parent, SimulatorInterface * simulato
       radioUiWidget = new SimulatedUIWidgetJumperT18(simulator, this);
       break;
     case Board::BOARD_RADIOMASTER_TX12:
+    case Board::BOARD_RADIOMASTER_TX12_MK2:
       radioUiWidget = new SimulatedUIWidgetTX12(simulator, this);
       break;
     case Board::BOARD_RADIOMASTER_ZORRO:

--- a/tools/build-companion.sh
+++ b/tools/build-companion.sh
@@ -65,7 +65,7 @@ cd build
 
 declare -a simulator_plugins=(x9lite x9lites
                               x7 x7-access
-                              t8 t12 tx12
+                              t8 t12 tx12 tx12mk2
                               zorro
                               tlite tpro lr3pro
                               x9d x9dp x9dp2019 x9e
@@ -97,6 +97,9 @@ do
             ;;
         tx12)
             BUILD_OPTIONS+="-DPCB=X7 -DPCBREV=TX12"
+            ;;
+        tx12mk2)
+            BUILD_OPTIONS+="-DPCB=X7 -DPCBREV=TX12MK2"
             ;;
         t8)
             BUILD_OPTIONS+="-DPCB=X7 -DPCBREV=T8"


### PR DESCRIPTION
Initial blind attempt to add TX12 MK2 support. This radio is identical to the TX12 as far as Companion is concerned, except it has two less switch options, and by currently ships with ELRS (so CRSF module protocol). 

This seems to be working so far in as far as reading and writing from a copy of my radio's settings via etx file - I'll do actual radio testing once a github build for windows is done and sleep ;)

And will then naturally be asking for a review from the Companion whisperer ;)

On another note... it looks like Companion is writing calibration data for pots/sliders that don't necessarily exist? i.e. for the TX12, with a recent `main` build of Companion, I'm seeing this for the TX12 ... a radio with standard gimbals and two pots (I would have said they were sliders but firmware/companion refer to them as pots so I'm not going to go there). Just wondering if it is a configuration value not set properly? 

```
calib:
  Rud:
    mid: 995
    spanNeg: 696
    spanPos: 760
  Ele:
    mid: 1037
    spanNeg: 690
    spanPos: 582
  Thr:
    mid: 994
    spanNeg: 623
    spanPos: 648
  Ail:
    mid: 1026
    spanNeg: 762
    spanPos: 681
  POT1:
    mid: 1044
    spanNeg: 315
    spanPos: 288
  POT2:
    mid: 1027
    spanNeg: 270
    spanPos: 297
  POT3:
    mid: 0
    spanNeg: 0
    spanPos: 0
  SLIDER1:
    mid: 0
    spanNeg: 0
    spanPos: 0
  SLIDER2:
    mid: 0
    spanNeg: 0
    spanPos: 0
 ```

