### PR TITLE
fix a bunch of warnings

### DIFF
--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -431,7 +431,9 @@ void editTimerCountdown(int timerIdx, coord_t y, LcdFlags attr, event_t event)
 #endif
 
 static const char* _pots_warn_modes[] = { "OFF", "Man", "Auto" };
+#if defined(FUNCTION_SWITCHES)
 static const char* _fct_sw_start[] = { STR_CHAR_UP, STR_CHAR_DOWN, "=" };
+#endif
 
 void menuModelSetup(event_t event)
 {
@@ -816,7 +818,6 @@ void menuModelSetup(event_t event)
           }
 
           swarnstate_t states = g_model.switchWarningState;
-          char c;
 
           lcdDrawTextAlignedLeft(y, STR_SWITCHWARNING);
 #if defined(PCBXLITE)

--- a/radio/src/gui/128x64/radio_setup.cpp
+++ b/radio/src/gui/128x64/radio_setup.cpp
@@ -136,7 +136,9 @@ void menuRadioSetup(event_t event)
   }
 #endif
 
+#if defined(PXX2)
   uint8_t old_editMode = s_editMode;
+#endif
 
   MENU(STR_RADIO_SETUP, menuTabGeneral, MENU_RADIO_SETUP, HEADER_LINE+ITEM_RADIO_SETUP_MAX, {
     HEADER_LINE_COLUMNS CASE_RTCLOCK(2) CASE_RTCLOCK(2) CASE_BATTGRAPH(1)

--- a/radio/src/gui/212x64/model_setup.cpp
+++ b/radio/src/gui/212x64/model_setup.cpp
@@ -730,7 +730,7 @@ void menuModelSetup(event_t event)
 #endif
         lcdDrawTextAlignedLeft(y, STR_SWITCHWARNING);
         swarnstate_t states = g_model.switchWarningState;
-        char c;
+
         if (attr) {
           s_editMode = 0;
           if (!READ_ONLY()) {

--- a/radio/src/gui/212x64/radio_setup.cpp
+++ b/radio/src/gui/212x64/radio_setup.cpp
@@ -123,7 +123,9 @@ void menuRadioSetup(event_t event)
   }
 #endif
 
+#if defined(PXX2)
   uint8_t old_editMode = s_editMode;
+#endif
 
   MENU(STR_RADIO_SETUP, menuTabGeneral, MENU_RADIO_SETUP, ITEM_RADIO_SETUP_MAX, {
     2, // date

--- a/radio/src/gui/colorlcd/LvglWrapper.cpp
+++ b/radio/src/gui/colorlcd/LvglWrapper.cpp
@@ -31,9 +31,11 @@ LvglWrapper* LvglWrapper::_instance = nullptr;
 
 static lv_indev_drv_t touchDriver;
 static lv_indev_drv_t keyboard_drv;
+#if defined(ROTARY_ENCODER_NAVIGATION)
 static lv_indev_drv_t rotaryDriver;
 
 static lv_indev_t* rotaryDevice = nullptr;
+#endif
 static lv_indev_t* keyboardDevice = nullptr;
 static lv_indev_t* touchDevice = nullptr;
 

--- a/radio/src/gui/colorlcd/access_settings.cpp
+++ b/radio/src/gui/colorlcd/access_settings.cpp
@@ -153,8 +153,6 @@ void BindWaitDialog::checkEvents()
 {
   auto& bindInfo = getPXX2BindInformationBuffer();
 
-  auto form = &content->form;
-
   if (moduleState[moduleIdx].mode == MODULE_MODE_NORMAL) {
 
     // returned to normal after bind
@@ -842,8 +840,8 @@ void RxOptions::update()
           selectionMax++;
     }
 
-    uint8_t mapping = hwSettings.receiverSettings.outputsMapping[i];
-    uint8_t channel = getShiftedChannel(moduleIdx, mapping);
+    //uint8_t mapping = hwSettings.receiverSettings.outputsMapping[i];
+    // uint8_t channel = getShiftedChannel(moduleIdx, mapping);
 
     // TODO
     // auto r = grid.getFieldSlot(2, 1);

--- a/radio/src/gui/colorlcd/input_mix_group.cpp
+++ b/radio/src/gui/colorlcd/input_mix_group.cpp
@@ -57,7 +57,7 @@ InputMixGroup::InputMixGroup(Window* parent, mixsrc_t idx) :
   if (idx >= MIXSRC_FIRST_CH && idx <= MIXSRC_LAST_CH
       && g_model.limitData[idx - MIXSRC_CH1].name[0] != '\0') {
     chText = lv_label_create(lvobj);
-    lv_label_set_text_fmt(chText, TR_CH "%u", idx - MIXSRC_CH1 + 1);
+    lv_label_set_text_fmt(chText, TR_CH "%zu", (size_t)(idx - MIXSRC_CH1 + 1));
     lv_obj_set_style_text_font(chText, getFont(FONT(XS)), 0);
 #if LCD_H > LCD_W
     lv_obj_set_style_pad_bottom(chText, -2, 0);

--- a/radio/src/gui/colorlcd/input_source.cpp
+++ b/radio/src/gui/colorlcd/input_source.cpp
@@ -122,20 +122,19 @@ InputSource::InputSource(Window* parent, ExpoData* input) :
 
   sensor_form = new FormGroup(this, rect_t{});
   sensor_form->setFlexLayout();
-  auto sensor_form_obj = sensor_form->getLvObj();
 
   FlexGridLayout grid(col_dsc, row_dsc);
   auto line = sensor_form->newLine(&grid);
 
   // Value
-  Window* w = new StaticText(line, rect_t{}, STR_VALUE, 0, COLOR_THEME_PRIMARY1);
+  new StaticText(line, rect_t{}, STR_VALUE, 0, COLOR_THEME_PRIMARY1);
   auto sensor = new SensorValue(line, rect_t{}, input);
 
 
   // Scale
   line = sensor_form->newLine(&grid);
-  w = new StaticText(line, rect_t{}, STR_SCALE, 0, COLOR_THEME_PRIMARY1);
-  w = new NumberEdit(line, rect_t{}, 0,
+  new StaticText(line, rect_t{}, STR_SCALE, 0, COLOR_THEME_PRIMARY1);
+  new NumberEdit(line, rect_t{}, 0,
                  maxTelemValue(input->srcRaw - MIXSRC_FIRST_TELEM + 1),
                  GET_SET_DEFAULT(input->scale), 0, sensor->getSensorPrec());
 

--- a/radio/src/gui/colorlcd/layouts/sliders.cpp
+++ b/radio/src/gui/colorlcd/layouts/sliders.cpp
@@ -106,11 +106,13 @@ void MainView6POS::paint(BitmapBuffer * dc)
 void MainView6POS::checkEvents()
 {
   Window::checkEvents();
+#if NUM_XPOTS > 0 // prevent compiler warning
   int16_t newValue = 1 + (potsPos[idx] & 0x0f);
   if (value != newValue) {
     value = newValue;
     invalidate();
   }
+#endif
 }
 
 MainViewVerticalSlider::MainViewVerticalSlider(Window* parent, uint8_t idx) :

--- a/radio/src/gui/colorlcd/lcd.cpp
+++ b/radio/src/gui/colorlcd/lcd.cpp
@@ -58,7 +58,7 @@ void lcdSetFlushCb(void (*cb)(lv_disp_drv_t *, uint16_t*, const rect_t&))
 
 static lv_disp_drv_t* refr_disp = nullptr;
 
-#if !defined(LCD_VERTICAL_INVERT)
+#if !defined(LCD_VERTICAL_INVERT) && 0
 // TODO: DMA copy would be possible (use function from draw_ctx???
 static void _copy_screen_area(uint16_t* dst, uint16_t* src, const lv_area_t& copy_area)
 {

--- a/radio/src/gui/colorlcd/model_inputs.cpp
+++ b/radio/src/gui/colorlcd/model_inputs.cpp
@@ -145,7 +145,7 @@ class InputLineButton : public InputMixButton
 
     if (line.name[0]) {
       int cnt = lv_snprintf(s, maxlen, "%.*s ", (int)sizeof(line.name), line.name);
-      if (cnt >= maxlen) maxlen = 0;
+      if ((size_t)cnt >= maxlen) maxlen = 0;
       else { maxlen -= cnt; s += cnt; }
     }
 
@@ -153,13 +153,13 @@ class InputLineButton : public InputMixButton
        if (line.swtch) {
          char* sw_pos = getSwitchPositionName(line.swtch);
          int cnt = lv_snprintf(s, maxlen, "%s ", sw_pos);
-         if (cnt >= maxlen) maxlen = 0;
+         if ((size_t)cnt >= maxlen) maxlen = 0;
          else { maxlen -= cnt; s += cnt; }
        }
        if (line.curve.value != 0) {
          getCurveRefString(s, maxlen, line.curve);
          int cnt = strnlen(s, maxlen);
-         if (cnt >= maxlen) maxlen = 0;
+         if ((size_t)cnt >= maxlen) maxlen = 0;
          else { maxlen -= cnt; s += cnt; }
        }
     }

--- a/radio/src/gui/colorlcd/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model_mixes.cpp
@@ -267,7 +267,7 @@ void MixLineButton::refresh()
 
   if (line.name[0]) {
     int cnt = lv_snprintf(s, maxlen, "%.*s ", (int)sizeof(line.name), line.name);
-    if (cnt >= maxlen) maxlen = 0;
+    if ((size_t)cnt >= maxlen) maxlen = 0;
     else { maxlen -= cnt; s += cnt; }
   }
 
@@ -275,13 +275,13 @@ void MixLineButton::refresh()
     if (line.swtch) {
       char* sw_pos = getSwitchPositionName(line.swtch);
       int cnt = lv_snprintf(s, maxlen, "%s ", sw_pos);
-      if (cnt >= maxlen) maxlen = 0;
+      if ((size_t)cnt >= maxlen) maxlen = 0;
       else { maxlen -= cnt; s += cnt; }
     }
     if (line.curve.value != 0) {
       getCurveRefString(s, maxlen, line.curve);
       int cnt = strnlen(s, maxlen);
-      if (cnt >= maxlen) maxlen = 0;
+      if ((size_t)cnt >= maxlen) maxlen = 0;
       else { maxlen -= cnt; s += cnt; }
     }
   }

--- a/radio/src/gui/colorlcd/model_telemetry.cpp
+++ b/radio/src/gui/colorlcd/model_telemetry.cpp
@@ -466,12 +466,12 @@ void ModelTelemetryPage::build(FormWindow * window, int8_t focusSensorIndex)
   grid.nextLine();
 
   new StaticText(window, grid.getLabelSlot(true), STR_LOWALARM, 0, COLOR_THEME_PRIMARY1);
-  auto edit = new NumberEdit(window, grid.getFieldSlot(), 0, 100,
+  new NumberEdit(window, grid.getFieldSlot(), 0, 100,
                              GET_SET_DEFAULT(g_model.rfAlarms.warning));
   grid.nextLine();
 
   new StaticText(window, grid.getLabelSlot(true), STR_CRITICALALARM, 0, COLOR_THEME_PRIMARY1);
-  edit = new NumberEdit(window, grid.getFieldSlot(), 0, 100,
+  new NumberEdit(window, grid.getFieldSlot(), 0, 100,
                         GET_SET_DEFAULT(g_model.rfAlarms.critical));
   grid.nextLine();
 

--- a/radio/src/gui/colorlcd/preview_window.h
+++ b/radio/src/gui/colorlcd/preview_window.h
@@ -293,7 +293,7 @@ class PreviewWindow : public FormGroup
 
     gettime(&t);
     int s = snprintf(str, sizeof(str), "%d %s\n", t.tm_mday, STR_MONTHS[t.tm_mon]);
-    if (s > 0 && s < sizeof(str) - 6 /* 00:00\0 */) {
+    if (s > 0 && (size_t)s < sizeof(str) - 6 /* 00:00\0 */) {
       getTimerString(str + s, getValue(MIXSRC_TX_TIME));
     }
     dc->drawText(rect.w - 40, 5, str, COLOR_THEME_PRIMARY2 | FONT(XS));

--- a/radio/src/gui/colorlcd/splash.cpp
+++ b/radio/src/gui/colorlcd/splash.cpp
@@ -52,9 +52,6 @@ void draw_splash_cb(lv_event_t * e)
 
 void drawSplash()
 {
-  constexpr LcdFlags splash_background_color =
-    COLOR2FLAGS(((0xC >> 3) << 11) | ((0x3F >> 2) << 5) | (0x66 >> 3));
-
   static bool loadSplashImg = true;
   static BitmapBuffer* splashImg = nullptr;
   static lv_obj_t* splashScreen = nullptr;

--- a/radio/src/gui/common/stdlcd/radio_sdmanager.cpp
+++ b/radio/src/gui/common/stdlcd/radio_sdmanager.cpp
@@ -372,7 +372,7 @@ void menuRadioSdManager(event_t _event)
       break;
 
     case EVT_KEY_LONG(KEY_ENTER):
-#if !defined(PCBX9) && !defined(RADIO_X7) && !defined(RADIO_X7ACCESS) // TODO NO_HEADER_LINE
+#if (HEADER_LINE > 0) && !defined(PCBX9) && !defined(RADIO_X7) && !defined(RADIO_X7ACCESS) // TODO NO_HEADER_LINE
       if (menuVerticalPosition < HEADER_LINE) {
         killEvents(_event);
         POPUP_MENU_ADD_ITEM(STR_SD_INFO);

--- a/radio/src/gui/common/stdlcd/radio_version.cpp
+++ b/radio/src/gui/common/stdlcd/radio_version.cpp
@@ -151,8 +151,8 @@ void menuRadioModulesVersion(event_t event)
 #if defined(CROSSFIRE)
       if (isModuleCrossfire(module)) {
         char statusText[64] = "";
-        sprintf(statusText, "%d Hz %lu Err",
-                1000000 / getMixerSchedulerPeriod(), telemetryErrors);
+        sprintf(statusText, "%d Hz %zu Err",
+                1000000 / getMixerSchedulerPeriod(), (size_t)telemetryErrors);
         lcdDrawText(COLUMN2_X, y, statusText);
         y += FH;
         continue;

--- a/radio/src/gui/common/stdlcd/utf8.cpp
+++ b/radio/src/gui/common/stdlcd/utf8.cpp
@@ -72,7 +72,7 @@ static wchar_t _utf8_lut[] = {
 #if !defined(NO_UTF8_LUT)
 static unsigned char lookup_utf8_mapping(wchar_t w)
 {
-  for (int i=0; i < DIM(_utf8_lut); i++) {
+  for (uint32_t i=0; i < DIM(_utf8_lut); i++) {
     if (w == _utf8_lut[i])
       return 0x95 + (uint8_t)i; // TODO: use constant
   }

--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -342,7 +342,7 @@ bool isSwitchAvailable(int swtch, SwitchContext context)
 
 #if NUM_XPOTS > 0
   if (swtch >= SWSRC_FIRST_MULTIPOS_SWITCH && swtch <= SWSRC_LAST_MULTIPOS_SWITCH) {
-    int index = (swtch - SWSRC_FIRST_MULTIPOS_SWITCH) / XPOTS_MULTIPOS_COUNT;
+    int index __attribute__((unused)) = (swtch - SWSRC_FIRST_MULTIPOS_SWITCH) / XPOTS_MULTIPOS_COUNT;
     return IS_POT_MULTIPOS(POT1+index);
   }
 #endif

--- a/radio/src/gui/screenshot.cpp
+++ b/radio/src/gui/screenshot.cpp
@@ -88,7 +88,7 @@ const char * writeScreenshot()
   auto h = snapshot->header.h;
 
   for (int y = h - 1; y >= 0; y--) {
-    for (int x = 0; x < w; x++) {
+    for (uint32_t x = 0; x < w; x++) {
 
       lv_color_t pixel = lv_img_buf_get_px_color(snapshot, x, y, {});
 

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -2587,7 +2587,7 @@ static int luaSources(lua_State * L)
 static int luaGetOutputValue(lua_State * L)
 {
   mixsrc_t idx = luaL_checkinteger(L, 1);
-  if (idx < MAX_OUTPUT_CHANNELS) {
+  if (idx < MAX_OUTPUT_CHANNELS) {           // mixsrc_t is unsigned, no need to check for <0
     lua_pushinteger(L, channelOutputs[idx]);
   } else {
     lua_pushinteger(L, 0);

--- a/radio/src/simu.cpp
+++ b/radio/src/simu.cpp
@@ -544,7 +544,9 @@ void OpenTxSim::refreshDisplay()
 
 #if !defined(COLORLCD)
     FXColor offColor = isBacklightEnabled() ? BL_COLOR : FXRGB(200, 200, 200);
+#if LCD_DEPTH == 1
     FXColor onColor = FXRGB(0, 0, 0);
+#endif
 #endif
     for (int x = 0; x < LCD_W; x++) {
       for (int y = 0; y < LCD_H; y++) {

--- a/radio/src/targets/common/arm/stm32/intmodule_serial_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/intmodule_serial_driver.cpp
@@ -184,8 +184,8 @@ void intmoduleSendBuffer(void* ctx, const uint8_t * data, uint8_t size)
 
 void intmoduleWaitForTxCompleted(void* ctx)
 {
-  auto modCtx = (IntmoduleCtx*)ctx;
 #if defined(INTMODULE_DMA_STREAM)
+  auto modCtx = (IntmoduleCtx*)ctx;
   stm32_usart_wait_for_tx_dma(modCtx->usart);
 #else
   while (intmoduleTxBufferRemaining > 0);

--- a/radio/src/targets/nv14/bootloader/boot_menu.cpp
+++ b/radio/src/targets/nv14/bootloader/boot_menu.cpp
@@ -107,8 +107,6 @@ static void bootloaderDrawBackground()
 
 void bootloaderDrawScreen(BootloaderState st, int opt, const char* str)
 {
-    static bool _first_screen = true;
-
     lcdInitDirectDrawing();
     bootloaderDrawBackground();
 
@@ -249,8 +247,6 @@ void bootloaderDrawScreen(BootloaderState st, int opt, const char* str)
       pos -= 79;
       lcd->drawSolidRect(79, 72 + (opt * 35), pos, 26, 2, BL_SELECTED);
     }
-
-    _first_screen = false;
 }
 
 void bootloaderDrawFilename(const char* str, uint8_t line, bool selected)

--- a/radio/src/targets/simu/simulcd.cpp
+++ b/radio/src/targets/simu/simulcd.cpp
@@ -57,7 +57,7 @@ static pixel_t _LCD_BUF2[DISPLAY_BUFFER_SIZE] __SDRAM;
 
 pixel_t* simuLcdBuf = _LCD_BUF1;
 pixel_t* simuLcdBackBuf = _LCD_BUF2;
-
+#if 0
 // Copy 2 pixels at once to speed up a little
 static void _copy_rotate_180(uint16_t* dst, uint16_t* src, const rect_t& copy_area)
 {
@@ -101,7 +101,7 @@ static void _rotate_area_180(lv_area_t& area)
   area.x2 = LCD_W - area.x1 - 1;
   area.x1 = LCD_W - tmp_coord - 1;
 }
-
+#endif
 static void _copy_screen_area(uint16_t* dst, uint16_t* src, const lv_area_t& copy_area)
 {
   lv_coord_t x1 = copy_area.x1;


### PR DESCRIPTION
Summary of changes:
fixes warning for simu and firmware for all targets
Some warnings are still in there:
colorlcd/color_edit.cpp, because I did not understand the intention of the code there
some string copy operations still create warnings in simu, because of a strict target size check
some warnings in lvgl will not be fixed 
