### PR TITLE
fix(color): Adjust about dialog size

### DIFF
--- a/radio/src/gui/colorlcd/view_about.cpp
+++ b/radio/src/gui/colorlcd/view_about.cpp
@@ -3,7 +3,7 @@
  *
  * Based on code named
  *   opentx - https://github.com/opentx/opentx
- *   th9x - http://code.google.com/p/th9x 
+ *   th9x - http://code.google.com/p/th9x
  *   er9x - http://code.google.com/p/er9x
  *   gruvin9x - http://code.google.com/p/gruvin9x
  *
@@ -20,6 +20,7 @@
  */
 
 #include "view_about.h"
+
 #include "opentx.h"
 #include "stamp.h"
 
@@ -28,34 +29,47 @@ const uint8_t _mask_qrcode[] = {
 };
 STATIC_LZ4_BITMAP(mask_qrcode);
 
-constexpr coord_t ABOUT_WIDTH = 220;
 #if defined(VERSION_TAG)
-const std::string about_str = "EdgeTX" " " "\"" CODENAME "\" (" VERSION_TAG ")";
+const std::string about_str = "EdgeTX" " (" VERSION_TAG ")\n" "\"" CODENAME "\"" ;
 #else
 const std::string about_str = "EdgeTX" " (" VERSION "-" VERSION_SUFFIX ")";
 #endif
 const std::string copyright_str = "Copyright (C) 2022 EdgeTX";
 
 AboutUs::AboutUs() :
-  MessageDialog(MainWindow::instance(), STR_ABOUT_US, "", "",
-                CENTERED | FONT(BOLD) | COLOR_THEME_SECONDARY1, CENTERED)
+    MessageDialog(MainWindow::instance(), STR_ABOUT_US, "", "",
+                  CENTERED | FONT(BOLD) | COLOR_THEME_SECONDARY1, CENTERED)
 {
-  content->setRect({(LCD_W - ABOUT_WIDTH) / 2, 20, ABOUT_WIDTH, LCD_H - 40});
+  constexpr int TOP_PADDING = 35;
+  constexpr coord_t ABOUT_WIDTH = 220;
 
-  messageWidget->setTop(content->top() + 40);
-  messageWidget->setHeight(2*PAGE_LINE_HEIGHT);
+#if LCD_H > LCD_W
+#if defined(VERSION_TAG)
+  constexpr int NUM_LINES = 4;
+  constexpr int DIALOG_HEIGHT = 280;
+#else
+  constexpr int NUM_LINES = 3;
+  constexpr int DIALOG_HEIGHT = 260;
+#endif
+  content->setRect({(LCD_W - ABOUT_WIDTH) / 2, (LCD_H - DIALOG_HEIGHT) / 2,
+                    ABOUT_WIDTH, DIALOG_HEIGHT});
+#else
+  constexpr int NUM_LINES = 3;
+  content->setRect({(LCD_W - ABOUT_WIDTH) / 2, 10, ABOUT_WIDTH, LCD_H - 20});
+#endif
+
+  messageWidget->setTop(content->top() + TOP_PADDING);
+  messageWidget->setHeight(NUM_LINES * PAGE_LINE_HEIGHT);
 
   messageWidget->setText(about_str + "\n" + copyright_str);
 
   qrcode = BitmapBuffer::load8bitMaskOnBackground(
       mask_qrcode, COLOR_THEME_SECONDARY1, COLOR_THEME_SECONDARY3);
   new StaticBitmap(content,
-                   rect_t{ content->width() / 2 - qrcode->width() / 2, 80,
-                       qrcode->width(), qrcode->height()},
+                   rect_t{content->width() / 2 - qrcode->width() / 2,
+                          TOP_PADDING + (NUM_LINES * PAGE_LINE_HEIGHT),
+                          qrcode->width(), qrcode->height()},
                    qrcode);
 }
 
-AboutUs::~AboutUs()
-{
-  delete qrcode;
-}
+AboutUs::~AboutUs() { delete qrcode; }


### PR DESCRIPTION
Fixes #2496

* Adjusts size of dialog to look better on NV18/EL18 - was full screeen height before
* Adjusts size of dialog content depending on the presence of version tag (on taller screen, )

I'm sure this could be done better using LVGL,
but is enough for now IMO.

Also let the auto-formatter loose on this file.

![snapshot_05](https://user-images.githubusercontent.com/5500713/194736881-01d97863-6d8c-4248-922b-eb6165c852f1.png)
![snapshot_06](https://user-images.githubusercontent.com/5500713/194736884-15ac5412-7af6-4b24-a023-e3bd642d171d.png)
![snapshot_16](https://user-images.githubusercontent.com/5500713/194736906-b27d73c7-e4f3-4840-9b83-20fba37d3160.png)
![snapshot_17](https://user-images.githubusercontent.com/5500713/194736909-fb4fbf93-5351-45b4-bf47-ef8c5b56dfa6.png)



