### PR TITLE
fix(color): Remove rem. `Window::setTextFlags()` font change usage

### DIFF
--- a/radio/src/gui/colorlcd/message_dialog.cpp
+++ b/radio/src/gui/colorlcd/message_dialog.cpp
@@ -21,18 +21,19 @@
 #include "static.h"
 
 MessageDialog::MessageDialog(Window* parent, const char* title,
-                             const char* message, const char* info) :
+                             const char* message, const char* info,
+                             LcdFlags messageFlags, LcdFlags infoFlags) :
     Dialog(parent, title, {50, 73, LCD_W - 100, LCD_H - 146})
 {
   messageWidget = new StaticText(
       this,
       {0, coord_t(height() - PAGE_LINE_HEIGHT) / 2, width(), PAGE_LINE_HEIGHT},
-      message, 0, CENTERED);
+      message, 0, messageFlags);
 
   infoWidget = new StaticText(this,
                               {0, 30 + coord_t(height() - PAGE_LINE_HEIGHT) / 2,
                                width(), PAGE_LINE_HEIGHT},
-                              info, 0, CENTERED);
+                              info, 0, infoFlags);
   setCloseWhenClickOutside(true);
 }
 

--- a/radio/src/gui/colorlcd/message_dialog.h
+++ b/radio/src/gui/colorlcd/message_dialog.h
@@ -28,7 +28,8 @@ class MessageDialog : public Dialog
 {
  public:
   MessageDialog(Window* parent, const char* title, const char* message,
-                const char* info = "");
+                const char* info = "", LcdFlags messageFlags = CENTERED,
+                LcdFlags infoFlags = CENTERED);
 
   void setInfoText(std::string text) { infoWidget->setText(std::move(text)); }
 

--- a/radio/src/gui/colorlcd/model_logical_switches.cpp
+++ b/radio/src/gui/colorlcd/model_logical_switches.cpp
@@ -68,9 +68,13 @@ class LogicalSwitchEditPage: public Page
     {
       Page::checkEvents();
       if (active != isActive()) {
+        if(isActive()) {
+          lv_obj_add_state(headerSwitchName->getLvObj(), LV_STATE_USER_1);
+        } else {
+          lv_obj_clear_state(headerSwitchName->getLvObj(), LV_STATE_USER_1);
+        }
+        active = isActive();
         invalidate();
-        headerSwitchName->setTextFlags(isActive() ? FONT(BOLD) | COLOR_THEME_ACTIVE : COLOR_THEME_PRIMARY2);
-        active = !active;
       }
     }
 
@@ -85,6 +89,9 @@ class LogicalSwitchEditPage: public Page
           {PAGE_TITLE_LEFT, PAGE_TITLE_TOP + PAGE_LINE_HEIGHT,
            LCD_W - PAGE_TITLE_LEFT, PAGE_LINE_HEIGHT},
           getSwitchPositionName(SWSRC_SW1 + index), 0, COLOR_THEME_PRIMARY2);
+
+      lv_obj_set_style_text_color(headerSwitchName->getLvObj(), makeLvColor(COLOR_THEME_ACTIVE), LV_STATE_USER_1);
+      lv_obj_set_style_text_font(headerSwitchName->getLvObj(), getFont(FONT(BOLD)), LV_STATE_USER_1);
     }
 
     void updateLogicalSwitchOneWindow()

--- a/radio/src/gui/colorlcd/special_functions.cpp
+++ b/radio/src/gui/colorlcd/special_functions.cpp
@@ -60,10 +60,13 @@ class SpecialFunctionEditPage : public Page
   {
     Page::checkEvents();
     if (active != isActive()) {
+      if(isActive()) {
+        lv_obj_add_state(headerSF->getLvObj(), LV_STATE_USER_1);
+      } else {
+        lv_obj_clear_state(headerSF->getLvObj(), LV_STATE_USER_1);
+      }
+      active = isActive();
       invalidate();
-      headerSF->setTextFlags(isActive() ? FONT(BOLD) | COLOR_THEME_ACTIVE
-                                        : COLOR_THEME_PRIMARY2);
-      active = !active;
     }
   }
 
@@ -80,6 +83,9 @@ class SpecialFunctionEditPage : public Page
          LCD_W - PAGE_TITLE_LEFT, 20},
         (functions == g_model.customFn ? "SF" : "GF") + std::to_string(index+1),
         0, COLOR_THEME_PRIMARY2);
+
+    lv_obj_set_style_text_color(headerSF->getLvObj(), makeLvColor(COLOR_THEME_ACTIVE), LV_STATE_USER_1);
+    lv_obj_set_style_text_font(headerSF->getLvObj(), getFont(FONT(BOLD)), LV_STATE_USER_1);
   }
 
   void updateSpecialFunctionOneWindow()

--- a/radio/src/gui/colorlcd/view_about.cpp
+++ b/radio/src/gui/colorlcd/view_about.cpp
@@ -37,11 +37,11 @@ const std::string about_str = "EdgeTX" " (" VERSION "-" VERSION_SUFFIX ")";
 const std::string copyright_str = "Copyright (C) 2022 EdgeTX";
 
 AboutUs::AboutUs() :
-  MessageDialog(MainWindow::instance(), STR_ABOUT_US, "")
+  MessageDialog(MainWindow::instance(), STR_ABOUT_US, "", "",
+                CENTERED | FONT(BOLD) | COLOR_THEME_SECONDARY1, CENTERED)
 {
   content->setRect({(LCD_W - ABOUT_WIDTH) / 2, 20, ABOUT_WIDTH, LCD_H - 40});
 
-  messageWidget->setTextFlags(CENTERED | FONT(BOLD) | COLOR_THEME_SECONDARY1);
   messageWidget->setTop(content->top() + 40);
   messageWidget->setHeight(2*PAGE_LINE_HEIGHT);
 


### PR DESCRIPTION
Fixes #2414 

Summary of changes:
- About: The MessageDialog constructor was extended adding the text flags. So the settings could be added at construction.
- LS & SF settings: A custom state was added with the style settings.