### PR TITLE
fix(color): Trainer stick labels not correct

### DIFF
--- a/radio/src/gui/colorlcd/radio_trainer.cpp
+++ b/radio/src/gui/colorlcd/radio_trainer.cpp
@@ -57,7 +57,7 @@ void RadioTrainerPage::build(FormWindow * form)
     TrainerMix* td = &g_eeGeneral.trainer.mix[chan - 1];
 
     auto line = form->newLine(&grid);
-    new StaticText(line, rect_t{}, STR_VSRCRAW[i + 1], 0, COLOR_THEME_PRIMARY1);
+    new StaticText(line, rect_t{}, STR_VSRCRAW[chan], 0, COLOR_THEME_PRIMARY1);
 
     auto box = new FormGroup(line, rect_t{});
     box->setFlexLayout(LV_FLEX_FLOW_ROW, lv_dpx(4));


### PR DESCRIPTION
Stick labels for trainer mode should match default channel order setting

Fixes #2025

Just need to sanity check/test again before mislabeling them completely! :-O However just referred back to otx and it looks right. 

https://github.com/opentx/opentx/blob/28f67c1e9a4e949c236f576a215e9becb52fd6ec/radio/src/gui/480x272/radio_trainer.cpp#L54