### PR TITLE
fix (color): Inability to select labels after editing them

### DIFF
--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -335,10 +335,10 @@ class MyMenu : public Menu
 
   void deleteLater(bool detach = true, bool trash = true) override
   {
+    Menu::deleteLater(detach, trash);
     if (_finishHandler != nullptr) {
       _finishHandler();
     }
-    Menu::deleteLater(detach, trash);
   }
 
  protected:

--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -70,6 +70,13 @@ static void setModelBitmap(std::string newValue)
 {
   strncpy(g_model.header.bitmap, newValue.c_str(),
           sizeof(g_model.header.bitmap));
+  g_model.header.bitmap[sizeof(g_model.header.bitmap)-1] = '\0';
+  auto model = modelslist.getCurrentModel();
+  if (model) {
+    strncpy(model->modelBitmap, newValue.c_str(),
+            sizeof(ModelCell::modelBitmap));
+    model->modelBitmap[sizeof(ModelCell::modelBitmap)-1] = '\0';
+  }
   SET_DIRTY();
 }
 


### PR DESCRIPTION
Corrects issue #2293. The menu needs to be deleted first before calling for the update. Keys work as expected now.

Also included a fix so the model bitmap updates instantly. Before you had to wait for a write to file to happen which took about 10seconds before the image was updated in the labels selector.