### PR TITLE
fix: various menu toolbar fixes

### DIFF
--- a/radio/src/gui/colorlcd/sourcechoice.cpp
+++ b/radio/src/gui/colorlcd/sourcechoice.cpp
@@ -66,14 +66,15 @@ SourceChoice::SourceChoice(Window* parent, const rect_t &rect, int16_t vmin,
     ChoiceEx(parent, rect, vmin, vmax, getValue, setValue)
 {
   setBeforeDisplayMenuHandler([=](Menu *menu) {
-    menu->setToolbar(new SourceChoiceMenuToolbar(this, menu));
+    auto tb = new SourceChoiceMenuToolbar(this, menu);
+    menu->setToolbar(tb);
+
 #if defined(AUTOSOURCE)
     menu->setWaitHandler([=]() {
       int16_t val = getMovedSource(vmin);
       if (val) {
-        fillMenu(menu);
+        tb->resetFilter();
         menu->select(getIndexFromValue(val));
-        // TODO: reset toolbar
       }
 #if defined(AUTOSWITCH)
       else {
@@ -81,9 +82,8 @@ SourceChoice::SourceChoice(Window* parent, const rect_t &rect, int16_t vmin,
         if (swtch && !IS_SWITCH_MULTIPOS(swtch)) {
           val = switchToMix(swtch);
           if (val && (val >= vmin) && (val <= vmax)) {
-            fillMenu(menu);
+            tb->resetFilter();
             menu->select(getIndexFromValue(val));
-            // TODO: reset toolbar
           }
         }
       }

--- a/radio/src/gui/colorlcd/switchchoice.cpp
+++ b/radio/src/gui/colorlcd/switchchoice.cpp
@@ -58,9 +58,11 @@ SwitchChoice::SwitchChoice(Window* parent, const rect_t& rect, int vmin,
     ChoiceEx(parent, rect, vmin, vmax, getValue, setValue)
 {
   setBeforeDisplayMenuHandler([=](Menu* menu) {
-    menu->setToolbar(new SwitchChoiceMenuToolbar(this, menu));
+    auto tb = new SwitchChoiceMenuToolbar(this, menu);
+    menu->setToolbar(tb);
+
 #if defined(AUTOSWITCH)
-    menu->setWaitHandler([menu, this, setValue]() {
+    menu->setWaitHandler([menu, this, setValue, tb]() {
       swsrc_t val = 0;
       swsrc_t swtch = getMovedSwitch();
       if (swtch) {
@@ -73,9 +75,9 @@ SwitchChoice::SwitchChoice(Window* parent, const rect_t& rect, int vmin,
           val = swtch;
         }
         if (val && (!isValueAvailable || isValueAvailable(val))) {
-          fillMenu(menu);
+          // if (filtered) fillMenu(menu);
+          tb->resetFilter();
           menu->select(getIndexFromValue(val));
-          // TODO: reset toolbar
         }
       }
     });


### PR DESCRIPTION
Summary:
- cycling through with keys should now also allow to clear all filters
- fixed scrolling behaviour when a filter is activated (menu body window scrolled to far, thus looking empty)
- touch behaviour fixed (only one icon activate at the same time, etc)
- reset toolbar when filter is cleared by auto-source/auto-switch
- clear filter with auto-source/auto-switch only if set (#2418)

Requires EdgeTX/libopenui#71

Also addresses some of the ancillary issues mentioned in #1029