### PR TITLE
Some widget fixes

### DIFF
--- a/radio/src/gui/colorlcd/view_main.h
+++ b/radio/src/gui/colorlcd/view_main.h
@@ -58,6 +58,7 @@ class ViewMain: public Window
     void enableTopbar();
     void disableTopbar();
     void updateTopbarVisibility();
+    bool enableWidgetSelect(bool enable);
 
     // Get the available space in the middle of the screen
     // (without topbar)
@@ -95,7 +96,6 @@ class ViewMain: public Window
     void setTopbarVisible(float visible);
 
     void openMenu();
-    bool enableWidgetSelect(bool enable);
     void refreshWidgetSelectTimer();
 
     static void long_pressed(lv_event_t* e);

--- a/radio/src/gui/colorlcd/widget.cpp
+++ b/radio/src/gui/colorlcd/widget.cpp
@@ -140,7 +140,10 @@ void Widget::setFullscreen(bool enable)
     lv_obj_set_style_bg_opa(lvobj, LV_OPA_MAX, LV_PART_MAIN);
     setRect(parent->getRect());
     fullscreen = true;
-    ViewMain::instance()->disableTopbar();
+
+    auto view = ViewMain::instance();
+    view->enableWidgetSelect(false);
+    view->disableTopbar();
     bringToTop();
 
     if (!lv_obj_get_group(lvobj)) {


### PR DESCRIPTION
Related to #2182 

Summary of changes:
- disable "widget select" mode when going full screen
- prevent pop-up dialogs from passing key events to parents (thus allowing for starting ex model settings while in widget settings).
