### PR TITLE
fix(color): min/max highlighting should depend on mixer channel value

### DIFF
--- a/radio/src/gui/colorlcd/output_edit.cpp
+++ b/radio/src/gui/colorlcd/output_edit.cpp
@@ -66,7 +66,7 @@ OutputEditWindow::OutputEditWindow(uint8_t channel) :
   title += "\n";
   title += getSourceString(MIXSRC_CH1 + channel);
 
-  chanZero = calcRESXto100(channelOutputs[channel]);
+  chanZero = calcRESXto100(ex_chans[channel]);
 
   auto form = new FormWindow(&body, rect_t{});
   auto form_obj = form->getLvObj();
@@ -82,7 +82,7 @@ void OutputEditWindow::checkEvents()
   if (value != newValue) {
     value = newValue;
 
-    int chanVal = calcRESXto100(channelOutputs[channel]);
+    int chanVal = calcRESXto100(ex_chans[channel]);
     minText->setBackgroudOpacity(chanVal < chanZero - 1 ? LV_OPA_COVER : LV_OPA_TRANSP);
     minText->setFont(chanVal < chanZero - 1 ? FONT(BOLD) : FONT(STD));
     minText->invalidate();


### PR DESCRIPTION
... and not the output value. Otherwise, it will highlight min/max when the sub-trim is changed.
