### PR TITLE
Allow LUA widget translations

### DIFF
--- a/radio/src/gui/colorlcd/widget_settings.cpp
+++ b/radio/src/gui/colorlcd/widget_settings.cpp
@@ -57,7 +57,7 @@ WidgetSettings::WidgetSettings(Window* parent, Widget* widget) :
     auto line = form->newLine(&grid);
 
     auto option = *optPtr;
-    new StaticText(line, rect_t{}, option.name, 0, COLOR_THEME_PRIMARY1);
+    new StaticText(line, rect_t{}, option.displayName ? option.displayName : option.name, 0, COLOR_THEME_PRIMARY1);
 
     switch (option.type) {
       case ZoneOption::Integer:

--- a/radio/src/gui/colorlcd/zone.h
+++ b/radio/src/gui/colorlcd/zone.h
@@ -77,6 +77,7 @@ struct ZoneOption
   ZoneOptionValue deflt;
   ZoneOptionValue min;
   ZoneOptionValue max;
+  const char * displayName;
 };
 
 struct ZoneOptionValueTyped

--- a/radio/src/lua/lua_widget_factory.h
+++ b/radio/src/lua/lua_widget_factory.h
@@ -38,8 +38,11 @@ class LuaWidgetFactory : public WidgetFactory
                  bool init = true) const override;
 
  protected:
+  void translateOptions(ZoneOption * options);
+
   int createFunction;
   int updateFunction;
   int refreshFunction;
   int backgroundFunction;
+  int translateFunction;
 };

--- a/radio/src/lua/widgets.cpp
+++ b/radio/src/lua/widgets.cpp
@@ -144,6 +144,7 @@ ZoneOption *createOptionsArray(int reference, uint8_t maxOptions)
             luaL_checktype(lsWidgets, -2, LUA_TNUMBER);  // key is number
             luaL_checktype(lsWidgets, -1, LUA_TSTRING);  // value is string
             option->name = lua_tostring(lsWidgets, -1);
+            option->displayName = nullptr;
             // TRACE("name = %s", option->name);
             break;
           case 1:
@@ -224,7 +225,7 @@ void luaLoadWidgetCallback()
   const char * name=NULL;
 
   int widgetOptions = 0, createFunction = 0, updateFunction = 0,
-      refreshFunction = 0, backgroundFunction = 0;
+      refreshFunction = 0, backgroundFunction = 0, translateFunction = 0;
 
   luaL_checktype(lsWidgets, -1, LUA_TTABLE);
 
@@ -253,6 +254,10 @@ void luaLoadWidgetCallback()
       backgroundFunction = luaL_ref(lsWidgets, LUA_REGISTRYINDEX);
       lua_pushnil(lsWidgets);
     }
+    else if (!strcmp(key, "translate")) {
+      translateFunction = luaL_ref(lsWidgets, LUA_REGISTRYINDEX);
+      lua_pushnil(lsWidgets);
+    }
   }
 
   if (name && createFunction) {
@@ -262,6 +267,8 @@ void luaLoadWidgetCallback()
       factory->updateFunction = updateFunction;
       factory->refreshFunction = refreshFunction;
       factory->backgroundFunction = backgroundFunction;   // NOSONAR
+      factory->translateFunction = translateFunction;
+      factory->translateOptions(options);
       TRACE("Loaded Lua widget %s", name);
     }
   }


### PR DESCRIPTION
Allows #221

Summary of changes:
Add the ability for Lua Widgets to display proper text in the Settings Menu as well as Display translated strings for Settings and The Widget name itself.

Backward compatibility is preserved as it adds a widget callback `translate(text, lang)` that is called if defined.

Example:

```lua
local name = "MyWidget"

local options = {
    {"FirstChannel", VALUE, 1},
    {"FillBackground", BOOL, 0},
    {"BgColor", COLOR, COLOR_THEME_SECONDARY3},
    {"TextColor", COLOR, COLOR_THEME_PRIMARY1},
    {"BarColor", COLOR, COLOR_THEME_SECONDARY1}
}

local function update(widget, options)
    widget.options = options
end

local function create(zone, options)
    local widget = {zone = zone, options = options}
    return widget
end

local function refresh(widget, event, touch)
end

local function translate(text, lang)
    local tr = {
        MyWidget = "My Widget",
        FirstChannel = "First Channel",
        FillBackground = "Fill Background?",
        BgColor = "Bg Color",
        TextColor = "Text Color",
        BarColor = "Color"
    }
    local tr_fr = {
        MyWidget = "Mon Gadget",
        FirstChannel = "Permier canal",
        FillBackground = "Remplir le fond ?",
        BgColor = "Couleur du fond",
        TextColor = "Couleur du texte",
        BarColor = "Couleur"
    }
    local v
    if lang == "FR" then
        v = tr_fr[text]
    else
        v = tr[text]
    end
    return v == nil and text or v
end

return {
    refresh = refresh,
    name = name,
    create = create,
    update = update,
    options = options,
    translate = translate
}
```

<img width="246" alt="Screen Shot 2022-09-05 at 10 18 51" src="https://user-images.githubusercontent.com/1387855/188460012-722b19a9-fc48-407d-aab6-6fd2283f7eb3.png">

<img width="259" alt="Screen Shot 2022-09-05 at 10 23 29" src="https://user-images.githubusercontent.com/1387855/188460103-154020bd-b132-4952-a7ed-0e59c50094e5.png">

<img width="456" alt="Screen Shot 2022-09-05 at 10 18 40" src="https://user-images.githubusercontent.com/1387855/188460132-96d4ea27-1d40-4dbf-b96d-832a7ded4768.png">

<img width="416" alt="Screen Shot 2022-09-05 at 10 23 35" src="https://user-images.githubusercontent.com/1387855/188460166-657a9b69-d666-4c25-9f7f-e54ca6dce520.png">





