### PR TITLE
fix(mpm): update internal module

### DIFF
--- a/radio/src/dmafifo.h
+++ b/radio/src/dmafifo.h
@@ -36,7 +36,7 @@ class DMAFifo
 
     void clear()
     {
-      ridx = 0;
+      ridx = N - stream->NDTR;
     }
 
     uint32_t size()

--- a/radio/src/io/multi_firmware_update.cpp
+++ b/radio/src/io/multi_firmware_update.cpp
@@ -122,8 +122,8 @@ class MultiInternalUpdateDriver: public MultiFirmwareUpdateDriver
     void deinit(bool inverted) override
     {
       IntmoduleSerialDriver.deinit(uart_ctx);
-      uart_ctx = nullptr;
       clear();
+      uart_ctx = nullptr;
     }
 };
 #endif


### PR DESCRIPTION
Fixes #2310 

Summary of changes:
- fix DMA fifo `clear()`
- fix MPM update UART context reset
