### PR TITLE
(fw) Fix 2386, deleting a label will cause a EM/Hang

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ project(EdgeTX)
 set(VERSION_MAJOR "2")
 set(VERSION_MINOR "8")
 set(VERSION_REVISION "0")
-set(CODENAME "dev")
+set(CODENAME "FlyingDutchman")
 
 if(DEFINED ENV{EDGETX_VERSION_TAG})
   set(VERSION_TAG "$ENV{EDGETX_VERSION_TAG}")

--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -784,15 +784,17 @@ void ModelLabelsWindow::buildBody(FormWindow *window)
           strncpy(tmpLabel, oldLabel.c_str(), LABEL_LENGTH);
           tmpLabel[LABEL_LENGTH] = '\0';
           new LabelDialog(this, tmpLabel, [=](std::string newLabel) {
-            auto rndialog =
-                new ProgressDialog(this, STR_RENAME_LABEL, [=]() {});
-            modelslabels.renameLabel(
-                oldLabel, newLabel, [=](const char *name, int percentage) {
-                  rndialog->updateProgress(name, percentage);
-                });
-            auto labels = getLabels();
-            lblselector->setNames(labels);
-            updateFilteredLabels(modelslabels.filteredLabels(), false);
+            if(newLabel.size() > 0) {
+              auto rndialog =
+                  new ProgressDialog(this, STR_RENAME_LABEL, [=]() {});
+              modelslabels.renameLabel(
+                  oldLabel, newLabel, [=](const char *name, int percentage) {
+                    rndialog->updateProgress(name, percentage);
+                  });
+              auto labels = getLabels();
+              lblselector->setNames(labels);
+              updateFilteredLabels(modelslabels.filteredLabels(), false);
+            }
           });
           return 0;
         });

--- a/radio/src/storage/modelslist.cpp
+++ b/radio/src/storage/modelslist.cpp
@@ -616,15 +616,19 @@ bool ModelMap::renameLabel(const std::string &from, std::string to,
   if (from == "") return true;
   DEBUG_TIMER_START(debugTimerYamlScan);
 
-  // Limit max label name. TODO: Warn user they entered too long of a string
-  to = to.substr(0, LABEL_LENGTH);
-  removeYAMLChars(to);
-  if(to.size() == 0) return true;
-
+  if(to.size() > 0) { // Ignore check if deleting a label, size will be zero
+    to = to.substr(0, LABEL_LENGTH); // Limit max label name. TODO: Warn user they entered too long of a string
+    removeYAMLChars(to); // Remove special chars
+    if(to.size() == 0 || from == to) { // Abort rename if no chars left or same
+      if (progress != nullptr) progress("", 100); // Kill progress dialog
+      return true;
+    }
+  }
 
   ModelData *modeldata = (ModelData *)malloc(sizeof(ModelData));
   if (!modeldata) {
     TRACE("Labels: Out Of Memory");
+    if (progress != nullptr) progress("", 100); // Kill progress dialog
     return true;
   }
 


### PR DESCRIPTION
Looks like I introduced this with removing YAML characters to prevent unwanted characters in the Label. When deleting labels, it does a rename of all the models labels to "". There was a check that was preventing this action because size was zero..

Ooops.