### PR TITLE
fix(color): Radio tools buttons fit screen better

### DIFF
--- a/radio/src/gui/colorlcd/radio_tools.cpp
+++ b/radio/src/gui/colorlcd/radio_tools.cpp
@@ -173,7 +173,10 @@ struct ToolButton : public TextButton {
         return 0;
       })
   {
-    setWidth(LV_DPI_DEF);
+    if (LCD_W > LCD_H)
+      setWidth((LCD_W - 3*10) / 3); // 3 columns on landscape
+    else
+      setWidth((LCD_W - 2*11) / 2); // 2 columns on portrait
     setHeight(LV_DPI_DEF / 2);
 
     lv_obj_set_width(label, lv_pct(100));


### PR DESCRIPTION
Summary of changes:

![image](https://user-images.githubusercontent.com/5500713/192516223-b0845992-7735-4b69-9b27-1f2e69a05bf7.png)
is now
![snapshot_02](https://user-images.githubusercontent.com/5500713/192516310-fe941614-789c-4c61-95e3-3029a303c989.png)

And
![snapshot_01](https://user-images.githubusercontent.com/5500713/192516377-42a081a6-aaf9-4d5d-b692-e5b91ca04d5e.png)
is now
![snapshot_02](https://user-images.githubusercontent.com/5500713/192516491-f007cc0c-8642-407f-bba9-9692bf8e659d.png)

