### PR TITLE
fix(color) - Change extension on models.yml to prevent second parsing

### DIFF
--- a/radio/src/storage/modelslist.cpp
+++ b/radio/src/storage/modelslist.cpp
@@ -1088,12 +1088,12 @@ bool ModelsList::loadYaml()
     }
 
     if(foundInRadio) {
-      const char *warning = sdMoveFile(MODELS_FILENAME, RADIO_PATH, MODELS_FILENAME, UNUSED_MODELS_PATH);
+      const char *warning = sdMoveFile(MODELS_FILENAME, RADIO_PATH, MODELS_FILENAME ".old", UNUSED_MODELS_PATH);
       if(warning)
         POPUP_WARNING(warning);
     }
     if(foundInModels) { // Will overwrite the copy from /radio if both existed, do last
-      const char *warning = sdMoveFile(MODELS_FILENAME, MODELS_PATH, MODELS_FILENAME, UNUSED_MODELS_PATH);
+      const char *warning = sdMoveFile(MODELS_FILENAME, MODELS_PATH, MODELS_FILENAME ".old", UNUSED_MODELS_PATH);
       if(warning)
         POPUP_WARNING(warning);
     }


### PR DESCRIPTION
I can see a situation where a user tries to restore a model that was moved into /models/unused. If they copy models.yml as well, they will loose any changes made in the meantime. 

This PR changes the filename to models.yml.old so it has to be thought about if you want to parse again.