### PR TITLE
Fix ghost module remote menu for 2.8

### DIFF
--- a/radio/src/gui/colorlcd/radio_ghost_module_config.h
+++ b/radio/src/gui/colorlcd/radio_ghost_module_config.h
@@ -31,6 +31,7 @@ class RadioGhostModuleConfig: public Page
 #if defined(HARDWARE_KEYS)
     void onEvent(event_t event) override;
     void checkEvents() override;
+    void onCancel() override;
 #endif
 
   protected:


### PR DESCRIPTION
This is a quick fix for Ghost module remote menu . Tested only oon TX16S, unsure of behavior on radio without rotary encoder like nv14 (but also unsure how it works today on those)

This fixes #2559