### PR TITLE
Model select

### DIFF
--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -11,7 +11,7 @@
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as
- * published by the Free Software Foundation. 
+ * published by the Free Software Foundation.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -301,13 +301,9 @@ class ModelButton : public Button
       dc->drawSizedText(width() / 2, 2, modelCell->modelName, LEN_MODEL_NAME,
                         COLOR_THEME_SECONDARY1 | CENTERED);
     } else {
-      LcdFlags textColor;
       dc->drawFilledRect(0, 0, width(), 20, SOLID, COLOR_THEME_PRIMARY2);
-
-      textColor = COLOR_THEME_SECONDARY1;
-
       dc->drawSizedText(width() / 2, 2, modelCell->modelName, LEN_MODEL_NAME,
-                        textColor | CENTERED);
+                        COLOR_THEME_SECONDARY1 | CENTERED);
     }
 
     if (!hasFocus()) {
@@ -463,7 +459,7 @@ void ModelsPageBody::saveAsTemplate(ModelCell *model)
   }
 }
 
-void ModelsPageBody::editLabels(ModelCell* model)
+void ModelsPageBody::editLabels(ModelCell *model)
 {
   auto labels = modelslabels.getLabels();
 
@@ -538,6 +534,7 @@ void ModelsPageBody::update(int selected)
       menu->addLine(STR_SELECT_MODEL, [=]() { selectModel(model); });
       menu->addLine(STR_DUPLICATE_MODEL, [=]() { duplicateModel(model); });
       menu->addLine(STR_EDIT_LABELS, [=]() { editLabels(model); });
+      menu->addLine(STR_SAVE_TEMPLATE, [=]() { saveAsTemplate(model); });
       if (model != curModel) {
         menu->addLine(STR_DELETE_MODEL, [=]() { deleteModel(model); });
       }

--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -11,7 +11,7 @@
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation. 
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -325,7 +325,7 @@ class ModelButton : public Button
   bool loaded = false;
   ModelCell *modelCell;
   BitmapBuffer *buffer = nullptr;
-  
+ 
   void onClicked() override {
     if (!lv_obj_has_state(lvobj, LV_STATE_FOCUSED)) {
       lv_group_focus_obj(lvobj);
@@ -333,7 +333,6 @@ class ModelButton : public Button
       Button::onClicked();
     }
   }
-  
 };
 
 //-----------------------------------------------------------------------------
@@ -441,15 +440,15 @@ void ModelsPageBody::deleteModel(ModelCell *model)
 
 void ModelsPageBody::saveAsTemplate(ModelCell *model)
 {
-  storageDirty(EE_MODEL);
-  storageCheck(true);
   constexpr size_t size = sizeof(model->modelName) + sizeof(YAML_EXT);
   char modelName[size];
   snprintf(modelName, size, "%s%s", model->modelName, YAML_EXT);
   char templatePath[FF_MAX_LFN];
   snprintf(templatePath, FF_MAX_LFN, "%s%c%s", PERS_TEMPL_PATH, '/', modelName);
+
   sdCheckAndCreateDirectory(TEMPLATES_PATH);
   sdCheckAndCreateDirectory(PERS_TEMPL_PATH);
+  
   if (isFileAvailable(templatePath)) {
     new ConfirmDialog(parent, STR_FILE_EXISTS, STR_ASK_OVERWRITE, [=] {
       sdCopyFile(model->modelFilename, MODELS_PATH, modelName, PERS_TEMPL_PATH);
@@ -457,6 +456,9 @@ void ModelsPageBody::saveAsTemplate(ModelCell *model)
   } else {
     sdCopyFile(model->modelFilename, MODELS_PATH, modelName, PERS_TEMPL_PATH);
   }
+
+  storageDirty(EE_MODEL);
+  storageCheck(true);
 }
 
 void ModelsPageBody::editLabels(ModelCell *model)

--- a/radio/src/gui/colorlcd/model_select.h
+++ b/radio/src/gui/colorlcd/model_select.h
@@ -87,7 +87,8 @@ class ModelsPageBody : public FormWindow
   void deleteModel(ModelCell* model);
   void editLabels(ModelCell* model);
   void saveAsTemplate(ModelCell *model);
-};
+}
+;
 
 class ModelLabelsWindow : public Page
 {

--- a/radio/src/gui/colorlcd/model_select.h
+++ b/radio/src/gui/colorlcd/model_select.h
@@ -11,7 +11,7 @@
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as
- * published by the Free Software Foundation.
+ * published by the Free Software Foundation. 
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of

--- a/radio/src/gui/colorlcd/model_select.h
+++ b/radio/src/gui/colorlcd/model_select.h
@@ -55,12 +55,31 @@ class ModelsPageBody : public FormWindow
     refreshLabels = std::move(fnc);
   }
 
+  void setFocusedMCell(ModelCell* mC)
+  { 
+    focusedMCell = mC;
+  }
+
+  ModelButton* getCurrentModelButton() 
+  { 
+    return currentModelButton;
+  }
+
+  void setInitialized()
+  { 
+    initialized = true; 
+  }
+
  protected:
   ModelsSortBy _sortOrder;
   bool isDirty = false;
   bool refresh = false;
   std::string selectedLabel;
   LabelsVector selectedLabels;
+  ModelCell *focusedMCell = nullptr;
+  ModelButton *currentModelButton = nullptr;
+  ModelButton *newFocusedButton = nullptr;
+  bool initialized = false;
   std::function<void()> refreshLabels = nullptr;
 
   void selectModel(ModelCell* model);

--- a/radio/src/gui/colorlcd/model_select.h
+++ b/radio/src/gui/colorlcd/model_select.h
@@ -11,7 +11,7 @@
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as
- * published by the Free Software Foundation. 
+ * published by the Free Software Foundation.
  *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
@@ -87,8 +87,7 @@ class ModelsPageBody : public FormWindow
   void deleteModel(ModelCell* model);
   void editLabels(ModelCell* model);
   void saveAsTemplate(ModelCell *model);
-}
-;
+};
 
 class ModelLabelsWindow : public Page
 {


### PR DESCRIPTION

Fixes #

Summary of changes:
Made Model Select page more consistent with other screens.
When selected, current model is visible and has focus in table of models.
A ModelButton will always have focus.
Tap on a ModelButton without focus will give it focus.
Tap on a ModelButton with focus and model will be selected and close screen.
LongTap on ModelButton will bring up context menu.
Changing order or filters will cause ModelButton which currently has focus to be visible and retain focus.
If a filter is chosen which eliminates the ModelButton with current focus the first ModelButton will get focus.
Give it a try.