### PR TITLE
fix(color): Duplicate model, write pending changes first

### DIFF
--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -403,6 +403,9 @@ void ModelsPageBody::selectModel(ModelCell *model)
 
 void ModelsPageBody::duplicateModel(ModelCell* model)
 {
+  storageFlushCurrentModel();
+  storageCheck(true);
+
   char duplicatedFilename[LEN_MODEL_FILENAME + 1];
   memcpy(duplicatedFilename, model->modelFilename,
          sizeof(duplicatedFilename));


### PR DESCRIPTION
Should only affect if you try to duplicate the current model.

If a write is pending, change of labels, etc. it wouldn't get copied into the duplicated model, but the labels still would have still been added to labels.yml until a re-scan.

Potential cause of issue #2561