### PR TITLE
Prevent OFF for internal module in hardware settings

### DIFF
--- a/radio/src/gui/colorlcd/hw_intmodule.cpp
+++ b/radio/src/gui/colorlcd/hw_intmodule.cpp
@@ -40,7 +40,7 @@ InternalModuleWindow::InternalModuleWindow(Window *parent) :
   FlexGridLayout grid(col_dsc, row_dsc, 2);
   setLayout(&grid);
 
-  new StaticText(this, rect_t{}, STR_MODE, 0, COLOR_THEME_PRIMARY1);
+  new StaticText(this, rect_t{}, STR_TYPE, 0, COLOR_THEME_PRIMARY1);
 
   auto box = new FormGroup(this, rect_t{});
   box->setFlexLayout(LV_FLEX_FLOW_ROW, lv_dpx(8));

--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -737,7 +737,6 @@ bool areModulesConflicting(int intModuleType, int extModuleType)
 bool isInternalModuleSupported(int moduleType)
 {
   switch(moduleType) {
-  case MODULE_TYPE_NONE: return true;
 #if defined(INTERNAL_MODULE_MULTI)
   case MODULE_TYPE_MULTIMODULE: return true;
 #endif


### PR DESCRIPTION
As it seems to confuse people and they are trying to set the internal module to `OFF` in the hardware settings, let's remove that possibility.

To make it clear once more:
- `Hardware Settings`: which module is installed in the radio (we don't actually support `OFF` here)
- `Model Settings`: should the internal module be turned `ON` or `OFF` for that model?
