### PR TITLE
fix: More Swedish translations and typo fixes 🇸🇪

### DIFF
--- a/companion/src/modeledit/mixerdialog.ui
+++ b/companion/src/modeledit/mixerdialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>527</width>
+    <width>531</width>
     <height>571</height>
    </rect>
   </property>
@@ -471,7 +471,7 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</string>
           </size>
          </property>
          <property name="text">
-          <string>imgage</string>
+          <string>image</string>
          </property>
         </widget>
        </item>

--- a/companion/src/translations/companion_sv.ts
+++ b/companion/src/translations/companion_sv.ts
@@ -6695,8 +6695,8 @@ p, li { white-space: pre-wrap; }
         <translation></translation>
     </message>
     <message>
-        <source>imgage</source>
-        <translation type="unfinished"></translation>
+        <source>image</source>
+        <translation>bild</translation>
     </message>
 </context>
 <context>
@@ -7505,11 +7505,11 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Open Drain</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <source>Push Pull</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <source>Antenna</source>
@@ -12169,9 +12169,9 @@ Uppdatera nu?</translation>
 Current firmware profile board will be used.
 
 Do you wish to continue?</source>
-        <translation>Varning: Radioinställningsfilen saknar &quot;board entry&quot;!
+        <translation>Varning: Radioinställningsfilen saknar radiotyp!
 
-&quot;Profile board&quot; för nuvarande firmware kommer användas.
+Radiotyp för nuvarande profil kommer användas.
 
 Vill du fortsätta?</translation>
     </message>
@@ -12179,7 +12179,7 @@ Vill du fortsätta?</translation>
         <source>Settings file board (%1) does not match current profile board (%2).
 
 Do you wish to continue?</source>
-        <translation>Inställningens &quot;file board&quot; (%1) matchar inte nuvarande &quot;profile board&quot; (%2).
+        <translation>Radiotyp i vald inställningsfil (%1) matchar inte aktuell profils radiotyp (%2).
 
 Vill du fortsätta?</translation>
     </message>

--- a/companion/src/translations/companion_sv.ts
+++ b/companion/src/translations/companion_sv.ts
@@ -3850,6 +3850,10 @@ Dessa inställningar gäller för alla modeller.</translation>
         <source>OneBit</source>
         <translation></translation>
     </message>
+    <message>
+        <source>SpaceMouse</source>
+        <translation></translation>
+    </message>
 </context>
 <context>
     <name>GeneralSetup</name>
@@ -5020,6 +5024,14 @@ att fungera. Detta går inte att ändra från radion.
     <message>
         <source>Unable to rename &quot;%1&quot; to &quot;%2&quot; the label already exists</source>
         <translation>Kan inte byta namn på &quot;%1&quot; till &quot;%2&quot; då etiketten redan finns</translation>
+    </message>
+    <message>
+        <source>Unable to add label &quot;%1&quot; to model &quot;%2&quot; not enough room</source>
+        <translation>Kan inte lägga till etikett &quot;%1&quot; till modell &quot;%2&quot;, inte tillräckligt med plats</translation>
+    </message>
+    <message>
+        <source>Unable to rename &quot;%1&quot; to &quot;%2&quot; not enough room in model %3</source>
+        <translation>Kan inte ändra namn &quot;%1&quot; till &quot;%2&quot;, inte tillräckligt med plats i modell %3</translation>
     </message>
 </context>
 <context>
@@ -6289,18 +6301,6 @@ Vill du spara ändringarna?</translation>
         <translation>Temporär modell kunde inte tas bort!</translation>
     </message>
     <message>
-        <source>Add Label</source>
-        <translation>Lägg till etikett</translation>
-    </message>
-    <message>
-        <source>Delete Label</source>
-        <translation>Ta bort etikett</translation>
-    </message>
-    <message>
-        <source>Labels</source>
-        <translation>Etiketter</translation>
-    </message>
-    <message>
         <source>Alt-L</source>
         <translation></translation>
     </message>
@@ -6343,6 +6343,42 @@ Vill du spara ändringarna?</translation>
     <message>
         <source>Export model</source>
         <translation>Exportera modell</translation>
+    </message>
+    <message>
+        <source>Alt-R</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Alt-+</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Alt--</source>
+        <translation></translation>
+    </message>
+    <message>
+        <source>Labels Management</source>
+        <translation>Etiketthantering</translation>
+    </message>
+    <message>
+        <source>Add</source>
+        <translation>Lägg till</translation>
+    </message>
+    <message>
+        <source>Rename</source>
+        <translation>Byt namn</translation>
+    </message>
+    <message>
+        <source>Move Up</source>
+        <translation>Flytta upp</translation>
+    </message>
+    <message>
+        <source>Move Down</source>
+        <translation>Flytta ner</translation>
+    </message>
+    <message>
+        <source>Show Labels Actions Toolbar</source>
+        <translation>Visa verktygsfältet för etiketter</translation>
     </message>
 </context>
 <context>
@@ -8067,7 +8103,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Enable Max Throw</source>
-        <translation type="unfinished">Aktivera max slaglängd</translation>
+        <translation>Aktivera max utslag</translation>
     </message>
     <message>
         <source>RF Channel Number</source>
@@ -8583,6 +8619,10 @@ r</translation>
     <message>
         <source>SW%1</source>
         <translation>BR%1</translation>
+    </message>
+    <message>
+        <source>sm%1</source>
+        <translation type="unfinished"></translation>
     </message>
 </context>
 <context>
@@ -11528,7 +11568,7 @@ Varning: Detta går inte att ångra! Är du säker?</translation>
     <name>UpdateParameters</name>
     <message>
         <source>None</source>
-        <translation>Inga</translation>
+        <translation>Inget</translation>
     </message>
     <message>
         <source>Exact</source>

--- a/companion/src/translations/companion_sv.ts
+++ b/companion/src/translations/companion_sv.ts
@@ -5834,15 +5834,15 @@ Vill du fortsätta?</translation>
     </message>
     <message>
         <source>Tabbed Windows</source>
-        <translation type="unfinished"></translation>
+        <translation>Som flikar</translation>
     </message>
     <message>
         <source>Use tabs to arrange open windows.</source>
-        <translation>Används tabbar för att arrangera öppna fönster.</translation>
+        <translation>Använd flikar för att arrangera öppna fönster.</translation>
     </message>
     <message>
         <source>Tile Windows</source>
-        <translation type="unfinished"></translation>
+        <translation>Bredvid varandra</translation>
     </message>
     <message>
         <source>Arrange open windows across all the available space.</source>
@@ -5850,7 +5850,7 @@ Vill du fortsätta?</translation>
     </message>
     <message>
         <source>Cascade Windows</source>
-        <translation type="unfinished"></translation>
+        <translation>Stapla på varandra</translation>
     </message>
     <message>
         <source>Arrange all open windows in a stack.</source>
@@ -6722,7 +6722,7 @@ p, li { white-space: pre-wrap; }
     <name>MixesPanel</name>
     <message>
         <source>Move Up</source>
-        <translation>Flytta uppåt</translation>
+        <translation>Flytta upp</translation>
     </message>
     <message>
         <source>Ctrl+Up</source>
@@ -6730,7 +6730,7 @@ p, li { white-space: pre-wrap; }
     </message>
     <message>
         <source>Move Down</source>
-        <translation>Flytta nedåt</translation>
+        <translation>Flytta ner</translation>
     </message>
     <message>
         <source>Ctrl+Down</source>
@@ -9270,11 +9270,11 @@ Gasen reverseras om alternativet väljs. Tomgång ligger då uppåt. Trim och ga
     </message>
     <message>
         <source>Move Up</source>
-        <translation>Flytta uppåt</translation>
+        <translation>Flytta upp</translation>
     </message>
     <message>
         <source>Move Down</source>
-        <translation>Flytta nedåt</translation>
+        <translation>Flytta ner</translation>
     </message>
     <message>
         <source>Paste</source>
@@ -10617,11 +10617,11 @@ För många fel - ger upp.</translation>
     </message>
     <message>
         <source>Move Up</source>
-        <translation>Flytta uppåt</translation>
+        <translation>Flytta upp</translation>
     </message>
     <message>
         <source>Move Down</source>
-        <translation>Flytta nedåt</translation>
+        <translation>Flytta ner</translation>
     </message>
     <message>
         <source>Paste</source>

--- a/companion/src/translations/companion_sv.ts
+++ b/companion/src/translations/companion_sv.ts
@@ -151,7 +151,7 @@
     </message>
     <message>
         <source>Menu Language</source>
-        <translation>Menyspråk</translation>
+        <translation>Språkinställningar</translation>
     </message>
     <message>
         <source>Default Stick Mode</source>

--- a/companion/src/translations/companion_sv.ts
+++ b/companion/src/translations/companion_sv.ts
@@ -151,7 +151,7 @@
     </message>
     <message>
         <source>Menu Language</source>
-        <translation>Språkinställningar</translation>
+        <translation>Språkinställning</translation>
     </message>
     <message>
         <source>Default Stick Mode</source>

--- a/radio/src/translations/se.h
+++ b/radio/src/translations/se.h
@@ -171,7 +171,7 @@
 #define TR_SF_SCREENSHOT                "Skärmbild"
 #define TR_SF_RACING_MODE               "Tävlingsläge"
 #define TR_SF_DISABLE_TOUCH             "Ej pekskärm"
-#define TR_SF_SET_SCREEN                "Set Main Screen"
+#define TR_SF_SET_SCREEN                "Sätt huvudskärm"
 #define TR_SF_RESERVE                   "[reserv]"
 
 #define TR_VFSWFUNC                     TR_SF_SAFETY,"Lärare","Spara trimmar","Nollställ","Sätt ",TR_ADJUST_GVAR,"Volym","Sätt failsafe","Range check","Module bind",TR_SOUND,TR_PLAY_TRACK,TR_PLAY_VALUE, TR_SF_RESERVE,TR_SF_PLAY_SCRIPT,TR_SF_RESERVE,TR_SF_BG_MUSIC,TR_VVARIO,TR_HAPTIC,TR_SDCLOGS,"Belysning",TR_SF_SCREENSHOT,TR_SF_RACING_MODE,TR_SF_DISABLE_TOUCH,TR_SF_SET_SCREEN TR_SF_TEST
@@ -373,8 +373,8 @@
 #define TR_MIXNAME                      TR("Namn","Mixernamn")
 #define TR_INPUTNAME                    TR("Input","Inputnamn")
 #define TR_EXPONAME                     TR("Namn","Radnamn")
-#define TR_BITMAP                       "Modellikon"
 #define TR_NO_PICTURE                   "Ingen bild"
+#define TR_BITMAP                       "Modellikon"
 #define TR_TIMER                        TR("Timer","Timer ")
 #define TR_START                        "Start"
 #define TR_ELIMITS                      TR("Gränser++","Utökade gränser")
@@ -679,7 +679,7 @@
 #define TR_NEW_MODEL                    "Ny modell"
 #define TR_INVALID_MODEL                "Ogiltig modell"
 #define TR_EDIT_LABELS                  "Redigera etiketter"
-#define TR_MOVE_UP                      "Flytta uppp"
+#define TR_MOVE_UP                      "Flytta upp"
 #define TR_MOVE_DOWN                    "Flytta ner"
 #define TR_ENTER_LABEL                  "Ange etikett"
 #define TR_LABEL                        "Etikett"

--- a/radio/src/translations/se.h
+++ b/radio/src/translations/se.h
@@ -453,7 +453,7 @@
 #define TR_LENGTH                       "Tid"
 #define TR_BEEP_LENGTH                  "Piplängd"
 #define TR_BEEP_PITCH                   "Pipton"
-#define TR_HAPTIC_LABEL                 "Vibrator"
+#define TR_HAPTIC_LABEL                 "Vibration"
 #define TR_STRENGTH                     "Styrka"
 #define TR_IMU_LABEL                    "IMU"
 #define TR_IMU_OFFSET                   "Offset"

--- a/radio/src/translations/se.h
+++ b/radio/src/translations/se.h
@@ -53,7 +53,7 @@
 #define TR_VLCD                         "Normal","Optrex"
 #define TR_VPERSISTENT                  "Av","Flygning","Nolla själv"
 #define TR_COUNTRY_CODES                TR("US","Amerika"),TR("JP","Japan"),TR("EU","Europa")
-#define TR_USBMODES                     "Fråga","Joystick"),TR("SD-kort","SD-kortlagring"),"Seriell"
+#define TR_USBMODES                     "Fråga","Joystick",TR("SD-kort","SD-kortlagring"),"Seriell"
 #define TR_JACK_MODES                   "Fråga","Audio","Lärare"
 #define TR_TELEMETRY_PROTOCOLS          "FrSky S.Port","FrSky D","FrSky D (sladd)","TBS Crossfire","Spektrum","AFHDS2A IBUS","Multi Telemetry"
 #define TR_SBUS_INVERSION_VALUES        "normal","ej inverterad"

--- a/radio/src/translations/se.h
+++ b/radio/src/translations/se.h
@@ -53,7 +53,7 @@
 #define TR_VLCD                         "Normal","Optrex"
 #define TR_VPERSISTENT                  "Av","Flygning","Nolla själv"
 #define TR_COUNTRY_CODES                TR("US","Amerika"),TR("JP","Japan"),TR("EU","Europa")
-#define TR_USBMODES                     "Fråga",TR("Joyst","Joystick"),TR("SD-kort","SD-kortlagring"),"Seriell"
+#define TR_USBMODES                     "Fråga","Joystick"),TR("SD-kort","SD-kortlagring"),"Seriell"
 #define TR_JACK_MODES                   "Fråga","Audio","Lärare"
 #define TR_TELEMETRY_PROTOCOLS          "FrSky S.Port","FrSky D","FrSky D (sladd)","TBS Crossfire","Spektrum","AFHDS2A IBUS","Multi Telemetry"
 #define TR_SBUS_INVERSION_VALUES        "normal","ej inverterad"
@@ -500,7 +500,7 @@
 #define TR_SLIDERWARNING                TR(INDENT "Regl. pos.", INDENT "Reglagepositioner")
 #define TR_POTWARNING                   TR(INDENT "Vredläge", INDENT "Vredlägen")
 #define TR_TIMEZONE                     "Tidszon"
-#define TR_ADJUST_RTC                   "Ändra RTC"
+#define TR_ADJUST_RTC                   "Justera RTC"
 #define TR_GPS                          "GPS"
 #define TR_RXCHANNELORD                 TR("Kanalordn. RX","Kanalordning i RX")
 #define TR_STICKS                       "Spakar"


### PR DESCRIPTION
Summary of changes: 
- Some final tweaks and changes for Swedish translations, firmware and Companion, now (hopefully) ready for 2.8 release.
- One typo corrected in mixerdialog.ui, probably of little importance but corrected nonetheless.
