### PR TITLE
Add extra line in telemetry screen for vertical LCD.

### DIFF
--- a/radio/src/gui/colorlcd/model_telemetry.cpp
+++ b/radio/src/gui/colorlcd/model_telemetry.cpp
@@ -483,6 +483,8 @@ void ModelTelemetryPage::build(FormWindow * window, int8_t focusSensorIndex)
   new StaticText(window, grid.getLabelSlot(true), STR_DISABLE_ALARM, 0, COLOR_THEME_PRIMARY1);
   new CheckBox(window, grid.getFieldSlot(), GET_SET_DEFAULT(g_model.rssiAlarms.disabled));
   grid.nextLine();
+  
+  if (LCD_W < LCD_H) grid.nextLine();
 
   // Sensors
   grid.setLabelWidth(140);


### PR DESCRIPTION
Temporary fix for #2254

Fixes #2254 

Summary of changes: add extra line in the Telemetry screen to avoid text overlap on the targets with vertical screens.
