### PR TITLE
fix(cpn): Align telemetry sensor subid with radios

### DIFF
--- a/companion/src/firmwares/edgetx/yaml_sensordata.cpp
+++ b/companion/src/firmwares/edgetx/yaml_sensordata.cpp
@@ -52,7 +52,7 @@ Node convert<SensorData>::encode(const SensorData& rhs)
     unsigned int instance = rhs.instance;
     if (instance != 0) {
       instance =
-          ((instance - 1) & 0x1F) | (rhs.rxIdx << 5) | (rhs.moduleIdx << 7);
+          ((instance) & 0x1F) | (rhs.rxIdx << 5) | (rhs.moduleIdx << 7);
     }
     node["id2"]["instance"] = instance;
     cfg["custom"]["ratio"] = rhs.ratio;
@@ -132,7 +132,7 @@ bool convert<SensorData>::decode(const Node& node, SensorData& rhs)
   if (rhs.type == SensorData::TELEM_TYPE_CUSTOM) {
     rhs.rxIdx = (rhs.instance >> 5) & 0x03;     // 2 bits Rx idx
     rhs.moduleIdx = (rhs.instance >> 7) & 0x1;  // 1 bit module idx
-    rhs.instance = (rhs.instance & 0x1F) + 1;   // 5 bits instance
+    rhs.instance = (rhs.instance & 0x1F);   // 5 bits instance
   }
 
   node["label"] >> rhs.label;

--- a/companion/src/firmwares/opentx/opentxeeprom.cpp
+++ b/companion/src/firmwares/opentx/opentxeeprom.cpp
@@ -2005,7 +2005,7 @@ class SensorField: public TransformedField {
       if (sensor.type == SensorData::TELEM_TYPE_CUSTOM) {
         _id = sensor.id;
         _subid = sensor.subid;
-        _instance = sensor.instance == 0 ? 0 : ((sensor.instance - 1) & 0x1F) | (sensor.rxIdx << 5) | (sensor.moduleIdx << 7);
+        _instance = sensor.instance == 0 ? 0 : ((sensor.instance) & 0x1F) | (sensor.rxIdx << 5) | (sensor.moduleIdx << 7);
         _ratio = sensor.ratio;
         _offset = sensor.offset;
       }
@@ -2032,7 +2032,7 @@ class SensorField: public TransformedField {
         else {
           sensor.id = _id;
           sensor.subid = _subid;
-          sensor.instance = (_instance & 0x1F) + (version <= 218 ? 0 : 1); // 5 bits instance
+          sensor.instance = (_instance & 0x1F); // 5 bits instance
           sensor.rxIdx = (_instance >> 5) & 0x03;    // 2 bits Rx idx
           sensor.moduleIdx = (_instance >> 7) & 0x1; // 1 bit module idx
           sensor.ratio = _ratio;


### PR DESCRIPTION
Fixes #2678 #2342
Partially fixes #2665

Summary of changes:
- do not offset subid/instance +1/-1 on settings read/write respectively