### PR TITLE
fix(cpn): Handle mixer scripts with no inputs def.

### DIFF
--- a/companion/src/firmwares/edgetx/yaml_modeldata.cpp
+++ b/companion/src/firmwares/edgetx/yaml_modeldata.cpp
@@ -543,10 +543,12 @@ struct convert<ScriptData> {
     node["file"] >> rhs.filename;
     node["name"] >> rhs.name;
 
-    for (int i=0; i < CPN_MAX_SCRIPT_INPUTS; i++) {
-      if (node["inputs"][std::to_string(i)]) {
-        if (node["inputs"][std::to_string(i)]["u"]["value"]) {
-          node["inputs"][std::to_string(i)]["u"]["value"] >> rhs.inputs[i];
+    if (node["inputs"]) {
+      for (int i = 0; i < CPN_MAX_SCRIPT_INPUTS; i++) {
+        if (node["inputs"][std::to_string(i)]) {
+          if (node["inputs"][std::to_string(i)]["u"]["value"]) {
+            node["inputs"][std::to_string(i)]["u"]["value"] >> rhs.inputs[i];
+          }
         }
       }
     }


### PR DESCRIPTION
Because it seems like I managed to configure it just so
and Companion didn't like that.

<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #2521

Summary of changes:
- Check for inputs before just trying to reading them ;)

model1 and model23 no longer make Companion crashy crash. 

[crash-1-23.etx.zip](https://github.com/EdgeTX/edgetx/files/9762143/crash-1-23.etx.zip)


Confirmed locally against ETX file with linux cpn build, and now against Windows build and TX16s hardware. No errors on read, and settings preserved on write. 

