### PR TITLE
feat: Remove TR# mixsrc when trainer disabled

### DIFF
--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -177,7 +177,7 @@ void ModelData::clear()
   for (unsigned i = 0; i < CPN_MAX_SENSORS; i++)
     sensorData[i].clear();
 
-  trainerMode = TRAINER_MODE_MASTER_JACK;
+  trainerMode = TRAINER_MODE_OFF;
 
   const char * layoutId = "Layout2P1";  // currently all using same default though might change for NV14
   RadioLayout::init(layoutId, customScreens);

--- a/companion/src/firmwares/rawsource.cpp
+++ b/companion/src/firmwares/rawsource.cpp
@@ -333,6 +333,9 @@ bool RawSource::isAvailable(const ModelData * const model, const GeneralSettings
     if (type == SOURCE_TYPE_VIRTUAL_INPUT && !model->isInputValid(index))
       return false;
 
+    if (type == SOURCE_TYPE_PPM && model->trainerMode == TRAINER_MODE_OFF)
+      return false;
+
     if (type == SOURCE_TYPE_CUSTOM_SWITCH && model->logicalSw[index].isEmpty())
       return false;
 

--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -247,6 +247,7 @@ ModulePanel::ModulePanel(QWidget * parent, ModelData & model, ModuleData & modul
       ui->trainerMode->setField(model.trainerMode);
       connect(ui->trainerMode, &AutoComboBox::currentDataChanged, this, [=] () {
               update();
+              emit updateItemModels();
               emit modified();
       });
     }
@@ -1538,6 +1539,7 @@ SetupPanel::SetupPanel(QWidget * parent, ModelData & model, GeneralSettings & ge
     modules[CPN_MAX_MODULES] = new ModulePanel(this, model, model.moduleData[CPN_MAX_MODULES], generalSettings, firmware, -1, panelFilteredModels);
     ui->modulesLayout->addWidget(modules[CPN_MAX_MODULES]);
     connect(modules[CPN_MAX_MODULES], &ModulePanel::modified, this, &SetupPanel::modified);
+    connect(modules[CPN_MAX_MODULES], &ModulePanel::updateItemModels, this, &SetupPanel::onModuleUpdateItemModels);
   }
 
   disableMouseScrolling();

--- a/radio/src/gui/common/stdlcd/model_inputs.cpp
+++ b/radio/src/gui/common/stdlcd/model_inputs.cpp
@@ -55,7 +55,12 @@ void insertExpo(uint8_t idx)
   ExpoData * expo = expoAddress(idx);
   memmove(expo+1, expo, (MAX_EXPOS-(idx+1))*sizeof(ExpoData));
   memclear(expo, sizeof(ExpoData));
-  expo->srcRaw = (s_currCh > 4 ? MIXSRC_Rud - 1 + s_currCh : MIXSRC_Rud - 1 + channelOrder(s_currCh));
+  for (int i = s_currCh; i < INPUTSRC_LAST; i++) {
+    expo->srcRaw = (s_currCh > 4 ? MIXSRC_Rud - 1 + i: MIXSRC_Rud - 1 + channelOrder(i));
+    if (isSourceAvailableInInputs(expo->srcRaw)) {
+      break;
+    }
+  }
   expo->curve.type = CURVE_REF_EXPO;
   expo->mode = 3; // pos+neg
   expo->chn = s_currCh - 1;

--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -217,6 +217,9 @@ bool isSourceAvailable(int source)
     return isChannelUsed(source - MIXSRC_FIRST_CH);
   }
 
+  if (source >= MIXSRC_FIRST_TRAINER && source <= MIXSRC_LAST_TRAINER)
+    return g_model.trainerData.mode > 0;
+
   if (source >= MIXSRC_FIRST_LOGICAL_SWITCH && source <= MIXSRC_LAST_LOGICAL_SWITCH) {
     LogicalSwitchData * cs = lswAddress(source - MIXSRC_FIRST_LOGICAL_SWITCH);
     return (cs->func != LS_FUNC_NONE);

--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -217,9 +217,6 @@ bool isSourceAvailable(int source)
     return isChannelUsed(source - MIXSRC_FIRST_CH);
   }
 
-  if (source >= MIXSRC_FIRST_TRAINER && source <= MIXSRC_LAST_TRAINER)
-    return g_model.trainerData.mode > 0;
-
   if (source >= MIXSRC_FIRST_LOGICAL_SWITCH && source <= MIXSRC_LAST_LOGICAL_SWITCH) {
     LogicalSwitchData * cs = lswAddress(source - MIXSRC_FIRST_LOGICAL_SWITCH);
     return (cs->func != LS_FUNC_NONE);
@@ -232,6 +229,9 @@ bool isSourceAvailable(int source)
 
   if (source >= MIXSRC_FIRST_RESERVE && source <= MIXSRC_LAST_RESERVE)
     return false;
+
+  if (source >= MIXSRC_FIRST_TRAINER && source <= MIXSRC_LAST_TRAINER)
+    return g_model.trainerData.mode > 0;
 
   if (source >= MIXSRC_FIRST_TELEM && source <= MIXSRC_LAST_TELEM) {
     div_t qr = div(source - MIXSRC_FIRST_TELEM, 3);
@@ -292,7 +292,7 @@ bool isSourceAvailableInInputs(int source)
   }
 
   if (source >= MIXSRC_FIRST_TRAINER && source <= MIXSRC_LAST_TRAINER)
-    return true;
+    return g_model.trainerData.mode > 0;
 
   if (source >= MIXSRC_FIRST_TELEM && source <= MIXSRC_LAST_TELEM) {
     div_t qr = div(source - MIXSRC_FIRST_TELEM, 3);


### PR DESCRIPTION
When a trainer mode is not enabled, there is no point
showing the TR# mixer sources. Once you enable a
trainer option, they will become visible again.

Tested on TX16S and TX12-MKII. TR# sources are only visible when Trainer mode not OFF.

Also fixes issue where validation of input availabliity was not happening on B&W radios :grin: