### PR TITLE
fix(telemetry): sensor processing with legacy polling disabled

### DIFF
--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -265,29 +265,32 @@ void telemetryWakeup()
   if (int_drv) pollTelemetry(INTERNAL_MODULE, int_drv, getIntModuleCtx());
 #endif
 
+  bool disable_legacy_polling = false;
 #if defined(HARDWARE_EXTERNAL_MODULE)
   auto ext_drv = getExtModuleDriver();
   if (ext_drv) {
     if (pollTelemetry(EXTERNAL_MODULE, ext_drv, getExtModuleCtx())) {
       // skip legacy telemetry polling in case external module
       // driver defines telemetry methods (getByte & processData)
-      return;
+      disable_legacy_polling = true;
     }
   }
 #endif
-                             
-  // TODO: needs to be moved to protocol/module init
-  //       as-is, it implies only ONE telemetry protocol
-  //       enabled at the same time
-  uint8_t requiredTelemetryProtocol = modelTelemetryProtocol();
 
-  if (telemetryProtocol != requiredTelemetryProtocol) {
-    telemetryInit(requiredTelemetryProtocol);
+  if (!disable_legacy_polling) {
+    // TODO: needs to be moved to protocol/module init
+    //       as-is, it implies only ONE telemetry protocol
+    //       enabled at the same time
+    uint8_t requiredTelemetryProtocol = modelTelemetryProtocol();
+
+    if (telemetryProtocol != requiredTelemetryProtocol) {
+      telemetryInit(requiredTelemetryProtocol);
+    }
+
+    // Poll external / S.PORT telemetry
+    // TODO: how to switch this OFF ???
+    pollExtTelemetryLegacy();
   }
-
-  // Poll external / S.PORT telemetry
-  // TODO: how to switch this OFF ???
-  pollExtTelemetryLegacy();
 
   for (int i=0; i<MAX_TELEMETRY_SENSORS; i++) {
     const TelemetrySensor & sensor = g_model.telemetrySensors[i];


### PR DESCRIPTION
## Issue description

External modules using the new module interface (direkt polling of telemetry based on driver) disabled legacy telemetry polling (S.PORT shared pin) to avoid confusing the telemetry parser. However, this fix (see #2504) was implemented poorly and removed sensor processing, which is done in the same function.

**External** modules / protocol impacted:
- `ACCESS`: `R9M ACCESS`
- `CRSF`: Crossfire, Tracer and ELRS

It would impact basically anything that is related to sensor processing:
- Vario sound (#2546)
- RF Link quality warnings (#2591)
- `Telemetry Lost` / `Telemetry Recovered` announcements
- Computed sensors (ex: Cell average)

## Fix

This PR fixes the issue by only skipping the polling itself, but not the sensor processing further down in the function.

Fixes #2546
Fixes #2591