### PR TITLE
feature: add support UTF-8 ° symbol for B&W radios

### DIFF
--- a/radio/src/gui/128x64/lcd.cpp
+++ b/radio/src/gui/128x64/lcd.cpp
@@ -878,7 +878,7 @@ void drawGPSCoord(coord_t x, coord_t y, int32_t value, const char * direction, L
   att &= ~RIGHT & ~BOLD;
   uint32_t absvalue = abs(value);
   lcdDrawNumber(x, y, absvalue / 1000000, att); // ddd
-  lcdDrawChar(lcdLastRightPos, y, '@', att);
+  lcdDrawChar(lcdLastRightPos, y, STR_CHAR_BW_DEGREE, att);
   absvalue = absvalue % 1000000;
   absvalue *= 60;
   if (g_eeGeneral.gpsFormat == 0 || !seconds) {

--- a/radio/src/gui/128x64/model_curve_edit.cpp
+++ b/radio/src/gui/128x64/model_curve_edit.cpp
@@ -47,7 +47,7 @@ void runPopupCurvePreset(event_t event)
   }
 
   lcdDrawNumber(WARNING_LINE_X+FW*7, WARNING_LINE_Y, 45 * reusableBuffer.curveEdit.preset / 4, LEFT|INVERS);
-  lcdDrawChar(lcdLastRightPos, WARNING_LINE_Y, '@', INVERS);
+  lcdDrawChar(lcdLastRightPos, WARNING_LINE_Y, STR_CHAR_BW_DEGREE, INVERS);
 
   if (warningResult) {
     warningResult = 0;

--- a/radio/src/gui/128x64/radio_diaganas.cpp
+++ b/radio/src/gui/128x64/radio_diaganas.cpp
@@ -135,12 +135,12 @@ void menuRadioDiagAnalogs(event_t event)
   uint8_t x = INDENT_WIDTH;
   lcdDrawText(x, y, "X:");
   lcdDrawNumber(x+3*FW-1, y, gyro.outputs[0] * 180 / 1024);
-  lcdDrawChar(lcdNextPos, y, '@');
+  lcdDrawChar(lcdNextPos, y, STR_CHAR_BW_DEGREE);
   lcdDrawNumber(x+10*FW-1, y, gyro.scaledX(), RIGHT);
   x = LCD_W/2 + INDENT_WIDTH;
   lcdDrawText(x, y, "Y:");
   lcdDrawNumber(x+3*FW-1, y, gyro.outputs[1] * 180 / 1024);
-  lcdDrawChar(lcdNextPos, y, '@');
+  lcdDrawChar(lcdNextPos, y, STR_CHAR_BW_DEGREE);
   lcdDrawNumber(x+10*FW-1, y, gyro.scaledY(), RIGHT);
 #endif
 }

--- a/radio/src/gui/128x64/radio_setup.cpp
+++ b/radio/src/gui/128x64/radio_setup.cpp
@@ -398,7 +398,7 @@ void menuRadioSetup(event_t event)
       case ITEM_RADIO_SETUP_IMU_MAX:
         lcdDrawText(INDENT_WIDTH, y, STR_IMU_MAX);
         lcdDrawNumber(RADIO_SETUP_2ND_COLUMN, y, IMU_MAX_DEFAULT + g_eeGeneral.imuMax, attr|LEFT);
-        lcdDrawChar(lcdLastRightPos, y, '@', attr);
+        lcdDrawChar(lcdLastRightPos, y, STR_CHAR_BW_DEGREE, attr);
         if (attr) {
           CHECK_INCDEC_GENVAR(event, g_eeGeneral.imuMax, IMU_MAX_DEFAULT - IMU_MAX_RANGE, IMU_MAX_DEFAULT + IMU_MAX_RANGE);
           lcdDrawText(LCD_W-4*FW, y, "(");
@@ -410,7 +410,7 @@ void menuRadioSetup(event_t event)
       case ITEM_RADIO_SETUP_IMU_OFFSET:
         lcdDrawText(INDENT_WIDTH, y, STR_IMU_OFFSET);
         lcdDrawNumber(RADIO_SETUP_2ND_COLUMN, y, g_eeGeneral.imuOffset, attr|LEFT);
-        lcdDrawChar(lcdLastRightPos, y, '@', attr);
+        lcdDrawChar(lcdLastRightPos, y, STR_CHAR_BW_DEGREE, attr);
         if (attr) {
           CHECK_INCDEC_GENVAR(event, g_eeGeneral.imuOffset, IMU_OFFSET_MIN, IMU_OFFSET_MAX);
           lcdDrawText(LCD_W-4*FW, y, "(");

--- a/radio/src/gui/212x64/lcd.cpp
+++ b/radio/src/gui/212x64/lcd.cpp
@@ -762,7 +762,7 @@ void drawGPSCoord(coord_t x, coord_t y, int32_t value, const char * direction, L
   att &= ~RIGHT;
   if (x > 10) x-=10;
   lcdDrawNumber(x, y, absvalue / 1000000, att); // ddd
-  lcdDrawChar(lcdLastRightPos, y, '@', att);
+  lcdDrawChar(lcdLastRightPos, y, STR_CHAR_BW_DEGREE, att);
   absvalue = absvalue % 1000000;
   absvalue *= 60;
   if (g_eeGeneral.gpsFormat == 0 || !seconds) {

--- a/radio/src/gui/212x64/model_curve_edit.cpp
+++ b/radio/src/gui/212x64/model_curve_edit.cpp
@@ -49,7 +49,7 @@ void runPopupCurvePreset(event_t event)
   }
 
   lcdDrawNumber(WARNING_LINE_X+FW*7, WARNING_LINE_Y, 45 * reusableBuffer.curveEdit.preset / 4, LEFT|INVERS);
-  lcdDrawChar(lcdLastRightPos, WARNING_LINE_Y, '@', INVERS);
+  lcdDrawChar(lcdLastRightPos, WARNING_LINE_Y, STR_CHAR_BW_DEGREE, INVERS);
 
   if (warningResult) {
     warningResult = 0;

--- a/radio/src/gui/common/stdlcd/utf8.cpp
+++ b/radio/src/gui/common/stdlcd/utf8.cpp
@@ -22,6 +22,7 @@
 
 #include <stdint.h>
 #include "definitions.h"
+#include "translations/untranslated.h"
 
 #if defined(TRANSLATIONS_FR)
 static wchar_t _utf8_lut[] = {
@@ -103,7 +104,9 @@ unsigned char map_utf8_char(const char*& s, uint8_t& len)
       return (unsigned char)w;
     }
     if(w == L'≥')
-      return '}';
+      return STR_CHAR_BW_GREATEREQUAL;
+    if(w == L'°')
+      return STR_CHAR_BW_DEGREE;
 #if !defined(NO_UTF8_LUT)
     return lookup_utf8_mapping(w);
 #else

--- a/radio/src/translations/cn.h
+++ b/radio/src/translations/cn.h
@@ -183,11 +183,7 @@
 #define SPEED_UNIT_METR                "kmh"
 
 #define TR_VUNITSSYSTEM                "公制",TR("英制","英制")
-#if defined(COLORLCD)
 #define TR_VTELEMUNIT                  "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","°C","°F","%","mAh","W","mW","dB","rpm","g","°","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#else
-#define TR_VTELEMUNIT                  "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","@C","@F","%","mAh","W","mW","dB","rpm","g","@","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#endif
 
 #define STR_V                          (STR_VTELEMUNIT[1])
 #define STR_A                          (STR_VTELEMUNIT[2])

--- a/radio/src/translations/cz.h
+++ b/radio/src/translations/cz.h
@@ -202,11 +202,7 @@
 #define SPEED_UNIT_METR                "kmh"
 
 #define TR_VUNITSSYSTEM                TR("Metr.","Metrické"),TR("Imper.","Imperiální")
-#if defined(COLORLCD)
 #define TR_VTELEMUNIT                  "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","°C","°F","%","mAh","W","mW","dB","rpm","g","°","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#else
-#define TR_VTELEMUNIT                  "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","@C","@F","%","mAh","W","mW","dB","rpm","g","@","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#endif
 
 #define STR_V                          (STR_VTELEMUNIT[1])
 #define STR_A                          (STR_VTELEMUNIT[2])

--- a/radio/src/translations/da.h
+++ b/radio/src/translations/da.h
@@ -183,11 +183,7 @@
 #define SPEED_UNIT_METR                "kmh"
 
 #define TR_VUNITSSYSTEM                "Metrisk",TR("Imper.","Imperiel")
-#if defined(COLORLCD)
 #define TR_VTELEMUNIT                  "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","°C","°F","%","mAh","W","mW","dB","rpm","g","°","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#else
-#define TR_VTELEMUNIT                  "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","@C","@F","%","mAh","W","mW","dB","rpm","g","@","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#endif
 
 #define STR_V                          (STR_VTELEMUNIT[1])
 #define STR_A                          (STR_VTELEMUNIT[2])

--- a/radio/src/translations/de.h
+++ b/radio/src/translations/de.h
@@ -186,11 +186,7 @@
 #define LENGTH_UNIT_METR               "m"
 #define SPEED_UNIT_METR                "kmh"
 #define TR_VUNITSSYSTEM                TR("Metrik","Metrisch"),TR("Imper.","Imperial")
-#if defined(COLORLCD)
 #define TR_VTELEMUNIT                  "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","°C","°F","%","mAh","W","mW","dB","rpm","g","°","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#else
-#define TR_VTELEMUNIT                  "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","@C","@F","%","mAh","W","mW","dB","rpm","g","@","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#endif
 
 #define STR_V                          (STR_VTELEMUNIT[1])
 #define STR_A                          (STR_VTELEMUNIT[2])

--- a/radio/src/translations/en.h
+++ b/radio/src/translations/en.h
@@ -183,11 +183,8 @@
 #define SPEED_UNIT_METR                "kmh"
 
 #define TR_VUNITSSYSTEM                "Metric",TR("Imper.","Imperial")
-#if defined(COLORLCD)
 #define TR_VTELEMUNIT                  "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","°C","°F","%","mAh","W","mW","dB","rpm","g","°","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#else
-#define TR_VTELEMUNIT                  "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","@C","@F","%","mAh","W","mW","dB","rpm","g","@","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#endif
+
 #define STR_V                          (STR_VTELEMUNIT[1])
 #define STR_A                          (STR_VTELEMUNIT[2])
 

--- a/radio/src/translations/es.h
+++ b/radio/src/translations/es.h
@@ -184,11 +184,8 @@
 #define SPEED_UNIT_METR        "kmh"
 
 #define TR_VUNITSSYSTEM        "Métrico","Imperial"
-#if defined(COLORLCD)
 #define TR_VTELEMUNIT          "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","°C","°F","%","mAh","W","mW","dB","rpm","g","°","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#else
-#define TR_VTELEMUNIT          "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","@C","@F","%","mAh","W","mW","dB","rpm","g","@","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#endif
+
 #define STR_V                  (STR_VTELEMUNIT[1])
 #define STR_A                  (STR_VTELEMUNIT[2])
 

--- a/radio/src/translations/fi.h
+++ b/radio/src/translations/fi.h
@@ -204,11 +204,8 @@
 #define SPEED_UNIT_METR                "kmh"
 
 #define TR_VUNITSSYSTEM                "Metric",TR("Imper.","Imperial")
-#if defined(COLORLCD)
 #define TR_VTELEMUNIT                  "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","°C","°F","%","mAh","W","mW","dB","rpm","g","°","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#else
-#define TR_VTELEMUNIT                  "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","@C","@F","%","mAh","W","mW","dB","rpm","g","@","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#endif
+
 #define STR_V                          (STR_VTELEMUNIT[1])
 #define STR_A                          (STR_VTELEMUNIT[2])
 

--- a/radio/src/translations/fr.h
+++ b/radio/src/translations/fr.h
@@ -205,11 +205,8 @@
 #define SPEED_UNIT_METR                "kmh"
 
 #define TR_VUNITSSYSTEM                TR("Métr.","Métriques"),TR("Impér.","Impériales")
-#if defined(COLORLCD)
 #define TR_VTELEMUNIT                  "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","°C","°F","%","mAh","W","mW","dB","rpm","g","°","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#else
-#define TR_VTELEMUNIT                  "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","@C","@F","%","mAh","W","mW","dB","rpm","g","@","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#endif
+
 #define STR_V                          (STR_VTELEMUNIT[1])
 #define STR_A                          (STR_VTELEMUNIT[2])
 

--- a/radio/src/translations/it.h
+++ b/radio/src/translations/it.h
@@ -187,11 +187,8 @@
 #define SPEED_UNIT_METR        "kmh"
 
 #define TR_VUNITSSYSTEM        TR("Metric","Metriche"),TR("Imper.","Imperiali")
-#if defined(COLORLCD)
 #define TR_VTELEMUNIT          "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","°C","°F","%","mAh","W","mW","dB","rpm","g","°","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#else
-#define TR_VTELEMUNIT          "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","@C","@F","%","mAh","W","mW","dB","rpm","g","@","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#endif
+
 #define STR_V                  (STR_VTELEMUNIT[1])
 #define STR_A                  (STR_VTELEMUNIT[2])
 

--- a/radio/src/translations/nl.h
+++ b/radio/src/translations/nl.h
@@ -186,11 +186,8 @@
 #define SPEED_UNIT_METR        "kmh"
 
 #define TR_VUNITSSYSTEM        TR("Mtrsch","Metrisch"),"Engels"
-#if defined(COLORLCD)
 #define TR_VTELEMUNIT          "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","°C","°F","%","mAh","W","mW","dB","rpm","g","°","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#else
-#define TR_VTELEMUNIT          "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","@C","@F","%","mAh","W","mW","dB","rpm","g","@","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#endif
+
 #define STR_V                  (STR_VTELEMUNIT[1])
 #define STR_A                  (STR_VTELEMUNIT[2])
 

--- a/radio/src/translations/pl.h
+++ b/radio/src/translations/pl.h
@@ -183,11 +183,8 @@
 #define SPEED_UNIT_METR        "kmh"
 
 #define TR_VUNITSSYSTEM        TR("Metr.","Metryczn"),TR("Imper.","Imperial")
-#if defined(COLORLCD)
 #define TR_VTELEMUNIT          "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","°C","°F","%","mAh","W","mW","dB","rpm","g","°","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#else
-#define TR_VTELEMUNIT          "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","@C","@F","%","mAh","W","mW","dB","rpm","g","@","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#endif
+
 #define STR_V                  (STR_VTELEMUNIT[1])
 #define STR_A                  (STR_VTELEMUNIT[2])
 

--- a/radio/src/translations/pt.h
+++ b/radio/src/translations/pt.h
@@ -181,11 +181,8 @@
 #define SPEED_UNIT_METR        "kmh"
 
 #define TR_VUNITSSYSTEM        "Metric",TR("Imper.","Imperial")
-#if defined(COLORLCD)
 #define TR_VTELEMUNIT          "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","°C","°F","%","mAh","W","mW","dB","rpm","g","°","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#else
-#define TR_VTELEMUNIT          "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","@C","@F","%","mAh","W","mW","dB","rpm","g","@","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#endif
+
 #define STR_V                  (STR_VTELEMUNIT[1])
 #define STR_A                  (STR_VTELEMUNIT[2])
 

--- a/radio/src/translations/se.h
+++ b/radio/src/translations/se.h
@@ -209,11 +209,8 @@
 #define SPEED_UNIT_METR                "kmh"
 
 #define TR_VUNITSSYSTEM                TR("Metr.","Metriska"),TR("Brit.","Brittiska")
-#if defined(COLORLCD)
-#define TR_VTELEMUNIT          "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","°C","°F","%","mAh","W","mW","dB","rpm","g","°","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#else
-#define TR_VTELEMUNIT          "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","@C","@F","%","mAh","W","mW","dB","rpm","g","@","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#endif
+#define TR_VTELEMUNIT                  "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","°C","°F","%","mAh","W","mW","dB","rpm","g","°","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
+
 #define STR_V                          (STR_VTELEMUNIT[1])
 #define STR_A                          (STR_VTELEMUNIT[2])
 

--- a/radio/src/translations/tw.h
+++ b/radio/src/translations/tw.h
@@ -183,11 +183,8 @@
 #define SPEED_UNIT_METR                "kmh"
 
 #define TR_VUNITSSYSTEM                "公制",TR("英制","英制")
-#if defined(COLORLCD)
 #define TR_VTELEMUNIT                  "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","°C","°F","%","mAh","W","mW","dB","rpm","g","°","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#else
-#define TR_VTELEMUNIT                  "-","V","A","mA","kts","m/s","f/s","kmh","mph","m","ft","@C","@F","%","mAh","W","mW","dB","rpm","g","@","rad","ml","fOz","mlm","Hz","mS","uS","km","dBm"
-#endif
+
 #define STR_V                          (STR_VTELEMUNIT[1])
 #define STR_A                          (STR_VTELEMUNIT[2])
 

--- a/radio/src/translations/untranslated.h
+++ b/radio/src/translations/untranslated.h
@@ -279,6 +279,9 @@
 #define STR_CHAR_TELEMETRY "\302\223"
 #define STR_CHAR_LUA       "\302\224"
 
+#define STR_CHAR_BW_GREATEREQUAL '}'
+#define STR_CHAR_BW_DEGREE       '@'
+
 #define TR_FSGROUPS                     "-","1","2","3"
 
 //


### PR DESCRIPTION
- remove translation workaround for the ° symbol
- switch every use of the @ char for a ° char to a new define
  - same for ≥ and }

This also allow Lua-Scripts to use the ° character, tested with a modified iNav script
