### PR TITLE
fix(color): window tree preventing superfluous drawing

### DIFF
--- a/radio/src/gui/colorlcd/draw_functions.cpp
+++ b/radio/src/gui/colorlcd/draw_functions.cpp
@@ -116,47 +116,6 @@ const uint8_t _LBM_SHUTDOWN_CIRCLE[] = {
 };
 STATIC_LZ4_BITMAP(LBM_SHUTDOWN_CIRCLE);
 
-class ShutdownAnimation: public FormGroup
-{
-  public:
-  ShutdownAnimation(uint32_t duration, uint32_t totalDuration):
-      FormGroup(MainWindow::instance(), {0, 0, LCD_W, LCD_H}, OPAQUE | FORM_NO_BORDER),
-      duration(duration),
-      totalDuration(totalDuration)
-    {
-      Layer::push(this);
-      bringToTop();
-      // setFocus(SET_FOCUS_DEFAULT);
-    }
-
-#if defined(DEBUG_WINDOWS)
-    std::string getName() const override
-    {
-      return "ShutdownAnimation";
-    }
-#endif
-    void paint(BitmapBuffer * dc) override
-    {
-    }
-
-    void deleteLater(bool detach = true, bool trash = true) override
-    {
-      Layer::pop(this);
-      Window::deleteLater(detach, trash);
-    }
-
-    void update(uint32_t newDuration, uint32_t newTotalDuration)
-    {
-      duration = newDuration;
-      totalDuration = newTotalDuration;
-    }
-
-  protected:
-    uint32_t duration;
-    uint32_t totalDuration;
-    std::string message;
-};
-
 void drawShutdownAnimation(uint32_t duration, uint32_t totalDuration,
                            const char* message)
 {

--- a/radio/src/gui/colorlcd/fullscreen_dialog.cpp
+++ b/radio/src/gui/colorlcd/fullscreen_dialog.cpp
@@ -28,7 +28,7 @@
 FullScreenDialog::FullScreenDialog(
     uint8_t type, std::string title, std::string message, std::string action,
     const std::function<void(void)>& confirmHandler) :
-    Window(MainWindow::instance(), {0, 0, LCD_W, LCD_H}, OPAQUE),
+    Window(Layer::back(), {0, 0, LCD_W, LCD_H}, OPAQUE),
     type(type),
     title(std::move(title)),
     message(std::move(message)),

--- a/radio/src/gui/colorlcd/page.cpp
+++ b/radio/src/gui/colorlcd/page.cpp
@@ -53,7 +53,7 @@ static constexpr rect_t _get_body_rect()
 }
 
 Page::Page(unsigned icon):
-  Window(MainWindow::instance(), {0, 0, LCD_W, LCD_H}, OPAQUE),
+  Window(Layer::back(), {0, 0, LCD_W, LCD_H}, OPAQUE),
   header(this, icon),
   body(this, _get_body_rect(), FORM_FORWARD_FOCUS)
 {

--- a/radio/src/gui/colorlcd/tabsgroup.cpp
+++ b/radio/src/gui/colorlcd/tabsgroup.cpp
@@ -140,7 +140,7 @@ static constexpr rect_t _get_body_rect()
 }
 
 TabsGroup::TabsGroup(uint8_t icon):
-  Window(MainWindow::instance(), { 0, 0, LCD_W, LCD_H }, OPAQUE),
+  Window(Layer::back(), { 0, 0, LCD_W, LCD_H }, OPAQUE),
   header(this, icon),
   body(this, _get_body_rect(), NO_FOCUS | FORM_FORWARD_FOCUS)
 {


### PR DESCRIPTION
This prevents the main view to be redrawn if fully covered by a tab group, a page or a full screen dialog.

Prior to this, main view widgets would be redrawn in the background while visiting radio or model settings, which is obviously useless and a waste of resources.