### PR TITLE
fix: auto-switch timeout raised to 1s

### DIFF
--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -689,7 +689,7 @@ swsrc_t getMovedSwitch()
     }
   }
 
-  if ((tmr10ms_t)(get_tmr10ms() - s_move_last_time) > 10)
+  if ((tmr10ms_t)(get_tmr10ms() - s_move_last_time) > 100)
     result = 0;
 
   s_move_last_time = get_tmr10ms();


### PR DESCRIPTION
Fixes #2418

Summary of changes:
- fix one part of #2418 (switch position being missed)

Please note that the current implementation will be need more changes as it refills the menu on every auto-detected input/switch to get rid of the filtering potentially done by the toolbar. This will need a bigger effort to change the way it is done.
