### PR TITLE
feat: Use rotary encoder velocity only on specific components

### DIFF
--- a/radio/src/gui/colorlcd/LvglWrapper.cpp
+++ b/radio/src/gui/colorlcd/LvglWrapper.cpp
@@ -246,11 +246,21 @@ static void rotaryDriverRead(lv_indev_drv_t *drv, lv_indev_data_t *data)
   if (diff != 0) {
     reset_inactivity();
 
+    bool use_accel = false;
+    auto i = lv_indev_get_act();
+    if (i) {
+      auto g = i->group;
+      if (g && lv_group_get_editing(g)) {
+        auto obj = lv_group_get_focused(g);
+        use_accel = obj && lv_obj_has_flag(obj, LV_OBJ_FLAG_ENCODER_ACCEL);
+      }
+    }
+    
     int8_t dir = 0;
     if (diff < 0) dir = -1;
     else if (diff > 0) dir = 1;
 
-    if (dir == prevDir) {
+    if (use_accel && (dir == prevDir)) {
       if (g_tmr10ms - lastEvent <= ROTENC_DELAY_HIGHSPEED) { // 160 ms
         // below ROTENC_DELAY_HIGHSPEED btw. events: accelerate
         accel += abs(diff);


### PR DESCRIPTION
Depends on EdgeTX/libopenui#66

Summary of changes:
- provide better support for encoder acceleration
- applies now only to number edit and drop-down menus (those with `LV_OBJ_FLAG_ENCODER_ACCEL`)
