### PR TITLE
Added characters for TRANSLATIONS_SE

### DIFF
--- a/radio/src/gui/common/stdlcd/utf8.cpp
+++ b/radio/src/gui/common/stdlcd/utf8.cpp
@@ -56,6 +56,10 @@ static wchar_t _utf8_lut[] = {
   L'ż', L'ź', L'Ą', L'Ć', L'Ę', L'Ł', L'Ń',
   L'Ó', L'Ś', L'Ż', L'Ź',
 };
+#elif defined(TRANSLATIONS_SE)
+static wchar_t _utf8_lut[] = {
+  L'å', L'ä', L'ö', L'Å', L'Ä', L'Ö',
+};
 #else
   #define NO_UTF8_LUT
 #endif


### PR DESCRIPTION
Fixes #2083

Summary of changes: 
Added characters for TRANSLATIONS_SE so that Swedish special characters are displayed on B/W radios.
Thank you @gagarinlg for identifying the cause of this issue.
