### PR TITLE
fix(PXX2): prevent legacy telemetry polling (S.PORT)

### DIFF
--- a/radio/src/pulses/afhds3.cpp
+++ b/radio/src/pulses/afhds3.cpp
@@ -1032,6 +1032,7 @@ static void* initInternal(uint8_t module)
   auto p_state = &protoState[module];
   p_state->init(module, &intmodulePulsesData, &IntmoduleSerialDriver);
 
+  telemetryProtocol = PROTOCOL_TELEMETRY_AFHDS3;
   mixerSchedulerSetPeriod(module, AFHDS3_UART_COMMAND_TIMEOUT * 1000 /* us */);
   INTERNAL_MODULE_ON();
 
@@ -1041,6 +1042,7 @@ static void* initInternal(uint8_t module)
 static void deinitInternal(void* context)
 {
   INTERNAL_MODULE_OFF();
+  telemetryProtocol = 0xFF;
   mixerSchedulerSetPeriod(INTERNAL_MODULE, 0);
 
   auto p_state = (ProtoState*)context;

--- a/radio/src/pulses/pxx2.cpp
+++ b/radio/src/pulses/pxx2.cpp
@@ -834,6 +834,8 @@ static void* pxx2InitExternal(uint8_t module, uint32_t baudrate)
   mixerSchedulerSetPeriod(module, PXX2_NO_HEARTBEAT_PERIOD);
   EXTERNAL_MODULE_ON();
 
+  telemetryProtocol = PROTOCOL_TELEMETRY_FRSKY_SPORT;
+
   auto state = &pxx2State[module];
   state->init(module, &extmodulePulsesData.pxx2, &ExtmoduleSerialDriver,
               ExtmoduleSerialDriver.init(&params));
@@ -856,6 +858,7 @@ static void pxx2DeInitExternal(void* context)
   EXTERNAL_MODULE_OFF();
   mixerSchedulerSetPeriod(EXTERNAL_MODULE, 0);
   ExtmoduleSerialDriver.deinit(context);
+  telemetryProtocol = 0xFF;
 }
 
 static void pxx2SetupPulsesExternal(void* context, int16_t* channels, uint8_t nChannels)


### PR DESCRIPTION
If the module driver defines its own method, legacy telemetry polling should be prevented.
This is to prevent the S.PORT line to interfere with PXX2 telemetry reception, especially with R9M ACCESS.

Fixes #2461.
