### PR TITLE
R9M access: fix subtype

### DIFF
--- a/radio/src/gui/colorlcd/module_setup.cpp
+++ b/radio/src/gui/colorlcd/module_setup.cpp
@@ -580,7 +580,7 @@ void ModuleSubTypeChoice::update()
     setSetValueHandler(SET_DEFAULT(md->subType));
     setAvailableHandler(nullptr);
   }
-  else if (isModuleR9M(moduleIdx)) {
+  else if (isModuleR9MNonAccess(moduleIdx)) {
     setMin(MODULE_SUBTYPE_R9M_FCC);
     setMax(MODULE_SUBTYPE_R9M_LAST);
     setValues(STR_R9M_REGION);
@@ -589,7 +589,7 @@ void ModuleSubTypeChoice::update()
     setAvailableHandler(nullptr);
   }
 #if defined(PXX2)
-  else if (isModulePXX2(moduleIdx)) {
+  else if (isModuleISRM(moduleIdx)) {
     setMin(MODULE_SUBTYPE_ISRM_PXX2_ACCESS);
     setMax(MODULE_SUBTYPE_ISRM_PXX2_ACCST_D16);
     setValues(STR_ISRM_RF_PROTOCOLS);

--- a/radio/src/gui/colorlcd/module_setup.cpp
+++ b/radio/src/gui/colorlcd/module_setup.cpp
@@ -273,7 +273,6 @@ void ModuleWindow::updateModule()
                             }
                           });
 
-
     if (isModuleBindRangeAvailable(moduleIdx)) {
       bindButton = new TextButton(box, rect_t{},STR_MODULE_BIND);
       bindButton->setPressHandler([=]() -> uint8_t {
@@ -360,7 +359,7 @@ void ModuleWindow::updateModule()
 #if defined(PXX2)
   else if (isModuleRFAccess(moduleIdx)) {
 
-// Register and Range buttons
+    // Register and Range buttons
     auto line = newLine(&grid);
     new StaticText(line, rect_t{}, STR_MODULE, 0, COLOR_THEME_PRIMARY1);
 

--- a/radio/src/pulses/pxx2.cpp
+++ b/radio/src/pulses/pxx2.cpp
@@ -101,12 +101,12 @@ uint8_t Pxx2Pulses::addFlag0(uint8_t module)
 
 void Pxx2Pulses::addFlag1(uint8_t module)
 {
-  uint8_t subType;
+  uint8_t subType = 0;
   if (isModuleXJT(module)) {
     static const uint8_t PXX2_XJT_MODULE_SUBTYPES[] = {0x01, 0x03, 0x02};
     subType = PXX2_XJT_MODULE_SUBTYPES[min<uint8_t>(g_model.moduleData[module].subType, 2)];
   }
-  else {
+  else if (isModuleISRM(module)) {
     subType = g_model.moduleData[module].subType;
   }
 


### PR DESCRIPTION
Fixes #1585 

Summary of changes:
- do not send a sub-type for PXX2 R9M modules