### PR TITLE
Change labels order for two labels list (#2269)

### DIFF
--- a/radio/src/gui/colorlcd/zone.h
+++ b/radio/src/gui/colorlcd/zone.h
@@ -29,7 +29,7 @@
 
 #if defined(_MSC_VER)
   #define OPTION_VALUE_UNSIGNED(x)    { uint32_t(x) }
-  #define OPTION_VALUE_SIGNED(x)      { uint32_t(x) }
+  #define OPTION_VALUE_SIGNED(x)      { int32_t(x) }
   #define OPTION_VALUE_BOOL(x)        {  bool(x) }
   #define OPTION_VALUE_STRING(...)    { *(ZoneOptionValue *)(const char *) #__VA_ARGS__ }
 #else

--- a/radio/src/storage/modelslist.cpp
+++ b/radio/src/storage/modelslist.cpp
@@ -481,7 +481,22 @@ bool ModelMap::moveLabelTo(unsigned curind, unsigned newind)
 
   std::swap(labels[curind], labels[newind]);
 
+  ModelMap newmap;
+  newmap.labels = labels;
+
+  for (auto &mm : modelslabels) {
+    uint16_t ind = mm.first;
+    if (ind == curind)
+      ind = newind;
+    else if (ind == newind)
+      ind = curind;
+    newmap.insert(std::make_pair(ind, mm.second));
+  }
+
+  modelslabels = newmap;
+
   modelslist.save(labels);
+  setDirty();
 
   return false;
 }

--- a/radio/src/storage/modelslist.cpp
+++ b/radio/src/storage/modelslist.cpp
@@ -479,25 +479,9 @@ bool ModelMap::moveLabelTo(unsigned curind, unsigned newind)
 
   if (labels.at(curind) == "") return true;
 
-  LabelsVector newOrder = labels;
+  std::swap(labels[curind], labels[newind]);
 
-  if (labels.size() > 2) {
-    if (curind < newind) {  // Move forward
-      std::rotate(newOrder.rend() - curind - 1, newOrder.rend() - curind,
-                  newOrder.rend() - newind);
-    } else {  // Move back
-      std::rotate(newOrder.begin() + curind, newOrder.begin() + curind + 1,
-                  newOrder.begin() + newind + 1);
-    }
-  } else {
-    newOrder[0] = labels[1];
-    newOrder[1] = labels[0];
-  }
-
-  // Reload the new labels order
-  modelslist.save(newOrder);
-  modelslist.clear();
-  modelslist.load();
+  modelslist.save(labels);
 
   return false;
 }

--- a/radio/src/storage/modelslist.cpp
+++ b/radio/src/storage/modelslist.cpp
@@ -481,12 +481,17 @@ bool ModelMap::moveLabelTo(unsigned curind, unsigned newind)
 
   LabelsVector newOrder = labels;
 
-  if (curind < newind) {  // Move forward
-    std::rotate(newOrder.rend() - curind - 1, newOrder.rend() - curind,
-                newOrder.rend() - newind);
-  } else {  // Move back
-    std::rotate(newOrder.begin() + curind, newOrder.begin() + curind + 1,
-                newOrder.begin() + newind + 1);
+  if (labels.size() > 2) {
+    if (curind < newind) {  // Move forward
+      std::rotate(newOrder.rend() - curind - 1, newOrder.rend() - curind,
+                  newOrder.rend() - newind);
+    } else {  // Move back
+      std::rotate(newOrder.begin() + curind, newOrder.begin() + curind + 1,
+                  newOrder.begin() + newind + 1);
+    }
+  } else {
+    newOrder[0] = labels[1];
+    newOrder[1] = labels[0];
   }
 
   // Reload the new labels order


### PR DESCRIPTION
Allow moving labels UP and Down when there are only two labels.
Fixes #2269

Summary of changes: std::rotate() does not support two elements vectors. Use swap instead.
