### PR TITLE
feat(color): mix/output bars show '0%'

### DIFF
--- a/radio/src/gui/colorlcd/channel_bar.cpp
+++ b/radio/src/gui/colorlcd/channel_bar.cpp
@@ -43,7 +43,7 @@ void MixerChannelBar::paint(BitmapBuffer * dc)
       limit<int>(-VIEW_CHANNELS_LIMIT_PCT, chanVal, VIEW_CHANNELS_LIMIT_PCT);
 
   // Draw mixer bar
-  if (chanVal > 0) {
+  if (chanVal >= 0) {
     dc->drawSolidFilledRect(
         0 + width() / 2, 0,
         divRoundClosest(chanVal * width(), VIEW_CHANNELS_LIMIT_PCT * 2),
@@ -108,7 +108,7 @@ void OutputChannelBar::paint(BitmapBuffer* dc)
       limit<int>(-VIEW_CHANNELS_LIMIT_PCT, chanVal, VIEW_CHANNELS_LIMIT_PCT);
 
   // Draw output bar
-  if (chanVal > 0) {
+  if (chanVal >= 0) {
     dc->drawSolidFilledRect(
         width() / 2, 0,
         divRoundClosest(chanVal * width(), VIEW_CHANNELS_LIMIT_PCT * 2),


### PR DESCRIPTION
Resolves #2575

Summary of changes:
- instead of omitting the percentage at 0% / center, now display it

![snapshot_01](https://user-images.githubusercontent.com/5500713/196151882-beb072f2-a57d-40cc-9236-e7b8adea24d6.png)
![snapshot_02](https://user-images.githubusercontent.com/5500713/196151889-de2c5ca4-52b7-4378-a17d-643fc59a8287.png)

