### PR TITLE
fix: Style/color tweaks

### DIFF
--- a/radio/src/gui/colorlcd/channel_bar.h
+++ b/radio/src/gui/colorlcd/channel_bar.h
@@ -78,7 +78,7 @@ class OutputChannelBar : public ChannelBar
   LcdFlags outputBarLimitsColor = COLOR_THEME_SECONDARY1;
 };
 
-constexpr coord_t lmargin = 25;
+constexpr coord_t lmargin = 15;
 
 class ComboChannelBar : public Window
 {
@@ -132,13 +132,13 @@ class ComboChannelBar : public Window
       // Override icon
 #if defined(OVERRIDE_CHANNEL_FUNCTION)
       if (safetyCh[channel] != OVERRIDE_CHANNEL_UNDEFINED)
-        dc->drawMask(0, 1, chanMonLockedBitmap, textColor);
+        dc->drawMask(0, 5, chanMonLockedBitmap, textColor);
 #endif
 
       // Channel reverted icon
       LimitData * ld = limitAddress(channel);
       if (ld && ld->revert) {
-        dc->drawMask(0, 20, chanMonInvertedBitmap, textColor);
+        dc->drawMask(0, 25, chanMonInvertedBitmap, textColor);
       }
     }
 

--- a/radio/src/gui/colorlcd/channel_bar.h
+++ b/radio/src/gui/colorlcd/channel_bar.h
@@ -28,6 +28,8 @@
 constexpr coord_t ROW_HEIGHT = 42;
 constexpr coord_t BAR_HEIGHT = 13;
 constexpr coord_t LEG_COLORBOX = 15;
+constexpr coord_t LMARGIN = 15;
+constexpr coord_t TMARGIN = 2;
 
 class ChannelBar : public Window
 {
@@ -78,8 +80,6 @@ class OutputChannelBar : public ChannelBar
   LcdFlags outputBarLimitsColor = COLOR_THEME_SECONDARY1;
 };
 
-constexpr coord_t lmargin = 15;
-
 class ComboChannelBar : public Window
 {
   public:
@@ -88,11 +88,11 @@ class ComboChannelBar : public Window
       Window(parent, rect), channel(channel)
     {
       outputChannelBar = new OutputChannelBar(
-          this, {leftMargin, BAR_HEIGHT, width() - leftMargin, BAR_HEIGHT},
+          this, {leftMargin, BAR_HEIGHT + TMARGIN, width() - leftMargin, BAR_HEIGHT},
           channel);
       new MixerChannelBar(
           this,
-          {leftMargin, 2 * BAR_HEIGHT + 1, width() - leftMargin, BAR_HEIGHT},
+          {leftMargin, (2 * BAR_HEIGHT) + TMARGIN + 1, width() - leftMargin, BAR_HEIGHT},
           channel);
     }
 
@@ -164,7 +164,7 @@ class ComboChannelBar : public Window
     uint8_t channel;
     OutputChannelBar *outputChannelBar = nullptr;
     int value = 0;
-    int leftMargin = lmargin;
+    int leftMargin = LMARGIN;
     uint32_t textColor = COLOR_THEME_SECONDARY1;
 #if defined(OVERRIDE_CHANNEL_FUNCTION)
     int safetyChValue = OVERRIDE_CHANNEL_UNDEFINED;

--- a/radio/src/gui/colorlcd/mixer_edit.cpp
+++ b/radio/src/gui/colorlcd/mixer_edit.cpp
@@ -50,7 +50,7 @@ class MixerEditStatusBar : public Window
                             {MIX_STATUS_BAR_MARGIN, 0,
                              rect.w - (MIX_STATUS_BAR_MARGIN * 2), rect.h},
                             channel);
-    channelBar->setLeftMargin(0);
+    channelBar->setLeftMargin(15);
     channelBar->setTextColor(COLOR_THEME_PRIMARY2);
     channelBar->setOutputChannelBarLimitColor(COLOR_THEME_EDIT);
   }

--- a/radio/src/gui/colorlcd/model_flightmodes.cpp
+++ b/radio/src/gui/colorlcd/model_flightmodes.cpp
@@ -246,7 +246,7 @@ void FlightModeBtn::paint(BitmapBuffer* dc)
 
   LcdFlags txt_flags;
   if (active) {
-    txt_flags = FONT(BOLD) | COLOR_THEME_PRIMARY2;
+    txt_flags = FONT(BOLD) | COLOR_THEME_PRIMARY1;
   } else {
     txt_flags = FONT(STD) | COLOR_THEME_SECONDARY1;
   }

--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -156,7 +156,7 @@ void SubScreenButton::event_cb(lv_event_t* e)
     label_draw_dsc.align = LV_TEXT_ALIGN_CENTER;
 
     if (btn->isActive()) {
-      label_draw_dsc.color = makeLvColor(COLOR_THEME_PRIMARY2);
+      label_draw_dsc.color = makeLvColor(COLOR_THEME_PRIMARY1);
     } else {
       label_draw_dsc.color = makeLvColor(COLOR_THEME_SECONDARY1);
     }

--- a/radio/src/gui/colorlcd/output_edit.cpp
+++ b/radio/src/gui/colorlcd/output_edit.cpp
@@ -44,7 +44,7 @@ class OutputEditStatusBar : public Window
       Window(parent, rect), _channel(channel)
   {
     channelBar = new ComboChannelBar(this, {OUTPUT_EDIT_STATUS_BAR_MARGIN, 0, rect.w - (OUTPUT_EDIT_STATUS_BAR_MARGIN * 2), rect.h}, channel);
-    channelBar->setLeftMargin(0);
+    channelBar->setLeftMargin(15);
     channelBar->setTextColor(COLOR_THEME_PRIMARY2);
     channelBar->setOutputChannelBarLimitColor(COLOR_THEME_EDIT);
   }

--- a/radio/src/gui/colorlcd/themes/etx_lv_theme.cpp
+++ b/radio/src/gui/colorlcd/themes/etx_lv_theme.cpp
@@ -418,7 +418,7 @@ static void style_init(void)
     style_init_reset(&styles.bg_color_active);
     lv_style_set_bg_color(&styles.bg_color_active, makeLvColor(COLOR_THEME_ACTIVE));
     lv_style_set_bg_opa(&styles.bg_color_active, LV_OPA_COVER);
-    lv_style_set_text_color(&styles.bg_color_active, makeLvColor(COLOR_THEME_PRIMARY2));
+    lv_style_set_text_color(&styles.bg_color_active, makeLvColor(COLOR_THEME_PRIMARY1));
 
     style_init_reset(&styles.bg_color_focus);
     lv_style_set_bg_color(&styles.bg_color_focus, makeLvColor(COLOR_THEME_FOCUS));

--- a/radio/src/gui/colorlcd/view_channels.cpp
+++ b/radio/src/gui/colorlcd/view_channels.cpp
@@ -70,9 +70,15 @@ void ChannelsViewPage::build(FormWindow * window)
 
   // Channels bars
   for (uint8_t chan = pageIndex * 8; chan < 8 + pageIndex * 8; chan++) {
+#if LCD_H > LCD_W
+    coord_t width = window->width() - (hmargin * 2);
+    coord_t xPos = hmargin;
+    coord_t yPos = (chan % 8) * ((window->height() - CHANNEL_VIEW_FOOTER_HEIGHT - 8) / 8);
+#else
     coord_t width = window->width() / 2 - hmargin;
     coord_t xPos = (chan % 8) >= 4 ? width + hmargin : hmargin;
     coord_t yPos = (chan % 4) * ((window->height() - CHANNEL_VIEW_FOOTER_HEIGHT - 4) / 4);
+#endif
     new ComboChannelBar(window, {xPos, yPos, width, 3 * BAR_HEIGHT + 1}, chan);
   }
 

--- a/radio/src/gui/colorlcd/view_channels.cpp
+++ b/radio/src/gui/colorlcd/view_channels.cpp
@@ -75,8 +75,8 @@ void ChannelsViewPage::build(FormWindow * window)
     coord_t xPos = hmargin;
     coord_t yPos = (chan % 8) * ((window->height() - CHANNEL_VIEW_FOOTER_HEIGHT - 8) / 8);
 #else
-    coord_t width = window->width() / 2 - hmargin;
-    coord_t xPos = (chan % 8) >= 4 ? width + hmargin : hmargin;
+    coord_t width = window->width() / 2 - (hmargin * 2);
+    coord_t xPos = (chan % 8) >= 4 ? width + (hmargin * 2) : hmargin;
     coord_t yPos = (chan % 4) * ((window->height() - CHANNEL_VIEW_FOOTER_HEIGHT - 4) / 4);
 #endif
     new ComboChannelBar(window, {xPos, yPos, width, 3 * BAR_HEIGHT + 1}, chan);


### PR DESCRIPTION
**Summary of changes:**
- text color for active LS buttons in monitor, which also affected some keyboard icons (for the better IMO)
- text color for active flight mode button
- text color for active internal/external/trainer button
- width/layout of channel monitors bars for portrait screens
- minor tweaks to alignment of channel monitor bar in relation to text, and icon layout

Before and afters
![image](https://user-images.githubusercontent.com/5500713/193433938-75b707d0-b65c-4b2d-afdc-d54d72f2b9f3.png)
![image](https://user-images.githubusercontent.com/5500713/193433939-dcd6ba0a-6ff2-4b64-bbe9-2cd4c8d5a8b2.png)

But I can't see what controls these buttons yet:
![image](https://user-images.githubusercontent.com/5500713/193433950-4193d55a-4223-47c1-b743-66f6f09df9e1.png)
![image](https://user-images.githubusercontent.com/5500713/193433951-24798858-2557-43a7-8e05-f8663e62d2b5.png)

