### PR TITLE
feat(color): Show index and name (when set) for GVs in input source

### DIFF
--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -727,16 +727,10 @@ char *getSourceString(char (&dest)[L], mixsrc_t idx)
   } else if (idx <= MIXSRC_LAST_GVAR) {
     idx -= MIXSRC_FIRST_GVAR;
 #if defined(LIBOPENUI)
+    char* s = strAppendStringWithIndex(dest, STR_GV, idx + 1);
     if (g_model.gvars[idx].name[0]) {
-      static char name[LEN_GVAR_NAME];
-      getGVarString(name, idx);
-      static char index[LEN_GVAR_NAME];  // TODO: perhaps name and index consts?
-      strAppendStringWithIndex(index, STR_GV, idx + 1);
-
-      snprintf(dest, 16, "%.*s:%.*s", (int)sizeof(index), index,
-               (int)sizeof(name), name);
-    } else {
-      strAppendStringWithIndex(dest, STR_GV, idx + 1);
+      s = strAppend(s, ":");
+      getGVarString(s, idx);
     }
 #else
     strAppendStringWithIndex(dest, STR_GV, idx + 1);

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -726,7 +726,21 @@ char *getSourceString(char (&dest)[L], mixsrc_t idx)
     }
   } else if (idx <= MIXSRC_LAST_GVAR) {
     idx -= MIXSRC_FIRST_GVAR;
+#if defined(LIBOPENUI)
+    if (g_model.gvars[idx].name[0]) {
+      static char name[LEN_GVAR_NAME];
+      getGVarString(name, idx);
+      static char index[LEN_GVAR_NAME];  // TODO: perhaps name and index consts?
+      strAppendStringWithIndex(index, STR_GV, idx + 1);
+
+      snprintf(dest, 16, "%.*s:%.*s", (int)sizeof(index), index,
+               (int)sizeof(name), name);
+    } else {
+      strAppendStringWithIndex(dest, STR_GV, idx + 1);
+    }
+#else
     strAppendStringWithIndex(dest, STR_GV, idx + 1);
+#endif
   } else if (idx < MIXSRC_FIRST_TIMER) {
     // Built-in sources: TX Voltage, Time, GPS (+ reserved)
     const char* src_str;


### PR DESCRIPTION
Resolves #2215

Summary of changes:
 * on colorlcd, when showing the sources list, if GV has a name, show its index and its name, as opposed to just its index. 
 
 This is just proof of concept... the code is still quite ugly... 
 
Before: 
![image](https://user-images.githubusercontent.com/5500713/185602751-0806aefb-04b5-422f-94d9-4f03565170b6.png)

After:
![image](https://user-images.githubusercontent.com/5500713/185602961-46155ffa-9759-4653-a72f-3a5ae5efa39a.png)

I'm pushing this to 2.9 as I want to piggyback and extend this on top of #2085, and also show names of LS when present. 

