### PR TITLE
Optionally support CRSF_VARIO in BARO_ALT telemetry

### DIFF
--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -120,6 +120,7 @@ void processCrossfireTelemetryFrame(uint8_t module)
     moduleState[module].counter = CRSF_FRAME_MODELID;
   }
 
+  uint8_t crsfPayloadLen = rxBuffer[1];
   uint8_t id = rxBuffer[2];
   int32_t value;
   switch(id) {
@@ -156,6 +157,10 @@ void processCrossfireTelemetryFrame(uint8_t module)
         }
         processCrossfireTelemetryValue(BARO_ALTITUDE_INDEX, value);
       }
+      // Length of TBS BARO_ALT has 4 payload bytes with just 2 bytes of altitude
+      // but support including VARIO if the declared payload length is 6 bytes or more
+      if (crsfPayloadLen > 5 && getCrossfireTelemetryValue<2>(5, value, module))
+        processCrossfireTelemetryValue(VERTICAL_SPEED_INDEX, value);
       break;
 
     case LINK_ID:


### PR DESCRIPTION
This extends the Crossfire telemetry BARO_ALT_ID item to optionally include the VARIO item as well.

## Reasoning
The BARO_ALT_ID item is 2 bytes of actual payload, wrapped with 4 bytes of header/crc. This makes it very inefficient to transfer due to the high overhead. The VARIO item is also only 2 bytes so these two items, which almost always exist together, can be updated from a single packet in one telemetry cycle. This is important due to the use of these items, which are to provide as real-time feedback as possible to glider pilots.

ExpressLRS will soon support native baro/vario receivers and we could split the frame on the TX module into two parts, but that doesn't get around the additional latency imposed by the half duplex eternal module connection, along with a possible low baud rate and packet rate limiting the bandwidth. Let's face it a lot of fixed wing people are still rockin' that X9D+ at 115k and running 50Hz or something silly. This has less processing overhead for everyone so I am proposing it be handled in the handset.

## Frame Definition
Current
`[CRSF_ADDRESS_RADIO_TRANSMITTER] [Len=4] [CRSF_FRAMETYPE_BARO_ALTITUDE] [2 bytes BARO_ALT] [CRC]`
Proposed
`[CRSF_ADDRESS_RADIO_TRANSMITTER] [Len=6] [CRSF_FRAMETYPE_BARO_ALTITUDE] [2 bytes BARO_ALT] [2 bytes CRSF_VARIO] [CRC]`

The encoding of the two items is not changed, and no new sensor ID is used. It simply allows for the length of the Baro Altitude frametype to optionally contain the additional value. This is also backward compatible for any system which didn't explicitly require the length of this frame to be exactly 6 bytes of declared payload.

## Testing
As no hardware is currently publicly available, I simply faked the sensor values in the TX module to verify this code worked properly. This may seem a bit premature but I know EdgeTX 2.8 feature freeze is coming up and said hardware will be available prior to EdgeTX 2.9, so it made sense to try to get this minor change included early.