### PR TITLE
fix(color): Limit label lengths, improve lbl display, prevent inv. char

### DIFF
--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -46,6 +46,7 @@ class AbstractStaticItemModel;
 constexpr char AIM_MODELDATA_TRAINERMODE[]  {"modeldata.trainermode"};
 constexpr char AIM_MODELDATA_FUNCSWITCHCONFIG[]  {"modeldata.funcswitchconfig"};
 constexpr char AIM_MODELDATA_FUNCSWITCHSTART[]  {"modeldata.funcswitchstart"};
+constexpr int LABEL_LENGTH=16;
 
 #define CHAR_FOR_NAMES " ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-."
 #define CHAR_FOR_NAMES_REGEX "[ A-Za-z0-9_.-,]*"

--- a/companion/src/firmwares/radiodata.cpp
+++ b/companion/src/firmwares/radiodata.cpp
@@ -106,33 +106,30 @@ void RadioData::convert(RadioDataConversionState & cstate)
 
 void RadioData::addLabel(QString label)
 {
-  label.replace("/c",",");
-  label.replace("//","/");
-  if(labels.indexOf(label) == -1)
+  label = unEscapeCSV(label);
+  if (labels.indexOf(label) == -1)
     labels.append(label);
 }
 
 bool RadioData::deleteLabel(QString label)
 {
   bool deleted = false;
-  QString csvLabel = label;
-  csvLabel.replace("/","//");
-  csvLabel.replace(",","/c");
 
   // Remove labels in the models
   for(auto& model : models) {
-    QStringList modelLabels = QString(model.labels).split(',',QString::SkipEmptyParts);
-    if(modelLabels.indexOf(csvLabel) >= 0)
+    QStringList modelLabels = fromCSV(model.labels);
+    if (modelLabels.indexOf(label) >= 0) {
       deleted = true;
-    modelLabels.removeAll(csvLabel);
-    strcpy(model.labels, QString(modelLabels.join(',')).toLocal8Bit().data());
+      modelLabels.removeAll(label);
+    }
+    strcpy(model.labels, toCSV(modelLabels).toLocal8Bit().data());
   }
 
   // Remove the label from the global list
   labels.removeAll(label);
 
   // If no labels remain, add a Favorites one
-  if(!labels.size()) {
+  if (!labels.size()) {
     addLabel(tr("Favorites"));
   }
   return deleted;
@@ -140,42 +137,44 @@ bool RadioData::deleteLabel(QString label)
 
 bool RadioData::deleteLabel(int index)
 {
-  if(index >= labels.size()) return false;
+  if (index >= labels.size()) return false;
   QString modelLabel = labels.at(index);
   return deleteLabel(modelLabel);
 }
 
 bool RadioData::renameLabel(QString from, QString to)
 {
-  bool success = true;
-  int lengthdiff = to.size() - from.size();
-  QString csvFrom = from;
-  QString csvTo = to;
-  csvFrom.replace("/","//");
-  csvFrom.replace(",","/c");
-  csvTo.replace("/","//");
-  csvTo.replace(",","/c");
+  bool success = true;  
+  QString csvFrom = escapeCSV(from);
+  QString csvTo = escapeCSV(to);
+  int lengthdiff = csvTo.size() - csvFrom.size();
 
-
-  // Check that rename is possible, not too long
+  // Check that rename is possible (Rename won't cause too long of a string)
   for(auto& model : models) {
-    if((int)strlen(model.labels) + lengthdiff > (int)sizeof(model.labels) - 1) {
-      success = false;
+    if ((int)strlen(model.labels) + lengthdiff > (int)sizeof(model.labels) - 1) {
+      success = false;     
+      throw std::length_error(model.name);
+      break;
     }
   }
-  if(success) {
+  if (success) {
     for(auto& model : models) {
       QStringList modelLabels = QString(model.labels).split(',',QString::SkipEmptyParts);
       int ind = modelLabels.indexOf(csvFrom);
-      if(ind != -1) {
+      if (ind != -1) {
         modelLabels.replace(ind, csvTo);
         QString outputcsv = QString(modelLabels.join(','));
-        if(outputcsv.toLocal8Bit().size() < (int)sizeof(model.labels));
+        if (outputcsv.toLocal8Bit().size() < (int)sizeof(model.labels)) {
           strcpy(model.labels, outputcsv.toLocal8Bit().data());
+        } else { // Shouldn't ever get here, from check above
+          success = false;
+          throw std::length_error(model.name);
+          break;
+        }
       }
     }
     int ind = labels.indexOf(from);
-    if(ind != -1) {
+    if (ind != -1) {
       labels.replace(ind, to);
     }
   }
@@ -184,42 +183,38 @@ bool RadioData::renameLabel(QString from, QString to)
 
 bool RadioData::renameLabel(int index, QString to)
 {
-  if(index >= labels.size()) return false;
+  if (index >= labels.size()) return false;
   QString from = labels.at(index);
   return renameLabel(from, to);
 }
 
 bool RadioData::addLabelToModel(int index, QString label)
 {
-  if(index >= models.size()) return false;
-
-  label.replace("/","//");
-  label.replace(",","/c");
+  if (index >= models.size()) return false;
+  label = escapeCSV(label);
 
   char *modelLabelCsv = models[index].labels;
   // Make sure it will fit
-  if(strlen(modelLabelCsv) + label.size() + 1 < sizeof(models[index].labels)-1) {
+  if (strlen(modelLabelCsv) + label.size() + 1 < sizeof(models[index].labels)-1) {
     QStringList modelLabels = QString(modelLabelCsv).split(',',QString::SkipEmptyParts);
-    if(modelLabels.indexOf(label) == -1) {
+    if (modelLabels.indexOf(label) == -1) {
       modelLabels.append(label);
       strcpy(models[index].labels, QString(modelLabels.join(',')).toLocal8Bit().data());
       return true;
     }
   }
+  throw std::length_error(models[index].name);
   return false;
 }
 
 bool RadioData::removeLabelFromModel(int index, QString label)
 {
-  if(index >= models.size()) return false;
-  label.replace("/","//");
-  label.replace(",","/c");
+  if (index >= models.size()) return false;
 
-  char *modelLabelCsv = models[index].labels;
-  QStringList modelLabels = QString(modelLabelCsv).split(',',QString::SkipEmptyParts);
-  if(modelLabels.indexOf(label) >= 0) {
-    modelLabels.removeAll(label);
-    strcpy(models[index].labels, QString(modelLabels.join(',')).toLocal8Bit().data());
+  QStringList lbls = fromCSV(models[index].labels);
+  if (lbls.indexOf(label) >= 0) {
+    lbls.removeAll(label);
+    strcpy(models[index].labels, toCSV(lbls).toLocal8Bit().data());
     return true;
   }
   return false;
@@ -233,4 +228,35 @@ void RadioData::addLabelsFromModels()
       addLabel(label);
     }
   }
+}
+
+QStringList RadioData::fromCSV(const QString &csv)
+{
+  QStringList lbls = QString(csv).split(',',QString::SkipEmptyParts);
+  for(QString &label: lbls) {
+    label = unEscapeCSV(label);
+  }
+  return lbls;
+}
+
+QString RadioData::toCSV(QStringList lbls)
+{
+  for(QString &label: lbls) {
+    label = escapeCSV(label);
+  }
+  return lbls.join(',');
+}
+
+QString RadioData::escapeCSV(QString str)
+{
+  str.replace("/","//");
+  str.replace(",","/c");
+  return str;
+}
+
+QString RadioData::unEscapeCSV(QString str)
+{
+  str.replace("/c",",");
+  str.replace("//","/");
+  return str;
 }

--- a/companion/src/firmwares/radiodata.h
+++ b/companion/src/firmwares/radiodata.h
@@ -27,6 +27,7 @@ class RadioData {
     bool deleteLabel(int index);
     bool renameLabel(QString from, QString to);
     bool renameLabel(int index, QString to);
+    void swapLabel(int indFrom, int indTo);
     bool addLabelToModel(int index, QString label);
     bool removeLabelFromModel(int index, QString label);
     void addLabelsFromModels();

--- a/companion/src/firmwares/radiodata.h
+++ b/companion/src/firmwares/radiodata.h
@@ -31,6 +31,11 @@ class RadioData {
     bool removeLabelFromModel(int index, QString label);
     void addLabelsFromModels();
 
+    static QStringList fromCSV(const QString &csv);
+    static QString toCSV(QStringList lbls);
+    static QString escapeCSV(QString str);
+    static QString unEscapeCSV(QString str);
+
     void setCurrentModel(unsigned int index);
     void fixModelFilenames();
     QString getNextModelFilename();
@@ -41,4 +46,5 @@ class RadioData {
 
   protected:
     void fixModelFilename(unsigned int index);
+
 };

--- a/companion/src/labels.cpp
+++ b/companion/src/labels.cpp
@@ -221,6 +221,14 @@ QValidator::State LabelValidator::validate(QString &label, int &pos) const
   QString lbl = RadioData::escapeCSV(label);
   if (lbl.toUtf8().size() > LABEL_LENGTH)
     return QValidator::Invalid;
+  if(lbl.contains('\\') || // TODO: Fix me to allow all, requires FW changes
+     lbl.contains('\"') ||
+     lbl.contains(':') ||
+     lbl.contains('-') ||
+     lbl.contains('\''))
+    return QValidator::Invalid;
+  if(lbl.size() == 0)
+    return QValidator::Intermediate;
   return QValidator::Acceptable;
 }
 
@@ -238,4 +246,9 @@ void LabelValidator::fixup(QString &input) const
     output.truncate(truncateAt);
   }
   input = QString(output);
+  input.remove('\\'); // TODO: Fix me to allow all, requires FW changes
+  input.remove('\"');
+  input.remove(':');
+  input.remove('-');
+  input.remove('\'');
 }

--- a/companion/src/labels.cpp
+++ b/companion/src/labels.cpp
@@ -102,7 +102,7 @@ QVariant LabelsModel::data(const QModelIndex &index, int role) const
       label = RadioData::escapeCSV(label);
       return modelLabels.indexOf(label)==-1?Qt::Unchecked:Qt::Checked;
     } else if (index.column() == 0 && selectedModel == -1) {
-      return Qt::PartiallyChecked;
+      return Qt::Unchecked;
     }
   }
   return QVariant();

--- a/companion/src/labels.h
+++ b/companion/src/labels.h
@@ -4,6 +4,9 @@
 #include <QList>
 #include <QAbstractItemModel>
 #include <QItemSelectionModel>
+#include <QValidator>
+#include <QLineEdit>
+#include <QStyledItemDelegate>
 
 #include "radiodata.h"
 
@@ -29,11 +32,6 @@ public:
   int rowCount(const QModelIndex &parent = QModelIndex()) const override;
   int columnCount(const QModelIndex &parent = QModelIndex()) const override;
   QVariant headerData(int section, Qt::Orientation orientation, int role = Qt::DisplayRole) const override;
-  Qt::DropActions supportedDropActions() const override;
-  QStringList mimeTypes() const override;
-  QMimeData *mimeData(const QModelIndexList &indexes) const override;
-  bool canDropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) const override;
-  bool dropMimeData(const QMimeData *data, Qt::DropAction action, int row, int column, const QModelIndex &parent) override;
   bool insertRows(int row, int count, const QModelIndex &parent) override;
   bool removeRows(int row, int count, const QModelIndex &parent) override;
 
@@ -53,4 +51,28 @@ private:
   int selectedModel;
   QList<QModelIndex> modelIndices;
   QList<LabelItem> labels;
+};
+
+class LabelValidator : public QValidator
+{
+  Q_OBJECT
+public:
+  QValidator::State validate(QString &label, int &pos) const;
+ void fixup(QString &input) const;
+};
+
+class LabelEditTextDelegate : public QStyledItemDelegate
+{
+  Q_OBJECT
+
+public:
+  LabelEditTextDelegate(QObject *parent = nullptr) : QStyledItemDelegate(parent) {}
+
+  QWidget *createEditor(QWidget *parent, const QStyleOptionViewItem &option,
+                        const QModelIndex &index) const
+  {
+    QLineEdit *editor = new QLineEdit(parent);
+    editor->setValidator(new LabelValidator);
+    return editor;
+  }
 };

--- a/companion/src/labels.h
+++ b/companion/src/labels.h
@@ -45,7 +45,7 @@ private slots:
 
 signals:
   void modelChanged(int index);
-  void renameFault(QString msg);
+  void labelsFault(QString msg);
 
 private:
   QItemSelectionModel *modelsSelection;

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -359,8 +359,8 @@ void MdiChild::retranslateUi()
   action[ACT_ITM_EDT]->setText(tr("Edit Model"));
   action[ACT_ITM_DEL]->setText(tr("Delete"));
 
-  action[ACT_LBL_ADD]->setText(tr("Add Label"));
-  action[ACT_LBL_DEL]->setText(tr("Delete Label"));
+  action[ACT_LBL_ADD]->setText(tr("Add"));
+  action[ACT_LBL_DEL]->setText(tr("Delete"));
   action[ACT_LBL_REN]->setText(tr("Rename"));
   action[ACT_LBL_MVU]->setText(tr("Move Up"));
   action[ACT_LBL_MVD]->setText(tr("Move Down"));

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -509,7 +509,7 @@ void MdiChild::initModelsList()
   labelsListModel = new LabelsModel(ui->modelsList->selectionModel(),
                                     &radioData, this);
   connect(labelsListModel, &LabelsModel::modelChanged, this, &MdiChild::modelLabelsChanged);
-  connect(labelsListModel, &LabelsModel::renameFault, this, &MdiChild::labelRenameFault);
+  connect(labelsListModel, &LabelsModel::labelsFault, this, &MdiChild::labelsFault);
   ui->lstLabels->setModel(labelsListModel);
   ui->lstLabels->setSelectionMode(QAbstractItemView::SingleSelection);
   ui->lstLabels->setDragEnabled(true);
@@ -1651,7 +1651,7 @@ void MdiChild::modelLabelsChanged()
   refresh();
 }
 
-void MdiChild::labelRenameFault(QString msg)
+void MdiChild::labelsFault(QString msg)
 {
   QMessageBox::warning(this, CPN_STR_TTL_WARNING, msg);
 }

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -221,7 +221,10 @@ void MdiChild::setupNavigation()
   addAct(ACT_MDL_WIZ, "wizard.png", SLOT(wizardEdit()), tr("Alt+W"));
 
   addAct(ACT_LBL_ADD, "add.png",    SLOT(labelAdd()), tr("Alt-L"));
-  addAct(ACT_LBL_DEL, "clear.png",    SLOT(labelDelete()), tr("Alt-L"));
+  addAct(ACT_LBL_DEL, "clear.png",  SLOT(labelDelete()), tr("Alt-L"));
+  addAct(ACT_LBL_REN, "edit.png",   SLOT(labelRename()), tr("Alt-R"));
+  addAct(ACT_LBL_MVU, "moveup.png", SLOT(labelMoveUp()), tr("Alt-+"));
+  addAct(ACT_LBL_MVD, "movedown.png", SLOT(labelMoveDown()), tr("Alt--"));
 
   addAct(ACT_MDL_DFT, "currentmodel.png", SLOT(setDefault()),     tr("Alt+U"));
   addAct(ACT_MDL_PRT, "print.png",        SLOT(print()),          QKeySequence::Print);
@@ -247,7 +250,7 @@ void MdiChild::setupNavigation()
   // Add labels Label to bottom layout
   if(lblLabels)
     lblLabels->deleteLater();
-  lblLabels = new QLabel(tr("Labels"));
+  lblLabels = new QLabel(tr("Labels Management"));
   lblLabels->setStyleSheet("font-weight: bold");
   ui->bottomLayout->addWidget(lblLabels);
 
@@ -261,6 +264,9 @@ void MdiChild::setupNavigation()
   labelsToolbar->setStyleSheet(tbCss);
   labelsToolbar->addAction(getAction(ACT_LBL_ADD));
   labelsToolbar->addAction(getAction(ACT_LBL_DEL));
+  labelsToolbar->addAction(getAction(ACT_LBL_REN));
+  labelsToolbar->addAction(getAction(ACT_LBL_MVU));
+  labelsToolbar->addAction(getAction(ACT_LBL_MVD));
   ui->bottomLayout->addWidget(labelsToolbar);
 
   if (radioToolbar)
@@ -355,6 +361,9 @@ void MdiChild::retranslateUi()
 
   action[ACT_LBL_ADD]->setText(tr("Add Label"));
   action[ACT_LBL_DEL]->setText(tr("Delete Label"));
+  action[ACT_LBL_REN]->setText(tr("Rename"));
+  action[ACT_LBL_MVU]->setText(tr("Move Up"));
+  action[ACT_LBL_MVD]->setText(tr("Move Down"));
 
   action[ACT_MDL_ADD]->setText(tr("Add Model"));
   action[ACT_MDL_ADD]->setIconText(tr("Model"));
@@ -369,6 +378,7 @@ void MdiChild::retranslateUi()
 
   radioToolbar->setWindowTitle(tr("Show Radio Actions Toolbar"));
   modelsToolbar->setWindowTitle(tr("Show Model Actions Toolbar"));
+  labelsToolbar->setWindowTitle(tr("Show Labels Actions Toolbar"));
 }
 
 QList<QAction *> MdiChild::getGeneralActions()
@@ -416,6 +426,9 @@ QList<QAction *> MdiChild::getLabelsActions()
   QList<QAction *> actGrp;
   actGrp.append(getAction(ACT_LBL_ADD));
   actGrp.append(getAction(ACT_LBL_DEL));
+  actGrp.append(getAction(ACT_LBL_REN));
+  actGrp.append(getAction(ACT_LBL_MVU));
+  actGrp.append(getAction(ACT_LBL_MVD));
   return actGrp;
 }
 
@@ -457,6 +470,9 @@ void MdiChild::showLabelsContextMenu(const QPoint &pos)
 
   contextMenu.addAction(action[ACT_LBL_ADD]);
   contextMenu.addAction(action[ACT_LBL_DEL]);
+  contextMenu.addAction(action[ACT_LBL_REN]);
+  contextMenu.addAction(action[ACT_LBL_MVU]);
+  contextMenu.addAction(action[ACT_LBL_MVD]);
 
   if (!contextMenu.isEmpty())
     contextMenu.exec(ui->lstLabels->mapToGlobal(pos));
@@ -467,6 +483,7 @@ void MdiChild::showContextMenu(const QPoint & pos)
   QMenu contextMenu;
   contextMenu.addAction(modelsToolbar->toggleViewAction());
   contextMenu.addAction(radioToolbar->toggleViewAction());
+  contextMenu.addAction(labelsToolbar->toggleViewAction());
   if (!contextMenu.isEmpty())
     contextMenu.exec(mapToGlobal(pos));
 }
@@ -512,12 +529,8 @@ void MdiChild::initModelsList()
   connect(labelsListModel, &LabelsModel::labelsFault, this, &MdiChild::labelsFault);
   ui->lstLabels->setModel(labelsListModel);
   ui->lstLabels->setSelectionMode(QAbstractItemView::SingleSelection);
-  ui->lstLabels->setDragEnabled(true);
-  ui->lstLabels->setAcceptDrops(true);
-  ui->lstLabels->setDropIndicatorShown(true);
-  ui->lstLabels->setDragDropOverwriteMode(false);
-  ui->lstLabels->setDragDropMode(QAbstractItemView::InternalMove);
   ui->lstLabels->setEditTriggers(QAbstractItemView::DoubleClicked | QAbstractItemView::EditKeyPressed);
+  ui->lstLabels->setItemDelegate(new LabelEditTextDelegate);
 
   ui->modelsList->setIndentation(0);
 
@@ -1635,20 +1648,54 @@ void MdiChild::modelSave()
 void MdiChild::labelAdd()
 {
   labelsListModel->insertRow(0);
+  QModelIndex newind = labelsListModel->index(0,0);
+  ui->lstLabels->setCurrentIndex(newind);
+  ui->lstLabels->edit(newind);
   setWindowModified(true);
 }
 
 void MdiChild::labelDelete()
 {
   int row = ui->lstLabels->selectionModel()->currentIndex().row();
+  if(row < 0) return;
   labelsListModel->removeRow(row);
   setWindowModified(true);
 }
 
-void MdiChild::modelLabelsChanged()
+void MdiChild::labelRename()
+{
+  int row = ui->lstLabels->selectionModel()->currentIndex().row();
+  if(row < 0) return;
+  QModelIndex newind = labelsListModel->index(row,0);
+  ui->lstLabels->setCurrentIndex(newind);
+  ui->lstLabels->edit(newind);
+}
+
+void MdiChild::labelMoveUp()
+{
+  int row = ui->lstLabels->selectionModel()->currentIndex().row();
+  radioData.swapLabel(row, row-1);
+  labelsListModel->buildLabelsList();
+  ui->lstLabels->selectionModel()->select(labelsListModel->index(row-1,0), QItemSelectionModel::ClearAndSelect |
+                                                                           QItemSelectionModel::Rows);
+}
+
+void MdiChild::labelMoveDown()
+{
+  int row = ui->lstLabels->selectionModel()->currentIndex().row();
+  radioData.swapLabel(row, row+1);
+  labelsListModel->buildLabelsList();
+  ui->lstLabels->selectionModel()->select(labelsListModel->index(row+1,0), QItemSelectionModel::ClearAndSelect |
+                                                                           QItemSelectionModel::Rows);
+
+}
+
+void MdiChild::modelLabelsChanged(int row)
 {
   setWindowModified(true);
   refresh();
+  ui->modelsList->selectionModel()->select(modelsListModel->index(row,0), QItemSelectionModel::ClearAndSelect |
+                                                                          QItemSelectionModel::Rows);
 }
 
 void MdiChild::labelsFault(QString msg)

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1676,8 +1676,8 @@ void MdiChild::labelMoveUp()
   int row = ui->lstLabels->selectionModel()->currentIndex().row();
   radioData.swapLabel(row, row-1);
   labelsListModel->buildLabelsList();
-  ui->lstLabels->selectionModel()->select(labelsListModel->index(row-1,0), QItemSelectionModel::ClearAndSelect |
-                                                                           QItemSelectionModel::Rows);
+  //ui->lstLabels->selectionModel()->select(labelsListModel->index(row-1,0), QItemSelectionModel::ClearAndSelect);
+  ui->lstLabels->selectionModel()->setCurrentIndex(labelsListModel->index(row-1,0), QItemSelectionModel::ClearAndSelect);
 }
 
 void MdiChild::labelMoveDown()
@@ -1685,8 +1685,8 @@ void MdiChild::labelMoveDown()
   int row = ui->lstLabels->selectionModel()->currentIndex().row();
   radioData.swapLabel(row, row+1);
   labelsListModel->buildLabelsList();
-  ui->lstLabels->selectionModel()->select(labelsListModel->index(row+1,0), QItemSelectionModel::ClearAndSelect |
-                                                                           QItemSelectionModel::Rows);
+  //ui->lstLabels->selectionModel()->select(labelsListModel->index(row+1,0), QItemSelectionModel::ClearAndSelect);
+  ui->lstLabels->selectionModel()->setCurrentIndex(labelsListModel->index(row+1,0), QItemSelectionModel::ClearAndSelect);
 
 }
 

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -483,7 +483,8 @@ void MdiChild::showContextMenu(const QPoint & pos)
   QMenu contextMenu;
   contextMenu.addAction(modelsToolbar->toggleViewAction());
   contextMenu.addAction(radioToolbar->toggleViewAction());
-  contextMenu.addAction(labelsToolbar->toggleViewAction());
+  if(firmware->getCapability(Capability::HasModelLabels))
+    contextMenu.addAction(labelsToolbar->toggleViewAction());
   if (!contextMenu.isEmpty())
     contextMenu.exec(mapToGlobal(pos));
 }

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1675,20 +1675,19 @@ void MdiChild::labelRename()
 void MdiChild::labelMoveUp()
 {
   int row = ui->lstLabels->selectionModel()->currentIndex().row();
+  if(row == 0) return;
   radioData.swapLabel(row, row-1);
   labelsListModel->buildLabelsList();
-  //ui->lstLabels->selectionModel()->select(labelsListModel->index(row-1,0), QItemSelectionModel::ClearAndSelect);
   ui->lstLabels->selectionModel()->setCurrentIndex(labelsListModel->index(row-1,0), QItemSelectionModel::ClearAndSelect);
 }
 
 void MdiChild::labelMoveDown()
 {
   int row = ui->lstLabels->selectionModel()->currentIndex().row();
+  if(row == labelsListModel->rowCount() -1) return;
   radioData.swapLabel(row, row+1);
   labelsListModel->buildLabelsList();
-  //ui->lstLabels->selectionModel()->select(labelsListModel->index(row+1,0), QItemSelectionModel::ClearAndSelect);
   ui->lstLabels->selectionModel()->setCurrentIndex(labelsListModel->index(row+1,0), QItemSelectionModel::ClearAndSelect);
-
 }
 
 void MdiChild::modelLabelsChanged(int row)

--- a/companion/src/mdichild.h
+++ b/companion/src/mdichild.h
@@ -56,6 +56,9 @@ class MdiChild : public QWidget
       ACT_ITM_DEL,  // delete model or cat
       ACT_LBL_ADD,
       ACT_LBL_DEL,
+      ACT_LBL_MVU,  // Move up
+      ACT_LBL_MVD,  // Move down
+      ACT_LBL_REN,  // Move down
       ACT_MDL_ADD,  // model actions...
       ACT_MDL_CPY,
       ACT_MDL_CUT,
@@ -140,7 +143,10 @@ class MdiChild : public QWidget
     void modelSave();
     void labelAdd();
     void labelDelete();
-    void modelLabelsChanged();
+    void labelRename();
+    void labelMoveUp();
+    void labelMoveDown();
+    void modelLabelsChanged(int row);
     void labelsFault(QString msg);
     void wizardEdit();
     void modelDuplicate();

--- a/companion/src/mdichild.h
+++ b/companion/src/mdichild.h
@@ -141,7 +141,7 @@ class MdiChild : public QWidget
     void labelAdd();
     void labelDelete();
     void modelLabelsChanged();
-    void labelRenameFault(QString msg);
+    void labelsFault(QString msg);
     void wizardEdit();
     void modelDuplicate();
 

--- a/companion/src/modelslist.cpp
+++ b/companion/src/modelslist.cpp
@@ -681,8 +681,8 @@ void ModelsListModel::refresh()
       }
       current->setData(currentColumn++, rxs);
     }
-   if (hasLabels) {     
-     QStringList labels = RadioData::fromCSV(model.labels);
+   if (hasLabels) {
+      QStringList labels = RadioData::fromCSV(QString::fromUtf8(model.labels));
      current->setData(currentColumn++, labels.join(QChar(0x2022)));
    }
   }

--- a/companion/src/modelslist.cpp
+++ b/companion/src/modelslist.cpp
@@ -681,8 +681,9 @@ void ModelsListModel::refresh()
       }
       current->setData(currentColumn++, rxs);
     }
-   if (hasLabels) {
-     current->setData(currentColumn++, QString(model.labels));
+   if (hasLabels) {     
+     QStringList labels = RadioData::fromCSV(model.labels);
+     current->setData(currentColumn++, labels.join(QChar(0x2022)));
    }
   }
 }

--- a/radio/src/dataconstants.h
+++ b/radio/src/dataconstants.h
@@ -38,6 +38,7 @@
 #endif
 
 #define LABELS_LENGTH 100 // Maximum length of the label string
+#define LABEL_LENGTH 16
 
 #if defined(PCBHORUS) || defined(PCBNV14)
   #define MAX_MODELS                   60

--- a/radio/src/dataconstants.h
+++ b/radio/src/dataconstants.h
@@ -38,7 +38,6 @@
 #endif
 
 #define LABELS_LENGTH 100 // Maximum length of the label string
-#define LABEL_LENGTH 20   // Maximum length of a single label
 
 #if defined(PCBHORUS) || defined(PCBNV14)
   #define MAX_MODELS                   60

--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -583,11 +583,9 @@ void ModelLabelsWindow::newModel()
     // On complete update the current cell's data
     modelslist.updateCurrentModelCell();
 
-    auto labels = getLabels();
-    lblselector->setNames(labels);
-    lblselector->setSelected(modelslabels.getLabels().size());
-    mdlselector->update(0);
-    setTitle();
+    // Close Window
+    auto w = Layer::back();
+    if (w) w->onCancel();
   });
 }
 

--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -495,8 +495,8 @@ class LabelDialog : public Dialog
       Dialog(parent, STR_ENTER_LABEL, rect_t{}),
       saveHandler(std::move(_saveHandler))
   {
-    strncpy(this->label, label, MAX_LABEL_SIZE);
-    this->label[MAX_LABEL_SIZE] = '\0';
+    strncpy(this->label, label, LABEL_LENGTH);
+    this->label[LABEL_LENGTH] = '\0';
 
     auto form = &content->form;
     form->padRow(lv_dpx(8));
@@ -504,7 +504,7 @@ class LabelDialog : public Dialog
     auto form_obj = form->getLvObj();
     lv_obj_set_style_flex_cross_place(form_obj, LV_FLEX_ALIGN_CENTER, 0);
 
-    new TextEdit(form, rect_t{}, label, MAX_LABEL_SIZE);
+    new TextEdit(form, rect_t{}, label, LABEL_LENGTH);
 
     auto box = new FormGroup(form, rect_t{});
     box->setFlexLayout(LV_FLEX_FLOW_ROW);
@@ -537,7 +537,7 @@ class LabelDialog : public Dialog
 
  protected:
   std::function<void(std::string label)> saveHandler;
-  char label[MAX_LABEL_SIZE + 1];
+  char label[LABEL_LENGTH + 1];
 };
 
 //-----------------------------------------------------------------------------
@@ -736,8 +736,8 @@ void ModelLabelsWindow::buildBody(FormWindow *window)
         menu->setTitle(selectedLabel);
         menu->addLine(STR_RENAME_LABEL, [=]() {
           auto oldLabel = labels[selected];
-          strncpy(tmpLabel, oldLabel.c_str(), MAX_LABEL_SIZE);
-          tmpLabel[MAX_LABEL_SIZE] = '\0';
+          strncpy(tmpLabel, oldLabel.c_str(), LABEL_LENGTH);
+          tmpLabel[LABEL_LENGTH] = '\0';
           new LabelDialog(this, tmpLabel, [=](std::string newLabel) {
             auto rndialog =
                 new ProgressDialog(this, STR_RENAME_LABEL, [=]() {});

--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -383,7 +383,6 @@ void ModelsPageBody::selectModel(ModelCell *model)
   storageCheck(true);
 
   modelslist.setCurrentModel(model);
-  checkAll();
 
   // Exit to main view
   auto w = Layer::back();

--- a/radio/src/gui/colorlcd/model_select.h
+++ b/radio/src/gui/colorlcd/model_select.h
@@ -30,8 +30,6 @@
 #include "storage/modelslist.h"
 #include "tabsgroup.h"
 
-constexpr int MAX_LABEL_SIZE = 20;
-
 class ModelButton;
 
 class ModelsPageBody : public FormWindow
@@ -78,7 +76,7 @@ class ModelLabelsWindow : public Page
 
  protected:
   ModelsSortBy sort = DEFAULT_MODEL_SORT;
-  char tmpLabel[MAX_LABEL_SIZE + 1] = "\0";
+  char tmpLabel[LABEL_LENGTH + 1] = "\0";
   ListBox *lblselector;
   ModelsPageBody *mdlselector;
   std::string currentLabel;

--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -120,7 +120,7 @@ void SubScreenButton::event_cb(lv_event_t* e)
   auto btn = (SubScreenButton*)lv_obj_get_user_data(obj);
   if (!btn) return;
 
-  lv_event_code_t code = lv_event_get_code(e);  
+  lv_event_code_t code = lv_event_get_code(e);
   if (code == LV_EVENT_DRAW_PART_BEGIN) {
 
     lv_obj_draw_part_dsc_t* dsc = lv_event_get_draw_part_dsc(e);
@@ -135,7 +135,7 @@ void SubScreenButton::event_cb(lv_event_t* e)
   } else if (code == LV_EVENT_DRAW_PART_END) {
 
     if (btn->text.empty()) return;
-    
+
     lv_obj_draw_part_dsc_t* dsc = lv_event_get_draw_part_dsc(e);
     if (dsc->part != LV_PART_MAIN) return;
 
@@ -236,7 +236,7 @@ void ModelSetupPage::build(FormWindow * window)
   new StaticText(line, rect_t{}, STR_LABELS, 0, COLOR_THEME_PRIMARY1);
   auto curmod = modelslist.getCurrentModel();
   labelTextButton =
-    new TextButton(line, rect_t{}, modelslabels.getLabelString(curmod ,STR_UNLABELEDMODEL), [=] () {
+    new TextButton(line, rect_t{}, modelslabels.getBulletLabelString(curmod ,STR_UNLABELEDMODEL), [=] () {
        Menu *menu = new Menu(window, true);
        menu->setTitle(STR_LABELS);
        for (auto &label: modelslabels.getLabels()) {
@@ -246,8 +246,8 @@ void ModelSetupPage::build(FormWindow * window)
                modelslabels.addLabelToModel(label, curmod);
              else
                modelslabels.removeLabelFromModel(label, curmod);
-             labelTextButton->setText(modelslabels.getLabelString(curmod,STR_UNLABELEDMODEL));
-             strcpy(g_model.header.labels, modelslabels.getLabelString(curmod,STR_UNLABELEDMODEL).c_str());
+             labelTextButton->setText(modelslabels.getBulletLabelString(curmod,STR_UNLABELEDMODEL));
+             strcpy(g_model.header.labels, modelslabels.getBulletLabelString(curmod,STR_UNLABELEDMODEL).c_str());
              SET_DIRTY();
            }, [=] () {
              return modelslabels.isLabelSelected(label, curmod);
@@ -278,7 +278,7 @@ void ModelSetupPage::build(FormWindow * window)
   form->setFlexLayout(LV_FLEX_FLOW_ROW_WRAP, lv_dpx(8));
   lv_obj_set_style_flex_main_place(form->getLvObj(), LV_FLEX_ALIGN_SPACE_EVENLY, 0);
   form->padAll(lv_dpx(8));
-  
+
   Window* btn = new IntmoduleButton(form);
   lv_obj_set_style_min_width(btn->getLvObj(), LV_DPI_DEF, 0);
 
@@ -335,11 +335,11 @@ TimerBtnMatrix::TimerBtnMatrix(Window* parent, const rect_t& r) :
   setText(1, TR_TIMER "2");
   setText(2, TR_TIMER "3");
   update();
-  
+
   lv_btnmatrix_set_btn_width(lvobj, 3, 2);
   lv_obj_set_width(lvobj, lv_pct(100));
   lv_obj_set_height(lvobj, LV_DPI_DEF / 2);
-  
+
   lv_obj_set_style_bg_opa(lvobj, LV_OPA_0, 0);
   lv_obj_set_style_pad_all(lvobj, lv_dpx(8), 0);
 

--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -247,7 +247,8 @@ void ModelSetupPage::build(FormWindow * window)
              else
                modelslabels.removeLabelFromModel(label, curmod);
              labelTextButton->setText(modelslabels.getBulletLabelString(curmod,STR_UNLABELEDMODEL));
-             strcpy(g_model.header.labels, modelslabels.getBulletLabelString(curmod,STR_UNLABELEDMODEL).c_str());
+             strncpy(g_model.header.labels, ModelMap::toCSV(modelslabels.getLabelsByModel(curmod)).c_str(),sizeof(g_model.header.labels));
+             g_model.header.labels[sizeof(g_model.header.labels)-1] = '\0';
              SET_DIRTY();
            }, [=] () {
              return modelslabels.isLabelSelected(label, curmod);

--- a/radio/src/storage/modelslist.cpp
+++ b/radio/src/storage/modelslist.cpp
@@ -1105,6 +1105,9 @@ bool ModelsList::load(Format fmt)
     TRACE("ERROR no Current Model Found");
     if (modelslist.size()) {
       modelslist.setCurrentModel(modelslist.at(0));
+      strncpy(g_eeGeneral.currModelFilename, modelslist.at(0)->modelFilename,
+              sizeof(g_eeGeneral.currModelFilename));
+      g_eeGeneral.currModelFilename[sizeof(g_eeGeneral.currModelFilename) - 1] = '\0';
       TRACE("  - Set current model to first available");
     } else {
       TRACE("  - No Models Found, making a new one");

--- a/radio/src/storage/modelslist.cpp
+++ b/radio/src/storage/modelslist.cpp
@@ -687,16 +687,19 @@ bool ModelMap::renameLabel(
 }
 
 /**
- * @brief Returns a comma separated list of the labels, used in model_setup
+ * @brief Returns a bullet separated list of the labels, used in model_setup
  *
  * @param curmod Model Cell
  * @param noresults String to return when no labels found
  * @return std::string of all Labels, if no results return
  */
 
-std::string ModelMap::getLabelString(ModelCell *curmod, const char *noresults)
+std::string ModelMap::getBulletLabelString(ModelCell *curmod, const char *noresults)
 {
   std::string lbls = ModelMap::toCSV(getLabelsByModel(curmod));
+  replace_all(lbls, ",", "\u2022");
+  replace_all(lbls, "/c", ",");
+  replace_all(lbls, "//", "/");
   if(lbls.size() == 0) {
     return noresults;
   }
@@ -741,7 +744,7 @@ bool ModelMap::updateModelFile(ModelCell *cell)
 {
   // Update memory copy if on current model
   if (cell == modelslist.getCurrentModel()) {
-    strncpy(g_model.header.labels, getLabelString(cell).c_str(),
+    strncpy(g_model.header.labels, ModelMap::toCSV(getLabelsByModel(cell)).c_str(),
             LABELS_LENGTH - 1);
     g_model.header.labels[LABELS_LENGTH - 1] = '\0';
     storageDirty(EE_MODEL);
@@ -757,7 +760,7 @@ bool ModelMap::updateModelFile(ModelCell *cell)
   bool fault = false;
   readModelYaml(cell->modelFilename, (uint8_t *)modeldata, sizeof(ModelData));
 
-  strncpy(modeldata->header.labels, getLabelString(cell).c_str(),
+  strncpy(modeldata->header.labels, ModelMap::toCSV(getLabelsByModel(cell)).c_str(),
           LABELS_LENGTH - 1);
   modeldata->header.labels[LABELS_LENGTH - 1] = '\0';
 

--- a/radio/src/storage/modelslist.h
+++ b/radio/src/storage/modelslist.h
@@ -49,9 +49,9 @@
 #define DEFAULT_MODEL_SORT NAME_ASC
 
 #if LCD_W > LCD_H // Landscape
-#define LABEL_TRUNCATE_LENGTH 23
+#define LABEL_TRUNCATE_LENGTH 21
 #else
-#define LABEL_TRUNCATE_LENGTH 18
+#define LABEL_TRUNCATE_LENGTH 16
 #endif
 
 struct ModelData;
@@ -168,6 +168,7 @@ class ModelMap : protected std::multimap<uint16_t, ModelCell *>
   static LabelsVector fromCSV(const char *str);
   static void escapeCSV(std::string &str);
   static void unEscapeCSV(std::string &str);
+  static void removeYAMLChars(std::string &str);
   static void replace_all(std::string &str,
                           const std::string &from,
                           const std::string &to);

--- a/radio/src/storage/modelslist.h
+++ b/radio/src/storage/modelslist.h
@@ -49,9 +49,9 @@
 #define DEFAULT_MODEL_SORT NAME_ASC
 
 #if LCD_W > LCD_H // Landscape
-#define LABEL_TRUNCATE_LENGTH 25
+#define LABEL_TRUNCATE_LENGTH 23
 #else
-#define LABEL_TRUNCATE_LENGTH 20
+#define LABEL_TRUNCATE_LENGTH 18
 #endif
 
 struct ModelData;

--- a/radio/src/storage/modelslist.h
+++ b/radio/src/storage/modelslist.h
@@ -47,6 +47,7 @@
   (LEN_MODEL_FILENAME + sizeof(" F,FF F,3F,FF\r\n") - 1)
 
 #define DEFAULT_MODEL_SORT NAME_ASC
+#define LABEL_TRUNCATE_LENGTH 25
 
 struct ModelData;
 struct ModuleData;
@@ -134,8 +135,7 @@ class ModelMap : protected std::multimap<uint16_t, ModelCell *>
       const std::string &,
       std::function<void(const char *file, int progress)> progress = nullptr);
   bool moveLabelTo(unsigned current, unsigned newind);
-  bool renameLabel(
-      const std::string &from, const std::string &to,
+  bool renameLabel(const std::string &from, std::string to,
       std::function<void(const char *file, int progress)> progress = nullptr);
   std::string getCurrentLabel() { return currentlabel; };
   void setCurrentLabel(const std::string &lbl)

--- a/radio/src/storage/modelslist.h
+++ b/radio/src/storage/modelslist.h
@@ -47,7 +47,12 @@
   (LEN_MODEL_FILENAME + sizeof(" F,FF F,3F,FF\r\n") - 1)
 
 #define DEFAULT_MODEL_SORT NAME_ASC
+
+#if LCD_W > LCD_H // Landscape
 #define LABEL_TRUNCATE_LENGTH 25
+#else
+#define LABEL_TRUNCATE_LENGTH 20
+#endif
 
 struct ModelData;
 struct ModuleData;
@@ -161,6 +166,8 @@ class ModelMap : protected std::multimap<uint16_t, ModelCell *>
 
   static std::string toCSV(const LabelsVector &labels);
   static LabelsVector fromCSV(const char *str);
+  static void escapeCSV(std::string &str);
+  static void unEscapeCSV(std::string &str);
   static void replace_all(std::string &str,
                           const std::string &from,
                           const std::string &to);

--- a/radio/src/storage/modelslist.h
+++ b/radio/src/storage/modelslist.h
@@ -143,7 +143,7 @@ class ModelMap : protected std::multimap<uint16_t, ModelCell *>
     currentlabel = lbl;
     setDirty();
   }
-  std::string getLabelString(ModelCell *, const char *noresults = "");
+  std::string getBulletLabelString(ModelCell *, const char *noresults = "");
   void setDirty(bool save = false);
   bool isDirty() { return _isDirty; }
 

--- a/radio/src/storage/yaml/yaml_labelslist.cpp
+++ b/radio/src/storage/yaml/yaml_labelslist.cpp
@@ -130,9 +130,9 @@ static bool find_node(void* ctx, char* buf, uint8_t len)
       bool found=false;
       for(auto &filehash : modelslist.fileHashInfo) {
         if(filehash.name == mi->current_attr) {
-          TRACE_LABELS_YAML("  Model %s has a real file, creating a modelcell", filehash.name);
+          TRACE_LABELS_YAML("  Model %s has a real file, creating a modelcell", mi->current_attr);
           if(filehash.celladded) {
-            TRACE_LABELS_YAML("    Duplicate found labels.yml model cell %s already added", filehash.name);
+            TRACE_LABELS_YAML("    Duplicate found labels.yml model cell %s already added", mi->current_attr);
             break;
           }
           ModelCell *model = new ModelCell(mi->current_attr);

--- a/radio/src/storage/yaml/yaml_labelslist.cpp
+++ b/radio/src/storage/yaml/yaml_labelslist.cpp
@@ -49,8 +49,8 @@ struct labelslist_iter
     bool        modeldatavalid; // Used to determine if reading yaml values is necessary
     uint8_t     level;
     uint8_t     section;
-    char        current_attr[LABEL_LENGTH+1]; // set after find_node()
-    char        current_label[LABEL_LENGTH+1]; // set after find_node()
+    char        current_attr[LABELS_LENGTH+1]; // set after find_node()
+    char        current_label[LABELS_LENGTH+1]; // set after find_node()
 };
 
 static labelslist_iter __labelslist_iter_inst;
@@ -158,8 +158,8 @@ static bool find_node(void* ctx, char* buf, uint8_t len)
     if(mi->level == 1 && mi->section == labelslist_iter::SEC_Labels)  {
       TRACE_LABELS_YAML("Label Found -- %s", mi->current_attr);
       modelslabels.addLabel(mi->current_attr);
-      strncpy(mi->current_label,mi->current_attr, LABEL_LENGTH);
-      mi->current_label[LABEL_LENGTH] = '\0';
+      strncpy(mi->current_label,mi->current_attr, LABELS_LENGTH);
+      mi->current_label[LABELS_LENGTH] = '\0';
     }
 
     return true;
@@ -167,7 +167,11 @@ static bool find_node(void* ctx, char* buf, uint8_t len)
 
 static void set_attr(void* ctx, char* buf, uint8_t len)
 {
-  char value[40];
+  char value[LABELS_LENGTH + 1];
+  if(len > LABELS_LENGTH) {
+    TRACE("ERROR: YAML too long for buffer");
+    return;
+  }
   memcpy(value, buf, len);
   value[len] = '\0';
 
@@ -256,7 +260,7 @@ static void set_attr(void* ctx, char* buf, uint8_t len)
 
   // Sort Order
   } else if (mi->level == 0 && mi->section == labelslist_iter::SEC_Sort)  {
-    TRACE_LABELS_YAML(" Sort Order Found -- %s", mi->current_attr);
+    TRACE_LABELS_YAML(" Sort Order Found -- %s", value);
     modelslabels.setSortOrder((ModelsSortBy)strtol(value,NULL,10));
   }
 }

--- a/radio/src/storage/yaml/yaml_parser.h
+++ b/radio/src/storage/yaml/yaml_parser.h
@@ -24,7 +24,7 @@
 
 #include <stdint.h>
 
-#define MAX_STR 40
+#define MAX_STR 100
 #define MAX_DEPTH 16 // 12 real + 4 virtual
 
 struct YamlParserCalls
@@ -78,7 +78,7 @@ class YamlParser
     // tree iterator state
     const YamlParserCalls* calls;
     void*                  ctx;
-    
+
     // Reset parser state for next line
     void reset();
 
@@ -97,7 +97,7 @@ public:
     YamlParser();
 
     void init(const YamlParserCalls* parser_calls, void* parser_ctx);
-    
+
     YamlResult parse(const char* buffer, unsigned int size);
 
     void set_eof() { eof = true; }


### PR DESCRIPTION
- (FW) Corrects Checkall() was running twice when opening a new model. (Throttle Warning / Control Warning)
- (FW) Buffer overflow on labels too long or too many
- (CPN) Added warnings to the user if labels are too long or too many on a model in companion.
- (FW) Fix: rename create extra partial labels if a model is close to the limit
- (BOTH) Switched the commas to bullets on radio and firmware to fix #2282 
- (FW) Close model_select after making a new model
- (BOTH) Prevent YAML characters in label name. **Temporary**, will have to re-work yaml parser a bit to fully allow all characters (Will be a new PR destined for 2.9) CPN w/validator, FW, remove them.
- (FW) Limit length of text box
- (BOTH) Limit label length to 16 bytes
- (CPN) Move label up and down and rename buttons