### PR TITLE
fix: splash image pixel format

### DIFF
--- a/radio/src/gui/colorlcd/splash.cpp
+++ b/radio/src/gui/colorlcd/splash.cpp
@@ -62,7 +62,7 @@ void drawSplash()
   // try splash from SD card first
   if (loadSplashImg && splashImg == nullptr) {
     if (!sdMounted()) sdInit();
-    splashImg = BitmapBuffer::loadBitmap(BITMAPS_PATH "/" SPLASH_FILE);
+    splashImg = BitmapBuffer::loadBitmap(BITMAPS_PATH "/" SPLASH_FILE, BMP_RGB565);
     loadSplashImg = false;
 
     if (splashImg == nullptr) {

--- a/radio/src/targets/simu/simulcd.cpp
+++ b/radio/src/targets/simu/simulcd.cpp
@@ -56,7 +56,7 @@ static pixel_t _LCD_BUF1[DISPLAY_BUFFER_SIZE] __SDRAM;
 static pixel_t _LCD_BUF2[DISPLAY_BUFFER_SIZE] __SDRAM;
 
 pixel_t* simuLcdBuf = _LCD_BUF1;
-pixel_t* simuLcdBackBuf = _LCD_BUF1;
+pixel_t* simuLcdBackBuf = _LCD_BUF2;
 
 // Copy 2 pixels at once to speed up a little
 static void _copy_rotate_180(uint16_t* dst, uint16_t* src, const rect_t& copy_area)


### PR DESCRIPTION
Fixes #2261 

Summary of changes:
- force pixel format to `RGB565` when loading splash image
