### PR TITLE
fix(lua): re-implement LUA "tap" events

### DIFF
--- a/radio/src/lua/lua_widget.h
+++ b/radio/src/lua/lua_widget.h
@@ -27,9 +27,16 @@
 
 #include "opentx_types.h"
 
+#define LUA_TAP_TIME 250 // 250 ms
+
 class LuaEventHandler
 {
 #if defined(HARDWARE_TOUCH)
+  // "tap" handling
+  static uint32_t downTime;
+  static uint32_t tapTime;
+  static uint32_t tapCount;
+  // "swipe" / "slide" handling
   static tmr10ms_t swipeTimeOut;
   static bool _sliding;
   static coord_t _startX;


### PR DESCRIPTION
As LVGL does not support natively the gestures handled by LUA with respect to touch sensors, this PR re-implements the "tap count" instead of relying on the internal driver exporting the data.

Fixes #2617

