### PR TITLE
Switch color labels in the widget editor between HSV and RGB (#2773)

### DIFF
--- a/radio/src/gui/colorlcd/color_editor.cpp
+++ b/radio/src/gui/colorlcd/color_editor.cpp
@@ -334,25 +334,39 @@ void ColorEditor::setColorEditorType(COLOR_EDITOR_TYPE colorType)
   if (_colorType != nullptr) {
     delete _colorType;
   }
-  if (colorType == RGB_COLOR_EDITOR) 
+  if (colorType == RGB_COLOR_EDITOR) {
     _colorType = new RGBColorType(this, _color);
-  else
+    setRGB();
+  } else {
     _colorType = new HSVColorType(this, _color);
+    setHSV();
+  }
   invalidate();
 }
 
-void ColorEditor::setRGB()
+void ColorEditor::setText()
 {
-  _color = _colorType->getRGB();
-
-  // update bars & labels
   for (int i = 0; i < MAX_BARS; i++) {
     auto bar = _colorType->bars[i];
+    lv_label_set_text_static(barLabels[i], _colorType->getLabelChars()[i]);
     lv_label_set_text_fmt(barValLabels[i], "%" PRIu32, bar->value);
     bar->invalidate();
   }
 
   if (_setValue != nullptr) _setValue(_color);
+}
+
+void ColorEditor::setRGB()
+{
+  _color = _colorType->getRGB();
+  // update bars & labels
+  setText();
+}
+
+void ColorEditor::setHSV()
+{
+  // update bars & labels
+  setText();
 }
 
 void ColorEditor::value_changed(lv_event_t* e)

--- a/radio/src/gui/colorlcd/color_editor.h
+++ b/radio/src/gui/colorlcd/color_editor.h
@@ -97,6 +97,8 @@ class ColorEditor : public FormGroup
   std::function<void(uint32_t)> _setValue;
   uint32_t _color;
 
+  void setText();
+  void setHSV();
   void setRGB();
   static void value_changed(lv_event_t* e);
 };


### PR DESCRIPTION
Fixes #2773 

Summary of changes: call setRGB() to change the labels.
Includes some code refactoring.
