### PR TITLE
Restore "go to channel monitor" Button

### DIFF
--- a/radio/src/gui/colorlcd/menu_model.cpp
+++ b/radio/src/gui/colorlcd/menu_model.cpp
@@ -61,7 +61,7 @@ ModelMenu::ModelMenu():
 #endif
   addTab(new ModelTelemetryPage());
 
-  addButton(&header);
+  addGoToMonitorsButton();
 }
 
 void ModelMenu::onEvent(event_t event)
@@ -76,10 +76,10 @@ void ModelMenu::onEvent(event_t event)
 #endif
 }
 
-void ModelMenu::addButton(TabsGroupHeader* header)
+void ModelMenu::addGoToMonitorsButton()
 {
   OpenTxTheme::instance()->createTextButton(
-      header, {LCD_W / 2 + 6, MENU_TITLE_TOP + 1, LCD_W / 2 - 8, MENU_TITLE_HEIGHT - 2},
+      &header, {LCD_W / 2 + 6, MENU_TITLE_TOP + 1, LCD_W / 2 - 8, MENU_TITLE_HEIGHT - 2},
       STR_OPEN_CHANNEL_MONITORS, [=]() {
         pushEvent(EVT_KEY_FIRST(KEY_MODEL));
         return 0;

--- a/radio/src/gui/colorlcd/menu_model.cpp
+++ b/radio/src/gui/colorlcd/menu_model.cpp
@@ -61,6 +61,7 @@ ModelMenu::ModelMenu():
 #endif
   addTab(new ModelTelemetryPage());
 
+  addButton(&header);
 }
 
 void ModelMenu::onEvent(event_t event)
@@ -73,4 +74,14 @@ void ModelMenu::onEvent(event_t event)
     TabsGroup::onEvent(event);
   }
 #endif
+}
+
+void ModelMenu::addButton(TabsGroupHeader* header)
+{
+  OpenTxTheme::instance()->createTextButton(
+      header, {LCD_W / 2 + 6, MENU_TITLE_TOP + 1, LCD_W / 2 - 8, MENU_TITLE_HEIGHT - 2},
+      STR_OPEN_CHANNEL_MONITORS, [=]() {
+        pushEvent(EVT_KEY_FIRST(KEY_MODEL));
+        return 0;
+      });
 }

--- a/radio/src/gui/colorlcd/menu_model.h
+++ b/radio/src/gui/colorlcd/menu_model.h
@@ -34,6 +34,9 @@ class ModelMenu : public TabsGroup
 #if defined(DEBUG_WINDOWS)
   std::string getName() const override { return "ModelMenu"; }
 #endif
+
+protected:
+ void addButton(TabsGroupHeader* header);
 };
 
 #endif // _MENU_MODEL_H_

--- a/radio/src/gui/colorlcd/menu_model.h
+++ b/radio/src/gui/colorlcd/menu_model.h
@@ -36,7 +36,7 @@ class ModelMenu : public TabsGroup
 #endif
 
 protected:
- void addButton(TabsGroupHeader* header);
+ void addGoToMonitorsButton(void);
 };
 
 #endif // _MENU_MODEL_H_


### PR DESCRIPTION
Summary of changes:
This PR brings back the "go to channel monitor" button, that was present in 2.7.

I would not insist on it, but I think it has some use.
For the TXs with buttons it is not really necessary, since this functionality is available with MDL button, but for the buttonless radios I think it adds some convenience.
