### PR TITLE
Companion updates save component settings from Update Settings tab

### DIFF
--- a/companion/src/updates/updateoptionsdialog.cpp
+++ b/companion/src/updates/updateoptionsdialog.cpp
@@ -249,6 +249,10 @@ UpdateOptionsDialog::UpdateOptionsDialog(QWidget * parent, UpdateFactories * fac
       chkCopies.at(i)->isChecked() ? flags |= UpdateInterface::UPDFLG_CopyDest : flags &= ~UpdateInterface::UPDFLG_CopyDest;
       ap.flags = flags;
     }
+
+    if (!isRun)
+      factories->saveAssetSettings(idx);
+
     QDialog::accept();
   });
 


### PR DESCRIPTION
Fixes #2634

@pfeerick note this is based on 2602 and thus why the big diff. The change for this PR is in https://github.com/EdgeTX/edgetx/compare/elecpower/cpn-fix-2634-upd-settings?expand=1#diff-565c6756adc52a80ae93eaf395cb23b75f09b37d09f4b70e53d6e175af0135c8 lines 252 - 255