### PR TITLE
fix(color): Disable invalid PG_UP and PG_DN handling on widget setup screen

### DIFF
--- a/radio/src/gui/colorlcd/widgets_setup.cpp
+++ b/radio/src/gui/colorlcd/widgets_setup.cpp
@@ -134,3 +134,12 @@ void SetupWidgetsPage::deleteLater(bool detach, bool trash)
 
   storageDirty(EE_MODEL);
 }
+
+void SetupWidgetsPage::onEvent(event_t event)
+{
+  if (event == EVT_KEY_FIRST(KEY_PGUP) || event == EVT_KEY_FIRST(KEY_PGDN)) {
+    killEvents(event);
+  } else {
+    FormWindow::onEvent(event);
+  }
+}

--- a/radio/src/gui/colorlcd/widgets_setup.h
+++ b/radio/src/gui/colorlcd/widgets_setup.h
@@ -46,6 +46,7 @@ class SetupWidgetsPage : public FormWindow
  protected:
   uint8_t customScreenIdx;
   unsigned savedView = 0;
+  void onEvent(event_t event)  override;
 };
 
 class SetupWidgetsPageSlot : public Button


### PR DESCRIPTION

Fixes #2621

Summary of changes: Disable PAG_UP and PG_DN buttons on the widgey setup scree.
The buttons were working incorrectly and there is a consensus (I feel) that they should not have any effect there.
