### PR TITLE
fix(isrm): flashing internal ISRM module

### DIFF
--- a/radio/src/pulses/modules_helpers.h
+++ b/radio/src/pulses/modules_helpers.h
@@ -789,10 +789,8 @@ inline void setDefaultPpmFrameLength(uint8_t moduleIdx)
 
 inline void resetAccessAuthenticationCount()
 {
-#if defined(ACCESS_LIB)
   // the module will reset on mode switch, we need to reset the authentication counter
   globalData.authenticationCount = 0;
-#endif
 }
 
 inline void resetAfhdsOptions(uint8_t moduleIdx)

--- a/radio/src/targets/common/arm/stm32/intmodule_serial_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/intmodule_serial_driver.cpp
@@ -118,6 +118,7 @@ static const IntmoduleCtx intmoduleCtx = {
 
 void intmoduleStop()
 {
+  INTERNAL_MODULE_OFF();
   stm32_usart_deinit(&intmoduleUSART);
 
   // reset callbacks


### PR DESCRIPTION
Fixes #1552

Summary of changes:
- properly handle flashing of internal module depending internal module set in radio settings
- deactivate UART on internal serial module as the module won't reset properly otherwise
- fix a minor issue with the authentication counter not properly reset for ISRM upgrade modules 
