### PR TITLE
fix(color): shortcut for model select

### DIFF
--- a/radio/src/gui/colorlcd/view_main.cpp
+++ b/radio/src/gui/colorlcd/view_main.cpp
@@ -245,6 +245,7 @@ void ViewMain::onEvent(event_t event)
       break;
 
     case EVT_KEY_LONG(KEY_MODEL):
+      killEvents(KEY_MODEL);
       new ModelLabelsWindow();
       break;
 


### PR DESCRIPTION
Prior to this fix the model settings would be opened as well when long pressing the model key.
