### PR TITLE
de optimization

### DIFF
--- a/radio/src/translations/de.h
+++ b/radio/src/translations/de.h
@@ -443,7 +443,7 @@
 #define TR_MINUTEBEEP                  TR("Min-Alarm", "Minuten-Alarm")
 #define TR_BEEPCOUNTDOWN               INDENT "Countdown"
 #define TR_PERSISTENT                  TR(INDENT "Permanent", INDENT "Permanent")
-#define TR_BACKLIGHT_LABEL             "LCD"
+#define TR_BACKLIGHT_LABEL             "Bildschirm"
 #define TR_GHOST_MENU_LABEL            "GHOST MENU"
 #define TR_STATUS                      "Status"
 #define TR_BLDELAY                     INDENT "Dauer"

--- a/radio/src/translations/de.h
+++ b/radio/src/translations/de.h
@@ -408,7 +408,7 @@
 #define TR_RANGE                       TR(INDENT "Bereich", INDENT "Variobereich m/s") // 9XR-Pro
 #define TR_CENTER                      TR(INDENT "Mitte", INDENT "Variomitte     m/s")
 #define TR_BAR                         "Balken"
-#define TR_ALARM                       TR("Alarme ", "Aufleuchten bei Alarm")  // 9XR-Pro
+#define TR_ALARM                       TR("Alarme ", "Alarme")  // 9XR-Pro
 #define TR_USRDATA                     "Daten berechnen aus"
 #define TR_BLADES                      TR("Prop", "Prop-Blätter") // 9XR-Pro
 #define TR_SCREEN                      "Seite: "
@@ -443,7 +443,7 @@
 #define TR_MINUTEBEEP                  TR("Min-Alarm", "Minuten-Alarm")
 #define TR_BEEPCOUNTDOWN               INDENT "Countdown"
 #define TR_PERSISTENT                  TR(INDENT "Permanent", INDENT "Permanent")
-#define TR_BACKLIGHT_LABEL             "LCD-Beleuchtung"
+#define TR_BACKLIGHT_LABEL             "LCD"
 #define TR_GHOST_MENU_LABEL            "GHOST MENU"
 #define TR_STATUS                      "Status"
 #define TR_BLDELAY                     INDENT "Dauer"


### PR DESCRIPTION
since the GPS button is now displayed by default (#2732), the labels for the "Alarms" and "LCD" are much too long and thus GPS is pushed into a new line. This looks unattractive and is a waste of space

<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #

Summary of changes:
