### PR TITLE
Add correct STATUS_LEDS definitions for RADIO_TPRO

### DIFF
--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -888,11 +888,13 @@ constexpr uint8_t OPENTX_START_NO_CHECKS = 0x04;
 
 #if defined(STATUS_LEDS)
   #define LED_ERROR_BEGIN()            ledRed()
-#if defined(RADIO_T8) || defined(RADIO_COMMANDO8)
-  // Because of green backlit logo, green is preferred on this radio
+// Green is preferred "ready to use" color for these radios
+#if defined(RADIO_T8) || defined(RADIO_COMMANDO8) || defined(RADIO_TLITE) || \
+    defined(RADIO_TPRO) || defined(RADIO_TX12)
   #define LED_ERROR_END()              ledGreen()
   #define LED_BIND()                   ledBlue()
 #else
+// Either green is not an option, or blue is preferred "ready to use" color
   #define LED_ERROR_END()              ledBlue()
 #endif
 #else

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -171,7 +171,11 @@ void boardInit()
 
 #if defined(STATUS_LEDS)
   ledInit();
+#if defined(RADIO_TLITE) || defined(RADIO_TPRO) || defined(RADIO_TX12)
+  ledBlue();
+#else
   ledGreen();
+#endif
 #endif
 
 // Support for FS Led to indicate battery charge level

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -1461,6 +1461,16 @@
   #define LED_RED_GPIO_PIN              GPIO_Pin_13 // PE.13
   #define LED_BLUE_GPIO                 GPIOE
   #define LED_BLUE_GPIO_PIN             GPIO_Pin_2  // PE.02
+#elif defined(RADIO_TPRO)
+  #define STATUS_LEDS
+  #define GPIO_LED_GPIO_ON              GPIO_SetBits
+  #define GPIO_LED_GPIO_OFF             GPIO_ResetBits
+  #define LED_GREEN_GPIO                GPIOB
+  #define LED_GREEN_GPIO_PIN            GPIO_Pin_1  // PB.01
+  #define LED_RED_GPIO                  GPIOC
+  #define LED_RED_GPIO_PIN              GPIO_Pin_5  // PC.05
+  #define LED_BLUE_GPIO                 GPIOC
+  #define LED_BLUE_GPIO_PIN             GPIO_Pin_4  // PC.04
 #elif defined(RADIO_TX12MK2)
   #define STATUS_LEDS
   #define GPIO_LED_GPIO_ON              GPIO_SetBits

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -1461,7 +1461,7 @@
   #define LED_RED_GPIO_PIN              GPIO_Pin_13 // PE.13
   #define LED_BLUE_GPIO                 GPIOE
   #define LED_BLUE_GPIO_PIN             GPIO_Pin_2  // PE.02
-#elif defined(RADIO_TPRO)
+#elif defined(RADIO_TLITE) || defined(RADIO_TPRO) || defined(RADIO_TX12)
   #define STATUS_LEDS
   #define GPIO_LED_GPIO_ON              GPIO_SetBits
   #define GPIO_LED_GPIO_OFF             GPIO_ResetBits

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -1475,12 +1475,12 @@
   #define STATUS_LEDS
   #define GPIO_LED_GPIO_ON              GPIO_SetBits
   #define GPIO_LED_GPIO_OFF             GPIO_ResetBits
-  #define LED_GREEN_GPIO                GPIOE
-  #define LED_GREEN_GPIO_PIN            GPIO_Pin_2  // PE.02
+  #define LED_GREEN_GPIO                GPIOA
+  #define LED_GREEN_GPIO_PIN            GPIO_Pin_7  // PA.07
   #define LED_RED_GPIO                  GPIOE
   #define LED_RED_GPIO_PIN              GPIO_Pin_13 // PE.13
-  #define LED_BLUE_GPIO                 GPIOA
-  #define LED_BLUE_GPIO_PIN             GPIO_Pin_7  // PA.07
+  #define LED_BLUE_GPIO                 GPIOE
+  #define LED_BLUE_GPIO_PIN             GPIO_Pin_2  // PE.02
 #elif defined(PCBX7)
   #define STATUS_LEDS
   #define GPIO_LED_GPIO_ON              GPIO_SetBits


### PR DESCRIPTION
I just wanted blue LEDs on my Jumper T-Pro. Instead I found a headache. 

PCBX7 STATUS_LED definitions were being used for RADIO_TPRO, resulting in incorrect GPIO pin assignments for GREEN and BLUE LED colors. LED_GREEN_GPIO_PIN would activate the blue LED, and vice versa for LED_BLUE_GPIO_PIN. 

To rectify this, a new definition for RADIO_TPRO has been created with proper GPIO pin assignments for LED_GREEN and LED_BLUE thanks to help from @pfeerick 

Yay!

<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->