### PR TITLE
chore(cmake): CMake cleanup and simplifications

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -59,9 +59,9 @@ function(AddCompilerFlags output)
     set(ARGS ${ARGS} -I${dir})
   endforeach()
 
-  # prevent some warnings
+  # Add hotfix for arm64
   set(ARGS ${ARGS} -Wno-asm-operand-widths -Wno-pragma-once-outside-header)
-  
+
   set(${output} ${${output}} ${ARGS} PARENT_SCOPE)
 endfunction()
 

--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -190,9 +190,21 @@ endif()
 
 if(RTC_BACKUP_RAM)
   add_definitions(-DRTC_BACKUP_RAM)
-  set(SRC ${SRC} storage/rlc.cpp)
-  set(FIRMWARE_SRC ${FIRMWARE_SRC} storage/rtc_backup.cpp)
-  set(GTEST_SRC ${GTEST_SRC} ${RADIO_SRC_DIR}/storage/rtc_backup.cpp)
+
+  GenerateDataCopy(datastructs_private.h datacopy.inc)
+
+  set(SRC ${SRC}
+    storage/rlc.cpp
+    storage/rtc_backup.cpp
+    )
+
+  set(FIRMWARE_SRC ${FIRMWARE_SRC}
+    storage/rtc_backup.cpp
+    ${CMAKE_CURRENT_BINARY_DIR}/datacopy.inc
+    )
+
+  # Add custom target for debugging
+  # add_custom_target(datacopy DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/datacopy.cpp)
 endif()
 
 if(LUA)
@@ -600,7 +612,7 @@ add_definitions(-DFREE_RTOS)
 
 add_executable(firmware ${SRC} ${FIRMWARE_HEADERS})
 link_libraries(firmware -lstdc++)
-add_dependencies(firmware ${RADIO_DEPENDENCIES} ${FIRMWARE_DEPENDENCIES})
+add_dependencies(firmware ${RADIO_DEPENDENCIES})
 set_target_properties(firmware PROPERTIES EXCLUDE_FROM_ALL TRUE)
 
 if(ACCESS_DENIED)

--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -196,15 +196,11 @@ if(RTC_BACKUP_RAM)
   set(SRC ${SRC}
     storage/rlc.cpp
     storage/rtc_backup.cpp
-    )
-
-  set(FIRMWARE_SRC ${FIRMWARE_SRC}
-    storage/rtc_backup.cpp
     ${CMAKE_CURRENT_BINARY_DIR}/datacopy.inc
     )
 
   # Add custom target for debugging
-  # add_custom_target(datacopy DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/datacopy.cpp)
+  add_custom_target(datacopy DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/datacopy.cpp)
 endif()
 
 if(LUA)
@@ -537,6 +533,23 @@ else()
 endif()
 
 if(NATIVE_BUILD)
+
+  set(RADIOLIB_NATIVE_SRC ${SRC})
+  if(SIMU_DISKIO)
+    set(RADIOLIB_NATIVE_SRC ${RADIOLIB_NATIVE_SRC}
+      ${FATFS_DIR}/ff.c ${FATFS_DIR}/ffunicode.c)
+  endif()
+
+  # Pack all radio sources into an object lib
+  add_library(radiolib_native OBJECT EXCLUDE_FROM_ALL
+    ${RADIOLIB_NATIVE_SRC})
+
+  # Add -DSIMU here PUBLIC, so it can be imported by other targets
+  # via INTERFACE_COMPILE_OPTIONS
+  target_compile_options(radiolib_native PUBLIC -DSIMU)
+  add_dependencies(radiolib_native ${RADIO_DEPENDENCIES})
+  set_property(TARGET radiolib_native PROPERTY POSITION_INDEPENDENT_CODE ON)
+  
   add_subdirectory(targets/simu)
   add_subdirectory(tests)
 endif()

--- a/radio/src/model_init.cpp
+++ b/radio/src/model_init.cpp
@@ -130,9 +130,7 @@ void applyDefaultTemplate()
 
 #if defined(COLORLCD)
 
-#if !defined(GTESTS)
   loadDefaultLayout();
-#endif
 
   // enable switch warnings
   for (int i = 0; i < NUM_SWITCHES; i++) {

--- a/radio/src/rtos.h
+++ b/radio/src/rtos.h
@@ -314,17 +314,9 @@ inline void RTOS_CREATE_TASK(pthread_t &taskId, void * (*task)(void *), const ch
   #define TASK_RETURN()                 vTaskDelete(nullptr)
 
 #else // no RTOS
-  static inline void RTOS_START()
-  {
-  }
 
-  static inline void RTOS_WAIT_MS(unsigned x)
-  {
-  }
+  #error "No RTOS implementation defined"
 
-  static inline void RTOS_WAIT_TICKS(unsigned x)
-  {
-  }
 #endif  // RTOS type
 
 #ifdef __cplusplus

--- a/radio/src/serial.cpp
+++ b/radio/src/serial.cpp
@@ -201,7 +201,7 @@ static void serialSetCallBacks(int mode, void* ctx, const etx_serial_port_t* por
     telemetrySetMirrorCb(ctx, sendByte);
     break;
 
-#if defined(CLI)
+#if defined(CLI) && !defined(SIMU)
   case UART_MODE_CLI:
     cliSetSerialDriver(ctx, drv);
     break;

--- a/radio/src/storage/rtc_backup.cpp
+++ b/radio/src/storage/rtc_backup.cpp
@@ -32,7 +32,7 @@ PACK(struct RamBackupUncompressed {
 #undef BACKUP
 };
 
-#include "datacopy.cpp"
+#include "datacopy.inc"
 
 Backup::RamBackupUncompressed ramBackupUncompressed __DMA;
 

--- a/radio/src/targets/horus/CMakeLists.txt
+++ b/radio/src/targets/horus/CMakeLists.txt
@@ -174,8 +174,6 @@ set(RADIO_DEPENDENCIES
   ${BITMAPS_TARGET}
   )
 
-set(FIRMWARE_DEPENDENCIES datacopy)
-
 add_definitions(-DPCBHORUS -DSTM32F429_439xx -DSTM32F429xx -DSDRAM -DCCMRAM -DCOLORLCD -DHARDWARE_KEYS)
 add_definitions(-DEEPROM_VARIANT=0 -DAUDIO -DVOICE -DRTCLOCK)
 add_definitions(-DGPS_USART_BAUDRATE=${INTERNAL_GPS_BAUDRATE})
@@ -319,20 +317,10 @@ endif()
 # Make malloc() thread-safe
 add_definitions(-DTHREADSAFE_MALLOC)
 
-if(PYTHONINTERP_FOUND)
-  add_custom_command(
-    OUTPUT ${PROJECT_BINARY_DIR}/radio/src/datacopy.cpp
-    WORKING_DIRECTORY ${RADIO_DIRECTORY}/src
-    COMMAND ${PYTHON_EXECUTABLE} ${RADIO_DIRECTORY}/util/generate_datacopy.py datastructs_private.h
-      -DPCBHORUS -DPCB${PCB} -DCPUARM -DSTM32F4 -DSTM32F429_439xx -DCOLORLCD -DBACKUP -DSIMU
-      -I. -Igui/colorlcd -Itargets/horus -Itargets/common/arm/stm32
-      -I${THIRDPARTY_DIR} -I${THIRDPARTY_DIR}/libopenui/src
-      -I${THIRDPARTY_DIR}/STM32F4xx_DSP_StdPeriph_Lib_V1.8.0/Libraries/STM32F4xx_StdPeriph_Driver/inc
-      -I${THIRDPARTY_DIR}/STM32F4xx_DSP_StdPeriph_Lib_V1.8.0/Libraries/CMSIS/Device/ST/STM32F4xx/Include
-      -I${THIRDPARTY_DIR}/STM32F4xx_DSP_StdPeriph_Lib_V1.8.0/Libraries/CMSIS/Include
-      -Wno-asm-operand-widths -Wno-pragma-once-outside-header ${SYSROOT_ARG}
-      > ${PROJECT_BINARY_DIR}/radio/src/datacopy.cpp
-    DEPENDS ${RADIO_DIRECTORY}/src/datastructs.h ${RADIO_DIRECTORY}/util/generate_datacopy.py
-    )
-  add_custom_target(datacopy DEPENDS ${PROJECT_BINARY_DIR}/radio/src/datacopy.cpp)
-endif()
+set(STM32LIB_SRC
+  STM32F4xx_StdPeriph_Driver/src/stm32f4xx_sdio.c
+  STM32F4xx_StdPeriph_Driver/src/stm32f4xx_fmc.c
+  STM32F4xx_StdPeriph_Driver/src/stm32f4xx_ltdc.c
+  STM32F4xx_StdPeriph_Driver/src/stm32f4xx_tim.c
+  STM32F4xx_StdPeriph_Driver/src/stm32f4xx_dma2d.c
+  )

--- a/radio/src/targets/nv14/CMakeLists.txt
+++ b/radio/src/targets/nv14/CMakeLists.txt
@@ -60,7 +60,6 @@ set(TOUCH_DRIVER touch_driver.cpp)
 set(HARDWARE_TOUCH YES)
 
 set(RADIO_DEPENDENCIES ${RADIO_DEPENDENCIES} ${BITMAPS_TARGET})
-set(FIRMWARE_DEPENDENCIES datacopy)
 
 set(HARDWARE_TOUCH ON)
 
@@ -164,21 +163,13 @@ set(FIRMWARE_SRC
 # Make malloc() thread-safe
 add_definitions(-DTHREADSAFE_MALLOC)
 
-if(PYTHONINTERP_FOUND)
-  add_custom_command(
-    OUTPUT ${PROJECT_BINARY_DIR}/radio/src/datacopy.cpp
-    WORKING_DIRECTORY ${RADIO_DIRECTORY}/src
-    COMMAND ${PYTHON_EXECUTABLE} ${RADIO_DIRECTORY}/util/generate_datacopy.py datastructs_private.h
-      -DPCBFLYSKY -DPCBNV14 -DCPUARM -DSTM32F4 -DSTM32F429_439xx -DCOLORLCD -DBACKUP -DSIMU
-      -I. -Igui/colorlcd -Itargets/nv14 -Itargets/common/arm/stm32
-      -I${THIRDPARTY_DIR} -I${THIRDPARTY_DIR}/libopenui/src
-      -I${THIRDPARTY_DIR}/STM32F4xx_DSP_StdPeriph_Lib_V1.8.0/Libraries/STM32F4xx_StdPeriph_Driver/inc
-      -I${THIRDPARTY_DIR}/STM32F4xx_DSP_StdPeriph_Lib_V1.8.0/Libraries/CMSIS/Device/ST/STM32F4xx/Include
-      -I${THIRDPARTY_DIR}/STM32F4xx_DSP_StdPeriph_Lib_V1.8.0/Libraries/CMSIS/Include
-      -Wno-asm-operand-widths -Wno-pragma-once-outside-header ${SYSROOT_ARG}
-    > ${PROJECT_BINARY_DIR}/radio/src/datacopy.cpp
-    DEPENDS ${RADIO_DIRECTORY}/src/datastructs.h ${RADIO_DIRECTORY}/util/generate_datacopy.py
-    )
-  add_custom_target(datacopy DEPENDS ${PROJECT_BINARY_DIR}/radio/src/datacopy.cpp)
-endif()
+set(STM32LIB_SRC
+  STM32F4xx_StdPeriph_Driver/src/stm32f4xx_sdio.c
+  STM32F4xx_StdPeriph_Driver/src/stm32f4xx_fmc.c
+  STM32F4xx_StdPeriph_Driver/src/stm32f4xx_ltdc.c
+  STM32F4xx_StdPeriph_Driver/src/stm32f4xx_tim.c
+  STM32F4xx_StdPeriph_Driver/src/stm32f4xx_dma2d.c
+  STM32F4xx_StdPeriph_Driver/src/stm32f4xx_exti.c
+  STM32F4xx_StdPeriph_Driver/src/stm32f4xx_syscfg.c
+  )
 

--- a/radio/src/targets/simu/CMakeLists.txt
+++ b/radio/src/targets/simu/CMakeLists.txt
@@ -48,6 +48,23 @@ if(SIMU_BOOTLOADER)
     )
 endif()
 
+if(RTC_BACKUP_RAM)
+  GenerateDataCopy(../../datastructs_private.h ../../datacopy.inc)
+  set(SIMU_SRC ${SIMU_SRC} ${CMAKE_CURRENT_BINARY_DIR}/../../datacopy.inc)
+endif()
+
+# Pack all radio sources into an object lib
+add_library(radiolib_native OBJECT EXCLUDE_FROM_ALL
+  ${SIMU_SRC})
+
+# Add -DSIMU here PRIVATE, whereby it is added again
+# for the executable targets
+target_compile_options(radiolib_native PRIVATE -DSIMU)
+add_dependencies(radiolib_native ${RADIO_DEPENDENCIES})
+
+# Replace SIMU_SRC with the object from radiolib_native
+set(SIMU_SRC $<TARGET_OBJECTS:radiolib_native>)
+
 if(Qt5Widgets_FOUND)
   set(SIMULATOR_FLAVOUR edgetx-${FLAVOUR})
   set(SIMULATOR_TARGET ${SIMULATOR_FLAVOUR}-simulator)
@@ -56,7 +73,6 @@ if(Qt5Widgets_FOUND)
   qt5_wrap_cpp(SIMULATOR_SRC ${COMPANION_SRC_DIRECTORY}/simulation/simulatorinterface.h opentxsimulator.h)
   list(APPEND SIMULATOR_SRC ${SIMU_SRC} opentxsimulator.cpp)
   add_library(${SIMULATOR_TARGET} SHARED ${SIMULATOR_SRC})
-  add_dependencies(${SIMULATOR_TARGET} ${RADIO_DEPENDENCIES})
   target_compile_definitions(${SIMULATOR_TARGET} PUBLIC ${APP_COMMON_DEFINES})  # set in top-level CMakeLists
   target_link_libraries(${SIMULATOR_TARGET} ${SDL_LIBRARY} Qt5::Core)
 
@@ -144,16 +160,11 @@ if(FOX_FOUND)
 
   add_executable(simu WIN32
     EXCLUDE_FROM_ALL
-    ${SIMU_SRC} ${RADIO_SRC_DIR}/simu.cpp)
-
-  add_dependencies(simu ${RADIO_DEPENDENCIES})
+    ${SIMU_SRC}
+    ${RADIO_SRC_DIR}/simu.cpp)
 
   target_include_directories(simu PUBLIC ${FOX_INCLUDE_DIR} )
   target_link_libraries(simu ${FOX_LIBRARY} pthread ${SDL_LIBRARY})
-  target_compile_definitions(simu PUBLIC -DSIMU)
-  if(SIMU_DISKIO)
-    target_compile_definitions(simu PUBLIC -DSIMU_DISKIO)
-  endif()
 endif()
 
 if(APPLE)

--- a/radio/src/targets/simu/CMakeLists.txt
+++ b/radio/src/targets/simu/CMakeLists.txt
@@ -54,11 +54,11 @@ set_property(TARGET simu_drivers PROPERTY POSITION_INDEPENDENT_CODE ON)
 set(SIMU_SRC
   $<TARGET_OBJECTS:radiolib_native>
   $<TARGET_OBJECTS:simu_drivers>
-  PARENT_SCOPE)
+  )
+set(SIMU_SRC ${SIMU_SRC} PARENT_SCOPE)
 
 # Set the options as well in parent scope to be used by unit tests
 set(SIMU_SRC_OPTIONS ${SIMU_SRC_OPTIONS} PARENT_SCOPE)
-
 
 if(Qt5Widgets_FOUND)
   set(SIMULATOR_FLAVOUR edgetx-${FLAVOUR})

--- a/radio/src/targets/simu/CMakeLists.txt
+++ b/radio/src/targets/simu/CMakeLists.txt
@@ -5,12 +5,7 @@ if(NOT SIMU_TARGET)
   return()
 endif()
 
-foreach(FILE ${SRC})
-  set(SIMU_SRC ${SIMU_SRC} ../../${FILE})
-endforeach()
-
-set(SIMU_SRC
-  ${SIMU_SRC}
+set(SIMU_DRIVERS
   simpgmspace.cpp
   simueeprom.cpp
   simufatfs.cpp
@@ -23,11 +18,6 @@ set(SIMU_SRC
   bt_driver.cpp
   )
 
-if(SIMU_DISKIO)
-  set(SIMU_SRC ${SIMU_SRC} ../../${FATFS_DIR}/ff.c ../../${FATFS_DIR}/option/ccsbcs.c)
-endif()
-
-remove_definitions(-DCLI)
 
 if(SDL_FOUND)
   include_directories(${SDL_INCLUDE_DIR})
@@ -40,7 +30,7 @@ endif()
 
 if(SIMU_BOOTLOADER)
   add_definitions(-DSIMU_BOOTLOADER)
-  set(SIMU_SRC ${SIMU_SRC}
+  set(SIMU_DRIVERS ${SIMU_DRIVERS}
     ../../targets/common/arm/stm32/bootloader/bin_files.cpp
     ../../targets/common/arm/stm32/bootloader/boot.cpp
     ../../targets/${TARGET_DIR}/bootloader/boot_menu.cpp
@@ -48,33 +38,44 @@ if(SIMU_BOOTLOADER)
     )
 endif()
 
-if(RTC_BACKUP_RAM)
-  GenerateDataCopy(../../datastructs_private.h ../../datacopy.inc)
-  set(SIMU_SRC ${SIMU_SRC} ${CMAKE_CURRENT_BINARY_DIR}/../../datacopy.inc)
-endif()
+# Pack all simu driver sources into an object lib
+add_library(simu_drivers OBJECT EXCLUDE_FROM_ALL
+  ${SIMU_DRIVERS})
 
-# Pack all radio sources into an object lib
-add_library(radiolib_native OBJECT EXCLUDE_FROM_ALL
-  ${SIMU_SRC})
+get_property(SIMU_SRC_OPTIONS
+  TARGET radiolib_native
+  PROPERTY INTERFACE_COMPILE_OPTIONS)
 
-# Add -DSIMU here PRIVATE, whereby it is added again
-# for the executable targets
-target_compile_options(radiolib_native PRIVATE -DSIMU)
-add_dependencies(radiolib_native ${RADIO_DEPENDENCIES})
-set_property(TARGET radiolib_native PROPERTY POSITION_INDEPENDENT_CODE ON)
+target_compile_options(simu_drivers PRIVATE ${SIMU_SRC_OPTIONS})
 
-# Replace SIMU_SRC with the object from radiolib_native
-set(SIMU_SRC $<TARGET_OBJECTS:radiolib_native>)
+set_property(TARGET simu_drivers PROPERTY POSITION_INDEPENDENT_CODE ON)
+
+# Replace SIMU_SRC with the objects from radiolib_native & simu_drivers
+set(SIMU_SRC
+  $<TARGET_OBJECTS:radiolib_native>
+  $<TARGET_OBJECTS:simu_drivers>
+  PARENT_SCOPE)
+
+# Set the options as well in parent scope to be used by unit tests
+set(SIMU_SRC_OPTIONS ${SIMU_SRC_OPTIONS} PARENT_SCOPE)
+
 
 if(Qt5Widgets_FOUND)
   set(SIMULATOR_FLAVOUR edgetx-${FLAVOUR})
   set(SIMULATOR_TARGET ${SIMULATOR_FLAVOUR}-simulator)
+
   add_definitions(-DSIMULATOR_FLAVOUR="${SIMULATOR_FLAVOUR}")
   include_directories(${COMPANION_SRC_DIRECTORY} ${COMPANION_SRC_DIRECTORY}/simulation)
-  qt5_wrap_cpp(SIMULATOR_SRC ${COMPANION_SRC_DIRECTORY}/simulation/simulatorinterface.h opentxsimulator.h)
+
+  qt5_wrap_cpp(SIMULATOR_SRC
+    ${COMPANION_SRC_DIRECTORY}/simulation/simulatorinterface.h
+    opentxsimulator.h
+    )
   list(APPEND SIMULATOR_SRC ${SIMU_SRC} opentxsimulator.cpp)
   add_library(${SIMULATOR_TARGET} SHARED ${SIMULATOR_SRC})
-  target_compile_definitions(${SIMULATOR_TARGET} PUBLIC ${APP_COMMON_DEFINES})  # set in top-level CMakeLists
+
+  target_compile_options(${SIMULATOR_TARGET} PRIVATE ${SIMU_SRC_OPTIONS})
+  target_compile_definitions(${SIMULATOR_TARGET} PUBLIC ${APP_COMMON_DEFINES})
   target_link_libraries(${SIMULATOR_TARGET} ${SDL_LIBRARY} Qt5::Core)
 
   # Remove debug symbols on release builds
@@ -155,10 +156,6 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNING_FLAGS}")
 use_cxx11()  # ensure gnu++11 in CXX_FLAGS with CMake < 3.1
 
 if(FOX_FOUND)
-  if(SIMU_DISKIO)
-    set(SIMU_SRC ${SIMU_SRC} ${FATFS_DIR}/FatFs/ff.c ${FATFS_DIR}/option/ccsbcs.c)
-  endif()
-
   add_executable(simu WIN32
     EXCLUDE_FROM_ALL
     ${SIMU_SRC}

--- a/radio/src/targets/simu/CMakeLists.txt
+++ b/radio/src/targets/simu/CMakeLists.txt
@@ -61,6 +61,7 @@ add_library(radiolib_native OBJECT EXCLUDE_FROM_ALL
 # for the executable targets
 target_compile_options(radiolib_native PRIVATE -DSIMU)
 add_dependencies(radiolib_native ${RADIO_DEPENDENCIES})
+set_property(TARGET radiolib_native PROPERTY POSITION_INDEPENDENT_CODE ON)
 
 # Replace SIMU_SRC with the object from radiolib_native
 set(SIMU_SRC $<TARGET_OBJECTS:radiolib_native>)
@@ -165,6 +166,7 @@ if(FOX_FOUND)
 
   target_include_directories(simu PUBLIC ${FOX_INCLUDE_DIR} )
   target_link_libraries(simu ${FOX_LIBRARY} pthread ${SDL_LIBRARY})
+  target_compile_options(simu PRIVATE -DSIMU)
 endif()
 
 if(APPLE)

--- a/radio/src/targets/simu/simueeprom.cpp
+++ b/radio/src/targets/simu/simueeprom.cpp
@@ -125,16 +125,15 @@ void eepromStartWrite(uint8_t * buffer, size_t address, size_t size)
   eepromTransmitData(address, buffer, size, false);
 }
 
+bool _eeprom_write_simu_delay = true;
+
 void eepromWriteBlock(uint8_t * buffer, size_t address, size_t size)
 {
   eepromStartWrite(buffer, address, size);
 
   while (!eepromIsTransferComplete()) {
-#if defined(GTESTS)
-    sleep(0/*ms*/);
-#else
-    sleep(1/*ms*/);
-#endif
+    if (_eeprom_write_simu_delay)
+      sleep(1/*ms*/);
   }
 }
 

--- a/radio/src/tasks.cpp
+++ b/radio/src/tasks.cpp
@@ -40,7 +40,7 @@ void stackPaint()
   menusStack.paint();
   mixerStack.paint();
   audioStack.paint();
-#if defined(CLI)
+#if defined(CLI) && !defined(SIMU)
   cliStack.paint();
 #endif
 }
@@ -266,7 +266,7 @@ void tasksStart()
   RTOS_CREATE_MUTEX(audioMutex);
   RTOS_CREATE_MUTEX(mixerMutex);
 
-#if defined(CLI)
+#if defined(CLI) && !defined(SIMU)
   cliStart();
 #endif
 

--- a/radio/src/tests/CMakeLists.txt
+++ b/radio/src/tests/CMakeLists.txt
@@ -41,9 +41,6 @@ if(GTEST_INCDIR AND GTEST_SRCDIR AND Qt5Widgets_FOUND)
     target_link_libraries(gtests-radio-lib PRIVATE ${SDL_LIBRARY})
   endif()
 
-  foreach(FILE ${SRC})
-    set(RADIO_SRC ${RADIO_SRC} ../${FILE})
-  endforeach()
 
   file(GLOB TEST_SRC_FILES ${RADIO_SRC_DIR}/tests/*.cpp)
 
@@ -56,18 +53,9 @@ if(GTEST_INCDIR AND GTEST_SRCDIR AND Qt5Widgets_FOUND)
     ${GTEST_SRC}
     ${TEST_SRC_FILES}
     ${CMAKE_CURRENT_SOURCE_DIR}/location.h
-    ${RADIO_SRC}
-    ../targets/simu/simpgmspace.cpp
-    ../targets/simu/simueeprom.cpp
-    ../targets/simu/simufatfs.cpp
-    ../targets/simu/simulcd.cpp
-    ../targets/simu/module_drivers.cpp
-    ../targets/simu/led_driver.cpp
-    ../targets/simu/backlight_driver.cpp
-    ../targets/simu/gyro_driver.cpp
-    ../targets/simu/bt_driver.cpp
+    $<TARGET_OBJECTS:radiolib_native>
     )
-  add_dependencies(gtests-radio ${RADIO_DEPENDENCIES} ${FIRMWARE_DEPENDENCIES} gtests-radio-lib)
+  add_dependencies(gtests-radio gtests-radio-lib)
   if(PCB STREQUAL X12S OR PCB STREQUAL X10)
     add_dependencies(gtests-radio ${HORUS_MODEL_FILES})
   endif()

--- a/radio/src/tests/CMakeLists.txt
+++ b/radio/src/tests/CMakeLists.txt
@@ -3,8 +3,6 @@
 if(GTEST_INCDIR AND GTEST_SRCDIR AND Qt5Widgets_FOUND)
   add_library(gtests-radio-lib STATIC EXCLUDE_FROM_ALL ${GTEST_SRCDIR}/src/gtest-all.cc )
   target_include_directories(gtests-radio-lib PUBLIC ${GTEST_INCDIR} ${GTEST_INCDIR}/gtest ${GTEST_SRCDIR})
-  add_definitions(-DSIMU -DGTESTS)
-  remove_definitions(-DCLI)
   set(TESTS_PATH ${RADIO_SRC_DIR}/tests)
   set(TESTS_BUILD_PATH ${CMAKE_CURRENT_BINARY_DIR})
   configure_file(${RADIO_SRC_DIR}/tests/location.h.in ${CMAKE_CURRENT_BINARY_DIR}/location.h @ONLY)
@@ -43,6 +41,10 @@ if(GTEST_INCDIR AND GTEST_SRCDIR AND Qt5Widgets_FOUND)
 
 
   file(GLOB TEST_SRC_FILES ${RADIO_SRC_DIR}/tests/*.cpp)
+  set(TEST_SRC_FILES ${TEST_SRC_FILES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/location.h
+    ${SIMU_SRC}
+    )
 
   if(MINGW)
     # struct packing breaks on MinGW w/out -mno-ms-bitfields: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=52991 & http://stackoverflow.com/questions/24015852/struct-packing-and-alignment-with-mingw
@@ -50,11 +52,10 @@ if(GTEST_INCDIR AND GTEST_SRCDIR AND Qt5Widgets_FOUND)
   endif()
 
   add_executable(gtests-radio EXCLUDE_FROM_ALL
-    ${GTEST_SRC}
     ${TEST_SRC_FILES}
-    ${CMAKE_CURRENT_SOURCE_DIR}/location.h
-    $<TARGET_OBJECTS:radiolib_native>
     )
+  target_compile_options(gtests-radio PRIVATE ${SIMU_SRC_OPTIONS})
+
   add_dependencies(gtests-radio gtests-radio-lib)
   if(PCB STREQUAL X12S OR PCB STREQUAL X10)
     add_dependencies(gtests-radio ${HORUS_MODEL_FILES})

--- a/radio/src/tests/gtests.cpp
+++ b/radio/src/tests/gtests.cpp
@@ -155,10 +155,14 @@ const char * nchar2string(const char * string, int size)
   return _stringResult;
 }
 
+extern bool _eeprom_write_simu_delay;
+
 int main(int argc, char **argv)
 {
   QCoreApplication app(argc, argv);
   simuInit();
+
+  _eeprom_write_simu_delay = false;
   startEepromThread(nullptr);
 #if defined(EEPROM_SIZE)
   eeprom = (uint8_t *)malloc(EEPROM_SIZE);


### PR DESCRIPTION
This PR improves the CMake files a bit, and cuts down some of the build time for commit tests.

Summary of changes:
- factorise datacopy into a macro
- use an object lib for most simu based source code (simu, Qt simulator plug-in and gtests)

TODO:
- [x] test Companion plugins load properly
