### PR TITLE
More compact views for inputs, mixers and outputs

### DIFF
--- a/radio/src/curves.cpp
+++ b/radio/src/curves.cpp
@@ -416,3 +416,34 @@ int applyCurrentCurve(int x)
   return applyCustomCurve(x, s_currIdxSubMenu);
 }
 #endif
+
+#if defined(COLORLCD)
+char *getCurveRefString(char *dest, size_t len, const CurveRef& curve)
+{
+  if (!len) return dest;
+  char *s = dest;
+
+  if (curve.value != 0) {
+    switch (curve.type) {
+      case CURVE_REF_DIFF:
+        *(s++) = 'D'; if (--len == 0) return dest;
+        getValueOrGVarString(s, len, curve.value, -100, 100, 0, "%");
+        return dest;
+
+      case CURVE_REF_EXPO:
+        *(s++) = 'E'; if (--len == 0) return dest;
+        getValueOrGVarString(s, len, curve.value, -100, 100, 0, "%");
+        return dest;
+
+      case CURVE_REF_FUNC:
+        strAppend(dest, STR_VCURVEFUNC[curve.value], len);
+        return dest;
+
+      case CURVE_REF_CUSTOM:
+        return getCurveString(dest, curve.value);
+    }
+  }
+
+  return dest;
+}
+#endif

--- a/radio/src/curves.h
+++ b/radio/src/curves.h
@@ -47,4 +47,6 @@ int applyCustomCurve(int x, uint8_t idx);
 int applyCurve(int x, CurveRef & curve);
 int applyCurrentCurve(int x);
 
+char *getCurveRefString(char *dest, size_t len, const CurveRef& curve);
+
 #endif

--- a/radio/src/gui/colorlcd/CMakeLists.txt
+++ b/radio/src/gui/colorlcd/CMakeLists.txt
@@ -207,6 +207,7 @@ add_gui_src(input_mix_group.cpp)
 add_gui_src(input_mix_button.cpp)
 add_gui_src(channel_bar.cpp)
 
+add_gui_src(list_line_button.cpp)
 add_gui_src(lvgl_widgets/input_mix_line.c)
 add_gui_src(lvgl_widgets/input_mix_group.c)
 

--- a/radio/src/gui/colorlcd/bitmaps.cpp
+++ b/radio/src/gui/colorlcd/bitmaps.cpp
@@ -161,17 +161,11 @@ static const uint8_t mask_stats_throttle_graph[] = {
 static const uint8_t mask_stats_timers[] = {
 #include "mask_stats_timers.lbm"
 };
-static const uint8_t mask_textline_curve[] = {
-#include "mask_textline_curve.lbm"
-};
 static const uint8_t mask_textline_delay[] = {
 #include "mask_textline_delay.lbm"
 };
 static const uint8_t mask_textline_delayslow[] = {
 #include "mask_textline_delayslow.lbm"
-};
-static const uint8_t mask_textline_fm[] = {
-#include "mask_textline_fm.lbm"
 };
 static const uint8_t mask_textline_label[] = {
 #include "mask_textline_label.lbm"
@@ -241,13 +235,12 @@ BitmapBuffer * chanMonInvertedBitmap = nullptr;
 BitmapBuffer * mixerSetupMixerBitmap = nullptr;
 BitmapBuffer * mixerSetupToBitmap = nullptr;
 BitmapBuffer * mixerSetupOutputBitmap = nullptr;
-BitmapBuffer * mixerSetupCurveIcon = nullptr;
+// BitmapBuffer * mixerSetupCurveIcon = nullptr;
 BitmapBuffer * mixerSetupSwitchIcon = nullptr;
 BitmapBuffer * mixerSetupLabelIcon = nullptr;
 BitmapBuffer * mixerSetupDelayIcon = nullptr;
 BitmapBuffer * mixerSetupSlowIcon = nullptr;
 BitmapBuffer * mixerSetupDelaySlowIcon = nullptr;
-BitmapBuffer * mixerSetupFlightmodeIcon = nullptr;
 
 struct _BuiltinBitmap {
 
@@ -277,9 +270,8 @@ static const _BuiltinBitmap _builtinBitmaps[] = {
     {BMP_8BIT, mask_sbar_output, &mixerSetupOutputBitmap},
 
     {BMP_8BIT, mask_textline_label, &mixerSetupLabelIcon},
-    {BMP_8BIT, mask_textline_curve, &mixerSetupCurveIcon},
+    // {BMP_8BIT, mask_textline_curve, &mixerSetupCurveIcon},
     {BMP_8BIT, mask_textline_switch, &mixerSetupSwitchIcon},
-    {BMP_8BIT, mask_textline_fm, &mixerSetupFlightmodeIcon},
     {BMP_8BIT, mask_textline_slow, &mixerSetupSlowIcon},
     {BMP_8BIT, mask_textline_delay, &mixerSetupDelayIcon},
     {BMP_8BIT, mask_textline_delayslow, &mixerSetupDelaySlowIcon},

--- a/radio/src/gui/colorlcd/bitmaps.h
+++ b/radio/src/gui/colorlcd/bitmaps.h
@@ -51,7 +51,6 @@ extern BitmapBuffer * mixerSetupAddBitmap;
 extern BitmapBuffer * mixerSetupMultiBitmap;
 extern BitmapBuffer * mixerSetupReplaceBitmap;
 extern BitmapBuffer * mixerSetupLabelIcon;
-extern BitmapBuffer * mixerSetupFlightmodeIcon;
 extern BitmapBuffer * mixerSetupCurveIcon;
 extern BitmapBuffer * mixerSetupSwitchIcon;
 extern BitmapBuffer * mixerSetupDelayIcon;

--- a/radio/src/gui/colorlcd/draw_functions.cpp
+++ b/radio/src/gui/colorlcd/draw_functions.cpp
@@ -259,12 +259,12 @@ void drawCurveRef(BitmapBuffer * dc, coord_t x, coord_t y, const CurveRef & curv
     switch (curve.type) {
       case CURVE_REF_DIFF:
         x = dc->drawText(x, y, "D", flags);
-        drawValueOrGVar(dc, x, y + 2, curve.value, -100, 100, LEFT | FONT(XS) | flags);
+        drawValueOrGVar(dc, x, y, curve.value, -100, 100, LEFT | flags);
         break;
 
       case CURVE_REF_EXPO:
         x = dc->drawText(x, y, "E", flags);
-        drawValueOrGVar(dc, x, y + 2, curve.value, -100, 100, LEFT | FONT(XS) | flags);
+        drawValueOrGVar(dc, x, y, curve.value, -100, 100, LEFT | flags);
         break;
 
       case CURVE_REF_FUNC:

--- a/radio/src/gui/colorlcd/input_mix_button.h
+++ b/radio/src/gui/colorlcd/input_mix_button.h
@@ -21,28 +21,25 @@
 
 #pragma once
 
-#include "button.h"
+#include "list_line_button.h"
+#include "opentx_types.h"
 
-class InputMixButton : public Button
+class InputMixButton : public ListLineButton
 {
+  lv_obj_t* fm_canvas = nullptr;
+  void* fm_buffer = nullptr;
+  uint16_t fm_modes = 0;
+
  public:
   InputMixButton(Window* parent, uint8_t index);
-
-  uint8_t getIndex() const { return index; }
-  void setIndex(uint8_t i) { index = i; }
-
-  void checkEvents() override;
-
-  void drawFlightModes(BitmapBuffer *dc, FlightModesType value,
-                       LcdFlags textColor, coord_t x, coord_t y);
+  ~InputMixButton();
 
  protected:
-  uint8_t index;
+  lv_obj_t* weight;
+  lv_obj_t* source;
+  lv_obj_t* opts;
 
-  static void self_size(lv_event_t* e);
-  static void value_changed(lv_event_t* e);
-
-  lv_coord_t calcHeight() const;
-  virtual size_t getLines() const = 0;
-  virtual bool isActive() const = 0;
+  void setWeight(gvar_t value, gvar_t min, gvar_t max);
+  void setSource(mixsrc_t idx);
+  void setFlightModes(uint16_t modes);
 };

--- a/radio/src/gui/colorlcd/input_mix_group.cpp
+++ b/radio/src/gui/colorlcd/input_mix_group.cpp
@@ -69,18 +69,28 @@ InputMixGroup::InputMixGroup(Window* parent, mixsrc_t idx) :
   lv_obj_set_size(line_container, lv_pct(100), LV_SIZE_CONTENT);
   lv_obj_set_flex_flow(line_container, LV_FLEX_FLOW_COLUMN);
   lv_obj_set_style_flex_cross_place(line_container, LV_FLEX_ALIGN_END, 0);
-  lv_obj_set_style_pad_row(line_container, lv_dpx(8), LV_PART_MAIN);
+  lv_obj_set_style_pad_row(line_container, lv_dpx(4), LV_PART_MAIN);
 }
 
-void InputMixGroup::addMixerMonitor(uint8_t channel)
+void InputMixGroup::enableMixerMonitor(uint8_t channel)
 {
-  rect_t r{ 0, 0, 100, 14 };
-  auto mon = new MixerChannelBar(this, r, channel);
-  mon->setDrawMiddleBar(false);
+  if (monitor != nullptr) return;
 
-  lv_obj_t* mon_obj = mon->getLvObj();
+  rect_t r{ 0, 0, 100, 14 };
+  monitor = new MixerChannelBar(this, r, channel);
+  monitor->setDrawMiddleBar(false);
+
+  lv_obj_t* mon_obj = monitor->getLvObj();
   lv_obj_set_parent(mon_obj, line_container);
+  lv_obj_move_to_index(mon_obj, 0);
   lv_obj_set_style_translate_x(mon_obj, -lv_dpx(8), 0);
+}
+
+void InputMixGroup::disableMixerMonitor()
+{
+  if (!monitor) return;
+  monitor->deleteLater();
+  monitor = nullptr;
 }
 
 void InputMixGroup::addLine(Window* line, const uint8_t* symbol)

--- a/radio/src/gui/colorlcd/input_mix_group.cpp
+++ b/radio/src/gui/colorlcd/input_mix_group.cpp
@@ -78,7 +78,6 @@ void InputMixGroup::enableMixerMonitor(uint8_t channel)
 
   rect_t r{ 0, 0, 100, 14 };
   monitor = new MixerChannelBar(this, r, channel);
-  monitor->setDrawMiddleBar(false);
 
   lv_obj_t* mon_obj = monitor->getLvObj();
   lv_obj_set_parent(mon_obj, line_container);

--- a/radio/src/gui/colorlcd/input_mix_group.h
+++ b/radio/src/gui/colorlcd/input_mix_group.h
@@ -26,6 +26,8 @@
 
 #include <list>
 
+class MixerChannelBar;
+
 class InputMixGroup : public Window
 {
   struct Line {
@@ -43,12 +45,17 @@ class InputMixGroup : public Window
   lv_obj_t* label;
   lv_obj_t* line_container;
 
+  MixerChannelBar* monitor = nullptr;
+  
   static void value_changed(lv_event_t* e);
   
  public:
   InputMixGroup(Window* parent, mixsrc_t idx);
 
-  void addMixerMonitor(uint8_t channel);
+  void enableMixerMonitor(uint8_t channel);
+  void disableMixerMonitor();
+
+  bool mixerMonitorEnabled() { return monitor != nullptr; }
     
   mixsrc_t getMixSrc() { return idx; }
   size_t getLineCount() { return lines.size(); }

--- a/radio/src/gui/colorlcd/list_line_button.cpp
+++ b/radio/src/gui/colorlcd/list_line_button.cpp
@@ -19,21 +19,27 @@
  * GNU General Public License for more details.
  */
 
-#ifndef _MODEL_OUTPUTS_H_
-#define _MODEL_OUTPUTS_H_
+#include "list_line_button.h"
+#include "opentx.h"
 
-#include "tabsgroup.h"
+#include "lvgl_widgets/input_mix_line.h"
 
-class OutputLineButton;
-
-class ModelOutputsPage : public PageTab
+void ListLineButton::value_changed(lv_event_t* e)
 {
- public:
-  ModelOutputsPage();
-  void build(FormWindow* window) override;
+  auto obj = lv_event_get_target(e);
+  auto btn = (ListLineButton*)lv_obj_get_user_data(obj);
+  if (btn) btn->refresh();
+}
 
- protected:
-  void editOutput(uint8_t channel, OutputLineButton* btn);
-};
+ListLineButton::ListLineButton(Window* parent, uint8_t index) :
+    Button(parent, rect_t{}, nullptr, 0, 0, input_mix_line_create),
+    index(index)
+{
+  lv_obj_add_event_cb(lvobj, ListLineButton::value_changed, LV_EVENT_VALUE_CHANGED, nullptr);
+}
 
-#endif // _MODEL_OUTPUTS_H_
+void ListLineButton::checkEvents()
+{
+  check(isActive());
+  Button::checkEvents();
+}

--- a/radio/src/gui/colorlcd/list_line_button.h
+++ b/radio/src/gui/colorlcd/list_line_button.h
@@ -19,21 +19,26 @@
  * GNU General Public License for more details.
  */
 
-#ifndef _MODEL_OUTPUTS_H_
-#define _MODEL_OUTPUTS_H_
+#pragma once
 
-#include "tabsgroup.h"
+#include "button.h"
+#include "opentx_types.h"
 
-class OutputLineButton;
-
-class ModelOutputsPage : public PageTab
+class ListLineButton : public Button
 {
  public:
-  ModelOutputsPage();
-  void build(FormWindow* window) override;
+  ListLineButton(Window* parent, uint8_t index);
+
+  uint8_t getIndex() const { return index; }
+  void setIndex(uint8_t i) { index = i; }
+
+  void checkEvents() override;
 
  protected:
-  void editOutput(uint8_t channel, OutputLineButton* btn);
-};
+  uint8_t index;
 
-#endif // _MODEL_OUTPUTS_H_
+  static void value_changed(lv_event_t* e);
+
+  virtual bool isActive() const = 0;
+  virtual void refresh() = 0;
+};

--- a/radio/src/gui/colorlcd/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model_mixes.cpp
@@ -324,8 +324,7 @@ InputMixGroup* ModelMixesPage::getGroupByIndex(uint8_t index)
 InputMixGroup* ModelMixesPage::createGroup(FormGroup* form, mixsrc_t src)
 {
   auto group = new InputMixGroup(form, src);
-  // TODO: make optional
-  // group->addMixerMonitor(src - MIXSRC_CH1);
+  if (showMonitors) group->enableMixerMonitor(src - MIXSRC_CH1);
   return group;
 }
 

--- a/radio/src/gui/colorlcd/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model_mixes.cpp
@@ -174,18 +174,22 @@ class MixLineButton : public InputMixButton
 {
  public:
   MixLineButton(Window* parent, uint8_t index);
-  void paint(BitmapBuffer* dc) override;
+
   void deleteLater(bool detach = true, bool trash = true) override;
+  void refresh() override;
 
  protected:
-  size_t getLines() const override;
   bool isActive() const override { return isMixActive(index); }
 };
 
 static void mix_draw_mplex(lv_event_t* e)
 {
+  auto target = (lv_obj_t*)lv_event_get_target(e);
+  auto group = (InputMixGroup*)lv_obj_get_user_data(target);
+  uint32_t offset = group->mixerMonitorEnabled() ? 1 : 0;
+  
   auto obj = (lv_obj_t*)lv_event_get_user_data(e);
-  if (!obj || (lv_obj_get_index(obj) <= 1)) return;
+  if (!obj || (lv_obj_get_index(obj) <= offset)) return;
 
   auto btn = (MixLineButton*)lv_obj_get_user_data(obj);
   if (!btn) return;
@@ -249,94 +253,56 @@ void MixLineButton::deleteLater(bool detach, bool trash)
   InputMixButton::deleteLater(detach, trash);
 }
 
-size_t MixLineButton::getLines() const
-{
-  size_t lines = 1;
-  const MixData* mix = mixAddress(index);
-
-  uint8_t delayslow = 0;
-  if (mix->speedDown || mix->speedUp) delayslow = 1;
-  if (mix->delayUp || mix->delayDown) delayslow += 2;
-
-  if (mix->flightModes || mix->name[0] || delayslow) {
-    lines += 1;
-  }
-
-  return lines;
-}
-
-void MixLineButton::paint(BitmapBuffer* dc)
+void MixLineButton::refresh()
 {
   const MixData& line = g_model.mixData[index];
-  LcdFlags textColor = COLOR_THEME_SECONDARY1;
+  setWeight(line.weight, MIX_WEIGHT_MIN, MIX_WEIGHT_MAX);
+  setSource(line.srcRaw);
 
-  coord_t border = lv_obj_get_style_border_width(lvobj, LV_PART_MAIN);
-  coord_t pad_left = lv_obj_get_style_pad_left(lvobj, LV_PART_MAIN);
-  coord_t pad_right = lv_obj_get_style_pad_right(lvobj, LV_PART_MAIN);
+  char tmp_str[64];
+  size_t maxlen = sizeof(tmp_str);
 
-  coord_t left = pad_left + border;
-  coord_t line_h = lv_obj_get_style_text_line_space(lvobj, LV_PART_MAIN)
-    + getFontHeight(FONT(STD));
+  char *s = tmp_str;
+  *s = '\0';
 
-#if LCD_W > LCD_H
-  const coord_t pad = 42;
-#else
-  const coord_t pad = 0;
-#endif
-  
-  // first line ...
-  coord_t y = 0;
-  y += border;
-  y += lv_obj_get_style_pad_top(lvobj, LV_PART_MAIN);
+  if (line.name[0]) {
+    int cnt = lv_snprintf(s, maxlen, "%.*s ", (int)sizeof(line.name), line.name);
+    if (cnt >= maxlen) maxlen = 0;
+    else { maxlen -= cnt; s += cnt; }
+  }
 
-  coord_t x = left;
-  drawValueOrGVar(dc, x, y, line.weight, MIX_WEIGHT_MIN, MIX_WEIGHT_MAX, textColor);
-  x += 46 + pad;
-
-  drawSource(dc, x, y, line.srcRaw, textColor);
-  x += 60 + pad;
-
-  // second line ...
   if (line.swtch || line.curve.value) {
     if (line.swtch) {
-      if (pad) dc->drawMask(x - 20, y, mixerSetupSwitchIcon, textColor);
-      drawSwitch(dc, x, y, line.swtch, textColor);
+      char* sw_pos = getSwitchPositionName(line.swtch);
+      int cnt = lv_snprintf(s, maxlen, "%s ", sw_pos);
+      if (cnt >= maxlen) maxlen = 0;
+      else { maxlen -= cnt; s += cnt; }
     }
-    x += 44 + pad;
-    if (line.curve.value) {
-      if (pad) dc->drawMask(x - 20, y, mixerSetupCurveIcon, textColor);
-      drawCurveRef(dc, x, y, line.curve, textColor);
-    }
-    // x += 48 + pad;
-  }
-
-  uint8_t delayslow = 0;
-  if (line.speedDown || line.speedUp) delayslow = 1;
-  if (line.delayUp || line.delayDown) delayslow += 2;
-
-  if (line.flightModes || line.name[0] || delayslow) {
-    y += line_h;
-    x = left;
-
-    if (line.flightModes) {
-      drawFlightModes(dc, line.flightModes, textColor, x, y);
-    }
-    x += 104 + 3*pad/2;
-
-    if (line.name[0]) {
-      dc->drawMask(x, y, mixerSetupLabelIcon, textColor);
-      dc->drawSizedText(x + 20, y, line.name, sizeof(line.name), textColor);
-    }
-
-    if (delayslow) {
-      BitmapBuffer* delayslowbmp[] = {mixerSetupSlowIcon, mixerSetupDelayIcon,
-                                      mixerSetupDelaySlowIcon};
-      const BitmapBuffer* mask = delayslowbmp[delayslow - 1];
-      coord_t w = lv_obj_get_width(lvobj);
-      w -= mask->width();
-      dc->drawMask(w - border - pad_right, y, mask, textColor);
+    if (line.curve.value != 0) {
+      getCurveRefString(s, maxlen, line.curve);
+      int cnt = strnlen(s, maxlen);
+      if (cnt >= maxlen) maxlen = 0;
+      else { maxlen -= cnt; s += cnt; }
     }
   }
+  lv_label_set_text_fmt(opts, "%.*s", (int)sizeof(tmp_str), tmp_str);
+
+  setFlightModes(line.flightModes);
+
+  // TODO: should we add these? then it would be best to have them in the font...
+  //
+  // uint8_t delayslow = 0;
+  // if (line.speedDown || line.speedUp) delayslow = 1;
+  // if (line.delayUp || line.delayDown) delayslow += 2;
+
+  // if (delayslow) {
+  //   BitmapBuffer* delayslowbmp[] = {mixerSetupSlowIcon, mixerSetupDelayIcon,
+  //                                   mixerSetupDelaySlowIcon};
+  //   const BitmapBuffer* mask = delayslowbmp[delayslow - 1];
+  //   coord_t w = lv_obj_get_width(lvobj);
+  //   w -= mask->width();
+  //   dc->drawMask(w - border - pad_right, y, mask, textColor);
+  // }
 }
 
 ModelMixesPage::ModelMixesPage() :
@@ -358,13 +324,16 @@ InputMixGroup* ModelMixesPage::getGroupByIndex(uint8_t index)
 InputMixGroup* ModelMixesPage::createGroup(FormGroup* form, mixsrc_t src)
 {
   auto group = new InputMixGroup(form, src);
-  group->addMixerMonitor(src - MIXSRC_CH1);
+  // TODO: make optional
+  // group->addMixerMonitor(src - MIXSRC_CH1);
   return group;
 }
 
 InputMixButton* ModelMixesPage::createLineButton(InputMixGroup *group, uint8_t index)
 {
   auto button = new MixLineButton(group, index);
+  button->refresh();
+
   lines.emplace_back(button);
   group->addLine(button);
 
@@ -537,15 +506,29 @@ void ModelMixesPage::pasteMixAfter(uint8_t dst_idx)
 
 void ModelMixesPage::build(FormWindow * window)
 {
+  scroll_win = window->getParent();
   window->setFlexLayout();
   window->padRow(lv_dpx(8));
-  
+
   form = new FormGroup(window, rect_t{});
   form->setFlexLayout();
-  form->padRow(lv_dpx(8));
+  form->padRow(lv_dpx(4));
 
   auto form_obj = form->getLvObj();
   lv_obj_set_width(form_obj, lv_pct(100));
+
+  auto box = new FormGroup(window, rect_t{});
+  box->setFlexLayout(LV_FLEX_FLOW_ROW, lv_dpx(8));
+  box->padLeft(lv_dpx(8));
+
+  auto box_obj = box->getLvObj();
+  lv_obj_set_width(box_obj, lv_pct(100));
+  lv_obj_set_style_flex_cross_place(box_obj, LV_FLEX_ALIGN_CENTER, 0);
+
+  new StaticText(box, rect_t{}, "Show mixer monitors", 0, COLOR_THEME_PRIMARY1);
+  new CheckBox(
+      box, rect_t{}, [=]() { return showMonitors; },
+      [=](uint8_t val) { enableMonitors(val); });
 
   auto btn = new TextButton(window, rect_t{}, LV_SYMBOL_PLUS, [=]() {
     newMix();
@@ -553,6 +536,7 @@ void ModelMixesPage::build(FormWindow * window)
   });
   auto btn_obj = btn->getLvObj();
   lv_obj_set_width(btn_obj, lv_pct(100));
+  lv_group_focus_obj(btn_obj);
 
   groups.clear();
   lines.clear();
@@ -580,3 +564,24 @@ void ModelMixesPage::build(FormWindow * window)
   }
 }
 
+void ModelMixesPage::enableMonitors(bool enabled)
+{
+  if (showMonitors == enabled) return;
+  showMonitors = enabled;
+
+  auto form_obj = form->getLvObj();
+  auto h = lv_obj_get_height(form_obj);
+  for(auto* group : groups) {
+    if (enabled) {
+      group->enableMixerMonitor(group->getMixSrc() - MIXSRC_CH1);
+    } else {
+      group->disableMixerMonitor();
+    }
+  }
+
+  lv_obj_update_layout(form_obj);
+  auto diff = h - lv_obj_get_height(form_obj);
+  auto scroll_obj = scroll_win->getLvObj();
+  lv_obj_scroll_by_bounded(scroll_obj, 0, diff, LV_ANIM_OFF);
+  TRACE("diff = %d", diff);
+}

--- a/radio/src/gui/colorlcd/model_mixes.h
+++ b/radio/src/gui/colorlcd/model_mixes.h
@@ -26,6 +26,9 @@
 
 class ModelMixesPage : public ModelInputsPage
 {
+  bool showMonitors = false;
+  Window* scroll_win = nullptr;
+  
  public:
   ModelMixesPage();
 
@@ -48,4 +51,6 @@ class ModelMixesPage : public ModelInputsPage
   void pasteMix(uint8_t dst_idx, uint8_t channel);
   void pasteMixBefore(uint8_t dst_idx);
   void pasteMixAfter(uint8_t dst_idx);
+
+  void enableMonitors(bool enabled);
 };

--- a/radio/src/gui/colorlcd/themes/etx_lv_theme.cpp
+++ b/radio/src/gui/colorlcd/themes/etx_lv_theme.cpp
@@ -839,15 +839,17 @@ static void theme_apply(lv_theme_t * th, lv_obj_t * obj)
     }
     else if (lv_obj_check_type(obj, &input_mix_line_class)) {
       lv_obj_add_style(obj, &styles.line_btn, 0);
-      lv_obj_add_style(obj, &styles.pad_small, 0);
+      lv_obj_add_style(obj, &styles.pad_tiny, 0);
       lv_obj_set_style_bg_color(obj, makeLvColor(COLOR_THEME_SECONDARY3),
                                 LV_STATE_CHECKED);
       lv_obj_add_style(obj, &styles.focus_border, LV_STATE_FOCUSED);
+      lv_obj_set_style_text_color(obj, makeLvColor(COLOR_THEME_SECONDARY1), 0);
+      lv_obj_set_style_text_font(obj, getFont(FONT(STD)), 0);
     }
 #endif
     else if (lv_obj_check_type(obj, &input_mix_group_class)) {
         lv_obj_add_style(obj, &styles.line_btn, 0);
-        lv_obj_add_style(obj, &styles.pad_small, 0);
+        lv_obj_add_style(obj, &styles.pad_tiny, 0);
         lv_obj_set_style_text_color(obj, makeLvColor(COLOR_THEME_SECONDARY1), 0);
         lv_obj_set_style_text_font(obj, getFont(FONT(BOLD)), 0);
     }

--- a/radio/src/gui/colorlcd/themes/flysky.cpp
+++ b/radio/src/gui/colorlcd/themes/flysky.cpp
@@ -250,14 +250,14 @@ class FlyskyTheme: public OpenTxTheme
       delete mixerSetupLabelIcon;
       mixerSetupLabelIcon = BitmapBuffer::loadMask(getFilePath("mask_textline_label.png"));
 
-      delete mixerSetupCurveIcon;
-      mixerSetupCurveIcon = BitmapBuffer::loadMask(getFilePath("mask_textline_curve.png"));
+      // delete mixerSetupCurveIcon;
+      // mixerSetupCurveIcon = BitmapBuffer::loadMask(getFilePath("mask_textline_curve.png"));
 
       delete mixerSetupSwitchIcon;
       mixerSetupSwitchIcon = BitmapBuffer::loadMask(getFilePath("mask_textline_switch.png"));
 
-      delete mixerSetupFlightmodeIcon;
-      mixerSetupFlightmodeIcon = BitmapBuffer::loadMask(getFilePath("mask_textline_fm.png"));
+      // delete mixerSetupFlightmodeIcon;
+      // mixerSetupFlightmodeIcon = BitmapBuffer::loadMask(getFilePath("mask_textline_fm.png"));
 
 //      delete mixerSetupSlowIcon;
 //      mixerSetupSlowIcon = BitmapBuffer::loadMask(getFilePath("mask_textline_slow.png"));

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -391,6 +391,21 @@ char *getGVarString(char *dest, int idx)
   return dest;
 }
 
+#if defined(LIBOPENUI)
+char *getValueOrGVarString(char *dest, size_t len, gvar_t value, gvar_t vmin, gvar_t vmax,
+                           LcdFlags flags, const char* suffix, gvar_t offset)
+{
+  if (GV_IS_GV_VALUE(value, vmin, vmax)) {
+    int index = GV_INDEX_CALC_DELTA(value, GV_GET_GV1_VALUE(vmin, vmax));
+    return getGVarString(dest, index);
+  }
+
+  value += offset;
+  BitmapBuffer::formatNumberAsString(dest, len, value, flags, 0, nullptr, suffix);
+  return dest;
+}
+#endif
+
 char *getFlightModeString(char *dest, int8_t idx)
 {
   char *s = dest;

--- a/radio/src/strhelpers.h
+++ b/radio/src/strhelpers.h
@@ -76,8 +76,11 @@ char *getFormattedTimerString(char *dest, int32_t tme, TimerOptions timerOptions
 char *getCurveString(char *dest, int idx);
 char *getGVarString(char *dest, int idx);
 char *getGVarString(int idx);
-const char* getSwitchWarnSymbol(uint8_t pos);
-const char* getSwitchPositionSymbol(uint8_t pos);
+char *getValueOrGVarString(char *dest, size_t len, gvar_t value, gvar_t vmin,
+                           gvar_t vmax, LcdFlags flags = 0,
+                           const char *suffix = nullptr, gvar_t offset = 0);
+const char *getSwitchWarnSymbol(uint8_t pos);
+const char *getSwitchPositionSymbol(uint8_t pos);
 char *getSwitchPositionName(char *dest, swsrc_t idx);
 char *getSwitchName(char *dest, swsrc_t idx);
 


### PR DESCRIPTION
After the new UI design for input, mixers, and outputs have trouble quite some people, mainly because of the reduction of the amount of information displayed at once on the screen, this PR offers more compact views that aim at finding a better compromise between touch UX and the amount of information displayed.

Summary of changes:
- Reduced margins / padding
- Live mixer monitors can be turned ON / OFF (non-persistent, OFF by default)
- Inputs, mixers, outputs use now grids into which single labels are placed rather than "on-the-fly" hard-coded drawing.
- delayed build of outputs screen to speed up tab switching (you might notice a little slow-down when scrolling the first time on the page).

The main goal is to be able to display at least 4 "simple" mixer channels on one screen:
<img width="480" alt="Screenshot 2022-08-21 at 15 52 32" src="https://user-images.githubusercontent.com/1050031/185794246-57c1e3ab-b54f-48d0-bd75-ff751a00a6de.png">

Some screenshots:
<img width="482" alt="Screenshot 2022-08-21 at 15 50 04" src="https://user-images.githubusercontent.com/1050031/185794136-48bedbd5-1d93-4228-a6d8-eadce80682db.png">
<img width="481" alt="Screenshot 2022-08-21 at 15 50 44" src="https://user-images.githubusercontent.com/1050031/185794161-bc603997-48f0-4ed5-958a-c835ccddc56d.png">
<img width="482" alt="Screenshot 2022-08-21 at 15 51 10" src="https://user-images.githubusercontent.com/1050031/185794179-2150d4c5-530c-4184-9ccf-77de212c71b6.png">
