### PR TITLE
fix(lua): array indexes in some set/get functions

### DIFF
--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1187,7 +1187,7 @@ static int luaGhostTelemetryPop(lua_State * L)
     lua_newtable(L);
     for (uint8_t i=0; i<length-2; i++) {
       luaInputTelemetryFifo->pop(data);
-      lua_pushinteger(L, i+1);
+      lua_pushinteger(L, i + 1);
       lua_pushinteger(L, data);
       lua_settable(L, -3);
     }
@@ -2587,7 +2587,7 @@ static int luaSources(lua_State * L)
 static int luaGetOutputValue(lua_State * L)
 {
   mixsrc_t idx = luaL_checkinteger(L, 1);
-  if (idx >= 0 && idx < MAX_OUTPUT_CHANNELS) {
+  if (idx < MAX_OUTPUT_CHANNELS) {
     lua_pushinteger(L, channelOutputs[idx]);
   } else {
     lua_pushinteger(L, 0);

--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -526,8 +526,9 @@ static int luaModelSetFlightMode(lua_State * L)
     }
     else if (!strcmp(key, "trimsValues")) {
       luaL_checktype(L, -1, LUA_TTABLE);
-      uint8_t idx = 0;
-      for (lua_pushnil(L); lua_next(L, -2); lua_pop(L, 1), idx++) {
+      for (lua_pushnil(L); lua_next(L, -2); lua_pop(L, 1)) {
+        int idx = luaL_checkinteger(L, -2) - 1; // key is integer
+        if (idx < 0 || idx >= NUM_TRIMS) continue;
         int16_t val = luaL_checkinteger(L, -1);
         if (idx < NUM_TRIMS)
           fm->trim[idx].value = (val & 0x3FF);
@@ -535,8 +536,9 @@ static int luaModelSetFlightMode(lua_State * L)
     }
     else if (!strcmp(key, "trimsModes")) {
       luaL_checktype(L, -1, LUA_TTABLE);
-      uint8_t idx = 0;
-      for (lua_pushnil(L); lua_next(L, -2); lua_pop(L, 1), idx++) {
+      for (lua_pushnil(L); lua_next(L, -2); lua_pop(L, 1)) {
+        int idx = luaL_checkinteger(L, -2) - 1; // key is integer
+        if (idx < 0 || idx >= NUM_TRIMS) continue;
         uint16_t val = luaL_checkinteger(L, -1);
         if (idx < NUM_TRIMS)
           fm->trim[idx].mode = (val & 0x1F);

--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -467,7 +467,7 @@ static int luaModelGetFlightMode(lua_State * L)
     lua_pushstring(L, "trimsValues");
     lua_newtable(L);
     for (uint8_t i = 0; i < NUM_TRIMS; i++) {
-      lua_pushinteger(L, i);
+      lua_pushinteger(L, i + 1);
       lua_pushinteger(L, fm->trim[i].value);
       lua_settable(L, -3);
     }
@@ -475,7 +475,7 @@ static int luaModelGetFlightMode(lua_State * L)
     lua_pushstring(L, "trimsModes");
     lua_newtable(L);
     for (uint8_t i = 0; i < NUM_TRIMS; i++) {
-      lua_pushinteger(L, i);
+      lua_pushinteger(L, i + 1);
       lua_pushinteger(L, fm->trim[i].mode);
       lua_settable(L, -3);
     }
@@ -1087,7 +1087,7 @@ static int luaModelGetCurve(lua_State *L)
     lua_newtable(L);
     int8_t * point = curveAddress(idx);
     for (int i=0; i < CurveHeader.points + 5; i++) {
-      lua_pushinteger(L, i);
+      lua_pushinteger(L, i + 1);
       lua_pushinteger(L, *point++);
       lua_settable(L, -3);
     }
@@ -1095,15 +1095,15 @@ static int luaModelGetCurve(lua_State *L)
     if (CurveHeader.type == CURVE_TYPE_CUSTOM) {
       lua_pushstring(L, "x");
       lua_newtable(L);
-      lua_pushinteger(L, 0);
+      lua_pushinteger(L, 1);
       lua_pushinteger(L, -100);
       lua_settable(L, -3);
       for (int i=0; i < CurveHeader.points + 3; i++) {
-        lua_pushinteger(L, i+1);
+        lua_pushinteger(L, i + 2);
         lua_pushinteger(L, *point++);
         lua_settable(L, -3);
       }
-      lua_pushinteger(L, CurveHeader.points + 4);
+      lua_pushinteger(L, CurveHeader.points + 5);
       lua_pushinteger(L, 100);
       lua_settable(L, -3);
       lua_settable(L, -3);
@@ -1198,7 +1198,7 @@ static int luaModelSetCurve(lua_State *L)
       bool isX = !strcmp(key, "x");
 
       for (lua_pushnil(L); lua_next(L, -2); lua_pop(L, 1)) {
-        int idx = luaL_checkinteger(L, -2) - 1;
+        int idx = luaL_checkinteger(L, -2) - 1; // key is integer
         if (idx < 0 || idx > MAX_POINTS_PER_CURVE) {
           lua_pushinteger(L, 4);
           return 1;

--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -530,8 +530,12 @@ static int luaModelSetFlightMode(lua_State * L)
         int idx = luaL_checkinteger(L, -2) - 1; // key is integer
         if (idx < 0 || idx >= NUM_TRIMS) continue;
         int16_t val = luaL_checkinteger(L, -1);
+        if (g_model.extendedTrims)
+          val = limit<int16_t>(val, TRIM_EXTENDED_MIN, TRIM_EXTENDED_MAX);
+        else
+          val = limit<int16_t>(val, TRIM_MIN, TRIM_MAX);
         if (idx < NUM_TRIMS)
-          fm->trim[idx].value = (val & 0x3FF);
+          fm->trim[idx].value = val;
       }
     }
     else if (!strcmp(key, "trimsModes")) {


### PR DESCRIPTION
## Description

**Warning: this PR introduces a change in behaviour**

Prior to this change, `model.getFlightMode()` and `model.getCurve()` would return arrays with integer indexes starting at `0`, which breaks a lot of things with LUA. For instance, copying such an array removes the first element (index `0` is not copied).

**Summary of changes:**
- fixed array indexes in `model.getFlightMode()`
- fixed array indexes in `model.getCurve()`
- use array indexes to allow for incomplete table in `model.setFlightMode()`

Fixes #976

## Test LUA script

This script has been used to test the correctness of the changes.

```lua
local toolName = "TNS|TrimMode|TNE"
local lastEvent = ""
local eventTime = 0

-- String identifying events
local function evt2str(event)
  if event == EVT_VIRTUAL_PREV then return "EVT_VIRTUAL_PREV"
  elseif event == EVT_VIRTUAL_NEXT then return "EVT_VIRTUAL_NEXT"
  elseif event == EVT_VIRTUAL_DEC then return "EVT_VIRTUAL_DEC"
  elseif event == EVT_VIRTUAL_INC then return "EVT_VIRTUAL_INC"
  elseif event == EVT_VIRTUAL_PREV_PAGE then return "EVT_VIRTUAL_PREV_PAGE"
  elseif event == EVT_VIRTUAL_NEXT_PAGE then return "EVT_VIRTUAL_NEXT_PAGE"
  elseif event == EVT_VIRTUAL_MENU then return "EVT_VIRTUAL_MENU"
  elseif event == EVT_VIRTUAL_ENTER then return "EVT_VIRTUAL_ENTER"
  elseif event == EVT_VIRTUAL_MENU_LONG then return "EVT_VIRTUAL_MENU_LONG"
  elseif event == EVT_VIRTUAL_ENTER_LONG then return "EVT_VIRTUAL_ENTER_LONG"
  elseif event == EVT_VIRTUAL_EXIT then return "EVT_VIRTUAL_EXIT"
  else 
    local txt = string.format("Event = %i", event)
    return txt
  end
end

local function run(event)
  
  lcd.clear()

  if event ~= 0 then -- We got a new event
     -- Save the event for subsequent cycles and mark the time
     if event ==  EVT_VIRTUAL_ENTER then
        modes = {}
        modes[5] = 31
        modes[6] = 31
        t = {}
        t["trimsModes"] = modes
        model.setFlightMode(0, t)
        lastEvent = "DISABLE trim 5 & 6"
        -- end
     elseif event ==  EVT_VIRTUAL_MENU then
        fms = model.getFlightMode(0)
        print("trimsModes:")
        for i,m in ipairs(fms["trimsModes"]) do
           print(i, m)
        end
        t = {}
        t["trimsModes"] = fms["trimsModes"]
        model.setFlightMode(0, t)
        lastEvent = "IDENT set modes"
     elseif event ==  EVT_VIRTUAL_PREV_PAGE then
        curve = model.getCurve(0)
        print("Curve 0")
        print(" - Y points:")
        for i,m in ipairs(curve["y"]) do
           print("\t", i, m)
        end
        if curve["x"] then
           print(" - X points:")
           for i,m in ipairs(curve["x"]) do
              print("\t", i, m)
           end
        end
        model.setCurve(0, curve)
        lastEvent = "IDENT curve 0"
     elseif event ==  EVT_VIRTUAL_NEXT_PAGE then
        curve = {}
        curve["y"] = { -50, -25, 0, 25, 50 }
        model.setCurve(0, curve)
        lastEvent = "SET curve 0"
     else
        lastEvent = evt2str(event)
     end
     eventTime = getTime()
  end

  -- Show the last event for 1 sec. in the upper left corner
  if getTime() - eventTime < 100 then
    lcd.drawText(3, 3, lastEvent)
  end

  return 0
end

return {run = run}
```