### PR TITLE
feat(telemetry): extend link quality warnings range

### DIFF
--- a/companion/src/firmwares/edgetx/yaml_modeldata.cpp
+++ b/companion/src/firmwares/edgetx/yaml_modeldata.cpp
@@ -555,17 +555,36 @@ struct convert<ScriptData> {
   }
 };
 
+struct RFAlarms {
+  int warning = 0;
+  int critical = 0;
+
+  RFAlarms() {}
+  
+  RFAlarms(const RSSIAlarmData& rhs)
+    : warning(rhs.warning), critical(rhs.critical)
+  {}
+};
+
 template <>
-struct convert<RSSIAlarmData> {
-  static Node encode(const RSSIAlarmData& rhs)
+struct convert<RFAlarms> {
+  static Node encode(const RFAlarms& rhs)
   {
     Node node;
-    node["disabled"] = (int)rhs.disabled;
-    node["warning"] = rhs.warning - 45;
-    node["critical"] = rhs.critical - 42;
+    node["warning"] = rhs.warning;
+    node["critical"] = rhs.critical;
     return node;
   }
+  static bool decode(const Node& node, RFAlarms& rhs)
+  {
+    node["warning"] >> rhs.warning;
+    node["critical"] >> rhs.critical;
+    return true;
+  }
+};
 
+template <>
+struct convert<RSSIAlarmData> {
   static bool decode(const Node& node, RSSIAlarmData& rhs)
   {
     node["disabled"] >> rhs.disabled;
@@ -904,7 +923,8 @@ Node convert<ModelData>::encode(const ModelData& rhs)
     node["altitudeSource"] = YamlTelemSource(rhs.frsky.altitudeSource);
   }
 
-  node["rssiAlarms"] = rhs.rssiAlarms;
+  node["rfAlarms"] = RFAlarms(rhs.rssiAlarms);
+  node["disableTelemetryWarning"] = (int)rhs.rssiAlarms.disabled;
 
   for (int i=0; i<CPN_MAX_MODULES; i++) {
     if (rhs.moduleData[i].protocol != PULSES_OFF) {
@@ -1096,7 +1116,22 @@ bool convert<ModelData>::decode(const Node& node, ModelData& rhs)
     rhs.frsky.altitudeSource = altitudeSource.src;
   }
 
-  node["rssiAlarms"] >> rhs.rssiAlarms;
+  if (node["rssiAlarms"]) {
+    // Old format (pre 2.8)
+    node["rssiAlarms"] >> rhs.rssiAlarms;
+  } else if (node["rfAlarms"] || node["disableTelemetryWarning"]) {
+    // New format (post 2.8)
+    RFAlarms rfAlarms;
+    node["rfAlarms"] >> rfAlarms;
+    rhs.rssiAlarms.warning = rfAlarms.warning;
+    rhs.rssiAlarms.critical = rfAlarms.critical;
+    node["disableTelemetryWarning"] >> rhs.rssiAlarms.disabled;
+  } else {
+    // Use old defaults
+    rhs.rssiAlarms.warning = 45;
+    rhs.rssiAlarms.critical = 42;
+    rhs.rssiAlarms.disabled = false;
+  }
 
   node["moduleData"] >> rhs.moduleData;
   for (int i=0; i<CPN_MAX_MODULES; i++) {

--- a/companion/src/modeledit/telemetry.cpp
+++ b/companion/src/modeledit/telemetry.cpp
@@ -518,9 +518,9 @@ void TelemetryPanel::setup()
   ui->ignoreSensorIds->setField(model->frsky.ignoreSensorIds, this);
   ui->disableTelemetryAlarms->setField(model->rssiAlarms.disabled);
 
-  ui->rssiAlarmWarningSB->setRange(45 - 30, 45 + 30);
+  ui->rssiAlarmWarningSB->setRange(0, 127);
   ui->rssiAlarmWarningSB->setValue(model->rssiAlarms.warning);
-  ui->rssiAlarmCriticalSB->setRange(42 - 30, 42 + 30);
+  ui->rssiAlarmCriticalSB->setRange(0, 127);
   ui->rssiAlarmCriticalSB->setValue(model->rssiAlarms.critical);
 
   ui->rssiSourceLabel->show();

--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -113,7 +113,7 @@ static inline void check_struct()
   CHKSIZE(TelemetrySensor, 14);
   CHKSIZE(ModuleData, 29);
   CHKSIZE(GVarData, 7);
-  CHKSIZE(RssiAlarmData, 2);
+  CHKSIZE(RFAlarmData, 2);
   CHKSIZE(TrainerData, 16);
 
 #if defined(PCBXLITES)

--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -271,21 +271,21 @@ PACK(struct ScriptData {
 #endif
 
 /*
- * Frsky Telemetry structure
+ * Frsky Telemetry structure (legacy read-only)
  */
 PACK(struct RssiAlarmData {
-  int8_t disabled:1;
-#if defined (PCBNV14)
-  uint8_t flysky_telemetry:1; // if set for FlySky receivers use native RSSI values instead of rescaled ones
-#else
-  int8_t  spare:1 SKIP;
-#endif
-  int8_t warning:6;
-  int8_t spare2:2 SKIP;
-  int8_t critical:6;
-  inline int8_t getWarningRssi() {return 45 + warning;}
-  inline int8_t getCriticalRssi() {return 42 + critical;}
- });
+  // int8_t disabled:1;
+  CUST_ATTR(disabled,r_rssiDisabled,nullptr);
+  // int8_t warning:6; + 45
+  CUST_ATTR(warning,r_rssiWarning,nullptr);
+  // int8_t critical:6; + 42
+  CUST_ATTR(critical,r_rssiCritical,nullptr);
+});
+
+PACK(struct RFAlarmData {
+  int8_t warning;
+  int8_t critical;
+});
 
 typedef int16_t ls_telemetry_value_t;
 
@@ -638,7 +638,8 @@ PACK(struct ModelData {
   uint8_t   extendedTrims:1;
   uint8_t   throttleReversed:1;
   uint8_t   enableCustomThrottleWarning:1;
-  uint8_t   spare3:7 SKIP;
+  uint8_t   disableTelemetryWarning:1;
+  uint8_t   spare3:6 SKIP;
   int8_t    customThrottleWarningPosition;
   BeepANACenter beepANACenter;
   MixData   mixData[MAX_MIXERS] NO_IDX;
@@ -664,7 +665,10 @@ PACK(struct ModelData {
 
   TOPBAR_DATA
 
-  NOBACKUP(RssiAlarmData rssiAlarms);
+#if defined(YAML_GENERATOR)
+  RssiAlarmData rssiAlarms;
+#endif
+  NOBACKUP(RFAlarmData rfAlarms);
 
   uint8_t thrTrimSw:3;
   uint8_t potsWarnMode:2 ENUM(PotsWarnMode);

--- a/radio/src/gui/128x64/model_telemetry.cpp
+++ b/radio/src/gui/128x64/model_telemetry.cpp
@@ -250,18 +250,18 @@ void menuModelTelemetry(event_t event)
       {
         bool warning = (k==ITEM_TELEMETRY_RSSI_ALARM1);
         lcdDrawTextAlignedLeft(y, (warning ? STR_LOWALARM : STR_CRITICALALARM));
-        lcdDrawNumber(TELEM_COL3, y, warning? g_model.rssiAlarms.getWarningRssi() : g_model.rssiAlarms.getCriticalRssi(), attr, 3);
+        lcdDrawNumber(TELEM_COL3, y, warning? g_model.rfAlarms.warning : g_model.rfAlarms.critical, attr, 3);
         if (attr && s_editMode>0) {
           if (warning)
-            CHECK_INCDEC_MODELVAR(event, g_model.rssiAlarms.warning, -30, 30);
+            CHECK_INCDEC_MODELVAR(event, g_model.rfAlarms.warning, 0, 100);
           else
-            CHECK_INCDEC_MODELVAR(event, g_model.rssiAlarms.critical, -30, 30);
+            CHECK_INCDEC_MODELVAR(event, g_model.rfAlarms.critical, 0, 100);
         }
         break;
       }
 
       case ITEM_TELEMETRY_DISABLE_ALARMS:
-        g_model.rssiAlarms.disabled = editCheckBox(g_model.rssiAlarms.disabled, TELEM_COL3, y, STR_DISABLE_ALARM, attr, event);
+        g_model.disableTelemetryWarning = editCheckBox(g_model.disableTelemetryWarning, TELEM_COL3, y, STR_DISABLE_ALARM, attr, event);
         break;
 
 #if defined(VARIO)

--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -70,7 +70,7 @@ void drawExternalAntennaAndRSSI()
 #endif
 
   if (TELEMETRY_RSSI() > 0) {
-    auto warningRSSI = g_model.rssiAlarms.getWarningRssi();
+    auto warningRSSI = g_model.rfAlarms.warning;
     int8_t value = TELEMETRY_RSSI() - warningRSSI;
     uint8_t step = (RSSI_MAX - warningRSSI) / 4;
     for (uint8_t i = 1; i < 5; i++) {

--- a/radio/src/gui/128x64/view_telemetry.cpp
+++ b/radio/src/gui/128x64/view_telemetry.cpp
@@ -38,7 +38,7 @@ void displayRssiLine()
     lcdDrawText(lcdLastLeftPos,STATUS_BAR_Y, "RSSI : ", RIGHT | SMLSIZE);
     lcdDrawRect(65, 57, 38, 7);
     uint8_t v = 4*rssi/11;
-    lcdDrawFilledRect(66+36-v, 58, v, 5, (rssi < g_model.rssiAlarms.getWarningRssi()) ? DOTTED : SOLID);
+    lcdDrawFilledRect(66+36-v, 58, v, 5, (rssi < g_model.rfAlarms.warning) ? DOTTED : SOLID);
   }
   else {
     lcdDrawText(7*FW, STATUS_BAR_Y, STR_NODATA, BLINK);

--- a/radio/src/gui/212x64/model_telemetry.cpp
+++ b/radio/src/gui/212x64/model_telemetry.cpp
@@ -253,18 +253,18 @@ void menuModelTelemetry(event_t event)
       {
         bool warning = (k==ITEM_TELEMETRY_RSSI_ALARM1);
         lcdDrawTextAlignedLeft(y, (warning ? STR_LOWALARM : STR_CRITICALALARM));
-        lcdDrawNumber(TELEM_COL2, y, warning? g_model.rssiAlarms.getWarningRssi() : g_model.rssiAlarms.getCriticalRssi(), LEFT|attr, 3);
+        lcdDrawNumber(TELEM_COL2, y, warning? g_model.rfAlarms.warning : g_model.rfAlarms.critical, LEFT|attr, 3);
         if (attr && s_editMode>0) {
           if (warning)
-            CHECK_INCDEC_MODELVAR(event, g_model.rssiAlarms.warning, -30, 30);
+            CHECK_INCDEC_MODELVAR(event, g_model.rfAlarms.warning, 0, 100);
           else
-            CHECK_INCDEC_MODELVAR(event, g_model.rssiAlarms.critical, -30, 30);
+            CHECK_INCDEC_MODELVAR(event, g_model.rfAlarms.critical, 0, 100);
         }
         break;
       }
 
       case ITEM_TELEMETRY_DISABLE_ALARMS:
-        g_model.rssiAlarms.disabled = editCheckBox(g_model.rssiAlarms.disabled, TELEM_COL3, y, STR_DISABLE_ALARM, attr, event);
+        g_model.disableTelemetryWarning = editCheckBox(g_model.disableTelemetryWarning, TELEM_COL3, y, STR_DISABLE_ALARM, attr, event);
         break;
 
 #if defined(VARIO)

--- a/radio/src/gui/212x64/view_main.cpp
+++ b/radio/src/gui/212x64/view_main.cpp
@@ -300,7 +300,7 @@ void displayTopBar()
 
   /* The inside of the RSSI gauge */
   if (TELEMETRY_RSSI() > 0) {
-    displayTopBarGauge(batt_icon_x+5*FW, TELEMETRY_RSSI() / 10, TELEMETRY_RSSI() < g_model.rssiAlarms.getWarningRssi());
+    displayTopBarGauge(batt_icon_x+5*FW, TELEMETRY_RSSI() / 10, TELEMETRY_RSSI() < g_model.rfAlarms.warning);
   }
 }
 

--- a/radio/src/gui/212x64/view_telemetry.cpp
+++ b/radio/src/gui/212x64/view_telemetry.cpp
@@ -36,7 +36,7 @@ void displayRssiLine()
     lcdDrawSizedText(0, STATUS_BAR_Y, STR_RX, 2);
     lcdDrawNumber(4*FW, STATUS_BAR_Y, rssi, LEADING0|RIGHT, 2);
     lcdDrawRect(BAR_LEFT, 57, 78, 7);
-    lcdDrawFilledRect(BAR_LEFT+1, 58, 19*rssi/25, 5, (rssi < g_model.rssiAlarms.getWarningRssi()) ? DOTTED : SOLID);
+    lcdDrawFilledRect(BAR_LEFT+1, 58, 19*rssi/25, 5, (rssi < g_model.rfAlarms.warning) ? DOTTED : SOLID);
   }
   else {
     lcdDrawText(7*FW, STATUS_BAR_Y, STR_NODATA, BLINK);

--- a/radio/src/gui/colorlcd/model_telemetry.cpp
+++ b/radio/src/gui/colorlcd/model_telemetry.cpp
@@ -466,22 +466,17 @@ void ModelTelemetryPage::build(FormWindow * window, int8_t focusSensorIndex)
   grid.nextLine();
 
   new StaticText(window, grid.getLabelSlot(true), STR_LOWALARM, 0, COLOR_THEME_PRIMARY1);
-  auto edit = new NumberEdit(window, grid.getFieldSlot(), -30, 30, GET_SET_DEFAULT(g_model.rssiAlarms.warning));
-  edit->setDisplayHandler([](int32_t value) {
-    return std::to_string(g_model.rssiAlarms.getWarningRssi());
-  });
-//  window->setFirstField(edit);
+  auto edit = new NumberEdit(window, grid.getFieldSlot(), 0, 100,
+                             GET_SET_DEFAULT(g_model.rfAlarms.warning));
   grid.nextLine();
 
   new StaticText(window, grid.getLabelSlot(true), STR_CRITICALALARM, 0, COLOR_THEME_PRIMARY1);
-  edit = new NumberEdit(window, grid.getFieldSlot(), -30, 30, GET_SET_DEFAULT(g_model.rssiAlarms.critical));
-  edit->setDisplayHandler([](int32_t value) {
-    return std::to_string(g_model.rssiAlarms.getCriticalRssi());
-  });
+  edit = new NumberEdit(window, grid.getFieldSlot(), 0, 100,
+                        GET_SET_DEFAULT(g_model.rfAlarms.critical));
   grid.nextLine();
 
   new StaticText(window, grid.getLabelSlot(true), STR_DISABLE_ALARM, 0, COLOR_THEME_PRIMARY1);
-  new CheckBox(window, grid.getFieldSlot(), GET_SET_DEFAULT(g_model.rssiAlarms.disabled));
+  new CheckBox(window, grid.getFieldSlot(), GET_SET_DEFAULT(g_model.disableTelemetryWarning));
   grid.nextLine();
   
   if (LCD_W < LCD_H) grid.nextLine();

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1890,8 +1890,8 @@ static int luaGetRSSI(lua_State * L)
     lua_pushunsigned(L, min((uint8_t)99, TELEMETRY_RSSI()));
   else
     lua_pushunsigned(L, 0);
-  lua_pushunsigned(L, g_model.rssiAlarms.getWarningRssi());
-  lua_pushunsigned(L, g_model.rssiAlarms.getCriticalRssi());
+  lua_pushunsigned(L, g_model.rfAlarms.warning);
+  lua_pushunsigned(L, g_model.rfAlarms.critical);
   return 3;
 }
 

--- a/radio/src/model_init.cpp
+++ b/radio/src/model_init.cpp
@@ -75,6 +75,15 @@ void setDefaultGVars()
 #endif
 }
 
+void setDefaultRSSIValues()
+{
+  // Set to legacy FrSky values until
+  // a better solution is found (module specific?)
+  //
+  g_model.rfAlarms.warning = 45;
+  g_model.rfAlarms.critical = 42;
+}
+
 void setVendorSpecificModelDefaults(uint8_t id)
 {
 #if defined(FRSKY_RELEASE)
@@ -108,6 +117,7 @@ void applyDefaultTemplate()
   setDefaultInputs();
   setDefaultMixes();
   setDefaultGVars();
+  setDefaultRSSIValues();
 
   setDefaultModelRegistrationID();
 

--- a/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
@@ -364,6 +364,31 @@ static bool w_mixSrcRaw(const YamlNode* node, uint32_t val, yaml_writer_func wf,
     return true;
 }
 
+static void r_rssiDisabled(void* user, uint8_t* data, uint32_t bitoffs,
+                           const char* val, uint8_t val_len)
+{
+  data += bitoffs >> 3UL;
+  data -= offsetof(ModelData, rfAlarms);
+  auto md = reinterpret_cast<ModelData*>(data);
+  md->disableTelemetryWarning = yaml_str2int(val, val_len);
+}
+
+static void r_rssiWarning(void* user, uint8_t* data, uint32_t bitoffs,
+                          const char* val, uint8_t val_len)
+{
+  data += bitoffs >> 3UL;
+  auto rf_alarm = reinterpret_cast<RFAlarmData*>(data);
+  rf_alarm->warning = yaml_str2int(val, val_len) + 45;
+}
+
+static void r_rssiCritical(void* user, uint8_t* data, uint32_t bitoffs,
+                           const char* val, uint8_t val_len)
+{
+  data += bitoffs >> 3UL;
+  auto rf_alarm = reinterpret_cast<RFAlarmData*>(data);
+  rf_alarm->critical = yaml_str2int(val, val_len) + 42;
+}
+
 static uint32_t r_vbat_min(const YamlNode* node, const char* val, uint8_t val_len)
 {
     int32_t v = yaml_str2int(val, val_len);

--- a/radio/src/storage/yaml/yaml_datastructs_lr3pro.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_lr3pro.cpp
@@ -568,11 +568,14 @@ static const struct YamlNode struct_VarioData[] = {
   YAML_END
 };
 static const struct YamlNode struct_RssiAlarmData[] = {
-  YAML_SIGNED( "disabled", 1 ),
-  YAML_PADDING( 1 ),
-  YAML_SIGNED( "warning", 6 ),
-  YAML_PADDING( 2 ),
-  YAML_SIGNED( "critical", 6 ),
+  YAML_CUSTOM("disabled",r_rssiDisabled,nullptr),
+  YAML_CUSTOM("warning",r_rssiWarning,nullptr),
+  YAML_CUSTOM("critical",r_rssiCritical,nullptr),
+  YAML_END
+};
+static const struct YamlNode struct_RFAlarmData[] = {
+  YAML_SIGNED( "warning", 8 ),
+  YAML_SIGNED( "critical", 8 ),
   YAML_END
 };
 static const struct YamlNode struct_PpmModule[] = {
@@ -822,7 +825,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "extendedTrims", 1 ),
   YAML_UNSIGNED( "throttleReversed", 1 ),
   YAML_UNSIGNED( "enableCustomThrottleWarning", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
+  YAML_PADDING( 6 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
@@ -840,7 +844,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_ARRAY("gvars", 56, 9, struct_GVarData, NULL),
   YAML_STRUCT("varioData", 40, struct_VarioData, NULL),
   YAML_UNSIGNED_CUST( "rssiSource", 8, r_tele_sensor, w_tele_sensor ),
-  YAML_STRUCT("rssiAlarms", 16, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rssiAlarms", 0, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rfAlarms", 16, struct_RFAlarmData, NULL),
   YAML_UNSIGNED( "thrTrimSw", 3 ),
   YAML_ENUM("potsWarnMode", 2, enum_PotsWarnMode),
   YAML_ENUM("jitterFilter", 2, enum_ModelOverridableEnable),

--- a/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
@@ -602,11 +602,14 @@ static const struct YamlNode struct_VarioData[] = {
   YAML_END
 };
 static const struct YamlNode struct_RssiAlarmData[] = {
-  YAML_SIGNED( "disabled", 1 ),
-  YAML_UNSIGNED( "flysky_telemetry", 1 ),
-  YAML_SIGNED( "warning", 6 ),
-  YAML_PADDING( 2 ),
-  YAML_SIGNED( "critical", 6 ),
+  YAML_CUSTOM("disabled",r_rssiDisabled,nullptr),
+  YAML_CUSTOM("warning",r_rssiWarning,nullptr),
+  YAML_CUSTOM("critical",r_rssiCritical,nullptr),
+  YAML_END
+};
+static const struct YamlNode struct_RFAlarmData[] = {
+  YAML_SIGNED( "warning", 8 ),
+  YAML_SIGNED( "critical", 8 ),
   YAML_END
 };
 static const struct YamlNode struct_PpmModule[] = {
@@ -853,7 +856,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "extendedTrims", 1 ),
   YAML_UNSIGNED( "throttleReversed", 1 ),
   YAML_UNSIGNED( "enableCustomThrottleWarning", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
+  YAML_PADDING( 6 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
@@ -871,7 +875,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_ARRAY("gvars", 56, 9, struct_GVarData, NULL),
   YAML_STRUCT("varioData", 40, struct_VarioData, NULL),
   YAML_UNSIGNED_CUST( "rssiSource", 8, r_tele_sensor, w_tele_sensor ),
-  YAML_STRUCT("rssiAlarms", 16, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rssiAlarms", 0, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rfAlarms", 16, struct_RFAlarmData, NULL),
   YAML_UNSIGNED( "thrTrimSw", 3 ),
   YAML_ENUM("potsWarnMode", 2, enum_PotsWarnMode),
   YAML_ENUM("jitterFilter", 2, enum_ModelOverridableEnable),

--- a/radio/src/storage/yaml/yaml_datastructs_t12.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t12.cpp
@@ -568,11 +568,14 @@ static const struct YamlNode struct_VarioData[] = {
   YAML_END
 };
 static const struct YamlNode struct_RssiAlarmData[] = {
-  YAML_SIGNED( "disabled", 1 ),
-  YAML_PADDING( 1 ),
-  YAML_SIGNED( "warning", 6 ),
-  YAML_PADDING( 2 ),
-  YAML_SIGNED( "critical", 6 ),
+  YAML_CUSTOM("disabled",r_rssiDisabled,nullptr),
+  YAML_CUSTOM("warning",r_rssiWarning,nullptr),
+  YAML_CUSTOM("critical",r_rssiCritical,nullptr),
+  YAML_END
+};
+static const struct YamlNode struct_RFAlarmData[] = {
+  YAML_SIGNED( "warning", 8 ),
+  YAML_SIGNED( "critical", 8 ),
   YAML_END
 };
 static const struct YamlNode struct_PpmModule[] = {
@@ -822,7 +825,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "extendedTrims", 1 ),
   YAML_UNSIGNED( "throttleReversed", 1 ),
   YAML_UNSIGNED( "enableCustomThrottleWarning", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
+  YAML_PADDING( 6 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
@@ -840,7 +844,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_ARRAY("gvars", 56, 9, struct_GVarData, NULL),
   YAML_STRUCT("varioData", 40, struct_VarioData, NULL),
   YAML_UNSIGNED_CUST( "rssiSource", 8, r_tele_sensor, w_tele_sensor ),
-  YAML_STRUCT("rssiAlarms", 16, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rssiAlarms", 0, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rfAlarms", 16, struct_RFAlarmData, NULL),
   YAML_UNSIGNED( "thrTrimSw", 3 ),
   YAML_ENUM("potsWarnMode", 2, enum_PotsWarnMode),
   YAML_ENUM("jitterFilter", 2, enum_ModelOverridableEnable),

--- a/radio/src/storage/yaml/yaml_datastructs_t8.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t8.cpp
@@ -568,11 +568,14 @@ static const struct YamlNode struct_VarioData[] = {
   YAML_END
 };
 static const struct YamlNode struct_RssiAlarmData[] = {
-  YAML_SIGNED( "disabled", 1 ),
-  YAML_PADDING( 1 ),
-  YAML_SIGNED( "warning", 6 ),
-  YAML_PADDING( 2 ),
-  YAML_SIGNED( "critical", 6 ),
+  YAML_CUSTOM("disabled",r_rssiDisabled,nullptr),
+  YAML_CUSTOM("warning",r_rssiWarning,nullptr),
+  YAML_CUSTOM("critical",r_rssiCritical,nullptr),
+  YAML_END
+};
+static const struct YamlNode struct_RFAlarmData[] = {
+  YAML_SIGNED( "warning", 8 ),
+  YAML_SIGNED( "critical", 8 ),
   YAML_END
 };
 static const struct YamlNode struct_PpmModule[] = {
@@ -822,7 +825,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "extendedTrims", 1 ),
   YAML_UNSIGNED( "throttleReversed", 1 ),
   YAML_UNSIGNED( "enableCustomThrottleWarning", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
+  YAML_PADDING( 6 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
@@ -840,7 +844,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_ARRAY("gvars", 56, 9, struct_GVarData, NULL),
   YAML_STRUCT("varioData", 40, struct_VarioData, NULL),
   YAML_UNSIGNED_CUST( "rssiSource", 8, r_tele_sensor, w_tele_sensor ),
-  YAML_STRUCT("rssiAlarms", 16, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rssiAlarms", 0, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rfAlarms", 16, struct_RFAlarmData, NULL),
   YAML_UNSIGNED( "thrTrimSw", 3 ),
   YAML_ENUM("potsWarnMode", 2, enum_PotsWarnMode),
   YAML_ENUM("jitterFilter", 2, enum_ModelOverridableEnable),

--- a/radio/src/storage/yaml/yaml_datastructs_tlite.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tlite.cpp
@@ -568,11 +568,14 @@ static const struct YamlNode struct_VarioData[] = {
   YAML_END
 };
 static const struct YamlNode struct_RssiAlarmData[] = {
-  YAML_SIGNED( "disabled", 1 ),
-  YAML_PADDING( 1 ),
-  YAML_SIGNED( "warning", 6 ),
-  YAML_PADDING( 2 ),
-  YAML_SIGNED( "critical", 6 ),
+  YAML_CUSTOM("disabled",r_rssiDisabled,nullptr),
+  YAML_CUSTOM("warning",r_rssiWarning,nullptr),
+  YAML_CUSTOM("critical",r_rssiCritical,nullptr),
+  YAML_END
+};
+static const struct YamlNode struct_RFAlarmData[] = {
+  YAML_SIGNED( "warning", 8 ),
+  YAML_SIGNED( "critical", 8 ),
   YAML_END
 };
 static const struct YamlNode struct_PpmModule[] = {
@@ -822,7 +825,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "extendedTrims", 1 ),
   YAML_UNSIGNED( "throttleReversed", 1 ),
   YAML_UNSIGNED( "enableCustomThrottleWarning", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
+  YAML_PADDING( 6 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
@@ -840,7 +844,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_ARRAY("gvars", 56, 9, struct_GVarData, NULL),
   YAML_STRUCT("varioData", 40, struct_VarioData, NULL),
   YAML_UNSIGNED_CUST( "rssiSource", 8, r_tele_sensor, w_tele_sensor ),
-  YAML_STRUCT("rssiAlarms", 16, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rssiAlarms", 0, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rfAlarms", 16, struct_RFAlarmData, NULL),
   YAML_UNSIGNED( "thrTrimSw", 3 ),
   YAML_ENUM("potsWarnMode", 2, enum_PotsWarnMode),
   YAML_ENUM("jitterFilter", 2, enum_ModelOverridableEnable),

--- a/radio/src/storage/yaml/yaml_datastructs_tpro.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tpro.cpp
@@ -574,11 +574,14 @@ static const struct YamlNode struct_VarioData[] = {
   YAML_END
 };
 static const struct YamlNode struct_RssiAlarmData[] = {
-  YAML_SIGNED( "disabled", 1 ),
-  YAML_PADDING( 1 ),
-  YAML_SIGNED( "warning", 6 ),
-  YAML_PADDING( 2 ),
-  YAML_SIGNED( "critical", 6 ),
+  YAML_CUSTOM("disabled",r_rssiDisabled,nullptr),
+  YAML_CUSTOM("warning",r_rssiWarning,nullptr),
+  YAML_CUSTOM("critical",r_rssiCritical,nullptr),
+  YAML_END
+};
+static const struct YamlNode struct_RFAlarmData[] = {
+  YAML_SIGNED( "warning", 8 ),
+  YAML_SIGNED( "critical", 8 ),
   YAML_END
 };
 static const struct YamlNode struct_PpmModule[] = {
@@ -828,7 +831,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "extendedTrims", 1 ),
   YAML_UNSIGNED( "throttleReversed", 1 ),
   YAML_UNSIGNED( "enableCustomThrottleWarning", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
+  YAML_PADDING( 6 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
@@ -846,7 +850,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_ARRAY("gvars", 56, 9, struct_GVarData, NULL),
   YAML_STRUCT("varioData", 40, struct_VarioData, NULL),
   YAML_UNSIGNED_CUST( "rssiSource", 8, r_tele_sensor, w_tele_sensor ),
-  YAML_STRUCT("rssiAlarms", 16, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rssiAlarms", 0, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rfAlarms", 16, struct_RFAlarmData, NULL),
   YAML_UNSIGNED( "thrTrimSw", 3 ),
   YAML_ENUM("potsWarnMode", 2, enum_PotsWarnMode),
   YAML_ENUM("jitterFilter", 2, enum_ModelOverridableEnable),

--- a/radio/src/storage/yaml/yaml_datastructs_tx12.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tx12.cpp
@@ -568,11 +568,14 @@ static const struct YamlNode struct_VarioData[] = {
   YAML_END
 };
 static const struct YamlNode struct_RssiAlarmData[] = {
-  YAML_SIGNED( "disabled", 1 ),
-  YAML_PADDING( 1 ),
-  YAML_SIGNED( "warning", 6 ),
-  YAML_PADDING( 2 ),
-  YAML_SIGNED( "critical", 6 ),
+  YAML_CUSTOM("disabled",r_rssiDisabled,nullptr),
+  YAML_CUSTOM("warning",r_rssiWarning,nullptr),
+  YAML_CUSTOM("critical",r_rssiCritical,nullptr),
+  YAML_END
+};
+static const struct YamlNode struct_RFAlarmData[] = {
+  YAML_SIGNED( "warning", 8 ),
+  YAML_SIGNED( "critical", 8 ),
   YAML_END
 };
 static const struct YamlNode struct_PpmModule[] = {
@@ -822,7 +825,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "extendedTrims", 1 ),
   YAML_UNSIGNED( "throttleReversed", 1 ),
   YAML_UNSIGNED( "enableCustomThrottleWarning", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
+  YAML_PADDING( 6 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
@@ -840,7 +844,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_ARRAY("gvars", 56, 9, struct_GVarData, NULL),
   YAML_STRUCT("varioData", 40, struct_VarioData, NULL),
   YAML_UNSIGNED_CUST( "rssiSource", 8, r_tele_sensor, w_tele_sensor ),
-  YAML_STRUCT("rssiAlarms", 16, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rssiAlarms", 0, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rfAlarms", 16, struct_RFAlarmData, NULL),
   YAML_UNSIGNED( "thrTrimSw", 3 ),
   YAML_ENUM("potsWarnMode", 2, enum_PotsWarnMode),
   YAML_ENUM("jitterFilter", 2, enum_ModelOverridableEnable),

--- a/radio/src/storage/yaml/yaml_datastructs_tx12mk2.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tx12mk2.cpp
@@ -568,11 +568,14 @@ static const struct YamlNode struct_VarioData[] = {
   YAML_END
 };
 static const struct YamlNode struct_RssiAlarmData[] = {
-  YAML_SIGNED( "disabled", 1 ),
-  YAML_PADDING( 1 ),
-  YAML_SIGNED( "warning", 6 ),
-  YAML_PADDING( 2 ),
-  YAML_SIGNED( "critical", 6 ),
+  YAML_CUSTOM("disabled",r_rssiDisabled,nullptr),
+  YAML_CUSTOM("warning",r_rssiWarning,nullptr),
+  YAML_CUSTOM("critical",r_rssiCritical,nullptr),
+  YAML_END
+};
+static const struct YamlNode struct_RFAlarmData[] = {
+  YAML_SIGNED( "warning", 8 ),
+  YAML_SIGNED( "critical", 8 ),
   YAML_END
 };
 static const struct YamlNode struct_PpmModule[] = {
@@ -822,7 +825,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "extendedTrims", 1 ),
   YAML_UNSIGNED( "throttleReversed", 1 ),
   YAML_UNSIGNED( "enableCustomThrottleWarning", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
+  YAML_PADDING( 6 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
@@ -840,7 +844,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_ARRAY("gvars", 56, 9, struct_GVarData, NULL),
   YAML_STRUCT("varioData", 40, struct_VarioData, NULL),
   YAML_UNSIGNED_CUST( "rssiSource", 8, r_tele_sensor, w_tele_sensor ),
-  YAML_STRUCT("rssiAlarms", 16, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rssiAlarms", 0, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rfAlarms", 16, struct_RFAlarmData, NULL),
   YAML_UNSIGNED( "thrTrimSw", 3 ),
   YAML_ENUM("potsWarnMode", 2, enum_PotsWarnMode),
   YAML_ENUM("jitterFilter", 2, enum_ModelOverridableEnable),

--- a/radio/src/storage/yaml/yaml_datastructs_x10.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x10.cpp
@@ -633,11 +633,14 @@ static const struct YamlNode struct_VarioData[] = {
   YAML_END
 };
 static const struct YamlNode struct_RssiAlarmData[] = {
-  YAML_SIGNED( "disabled", 1 ),
-  YAML_PADDING( 1 ),
-  YAML_SIGNED( "warning", 6 ),
-  YAML_PADDING( 2 ),
-  YAML_SIGNED( "critical", 6 ),
+  YAML_CUSTOM("disabled",r_rssiDisabled,nullptr),
+  YAML_CUSTOM("warning",r_rssiWarning,nullptr),
+  YAML_CUSTOM("critical",r_rssiCritical,nullptr),
+  YAML_END
+};
+static const struct YamlNode struct_RFAlarmData[] = {
+  YAML_SIGNED( "warning", 8 ),
+  YAML_SIGNED( "critical", 8 ),
   YAML_END
 };
 static const struct YamlNode struct_PpmModule[] = {
@@ -884,7 +887,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "extendedTrims", 1 ),
   YAML_UNSIGNED( "throttleReversed", 1 ),
   YAML_UNSIGNED( "enableCustomThrottleWarning", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
+  YAML_PADDING( 6 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
@@ -902,7 +906,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_ARRAY("gvars", 56, 9, struct_GVarData, NULL),
   YAML_STRUCT("varioData", 40, struct_VarioData, NULL),
   YAML_UNSIGNED_CUST( "rssiSource", 8, r_tele_sensor, w_tele_sensor ),
-  YAML_STRUCT("rssiAlarms", 16, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rssiAlarms", 0, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rfAlarms", 16, struct_RFAlarmData, NULL),
   YAML_UNSIGNED( "thrTrimSw", 3 ),
   YAML_ENUM("potsWarnMode", 2, enum_PotsWarnMode),
   YAML_ENUM("jitterFilter", 2, enum_ModelOverridableEnable),

--- a/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
@@ -631,11 +631,14 @@ static const struct YamlNode struct_VarioData[] = {
   YAML_END
 };
 static const struct YamlNode struct_RssiAlarmData[] = {
-  YAML_SIGNED( "disabled", 1 ),
-  YAML_PADDING( 1 ),
-  YAML_SIGNED( "warning", 6 ),
-  YAML_PADDING( 2 ),
-  YAML_SIGNED( "critical", 6 ),
+  YAML_CUSTOM("disabled",r_rssiDisabled,nullptr),
+  YAML_CUSTOM("warning",r_rssiWarning,nullptr),
+  YAML_CUSTOM("critical",r_rssiCritical,nullptr),
+  YAML_END
+};
+static const struct YamlNode struct_RFAlarmData[] = {
+  YAML_SIGNED( "warning", 8 ),
+  YAML_SIGNED( "critical", 8 ),
   YAML_END
 };
 static const struct YamlNode struct_PpmModule[] = {
@@ -882,7 +885,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "extendedTrims", 1 ),
   YAML_UNSIGNED( "throttleReversed", 1 ),
   YAML_UNSIGNED( "enableCustomThrottleWarning", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
+  YAML_PADDING( 6 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
@@ -900,7 +904,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_ARRAY("gvars", 56, 9, struct_GVarData, NULL),
   YAML_STRUCT("varioData", 40, struct_VarioData, NULL),
   YAML_UNSIGNED_CUST( "rssiSource", 8, r_tele_sensor, w_tele_sensor ),
-  YAML_STRUCT("rssiAlarms", 16, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rssiAlarms", 0, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rfAlarms", 16, struct_RFAlarmData, NULL),
   YAML_UNSIGNED( "thrTrimSw", 3 ),
   YAML_ENUM("potsWarnMode", 2, enum_PotsWarnMode),
   YAML_ENUM("jitterFilter", 2, enum_ModelOverridableEnable),

--- a/radio/src/storage/yaml/yaml_datastructs_x7.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x7.cpp
@@ -568,11 +568,14 @@ static const struct YamlNode struct_VarioData[] = {
   YAML_END
 };
 static const struct YamlNode struct_RssiAlarmData[] = {
-  YAML_SIGNED( "disabled", 1 ),
-  YAML_PADDING( 1 ),
-  YAML_SIGNED( "warning", 6 ),
-  YAML_PADDING( 2 ),
-  YAML_SIGNED( "critical", 6 ),
+  YAML_CUSTOM("disabled",r_rssiDisabled,nullptr),
+  YAML_CUSTOM("warning",r_rssiWarning,nullptr),
+  YAML_CUSTOM("critical",r_rssiCritical,nullptr),
+  YAML_END
+};
+static const struct YamlNode struct_RFAlarmData[] = {
+  YAML_SIGNED( "warning", 8 ),
+  YAML_SIGNED( "critical", 8 ),
   YAML_END
 };
 static const struct YamlNode struct_PpmModule[] = {
@@ -822,7 +825,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "extendedTrims", 1 ),
   YAML_UNSIGNED( "throttleReversed", 1 ),
   YAML_UNSIGNED( "enableCustomThrottleWarning", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
+  YAML_PADDING( 6 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
@@ -840,7 +844,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_ARRAY("gvars", 56, 9, struct_GVarData, NULL),
   YAML_STRUCT("varioData", 40, struct_VarioData, NULL),
   YAML_UNSIGNED_CUST( "rssiSource", 8, r_tele_sensor, w_tele_sensor ),
-  YAML_STRUCT("rssiAlarms", 16, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rssiAlarms", 0, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rfAlarms", 16, struct_RFAlarmData, NULL),
   YAML_UNSIGNED( "thrTrimSw", 3 ),
   YAML_ENUM("potsWarnMode", 2, enum_PotsWarnMode),
   YAML_ENUM("jitterFilter", 2, enum_ModelOverridableEnable),

--- a/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
@@ -576,11 +576,14 @@ static const struct YamlNode struct_VarioData[] = {
   YAML_END
 };
 static const struct YamlNode struct_RssiAlarmData[] = {
-  YAML_SIGNED( "disabled", 1 ),
-  YAML_PADDING( 1 ),
-  YAML_SIGNED( "warning", 6 ),
-  YAML_PADDING( 2 ),
-  YAML_SIGNED( "critical", 6 ),
+  YAML_CUSTOM("disabled",r_rssiDisabled,nullptr),
+  YAML_CUSTOM("warning",r_rssiWarning,nullptr),
+  YAML_CUSTOM("critical",r_rssiCritical,nullptr),
+  YAML_END
+};
+static const struct YamlNode struct_RFAlarmData[] = {
+  YAML_SIGNED( "warning", 8 ),
+  YAML_SIGNED( "critical", 8 ),
   YAML_END
 };
 static const struct YamlNode struct_PpmModule[] = {
@@ -835,7 +838,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "extendedTrims", 1 ),
   YAML_UNSIGNED( "throttleReversed", 1 ),
   YAML_UNSIGNED( "enableCustomThrottleWarning", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
+  YAML_PADDING( 6 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
@@ -855,7 +859,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED_CUST( "rssiSource", 8, r_tele_sensor, w_tele_sensor ),
   YAML_UNSIGNED_CUST( "voltsSource", 8, r_tele_sensor, w_tele_sensor ),
   YAML_UNSIGNED_CUST( "altitudeSource", 8, r_tele_sensor, w_tele_sensor ),
-  YAML_STRUCT("rssiAlarms", 16, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rssiAlarms", 0, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rfAlarms", 16, struct_RFAlarmData, NULL),
   YAML_UNSIGNED( "thrTrimSw", 3 ),
   YAML_ENUM("potsWarnMode", 2, enum_PotsWarnMode),
   YAML_ENUM("jitterFilter", 2, enum_ModelOverridableEnable),

--- a/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
@@ -615,11 +615,14 @@ static const struct YamlNode struct_VarioData[] = {
   YAML_END
 };
 static const struct YamlNode struct_RssiAlarmData[] = {
-  YAML_SIGNED( "disabled", 1 ),
-  YAML_PADDING( 1 ),
-  YAML_SIGNED( "warning", 6 ),
-  YAML_PADDING( 2 ),
-  YAML_SIGNED( "critical", 6 ),
+  YAML_CUSTOM("disabled",r_rssiDisabled,nullptr),
+  YAML_CUSTOM("warning",r_rssiWarning,nullptr),
+  YAML_CUSTOM("critical",r_rssiCritical,nullptr),
+  YAML_END
+};
+static const struct YamlNode struct_RFAlarmData[] = {
+  YAML_SIGNED( "warning", 8 ),
+  YAML_SIGNED( "critical", 8 ),
   YAML_END
 };
 static const struct YamlNode struct_PpmModule[] = {
@@ -874,7 +877,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "extendedTrims", 1 ),
   YAML_UNSIGNED( "throttleReversed", 1 ),
   YAML_UNSIGNED( "enableCustomThrottleWarning", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
+  YAML_PADDING( 6 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
@@ -894,7 +898,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED_CUST( "rssiSource", 8, r_tele_sensor, w_tele_sensor ),
   YAML_UNSIGNED_CUST( "voltsSource", 8, r_tele_sensor, w_tele_sensor ),
   YAML_UNSIGNED_CUST( "altitudeSource", 8, r_tele_sensor, w_tele_sensor ),
-  YAML_STRUCT("rssiAlarms", 16, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rssiAlarms", 0, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rfAlarms", 16, struct_RFAlarmData, NULL),
   YAML_UNSIGNED( "thrTrimSw", 3 ),
   YAML_ENUM("potsWarnMode", 2, enum_PotsWarnMode),
   YAML_ENUM("jitterFilter", 2, enum_ModelOverridableEnable),

--- a/radio/src/storage/yaml/yaml_datastructs_x9lite.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9lite.cpp
@@ -553,11 +553,14 @@ static const struct YamlNode struct_VarioData[] = {
   YAML_END
 };
 static const struct YamlNode struct_RssiAlarmData[] = {
-  YAML_SIGNED( "disabled", 1 ),
-  YAML_PADDING( 1 ),
-  YAML_SIGNED( "warning", 6 ),
-  YAML_PADDING( 2 ),
-  YAML_SIGNED( "critical", 6 ),
+  YAML_CUSTOM("disabled",r_rssiDisabled,nullptr),
+  YAML_CUSTOM("warning",r_rssiWarning,nullptr),
+  YAML_CUSTOM("critical",r_rssiCritical,nullptr),
+  YAML_END
+};
+static const struct YamlNode struct_RFAlarmData[] = {
+  YAML_SIGNED( "warning", 8 ),
+  YAML_SIGNED( "critical", 8 ),
   YAML_END
 };
 static const struct YamlNode struct_PpmModule[] = {
@@ -807,7 +810,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "extendedTrims", 1 ),
   YAML_UNSIGNED( "throttleReversed", 1 ),
   YAML_UNSIGNED( "enableCustomThrottleWarning", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
+  YAML_PADDING( 6 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
@@ -825,7 +829,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_ARRAY("gvars", 56, 9, struct_GVarData, NULL),
   YAML_STRUCT("varioData", 40, struct_VarioData, NULL),
   YAML_UNSIGNED_CUST( "rssiSource", 8, r_tele_sensor, w_tele_sensor ),
-  YAML_STRUCT("rssiAlarms", 16, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rssiAlarms", 0, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rfAlarms", 16, struct_RFAlarmData, NULL),
   YAML_UNSIGNED( "thrTrimSw", 3 ),
   YAML_ENUM("potsWarnMode", 2, enum_PotsWarnMode),
   YAML_ENUM("jitterFilter", 2, enum_ModelOverridableEnable),

--- a/radio/src/storage/yaml/yaml_datastructs_x9lites.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9lites.cpp
@@ -563,11 +563,14 @@ static const struct YamlNode struct_VarioData[] = {
   YAML_END
 };
 static const struct YamlNode struct_RssiAlarmData[] = {
-  YAML_SIGNED( "disabled", 1 ),
-  YAML_PADDING( 1 ),
-  YAML_SIGNED( "warning", 6 ),
-  YAML_PADDING( 2 ),
-  YAML_SIGNED( "critical", 6 ),
+  YAML_CUSTOM("disabled",r_rssiDisabled,nullptr),
+  YAML_CUSTOM("warning",r_rssiWarning,nullptr),
+  YAML_CUSTOM("critical",r_rssiCritical,nullptr),
+  YAML_END
+};
+static const struct YamlNode struct_RFAlarmData[] = {
+  YAML_SIGNED( "warning", 8 ),
+  YAML_SIGNED( "critical", 8 ),
   YAML_END
 };
 static const struct YamlNode struct_PpmModule[] = {
@@ -817,7 +820,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "extendedTrims", 1 ),
   YAML_UNSIGNED( "throttleReversed", 1 ),
   YAML_UNSIGNED( "enableCustomThrottleWarning", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
+  YAML_PADDING( 6 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
@@ -835,7 +839,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_ARRAY("gvars", 56, 9, struct_GVarData, NULL),
   YAML_STRUCT("varioData", 40, struct_VarioData, NULL),
   YAML_UNSIGNED_CUST( "rssiSource", 8, r_tele_sensor, w_tele_sensor ),
-  YAML_STRUCT("rssiAlarms", 16, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rssiAlarms", 0, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rfAlarms", 16, struct_RFAlarmData, NULL),
   YAML_UNSIGNED( "thrTrimSw", 3 ),
   YAML_ENUM("potsWarnMode", 2, enum_PotsWarnMode),
   YAML_ENUM("jitterFilter", 2, enum_ModelOverridableEnable),

--- a/radio/src/storage/yaml/yaml_datastructs_xlite.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_xlite.cpp
@@ -560,11 +560,14 @@ static const struct YamlNode struct_VarioData[] = {
   YAML_END
 };
 static const struct YamlNode struct_RssiAlarmData[] = {
-  YAML_SIGNED( "disabled", 1 ),
-  YAML_PADDING( 1 ),
-  YAML_SIGNED( "warning", 6 ),
-  YAML_PADDING( 2 ),
-  YAML_SIGNED( "critical", 6 ),
+  YAML_CUSTOM("disabled",r_rssiDisabled,nullptr),
+  YAML_CUSTOM("warning",r_rssiWarning,nullptr),
+  YAML_CUSTOM("critical",r_rssiCritical,nullptr),
+  YAML_END
+};
+static const struct YamlNode struct_RFAlarmData[] = {
+  YAML_SIGNED( "warning", 8 ),
+  YAML_SIGNED( "critical", 8 ),
   YAML_END
 };
 static const struct YamlNode struct_PpmModule[] = {
@@ -814,7 +817,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "extendedTrims", 1 ),
   YAML_UNSIGNED( "throttleReversed", 1 ),
   YAML_UNSIGNED( "enableCustomThrottleWarning", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
+  YAML_PADDING( 6 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
@@ -832,7 +836,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_ARRAY("gvars", 56, 9, struct_GVarData, NULL),
   YAML_STRUCT("varioData", 40, struct_VarioData, NULL),
   YAML_UNSIGNED_CUST( "rssiSource", 8, r_tele_sensor, w_tele_sensor ),
-  YAML_STRUCT("rssiAlarms", 16, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rssiAlarms", 0, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rfAlarms", 16, struct_RFAlarmData, NULL),
   YAML_UNSIGNED( "thrTrimSw", 3 ),
   YAML_ENUM("potsWarnMode", 2, enum_PotsWarnMode),
   YAML_ENUM("jitterFilter", 2, enum_ModelOverridableEnable),

--- a/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
@@ -564,11 +564,14 @@ static const struct YamlNode struct_VarioData[] = {
   YAML_END
 };
 static const struct YamlNode struct_RssiAlarmData[] = {
-  YAML_SIGNED( "disabled", 1 ),
-  YAML_PADDING( 1 ),
-  YAML_SIGNED( "warning", 6 ),
-  YAML_PADDING( 2 ),
-  YAML_SIGNED( "critical", 6 ),
+  YAML_CUSTOM("disabled",r_rssiDisabled,nullptr),
+  YAML_CUSTOM("warning",r_rssiWarning,nullptr),
+  YAML_CUSTOM("critical",r_rssiCritical,nullptr),
+  YAML_END
+};
+static const struct YamlNode struct_RFAlarmData[] = {
+  YAML_SIGNED( "warning", 8 ),
+  YAML_SIGNED( "critical", 8 ),
   YAML_END
 };
 static const struct YamlNode struct_PpmModule[] = {
@@ -818,7 +821,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "extendedTrims", 1 ),
   YAML_UNSIGNED( "throttleReversed", 1 ),
   YAML_UNSIGNED( "enableCustomThrottleWarning", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
+  YAML_PADDING( 6 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
@@ -836,7 +840,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_ARRAY("gvars", 56, 9, struct_GVarData, NULL),
   YAML_STRUCT("varioData", 40, struct_VarioData, NULL),
   YAML_UNSIGNED_CUST( "rssiSource", 8, r_tele_sensor, w_tele_sensor ),
-  YAML_STRUCT("rssiAlarms", 16, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rssiAlarms", 0, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rfAlarms", 16, struct_RFAlarmData, NULL),
   YAML_UNSIGNED( "thrTrimSw", 3 ),
   YAML_ENUM("potsWarnMode", 2, enum_PotsWarnMode),
   YAML_ENUM("jitterFilter", 2, enum_ModelOverridableEnable),

--- a/radio/src/storage/yaml/yaml_datastructs_zorro.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_zorro.cpp
@@ -568,11 +568,14 @@ static const struct YamlNode struct_VarioData[] = {
   YAML_END
 };
 static const struct YamlNode struct_RssiAlarmData[] = {
-  YAML_SIGNED( "disabled", 1 ),
-  YAML_PADDING( 1 ),
-  YAML_SIGNED( "warning", 6 ),
-  YAML_PADDING( 2 ),
-  YAML_SIGNED( "critical", 6 ),
+  YAML_CUSTOM("disabled",r_rssiDisabled,nullptr),
+  YAML_CUSTOM("warning",r_rssiWarning,nullptr),
+  YAML_CUSTOM("critical",r_rssiCritical,nullptr),
+  YAML_END
+};
+static const struct YamlNode struct_RFAlarmData[] = {
+  YAML_SIGNED( "warning", 8 ),
+  YAML_SIGNED( "critical", 8 ),
   YAML_END
 };
 static const struct YamlNode struct_PpmModule[] = {
@@ -822,7 +825,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "extendedTrims", 1 ),
   YAML_UNSIGNED( "throttleReversed", 1 ),
   YAML_UNSIGNED( "enableCustomThrottleWarning", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
+  YAML_PADDING( 6 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
@@ -840,7 +844,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_ARRAY("gvars", 56, 9, struct_GVarData, NULL),
   YAML_STRUCT("varioData", 40, struct_VarioData, NULL),
   YAML_UNSIGNED_CUST( "rssiSource", 8, r_tele_sensor, w_tele_sensor ),
-  YAML_STRUCT("rssiAlarms", 16, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rssiAlarms", 0, struct_RssiAlarmData, NULL),
+  YAML_STRUCT("rfAlarms", 16, struct_RFAlarmData, NULL),
   YAML_UNSIGNED( "thrTrimSw", 3 ),
   YAML_ENUM("potsWarnMode", 2, enum_PotsWarnMode),
   YAML_ENUM("jitterFilter", 2, enum_ModelOverridableEnable),

--- a/radio/src/telemetry/flysky_nv14.cpp
+++ b/radio/src/telemetry/flysky_nv14.cpp
@@ -152,13 +152,7 @@ int32_t GetSensorValueFlySkyNv14(const FlyskyNv14Sensor* sensor,
   if (pre_10_0_14_RmFw) {
     if (sensor->id == FLYSKY_SENSOR_RX_RSSI) {
       if (value < -200) value = -200;
-      // if g_model.rssiAlarms.flysky_telemetry == 1
-      // RSSI will be kept within native FlySky range [-90, -60]
-      if (!g_model.rssiAlarms.flysky_telemetry) {
-        value *= 2;
-        value += 220;
-      }
-      telemetryData.rssi.set(value);
+      telemetryData.rssi.set(value * 2 + 220);
     }
   } else if (sensor->id == FLYSKY_SENSOR_RX_SIGNAL) {
     telemetryData.rssi.set(value);

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -322,7 +322,7 @@ void telemetryWakeup()
       }
     }
 
-    if (sensorLost && TELEMETRY_STREAMING() && !g_model.rssiAlarms.disabled) {
+    if (sensorLost && TELEMETRY_STREAMING() && !g_model.disableTelemetryWarning) {
       audioEvent(AU_SENSOR_LOST);
     }
 
@@ -334,13 +334,13 @@ void telemetryWakeup()
     }
 #endif
 
-    if (!g_model.rssiAlarms.disabled) {
+    if (!g_model.disableTelemetryWarning) {
       if (TELEMETRY_STREAMING()) {
-        if (TELEMETRY_RSSI() < g_model.rssiAlarms.getCriticalRssi() ) {
+        if (TELEMETRY_RSSI() < g_model.rfAlarms.critical ) {
           AUDIO_RSSI_RED();
           SCHEDULE_NEXT_ALARMS_CHECK(10/*seconds*/);
         }
-        else if (TELEMETRY_RSSI() < g_model.rssiAlarms.getWarningRssi() ) {
+        else if (TELEMETRY_RSSI() < g_model.rfAlarms.warning ) {
           AUDIO_RSSI_ORANGE();
           SCHEDULE_NEXT_ALARMS_CHECK(10/*seconds*/);
         }


### PR DESCRIPTION
This PR should allow to setup telemetry warnings in a useful way for protocols requiring higher warning values, such as ELRS / Crossfire where the link quality reported is actually a percentage.

Fixes #2205

Summary of changes:
- extend warning values range to a full byte (from 6 bits).
- moved disable bit to the others. 

TODOs:
- [x] companion support
- [x] set useful default values (`45/42` as per legacy)