### PR TITLE
fix(MSD): confirmation dialog properly shown

### DIFF
--- a/radio/src/gui/colorlcd/fullscreen_dialog.cpp
+++ b/radio/src/gui/colorlcd/fullscreen_dialog.cpp
@@ -25,10 +25,17 @@
 #include "opentx.h"
 #include "libopenui.h"
 
+static Window* _get_parent()
+{
+  Window* p = Layer::back();
+  if (!p) p = MainWindow::instance();
+  return p;
+}
+
 FullScreenDialog::FullScreenDialog(
     uint8_t type, std::string title, std::string message, std::string action,
     const std::function<void(void)>& confirmHandler) :
-    Window(Layer::back(), {0, 0, LCD_W, LCD_H}, OPAQUE),
+    Window(_get_parent(), {0, 0, LCD_W, LCD_H}, OPAQUE),
     type(type),
     title(std::move(title)),
     message(std::move(message)),


### PR DESCRIPTION
Prior to this fix, the confirmation dialog would crash because of an issue in libopenui and even then would not be displayed for the lack of the proper parent window.

Fixes #2741

Summary of changes:
- fix `libopenui` to properly check validity of pointers before passing objects to LVGL functions (`lv_obj_move_foreground`)
- use the most suitable parent when creating a confirmation dialog