### PR TITLE
fix(gui): add missing channel IDs to mixer and output tabs. 

### DIFF
--- a/radio/src/gui/colorlcd/channel_bar.h
+++ b/radio/src/gui/colorlcd/channel_bar.h
@@ -116,7 +116,7 @@ class ComboChannelBar : public Window
 
     void paint(BitmapBuffer * dc) override
     {
-      char chanString[] = "CH32 ";
+      char chanString[] = TR_CH"32 ";
       int usValue = PPM_CH_CENTER(channel) + channelOutputs[channel] / 2;
 
       // Channel number

--- a/radio/src/gui/colorlcd/input_mix_group.cpp
+++ b/radio/src/gui/colorlcd/input_mix_group.cpp
@@ -29,7 +29,7 @@
 #include <algorithm>
 
 static const lv_coord_t col_dsc[] = {
-  LV_DPI_DEF / 2, LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST,
+  lv_coord_t(LV_DPI_DEF * 0.65), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST,
 };
 
 static const lv_coord_t row_dsc[] = {
@@ -53,21 +53,23 @@ InputMixGroup::InputMixGroup(Window* parent, mixsrc_t idx) :
   lv_obj_add_event_cb(lvobj, InputMixGroup::value_changed,
                       LV_EVENT_VALUE_CHANGED, nullptr);
 
-  chText = lv_label_create(lvobj);
-  lv_label_set_text_fmt(chText, "%02u: ", idx - MIXSRC_CH1 + 1);
-  lv_obj_set_style_text_font(chText, getFont(FONT(XS)), 0);
-  lv_obj_set_style_pad_top(chText, 0, 0);
-  lv_obj_set_grid_cell(chText,
-                       LV_GRID_ALIGN_START, 0, 1,
-                       LV_GRID_ALIGN_START, 0, 1);
+  lv_obj_t* chText = nullptr;
+  if (idx >= MIXSRC_FIRST_CH && idx <= MIXSRC_LAST_CH) {
+    chText = lv_label_create(lvobj);
+    lv_label_set_text_fmt(chText, "%02u: ", idx - MIXSRC_CH1 + 1);
+    lv_obj_set_style_text_font(chText, getFont(FONT(XS)), 0);
+    lv_obj_set_style_pad_top(chText, 0, 0);
+    lv_obj_set_grid_cell(chText,
+                         LV_GRID_ALIGN_START, 0, 1,
+                         LV_GRID_ALIGN_START, 0, 1);
+  }
 
   label = lv_label_create(lvobj);
   lv_label_set_text(label, getSourceString(idx));
   lv_obj_set_style_pad_top(label, 3, 0);
   lv_obj_set_style_pad_bottom(label, 0, 0);
-  lv_obj_set_grid_cell(label,
-                       LV_GRID_ALIGN_START, 0, 1,
-                       LV_GRID_ALIGN_END, 0, 1);
+  lv_obj_set_grid_cell(label, LV_GRID_ALIGN_START, 0, 1,
+                       chText ? LV_GRID_ALIGN_END : LV_GRID_ALIGN_START, 0, 1);
 
   auto box = window_create(lvobj);
   lv_obj_set_size(box, lv_pct(100), LV_SIZE_CONTENT);

--- a/radio/src/gui/colorlcd/input_mix_group.cpp
+++ b/radio/src/gui/colorlcd/input_mix_group.cpp
@@ -58,15 +58,16 @@ InputMixGroup::InputMixGroup(Window* parent, mixsrc_t idx) :
     chText = lv_label_create(lvobj);
     lv_label_set_text_fmt(chText, "%02u: ", idx - MIXSRC_CH1 + 1);
     lv_obj_set_style_text_font(chText, getFont(FONT(XS)), 0);
-    lv_obj_set_style_pad_top(chText, 0, 0);
+    lv_obj_set_style_pad_top(chText, -2, 0);
     lv_obj_set_grid_cell(chText,
                          LV_GRID_ALIGN_START, 0, 1,
                          LV_GRID_ALIGN_START, 0, 1);
   }
 
   label = lv_label_create(lvobj);
+  lv_obj_set_style_text_font(label, getFont(FONT(STD)), 0);
+
   lv_label_set_text(label, getSourceString(idx));
-  lv_obj_set_style_pad_top(label, 3, 0);
   lv_obj_set_style_pad_bottom(label, 0, 0);
   lv_obj_set_grid_cell(label, LV_GRID_ALIGN_START, 0, 1,
                        chText ? LV_GRID_ALIGN_END : LV_GRID_ALIGN_START, 0, 1);

--- a/radio/src/gui/colorlcd/input_mix_group.cpp
+++ b/radio/src/gui/colorlcd/input_mix_group.cpp
@@ -54,23 +54,29 @@ InputMixGroup::InputMixGroup(Window* parent, mixsrc_t idx) :
                       LV_EVENT_VALUE_CHANGED, nullptr);
 
   lv_obj_t* chText = nullptr;
-  if (idx >= MIXSRC_FIRST_CH && idx <= MIXSRC_LAST_CH) {
+  if (idx >= MIXSRC_FIRST_CH && idx <= MIXSRC_LAST_CH
+      && g_model.limitData[idx - MIXSRC_CH1].name[0] != '\0') {
     chText = lv_label_create(lvobj);
-    lv_label_set_text_fmt(chText, "%02u: ", idx - MIXSRC_CH1 + 1);
+    lv_label_set_text_fmt(chText, TR_CH "%u", idx - MIXSRC_CH1 + 1);
     lv_obj_set_style_text_font(chText, getFont(FONT(XS)), 0);
-    lv_obj_set_style_pad_top(chText, -2, 0);
+#if LCD_H > LCD_W
+    lv_obj_set_style_pad_bottom(chText, -2, 0);
+#endif
     lv_obj_set_grid_cell(chText,
                          LV_GRID_ALIGN_START, 0, 1,
-                         LV_GRID_ALIGN_START, 0, 1);
+                         LV_GRID_ALIGN_END, 0, 1);
   }
 
   label = lv_label_create(lvobj);
   lv_obj_set_style_text_font(label, getFont(FONT(STD)), 0);
-
+#if LCD_H > LCD_W
+  if(chText)
+    lv_obj_set_style_pad_top(label, -1, 0);
+#endif
   lv_label_set_text(label, getSourceString(idx));
-  lv_obj_set_style_pad_bottom(label, 0, 0);
-  lv_obj_set_grid_cell(label, LV_GRID_ALIGN_START, 0, 1,
-                       chText ? LV_GRID_ALIGN_END : LV_GRID_ALIGN_START, 0, 1);
+  lv_obj_set_grid_cell(label,
+                       LV_GRID_ALIGN_START, 0, 1,
+                       chText?LV_GRID_ALIGN_START:LV_GRID_ALIGN_CENTER, 0, 1);
 
   auto box = window_create(lvobj);
   lv_obj_set_size(box, lv_pct(100), LV_SIZE_CONTENT);

--- a/radio/src/gui/colorlcd/input_mix_group.cpp
+++ b/radio/src/gui/colorlcd/input_mix_group.cpp
@@ -53,11 +53,21 @@ InputMixGroup::InputMixGroup(Window* parent, mixsrc_t idx) :
   lv_obj_add_event_cb(lvobj, InputMixGroup::value_changed,
                       LV_EVENT_VALUE_CHANGED, nullptr);
 
-  label = lv_label_create(lvobj);
-  lv_label_set_text(label, getSourceString(idx));
-  lv_obj_set_grid_cell(label,
+  chText = lv_label_create(lvobj);
+  lv_label_set_text_fmt(chText, "%02u: ", idx - MIXSRC_CH1 + 1);
+  lv_obj_set_style_text_font(chText, getFont(FONT(XS)), 0);
+  lv_obj_set_style_pad_top(chText, 0, 0);
+  lv_obj_set_grid_cell(chText,
                        LV_GRID_ALIGN_START, 0, 1,
                        LV_GRID_ALIGN_START, 0, 1);
+
+  label = lv_label_create(lvobj);
+  lv_label_set_text(label, getSourceString(idx));
+  lv_obj_set_style_pad_top(label, 3, 0);
+  lv_obj_set_style_pad_bottom(label, 0, 0);
+  lv_obj_set_grid_cell(label,
+                       LV_GRID_ALIGN_START, 0, 1,
+                       LV_GRID_ALIGN_END, 0, 1);
 
   auto box = window_create(lvobj);
   lv_obj_set_size(box, lv_pct(100), LV_SIZE_CONTENT);

--- a/radio/src/gui/colorlcd/input_mix_group.h
+++ b/radio/src/gui/colorlcd/input_mix_group.h
@@ -42,6 +42,7 @@ class InputMixGroup : public Window
   mixsrc_t idx;
   std::list<Line> lines;
 
+  lv_obj_t* chText;
   lv_obj_t* label;
   lv_obj_t* line_container;
 

--- a/radio/src/gui/colorlcd/input_mix_group.h
+++ b/radio/src/gui/colorlcd/input_mix_group.h
@@ -42,7 +42,6 @@ class InputMixGroup : public Window
   mixsrc_t idx;
   std::list<Line> lines;
 
-  lv_obj_t* chText;
   lv_obj_t* label;
   lv_obj_t* line_container;
 

--- a/radio/src/gui/colorlcd/model_outputs.cpp
+++ b/radio/src/gui/colorlcd/model_outputs.cpp
@@ -153,9 +153,17 @@ class OutputLineButton : public ListLineButton
     lv_obj_set_grid_dsc_array(lvobj, col_dsc, row_dsc);
 
     source = lv_label_create(lvobj);
+
+#if LCD_H > LCD_W
     lv_obj_set_style_text_font(source, getFont(FONT(BOLD)), 0);
     lv_obj_set_grid_cell(source, LV_GRID_ALIGN_START, 0, 1,
-                         LV_GRID_ALIGN_START, 0, 1);
+                         LV_GRID_ALIGN_CENTER, 0, 2);
+
+#else
+    lv_obj_set_style_text_font(source, getFont(FONT(XS)), 0);
+    lv_obj_set_grid_cell(source, LV_GRID_ALIGN_START, 0, 1,
+                         LV_GRID_ALIGN_CENTER, 0, 1);
+#endif
 
     lv_obj_add_event_cb(lvobj, OutputLineButton::on_draw, LV_EVENT_DRAW_MAIN, nullptr);
   }
@@ -166,8 +174,11 @@ class OutputLineButton : public ListLineButton
     
     const LimitData* output = limitAddress(index);
 
-    lv_label_set_text(source, getSourceString(MIXSRC_CH1 + index));
-
+#if LCD_H > LCD_W
+    lv_label_set_text_fmt(source, "%02u:\n%s", index +1, getSourceString(MIXSRC_CH1 + index));
+#else
+    lv_label_set_text_fmt(source, "%02u: %s", index +1, getSourceString(MIXSRC_CH1 + index));
+#endif
     if (output->revert) {
       lv_obj_clear_flag(revert, LV_OBJ_FLAG_HIDDEN);
     } else {

--- a/radio/src/gui/colorlcd/model_outputs.cpp
+++ b/radio/src/gui/colorlcd/model_outputs.cpp
@@ -172,12 +172,17 @@ class OutputLineButton : public ListLineButton
     if (!init) return;
     
     const LimitData* output = limitAddress(index);
-
-#if LCD_H > LCD_W
-    lv_label_set_text_fmt(source, "%02u:\n%s", index +1, getSourceString(MIXSRC_CH1 + index));
-#else
-    lv_label_set_text_fmt(source, "%02u: %s", index +1, getSourceString(MIXSRC_CH1 + index));
+    if(g_model.limitData[index].name[0] != '\0')
+    {
+#if LCD_W > LCD_H
+      lv_obj_set_style_text_line_space(source, -3, LV_PART_MAIN);
+      lv_obj_set_style_pad_top(source, -7, 0);
+      lv_obj_set_style_pad_bottom(source, -7, 0);
 #endif
+      lv_label_set_text_fmt(source, "%s\n" TR_CH "%u", getSourceString(MIXSRC_CH1 + index), index + 1);
+    } else {
+      lv_label_set_text(source, getSourceString(MIXSRC_CH1 + index));
+    }
     if (output->revert) {
       lv_obj_clear_flag(revert, LV_OBJ_FLAG_HIDDEN);
     } else {

--- a/radio/src/gui/colorlcd/model_outputs.cpp
+++ b/radio/src/gui/colorlcd/model_outputs.cpp
@@ -155,7 +155,6 @@ class OutputLineButton : public ListLineButton
     source = lv_label_create(lvobj);
 
 #if LCD_H > LCD_W
-    lv_obj_set_style_text_font(source, getFont(FONT(BOLD)), 0);
     lv_obj_set_grid_cell(source, LV_GRID_ALIGN_START, 0, 1,
                          LV_GRID_ALIGN_CENTER, 0, 2);
 

--- a/radio/src/gui/colorlcd/model_outputs.cpp
+++ b/radio/src/gui/colorlcd/model_outputs.cpp
@@ -181,6 +181,7 @@ class OutputLineButton : public ListLineButton
 #endif
       lv_label_set_text_fmt(source, "%s\n" TR_CH "%u", getSourceString(MIXSRC_CH1 + index), index + 1);
     } else {
+      lv_obj_set_style_text_font(source, getFont(FONT(STD)), 0);
       lv_label_set_text(source, getSourceString(MIXSRC_CH1 + index));
     }
     if (output->revert) {


### PR DESCRIPTION
Fixes #2073

Summary of changes: add missing channel ids to mixer and output tabs
This PR currently creates those ouputs:
![grafik](https://user-images.githubusercontent.com/54738901/194637030-919638cc-b127-4b2f-8f16-5683e7843518.png)
![grafik](https://user-images.githubusercontent.com/54738901/194637044-028d4853-4134-43bf-847b-2650a6a106b1.png)
![grafik](https://user-images.githubusercontent.com/54738901/194637110-76f355d2-12f6-4936-8451-1646aac5c428.png)
![grafik](https://user-images.githubusercontent.com/54738901/194637163-45386150-b4a3-480a-a9a5-ca5864edb675.png)

