### PR TITLE
View main fixes

### DIFF
--- a/radio/src/gui/colorlcd/layout.cpp
+++ b/radio/src/gui/colorlcd/layout.cpp
@@ -119,18 +119,24 @@ void loadCustomScreens()
 
     // layout is ok, let's add it
     viewMain->addMainView(screen, i);
-    // screen->attach(viewMain);
-    // viewMain->setMainViewsCount(i + 1);
-    // screen->setLeft(viewMain->getMainViewLeftPos(i));
     i++;
   }
 
   auto topbar = viewMain->getTopbar();
   topbar->load();
+
+  if (g_model.view < viewMain->getMainViewsCount()) {
+    viewMain->setCurrentMainView(g_model.view);
+  } else if (viewMain->getMainViewsCount() > 0) {
+    g_model.view = viewMain->getMainViewsCount() - 1;
+    storageDirty(EE_MODEL);
+    viewMain->setCurrentMainView(g_model.view);
+  }
+  // else {
+  //   TODO: load some default view?
+  // }
   
-  viewMain->setCurrentMainView(0);
   viewMain->updateTopbarVisibility();
-  // viewMain->setFocus();
 }
 
 //

--- a/radio/src/gui/colorlcd/menu_screen.cpp
+++ b/radio/src/gui/colorlcd/menu_screen.cpp
@@ -59,6 +59,7 @@ void ScreenMenu::updateTabs()
   }
 
   // set the active tab to the currently shown screen on the MainView
-  if ((unsigned)(g_model.view + 1) < getTabs())
-    setCurrentTab(g_model.view + 1);
+  auto view = ViewMain::instance()->getCurrentMainView();
+  if (view + 1 < getTabs())
+    setCurrentTab(view + 1);
 }

--- a/radio/src/gui/colorlcd/view_main.h
+++ b/radio/src/gui/colorlcd/view_main.h
@@ -64,8 +64,6 @@ class ViewMain: public Window
     rect_t getMainZone(rect_t zone, bool hasTopbar) const;
 
     unsigned getMainViewsCount() const;
-    //coord_t getMainViewLeftPos(unsigned view) const;
-  
     unsigned getCurrentMainView() const;
     void setCurrentMainView(unsigned view);
 


### PR DESCRIPTION
Fixes #2212 (partly)

Summary of changes:
- Screen setup now starts with the tab corresponding to the active view.
- Active view is saved and restored.