### PR TITLE
fix(lua): send EVT_VIRTUAL_EXIT only on short EXIT press

### DIFF
--- a/radio/src/lua/lua_widget.cpp
+++ b/radio/src/lua/lua_widget.cpp
@@ -145,6 +145,7 @@ void LuaEventHandler::onCancel()
 
 void LuaEventHandler::onEvent(event_t event)
 {
+  if (event == EVT_KEY_LONG(KEY_EXIT)) killEvents(KEY_EXIT);
   luaPushEvent(event);
 }
 


### PR DESCRIPTION
Fixes #2436

Summary of changes:
- `EVT_KEY_BREAK(KEY_EXIT)` is now mapped to `LV_EVENT_CANCEL` (previously `EVT_KEY_FIRST(KEY_EXIT)`)
- `short` and `long` `EXIT`/`RTN` work the same everywhere (`BREAK` event is generated, thus `onCancel()` is called)
- except in LUA where `long EXIT` **does not** generate a `BREAK` event.