### PR TITLE
fix: Don't allow select MULTI_TRAINER if no MULTI

### DIFF
--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -882,7 +882,18 @@ bool isTrainerModeAvailable(int mode)
        mode == TRAINER_MODE_MASTER_CPPM_EXTERNAL_MODULE))
     return false;
 #endif
-  
+
+#if !defined(MULTIMODULE)
+  if (mode == TRAINER_MODE_MULTI) 
+    return false;
+#else
+  if (mode == TRAINER_MODE_MULTI &&
+      ((!IS_INTERNAL_MODULE_ENABLED() && !IS_EXTERNAL_MODULE_ENABLED()) ||
+       (!isModuleMultimodule(INTERNAL_MODULE) &&
+        !isModuleMultimodule(EXTERNAL_MODULE))))
+    return false;
+#endif
+
   return true;
 }
 

--- a/radio/src/translations/da.h
+++ b/radio/src/translations/da.h
@@ -270,7 +270,7 @@
 #define TR_EXTRA_VSRCRAW               "Bat","Time","GPS",TR_RESERVE_VSRCRAW,TR_RESERVE_VSRCRAW,TR_RESERVE_VSRCRAW,TR_RESERVE_VSRCRAW,"Tmr1","Tmr2","Tmr3"
 
 #define TR_VTMRMODES                   "FRA","TIL","Strt","THs","TH%","THt"
-#define TR_VTRAINER_MASTER_OFF         "Fra"
+#define TR_VTRAINER_MASTER_OFF         "FRA"
 #define TR_VTRAINER_MASTER_JACK        "Træner/Jack"
 #define TR_VTRAINER_SLAVE_JACK         "Elev/Jack"
 #define TR_VTRAINER_MASTER_SBUS_MODULE "Træner/SBUS modul"

--- a/radio/src/translations/en.h
+++ b/radio/src/translations/en.h
@@ -269,7 +269,7 @@
 #define TR_EXTRA_VSRCRAW               "Batt","Time","GPS",TR_RESERVE_VSRCRAW,TR_RESERVE_VSRCRAW,TR_RESERVE_VSRCRAW,TR_RESERVE_VSRCRAW,"Tmr1","Tmr2","Tmr3"
 
 #define TR_VTMRMODES                   "OFF","ON","Strt","THs","TH%","THt"
-#define TR_VTRAINER_MASTER_OFF         "Off"
+#define TR_VTRAINER_MASTER_OFF         "OFF"
 #define TR_VTRAINER_MASTER_JACK        "Master/Jack"
 #define TR_VTRAINER_SLAVE_JACK         "Slave/Jack"
 #define TR_VTRAINER_MASTER_SBUS_MODULE "Master/SBUS Module"

--- a/radio/src/translations/fi.h
+++ b/radio/src/translations/fi.h
@@ -287,7 +287,7 @@
 #define TR_EXTRA_VSRCRAW               "Batt","Time","GPS",TR_RESERVE_VSRCRAW,TR_RESERVE_VSRCRAW,TR_RESERVE_VSRCRAW,TR_RESERVE_VSRCRAW,"Tmr1","Tmr2","Tmr3"
 
 #define TR_VTMRMODES                   "OFF","ABS","THs","TH%","THt"
-#define TR_VTRAINER_MASTER_OFF         "Off"
+#define TR_VTRAINER_MASTER_OFF         "OFF"
 #define TR_VTRAINER_MASTER_JACK        "Master/Jack"
 #define TR_VTRAINER_SLAVE_JACK         "Slave/Jack"
 #define TR_VTRAINER_MASTER_SBUS_MODULE "Master/SBUS Module"

--- a/radio/src/translations/se.h
+++ b/radio/src/translations/se.h
@@ -286,7 +286,7 @@
 #define TR_EXTRA_VSRCRAW                "Batt","Tid","GPS",TR_RESERVE_VSRCRAW,TR_RESERVE_VSRCRAW,TR_RESERVE_VSRCRAW,TR_RESERVE_VSRCRAW,"Tmr1","Tmr2","Tmr3"
 
 #define TR_VTMRMODES                    "Av","På","GAs","GA%","GAt"
-#define TR_VTRAINER_MASTER_OFF          "Av"
+#define TR_VTRAINER_MASTER_OFF          "AV"
 #define TR_VTRAINER_MASTER_JACK         "Lärare/Uttag"
 #define TR_VTRAINER_SLAVE_JACK          "Elev/Uttag"
 #define TR_VTRAINER_MASTER_SBUS_MODULE  "Lärare/SBUS-modul"


### PR DESCRIPTION
Fixes #1563 by ensuring Multi Trainer opt is not shown if no MPM
is enabled, as well as if MPM suport is not even compiled in.

It should only prevent `TRAINER_MODE_MULTI` being an selectable trainer mode if:
- `MULTIMODULE` support not enabled
- You don't have any modules enabled at all
- Neither of the enabled modules are MPM

It seems that having two MPMs enabled is a valid case, so I've left that case alone.

Hardware tested on TX16S and TX12-MK2, and working as expected. 

For me, this is both a bug (letting you select something that you can't) and an enhancement (don't show me stuff I can't use)... 🤷 😆 