### PR TITLE
chore(compilation): silence some warning on apple silicon

### DIFF
--- a/cmake/toolchain/native.cmake
+++ b/cmake/toolchain/native.cmake
@@ -1,2 +1,6 @@
 # Native toolchain
 
+if(APPLE)
+  set(CMAKE_C_FLAGS "-Wno-asm-operand-widths -Wno-deprecated-declarations")
+  set(CMAKE_CXX_FLAGS "-Wno-asm-operand-widths -Wno-deprecated-declarations")
+endif()


### PR DESCRIPTION
When compiling `simu`, `clang` complains about all the StdPeriph headers declaring assembly with invalid operand width.