### PR TITLE
fix(sdcard): use init marker in initialised BSS segment

### DIFF
--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -182,10 +182,6 @@ void boardInit()
 
   audioInit();
 
-  // we need to initialize g_FATFS_Obj here, because it is in .ram section (because of DMA access)
-  // and this section is un-initialized
-  memset(&g_FATFS_Obj, 0, sizeof(g_FATFS_Obj));
-
   keysInit();
   rotaryEncoderInit();
 

--- a/radio/src/targets/horus/diskio.cpp
+++ b/radio/src/targets/horus/diskio.cpp
@@ -311,7 +311,8 @@ DRESULT disk_ioctl (
 
 // TODO everything here should not be in the driver layer ...
 
-FATFS g_FATFS_Obj __DMA;    // initialized in boardInit()
+bool _g_FATFS_init = false;
+FATFS g_FATFS_Obj __DMA; // this is in uninitialised section !!!
 
 #if defined(LOG_TELEMETRY)
 FIL g_telemetryFile = {};
@@ -349,6 +350,7 @@ void sdMount()
   
   if (f_mount(&g_FATFS_Obj, "", 1) == FR_OK) {
     // call sdGetFreeSectors() now because f_getfree() takes a long time first time it's called
+    _g_FATFS_init = true;
     sdGetFreeSectors();
 
 #if defined(LOG_TELEMETRY)
@@ -392,7 +394,7 @@ void sdDone()
 
 uint32_t sdMounted()
 {
-  return g_FATFS_Obj.fs_type != 0;
+  return _g_FATFS_init && (g_FATFS_Obj.fs_type != 0);
 }
 
 uint32_t sdIsHC()

--- a/radio/src/targets/taranis/diskio.cpp
+++ b/radio/src/targets/taranis/diskio.cpp
@@ -954,7 +954,8 @@ void sdPoll10ms()
 
 // TODO everything here should not be in the driver layer ...
 
-FATFS g_FATFS_Obj __DMA;
+bool _g_FATFS_init = false;
+FATFS g_FATFS_Obj __DMA; // this is in uninitialised section !!!
 
 #if defined(LOG_TELEMETRY)
 FIL g_telemetryFile = {};
@@ -985,6 +986,7 @@ void sdMount()
   TRACE("sdMount");
   if (f_mount(&g_FATFS_Obj, "", 1) == FR_OK) {
     // call sdGetFreeSectors() now because f_getfree() takes a long time first time it's called
+    _g_FATFS_init = true;
     sdGetFreeSectors();
     
 #if defined(LOG_TELEMETRY)
@@ -1020,7 +1022,7 @@ void sdDone()
 
 uint32_t sdMounted()
 {
-  return g_FATFS_Obj.fs_type != 0;
+  return _g_FATFS_init && (g_FATFS_Obj.fs_type != 0);
 }
 
 uint32_t sdIsHC()


### PR DESCRIPTION
`g_FATFS_Obj` is located in `__DMA` section, which is not initialised, so that testing `sdMounted()` at boot relies on the fact that the bootloader linker script declares BSS in internal SRAM and not in CCM, as the firmware linker script does.
