### PR TITLE
Fixes for MPM UI for colorlcd

### DIFF
--- a/radio/src/gui/colorlcd/mpm_settings.cpp
+++ b/radio/src/gui/colorlcd/mpm_settings.cpp
@@ -278,6 +278,9 @@ MultimoduleSettings::MultimoduleSettings(Window *parent,
   new CheckBox(line, rect_t{}, GET_SET_DEFAULT(md->multi.disableTelemetry));
 
   cm_line = new MPMChannelMap(this, &grid, moduleIdx);
+
+  // Ensure elements properly initalised
+  update();
 }
 
 void MultimoduleSettings::update()

--- a/radio/src/gui/colorlcd/mpm_settings.cpp
+++ b/radio/src/gui/colorlcd/mpm_settings.cpp
@@ -158,7 +158,7 @@ MPMSubtype::MPMSubtype(FormGroup* form, FlexGridLayout *layout, uint8_t moduleId
 
 void MPMSubtype::update(const MultiRfProtocols::RfProto* rfProto, ModuleData* md)
 {
-  if (!rfProto) {
+  if (!rfProto || rfProto->subProtos.size() == 0) {
     lv_obj_add_flag(lvobj, LV_OBJ_FLAG_HIDDEN);
     return;
   }

--- a/radio/src/gui/colorlcd/mpm_settings.cpp
+++ b/radio/src/gui/colorlcd/mpm_settings.cpp
@@ -27,6 +27,14 @@
 
 #define SET_DIRTY() storageDirty(EE_MODEL)
 
+static void update_mpm_settings(lv_event_t* e)
+{
+  MultimoduleSettings* ms = (MultimoduleSettings*)lv_event_get_user_data(e);
+  if (!ms) return;
+
+  ms->update();
+}
+
 struct MPMProtoOption : public FormGroup::Line
 {
   StaticText* label;
@@ -261,7 +269,9 @@ MultimoduleSettings::MultimoduleSettings(Window *parent,
       COLOR_THEME_PRIMARY1);
 
   st_line = new MPMSubtype(this, &grid, moduleIdx);
-  // TODO: set event cb on st_line->choice / LV_EVENT_VALUE_CHANGED ?
+
+  lv_obj_add_event_cb(st_line->getLvObj(), update_mpm_settings,
+                      LV_EVENT_VALUE_CHANGED, this);
 
   opt_line = new MPMProtoOption(this, &grid);
   sr_line = new MPMServoRate(this, &grid, moduleIdx);

--- a/radio/src/gui/colorlcd/mpm_settings.cpp
+++ b/radio/src/gui/colorlcd/mpm_settings.cpp
@@ -79,26 +79,30 @@ void MPMProtoOption::update(const MultiRfProtocols::RfProto* rfProto, ModuleData
     choice->setValues(STR_MULTI_POWER);
     choice->setMin(0);
     choice->setMax(15);
+    choice->setValue(md->multi.optionValue);
     choice->setGetValueHandler(GET_DEFAULT(md->multi.optionValue));
     choice->setSetValueHandler(SET_DEFAULT(md->multi.optionValue));
     lv_obj_clear_flag(choice->getLvObj(), LV_OBJ_FLAG_HIDDEN);
-  } else if (title == STR_MULTI_TELEMETRY) {
+  } else if (title == STR_MULTI_TELEMETRY) { // e.g. Bayang
     choice->setValues(STR_MULTI_TELEMETRY_MODE);
     choice->setMin(min);
     choice->setMax(max);
+    choice->setValue(md->multi.optionValue);
     choice->setGetValueHandler(GET_DEFAULT(md->multi.optionValue));
     choice->setSetValueHandler(SET_DEFAULT(md->multi.optionValue));
     lv_obj_clear_flag(choice->getLvObj(), LV_OBJ_FLAG_HIDDEN);
-  } else if (title == STR_MULTI_WBUS) {
+  } else if (title == STR_MULTI_WBUS) { // e.g. WFLY2 but may not be used anymore
     choice->setValues(STR_MULTI_WBUS_MODE);
     choice->setMin(0);
     choice->setMax(1);
+    choice->setValue(md->multi.optionValue);
     choice->setGetValueHandler(GET_DEFAULT(md->multi.optionValue));
     choice->setSetValueHandler(SET_DEFAULT(md->multi.optionValue));
     lv_obj_clear_flag(choice->getLvObj(), LV_OBJ_FLAG_HIDDEN);
   } else if (rfProto->proto == MODULE_SUBTYPE_MULTI_FS_AFHDS2A) {
     edit->setMin(50);
     edit->setMax(400);
+    edit->setValue(50 + 5 * md->multi.optionValue);
     edit->setGetValueHandler(GET_DEFAULT(50 + 5 * md->multi.optionValue));
     edit->setSetValueHandler(SET_VALUE(md->multi.optionValue, (newValue - 50) / 5));
     edit->setStep(5);
@@ -111,16 +115,19 @@ void MPMProtoOption::update(const MultiRfProtocols::RfProto* rfProto, ModuleData
     lv_obj_clear_flag(cb->getLvObj(), LV_OBJ_FLAG_HIDDEN);
   } else {
     if (min == 0 && max == 1) {
+      cb->setValue(md->multi.optionValue);
       cb->setGetValueHandler(GET_DEFAULT(md->multi.optionValue));
       cb->setSetValueHandler(SET_DEFAULT(md->multi.optionValue));
       lv_obj_clear_flag(cb->getLvObj(), LV_OBJ_FLAG_HIDDEN);
     } else {
       edit->setMin(-128);
       edit->setMax(127);
+      edit->setValue(md->multi.optionValue);
       edit->setGetValueHandler(GET_DEFAULT(md->multi.optionValue));
       edit->setSetValueHandler(SET_DEFAULT(md->multi.optionValue));
       lv_obj_clear_flag(edit->getLvObj(), LV_OBJ_FLAG_HIDDEN);
-      lv_obj_clear_flag(rssi->getLvObj(), LV_OBJ_FLAG_HIDDEN);
+      if (title == STR_MULTI_RFTUNE)
+        lv_obj_clear_flag(rssi->getLvObj(), LV_OBJ_FLAG_HIDDEN);
     }
   }
 }

--- a/radio/src/gui/colorlcd/mpm_settings.cpp
+++ b/radio/src/gui/colorlcd/mpm_settings.cpp
@@ -121,14 +121,14 @@ void MPMProtoOption::update(const MultiRfProtocols::RfProto* rfProto, ModuleData
       md->multi.optionValue = (md->multi.optionValue & 0xFE) + newValue;
       SET_DIRTY();
     });
+    cb->update();
     lv_obj_clear_flag(cb->getLvObj(), LV_OBJ_FLAG_HIDDEN);
-    lv_event_send(cb->getLvObj(), LV_EVENT_VALUE_CHANGED, nullptr);
   } else {
     if (min == 0 && max == 1) {
       cb->setGetValueHandler(GET_DEFAULT(md->multi.optionValue));
       cb->setSetValueHandler(SET_DEFAULT(md->multi.optionValue));
+      cb->update();
       lv_obj_clear_flag(cb->getLvObj(), LV_OBJ_FLAG_HIDDEN);
-      lv_event_send(cb->getLvObj(), LV_EVENT_VALUE_CHANGED, nullptr);
     } else {
       edit->setMin(-128);
       edit->setMax(127);

--- a/radio/src/gui/colorlcd/mpm_settings.cpp
+++ b/radio/src/gui/colorlcd/mpm_settings.cpp
@@ -238,6 +238,8 @@ struct MPMChannelMap : public FormGroup::Line
 {
   MPMChannelMap(FormGroup* form, FlexGridLayout *layout, uint8_t moduleIdx);
   void update(const MultiRfProtocols::RfProto* rfProto);
+ private:
+  CheckBox* cb;
 };
 
 MPMChannelMap::MPMChannelMap(FormGroup* form, FlexGridLayout *layout, uint8_t moduleIdx) :
@@ -247,13 +249,14 @@ MPMChannelMap::MPMChannelMap(FormGroup* form, FlexGridLayout *layout, uint8_t mo
   new StaticText(this, rect_t{}, STR_DISABLE_CH_MAP, 0, COLOR_THEME_PRIMARY1);
 
   auto md = &g_model.moduleData[moduleIdx];
-  new CheckBox(this, rect_t{}, GET_SET_DEFAULT(md->multi.disableMapping));
-}  
+  cb = new CheckBox(this, rect_t{}, GET_SET_DEFAULT(md->multi.disableMapping));
+}
 
 void MPMChannelMap::update(const MultiRfProtocols::RfProto* rfProto)
 {
   if (rfProto && rfProto->supportsDisableMapping()) {
     lv_obj_clear_flag(lvobj, LV_OBJ_FLAG_HIDDEN);
+    cb->update();
   } else {
     lv_obj_add_flag(lvobj, LV_OBJ_FLAG_HIDDEN);
   }

--- a/radio/src/gui/colorlcd/mpm_settings.cpp
+++ b/radio/src/gui/colorlcd/mpm_settings.cpp
@@ -113,8 +113,8 @@ void MPMProtoOption::update(const MultiRfProtocols::RfProto* rfProto, ModuleData
     edit->setGetValueHandler(GET_DEFAULT(50 + 5 * md->multi.optionValue));
     edit->setSetValueHandler(SET_VALUE(md->multi.optionValue, (newValue - 50) / 5));
     edit->setStep(5);
+    edit->update();
     lv_obj_clear_flag(edit->getLvObj(), LV_OBJ_FLAG_HIDDEN);
-    lv_event_send(edit->getLvObj(), LV_EVENT_VALUE_CHANGED, nullptr);
   } else if (rfProto->proto == MODULE_SUBTYPE_MULTI_DSM2) {
     cb->setGetValueHandler([=]() { return md->multi.optionValue & 0x01; });
     cb->setSetValueHandler([=](int8_t newValue) {
@@ -135,7 +135,7 @@ void MPMProtoOption::update(const MultiRfProtocols::RfProto* rfProto, ModuleData
       edit->setGetValueHandler(GET_DEFAULT(md->multi.optionValue));
       edit->setSetValueHandler(SET_DEFAULT(md->multi.optionValue));
       lv_obj_clear_flag(edit->getLvObj(), LV_OBJ_FLAG_HIDDEN);
-      lv_event_send(edit->getLvObj(), LV_EVENT_VALUE_CHANGED, nullptr);
+      edit->update();
       if (title == STR_MULTI_RFTUNE)
         lv_obj_clear_flag(rssi->getLvObj(), LV_OBJ_FLAG_HIDDEN);
     }

--- a/radio/src/gui/colorlcd/mpm_settings.cpp
+++ b/radio/src/gui/colorlcd/mpm_settings.cpp
@@ -87,53 +87,54 @@ void MPMProtoOption::update(const MultiRfProtocols::RfProto* rfProto, ModuleData
     choice->setValues(STR_MULTI_POWER);
     choice->setMin(0);
     choice->setMax(15);
-    choice->setValue(md->multi.optionValue);
     choice->setGetValueHandler(GET_DEFAULT(md->multi.optionValue));
     choice->setSetValueHandler(SET_DEFAULT(md->multi.optionValue));
     lv_obj_clear_flag(choice->getLvObj(), LV_OBJ_FLAG_HIDDEN);
+    lv_event_send(choice->getLvObj(), LV_EVENT_VALUE_CHANGED, nullptr);
   } else if (title == STR_MULTI_TELEMETRY) { // e.g. Bayang
     choice->setValues(STR_MULTI_TELEMETRY_MODE);
     choice->setMin(min);
     choice->setMax(max);
-    choice->setValue(md->multi.optionValue);
     choice->setGetValueHandler(GET_DEFAULT(md->multi.optionValue));
     choice->setSetValueHandler(SET_DEFAULT(md->multi.optionValue));
     lv_obj_clear_flag(choice->getLvObj(), LV_OBJ_FLAG_HIDDEN);
+    lv_event_send(choice->getLvObj(), LV_EVENT_VALUE_CHANGED, nullptr);
   } else if (title == STR_MULTI_WBUS) { // e.g. WFLY2 but may not be used anymore
     choice->setValues(STR_MULTI_WBUS_MODE);
     choice->setMin(0);
     choice->setMax(1);
-    choice->setValue(md->multi.optionValue);
     choice->setGetValueHandler(GET_DEFAULT(md->multi.optionValue));
     choice->setSetValueHandler(SET_DEFAULT(md->multi.optionValue));
     lv_obj_clear_flag(choice->getLvObj(), LV_OBJ_FLAG_HIDDEN);
+    lv_event_send(choice->getLvObj(), LV_EVENT_VALUE_CHANGED, nullptr);
   } else if (rfProto->proto == MODULE_SUBTYPE_MULTI_FS_AFHDS2A) {
     edit->setMin(50);
     edit->setMax(400);
-    edit->setValue(50 + 5 * md->multi.optionValue);
     edit->setGetValueHandler(GET_DEFAULT(50 + 5 * md->multi.optionValue));
     edit->setSetValueHandler(SET_VALUE(md->multi.optionValue, (newValue - 50) / 5));
     edit->setStep(5);
     lv_obj_clear_flag(edit->getLvObj(), LV_OBJ_FLAG_HIDDEN);
+    lv_event_send(edit->getLvObj(), LV_EVENT_VALUE_CHANGED, nullptr);
   } else if (rfProto->proto == MODULE_SUBTYPE_MULTI_DSM2) {
     cb->setGetValueHandler([=]() { return md->multi.optionValue & 0x01; });
     cb->setSetValueHandler([=](int8_t newValue) {
       md->multi.optionValue = (md->multi.optionValue & 0xFE) + newValue;
     });
     lv_obj_clear_flag(cb->getLvObj(), LV_OBJ_FLAG_HIDDEN);
+    lv_event_send(cb->getLvObj(), LV_EVENT_VALUE_CHANGED, nullptr);
   } else {
     if (min == 0 && max == 1) {
-      cb->setValue(md->multi.optionValue);
       cb->setGetValueHandler(GET_DEFAULT(md->multi.optionValue));
       cb->setSetValueHandler(SET_DEFAULT(md->multi.optionValue));
       lv_obj_clear_flag(cb->getLvObj(), LV_OBJ_FLAG_HIDDEN);
+      lv_event_send(cb->getLvObj(), LV_EVENT_VALUE_CHANGED, nullptr);
     } else {
       edit->setMin(-128);
       edit->setMax(127);
-      edit->setValue(md->multi.optionValue);
       edit->setGetValueHandler(GET_DEFAULT(md->multi.optionValue));
       edit->setSetValueHandler(SET_DEFAULT(md->multi.optionValue));
       lv_obj_clear_flag(edit->getLvObj(), LV_OBJ_FLAG_HIDDEN);
+      lv_event_send(edit->getLvObj(), LV_EVENT_VALUE_CHANGED, nullptr);
       if (title == STR_MULTI_RFTUNE)
         lv_obj_clear_flag(rssi->getLvObj(), LV_OBJ_FLAG_HIDDEN);
     }

--- a/radio/src/gui/colorlcd/mpm_settings.cpp
+++ b/radio/src/gui/colorlcd/mpm_settings.cpp
@@ -205,6 +205,10 @@ MPMServoRate::MPMServoRate(FormGroup* form, FlexGridLayout *layout, uint8_t modu
 
 struct MPMAutobind : public FormGroup::Line {
   MPMAutobind(FormGroup* form, FlexGridLayout* layout, uint8_t moduleIdx);
+  void update() const { cb->update(); }
+
+ private:
+  CheckBox* cb;
 };
 
 MPMAutobind::MPMAutobind(FormGroup* form, FlexGridLayout *layout, uint8_t moduleIdx) :
@@ -214,7 +218,7 @@ MPMAutobind::MPMAutobind(FormGroup* form, FlexGridLayout *layout, uint8_t module
   new StaticText(this, rect_t{}, STR_MULTI_AUTOBIND, 0, COLOR_THEME_PRIMARY1);
 
   auto md = &g_model.moduleData[moduleIdx];
-  new CheckBox(this, rect_t{}, GET_SET_DEFAULT(md->multi.autoBindMode));
+  cb = new CheckBox(this, rect_t{}, GET_SET_DEFAULT(md->multi.autoBindMode));
 }
 
 struct MPMChannelMap : public FormGroup::Line
@@ -311,6 +315,7 @@ void MultimoduleSettings::update()
   } else {
     lv_obj_add_flag(sr_line->getLvObj(), LV_OBJ_FLAG_HIDDEN);
     lv_obj_clear_flag(ab_line->getLvObj(), LV_OBJ_FLAG_HIDDEN);
+    ab_line->update();
   }
 
   cm_line->update(rfProto);

--- a/radio/src/gui/colorlcd/mpm_settings.cpp
+++ b/radio/src/gui/colorlcd/mpm_settings.cpp
@@ -119,6 +119,7 @@ void MPMProtoOption::update(const MultiRfProtocols::RfProto* rfProto, ModuleData
     cb->setGetValueHandler([=]() { return md->multi.optionValue & 0x01; });
     cb->setSetValueHandler([=](int8_t newValue) {
       md->multi.optionValue = (md->multi.optionValue & 0xFE) + newValue;
+      SET_DIRTY();
     });
     lv_obj_clear_flag(cb->getLvObj(), LV_OBJ_FLAG_HIDDEN);
     lv_event_send(cb->getLvObj(), LV_EVENT_VALUE_CHANGED, nullptr);
@@ -198,6 +199,7 @@ MPMServoRate::MPMServoRate(FormGroup* form, FlexGridLayout *layout, uint8_t modu
       [=](int16_t newValue) {
         md->multi.optionValue =
             (md->multi.optionValue & 0xFD) + (newValue << 1);
+        SET_DIRTY();
       });
 }
 

--- a/radio/src/gui/colorlcd/mpm_settings.h
+++ b/radio/src/gui/colorlcd/mpm_settings.h
@@ -42,8 +42,8 @@ class MultimoduleSettings : public FormGroup, public ModuleOptions
   MPMAutobind* ab_line;
   MPMChannelMap* cm_line;
 
+ public:
+  MultimoduleSettings(Window* parent, const FlexGridLayout& g,
+                      uint8_t moduleIdx);
   void update() override;
-    
-public:
-  MultimoduleSettings(Window* parent, const FlexGridLayout& g, uint8_t moduleIdx);
 };

--- a/radio/src/gui/colorlcd/mpm_settings.h
+++ b/radio/src/gui/colorlcd/mpm_settings.h
@@ -22,6 +22,7 @@
 #pragma once
 
 #include "form.h"
+#include "checkbox.h"
 #include "module_setup.h"
 
 struct ModuleData;
@@ -40,6 +41,8 @@ class MultimoduleSettings : public FormGroup, public ModuleOptions
   MPMProtoOption* opt_line;
   MPMServoRate* sr_line;
   MPMAutobind* ab_line;
+  CheckBox* lp_mode;
+  CheckBox* disable_telem;
   MPMChannelMap* cm_line;
 
  public:

--- a/radio/src/io/multi_protolist.cpp
+++ b/radio/src/io/multi_protolist.cpp
@@ -400,6 +400,15 @@ void MultiRfProtocols::fillBuiltinProtos()
     rfProto.flags =
         (pdef->failsafe ? 0x01 : 0) | (pdef->disable_ch_mapping ? 0x02 : 0);
 
+    if (pdef->optionsstr != nullptr) {
+      for (uint8_t i = 0; i < getMaxMultiOptions(); i++) {
+        if (pdef->optionsstr == mm_options_strings::options[i]) {
+          rfProto.flags |= i << 4;
+          break;
+        }
+      }
+    }
+
     if (pdef->subTypeString) {
       rfProto.fillSubProtoList(pdef->subTypeString, pdef->maxSubtype + 1);
     }


### PR DESCRIPTION
Resolves #2203

Summary of changes:
- set field values to current option value when configuring fields
- hide sub-protocol choice if the list is empty
