### PR TITLE
fix(color): set current model after label update

### DIFF
--- a/radio/src/storage/modelslist.cpp
+++ b/radio/src/storage/modelslist.cpp
@@ -1144,6 +1144,8 @@ bool ModelsList::loadYaml()
       modelslist.push_back(model);
       filehash.celladded = true;
       model->_isDirty = true;
+      if(filehash.curmodel == true)
+        modelslist.setCurrentModel(model);
     }
   }
 

--- a/radio/src/storage/modelslist.h
+++ b/radio/src/storage/modelslist.h
@@ -77,7 +77,7 @@ class ModelCell
   char modelName[LEN_MODEL_NAME + 1] = "";
   char modelFinfoHash[FILE_HASH_LENGTH + 1] = "";
 #if LEN_BITMAP_NAME > 0
-  char modelBitmap[LEN_BITMAP_NAME] = "";
+  char modelBitmap[LEN_BITMAP_NAME + 1] = "";
 #endif
   gtime_t lastOpened = 0;
   bool _isDirty = true;


### PR DESCRIPTION
Fixes #2460

Here Companion only outputs a more or less empty labels file, so that models are scanned on startup, however not setting the current model properly in this particular case.