### PR TITLE
More RGB Status Led fixes

### DIFF
--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -890,9 +890,10 @@ constexpr uint8_t OPENTX_START_NO_CHECKS = 0x04;
   #define LED_ERROR_BEGIN()            ledRed()
 // Green is preferred "ready to use" color for these radios
 #if defined(RADIO_T8) || defined(RADIO_COMMANDO8) || defined(RADIO_TLITE) || \
-    defined(RADIO_TPRO) || defined(RADIO_TX12)
-  #define LED_ERROR_END()              ledGreen()
-  #define LED_BIND()                   ledBlue()
+    defined(RADIO_TPRO) || defined(RADIO_TX12) || defined(RADIO_TX12MK2) ||  \
+    defined(RADIO_ZORRO)
+#define LED_ERROR_END() ledGreen()
+#define LED_BIND() ledBlue()
 #else
 // Either green is not an option, or blue is preferred "ready to use" color
   #define LED_ERROR_END()              ledBlue()

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -171,7 +171,9 @@ void boardInit()
 
 #if defined(STATUS_LEDS)
   ledInit();
-#if defined(RADIO_TLITE) || defined(RADIO_TPRO) || defined(RADIO_TX12)
+#if defined(RADIO_T8) || defined(RADIO_COMMANDO8) || defined(RADIO_TLITE) || \
+    defined(RADIO_TPRO) || defined(RADIO_TX12) || defined(RADIO_TX12MK2) ||  \
+    defined(RADIO_ZORRO)
   ledBlue();
 #else
   ledGreen();

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -1455,12 +1455,12 @@
   #define STATUS_LEDS
   #define GPIO_LED_GPIO_ON              GPIO_SetBits
   #define GPIO_LED_GPIO_OFF             GPIO_ResetBits
-  #define LED_GREEN_GPIO                GPIOA
-  #define LED_GREEN_GPIO_PIN            GPIO_Pin_7  // PA.07
+  #define LED_GREEN_GPIO                GPIOE
+  #define LED_GREEN_GPIO_PIN            GPIO_Pin_2  // PE.02
   #define LED_RED_GPIO                  GPIOE
   #define LED_RED_GPIO_PIN              GPIO_Pin_13 // PE.13
-  #define LED_BLUE_GPIO                 GPIOE
-  #define LED_BLUE_GPIO_PIN             GPIO_Pin_2  // PE.02
+  #define LED_BLUE_GPIO                 GPIOA
+  #define LED_BLUE_GPIO_PIN             GPIO_Pin_7  // PA.07
 #elif defined(RADIO_TLITE) || defined(RADIO_TPRO) || defined(RADIO_TX12)
   #define STATUS_LEDS
   #define GPIO_LED_GPIO_ON              GPIO_SetBits


### PR DESCRIPTION
- Forgot to add TX12-MK2 to the list of radios prefering Blue => Green sequence
- Zorro LED G & B GPIOS were also swapped, so added to the list also

Future todo - have each radio raise a flag for blue over green status color rather than having to test for different radios. Or possibly the other way around, as quite a few radios have RGB and can do/prefer Startup Blue, Normal Green. 