### PR TITLE
Verify that model exists prior to using it in CP (Fix #2437)

### DIFF
--- a/companion/src/modeledit/customfunctions.cpp
+++ b/companion/src/modeledit/customfunctions.cpp
@@ -510,7 +510,10 @@ void CustomFunctionsPanel::refreshCustomFunction(int i, bool modified)
       } else if (func == FuncSetScreen) {
         fswtchParam[i]->setDecimals(0);
         fswtchParam[i]->setMinimum(1);
-        fswtchParam[i]->setMaximum(model->getCustomScreensCount());
+        if(model)
+          fswtchParam[i]->setMaximum(model->getCustomScreensCount());
+        else
+          fswtchParam[i]->setMaximum(1);
         fswtchParam[i]->setSingleStep(1);
         cfn.param = fswtchParam[i]->value();
         fswtchParam[i]->setValue(cfn.param);


### PR DESCRIPTION
For global functions in the simulator it is possible that no model is defined.
Fixes #2437 

Summary of changes: check for the model existence prior to using it. 
