### PR TITLE
fix(color): prevent event bubbling in Page and TabsGroup

### DIFF
--- a/radio/src/gui/colorlcd/page.cpp
+++ b/radio/src/gui/colorlcd/page.cpp
@@ -83,3 +83,8 @@ void Page::onClicked()
 {
   Keyboard::hide();
 }
+
+void Page::onEvent(event_t event)
+{
+  // block event bubbling
+}

--- a/radio/src/gui/colorlcd/page.h
+++ b/radio/src/gui/colorlcd/page.h
@@ -61,6 +61,8 @@ class Page : public Window
  protected:
   PageHeader header;
   FormWindow body;
+
+  void onEvent(event_t event) override;
 };
 
 #endif // _PAGE_H_

--- a/radio/src/gui/colorlcd/tabsgroup.cpp
+++ b/radio/src/gui/colorlcd/tabsgroup.cpp
@@ -271,8 +271,6 @@ void TabsGroup::onEvent(event_t event)
     killEvents(event);
     uint8_t current = header.carousel.getCurrentIndex();
     setCurrentTab(current == 0 ? tabs.size() - 1 : current - 1);
-  } else if (parent) {
-    parent->onEvent(event);
   }
 #endif
 }


### PR DESCRIPTION
... otherwise unexpected things happen.

Fixes #2595