### PR TITLE
Fix 32 bits negative values YAML saving (#2270)

### DIFF
--- a/radio/src/storage/yaml/yaml_bits.cpp
+++ b/radio/src/storage/yaml/yaml_bits.cpp
@@ -244,7 +244,7 @@ char* yaml_rgb2hex(uint32_t i)
 
 int32_t yaml_to_signed(uint32_t i, uint32_t bits)
 {
-    if (i & (1 << (bits-1))) {
+    if (bits < 32 && (i & (1 << (bits-1)))) {
         i |= 0xFFFFFFFF << bits;
     }
 


### PR DESCRIPTION
Fixes #2270

Summary of changes:
No need for a bitwise OR if the value is a 32bits negative number. It's supposed to return the same value.