### PR TITLE
fix(lua): [page down long] translation to [page up]

### DIFF
--- a/radio/src/lua/lua_widget.cpp
+++ b/radio/src/lua/lua_widget.cpp
@@ -169,7 +169,14 @@ void LuaEventHandler::onCancel()
 
 void LuaEventHandler::onEvent(event_t event)
 {
-  if (event == EVT_KEY_LONG(KEY_EXIT)) killEvents(KEY_EXIT);
+  if (event == EVT_KEY_LONG(KEY_EXIT)) {
+    killEvents(KEY_EXIT);
+  }
+#if !defined(KEYS_GPIO_REG_PGUP)
+  else if (event == EVT_KEY_LONG(KEY_PGDN)) {
+    killEvents(KEY_PGDN);
+  }
+#endif
   luaPushEvent(event);
 }
 


### PR DESCRIPTION
Suppress `EVT_KEY_BREAK(KEY_PGDN)` after `EVT_KEY_LONG(KEY_PGDN)` on targets which don't have a physical `KEY_PGUP`.

This way, the sequence is now clean: no more `EVT_VIRTUAL_NEXT_PAGE` emitted after `EVT_VIRTUAL_PREV_PAGE` on these targets.
