### PR TITLE
Prevent multiple audio beeps on touch

### DIFF
--- a/radio/src/gui/colorlcd/LvglWrapper.cpp
+++ b/radio/src/gui/colorlcd/LvglWrapper.cpp
@@ -219,9 +219,14 @@ extern "C" void touchDriverRead(lv_indev_drv_t *drv, lv_indev_data_t *data)
     copy_ts_to_indev_data(st, data);
   }
 
+  static bool onebeep=true; // TODO... This probably needs to be fixed in the driver it's sending two events
   if (st.event == TE_DOWN) { // on first touch (same logic as key down)
       reset_inactivity();    // reset activity counter
-      audioKeyPress();       // provide acoustic and/or haptic feedback if requested in settings
+      if(onebeep)
+        audioKeyPress();       // provide acoustic and/or haptic feedback if requested in settings
+      onebeep = false;
+  } else {
+    onebeep = true;
   }
   
   backup_touch_data(data);


### PR DESCRIPTION
-  **Radio** - TX16S MK1
-  **Branch** - Main

I'm not sure if everyone's radio does this but it was starting to make me 😜. If you touch and slide a little up you get multiple audio beeps. This probably an underlying issue in the driver I assume, why it's sending two TE_DOWN events and causing multiple beeps.

I tried to navigate the driver and see why but didn't have much luck. I see why trace could be a super helpful tool here.

This is the **patch job** but prevents the the multiple beeping on same down event.

This after a touch and slide. Pressing and releasing in the same location won't do it.
```
222.27s: touch state = 0x81
222.27s: touch event = DOWN  ------ First Beep
222.27s: INDEV_STATE_PRESSED
222.27s: PRESSED[150|72]
222.31s: {5,50,136,231}
222.31s: {142,148,306,239}
222.57s: touch state = 0x81
222.57s: touch event = DOWN  ----- Second Beep
222.57s: INDEV_STATE_PRESSED
222.62s: touch state = 0x81
222.62s: touch event = SLIDE
222.62s: INDEV_STATE_PRESSED
222.62s: SCROLL_BEGIN
```