### PR TITLE
fix(color): `@` displayed on radios instead of `°` 

### DIFF
--- a/radio/src/gui/colorlcd/draw_functions.cpp
+++ b/radio/src/gui/colorlcd/draw_functions.cpp
@@ -365,10 +365,10 @@ void drawDate(BitmapBuffer * dc, coord_t x, coord_t y, TelemetryItem & telemetry
 
 coord_t drawGPSCoord(BitmapBuffer * dc, coord_t x, coord_t y, int32_t value, const char * direction, LcdFlags flags, bool seconds=true)
 {
-  char s[32];
+  char s[32] = {};
   uint32_t absvalue = abs(value);
   char * tmp = strAppendUnsigned(s, absvalue / 1000000);
-  *tmp++ = '@';
+  tmp = strAppend(tmp, "°");
   absvalue = absvalue % 1000000;
   absvalue *= 60;
   if (g_eeGeneral.gpsFormat == 0 || !seconds) {

--- a/radio/src/gui/colorlcd/model_curves.cpp
+++ b/radio/src/gui/colorlcd/model_curves.cpp
@@ -334,7 +334,7 @@ void ModelCurvesPage::build(FormWindow * window, int8_t focusIndex)
       Menu *menu = new Menu(window);
       for (int angle = -45; angle <= 45; angle += 15) {
         char label[16];
-        strAppend(strAppendSigned(label, angle), "@");
+        strAppend(strAppendSigned(label, angle), "°");
         menu->addLine(label, [=]() {
           int dx = 2000 / (5 + curve.points - 1);
           for (uint8_t i = 0; i < 5 + curve.points; i++) {


### PR DESCRIPTION
fix: GPS coordinates on color lcd radios now shows °, instead of @
fix: curve selector for predefined curves now shows °, instead of @

fixes part of #2163 
