### PR TITLE
fix(gh): Don't install `arm-none-eabi-gcc` pkg

### DIFF
--- a/.github/workflows/win-cpn-32.yml
+++ b/.github/workflows/win-cpn-32.yml
@@ -45,7 +45,6 @@ jobs:
                                 mingw-w64-i686-python-pip \
                                 mingw-w64-i686-python-pillow \
                                 mingw-w64-i686-python-lz4 \
-                                mingw-w64-i686-arm-none-eabi-gcc \
                                 mingw-w64-i686-libjpeg-turbo \
                                 mingw-w64-i686-zlib \
                                 mingw-w64-i686-libtiff \


### PR DESCRIPTION
`mingw-w64-i686-arm-none-eabi-gcc` is not actually a build dependency.

Fixes recent build failures of win32 Companion builds, which started due to this package being pulled from the MSYS package repo yesterday. 

i.e. 6b01a0c6732146c72b729937771c9e399d037795

@rotorman You may want to check your package install scripts and update them as necessary ;)