### PR TITLE
fix: Always show GPS button in radio setup

### DIFF
--- a/radio/src/gui/colorlcd/radio_setup.cpp
+++ b/radio/src/gui/colorlcd/radio_setup.cpp
@@ -545,7 +545,6 @@ class BacklightPage : public Page {
     }
 };
 
-#if defined(INTERNAL_GPS)
 class GpsPage : public Page {
   public:
 	GpsPage() :
@@ -583,7 +582,6 @@ class GpsPage : public Page {
       line = body.newLine(&grid);
     }
 };
-#endif
 
 RadioSetupPage::RadioSetupPage():
   PageTab(STR_RADIO_SETUP, ICON_RADIO_SETUP)
@@ -609,10 +607,8 @@ void RadioSetupPage::build(FormWindow * window)
 #endif
       {STR_ALARM, []() { new AlarmsPage(); }},
       {STR_BACKLIGHT_LABEL, []() { new BacklightPage(); }},
-#if defined(INTERNAL_GPS)
       {STR_GPS, [](){new GpsPage();}},
-#endif
-  });
+});
 
 
 #if defined(PWR_BUTTON_PRESS)

--- a/radio/src/translations/de.h
+++ b/radio/src/translations/de.h
@@ -404,13 +404,13 @@
 #else
 #define TR_GV                          TR("G", "GV")
 #endif
-#define TR_ACHANNEL                    TR("A\004gemessen", "A\004Kanal gemessen =>") // 9XR-Pro
-#define TR_RANGE                       TR(INDENT "Bereich", INDENT "Variobereich m/s") // 9XR-Pro
+#define TR_ACHANNEL                    TR("A\004gemessen", "A\004Kanal gemessen =>")
+#define TR_RANGE                       TR(INDENT "Bereich", INDENT "Variobereich m/s")
 #define TR_CENTER                      TR(INDENT "Mitte", INDENT "Variomitte     m/s")
 #define TR_BAR                         "Balken"
-#define TR_ALARM                       TR("Alarme ", "Alarme")  // 9XR-Pro
+#define TR_ALARM                       "Alarme"
 #define TR_USRDATA                     "Daten berechnen aus"
-#define TR_BLADES                      TR("Prop", "Prop-Blätter") // 9XR-Pro
+#define TR_BLADES                      TR("Prop", "Prop-Blätter")
 #define TR_SCREEN                      "Seite: "
 #define TR_SOUND_LABEL                 "Töne"
 #define TR_LENGTH                      "Dauer"

--- a/radio/src/translations/de.h
+++ b/radio/src/translations/de.h
@@ -408,7 +408,7 @@
 #define TR_RANGE                       TR(INDENT "Bereich", INDENT "Variobereich m/s") // 9XR-Pro
 #define TR_CENTER                      TR(INDENT "Mitte", INDENT "Variomitte     m/s")
 #define TR_BAR                         "Balken"
-#define TR_ALARM                       TR("Alarme ", "Aufleuchten bei Alarm")  // 9XR-Pro
+#define TR_ALARM                       TR("Alarme ", "Alarme")  // 9XR-Pro
 #define TR_USRDATA                     "Daten berechnen aus"
 #define TR_BLADES                      TR("Prop", "Prop-Blätter") // 9XR-Pro
 #define TR_SCREEN                      "Seite: "
@@ -443,7 +443,7 @@
 #define TR_MINUTEBEEP                  TR("Min-Alarm", "Minuten-Alarm")
 #define TR_BEEPCOUNTDOWN               INDENT "Countdown"
 #define TR_PERSISTENT                  TR(INDENT "Permanent", INDENT "Permanent")
-#define TR_BACKLIGHT_LABEL             "LCD-Beleuchtung"
+#define TR_BACKLIGHT_LABEL             "Bildschirm"
 #define TR_GHOST_MENU_LABEL            "GHOST MENU"
 #define TR_STATUS                      "Status"
 #define TR_BLDELAY                     INDENT "Dauer"


### PR DESCRIPTION
It is related to GPS telemetry, not internal GPS.
This probably needs to implemented differently in the future.

<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #2727

Summary of changes:
