### PR TITLE
Show model notes when switching to a different model (#2722)

### DIFF
--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -397,8 +397,12 @@ void ModelsPageBody::selectModel(ModelCell *model)
   storageCheck(true);
 
   // Exit to main view
-  auto w = Layer::back();
-  if (w) w->onCancel();
+  // If modelNotes are displayed this happens in the
+  // ~ViewTextWindow()
+  if (!(g_model.displayChecklist && modelHasNotes())) {
+    auto w = Layer::back();
+    if (w) w->onCancel();
+  }
 }
 
 void ModelsPageBody::duplicateModel(ModelCell* model)

--- a/radio/src/gui/colorlcd/view_text.h
+++ b/radio/src/gui/colorlcd/view_text.h
@@ -28,6 +28,7 @@
 #include "sdcard.h"
 
 #include "LvglWrapper.h"
+#include "Layer.h"
 
 constexpr int maxTxtBuffSize = 64 * 1024;
 
@@ -54,6 +55,8 @@ class ViewTextWindow : public Page
       free(buffer);
       buffer = nullptr;
     }
+    auto w = Layer::back();
+    if (w) w->onCancel();
   }
 
 #if defined(DEBUG_WINDOWS)

--- a/radio/src/gui/colorlcd/view_text.h
+++ b/radio/src/gui/colorlcd/view_text.h
@@ -28,7 +28,7 @@
 #include "sdcard.h"
 
 #include "LvglWrapper.h"
-#include "Layer.h"
+#include "layer.h"
 
 constexpr int maxTxtBuffSize = 64 * 1024;
 


### PR DESCRIPTION

Fixes #2722 

Summary of changes: change layers manipulation for model selection.

I'm not sure this is the proper solution, but I do have doubts about the whole idea to reshuffle the stack without deleting the object. 
