### PR TITLE
fix(cpn): Workaround MacOS 13 filesystem type change

### DIFF
--- a/companion/src/radiointerface.cpp
+++ b/companion/src/radiointerface.cpp
@@ -302,7 +302,7 @@ QString findMassstoragePath(const QString & filename, bool onlyPath)
   QString probefile;
   bool found = false;
 
-  QRegularExpression fstypeRe("^(v?fat|msdos)", QRegularExpression::CaseInsensitiveOption);  // Linux: "vfat"; macOS: "msdos"; Win: "FAT32"
+  QRegularExpression fstypeRe("^(v?fat|msdos|lifs)", QRegularExpression::CaseInsensitiveOption);  // Linux: "vfat"; macOS: "msdos" or "lifs"; Win: "FAT32"
 
   foreach(const QStorageInfo & si, QStorageInfo::mountedVolumes()) {
     //qDebug() << si.rootPath() << si.name() << si.device() << si.displayName() << si.fileSystemType() << si.isReady();


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #

Summary of changes:

On MacOS 13 the EdgeTX companion will not find the radio's SD card.  The reason is that the companion app looks for volumes of type "fat", "vfat", or "msdos"; while the latest MacOS mounts the radio with type "lifs".  

This fix extends the regular expression to match that type. 
