### PR TITLE
fix(color): some lines containing boxes could be scrolled horizontally

### DIFF
--- a/radio/src/gui/colorlcd/channel_range.cpp
+++ b/radio/src/gui/colorlcd/channel_range.cpp
@@ -28,6 +28,7 @@ ChannelRange::ChannelRange(Window* parent) :
     FormGroup(parent, rect_t{})
 {
   setFlexLayout(LV_FLEX_FLOW_ROW);
+  lv_obj_set_width(lvobj, LV_SIZE_CONTENT);
 }
 
 void ChannelRange::build()

--- a/radio/src/gui/colorlcd/module_setup.cpp
+++ b/radio/src/gui/colorlcd/module_setup.cpp
@@ -123,6 +123,7 @@ FailsafeChoice::FailsafeChoice(Window* parent, uint8_t moduleIdx) :
   FormGroup(parent, rect_t{})
 {
   setFlexLayout(LV_FLEX_FLOW_ROW);
+  lv_obj_set_width(lvobj, LV_SIZE_CONTENT);
 
   auto md = &g_model.moduleData[moduleIdx];
   auto choice =
@@ -245,6 +246,7 @@ void ModuleWindow::updateModule()
       new StaticText(line, rect_t{},"");
       auto box = new FormGroup(line, rect_t{});
       box->setFlexLayout(LV_FLEX_FLOW_ROW, lv_dpx(8));
+      lv_obj_set_width(box->getLvObj(), LV_SIZE_CONTENT);
       idUnique = new StaticText(box, rect_t{}, "", 0, 0);
       updateIDStaticText(moduleIdx);
     }
@@ -254,6 +256,7 @@ void ModuleWindow::updateModule()
 
     auto box = new FormGroup(line, rect_t{});
     box->setFlexLayout(LV_FLEX_FLOW_ROW, lv_dpx(8));
+    lv_obj_set_width(box->getLvObj(), LV_SIZE_CONTENT);
 
     // Model index
     auto modelId = &g_model.header.modelId[moduleIdx];
@@ -726,6 +729,7 @@ ModulePage::ModulePage(uint8_t moduleIdx) : Page(ICON_MODEL_SETUP)
 
   auto box = new FormGroup(line, rect_t{});
   box->setFlexLayout(LV_FLEX_FLOW_ROW);
+  lv_obj_set_width(box->getLvObj(), LV_SIZE_CONTENT);
 
   ModuleData* md = &g_model.moduleData[moduleIdx];
   auto moduleChoice = new Choice(box, rect_t{}, STR_INTERNAL_MODULE_PROTOCOLS,

--- a/radio/src/gui/colorlcd/timer_setup.cpp
+++ b/radio/src/gui/colorlcd/timer_setup.cpp
@@ -65,6 +65,8 @@ TimerWindow::TimerWindow(uint8_t timer) : Page(ICON_STATS_TIMERS)
 
   auto form = new FormGroup(&body, rect_t{});
   form->setFlexLayout();
+  form->padAll(lv_dpx(8));
+
   FlexGridLayout grid(line_col_dsc, line_row_dsc, 2);
 
   TimerData* p_timer = &g_model.timers[timer];
@@ -116,6 +118,7 @@ TimerWindow::TimerWindow(uint8_t timer) : Page(ICON_STATS_TIMERS)
 
   auto box = new FormGroup(line, rect_t{});
   box->setFlexLayout(LV_FLEX_FLOW_ROW);
+  lv_obj_set_width(box->getLvObj(), LV_SIZE_CONTENT);
 
   new Choice(box, rect_t{}, STR_VBEEPCOUNTDOWN, COUNTDOWN_SILENT,
              COUNTDOWN_COUNT - 1, GET_SET_DEFAULT(p_timer->countdownBeep));


### PR DESCRIPTION
Like this (line scrolled to the left):
<img width="321" alt="Screenshot 2022-10-04 at 11 22 38" src="https://user-images.githubusercontent.com/1050031/193783843-45b7fdab-715e-4118-8972-a6f9a643ca44.png">
