### PR TITLE
fix(yaml): RF link alarms

### DIFF
--- a/radio/src/storage/sdcard_yaml.cpp
+++ b/radio/src/storage/sdcard_yaml.cpp
@@ -381,6 +381,9 @@ const char * readModelYaml(const char * filename, uint8_t * buffer, uint32_t siz
       // md->swashR.collectiveWeight = 100;
       // md->swashR.aileronWeight    = 100;
       // md->swashR.elevatorWeight   = 100;
+
+      md->rfAlarms.warning = 45;
+      md->rfAlarms.critical = 42;
     }
 
     return readYamlFile(path, YamlTreeWalker::get_parser_calls(), &tree, NULL);

--- a/radio/src/tests/conversions.cpp
+++ b/radio/src/tests/conversions.cpp
@@ -470,6 +470,10 @@ TEST(Conversions, ConversionTX16SFrom25)
   EXPECT_EQ(FUNC_ADJUST_GVAR_INCDEC, CFN_GVAR_MODE(&(g_model.customFn[1])));
   EXPECT_EQ(5, CFN_PARAM(&(g_model.customFn[1])));
 
+  EXPECT_EQ(g_model.disableTelemetryWarning, 0);
+  EXPECT_EQ(g_model.rfAlarms.warning, 45);
+  EXPECT_EQ(g_model.rfAlarms.critical, 42);
+  
   const auto& top_widget = g_model.topbarData.zones[3];
   EXPECT_STRNEQ("Value", top_widget.widgetName);
 
@@ -530,6 +534,9 @@ TEST(Conversions, ConversionTX16SFrom25)
   EXPECT_EQ(SWSRC_FIRST_LOGICAL_SWITCH + 4, g_model.logicalSw[5].v2);
   EXPECT_EQ(SWSRC_NONE, g_model.logicalSw[5].andsw);
 
+  f_unlink("/RADIO/radio.bin");
+  f_unlink("/MODELS/model1.bin");
+  f_unlink("/MODELS/model2.bin");
   simuFatfsSetPaths("","");
 }
 #endif


### PR DESCRIPTION
Set warning/critical to default values before reading YAML model file. Otherwise, these values will be 0 if either the old or the new tags are not present, which is the case when coming from 2.7.

Fixes #2591 
