### PR TITLE
do not display model image when outside of the IMAGES folder (fix for#2482)

### DIFF
--- a/radio/src/gui/colorlcd/file_browser.cpp
+++ b/radio/src/gui/colorlcd/file_browser.cpp
@@ -203,7 +203,10 @@ void FileBrowser::onDrawEnd(uint16_t row, uint16_t col, lv_obj_draw_part_dsc_t* 
 
 void FileBrowser::onSelected(const char* name, bool is_dir)
 {
-  if (is_dir) return;
+  if (is_dir) {
+    if (fileSelected) fileSelected(nullptr, nullptr, nullptr);
+    return;
+  }
   const char* path = getCurrentPath();
   const char* fullpath = getFullPath(name);  
   if (fileSelected) fileSelected(path, name, fullpath);

--- a/radio/src/gui/colorlcd/file_preview.cpp
+++ b/radio/src/gui/colorlcd/file_preview.cpp
@@ -38,11 +38,13 @@ void FilePreview::setFile(const char *filename)
   if (bitmap != nullptr) delete bitmap;
   bitmap = nullptr;
 
-  const char *ext = getFileExtension(filename);
-  if (ext && isExtensionMatching(ext, BITMAPS_EXT)) {
-    bitmap = BitmapBuffer::loadBitmap(filename);
-  } else {
-    bitmap = nullptr;
+  if (filename) {
+    const char *ext = getFileExtension(filename);
+    if (ext && isExtensionMatching(ext, BITMAPS_EXT)) {
+      bitmap = BitmapBuffer::loadBitmap(filename);
+    } else {
+      bitmap = nullptr;
+    }
   }
   invalidate();
 }


### PR DESCRIPTION
This PR stops image display when file browser gord outside of the IMAGES folder

Fixes #2482 (the second part of it. The first part is in the libopenui EdgeTX/libopenui#75)

Summary of changes: adds support for nullptr in fileSelectd() and sends nullptr to fileSelected() when the "<.." (move outside of the folder) button is selected.
