### PR TITLE
add setDefault() to PPM Center

### DIFF
--- a/radio/src/gui/colorlcd/output_edit.cpp
+++ b/radio/src/gui/colorlcd/output_edit.cpp
@@ -189,6 +189,7 @@ void OutputEditWindow::buildBody(FormWindow* form)
                                SET_VALUE(output->ppmCenter, newValue - PPM_CENTER));
   center->setFastStep(20);
   center->setAccelFactor(8);
+  center->setDefault(PPM_CENTER);
 
   // Subtrims mode
   label = new StaticText(line, rect_t{}, TR_LIMITS_HEADERS_SUBTRIMMODE, 0,


### PR DESCRIPTION

Fixes #2757 

Summary of changes: add getDefault() to the PPM center numberEdit()
