### PR TITLE
Fix Copy/Move/Paste mixer line

### DIFF
--- a/radio/src/gui/colorlcd/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model_mixes.cpp
@@ -359,7 +359,7 @@ InputMixButton* ModelMixesPage::createLineButton(InputMixGroup *group, uint8_t i
         _copyMode = COPY_MODE;
         _copySrc = button;
       });
-      if (s_copyMode != 0) {
+      if (_copyMode != 0) {
         menu->addLine(STR_PASTE_BEFORE, [=]() {
           uint8_t idx = button->getIndex();
           pasteMixBefore(idx);
@@ -494,13 +494,13 @@ static int _mixChnFromIndex(uint8_t index)
 void ModelMixesPage::pasteMixBefore(uint8_t dst_idx)
 {
   int channel = _mixChnFromIndex(dst_idx);
-  pasteInput(dst_idx, channel);
+  pasteMix(dst_idx, channel);
 }
 
 void ModelMixesPage::pasteMixAfter(uint8_t dst_idx)
 {
   int channel = _mixChnFromIndex(dst_idx);
-  pasteInput(dst_idx + 1, channel);
+  pasteMix(dst_idx + 1, channel);
 }
 
 void ModelMixesPage::build(FormWindow * window)


### PR DESCRIPTION
Fix functionality of moving and pasting mixes.

Fixes #2398 

Summary of changes: use pasteMix() for mixes rather than pasteInput(). (Kind of make sense.)
Use the relevant class member instead of global variable to detect the fact that a line was saved for Paste/Move.
