### PR TITLE
fix: rotary encoder events in standalone LUA

### DIFF
--- a/radio/src/gui/colorlcd/standalone_lua.cpp
+++ b/radio/src/gui/colorlcd/standalone_lua.cpp
@@ -56,6 +56,9 @@ StandaloneLuaWindow::StandaloneLuaWindow() :
     lcdBuffer(BMP_RGB565, LCD_W, LCD_H),
     popup({50, 73, LCD_W - 100, LCD_H - 146})
 {
+  lv_obj_clear_flag(lvobj, LV_OBJ_FLAG_SCROLLABLE);
+  lv_obj_clear_flag(lvobj, LV_OBJ_FLAG_CLICK_FOCUSABLE);
+
   // setup LUA event handler
   setupHandler(this);
 }


### PR DESCRIPTION
Summary:
- prevent group editing to be removed via `click-focus`