### PR TITLE
fix: prevent endless loop with SBUS trainer on model change

### DIFF
--- a/radio/src/dmafifo.h
+++ b/radio/src/dmafifo.h
@@ -54,7 +54,7 @@ class DMAFifo
 #if defined(SIMU)
       return true;
 #endif
-      return (ridx == N - stream->NDTR);
+      return !(stream->CR & DMA_SxCR_EN) || (ridx == N - stream->NDTR);
     }
 
     bool pop(uint8_t & element)

--- a/radio/src/pulses/pulses.cpp
+++ b/radio/src/pulses/pulses.cpp
@@ -458,7 +458,9 @@ bool setupPulsesInternalModule(uint8_t protocol)
 
 void stopPulsesInternalModule()
 {
-  if (moduleState[INTERNAL_MODULE].protocol != PROTOCOL_CHANNELS_UNINITIALIZED) {
+  auto& proto = moduleState[INTERNAL_MODULE].protocol;
+  if (proto != PROTOCOL_CHANNELS_UNINITIALIZED &&
+      proto != PROTOCOL_CHANNELS_NONE) {
     if (internalModuleDriver) {
       internalModuleDriver->deinit(internalModuleContext);
       internalModuleDriver = nullptr;
@@ -467,7 +469,7 @@ void stopPulsesInternalModule()
       mixerSchedulerSetPeriod(INTERNAL_MODULE, 0);
       intmoduleStop();
     }
-    moduleState[INTERNAL_MODULE].protocol = PROTOCOL_CHANNELS_NONE;
+    proto = PROTOCOL_CHANNELS_NONE;
   }
 }
 
@@ -766,8 +768,9 @@ void extmoduleSendNextFrame()
 
 void stopPulsesExternalModule()
 {
-  if (moduleState[EXTERNAL_MODULE].protocol !=
-      PROTOCOL_CHANNELS_UNINITIALIZED) {
+  auto& proto = moduleState[EXTERNAL_MODULE].protocol;
+  if (proto != PROTOCOL_CHANNELS_UNINITIALIZED &&
+      proto != PROTOCOL_CHANNELS_NONE) {
     if (externalModuleDriver) {
       externalModuleDriver->deinit(externalModuleContext);
       externalModuleDriver = nullptr;
@@ -776,7 +779,7 @@ void stopPulsesExternalModule()
       mixerSchedulerSetPeriod(EXTERNAL_MODULE, 0);
       extmoduleStop();
     }
-    moduleState[EXTERNAL_MODULE].protocol = PROTOCOL_CHANNELS_NONE;
+    proto = PROTOCOL_CHANNELS_NONE;
   }
 }
 


### PR DESCRIPTION
## Description

De-initialising the external module while SBUS trainer is used on external module RX leads to the following sequence:
- `extmoduleStop()` is called, thus shutting down the timer DMA
- on certain targets, the timer DMA stream is the same as the external module RX DMA stream
- when this DMA stream is used by the SBUS trainer input, this leads to DMAFifo to return random bytes continuously
- thus driving `processSbusInput()` into an endless loop, which is run in the mixer task
- as the mixer task has the highest priority, it runs forever
- after some time the watchdog timer expires, and causes a reboot

## Solution

- prevent de-initialising modules that have not been initialised (`NONE` protocol)
- harden `DMAFifo` to prevent endless polling from a disabled DMA stream

Fixes #1898 