### PR TITLE
feat(color): Labels Pgup/Down keys move up down selected label

### DIFF
--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -566,6 +566,36 @@ ModelLabelsWindow::ModelLabelsWindow() : Page(ICON_MODEL)
   }
 }
 
+#if defined(HARDWARE_KEYS)
+void ModelLabelsWindow::onEvent(event_t event)
+{
+  if (event == EVT_KEY_BREAK(KEY_PGDN) || event == EVT_KEY_BREAK(KEY_PGUP)) {
+    std::set<uint32_t> curSel = lblselector->getSelection();
+    std::set<uint32_t> sellist;
+    int select = 0;
+    int rowcount = lblselector->getRowCount();
+    if (event == EVT_KEY_BREAK(KEY_PGDN)) {
+      if(curSel.size())
+        select = (*curSel.rbegin() + 1) % rowcount;
+    } else if (event == EVT_KEY_BREAK(KEY_PGUP)) {
+      if(curSel.size()) {
+        select = (int)*curSel.begin() - 1;
+        if(select < 0)
+          select += rowcount;
+      } else {
+        select = rowcount - 1;
+      }
+    }
+    sellist.insert(select);
+    lblselector->setSelected(sellist); // Check the items
+    lblselector->setSelected(select); // Causes the list to scroll
+    updateFilteredLabels(sellist); // Update the models
+  } else {
+    Page::onEvent(event);
+  }
+}
+#endif
+
 void ModelLabelsWindow::newModel()
 {
   // Save current

--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -569,15 +569,31 @@ ModelLabelsWindow::ModelLabelsWindow() : Page(ICON_MODEL)
 #if defined(HARDWARE_KEYS)
 void ModelLabelsWindow::onEvent(event_t event)
 {
-  if (event == EVT_KEY_BREAK(KEY_PGDN) || event == EVT_KEY_BREAK(KEY_PGUP)) {
+#if defined(KEYS_GPIO_REG_PGUP)
+  if (event == EVT_KEY_BREAK(KEY_PGUP) ||
+      event == EVT_KEY_BREAK(KEY_PGDN)) {
+#elif defined(PCBNV14)
+  if (event == EVT_KEY_BREAK(KEY_LEFT) ||
+      event == EVT_KEY_BREAK(KEY_RIGHT)) {
+#else
+  if (event == EVT_KEY_LONG(KEY_PGDN) ||
+      event == EVT_KEY_BREAK(KEY_PGDN)) {
+#endif
     std::set<uint32_t> curSel = lblselector->getSelection();
     std::set<uint32_t> sellist;
     int select = 0;
     int rowcount = lblselector->getRowCount();
+#if defined(KEYS_GPIO_REG_PGUP)
     if (event == EVT_KEY_BREAK(KEY_PGDN)) {
+#elif defined(PCBNV14)
+    if (event == EVT_KEY_BREAK(KEY_LEFT)) {
+#else
+    if (event == EVT_KEY_BREAK(KEY_PGDN)) {
+#endif
       if(curSel.size())
         select = (*curSel.rbegin() + 1) % rowcount;
-    } else if (event == EVT_KEY_BREAK(KEY_PGUP)) {
+    } else {
+      killEvents(event);
       if(curSel.size()) {
         select = (int)*curSel.begin() - 1;
         if(select < 0)

--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -572,9 +572,6 @@ void ModelLabelsWindow::onEvent(event_t event)
 #if defined(KEYS_GPIO_REG_PGUP)
   if (event == EVT_KEY_BREAK(KEY_PGUP) ||
       event == EVT_KEY_BREAK(KEY_PGDN)) {
-#elif defined(PCBNV14)
-  if (event == EVT_KEY_BREAK(KEY_LEFT) ||
-      event == EVT_KEY_BREAK(KEY_RIGHT)) {
 #else
   if (event == EVT_KEY_LONG(KEY_PGDN) ||
       event == EVT_KEY_BREAK(KEY_PGDN)) {
@@ -585,8 +582,6 @@ void ModelLabelsWindow::onEvent(event_t event)
     int rowcount = lblselector->getRowCount();
 #if defined(KEYS_GPIO_REG_PGUP)
     if (event == EVT_KEY_BREAK(KEY_PGDN)) {
-#elif defined(PCBNV14)
-    if (event == EVT_KEY_BREAK(KEY_LEFT)) {
 #else
     if (event == EVT_KEY_BREAK(KEY_PGDN)) {
 #endif

--- a/radio/src/gui/colorlcd/model_select.h
+++ b/radio/src/gui/colorlcd/model_select.h
@@ -91,6 +91,10 @@ class ModelLabelsWindow : public Page
     return labels;
   }
 
+#if defined(HARDWARE_KEYS)
+  void onEvent(event_t event) override;
+#endif
+
   void newModel();
   void newLabel();
   void buildHead(PageHeader *window);


### PR DESCRIPTION
Allows you to step through the labels using the page keys as discussed in issue #2285 

Hopefully someone can tell me if the keys make sense. Seems backwards on the TX16s with the PG down key on the top Pg Up on the bottom. I don't have any other color LCD's to compare with.