### PR TITLE
fix(cpn): ACCESS owner registration id validation (#2672)

### DIFF
--- a/companion/src/generaledit/generalsetup.cpp
+++ b/companion/src/generaledit/generalsetup.cpp
@@ -326,8 +326,6 @@ ui(new Ui::GeneralSetup)
     ui->vBatMaxDSB->hide();
   }
 
-  update();
-
   disableMouseScrolling();
 }
 
@@ -794,20 +792,4 @@ void GeneralSetupPanel::stickReverseEdited()
 {
   generalSettings.stickReverse = ((int)ui->stickReverse1->isChecked()) | ((int)ui->stickReverse2->isChecked()<<1) | ((int)ui->stickReverse3->isChecked()<<2) | ((int)ui->stickReverse4->isChecked()<<3);
   emit modified();
-}
-
-void GeneralSetupPanel::update()
-{
-  lock = true;
-
-  if (IS_ACCESS_RADIO(firmware->getBoard(), firmware->getId()) || generalSettings.internalModule == MODULE_TYPE_ISRM_PXX2) {
-    ui->label_registrationId->show();
-    ui->registrationId->show();
-  }
-  else {
-    ui->label_registrationId->hide();
-    ui->registrationId->hide();
-  }
-
-  lock = false;
 }

--- a/companion/src/generaledit/generalsetup.cpp
+++ b/companion/src/generaledit/generalsetup.cpp
@@ -322,6 +322,16 @@ ui(new Ui::GeneralSetup)
     ui->vBatMaxDSB->hide();
   }
 
+  if (IS_ACCESS_RADIO(firmware->getBoard(), firmware->getId())) {
+    QRegExp rx(CHAR_FOR_NAMES_REGEX);
+    ui->registrationId->setValidator(new QRegExpValidator(rx, this));
+    ui->registrationId->setMaxLength(REGISTRATION_ID_LEN);
+  }
+  else {
+    ui->label_registrationId->hide();
+    ui->registrationId->hide();
+  }
+
   disableMouseScrolling();
 }
 
@@ -460,8 +470,8 @@ void GeneralSetupPanel::setValues()
   ui->pwrOnDelay->setValue(2 - generalSettings.pwrOnSpeed);
   ui->pwrOffDelay->setValue(2 - generalSettings.pwrOffSpeed);
 
-    // TODO: only if ACCESS available??
-  ui->registrationId->setText(generalSettings.registrationId);
+  if (IS_ACCESS_RADIO(firmware->getBoard(), firmware->getId()))
+    ui->registrationId->setText(generalSettings.registrationId);
 }
 
 void GeneralSetupPanel::on_faimode_CB_stateChanged(int)
@@ -781,10 +791,7 @@ void GeneralSetupPanel::on_blAlarm_ChkB_stateChanged()
 
 void GeneralSetupPanel::on_registrationId_editingFinished()
 {
-  //copy ownerID back to generalSettings.registrationId
-  QByteArray array = ui->registrationId->text().toLocal8Bit();
-  strncpy(generalSettings.registrationId, array, 8);
-  generalSettings.registrationId[8] = '\0';
+  strncpy(generalSettings.registrationId, ui->registrationId->text().toLatin1(), REGISTRATION_ID_LEN);
   emit modified();
 }
 

--- a/companion/src/generaledit/generalsetup.cpp
+++ b/companion/src/generaledit/generalsetup.cpp
@@ -275,6 +275,10 @@ ui(new Ui::GeneralSetup)
     ui->pwrOnDelay->hide();
   }
 
+  QRegExp rx(CHAR_FOR_NAMES_REGEX);
+  ui->registrationId->setValidator(new QRegExpValidator(rx, this));
+  ui->registrationId->setMaxLength(REGISTRATION_ID_LEN);
+
   setValues();
 
   lock = false;
@@ -322,15 +326,7 @@ ui(new Ui::GeneralSetup)
     ui->vBatMaxDSB->hide();
   }
 
-  if (IS_ACCESS_RADIO(firmware->getBoard(), firmware->getId())) {
-    QRegExp rx(CHAR_FOR_NAMES_REGEX);
-    ui->registrationId->setValidator(new QRegExpValidator(rx, this));
-    ui->registrationId->setMaxLength(REGISTRATION_ID_LEN);
-  }
-  else {
-    ui->label_registrationId->hide();
-    ui->registrationId->hide();
-  }
+  update();
 
   disableMouseScrolling();
 }
@@ -470,8 +466,7 @@ void GeneralSetupPanel::setValues()
   ui->pwrOnDelay->setValue(2 - generalSettings.pwrOnSpeed);
   ui->pwrOffDelay->setValue(2 - generalSettings.pwrOffSpeed);
 
-  if (IS_ACCESS_RADIO(firmware->getBoard(), firmware->getId()))
-    ui->registrationId->setText(generalSettings.registrationId);
+  ui->registrationId->setText(generalSettings.registrationId);
 }
 
 void GeneralSetupPanel::on_faimode_CB_stateChanged(int)
@@ -799,4 +794,20 @@ void GeneralSetupPanel::stickReverseEdited()
 {
   generalSettings.stickReverse = ((int)ui->stickReverse1->isChecked()) | ((int)ui->stickReverse2->isChecked()<<1) | ((int)ui->stickReverse3->isChecked()<<2) | ((int)ui->stickReverse4->isChecked()<<3);
   emit modified();
+}
+
+void GeneralSetupPanel::update()
+{
+  lock = true;
+
+  if (IS_ACCESS_RADIO(firmware->getBoard(), firmware->getId()) || generalSettings.internalModule == MODULE_TYPE_ISRM_PXX2) {
+    ui->label_registrationId->show();
+    ui->registrationId->show();
+  }
+  else {
+    ui->label_registrationId->hide();
+    ui->registrationId->hide();
+  }
+
+  lock = false;
 }

--- a/companion/src/generaledit/generalsetup.h
+++ b/companion/src/generaledit/generalsetup.h
@@ -36,6 +36,8 @@ class GeneralSetupPanel : public GeneralPanel
     GeneralSetupPanel(QWidget *parent, GeneralSettings & generalSettings, Firmware * firmware);
     virtual ~GeneralSetupPanel();
 
+    virtual void update();
+
   private slots:
     void on_splashScreenChkB_stateChanged(int);
     void on_splashScreenDuration_currentIndexChanged(int index);

--- a/companion/src/generaledit/generalsetup.h
+++ b/companion/src/generaledit/generalsetup.h
@@ -36,8 +36,6 @@ class GeneralSetupPanel : public GeneralPanel
     GeneralSetupPanel(QWidget *parent, GeneralSettings & generalSettings, Firmware * firmware);
     virtual ~GeneralSetupPanel();
 
-    virtual void update();
-
   private slots:
     void on_splashScreenChkB_stateChanged(int);
     void on_splashScreenDuration_currentIndexChanged(int index);

--- a/companion/src/generaledit/generalsetup.ui
+++ b/companion/src/generaledit/generalsetup.ui
@@ -733,9 +733,6 @@
      </item>
      <item row="20" column="1">
       <widget class="QLineEdit" name="registrationId">
-       <property name="inputMask">
-        <string>nnnnnnNN</string>
-       </property>
        <property name="maxLength">
         <number>8</number>
        </property>
@@ -1046,7 +1043,7 @@
       </layout>
      </item>
      <item row="20" column="0">
-      <widget class="QLabel" name="label">
+      <widget class="QLabel" name="label_registrationId">
        <property name="text">
         <string>Owner Registration ID</string>
        </property>


### PR DESCRIPTION
Fixes #2672

Summary of changes:
- add standard name validation
- hide label and field if radio does not support ACCESS

Note: decision required on inconsistent validation across radios