### PR TITLE
fix: clear internal module FIFO after DMA init

### DIFF
--- a/radio/src/targets/common/arm/stm32/intmodule_serial_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/intmodule_serial_driver.cpp
@@ -148,10 +148,10 @@ void* intmoduleSerialStart(const etx_serial_init* params)
 
   stm32_usart_init(&intmoduleUSART, params);
 
-  intmoduleCtx.rxFifo->clear();
   if (params->rx_enable && intmoduleUSART.rxDMA) {
     stm32_usart_init_rx_dma(&intmoduleUSART, intmoduleFifo.buffer(), intmoduleFifo.size());
   }  
+  intmoduleCtx.rxFifo->clear();
   
   return (void*)&intmoduleCtx;
 }


### PR DESCRIPTION
Otherwise, NDTR will be 0 instead of [buffer size], and thus the read index will not be set to the correct value.

Fixes #2368 
