### PR TITLE
Change TR2 and TR3 definitions for TR_for_NV14

### DIFF
--- a/radio/src/translations.h
+++ b/radio/src/translations.h
@@ -78,8 +78,8 @@
 #endif
 
 #if LCD_W < LCD_H    // Portrait mode
-  #define TR3(x, y, z) z
-  #define TR2(x, y) y
+  #define TR3(x, y, z) y
+  #define TR2(x, y) x
 #elif LCD_W >= 480
   #define TR3(x, y, z) z
   #define TR2(x, y) y


### PR DESCRIPTION
Fixes #2254

Summary of changes: use shorter strings for NV14
