### PR TITLE
fix(color): EXIT key handling

### DIFF
--- a/radio/src/gui/colorlcd/LvglWrapper.cpp
+++ b/radio/src/gui/colorlcd/LvglWrapper.cpp
@@ -157,8 +157,9 @@ static void keyboardDriverRead(lv_indev_drv_t *drv, lv_indev_data_t *data)
 
   // simulate EXIT release: necessary to map
   // EVT_KEY_BREAK(KEY_EXIT) to LV_EVENT_CANCEL
-  if (data->key == KEY_EXIT && data->state == LV_INDEV_STATE_PRESSED) {
+  if (data->key == LV_KEY_ESC && data->state == LV_INDEV_STATE_PRESSED) {
     data->state = LV_INDEV_STATE_RELEASED;
+    backup_kb_data(data);
   }
 }
 


### PR DESCRIPTION
This PR fixes an issue introduced in #2573.

What happens is the following:
- `KEY_EXIT` is pressed and released (`EVT_KEY_BREAK(KEY_EXIT)`)
- this gets translated into `[LV_KEY_ESC / LV_INDEV_STATE_PRESSED]`
- now, as the matching was wrong (`KEY_EXIT` instead of `LV_KEY_ESC`), the state would never become `LV_INDEV_STATE_RELEASED` again.
- any none LVGL key (anything apart from `ENTER` and `EXIT`) would then trigger a double `CANCEL`.
