### PR TITLE
Speed up bulk menu addition.

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "libopenui"]
 	path = radio/src/thirdparty/libopenui
-	url = https://github.com/EdgeTX/libopenui.git
+	url = https://github.com/banyaszg/libopenui.git
 [submodule "radio/src/thirdparty/AccessDenied"]
 	path = radio/src/thirdparty/AccessDenied
 	url = https://github.com/raphaelcoeffic/AccessDenied.git

--- a/radio/src/gui/colorlcd/model_curves.cpp
+++ b/radio/src/gui/colorlcd/model_curves.cpp
@@ -335,7 +335,7 @@ void ModelCurvesPage::build(FormWindow * window, int8_t focusIndex)
       for (int angle = -45; angle <= 45; angle += 15) {
         char label[16];
         strAppend(strAppendSigned(label, angle), "°");
-        menu->addLine(label, [=]() {
+        menu->addLineBuffered(label, [=]() {
           int dx = 2000 / (5 + curve.points - 1);
           for (uint8_t i = 0; i < 5 + curve.points; i++) {
             int x = -1000 + i * dx;
@@ -348,6 +348,7 @@ void ModelCurvesPage::build(FormWindow * window, int8_t focusIndex)
           rebuild(window, index);
         });
       }
+      menu->updateLines();
     };
 
     if (isCurveUsed(index)) {

--- a/radio/src/gui/colorlcd/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model_mixes.cpp
@@ -421,9 +421,10 @@ void ModelMixesPage::newMix()
       }
     } else {
       std::string ch_name(getSourceString(MIXSRC_CH1 + ch));
-      menu->addLine(ch_name.c_str(), [=]() { insertMix(ch, index); });
+      menu->addLineBuffered(ch_name.c_str(), [=]() { insertMix(ch, index); });
     }
   }
+  menu->updateLines();
 }
 
 void ModelMixesPage::editMix(uint8_t channel, uint8_t index)

--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -441,7 +441,7 @@ void ModelsPageBody::editLabels(ModelCell* model)
     });
 
     for (auto &label : modelslabels.getLabels()) {
-      menu->addLine(
+      menu->addLineBuffered(
           label,
           [=]() {
             if (!modelslabels.isLabelSelected(label, model))
@@ -453,6 +453,7 @@ void ModelsPageBody::editLabels(ModelCell* model)
           },
           [=]() { return modelslabels.isLabelSelected(label, model); });
     }
+    menu->updateLines();
   }
 }
 

--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -247,7 +247,7 @@ void ModelSetupPage::build(FormWindow * window)
        Menu *menu = new Menu(window, true);
        menu->setTitle(STR_LABELS);
        for (auto &label: modelslabels.getLabels()) {
-         menu->addLine(label,
+         menu->addLineBuffered(label,
            [=] () {
              if (!modelslabels.isLabelSelected(label, curmod))
                modelslabels.addLabelToModel(label, curmod);
@@ -261,6 +261,7 @@ void ModelSetupPage::build(FormWindow * window)
              return modelslabels.isLabelSelected(label, curmod);
            });
        }
+       menu->updateLines();
        return 0;
      });
 


### PR DESCRIPTION
Fixes #2284

Summary of changes:
Speed up menu initializítion by delaying the UI update and do it in one step at the end.
Modified parts:
- [x] ModelSetupPage::build()
- [x] ModelsPageBody::editLabels()
- [x] ModelCurvesPage::build()
- [x] ModelMixesPage::newMix()

Requires [libopenui#77](https://github.com/EdgeTX/libopenui/pull/77)