### PR TITLE
Allow CPP Widgets Override with LUA

### DIFF
--- a/radio/src/gui/colorlcd/widget.cpp
+++ b/radio/src/gui/colorlcd/widget.cpp
@@ -158,11 +158,6 @@ std::list<const WidgetFactory *> & getRegisteredWidgets()
   return widgets;
 }
 
-void registerWidget(const WidgetFactory * factory)
-{
-  TRACE("register widget %s", factory->getName());
-  getRegisteredWidgets().push_back(factory);
-}
 
 void unregisterWidget(const WidgetFactory * factory)
 {
@@ -179,6 +174,17 @@ const WidgetFactory * getWidgetFactory(const char * name)
     }
   }
   return nullptr;
+}
+
+void registerWidget(const WidgetFactory * factory)
+{
+  auto name = factory->getName();
+  auto oldWidget = getWidgetFactory(name);
+  if (oldWidget) {
+    unregisterWidget(oldWidget);
+  }
+  TRACE("register widget %s", name);
+  getRegisteredWidgets().push_back(factory);
 }
 
 Widget* loadWidget(const char* name, Window* parent, const rect_t& rect,

--- a/radio/src/gui/colorlcd/widget.h
+++ b/radio/src/gui/colorlcd/widget.h
@@ -157,11 +157,12 @@ class WidgetFactory
           TRACE("WidgetFactory::initPersistentData() setting option '%s'", option->name);
           // TODO compiler bug? The CPU freezes ... persistentData->options[i++] = option->deflt;
           auto optVal = &persistentData->options[i];
-          if (setDefault) {
+          auto optType = zoneValueEnumFromType(option->type);
+          if (setDefault || optVal->type != optType) {
             // reset to default value
             memcpy(&optVal->value, &option->deflt, sizeof(ZoneOptionValue));
+            optVal->type = optType;
           }
-          optVal->type = zoneValueEnumFromType(option->type);
         }
       }
     }


### PR DESCRIPTION
Allows #221 

Summary of changes:

Iterate the Widgets factory backward to give priority to the Lua widgets over the internal C++  Widgets.
This allows reimplementing the internal widgets with Lua without any sacrifice or `defines`.
