### PR TITLE
fix: Re-add Switch and Curve long press functionality

### DIFF
--- a/radio/src/gui/colorlcd/curve_param.cpp
+++ b/radio/src/gui/colorlcd/curve_param.cpp
@@ -20,106 +20,105 @@
  */
 
 #include "curve_param.h"
+
 #include "gvar_numberedit.h"
 #include "model_curves.h"
-
 #include "opentx.h"
 
 #define SET_DIRTY() storageDirty(EE_MODEL)
 
-static const char *_curve_type[] = {"Diff", "Expo", "Func", "Cstm"};
+static const char* _curve_type[] = {"Diff", "Expo", "Func", "Cstm"};
 
 void CurveParam::LongPressHandler(void* data)
 {
-    int8_t* value = (int8_t*)data;
-    if (*value != 0)  {
-      ModelCurvesPage::pushEditCurve(abs(*value) - 1);
-    }
+  int8_t* value = (int8_t*)data;
+  if (*value != 0) {
+    ModelCurvesPage::pushEditCurve(abs(*value) - 1);
+  }
 }
 
-void CurveParam::value_changed(lv_event_t * e)
-  {
-    auto obj = lv_event_get_target(e);
-    auto param = (CurveParam*)lv_obj_get_user_data(obj);
-    if (!param) return;
+void CurveParam::value_changed(lv_event_t* e)
+{
+  auto obj = lv_event_get_target(e);
+  auto param = (CurveParam*)lv_obj_get_user_data(obj);
+  if (!param) return;
 
-    param->update();
-  }
+  param->update();
+}
 
-  CurveParam::CurveParam(Window * parent, const rect_t& rect, CurveRef* ref) :
-      Window(parent, rect), ref(ref)
-  {
-    lv_obj_set_flex_flow(lvobj, LV_FLEX_FLOW_ROW_WRAP);
-    lv_obj_set_style_pad_column(lvobj, lv_dpx(4), 0);
-    lv_obj_set_style_flex_cross_place(lvobj, LV_FLEX_ALIGN_CENTER, 0);
-    lv_obj_set_size(lvobj, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
+CurveParam::CurveParam(Window* parent, const rect_t& rect, CurveRef* ref) :
+    Window(parent, rect), ref(ref)
+{
+  lv_obj_set_flex_flow(lvobj, LV_FLEX_FLOW_ROW_WRAP);
+  lv_obj_set_style_pad_column(lvobj, lv_dpx(4), 0);
+  lv_obj_set_style_flex_cross_place(lvobj, LV_FLEX_ALIGN_CENTER, 0);
+  lv_obj_set_size(lvobj, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
 
-    new Choice(this, rect_t{}, _curve_type, 0, CURVE_REF_CUSTOM,
-               GET_DEFAULT(ref->type), [=](int32_t newValue) {
-                 ref->type = newValue;
-                 ref->value = 0;
-                 SET_DIRTY();
-                 lv_event_send(lvobj, LV_EVENT_VALUE_CHANGED, nullptr);
-               });
-    lv_obj_add_event_cb(lvobj, CurveParam::value_changed,
-                        LV_EVENT_VALUE_CHANGED, nullptr);
+  new Choice(this, rect_t{}, _curve_type, 0, CURVE_REF_CUSTOM,
+             GET_DEFAULT(ref->type), [=](int32_t newValue) {
+               ref->type = newValue;
+               ref->value = 0;
+               SET_DIRTY();
+               lv_event_send(lvobj, LV_EVENT_VALUE_CHANGED, nullptr);
+             });
+  lv_obj_add_event_cb(lvobj, CurveParam::value_changed, LV_EVENT_VALUE_CHANGED,
+                      nullptr);
 
-    // CURVE_REF_DIFF
-    // CURVE_REF_EXPO
-    value_edit = new GVarNumberEdit(this, rect_t{}, -100, 100,
-                                    GET_SET_DEFAULT(ref->value));
-    value_edit->setSuffix("%");
+  // CURVE_REF_DIFF
+  // CURVE_REF_EXPO
+  value_edit = new GVarNumberEdit(this, rect_t{}, -100, 100,
+                                  GET_SET_DEFAULT(ref->value));
+  value_edit->setSuffix("%");
 
-    // CURVE_REF_FUNC
-    func_choice = new Choice(this, rect_t{}, STR_VCURVEFUNC, 0, CURVE_BASE - 1,
+  // CURVE_REF_FUNC
+  func_choice = new Choice(this, rect_t{}, STR_VCURVEFUNC, 0, CURVE_BASE - 1,
+                           GET_SET_DEFAULT(ref->value));
+
+  // CURVE_REF_CUSTOM
+  cust_choice = new ChoiceEx(this, rect_t{}, -MAX_CURVES, MAX_CURVES,
                              GET_SET_DEFAULT(ref->value));
+  cust_choice->setTextHandler([](int value) { return getCurveString(value); });
+  cust_choice->set_lv_LongPressHandler(LongPressHandler, &(ref->value));
 
-    // CURVE_REF_CUSTOM
-    cust_choice = new ChoiceEx(this, rect_t{}, -MAX_CURVES, MAX_CURVES,
-                               GET_SET_DEFAULT(ref->value));
-    cust_choice->setTextHandler(
-        [](int value) { return getCurveString(value); });
-    cust_choice->set_lv_LongPressHandler(LongPressHandler,  &(ref->value));
+  update();
+}
 
-    update();
+void CurveParam::update()
+{
+  bool has_focus = act_field && act_field->hasFocus();
+
+  auto value_obj = value_edit->getLvObj();
+  auto func_obj = func_choice->getLvObj();
+  auto cust_obj = cust_choice->getLvObj();
+
+  lv_obj_add_flag(value_obj, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_add_flag(func_obj, LV_OBJ_FLAG_HIDDEN);
+  lv_obj_add_flag(cust_obj, LV_OBJ_FLAG_HIDDEN);
+
+  switch (ref->type) {
+    case CURVE_REF_DIFF:
+    case CURVE_REF_EXPO:
+      lv_obj_clear_flag(value_obj, LV_OBJ_FLAG_HIDDEN);
+      act_field = value_edit;
+      break;
+
+    case CURVE_REF_FUNC:
+      lv_obj_clear_flag(func_obj, LV_OBJ_FLAG_HIDDEN);
+      act_field = func_choice;
+      break;
+
+    case CURVE_REF_CUSTOM:
+      lv_obj_clear_flag(cust_obj, LV_OBJ_FLAG_HIDDEN);
+      act_field = cust_choice;
+      break;
+
+    default:
+      return;
   }
 
-  void CurveParam::update()
-  {
-    bool has_focus = act_field && act_field->hasFocus();
-
-    auto value_obj = value_edit->getLvObj();
-    auto func_obj = func_choice->getLvObj();
-    auto cust_obj = cust_choice->getLvObj();
-
-    lv_obj_add_flag(value_obj, LV_OBJ_FLAG_HIDDEN);
-    lv_obj_add_flag(func_obj, LV_OBJ_FLAG_HIDDEN);
-    lv_obj_add_flag(cust_obj, LV_OBJ_FLAG_HIDDEN);
-
-    switch (ref->type) {
-      case CURVE_REF_DIFF:
-      case CURVE_REF_EXPO:
-        lv_obj_clear_flag(value_obj, LV_OBJ_FLAG_HIDDEN);
-        act_field = value_edit;
-        break;
-
-      case CURVE_REF_FUNC:
-        lv_obj_clear_flag(func_obj, LV_OBJ_FLAG_HIDDEN);
-        act_field = func_choice;
-        break;
-
-      case CURVE_REF_CUSTOM:
-        lv_obj_clear_flag(cust_obj, LV_OBJ_FLAG_HIDDEN);
-        act_field = cust_choice;
-        break;
-
-      default:
-        return;
-    }
-
-    auto act_obj = act_field->getLvObj();
-    if (has_focus) {
-      lv_group_focus_obj(act_obj);
-    }
-    lv_event_send(act_obj, LV_EVENT_VALUE_CHANGED, nullptr);
+  auto act_obj = act_field->getLvObj();
+  if (has_focus) {
+    lv_group_focus_obj(act_obj);
   }
+  lv_event_send(act_obj, LV_EVENT_VALUE_CHANGED, nullptr);
+}

--- a/radio/src/gui/colorlcd/curve_param.cpp
+++ b/radio/src/gui/colorlcd/curve_param.cpp
@@ -29,95 +29,97 @@
 
 static const char *_curve_type[] = {"Diff", "Expo", "Func", "Cstm"};
 
-void CurveParam::value_changed(lv_event_t* e)
+void CurveParam::LongPressHandler(void* data)
 {
-  auto obj = lv_event_get_target(e);
-  auto param = (CurveParam*)lv_obj_get_user_data(obj);
-  if (!param) return;
-
-  param->update();
+    int8_t* value = (int8_t*)data;
+    if (*value != 0)  {
+      ModelCurvesPage::pushEditCurve(abs(*value) - 1);
+    }
 }
 
-CurveParam::CurveParam(Window* parent, const rect_t& rect, CurveRef* ref) :
-    Window(parent, rect),
-    ref(ref)
-{
-  lv_obj_set_flex_flow(lvobj, LV_FLEX_FLOW_ROW_WRAP);
-  lv_obj_set_style_pad_column(lvobj, lv_dpx(4), 0);
-  lv_obj_set_style_flex_cross_place(lvobj, LV_FLEX_ALIGN_CENTER, 0);
-  lv_obj_set_size(lvobj, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
-  
-  new Choice(this, rect_t{}, _curve_type, 0,
-             CURVE_REF_CUSTOM, GET_DEFAULT(ref->type),
-             [=](int32_t newValue) {
-               ref->type = newValue;
-               ref->value = 0;
-               SET_DIRTY();
-               lv_event_send(lvobj, LV_EVENT_VALUE_CHANGED, nullptr);
-             });
-  lv_obj_add_event_cb(lvobj, CurveParam::value_changed, LV_EVENT_VALUE_CHANGED,
-                      nullptr);
+void CurveParam::value_changed(lv_event_t * e)
+  {
+    auto obj = lv_event_get_target(e);
+    auto param = (CurveParam*)lv_obj_get_user_data(obj);
+    if (!param) return;
 
-  // CURVE_REF_DIFF
-  // CURVE_REF_EXPO
-  value_edit = new GVarNumberEdit(this, rect_t{}, -100, 100,
-                                  GET_SET_DEFAULT(ref->value));
-  value_edit->setSuffix("%");
-
-  // CURVE_REF_FUNC
-  func_choice = new Choice(this, rect_t{}, STR_VCURVEFUNC, 0, CURVE_BASE - 1,
-                           GET_SET_DEFAULT(ref->value));
-
-  
-  // CURVE_REF_CUSTOM
-  cust_choice = new ChoiceEx(this, rect_t{}, -MAX_CURVES, MAX_CURVES,
-                                  GET_SET_DEFAULT(ref->value));
-  cust_choice->setTextHandler([](int value) { return getCurveString(value); });
-  cust_choice->setLongPressHandler([ref](event_t event) {
-    // if no curve is specified then dont link to curve page
-    if (ref->value != 0) ModelCurvesPage::pushEditCurve(abs(ref->value) - 1);
-  });
-
-  update();
-}
-
-void CurveParam::update()
-{
-  bool has_focus = act_field && act_field->hasFocus();
-
-  auto value_obj = value_edit->getLvObj();
-  auto func_obj = func_choice->getLvObj();
-  auto cust_obj = cust_choice->getLvObj();
-  
-  lv_obj_add_flag(value_obj, LV_OBJ_FLAG_HIDDEN);
-  lv_obj_add_flag(func_obj, LV_OBJ_FLAG_HIDDEN);
-  lv_obj_add_flag(cust_obj, LV_OBJ_FLAG_HIDDEN);
-  
-  switch(ref->type) {
-  case CURVE_REF_DIFF:
-  case CURVE_REF_EXPO:
-    lv_obj_clear_flag(value_obj, LV_OBJ_FLAG_HIDDEN);
-    act_field = value_edit;
-    break;
-
-  case CURVE_REF_FUNC:
-    lv_obj_clear_flag(func_obj, LV_OBJ_FLAG_HIDDEN);
-    act_field = func_choice;
-    break;
-    
-  case CURVE_REF_CUSTOM:
-    lv_obj_clear_flag(cust_obj, LV_OBJ_FLAG_HIDDEN);
-    act_field = cust_choice;
-    break;
-
-  default:
-    return;
+    param->update();
   }
 
-  auto act_obj = act_field->getLvObj();
-  if (has_focus) {
-    lv_group_focus_obj(act_obj);
-  }
-  lv_event_send(act_obj, LV_EVENT_VALUE_CHANGED, nullptr);
-}
+  CurveParam::CurveParam(Window * parent, const rect_t& rect, CurveRef* ref) :
+      Window(parent, rect), ref(ref)
+  {
+    lv_obj_set_flex_flow(lvobj, LV_FLEX_FLOW_ROW_WRAP);
+    lv_obj_set_style_pad_column(lvobj, lv_dpx(4), 0);
+    lv_obj_set_style_flex_cross_place(lvobj, LV_FLEX_ALIGN_CENTER, 0);
+    lv_obj_set_size(lvobj, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
 
+    new Choice(this, rect_t{}, _curve_type, 0, CURVE_REF_CUSTOM,
+               GET_DEFAULT(ref->type), [=](int32_t newValue) {
+                 ref->type = newValue;
+                 ref->value = 0;
+                 SET_DIRTY();
+                 lv_event_send(lvobj, LV_EVENT_VALUE_CHANGED, nullptr);
+               });
+    lv_obj_add_event_cb(lvobj, CurveParam::value_changed,
+                        LV_EVENT_VALUE_CHANGED, nullptr);
+
+    // CURVE_REF_DIFF
+    // CURVE_REF_EXPO
+    value_edit = new GVarNumberEdit(this, rect_t{}, -100, 100,
+                                    GET_SET_DEFAULT(ref->value));
+    value_edit->setSuffix("%");
+
+    // CURVE_REF_FUNC
+    func_choice = new Choice(this, rect_t{}, STR_VCURVEFUNC, 0, CURVE_BASE - 1,
+                             GET_SET_DEFAULT(ref->value));
+
+    // CURVE_REF_CUSTOM
+    cust_choice = new ChoiceEx(this, rect_t{}, -MAX_CURVES, MAX_CURVES,
+                               GET_SET_DEFAULT(ref->value));
+    cust_choice->setTextHandler(
+        [](int value) { return getCurveString(value); });
+    cust_choice->set_lv_LongPressHandler(LongPressHandler,  &(ref->value));
+
+    update();
+  }
+
+  void CurveParam::update()
+  {
+    bool has_focus = act_field && act_field->hasFocus();
+
+    auto value_obj = value_edit->getLvObj();
+    auto func_obj = func_choice->getLvObj();
+    auto cust_obj = cust_choice->getLvObj();
+
+    lv_obj_add_flag(value_obj, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(func_obj, LV_OBJ_FLAG_HIDDEN);
+    lv_obj_add_flag(cust_obj, LV_OBJ_FLAG_HIDDEN);
+
+    switch (ref->type) {
+      case CURVE_REF_DIFF:
+      case CURVE_REF_EXPO:
+        lv_obj_clear_flag(value_obj, LV_OBJ_FLAG_HIDDEN);
+        act_field = value_edit;
+        break;
+
+      case CURVE_REF_FUNC:
+        lv_obj_clear_flag(func_obj, LV_OBJ_FLAG_HIDDEN);
+        act_field = func_choice;
+        break;
+
+      case CURVE_REF_CUSTOM:
+        lv_obj_clear_flag(cust_obj, LV_OBJ_FLAG_HIDDEN);
+        act_field = cust_choice;
+        break;
+
+      default:
+        return;
+    }
+
+    auto act_obj = act_field->getLvObj();
+    if (has_focus) {
+      lv_group_focus_obj(act_obj);
+    }
+    lv_event_send(act_obj, LV_EVENT_VALUE_CHANGED, nullptr);
+  }

--- a/radio/src/gui/colorlcd/curve_param.h
+++ b/radio/src/gui/colorlcd/curve_param.h
@@ -43,7 +43,8 @@ class CurveParam : public Window
 
   void update();
   static void value_changed(lv_event_t* e);
-  
-public:
-  CurveParam(Window* parent, const rect_t& rect, CurveRef* ref);
+  static void LongPressHandler(void* data);
+
+public : 
+CurveParam(Window* parent, const rect_t& rect, CurveRef* ref);
 };

--- a/radio/src/gui/colorlcd/curve_param.h
+++ b/radio/src/gui/colorlcd/curve_param.h
@@ -45,6 +45,6 @@ class CurveParam : public Window
   static void value_changed(lv_event_t* e);
   static void LongPressHandler(void* data);
 
-public : 
-CurveParam(Window* parent, const rect_t& rect, CurveRef* ref);
+ public:
+  CurveParam(Window* parent, const rect_t& rect, CurveRef* ref);
 };

--- a/radio/src/gui/colorlcd/switchchoice.cpp
+++ b/radio/src/gui/colorlcd/switchchoice.cpp
@@ -28,7 +28,6 @@
 #include "opentx.h"
 #include "strhelpers.h"
 
-
 class SwitchChoiceMenuToolbar : public MenuToolbar
 {
  public:
@@ -42,7 +41,7 @@ class SwitchChoiceMenuToolbar : public MenuToolbar
   }
 };
 
-void SwitchChoice::LongPressHandler(void* data) 
+void SwitchChoice::LongPressHandler(void* data)
 {
   SwitchChoice* swch = (SwitchChoice*)data;
   if (!swch) return;
@@ -52,7 +51,6 @@ void SwitchChoice::LongPressHandler(void* data)
     swch->invalidate();
   }
 }
-
 
 SwitchChoice::SwitchChoice(Window* parent, const rect_t& rect, int vmin,
                            int vmax, std::function<int16_t()> getValue,

--- a/radio/src/gui/colorlcd/switchchoice.cpp
+++ b/radio/src/gui/colorlcd/switchchoice.cpp
@@ -28,6 +28,7 @@
 #include "opentx.h"
 #include "strhelpers.h"
 
+
 class SwitchChoiceMenuToolbar : public MenuToolbar
 {
  public:
@@ -40,6 +41,18 @@ class SwitchChoiceMenuToolbar : public MenuToolbar
               SWSRC_LAST_LOGICAL_SWITCH);
   }
 };
+
+void SwitchChoice::LongPressHandler(void* data) 
+{
+  SwitchChoice* swch = (SwitchChoice*)data;
+  if (!swch) return;
+  int16_t val = swch->_getValue();
+  if (swch->isValueAvailable && swch->isValueAvailable(-val)) {
+    swch->setValue(-val);
+    swch->invalidate();
+  }
+}
+
 
 SwitchChoice::SwitchChoice(Window* parent, const rect_t& rect, int vmin,
                            int vmax, std::function<int16_t()> getValue,
@@ -78,13 +91,7 @@ SwitchChoice::SwitchChoice(Window* parent, const rect_t& rect, int vmin,
     return std::string(getSwitchPositionName(value));
   });
 
-  setLongPressHandler([=](event_t) {
-    int16_t val = getValue();
-    if (isValueAvailable && isValueAvailable(-val)) {
-      setValue(-val);
-      invalidate();
-    }
-  });
+  set_lv_LongPressHandler(LongPressHandler, this);
 
   setAvailableHandler(isSwitchAvailableInMixes);
 }

--- a/radio/src/gui/colorlcd/switchchoice.h
+++ b/radio/src/gui/colorlcd/switchchoice.h
@@ -31,9 +31,14 @@ class SwitchChoice : public ChoiceEx
   SwitchChoice(Window* parent, const rect_t& rect, int vmin, int vmax,
                std::function<int16_t()> getValue,
                std::function<void(int16_t)> setValue);
+  
+  static void LongPressHandler(void* data);
+
+
+protected:
 
 #if defined(DEBUG_WINDOWS)
-  std::string getName() const override { return "SwitchChoice"; }
+      std::string getName() const override { return "SwitchChoice"; }
 #endif
 };
 

--- a/radio/src/gui/colorlcd/switchchoice.h
+++ b/radio/src/gui/colorlcd/switchchoice.h
@@ -22,8 +22,8 @@
 #ifndef _SWITCHCHOICE_H_
 #define _SWITCHCHOICE_H_
 
-#include "form.h"
 #include "choiceex.h"
+#include "form.h"
 
 class SwitchChoice : public ChoiceEx
 {
@@ -31,15 +31,13 @@ class SwitchChoice : public ChoiceEx
   SwitchChoice(Window* parent, const rect_t& rect, int vmin, int vmax,
                std::function<int16_t()> getValue,
                std::function<void(int16_t)> setValue);
-  
+
   static void LongPressHandler(void* data);
 
-
-protected:
-
+ protected:
 #if defined(DEBUG_WINDOWS)
-      std::string getName() const override { return "SwitchChoice"; }
+  std::string getName() const override { return "SwitchChoice"; }
 #endif
 };
 
-#endif // _SWITCHCHOICE_H_
+#endif  // _SWITCHCHOICE_H_


### PR DESCRIPTION
Fixes #2312 and (indirectly) fixes #2286 
Also fixes unreported crash/emergency mode when going from Inputs tab to Edit curve screen.

Requires #EdgeTX/libopenui65 
https://github.com/EdgeTX/libopenui/pull/65

Summary of changes:
- Long press on switch button inverts the switch; e.g. SA_UP -> !SA_UP
- On the Inputs screen long press on the "curve" button bring "Edit Curve" screen.

As a side effect of removing old event handler(s) from ChoiceEx in libopneui #2286 is also fixed, but it looks like @raphaelcoeffic removed them earlier.
