### PR TITLE
cpn(fix): gyro and joystick

### DIFF
--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -432,13 +432,13 @@ int Boards::getCapability(Board::Type board, Board::Capability capability)
         return 0;
 
     case MouseAnalogs:
-      if (IS_HORUS_X12S(board))
+      if (IS_FAMILY_HORUS_OR_T16(board))
         return 2;
       else
         return 0;
 
     case GyroAnalogs:
-      if (IS_TARANIS_XLITES(board))
+      if (IS_TARANIS_XLITES(board) || IS_FAMILY_HORUS_OR_T16(board))
         return 2;
       else
         return 0;
@@ -591,12 +591,12 @@ StringTagMappingTable Boards::getAnalogNamesLookupTable(Board::Type board)
                               {"LS", "SLIDER3"},
                               {"RS", "SLIDER4"},
                           });
-  } else if (IS_TARANIS_XLITE(board)) {
+  } else if (IS_TARANIS_XLITES(board)) {
     tbl.insert(tbl.end(), {
                               {"S1", "POT1"},
                               {"S2", "POT2"},
-                              {"GyrX", "GYRO1"},
-                              {"GyrY", "GYRO2"},
+                              {"TltX", "TILT_X"},
+                              {"TltY", "TILT_Y"},
                           });
   } else if ((IS_TARANIS_SMALL(board) && !IS_JUMPER_TLITE(board)) || IS_FLYSKY_NV14(board)) {
     tbl.insert(tbl.end(), {
@@ -622,6 +622,8 @@ StringTagMappingTable Boards::getAnalogNamesLookupTable(Board::Type board)
                               {"RS", "RS"},
                               {"JSx", "MOUSE1"},
                               {"JSy", "MOUSE2"},
+                              {"TltX", "TILT_X"},
+                              {"TltY", "TILT_Y"},
                           });
   } else if (IS_HORUS_X10(board) || IS_FAMILY_T16(board)) {
     tbl.insert(tbl.end(), {
@@ -634,6 +636,10 @@ StringTagMappingTable Boards::getAnalogNamesLookupTable(Board::Type board)
                               {"EX4", "EXT4"},
                               {"LS", "LS"},
                               {"RS", "RS"},
+                              {"JSx", "MOUSE1"},
+                              {"JSy", "MOUSE2"},
+                              {"TltX", "TILT_X"},
+                              {"TltY", "TILT_Y"},
                           });
   }
 

--- a/companion/src/firmwares/edgetx/yaml_rawsource.cpp
+++ b/companion/src/firmwares/edgetx/yaml_rawsource.cpp
@@ -250,6 +250,16 @@ RawSource YamlRawSourceDecode(const std::string& src_str)
     YAML::Node node(src_str);
     std::string ana_str;
     node >> ana_str;
+
+    // 2.8 conversion of GYRO1 and GYRO2 to TILT_X and TILT_Y respectively
+    if (ana_str.size() == 5) {
+      if (ana_str.substr(0, 5) == "GYRO1") {
+        ana_str = "TILT_X";
+      } else if (ana_str.substr(0, 5) == "GYRO2") {
+        ana_str = "TILT_Y";
+      }
+    }
+
     int ana_idx = getCurrentFirmware()->getAnalogInputIndex(ana_str.c_str());
     if (ana_idx >= 0) {
       rhs.type = SOURCE_TYPE_STICK;

--- a/companion/src/firmwares/opentx/opentxeeprom.cpp
+++ b/companion/src/firmwares/opentx/opentxeeprom.cpp
@@ -29,8 +29,6 @@
 using namespace Board;
 
 #define MAX_VIEWS(board)                      (HAS_LARGE_LCD(board) ? 2 : 256)
-#define MAX_GYRO_ANALOGS(board, version)      (version >= 219 ? Boards::getCapability(board, Board::GyroAnalogs) : 0)
-
 inline int MAX_SWITCHES(Board::Type board, int version)
 {
   if (version <= 218) {
@@ -186,6 +184,16 @@ inline int MAX_MOUSE_ANALOG_SOURCES(Board::Type board, int version)
     return 2;
   else
     return 0;
+}
+
+inline int MAX_GYRO_ANALOGS(Board::Type board, int version)
+{
+  if (version <= 220) {
+    if (IS_FAMILY_HORUS_OR_T16(board))
+      return 0;
+  }
+
+  return Boards::getCapability(board, Board::GyroAnalogs);
 }
 
 #define MAX_ROTARY_ENCODERS(board)            0


### PR DESCRIPTION
Fixes #2694

Summary of changes:
- align gyro and joysticks for X10, X12S and X Lite to radios
- add yaml conversion for GYRO1 and GYRO2 to TILT-X and TILT-Y
- add bin conversion