### PR TITLE
File browser touch preview

### DIFF
--- a/radio/src/gui/colorlcd/file_browser.cpp
+++ b/radio/src/gui/colorlcd/file_browser.cpp
@@ -203,7 +203,10 @@ void FileBrowser::onDrawEnd(uint16_t row, uint16_t col, lv_obj_draw_part_dsc_t* 
 
 void FileBrowser::onSelected(const char* name, bool is_dir)
 {
-  if (is_dir) return;
+  if (is_dir) {
+    if (fileSelected) fileSelected(nullptr, nullptr, nullptr);
+    return;
+  }
   const char* path = getCurrentPath();
   const char* fullpath = getFullPath(name);  
   if (fileSelected) fileSelected(path, name, fullpath);

--- a/radio/src/gui/colorlcd/file_browser.cpp
+++ b/radio/src/gui/colorlcd/file_browser.cpp
@@ -207,9 +207,11 @@ void FileBrowser::onSelected(const char* name, bool is_dir)
     if (fileSelected) fileSelected(nullptr, nullptr, nullptr);
     return;
   }
+
   const char* path = getCurrentPath();
   const char* fullpath = getFullPath(name);  
   if (fileSelected) fileSelected(path, name, fullpath);
+  selected = name;
 }
 
 void FileBrowser::onPress(const char* name, bool is_dir)
@@ -219,7 +221,15 @@ void FileBrowser::onPress(const char* name, bool is_dir)
   if (is_dir) {
     f_chdir(fullpath);
     refresh();
-  } else if (fileAction){
+    return;
+  }
+
+  if (!selected || (selected != name)) {
+    onSelected(name, is_dir);
+    return;
+  }
+  
+  if (fileAction){
     fileAction(path, name, fullpath);
   }
 }

--- a/radio/src/gui/colorlcd/file_browser.h
+++ b/radio/src/gui/colorlcd/file_browser.h
@@ -48,6 +48,7 @@ class FileBrowser : public TableField
   void onDrawEnd(uint16_t row, uint16_t col, lv_obj_draw_part_dsc_t* dsc) override;
 
  private:
+  const char* selected = nullptr;
   FileAction fileAction;
   FileAction fileSelected;
 };

--- a/radio/src/gui/colorlcd/file_preview.cpp
+++ b/radio/src/gui/colorlcd/file_preview.cpp
@@ -38,11 +38,13 @@ void FilePreview::setFile(const char *filename)
   if (bitmap != nullptr) delete bitmap;
   bitmap = nullptr;
 
-  const char *ext = getFileExtension(filename);
-  if (ext && isExtensionMatching(ext, BITMAPS_EXT)) {
-    bitmap = BitmapBuffer::loadBitmap(filename);
-  } else {
-    bitmap = nullptr;
+  if (filename) {
+    const char *ext = getFileExtension(filename);
+    if (ext && isExtensionMatching(ext, BITMAPS_EXT)) {
+      bitmap = BitmapBuffer::loadBitmap(filename);
+    } else {
+      bitmap = nullptr;
+    }
   }
   invalidate();
 }


### PR DESCRIPTION
This is an alternative implementation to the changes proposed in #2491. It does not required any `libopenui` changes.

Summary of changes:
- simple touch selects a file (including preview if available)
- touching a selected file triggers the contextual menu