### PR TITLE
fix(color): Prevent false duplicate models fix for #2408

### DIFF
--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -382,10 +382,10 @@ void ModelsPageBody::selectModel(ModelCell *model)
          LEN_MODEL_FILENAME);
 
   loadModel(g_eeGeneral.currModelFilename, true);
+  modelslist.setCurrentModel(model);
+
   storageDirty(EE_GENERAL);
   storageCheck(true);
-
-  modelslist.setCurrentModel(model);
 
   // Exit to main view
   auto w = Layer::back();


### PR DESCRIPTION
I was still unable to reproduce #2408, but looking into the code this is one place I think there could be an issue. Making a draft pull so actions can run and hopefully users who have the issue in #2408 can test to see if it helps.

I thinking there might be a timing issue here, if there was a labels write pending and the model is changed before this happens, it may have updated to the incorrect cell in memory.