### PR TITLE
fix: "Show Channel Monitor" btn only on touch only radios

### DIFF
--- a/radio/src/gui/colorlcd/menu_model.cpp
+++ b/radio/src/gui/colorlcd/menu_model.cpp
@@ -61,7 +61,9 @@ ModelMenu::ModelMenu():
 #endif
   addTab(new ModelTelemetryPage());
 
+#if defined(PCBNV14) || defined(PCBPL18)
   addGoToMonitorsButton();
+#endif
 }
 
 void ModelMenu::onEvent(event_t event)
@@ -76,6 +78,7 @@ void ModelMenu::onEvent(event_t event)
 #endif
 }
 
+#if defined(PCBNV14) || defined(PCBPL18)
 void ModelMenu::addGoToMonitorsButton()
 {
   OpenTxTheme::instance()->createTextButton(
@@ -85,3 +88,4 @@ void ModelMenu::addGoToMonitorsButton()
         return 0;
       });
 }
+#endif

--- a/radio/src/gui/colorlcd/menu_model.h
+++ b/radio/src/gui/colorlcd/menu_model.h
@@ -35,8 +35,10 @@ class ModelMenu : public TabsGroup
   std::string getName() const override { return "ModelMenu"; }
 #endif
 
+#if defined(PCBNV14) || defined(PCBPL18)
 protected:
  void addGoToMonitorsButton(void);
+#endif
 };
 
 #endif // _MENU_MODEL_H_


### PR DESCRIPTION
Summary of changes:
- Only show the "Show Channel Monitor" button on radios that are known to be touch only, since they can't access the MDL hard key shortcut. 