### PR TITLE
feat(lua): Add several Lua API funcs and constants

### DIFF
--- a/radio/src/lua/api_colorlcd.cpp
+++ b/radio/src/lua/api_colorlcd.cpp
@@ -836,6 +836,39 @@ static int luaLcdDrawFilledRectangle(lua_State *L)
 
 
 /*luadoc
+@function lcd.invertRect(x, y, w, h [, flags])
+
+Invert a rectangle zone from top left corner (x,y) of specified width and height
+
+@param x,y (positive numbers) top left corner position
+
+@param w (number) width in pixels
+
+@param h (number) height in pixels
+
+@param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html)
+
+@status current Introduced in 2.8.0
+*/
+static int luaLcdInvertRect(lua_State *L)
+{
+  if (!luaLcdAllowed || !luaLcdBuffer)
+    return 0;
+
+  int x = luaL_checkinteger(L, 1);
+  int y = luaL_checkinteger(L, 2);
+  int w = luaL_checkinteger(L, 3);
+  int h = luaL_checkinteger(L, 4);
+
+  LcdFlags flags = luaL_optunsigned(L, 5, 0);
+  flags = flagsRGB(flags);
+
+  luaLcdBuffer->invertRect(x, y, w, h, flags);
+
+  return 0;
+}
+
+/*luadoc
 @function lcd.drawGauge(x, y, w, h, fill, maxfill [, flags])
 
 Draw a simple gauge that is filled based upon fill value
@@ -1350,6 +1383,7 @@ const luaL_Reg lcdLib[] = {
   { "drawLine", luaLcdDrawLine },
   { "drawRectangle", luaLcdDrawRectangle },
   { "drawFilledRectangle", luaLcdDrawFilledRectangle },
+  { "invertRect", luaLcdInvertRect },
   { "drawText", luaLcdDrawText },
   { "drawTextLines", luaLcdDrawTextLines },
   { "sizeText", luaLcdSizeText },

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -2603,6 +2603,10 @@ const luaR_value_entry opentxConstants[] = {
   { "SWITCH_COUNT", SWSRC_COUNT },
   { "MAX_SENSORS", MAX_TELEMETRY_SENSORS },
 
+  { "MAX_OUTPUT_CHANNELS", MAX_OUTPUT_CHANNELS },
+  { "LIMIT_EXT_PERCENT", LIMIT_EXT_PERCENT },
+  { "LIMIT_STD_PERCENT", LIMIT_STD_PERCENT },
+
   { "LS_FUNC_NONE", LS_FUNC_NONE },
   { "LS_FUNC_VEQUAL", LS_FUNC_VEQUAL },
   { "LS_FUNC_VALMOSTEQUAL", LS_FUNC_VALMOSTEQUAL },
@@ -2653,6 +2657,8 @@ const luaR_value_entry opentxConstants[] = {
   { "COLOR", ZoneOption::Color },
   { "BOOL", ZoneOption::Bool },
   { "STRING", ZoneOption::String },
+  { "TIMER", ZoneOption::Timer },
+  { "TEXT_SIZE", ZoneOption::TextSize },
   { "MENU_HEADER_HEIGHT", COLOR2FLAGS(MENU_HEADER_HEIGHT) },
 
   // Colors gui/colorlcd/colors.h

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -2447,6 +2447,27 @@ static int luaSources(lua_State * L)
   return 3;
 }
 
+/*luadoc
+@function getOutputValue(outputIndex)
+
+@param outputIndex: integer identifying the output channel number 0 for CH1, up to MAX_OUTPUT_CHANNELS - 1.
+
+@retval value current output value (number). Zero is returned for:
+ * non-existing outputs
+
+@status current Introduced in 2.8.0
+*/
+static int luaGetOutputValue(lua_State * L)
+{
+  mixsrc_t idx = luaL_checkinteger(L, 1);
+  if (idx >= 0 && idx < MAX_OUTPUT_CHANNELS) {
+    lua_pushinteger(L, channelOutputs[idx]);
+  } else {
+    lua_pushinteger(L, 0);
+  }
+  return 1;
+}
+
 const luaL_Reg opentxLib[] = {
   { "getTime", luaGetTime },
   { "getDateTime", luaGetDateTime },
@@ -2459,6 +2480,7 @@ const luaL_Reg opentxLib[] = {
   { "getRotEncSpeed", luaGetRotEncSpeed },
   { "getRotEncMode", luaGetRotEncMode },
   { "getValue", luaGetValue },
+  { "getOutputValue", luaGetOutputValue },
   { "getRAS", luaGetRAS },
   { "getTxGPS", luaGetTxGPS },
   { "getFieldInfo", luaGetFieldInfo },

--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -260,8 +260,9 @@ Get model timer parameters
  * `minuteBeep` (boolean) minute beep
  * `persistent` (number) persistent timer
  * `name` (string) timer name
+ * `showElapsed` (boolean) show elapsed
 
-@status current Introduced in 2.0.0, name added in 2.3.6
+@status current Introduced in 2.0.0, name added in 2.3.6, showElapsed added in 2.8.0
 */
 static int luaModelGetTimer(lua_State *L)
 {
@@ -276,6 +277,7 @@ static int luaModelGetTimer(lua_State *L)
     lua_pushtableboolean(L, "minuteBeep", timer.minuteBeep);
     lua_pushtableinteger(L, "persistent", timer.persistent);
     lua_pushtablenstring(L, "name", timer.name);
+    lua_pushtableboolean(L, "showElapsed", timer.showElapsed);
   }
   else {
     lua_pushnil(L);
@@ -295,7 +297,7 @@ Set model timer parameters
 @notice If a parameter is missing from the value, then
 that parameter remains unchanged.
 
-@status current Introduced in 2.0.0, name added in 2.3.6
+@status current Introduced in 2.0.0, name added in 2.3.6, showElapsed added in 2.8.0
 */
 static int luaModelSetTimer(lua_State *L)
 {
@@ -325,9 +327,12 @@ static int luaModelSetTimer(lua_State *L)
       else if (!strcmp(key, "persistent")) {
         timer.persistent = luaL_checkinteger(L, -1);
       }
-      if (!strcmp(key, "name")) {
+      else if (!strcmp(key, "name")) {
         const char * name = luaL_checkstring(L, -1);
         strncpy(timer.name, name, sizeof(timer.name));
+      }
+      else if (!strcmp(key, "showElapsed")) {
+        timer.showElapsed = lua_toboolean(L, -1);
       }
     }
     storageDirty(EE_MODEL);

--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -38,22 +38,26 @@ Get current Model information
 
 @retval table model information:
  * `name` (string) model name
+ * `extendedLimits` (boolean) extended limits enabled
  * `bitmap` (string) bitmap name (not present on X7)
  * `filename` (string) model filename
 
-@status current Introduced in 2.0.6, changed in 2.2.0, filename added in 2.6.0
+@status current Introduced in 2.0.6, changed in 2.2.0, filename added in 2.6.0, extendedLimits and labels added in 2.8.0
 */
 static int luaModelGetInfo(lua_State *L)
 {
   lua_newtable(L);
   lua_pushtablenstring(L, "name", g_model.header.name);
+  lua_pushtableboolean(L, "extendedLimits", g_model.extendedLimits);
 #if LCD_DEPTH > 1
   lua_pushtablenstring(L, "bitmap", g_model.header.bitmap);
 #endif
 
 #if defined(STORAGE_MODELSLIST)
+  lua_pushtablenstring(L, "labels", g_model.header.labels);
   lua_pushtablenstring(L, "filename", g_eeGeneral.currModelFilename);
 #else
+  lua_pushtablenstring(L, "labels", "");
   char fname[MODELIDX_STRLEN + sizeof(YAML_EXT)];
   getModelNumberStr(g_eeGeneral.currModel, fname);
   strcat(fname, YAML_EXT);
@@ -73,7 +77,7 @@ Set the current Model information
 @notice If a parameter is missing from the value, then
 that parameter remains unchanged.
 
-@status current Introduced in 2.0.6, changed in TODO
+@status current Introduced in 2.0.6, extendedLimits added in 2.8.0
 */
 static int luaModelSetInfo(lua_State *L)
 {
@@ -87,6 +91,9 @@ static int luaModelSetInfo(lua_State *L)
 #if defined(EEPROM)
       memcpy(modelHeaders[g_eeGeneral.currModel].name, g_model.header.name, sizeof(g_model.header.name));
 #endif
+    }
+    else if (!strcmp(key, "extendedLimits")) {
+      g_model.extendedLimits = lua_toboolean(L, -1);
     }
 #if LCD_DEPTH > 1
     else if (!strcmp(key, "bitmap")) {

--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -39,16 +39,18 @@ Get current Model information
 @retval table model information:
  * `name` (string) model name
  * `extendedLimits` (boolean) extended limits enabled
+ * `jitterFilter` (number) model level ADC filter
  * `bitmap` (string) bitmap name (not present on X7)
  * `filename` (string) model filename
 
-@status current Introduced in 2.0.6, changed in 2.2.0, filename added in 2.6.0, extendedLimits and labels added in 2.8.0
+@status current Introduced in 2.0.6, changed in 2.2.0, filename added in 2.6.0, extendedLimits, jitterFilter, and labels added in 2.8.0
 */
 static int luaModelGetInfo(lua_State *L)
 {
   lua_newtable(L);
   lua_pushtablenstring(L, "name", g_model.header.name);
   lua_pushtableboolean(L, "extendedLimits", g_model.extendedLimits);
+  lua_pushtableinteger(L, "jitterFilter", g_model.jitterFilter);
 #if LCD_DEPTH > 1
   lua_pushtablenstring(L, "bitmap", g_model.header.bitmap);
 #endif
@@ -77,7 +79,7 @@ Set the current Model information
 @notice If a parameter is missing from the value, then
 that parameter remains unchanged.
 
-@status current Introduced in 2.0.6, extendedLimits added in 2.8.0
+@status current Introduced in 2.0.6, extendedLimits and jitterFilter added in 2.8.0
 */
 static int luaModelSetInfo(lua_State *L)
 {
@@ -94,6 +96,11 @@ static int luaModelSetInfo(lua_State *L)
     }
     else if (!strcmp(key, "extendedLimits")) {
       g_model.extendedLimits = lua_toboolean(L, -1);
+    }
+    else if (!strcmp(key, "jitterFilter")) {
+      auto j = lua_tounsigned(L, -1);
+      if (j > OVERRIDE_ON) j = OVERRIDE_ON;
+      g_model.jitterFilter = j;
     }
 #if LCD_DEPTH > 1
     else if (!strcmp(key, "bitmap")) {

--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -1635,6 +1635,87 @@ static int luaModelResetSensor(lua_State *L)
   return 1;
 }
 
+#if defined(HELI)
+/*luadoc
+@function model.getSwashRing()
+
+Get heli swash parameters
+
+@retval table with heli swash parameters:
+* `type` (number) 0=---, 1=120, 2=120X, 3=140, 4=90
+* `value` (number) swash ring value (normally 0)
+* 'collectiveSource' (number) source index
+* 'aileronSource' (number) source index
+* 'elevatorSource' (number) source index
+* 'collectiveWeight'(value) -100 to 100
+* 'aileronWeight' (value) -100 to 100
+* 'elevatorWeight' (value) -100 to 100
+
+ @status current Introduced in 2.8.0
+*/
+static int luaModelGetSwashRing(lua_State *L)
+{
+  lua_newtable(L);
+  lua_pushtableinteger(L, "type", g_model.swashR.type);
+  lua_pushtableinteger(L, "value", g_model.swashR.value);
+  lua_pushtableinteger(L, "collectiveSource", g_model.swashR.collectiveSource);
+  lua_pushtableinteger(L, "aileronSource", g_model.swashR.aileronSource);
+  lua_pushtableinteger(L, "elevatorSource", g_model.swashR.elevatorSource);
+  lua_pushtableinteger(L, "collectiveWeight", g_model.swashR.collectiveWeight);
+  lua_pushtableinteger(L, "aileronWeight", g_model.swashR.aileronWeight);
+  lua_pushtableinteger(L, "elevatorWeight", g_model.swashR.elevatorWeight);
+
+  return 1;
+}
+
+/*luadoc
+@function model.setSwashRing(params)
+
+Set heli swash parameters
+
+@param value (table) swash ring parameters, see model.getSwashRing() for table format
+
+@notice If a parameter is missing, then that parameter remains unchanged.
+
+@status current Introduced in 2.8.0
+*/
+static int luaModelSetSwashRing(lua_State *L)
+{
+  luaL_checktype(L, -1, LUA_TTABLE);
+  for (lua_pushnil(L); lua_next(L, -2); lua_pop(L, 1)) {
+    luaL_checktype(L, -2, LUA_TSTRING); // key is string
+    const char * key = luaL_checkstring(L, -2);
+    if (!strcmp(key, "type")) {
+      g_model.swashR.type = luaL_checkinteger(L, -1);
+    }
+    else if (!strcmp(key, "value")) {
+      g_model.swashR.value = luaL_checkinteger(L, -1);
+    }
+    else if (!strcmp(key, "collectiveSource")) {
+      g_model.swashR.collectiveSource = luaL_checkinteger(L, -1);
+    }
+    else if (!strcmp(key, "aileronSource")) {
+      g_model.swashR.aileronSource = luaL_checkinteger(L, -1);
+    }
+    else if (!strcmp(key, "elevatorSource")) {
+      g_model.swashR.elevatorSource = luaL_checkinteger(L, -1);
+    }
+    else if (!strcmp(key, "collectiveWeight")) {
+      g_model.swashR.collectiveWeight = luaL_checkinteger(L, -1);
+    }
+    else if (!strcmp(key, "aileronWeight")) {
+      g_model.swashR.aileronWeight = luaL_checkinteger(L, -1);
+    }
+    else if (!strcmp(key, "elevatorWeight")) {
+      g_model.swashR.elevatorWeight = luaL_checkinteger(L, -1);
+    }
+  }
+
+  storageDirty(EE_MODEL);
+  return 0;
+}
+#endif // HELI
+
 const luaL_Reg modelLib[] = {
   { "getInfo", luaModelGetInfo },
   { "setInfo", luaModelSetInfo },
@@ -1671,5 +1752,9 @@ const luaL_Reg modelLib[] = {
 #endif
   { "getSensor", luaModelGetSensor },
   { "resetSensor", luaModelResetSensor },
-  { NULL, NULL }  /* sentinel */
+#if defined(HELI)
+  { "getSwashRing", luaModelGetSwashRing },
+  { "setSwashRing", luaModelSetSwashRing },
+#endif
+  { nullptr, nullptr }  /* sentinel */
 };


### PR DESCRIPTION
Allows #221

Summary of changes:
Add missing LUA functions and constants to be able to recreate the C++ native widgets in LUA.

- [X] Add Bitmap.toMask and lcd.drawBitmapPattern functions: Draw pattern masks from PNG Bitmaps
- [X] Add lcd.invertRect function: Invert a rectangle
- [X] Add Bitmap.resize function: Resize a Bitmap to the desired dimensions
- [X] Add getOutputValue function: Get the value of the channel as sent to the RX
- [X] Add timer showElapsed configuration
- [X] Add model extendedLimits configuration
- [X] Get model labels
- [X] Add some global constants (MAX_OUTPUT_CHANNELS, LIMIT_EXT_PERCENT, LIMIT_STD_PERCENT)
- [X] Add model jitterFilter (ADC Filter) configuration
- [X] Add model.getSwashRing and setSwashRing functions
