### PR TITLE
Companion update: switch from component names to ids

### DIFF
--- a/companion/src/storage/appdata.cpp
+++ b/companion/src/storage/appdata.cpp
@@ -346,7 +346,7 @@ bool ComponentData::existsOnDisk()
 void ComponentData::clearRelease()
 {
   releaseReset();
-  idReset();
+  releaseIdReset();
   prereleaseReset();
   dateReset();
   versionReset();
@@ -516,15 +516,6 @@ QMap<int, QString> AppData::getActiveProfiles() const
   return active;
 }
 
-int AppData::getComponentIndex(QString name) const
-{
-  for (int i=0; i<MAX_COMPONENTS; i++) {
-    if (g.component[i].existsOnDisk() && g.component[i].name() == name)
-       return i;
-  }
-  return -1;
-}
-
 void AppData::convertSettings(QSettings & settings)
 {
   quint32 savedVer = settings.value(SETTINGS_VERSION_KEY, 0).toUInt();
@@ -563,6 +554,18 @@ void AppData::convertSettings(QSettings & settings)
                                         << " to (" << newval << ")";
           }
         }
+      }
+    }
+  }
+
+  if (savedMajMin < 0x209) {
+    //  2.9 component id renamed releaseId - copy value before calling clearUnusedSettings
+    qInfo().noquote() << "Converting components - moving id to releaseId";
+    static const QString path = QStringLiteral("Components/component%1/%2");
+    for (int i = 0; i < MAX_COMPONENTS; i++) {
+      if (settings.contains(path.arg(i).arg("id"))) {
+        const QVariant id = settings.value(path.arg(i).arg("id"));
+        settings.setValue(path.arg(i).arg("releaseId"), id);
       }
     }
   }

--- a/companion/src/storage/appdata.h
+++ b/companion/src/storage/appdata.h
@@ -39,7 +39,7 @@
 
 //! CPN_SETTINGS_REVISION is used to track settings changes independently of EdgeTX version. It should be reset to zero whenever settings are migrated to new COMPANY or PRODUCT.
 //! \note !! Increment this value if properties are removed or refactored. It will trigger a conversion/cleanup of any stored settings. \sa AppData::convertSettings()
-#define CPN_SETTINGS_REVISION       1 // Note: bumped to ensure 2.7 Nightly version users also get upgraded
+#define CPN_SETTINGS_REVISION       2 // Note: bumped for fix during 2.8 RCs
 
 //! CPN_SETTINGS_VERSION is used for settings data version tracking.
 #define CPN_SETTINGS_VERSION        ((VERSION_NUMBER << 8) | CPN_SETTINGS_REVISION)
@@ -495,11 +495,10 @@ class ComponentData: public CompStoreObj
     friend class AppData;
 
   private:
-    PROPERTYSTR (name)
     PROPERTY    (bool,           checkForUpdate,  false)
     PROPERTY    (ReleaseChannel, releaseChannel,  RELEASE_CHANNEL_STABLE)
     PROPERTYSTRD(                release,         "unknown")
-    PROPERTY    (int,            id,              0)
+    PROPERTY    (int,            releaseId,       0)
     PROPERTY    (bool,           prerelease,      false)
     PROPERTYSTRD(                version,         "0")
     PROPERTYSTRD(                date,            "")
@@ -574,8 +573,6 @@ class AppData: public CompStoreObj
     //! List of all active profiles mapped by index.
     QMap<int, QString> getActiveProfiles() const;
 
-    //! Get a modifiable (non-const) index to ComponentData for \a name. Returns -1 if \a name not found.
-    int getComponentIndex(QString name) const;
     //! Get a modifiable (non-const) reference to the ComponentData at \a index. Returns component[0] if \a index is invalid.
     ComponentData & getComponent(int index);
     //! Get a non-modifiable (const) reference to the ComponentData at \a index. Returns component[0] if \a index is invalid.

--- a/companion/src/updates/repomodels.cpp
+++ b/companion/src/updates/repomodels.cpp
@@ -433,17 +433,35 @@ bool AssetsFilteredItemModel::setCopyFilter(const int id, const QString filter)
   return setMetaDataValue(id, UpdatesItemModel::IMDR_CopyFilter, QVariant(filter));
 }
 
+
+/*
+    RepoMetaData
+*/
+
+RepoMetaData::RepoMetaData(QObject * parent) :
+  QObject(parent)
+{
+
+}
+
 /*
     ReleasesMetaData
 */
 
 ReleasesMetaData::ReleasesMetaData(QObject * parent) :
-  QObject(parent),
-  m_repo(""),
+  RepoMetaData(parent),
   m_id(0)
 {
   itemModel = new ReleasesItemModel();
   filteredItemModel = new ReleasesFilteredItemModel(itemModel);
+}
+
+void ReleasesMetaData::init(const QString repo, const QString nightly, const int settingsIndex, const int resultsPerPage)
+{
+  m_repo = repo;
+  m_resultsPerPage = resultsPerPage;
+  itemModel->setNightlyName(nightly);
+  itemModel->setSettingsIndex(settingsIndex);
 }
 
 bool ReleasesMetaData::refreshRequired()
@@ -490,10 +508,16 @@ QString ReleasesMetaData::version()
 */
 
 AssetsMetaData::AssetsMetaData(QObject * parent) :
-  QObject(parent)
+  RepoMetaData(parent)
 {
   itemModel = new AssetsItemModel();
   filteredItemModel = new AssetsFilteredItemModel(itemModel);
+}
+
+void AssetsMetaData::init(const QString repo, const int resultsPerPage)
+{
+  m_repo = repo;
+  m_resultsPerPage = resultsPerPage;
 }
 
 int AssetsMetaData::getSetId(int row)

--- a/companion/src/updates/repomodels.h
+++ b/companion/src/updates/repomodels.h
@@ -202,18 +202,32 @@ class AssetsFilteredItemModel : public UpdatesFilteredItemModel
   private:
 };
 
-class ReleasesMetaData : public QObject
+class RepoMetaData : public QObject
+{
+    Q_OBJECT
+  public:
+    explicit RepoMetaData(QObject * parent);
+    virtual ~RepoMetaData() {};
+
+    const QString urlReleases() { return QString("%1/releases").arg(m_repo); }
+    const QString urlReleaseLatest() { return QString("%1/latest").arg(urlReleases()); }
+    const QString urlContent(const QString & path) { return QString("%1/contents/%2").arg(m_repo).arg(path); }
+
+  protected:
+    QString m_repo;
+    int m_resultsPerPage;
+};
+
+class ReleasesMetaData : public RepoMetaData
 {
     Q_OBJECT
   public:
     explicit ReleasesMetaData(QObject * parent);
     virtual ~ReleasesMetaData() {};
 
-    bool refreshRequired();
+    void init(const QString repo, const QString nightly, const int settingsIndex, const int resultsPerPage);
 
-    void setRepo(QString repo) { m_repo = repo; }
-    void setNightlyName(QString name) { itemModel->setNightlyName(name); }
-    void setSettingsIndex(const int index) { itemModel->setSettingsIndex(index); }
+    bool refreshRequired();
     void setReleaseChannel(const int channel) { itemModel->setReleaseChannel(channel); }
 
     void setId(int id) { m_id = id; }
@@ -234,25 +248,22 @@ class ReleasesMetaData : public QObject
     bool prerelease() { return filteredItemModel->prerelease(m_id); }
     QString version();
 
-    QString urlReleases() { return QString("%1/releases").arg(m_repo); }
-    QString urlReleaseLatest() { return QString("%1/latest").arg(urlReleases()); }
-    QString urlRelease() { return QString("%1/%2").arg(urlReleases()).arg(m_id); }
+    const QString urlRelease() { return QString("%1/%2").arg(urlReleases()).arg(m_id); }
 
   private:
     ReleasesItemModel *itemModel;
     ReleasesFilteredItemModel *filteredItemModel;
-    QString m_repo;
     int m_id;
 };
 
-class AssetsMetaData : public QObject
+class AssetsMetaData : public RepoMetaData
 {
     Q_OBJECT
   public:
     explicit AssetsMetaData(QObject * parent);
     virtual ~AssetsMetaData() {};
 
-    void setRepo(QString repo) { m_repo = repo; }
+    void init(const QString repo, const int resultsPerPage);
 
     void setId(int id) { m_id = id; }
     int id() { return m_id; }
@@ -282,17 +293,13 @@ class AssetsMetaData : public QObject
     QString copyFilter() { return filteredItemModel->metaDataValue(m_id, UpdatesItemModel::IMDR_CopyFilter).toString(); }
     int flags() { return filteredItemModel->metaDataValue(m_id, UpdatesItemModel::IMDR_Flags).toInt(); }
 
-    QString urlReleaseAssets(int releaseId, int max)
-                            { return QString("%1/%2/assets").arg(urlReleases()).arg(releaseId) % (max > -1 ? QString("\?per_page=%1").arg(max) : ""); }
-    QString urlAsset() { return QString("%1/assets/%2").arg(urlReleases()).arg(m_id); }
-
-    QString urlContent(QString path) { return QString("%1/contents/%2").arg(m_repo).arg(path); }
+    const QString urlReleaseAssets(int releaseId) {
+                                   return QString("%1/%2/assets").arg(urlReleases()).arg(releaseId) % (m_resultsPerPage > -1 ?
+                                   QString("\?per_page=%1").arg(m_resultsPerPage) : ""); }
+    const QString urlAsset() { return QString("%1/assets/%2").arg(urlReleases()).arg(m_id); }
 
   private:
     AssetsItemModel *itemModel;
     AssetsFilteredItemModel *filteredItemModel;
-    QString m_repo;
     int m_id;
-
-    QString urlReleases() { return m_repo % "/releases"; }
 };

--- a/companion/src/updates/updatecompanion.cpp
+++ b/companion/src/updates/updatecompanion.cpp
@@ -55,9 +55,7 @@
 UpdateCompanion::UpdateCompanion(QWidget * parent) :
   UpdateInterface(parent)
 {
-  setName(tr("Companion"));
-  setRepo(QString(GH_REPOS_EDGETX).append("/edgetx"));
-  setReleasesNightlyName("nightly");
+  init(CID_Companion, tr("Companion"), QString(GH_REPOS_EDGETX).append("/edgetx"), "nightly");
 }
 
 void UpdateCompanion::initAssetSettings()
@@ -65,9 +63,9 @@ void UpdateCompanion::initAssetSettings()
   if (!isValidSettingsIndex())
     return;
 
-  g.component[settingsIndex()].initAllAssets();
+  g.component[id()].initAllAssets();
 
-  ComponentAssetData &cad = g.component[settingsIndex()].asset[0];
+  ComponentAssetData &cad = g.component[id()].asset[0];
 
   cad.desc("installer");
   cad.processes((UPDFLG_Common_Asset | UPDFLG_AsyncInstall) & ~UPDFLG_CopyDest);

--- a/companion/src/updates/updatefirmware.cpp
+++ b/companion/src/updates/updatefirmware.cpp
@@ -25,9 +25,7 @@
 UpdateFirmware::UpdateFirmware(QWidget * parent) :
   UpdateInterface(parent)
 {
-  setName(tr("Firmware"));
-  setRepo(QString(GH_REPOS_EDGETX).append("/edgetx"));
-  setReleasesNightlyName("nightly");
+  init(CID_Firmware, tr("Firmware"), QString(GH_REPOS_EDGETX).append("/edgetx"), "nightly");
 }
 
 void UpdateFirmware::initAssetSettings()
@@ -35,9 +33,9 @@ void UpdateFirmware::initAssetSettings()
   if (!isValidSettingsIndex())
     return;
 
-  g.component[settingsIndex()].initAllAssets();
+  g.component[id()].initAllAssets();
 
-  ComponentAssetData &cad = g.component[settingsIndex()].asset[0];
+  ComponentAssetData &cad = g.component[id()].asset[0];
 
   cad.desc("binary");
   cad.processes(UPDFLG_Common_Asset | UPDFLG_AsyncInstall);

--- a/companion/src/updates/updateinterface.cpp
+++ b/companion/src/updates/updateinterface.cpp
@@ -114,19 +114,17 @@ QString UpdateParameters::updateFilterTypeToString(UpdateFilterType uft)
 UpdateInterface::UpdateInterface(QWidget * parent) :
   QWidget(parent),
   progress(nullptr),
-  resultsPerPage(-1),
   reply(nullptr),
   buffer(new QByteArray()),
   file(nullptr),
-  m_settingsIdx(-1)
+  m_id(CID_Unknown),
+  m_name("")
 {
   QNetworkProxyFactory::setUseSystemConfiguration(true);
 
   releases = new ReleasesMetaData(this);
   assets = new AssetsMetaData(this);
   params = new UpdateParameters(this);
-
-  setReleasesNightlyName("");
 }
 
 UpdateInterface::~UpdateInterface()
@@ -141,6 +139,76 @@ UpdateInterface::~UpdateInterface()
   delete params;
 }
 
+void UpdateInterface::init(ComponentIdentity id, QString name, QString repo, QString nightly, int resultsPerPage)
+{
+  setId(id);
+  setName(name);
+
+  initAppSettings();
+
+  releases->init(repo, nightly, resultsPerPage, id);
+  assets->init(repo, resultsPerPage);
+
+  currentRelease();
+}
+
+void UpdateInterface::initAppSettings()
+{
+  if (!isValidSettingsIndex()) {
+    reportProgress(tr("Component id: %1 exceeds maximum application settings components: %2!").arg(m_id).arg(MAX_COMPONENTS), QtCriticalMsg);
+    return;
+  }
+
+  if (!g.component[m_id].existsOnDisk()) {
+    g.component[m_id].init();
+  }
+
+  if (!g.component[m_id].asset[0].existsOnDisk())
+    initAssetSettings();
+}
+
+void UpdateInterface::loadAssetSettings()
+{
+  if (!isValidSettingsIndex())
+    return;
+
+  params->assets.clear();
+
+  for (int i = 0; i < MAX_COMPONENT_ASSETS && g.component[m_id].asset[i].existsOnDisk(); i++) {
+    UpdateParameters::AssetParams &ap = params->addAsset();
+    ComponentAssetData &cad = g.component[m_id].asset[i];
+
+    ap.processes = cad.processes();
+    ap.flags = cad.flags();
+    ap.filterType = (UpdateParameters::UpdateFilterType)cad.filterType();
+    ap.filter = cad.filter();
+    ap.maxExpected = cad.maxExpected();
+    ap.destSubDir = cad.destSubDir();
+    ap.copyFilterType = (UpdateParameters::UpdateFilterType)cad.copyFilterType();
+    ap.copyFilter = cad.copyFilter();
+  }
+}
+
+void UpdateInterface::saveAssetSettings()
+{
+  if (!isValidSettingsIndex())
+    return;
+
+  for (int i = 0; i < MAX_COMPONENT_ASSETS && g.component[m_id].asset[i].existsOnDisk(); i++) {
+    const UpdateParameters::AssetParams &ap = params->assets.at(i);
+    ComponentAssetData &cad = g.component[m_id].asset[i];
+
+    //  DO NOT overwrite cad.processes
+    cad.flags(ap.flags);
+    cad.filterType(ap.filterType);
+    cad.filter(ap.filter);
+    cad.maxExpected(ap.maxExpected);
+    cad.destSubDir(ap.destSubDir);
+    cad.copyFilterType(ap.copyFilterType);
+    cad.copyFilter(ap.copyFilter);
+  }
+}
+
 bool UpdateInterface::update(ProgressWidget * progress)
 {
   if (!(params->flags & UPDFLG_Update))
@@ -149,30 +217,30 @@ bool UpdateInterface::update(ProgressWidget * progress)
   this->progress = progress;
 
   if (progress) {
-    progress->setInfo(tr("Processing updates for: %1").arg(name));
+    progress->setInfo(tr("Processing updates for: %1").arg(m_name));
     progress->setValue(0);
     progress->setMaximum(100);
   }
 
-  reportProgress(tr("Processing updates for: %1").arg(name), QtInfoMsg);
+  reportProgress(tr("Processing updates for: %1").arg(m_name), QtInfoMsg);
 
   if (!preparation()) {
-    reportProgress(tr("%1 preparation failed").arg(name), QtCriticalMsg);
+    reportProgress(tr("%1 preparation failed").arg(m_name), QtCriticalMsg);
     return false;
   }
 
   if (!download()) {
-    reportProgress(tr("%1 download failed").arg(name), QtCriticalMsg);
+    reportProgress(tr("%1 download failed").arg(m_name), QtCriticalMsg);
     return false;
   }
 
   if (!decompress()) {
-    reportProgress(tr("%1 decompress failed").arg(name), QtCriticalMsg);
+    reportProgress(tr("%1 decompress failed").arg(m_name), QtCriticalMsg);
     return false;
   }
 
   if (!copyToDestination()) {
-    reportProgress(tr("%1 copy to destination failed").arg(name), QtCriticalMsg);
+    reportProgress(tr("%1 copy to destination failed").arg(m_name), QtCriticalMsg);
     return false;
   }
 
@@ -183,19 +251,19 @@ bool UpdateInterface::update(ProgressWidget * progress)
   }
 
   if (!asyncInstall()) {
-    reportProgress(tr("%1 start async failed").arg(name), QtCriticalMsg);
+    reportProgress(tr("%1 start async failed").arg(m_name), QtCriticalMsg);
     return false;
   }
 
   if (!housekeeping()) {
-    reportProgress(tr("%1 housekeeping failed").arg(name), QtCriticalMsg);
+    reportProgress(tr("%1 housekeeping failed").arg(m_name), QtCriticalMsg);
     return false;
   }
 
-  reportProgress(tr("%1 update successful").arg(name), QtInfoMsg);
+  reportProgress(tr("%1 update successful").arg(m_name), QtInfoMsg);
 
   if (!progress)
-    QMessageBox::information(progress, CPN_STR_APP_NAME, tr("%1 update successful").arg(name));
+    QMessageBox::information(progress, CPN_STR_APP_NAME, tr("%1 update successful").arg(m_name));
 
   return true;
 }
@@ -288,87 +356,9 @@ void UpdateInterface::criticalMsg(const QString & msg)
   QMessageBox::critical(progress, tr("Update Interface"), msg);
 }
 
-void UpdateInterface::setName(QString name)
-{
-  this->name = name;
-  setSettingsIndex();
-  currentRelease();
-}
-
-void UpdateInterface::setRepo(QString repo)
-{
-  releases->setRepo(repo);
-  assets->setRepo(repo);
-}
-
-void UpdateInterface::setSettingsIndex()
-{
-  int i = g.getComponentIndex(name);
-
-  if (i < 0) {
-    for (i = 0; i < MAX_COMPONENTS && g.component[i].existsOnDisk(); i++)
-      ;
-    if (i >= MAX_COMPONENTS) {
-      reportProgress(tr("No free slot to save interface settings!"), QtCriticalMsg);
-      i = -1;
-    }
-    else {
-      g.component[i].init();
-      g.component[i].name(name);
-    }
-  }
-
-  m_settingsIdx = i;
-  releases->setSettingsIndex(m_settingsIdx);
-  if (isValidSettingsIndex() && !g.component[m_settingsIdx].asset[0].existsOnDisk())
-    initAssetSettings();
-}
-
-void UpdateInterface::loadAssetSettings()
-{
-  if (!isValidSettingsIndex())
-    return;
-
-  params->assets.clear();
-
-  for (int i = 0; i < MAX_COMPONENT_ASSETS && g.component[m_settingsIdx].asset[i].existsOnDisk(); i++) {
-    UpdateParameters::AssetParams &ap = params->addAsset();
-    ComponentAssetData &cad = g.component[m_settingsIdx].asset[i];
-
-    ap.processes = cad.processes();
-    ap.flags = cad.flags();
-    ap.filterType = (UpdateParameters::UpdateFilterType)cad.filterType();
-    ap.filter = cad.filter();
-    ap.maxExpected = cad.maxExpected();
-    ap.destSubDir = cad.destSubDir();
-    ap.copyFilterType = (UpdateParameters::UpdateFilterType)cad.copyFilterType();
-    ap.copyFilter = cad.copyFilter();
-  }
-}
-
-void UpdateInterface::saveAssetSettings()
-{
-  if (!isValidSettingsIndex())
-    return;
-
-  for (int i = 0; i < MAX_COMPONENT_ASSETS && g.component[m_settingsIdx].asset[i].existsOnDisk(); i++) {
-    const UpdateParameters::AssetParams &ap = params->assets.at(i);
-    ComponentAssetData &cad = g.component[m_settingsIdx].asset[i];
-
-    //  ap.processes do not overwrite as read only
-    cad.flags(ap.flags);
-    cad.filterType(ap.filterType);
-    cad.filter(ap.filter);
-    cad.maxExpected(ap.maxExpected);
-    cad.destSubDir(ap.destSubDir);
-    cad.copyFilterType(ap.copyFilterType);
-    cad.copyFilter(ap.copyFilter);
-  }
-}
-
 bool UpdateInterface::isUpdateable()
 {
-  return g.component[m_settingsIdx].checkForUpdate();
+  return g.component[m_id].checkForUpdate();
 }
 
 void UpdateInterface::resetEnvironment()
@@ -378,7 +368,7 @@ void UpdateInterface::resetEnvironment()
   progress = nullptr;
 
   params->logLevel = g.updLogLevel();
-  setReleaseChannel(g.component[m_settingsIdx].releaseChannel());
+  setReleaseChannel(g.component[m_id].releaseChannel());
   params->updateRelease = "";
   setFlavourLanguage();
   loadAssetSettings();
@@ -398,7 +388,13 @@ void UpdateInterface::resetEnvironment()
 void UpdateInterface::setReleaseChannel(int channel)
 {
   params->releaseChannel = channel;
+  //repoReleasesMetaData();
   releases->setReleaseChannel(channel);
+}
+
+void UpdateInterface::setReleaseId(QString val)
+{
+  releases->getSetId(val);
 }
 
 void UpdateInterface::setFlavourLanguage()
@@ -460,19 +456,21 @@ void UpdateInterface::setParamFolders()
 
 void UpdateInterface::clearRelease()
 {
-  g.component[m_settingsIdx].clearRelease();
+  g.component[m_id].clearRelease();
   currentRelease();
 }
 
 const QString UpdateInterface::currentRelease()
 {
-  params->currentRelease = g.component[m_settingsIdx].release();
+  params->currentRelease = g.component[m_id].release();
   return params->currentRelease;
 }
 
 QString UpdateInterface::latestRelease()
 {
-  repoReleasesMetaData();
+  if (!repoReleasesMetaData())
+    return tr("unknown");
+
   return releases->name();
 }
 
@@ -486,7 +484,7 @@ const QString UpdateInterface::updateRelease()
 
 const bool UpdateInterface::isUpdateAvailable()
 {
-  if (g.component[m_settingsIdx].checkForUpdate())
+  if (g.component[m_id].checkForUpdate())
     return !isLatestRelease();
   else {
     return false;
@@ -510,11 +508,13 @@ const bool UpdateInterface::isLatestVersion(const QString & installed, const QSt
 
 const bool UpdateInterface::isLatestRelease()
 {
-  repoReleasesMetaData();
+  if (!repoReleasesMetaData())
+    return false;
+
   QString currentVer = currentVersion();
   QString latestVer = releases->version();
   // nightlies often have the same version so also check id
-  if (isLatestVersion(currentVer, latestVer) && g.component[m_settingsIdx].id() == releases->id()) {
+  if (isLatestVersion(currentVer, latestVer) && g.component[m_id].releaseId() == releases->id()) {
     return true;
   }
   else {
@@ -524,12 +524,14 @@ const bool UpdateInterface::isLatestRelease()
 
 const QString UpdateInterface::currentVersion()
 {
-  return g.component[m_settingsIdx].version();
+  return g.component[m_id].version();
 }
 
 const QStringList UpdateInterface::getReleases()
 {
-  repoReleasesMetaData();
+  if (!repoReleasesMetaData())
+    return QStringList();
+
   return releases->list();
 }
 
@@ -541,17 +543,20 @@ bool UpdateInterface::repoReleasesMetaData()
       releases->setId(0);
       return false;
     }
-  }
 
-  releases->getSetId();
+    releases->getSetId();
+  }
 
   return true;
 }
 
 bool UpdateInterface::repoReleaseAssetsMetaData()
 {
+  if (!repoReleasesMetaData())
+    return false;
+
   if (!downloadReleaseAssetsMetaData(releases->id())) {
-    reportProgress(tr("Unable to download release channel assets information"), QtDebugMsg);
+    reportProgress(tr("Unable to download release assets information"), QtDebugMsg);
     return false;
   }
 
@@ -584,14 +589,14 @@ bool UpdateInterface::setRunFolders()
     }
   }
 
-  downloadDir = QString("%1/%2/%3").arg(params->downloadDir).arg(name).arg(fldr);
+  downloadDir = QString("%1/%2/%3").arg(params->downloadDir).arg(m_name).arg(fldr);
 
   if (!checkCreateDirectory(downloadDir, UPDFLG_Download))
     return false;
 
   //reportProgress(tr("Download directory: %1").arg(downloadDir), QtDebugMsg);
 
-  decompressDir = QString("%1/%2/%3").arg(params->decompressDir).arg(name).arg(fldr);
+  decompressDir = QString("%1/%2/%3").arg(params->decompressDir).arg(m_name).arg(fldr);
 
   if (!checkCreateDirectory(decompressDir, UPDFLG_Decompress))
     return false;
@@ -624,6 +629,38 @@ bool UpdateInterface::checkCreateDirectory(const QString & dir, const UpdateFlag
   return true;
 }
 
+ bool UpdateInterface::getReleaseJsonAsset(const QString assetName, QJsonDocument * json)
+{
+  if (!repoReleaseAssetsMetaData())
+    return false;
+
+  if (!assets->getSetId(assetName))
+    return false;
+
+  if (!downloadAssetToBuffer(assets->id())) {
+    return false;
+  }
+
+  if (!convertDownloadToJson(json)) {
+    return false;
+  }
+
+  return true;
+}
+
+ bool UpdateInterface::getRepoJsonFile(const QString filename, QJsonDocument * json)
+{
+  if (!downloadTextFileToBuffer(filename)) {
+    return false;
+  }
+
+  if (!convertDownloadToJson(json)) {
+    return false;
+  }
+
+  return true;
+}
+
 bool UpdateInterface::downloadReleasesMetaData()
 {
   //progressMessage(tr("Download releases metadata"));
@@ -649,7 +686,7 @@ bool UpdateInterface::downloadReleaseMetaData(const int releaseId)
 bool UpdateInterface::downloadReleaseAssetsMetaData(const int releaseId)
 {
   //progressMessage(tr("Download release %1 assets metadata").arg(releaseId));
-  downloadMetaData(MDT_ReleaseAssets, assets->urlReleaseAssets(releaseId, resultsPerPage));
+  downloadMetaData(MDT_ReleaseAssets, assets->urlReleaseAssets(releaseId));
   return downloadSuccess;
 }
 
@@ -1380,10 +1417,10 @@ bool UpdateInterface::asyncInstall()
 bool UpdateInterface::saveReleaseSettings()
 {
   reportProgress(tr("Save release settings"), QtDebugMsg);
-  g.component[m_settingsIdx].release(releases->name());
-  g.component[m_settingsIdx].version(releases->version());
-  g.component[m_settingsIdx].id(releases->id());
-  g.component[m_settingsIdx].date(releases->date());
+  g.component[m_id].release(releases->name());
+  g.component[m_id].version(releases->version());
+  g.component[m_id].releaseId(releases->id());
+  g.component[m_id].date(releases->date());
 
   return true;
 }
@@ -1405,6 +1442,12 @@ UpdateFactories::~UpdateFactories()
 
 void UpdateFactories::registerUpdateFactory(UpdateFactoryInterface * factory)
 {
+  foreach (UpdateFactoryInterface * registeredFactory, registeredUpdateFactories) {
+    if (registeredFactory->id() == factory->id()) {
+      qDebug() << "Duplicate factory - id:" << factory->id() << "name:" << factory->name();
+      return;
+    }
+  }
   registeredUpdateFactories.append(factory);
   qDebug() << "Registered update factory:" << factory->name();
 }
@@ -1429,63 +1472,60 @@ void UpdateFactories::unregisterUpdateFactories()
     delete factory;
 }
 
-void UpdateFactories::initAssetSettings(const QString & name)
+UpdateInterface * UpdateFactories::interface(const int id)
 {
   foreach (UpdateFactoryInterface * factory, registeredUpdateFactories) {
-    if (name == factory->name()) {
-      factory->instance()->initAssetSettings();
-      break;
-    }
+    if (id == factory->id())
+      return factory->instance();
   }
+  qDebug() << "Critical error - Interface not found for id:" << id;
+  return nullptr;
 }
 
-void UpdateFactories::saveAssetSettings(const QString & name)
+const QString UpdateFactories::name(const int id)
 {
-  foreach (UpdateFactoryInterface * factory, registeredUpdateFactories) {
-    if (name == factory->name()) {
-      factory->instance()->saveAssetSettings();
-      break;
-    }
-  }
+  UpdateInterface * iface = interface(id);
+  if (iface)
+    return iface->name();
+
+  return "";
 }
 
-UpdateParameters * const UpdateFactories::getParams(const QString & name)
+void UpdateFactories::saveAssetSettings(const int id)
 {
-  foreach (UpdateFactoryInterface * factory, registeredUpdateFactories) {
-    if (name == factory->name()) {
-      return factory->instance()->getParams();
-      break;
-    }
-  }
+  UpdateInterface * iface = interface(id);
+  if (iface)
+    iface->saveAssetSettings();
+}
+
+UpdateParameters * const UpdateFactories::getParams(const int id)
+{
+  UpdateInterface * iface = interface(id);
+  if (iface)
+    return iface->getParams();
 
   return nullptr;
 }
 
-void UpdateFactories::resetEnvironment(const QString & name)
+void UpdateFactories::resetEnvironment(const int id)
 {
-  foreach (UpdateFactoryInterface * factory, registeredUpdateFactories) {
-    if (name == factory->name()) {
-      factory->instance()->resetEnvironment();
-      break;
-    }
-  }
+  UpdateInterface * iface = interface(id);
+  if (iface)
+    iface->resetEnvironment();
 }
 
 void UpdateFactories::resetAllEnvironments()
 {
   foreach (UpdateFactoryInterface * factory, registeredUpdateFactories) {
-    resetEnvironment(factory->name());
+    resetEnvironment(factory->id());
   }
 }
 
-void UpdateFactories::setRunUpdate(const QString & name)
+void UpdateFactories::setRunUpdate(const int id)
 {
-  foreach (UpdateFactoryInterface * factory, registeredUpdateFactories) {
-    if (name == factory->name()) {
-      factory->instance()->setRunUpdate();
-      break;
-    }
-  }
+  UpdateInterface * iface = interface(id);
+  if (iface)
+    iface->setRunUpdate();
 }
 
 const QMap<QString, int> UpdateFactories::sortedComponentsList(bool updateableOnly)
@@ -1495,114 +1535,85 @@ const QMap<QString, int> UpdateFactories::sortedComponentsList(bool updateableOn
   foreach (UpdateFactoryInterface * factory, registeredUpdateFactories) {
     if (updateableOnly && !factory->instance()->isUpdateable())
       continue;
-    map.insert(factory->name(), factory->instance()->settingsIndex());
+    map.insert(factory->name(), factory->id());
   }
 
   return map;
 }
 
-void UpdateFactories::clearRelease(const QString & name)
+void UpdateFactories::clearRelease(const int id)
 {
-  foreach (UpdateFactoryInterface * factory, registeredUpdateFactories) {
-    if (name == factory->name()) {
-      factory->instance()->clearRelease();
-      break;
-    }
-  }
+  UpdateInterface * iface = interface(id);
+  if (iface)
+    iface->clearRelease();
 }
 
-void UpdateFactories::setReleaseChannel(const QString & name, int channel)
+void UpdateFactories::setReleaseChannel(const int id, int channel)
 {
-  foreach (UpdateFactoryInterface * factory, registeredUpdateFactories) {
-    if (name == factory->name()) {
-      factory->instance()->setReleaseChannel(channel);
-      break;
-    }
-  }
+  UpdateInterface * iface = interface(id);
+  if (iface)
+    iface->setReleaseChannel(channel);
 }
 
-const QString UpdateFactories::currentRelease(const QString & name)
+void UpdateFactories::setReleaseId(const int id, QString val)
 {
-  QString ret;
-
-  foreach (UpdateFactoryInterface * factory, registeredUpdateFactories) {
-    if (name == factory->name()) {
-      ret = factory->instance()->currentRelease();
-      break;
-    }
-  }
-
-  return ret;
+  UpdateInterface * iface = interface(id);
+  if (iface)
+    iface->setReleaseId(val);
 }
 
-const QString UpdateFactories::updateRelease(const QString & name)
+const QString UpdateFactories::currentRelease(const int id)
 {
-  QString ret;
+  UpdateInterface * iface = interface(id);
+  if (iface)
+    return iface->currentRelease();
 
-  foreach (UpdateFactoryInterface * factory, registeredUpdateFactories) {
-    if (name == factory->name()) {
-      ret = factory->instance()->updateRelease();
-      break;
-    }
-  }
-
-  return ret;
+  return "";
 }
 
-const bool UpdateFactories::isLatestRelease(const QString & name)
+const QString UpdateFactories::updateRelease(const int id)
 {
-  bool ret = true;
+  UpdateInterface * iface = interface(id);
+  if (iface)
+    return iface->updateRelease();
 
-  foreach (UpdateFactoryInterface * factory, registeredUpdateFactories) {
-    if (name == factory->name()) {
-      ret = factory->instance()->isLatestRelease();
-      break;
-    }
-  }
-
-  return ret;
+  return "";
 }
 
-const QString UpdateFactories::latestRelease(const QString & name)
+const bool UpdateFactories::isLatestRelease(const int id)
 {
-  QString ret;
+  UpdateInterface * iface = interface(id);
+  if (iface)
+    return iface->isLatestRelease();
 
-  foreach (UpdateFactoryInterface * factory, registeredUpdateFactories) {
-    if (name == factory->name()) {
-      ret = factory->instance()->latestRelease();
-      break;
-    }
-  }
-
-  return ret;
+  return true;
 }
 
-const QStringList UpdateFactories::releases(const QString & name)
+const QString UpdateFactories::latestRelease(const int id)
 {
-  QStringList ret;
+  UpdateInterface * iface = interface(id);
+  if (iface)
+    return iface->latestRelease();
 
-  foreach (UpdateFactoryInterface * factory, registeredUpdateFactories) {
-    if (name == factory->name()) {
-      ret = factory->instance()->getReleases();
-      break;
-    }
-  }
-
-  return ret;
+  return "";
 }
 
-bool UpdateFactories::update(const QString & name, ProgressWidget * progress)
+const QStringList UpdateFactories::releases(const int id)
 {
-  bool ret = false;
+  UpdateInterface * iface = interface(id);
+  if (iface)
+    return iface->getReleases();
 
-  foreach (UpdateFactoryInterface * factory, registeredUpdateFactories) {
-    if (name == factory->name()) {
-      ret = factory->instance()->update(progress);
-      break;
-    }
-  }
+  return QStringList();
+}
 
-  return ret;
+bool UpdateFactories::update(const int id, ProgressWidget * progress)
+{
+  UpdateInterface * iface = interface(id);
+  if (iface)
+    return iface->update(progress);
+
+  return false;
 }
 
 bool UpdateFactories::updateAll(ProgressWidget * progress)
@@ -1610,7 +1621,7 @@ bool UpdateFactories::updateAll(ProgressWidget * progress)
   bool ret = false;
 
   foreach (UpdateFactoryInterface * factory, registeredUpdateFactories) {
-    ret = update(factory->name(), progress);
+    ret = factory->instance()->update(progress);
     if (!ret)
       break;
   }
@@ -1618,17 +1629,36 @@ bool UpdateFactories::updateAll(ProgressWidget * progress)
   return ret;
 }
 
-const bool UpdateFactories::isUpdateAvailable(QStringList & names)
+const bool UpdateFactories::isUpdateAvailable(QMap<QString, int> & list)
 {
   bool ret = false;
-  names.clear();
+
+  list.clear();
 
   foreach (UpdateFactoryInterface * factory, registeredUpdateFactories) {
     if (factory->instance()->isUpdateable() && factory->instance()->isUpdateAvailable()) {
-      names.append(factory->name());
+      list.insert(factory->name(), factory->id());
       ret = true;
     }
   }
 
   return ret;
+}
+
+bool UpdateFactories::getReleaseJsonAsset(const int id, const QString assetName, QJsonDocument * json)
+{
+  UpdateInterface * iface = interface(id);
+  if (iface)
+    return iface->getReleaseJsonAsset(assetName, json);
+
+  return false;
+}
+
+bool UpdateFactories::getRepoJsonFile(const int id, const QString filename, QJsonDocument * json)
+{
+  UpdateInterface * iface = interface(id);
+  if (iface)
+    return iface->getRepoJsonFile(filename, json);
+
+  return false;
 }

--- a/companion/src/updates/updateinterface.h
+++ b/companion/src/updates/updateinterface.h
@@ -114,10 +114,25 @@ class UpdateInterface : public QWidget
     };
     Q_ENUM(UpdateFlags)
 
+    //  The CID is used as a key to the application settings therefore
+    //  ids must be explicit so no renumbering if components removed
+    //  new components must be added to the end of the enum
+    enum ComponentIdentity {
+      CID_Unknown         = -1,
+      CID_SDCard          = 0,
+      CID_Firmware        = 1,
+      CID_Sounds          = 2,
+      CID_Themes          = 3,
+      CID_MultiProtocol   = 4,
+      CID_Companion       = 5,
+    };
+    Q_ENUM(ComponentIdentity)
+
     explicit UpdateInterface(QWidget * parent);
     virtual ~UpdateInterface();
 
-    const QString getName() const { return name; }
+    const int id() const { return (int)m_id; }
+    const QString name() const { return m_name; }
 
   protected:
     friend class UpdateFactories;
@@ -127,8 +142,6 @@ class UpdateInterface : public QWidget
     UpdateParameters *params;
     ProgressWidget *progress;
 
-    QString name;
-    int resultsPerPage;
     QString downloadDir;
     QString decompressDir;
     QString updateDir;
@@ -155,14 +168,17 @@ class UpdateInterface : public QWidget
     virtual const bool isLatestRelease();
     virtual const bool isLatestVersion(const QString & current, const QString & latest);
     virtual QString latestRelease();
+
     void clearRelease();
     const QStringList getReleases();
 
-    void setName(QString name);
-    void setRepo(QString repo);
-    void setResultsPerPage(int cnt) { resultsPerPage = cnt; }
-    void setReleasesNightlyName(QString name) { releases->setNightlyName(name); }
+    void init(ComponentIdentity id, QString name, QString repo, QString nightly = "", int resultsPerPage = -1);
+
+    void setId(ComponentIdentity id) { m_id = id; }
+    void setName(QString name) { m_name = name; }
+
     void setReleaseChannel(int channel);
+    void setReleaseId(QString val);
 
     void setParamFolders();
     UpdateParameters * getParams() { return params; }
@@ -177,6 +193,7 @@ class UpdateInterface : public QWidget
     bool downloadReleaseLatestMetaData();
     bool downloadReleaseMetaData(const int releaseId);
 
+    bool getReleaseJsonAsset(const QString assetName, QJsonDocument * json);
     bool downloadReleaseAssetsMetaData(const int releaseId);
     bool downloadAssetMetaData(const int assetId);
     bool getSetAssets(const UpdateParameters::AssetParams & ap);
@@ -187,6 +204,7 @@ class UpdateInterface : public QWidget
     bool copyFlaggedAssets();
     bool copyStructure();
     bool copyFiles();
+
     bool saveReleaseSettings();
 
     bool downloadAssetToBuffer(const int assetId);
@@ -196,14 +214,15 @@ class UpdateInterface : public QWidget
     bool decompressArchive(const QString & archivePath, const QString & destPath);
     QByteArray * getDownloadBuffer() { return buffer; }
 
+    bool getRepoJsonFile(const QString filename, QJsonDocument * json);
+
     void reportProgress(const QString & text, const int type = QtInfoMsg);
     void progressMessage(const QString & text);
     void criticalMsg(const QString & msg);
     static QString downloadDataTypeToString(DownloadDataType val);
     static QString updateFlagsToString(UpdateFlags val);
     void setFlavourLanguage();
-    int settingsIndex() { return m_settingsIdx; }
-    bool isValidSettingsIndex() { return m_settingsIdx > -1 && m_settingsIdx < MAX_COMPONENTS; }
+    bool isValidSettingsIndex() { return m_id > -1 && m_id < MAX_COMPONENTS; }
 
   private slots:
     void onDownloadFinished(QNetworkReply * reply, DownloadDataType ddt, int subtype);
@@ -215,13 +234,14 @@ class UpdateInterface : public QWidget
     QByteArray *buffer;
     QFile *file;
     QUrl url;
+    int m_id;
+    QString m_name;
 
     bool downloadSuccess;
-    int m_settingsIdx;
 
     static QString semanticVersion(QString version);
 
-    void setSettingsIndex();
+    void initAppSettings();
     bool setRunFolders();
     bool checkCreateDirectory(const QString & dirSetting, const UpdateFlags flag);
 
@@ -238,7 +258,8 @@ class UpdateFactoryInterface
     explicit UpdateFactoryInterface() {}
     virtual ~UpdateFactoryInterface() {}
     virtual UpdateInterface * instance() = 0;
-    virtual QString name() = 0;
+    virtual const QString name() = 0;
+    virtual const int id() = 0;
 };
 
 template <class T>
@@ -252,7 +273,8 @@ class UpdateFactory : public UpdateFactoryInterface
     virtual ~UpdateFactory() {}
 
     virtual UpdateInterface * instance() { return m_instance; }
-    virtual QString name() { return m_instance->getName(); }
+    virtual const QString name() { return m_instance->name(); }
+    virtual const int id() { return m_instance->id(); }
 
   private:
     UpdateInterface *m_instance;
@@ -266,31 +288,38 @@ class UpdateFactories : public QWidget
     explicit UpdateFactories(QWidget * parent = nullptr);
     virtual ~UpdateFactories();
 
+    const QString name(const int id);
+
     void registerUpdateFactory(UpdateFactoryInterface * factory);
     void registerUpdateFactories();
     void unregisterUpdateFactories();
 
-    void initAssetSettings(const QString & name);
-    void saveAssetSettings(const QString & name);
+    void saveAssetSettings(const int id);
 
-    UpdateParameters * const getParams(const QString & name);
-    void resetEnvironment(const QString & name);
+    UpdateParameters * const getParams(const int id);
+    void resetEnvironment(const int id);
     void resetAllEnvironments();
-    void setRunUpdate(const QString & name);
+    void setRunUpdate(const int id);
     const QMap<QString, int> sortedComponentsList(bool updateableOnly = false);
 
-    void clearRelease(const QString & name);
-    void setReleaseChannel(const QString & name, int channel);
-    const QString currentRelease(const QString & name);
-    const QString updateRelease(const QString & name);
-    const bool isLatestRelease(const QString & name);
-    const QString latestRelease(const QString & name);
-    const QStringList releases(const QString & name);
+    void clearRelease(const int id);
+    void setReleaseChannel(const int id, int channel);
+    void setReleaseId(const int id, QString val);
+    const QString currentRelease(const int id);
+    const QString updateRelease(const int id);
+    const bool isLatestRelease(const int id);
+    const QString latestRelease(const int id);
+    const QStringList releases(const int id);
+    bool getReleaseJsonAsset(const int id, const QString assetName, QJsonDocument * json);
 
-    bool update(const QString & name, ProgressWidget * progress = nullptr);
+    bool getRepoJsonFile(const int id, const QString filename, QJsonDocument * json);
+
+    bool update(const int id, ProgressWidget * progress = nullptr);
     bool updateAll(ProgressWidget * progress = nullptr);
-    const bool isUpdateAvailable(QStringList & names);
+    const bool isUpdateAvailable(QMap<QString, int> & names);
 
   private:
     QVector<UpdateFactoryInterface *> registeredUpdateFactories;
+
+    UpdateInterface * interface(const int id);
 };

--- a/companion/src/updates/updatemultiprotocol.cpp
+++ b/companion/src/updates/updatemultiprotocol.cpp
@@ -24,9 +24,8 @@
 UpdateMultiProtocol::UpdateMultiProtocol(QWidget * parent) :
   UpdateInterface(parent)
 {
-  setName(tr("Multiprotocol"));
-  setRepo(QString(GITHUB_API_REPOS).append("/pascallanger/DIY-Multiprotocol-TX-Module"));
-  setResultsPerPage(50);  //  GitHub REST API default 30
+  // GitHub REST API default ResultsPerPage = 30
+  init(CID_MultiProtocol, tr("Multiprotocol"), QString(GITHUB_API_REPOS).append("/pascallanger/DIY-Multiprotocol-TX-Module"), "", 50);
 }
 
 void UpdateMultiProtocol::initAssetSettings()
@@ -34,10 +33,10 @@ void UpdateMultiProtocol::initAssetSettings()
   if (!isValidSettingsIndex())
     return;
 
-  g.component[settingsIndex()].initAllAssets();
+  g.component[id()].initAllAssets();
 
   {
-  ComponentAssetData &cad = g.component[settingsIndex()].asset[0];
+  ComponentAssetData &cad = g.component[id()].asset[0];
   cad.desc("scripts");
   cad.processes(UPDFLG_Common_Asset);
   cad.flags(cad.processes() | UPDFLG_CopyStructure);
@@ -46,7 +45,7 @@ void UpdateMultiProtocol::initAssetSettings()
   cad.maxExpected(1);
   }
   {
-  ComponentAssetData &cad = g.component[settingsIndex()].asset[1];
+  ComponentAssetData &cad = g.component[id()].asset[1];
   cad.desc("binaries");
   cad.processes(UPDFLG_Common_Asset &~ UPDFLG_Decompress);
   cad.flags(cad.processes() | UPDFLG_CopyFiles);

--- a/companion/src/updates/updateoptionsdialog.cpp
+++ b/companion/src/updates/updateoptionsdialog.cpp
@@ -35,24 +35,24 @@ UpdateOptionsDialog::UpdateOptionsDialog(QWidget * parent, UpdateFactories * fac
   ui(new Ui::UpdateOptionsDialog),
   factories(factories),
   idx(idx),
-  name(g.component[idx].name()),
   isRun(isRun)
 {
   ui->setupUi(this);
 
-  if (!isRun) factories->resetEnvironment(name);
+  if (!isRun)
+    factories->resetEnvironment(idx);
 
-  params = factories->getParams(name);
+  params = factories->getParams(idx);
 
-  setWindowTitle(tr("%1 %2").arg(name).arg(tr("Options")));
+  setWindowTitle(tr("%1 %2").arg(factories->name(idx)).arg(tr("Options")));
 
-  ui->txtCurrentRelease->setText(factories->currentRelease(name));
+  ui->txtCurrentRelease->setText(factories->currentRelease(idx));
 
   connect(ui->btnClearRelease, &QPushButton::clicked, [=]() {
     if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Clear current release information. Are you sure?"),
                              QMessageBox::Yes |QMessageBox::No, QMessageBox::No) == QMessageBox::Yes) {
-      factories->clearRelease(name);
-      ui->txtCurrentRelease->setText(factories->currentRelease(name));
+      factories->clearRelease(idx);
+      ui->txtCurrentRelease->setText(factories->currentRelease(idx));
       emit changed(idx);
 
     }

--- a/companion/src/updates/updateoptionsdialog.h
+++ b/companion/src/updates/updateoptionsdialog.h
@@ -55,7 +55,6 @@ class UpdateOptionsDialog : public QDialog
     Ui::UpdateOptionsDialog *ui;
     UpdateFactories *factories;
     const int idx;
-    const QString name;
     const bool isRun;
     UpdateParameters *params;
 

--- a/companion/src/updates/updates.cpp
+++ b/companion/src/updates/updates.cpp
@@ -67,12 +67,21 @@ void Updates::autoUpdates(bool interactive)
 
   factories->resetAllEnvironments();
 
-  QStringList list;
+  QMap<QString, int> components;
 
-  if (!factories->isUpdateAvailable(list)) {
+  if (!factories->isUpdateAvailable(components)) {
     if (interactive)
       QMessageBox::information(parentWidget(), CPN_STR_APP_NAME, tr("No updates available at this time"));
     return;
+  }
+
+  QMapIterator<QString, int> it(components);
+
+  QStringList list;
+
+  while (it.hasNext()) {
+    it.next();
+    list << it.key();
   }
 
   if (QMessageBox::question(parentWidget(), CPN_STR_APP_NAME % ": " % tr("Checking for Updates"),
@@ -81,9 +90,12 @@ void Updates::autoUpdates(bool interactive)
     return;
   }
 
-  for (int i = 0; i < list.count(); i++) {
-    factories->setRunUpdate(list.at(i));
-    factories->updateRelease(list.at(i));
+  it.toFront();
+
+  while (it.hasNext()) {
+    it.next();
+    factories->setRunUpdate(it.value());
+    factories->updateRelease(it.value());
   }
 
   runUpdate();

--- a/companion/src/updates/updatesdcard.cpp
+++ b/companion/src/updates/updatesdcard.cpp
@@ -26,8 +26,7 @@
 UpdateSDCard::UpdateSDCard(QWidget * parent) :
   UpdateInterface(parent)
 {
-  setName(tr("SD Card"));
-  setRepo(QString(GH_REPOS_EDGETX).append("/edgetx-sdcard"));
+  init(CID_SDCard, tr("SD Card"), QString(GH_REPOS_EDGETX).append("/edgetx-sdcard"));
 }
 
 void UpdateSDCard::initAssetSettings()
@@ -35,9 +34,9 @@ void UpdateSDCard::initAssetSettings()
   if (!isValidSettingsIndex())
     return;
 
-  g.component[settingsIndex()].initAllAssets();
+  g.component[id()].initAllAssets();
 
-  ComponentAssetData &cad = g.component[settingsIndex()].asset[0];
+  ComponentAssetData &cad = g.component[id()].asset[0];
   cad.desc("files");
   cad.processes(UPDFLG_Common_Asset);
   cad.flags(cad.processes() | UPDFLG_Locked | UPDFLG_CopyStructure);
@@ -54,8 +53,8 @@ bool UpdateSDCard::flagAssets()
   /*
   {
     "targets": [
-      ["Flysky NV14", "nv14-", "nv14"],
-      ["FrSky Horus X10", "x10-", "horus"],
+      ["Flysky NV14", "nv14-", "c320x480"],
+      ["FrSky Horus X10", "x10-", "c480x272"],
   */
 
   const QString mappingfile = "sdcard.json";

--- a/companion/src/updates/updatesdialog.cpp
+++ b/companion/src/updates/updatesdialog.cpp
@@ -163,8 +163,7 @@ UpdatesDialog::UpdatesDialog(QWidget * parent, UpdateFactories * factories) :
 
   while (it.hasNext()) {
     it.next();
-    int i = it.value();
-
+    const int i = it.value();
     const QString name = it.key();
 
     row++;
@@ -173,7 +172,7 @@ UpdatesDialog::UpdatesDialog(QWidget * parent, UpdateFactories * factories) :
     msg->setText(tr("Retrieving latest release information for %1").arg(name));
     chkUpdate[i] = new QCheckBox();
     chkUpdate[i]->setProperty("index", i);
-    chkUpdate[i]->setChecked(!factories->isLatestRelease(name));
+    chkUpdate[i]->setChecked(!factories->isLatestRelease(i));
     grid->addWidget(chkUpdate[i], row, col++);
     grid->setAlignment(chkUpdate[i], Qt::AlignHCenter);
 
@@ -185,27 +184,26 @@ UpdatesDialog::UpdatesDialog(QWidget * parent, UpdateFactories * factories) :
     cboRelChannel[i]->setCurrentIndex(g.component[i].releaseChannel());
     grid->addWidget(cboRelChannel[i], row, col++);
 
-    lblCurrentRel[i] = new QLabel(factories->currentRelease(name));
+    lblCurrentRel[i] = new QLabel(factories->currentRelease(i));
     grid->addWidget(lblCurrentRel[i], row, col++);
 
     cboUpdateRel[i] = new QComboBox();
-    cboUpdateRel[i]->addItems(factories->releases(name));
+    cboUpdateRel[i]->addItems(factories->releases(i));
     grid->addWidget(cboUpdateRel[i], row, col++);
 
     connect(cboRelChannel[i], QOverload<int>::of(&QComboBox::currentIndexChanged), [=] (const int index) {
-      factories->setReleaseChannel(name, index);
+      factories->setReleaseChannel(i, index);
       cboUpdateRel[i]->clear();
-      cboUpdateRel[i]->addItems(factories->releases(name));
+      cboUpdateRel[i]->addItems(factories->releases(i));
     });
 
     btnOptions[i] = new QPushButton(tr("Options"));
     connect(btnOptions[i], &QPushButton::clicked, [=]() {
       UpdateOptionsDialog *dlg = new UpdateOptionsDialog(this, factories, i, true);
       connect(dlg, &UpdateOptionsDialog::changed, [=](const int i) {
-        QString name = g.component[i].name();
-        chkUpdate[i]->setChecked(!factories->isLatestRelease(name));
-        lblCurrentRel[i]->setText(factories->currentRelease(name));
-        cboUpdateRel[i]->setCurrentText(factories->updateRelease(name));
+        chkUpdate[i]->setChecked(!factories->isLatestRelease(i));
+        lblCurrentRel[i]->setText(factories->currentRelease(i));
+        cboUpdateRel[i]->setCurrentText(factories->updateRelease(i));
       });
       dlg->exec();
       dlg->deleteLater();
@@ -270,12 +268,11 @@ void UpdatesDialog::accept()
 
   while (it.hasNext()) {
     it.next();
-    int i = it.value();
+    const int i = it.value();
 
     if (chkUpdate[i]->isChecked()) {
       cnt++;
-      const QString name = it.key();
-      UpdateParameters *params = factories->getParams(name);
+      UpdateParameters *params = factories->getParams(i);
       params->updateRelease = cboUpdateRel[i]->currentText();
       params->flags |= UpdateInterface::UPDFLG_Update;
       params->downloadDir = ui->leDownloadDir->text();
@@ -316,8 +313,8 @@ void UpdatesDialog::saveAsDefaults()
 
   while (it.hasNext()) {
     it.next();
-    int i = it.value();
+    const int i = it.value();
     g.component[i].releaseChannel((ComponentData::ReleaseChannel)cboRelChannel[i]->currentIndex());
-    factories->saveAssetSettings(it.key());
+    factories->saveAssetSettings(i);
   }
 }

--- a/companion/src/updates/updatesounds.cpp
+++ b/companion/src/updates/updatesounds.cpp
@@ -27,11 +27,10 @@
 #include <QItemSelectionModel>
 
 UpdateSounds::UpdateSounds(QWidget * parent) :
-  UpdateInterface(parent),
-  langPacks(new QStandardItemModel())
+  UpdateInterface(parent)
 {
-  setName(tr("Sounds"));
-  setRepo(QString(GH_REPOS_EDGETX).append("/edgetx-sdcard-sounds"));
+  init(CID_Sounds, tr("Sounds"), QString(GH_REPOS_EDGETX).append("/edgetx-sdcard-sounds"));
+  langPacks = new QStandardItemModel();
 }
 
 UpdateSounds::~UpdateSounds()
@@ -44,9 +43,9 @@ void UpdateSounds::initAssetSettings()
   if (!isValidSettingsIndex())
     return;
 
-  g.component[settingsIndex()].initAllAssets();
+  g.component[id()].initAllAssets();
 
-  ComponentAssetData &cad = g.component[settingsIndex()].asset[0];
+  ComponentAssetData &cad = g.component[id()].asset[0];
   cad.desc("sounds");
   cad.processes(UPDFLG_Common_Asset);
   cad.flags(cad.processes() | UPDFLG_CopyStructure);

--- a/companion/src/updates/updatethemes.cpp
+++ b/companion/src/updates/updatethemes.cpp
@@ -24,8 +24,7 @@
 UpdateThemes::UpdateThemes(QWidget * parent) :
   UpdateInterface(parent)
 {
-  setName(tr("Themes"));
-  setRepo(QString(GH_REPOS_EDGETX).append("/themes"));
+  init(CID_Themes, tr("Themes"), QString(GH_REPOS_EDGETX).append("/themes"));
 }
 
 void UpdateThemes::initAssetSettings()
@@ -33,9 +32,9 @@ void UpdateThemes::initAssetSettings()
   if (!isValidSettingsIndex())
     return;
 
-  g.component[settingsIndex()].initAllAssets();
+  g.component[id()].initAllAssets();
 
-  ComponentAssetData &cad = g.component[settingsIndex()].asset[0];
+  ComponentAssetData &cad = g.component[id()].asset[0];
   cad.desc("files");
   cad.processes(UPDFLG_Common_Asset);
   cad.flags(cad.processes() | UPDFLG_CopyStructure);


### PR DESCRIPTION
Updateable component names are translated and as such there is a possibility that the translated name is invalid in some use cases. This issue was detected in PR #2594.
