### PR TITLE
fix(gui): line height in EdgeTX<2.8 was smaller at the same font size…

### DIFF
--- a/radio/src/gui/colorlcd/draw_functions.cpp
+++ b/radio/src/gui/colorlcd/draw_functions.cpp
@@ -580,7 +580,7 @@ void drawTextLines(BitmapBuffer * dc, coord_t left, coord_t top, coord_t width, 
 {
   coord_t x = left;
   coord_t y = top;
-  coord_t line = getFontHeight(flags & 0xFFFF);
+  coord_t line = getFontHeightCondensed(flags & 0xFFFF);
   coord_t space = getTextWidth(" ", 1, flags);
   coord_t word;
   const char * nxt = str;

--- a/radio/src/gui/colorlcd/fonts.cpp
+++ b/radio/src/gui/colorlcd/fonts.cpp
@@ -43,6 +43,17 @@
   FONT_TABLE(roboto);
 #endif
 
+// used to set the line height to the line heights used in Edgetx < 2.7 and OpenTX
+static const int8_t FontHeightCorrection[FONTS_COUNT] {
+  -2, // STD
+  -2, // BOLD
+  -2, // XXS
+  -2, // XS
+  -3, // L
+  -5, // XL
+  -2, // XXL
+};
+
 #endif // BOOT
 
 const lv_font_t* getFont(LcdFlags flags)
@@ -60,6 +71,12 @@ uint8_t getFontHeight(LcdFlags flags)
 {
   auto font = getFont(flags);
   return lv_font_get_line_height(font);
+}
+
+uint8_t getFontHeightCondensed(LcdFlags flags)
+{
+  auto font = getFont(flags);
+  return lv_font_get_line_height(font) + FontHeightCorrection[FONT_INDEX(flags)];
 }
 
 int getTextWidth(const char * s, int len, LcdFlags flags)

--- a/radio/src/gui/colorlcd/fonts.cpp
+++ b/radio/src/gui/colorlcd/fonts.cpp
@@ -43,6 +43,8 @@
   FONT_TABLE(roboto);
 #endif
 
+#endif // BOOT
+
 // used to set the line height to the line heights used in Edgetx < 2.7 and OpenTX
 static const int8_t FontHeightCorrection[FONTS_COUNT] {
   -2, // STD
@@ -53,8 +55,6 @@ static const int8_t FontHeightCorrection[FONTS_COUNT] {
   -5, // XL
   -2, // XXL
 };
-
-#endif // BOOT
 
 const lv_font_t* getFont(LcdFlags flags)
 {


### PR DESCRIPTION
… as with Edgetx >=2.8

to allow lua scripts to be optimized for odler and newer versions, drawTextLines now draws the text vertically condensed

needs https://github.com/EdgeTX/libopenui/pull/69

Fixes line-height part of #2372 