### PR TITLE
Check FM Trims translateable for color radios

### DIFF
--- a/radio/src/gui/colorlcd/model_flightmodes.cpp
+++ b/radio/src/gui/colorlcd/model_flightmodes.cpp
@@ -324,7 +324,7 @@ void ModelFlightModesPage::build(FormWindow * window)
     new FlightModeBtn(fm_box, i);
   }
 
-  new TextButton(window, rect_t{}, "Check FM Trims", [&]() -> uint8_t {
+  new TextButton(window, rect_t{}, STR_CHECKTRIMS, [&]() -> uint8_t {
     if (trimsCheckTimer)
       trimsCheckTimer = 0;
     else

--- a/radio/src/translations/cn.h
+++ b/radio/src/translations/cn.h
@@ -353,9 +353,9 @@
 #define TR_FADEOUT                     "渐出"
 #define TR_DEFAULT                     "(默认)"
 #if defined(COLORLCD)
-  #define TR_CHECKTRIMS "检查当前飞行模式微调"
+  #define TR_CHECKTRIMS                "检查当前飞行模式微调"
 #else
-  #define TR_CHECKTRIMS "\006检查\012微调"
+  #define TR_CHECKTRIMS                "\006检查\012微调"
 #endif
 #define OFS_CHECKTRIMS                 CENTER_OFS+(9*FW)
 #define TR_SWASHTYPE                   "斜盘类型"

--- a/radio/src/translations/cn.h
+++ b/radio/src/translations/cn.h
@@ -353,9 +353,9 @@
 #define TR_FADEOUT                     "渐出"
 #define TR_DEFAULT                     "(默认)"
 #if defined(COLORLCD)
-  #define TR_CHECKTRIMS                "Check FM Trims"
+  #define TR_CHECKTRIMS "检查当前飞行模式微调"
 #else
-  #define TR_CHECKTRIMS                "\006Check\012trims"
+  #define TR_CHECKTRIMS "\006检查\012微调"
 #endif
 #define OFS_CHECKTRIMS                 CENTER_OFS+(9*FW)
 #define TR_SWASHTYPE                   "斜盘类型"

--- a/radio/src/translations/cn.h
+++ b/radio/src/translations/cn.h
@@ -352,7 +352,11 @@
 #define TR_FADEIN                      "渐入"
 #define TR_FADEOUT                     "渐出"
 #define TR_DEFAULT                     "(默认)"
-#define TR_CHECKTRIMS                  "\006Check\012trims"
+#if defined(COLORLCD)
+  #define TR_CHECKTRIMS                "Check FM Trims"
+#else
+  #define TR_CHECKTRIMS                "\006Check\012trims"
+#endif
 #define OFS_CHECKTRIMS                 CENTER_OFS+(9*FW)
 #define TR_SWASHTYPE                   "斜盘类型"
 #define TR_COLLECTIVE                  TR("螺距源", "螺距混控源")

--- a/radio/src/translations/cz.h
+++ b/radio/src/translations/cz.h
@@ -375,7 +375,7 @@
 #if defined(COLORLCD)
   #define TR_CHECKTRIMS                "Kontrolovat trimy"
 #else
-  #define TR_CHECKTRIMS                "\011Kont.\010Trimy"
+  #define TR_CHECKTRIMS                "\006Kont.\012Trimy"
 #endif
 #define OFS_CHECKTRIMS                 (9*FW)
 #define TR_SWASHTYPE                   "Typ cykliky"

--- a/radio/src/translations/cz.h
+++ b/radio/src/translations/cz.h
@@ -376,8 +376,9 @@
   #define TR_CHECKTRIMS                "Kontrolovat trimy"
 #else
   #define TR_CHECKTRIMS                "\011Kont.\010Trimy"
-#endif#define OFS_CHECKTRIMS                 (9*FW)
-define TR_SWASHTYPE                   "Typ cykliky"
+#endif
+#define OFS_CHECKTRIMS                 (9*FW)
+#define TR_SWASHTYPE                   "Typ cykliky"
 #define TR_COLLECTIVE                  "Kolektiv"
 #define TR_AILERON                     "Boční cyklika"
 #define TR_ELEVATOR                    TR3("Podélná cykl.", "Podélná cykl.", "Podélná cyklika")

--- a/radio/src/translations/cz.h
+++ b/radio/src/translations/cz.h
@@ -372,7 +372,11 @@
 #define TR_FADEIN                      "Přechod Zap"
 #define TR_FADEOUT                     "Přechod Vyp"
 #define TR_DEFAULT                     "(výchozí)"
-#define TR_CHECKTRIMS                  "\011Kont.\010Trimy"
+#if defined(COLORLCD)
+  #define TR_CHECKTRIMS                "Kont. Trimy"
+#else
+  #define TR_CHECKTRIMS                "\011Kont.\010Trimy"
+#endif
 #define OFS_CHECKTRIMS                 (9*FW)
 #define TR_SWASHTYPE                   "Typ cykliky"
 #define TR_COLLECTIVE                  "Kolektiv"

--- a/radio/src/translations/cz.h
+++ b/radio/src/translations/cz.h
@@ -373,12 +373,11 @@
 #define TR_FADEOUT                     "Přechod Vyp"
 #define TR_DEFAULT                     "(výchozí)"
 #if defined(COLORLCD)
-  #define TR_CHECKTRIMS                "Kont. Trimy"
+  #define TR_CHECKTRIMS                "Kontrolovat trimy"
 #else
   #define TR_CHECKTRIMS                "\011Kont.\010Trimy"
-#endif
-#define OFS_CHECKTRIMS                 (9*FW)
-#define TR_SWASHTYPE                   "Typ cykliky"
+#endif#define OFS_CHECKTRIMS                 (9*FW)
+define TR_SWASHTYPE                   "Typ cykliky"
 #define TR_COLLECTIVE                  "Kolektiv"
 #define TR_AILERON                     "Boční cyklika"
 #define TR_ELEVATOR                    TR3("Podélná cykl.", "Podélná cykl.", "Podélná cyklika")

--- a/radio/src/translations/da.h
+++ b/radio/src/translations/da.h
@@ -358,9 +358,9 @@
 #define TR_FADEOUT                     "Tone ud"
 #define TR_DEFAULT                     "(standard)"
 #if defined(COLORLCD)
-  #define TR_CHECKTRIMS                "Check trim"
+  #define TR_CHECKTRIMS                "Kontroller FT trim"
 #else
-  #define TR_CHECKTRIMS                CENTER "\006Check\012trim"
+  #define TR_CHECKTRIMS                CENTER "\006Kontroller\012trim"
 #endif
 #define OFS_CHECKTRIMS                 CENTER_OFS+(9*FW)
 #define TR_SWASHTYPE                   "Swash Type"

--- a/radio/src/translations/da.h
+++ b/radio/src/translations/da.h
@@ -357,7 +357,11 @@
 #define TR_FADEIN                      "Tone ind"
 #define TR_FADEOUT                     "Tone ud"
 #define TR_DEFAULT                     "(standard)"
-#define TR_CHECKTRIMS                  CENTER "\006Check\012trim"
+#if defined(COLORLCD)
+  #define TR_CHECKTRIMS                "Check trim"
+#else
+  #define TR_CHECKTRIMS                CENTER "\006Check\012trim"
+#endif
 #define OFS_CHECKTRIMS                 CENTER_OFS+(9*FW)
 #define TR_SWASHTYPE                   "Swash Type"
 #define TR_COLLECTIVE                  TR("Collective", "Coll. pitch kilde")

--- a/radio/src/translations/de.h
+++ b/radio/src/translations/de.h
@@ -358,7 +358,11 @@
 #define TR_FADEIN                      "Langs. Ein"
 #define TR_FADEOUT                     "Langs. Aus"
 #define TR_DEFAULT                     "(Normal)"
-#define TR_CHECKTRIMS                  CENTER"\006Check\012Trims"
+#if defined(COLORLCD)
+  #define TR_CHECKTRIMS                "Check FM Trims"
+#else
+  #define TR_CHECKTRIMS                CENTER"\006Check\012Trims"
+#endif
 #define OFS_CHECKTRIMS                 CENTER_OFS+(9*FW)
 #define TR_SWASHTYPE                   TR("Typ Taumelsch", "Typ  Taumelscheibe")
 #define TR_COLLECTIVE                  TR("Kollekt. Pitch", "Kollekt. Pitch Quelle")

--- a/radio/src/translations/de.h
+++ b/radio/src/translations/de.h
@@ -342,16 +342,16 @@
 #define TR_TRIMINC                     TR("Trimschritt", "Trimmschritte")
 #define TR_DISPLAY_TRIMS               TR("Trimmanzeige", "Trimmwerte anzeigen")
 #define TR_TTRACE                      TR("Gasquelle", INDENT "Gas-Timerquelle")
-#define TR_TTRIM 	       	           TR("Gastrim", INDENT "Gas-Leerlauftrim")
+#define TR_TTRIM 	       	             TR("Gastrim", INDENT "Gas-Leerlauftrim")
 #define TR_TTRIM_SW                    TR("T-Trim-Sw", INDENT "Trim switch")
 #define TR_BEEPCTR                     TR("MittePieps", "Mittelstell. -Pieps")
 #define TR_USE_GLOBAL_FUNCS            TR("Glob. Funkt.", "Globale Funkt verw.")
-#define TR_PROTOCOL          		   TR("Protok.", "Protokoll")
-#define TR_PPMFRAME          	  	   INDENT "PPM-Frame"
+#define TR_PROTOCOL          		       TR("Protok.", "Protokoll")
+#define TR_PPMFRAME          	  	     INDENT "PPM-Frame"
 #define TR_REFRESHRATE             	   TR(INDENT "Refresh", INDENT "Refresh Rate")
 #define STR_WARN_BATTVOLTAGE           TR(INDENT "Ausg. ist VBAT: ", INDENT "Warnung: Ausg.pegel ist VBAT: ")
 #define TR_WARN_5VOLTS                 "Warnung: Ausgangspegel ist 5 Volt"
-#define TR_MS                 		   "ms"
+#define TR_MS                 		     "ms"
 #define TR_FREQUENCY                   INDENT "Frequenz"
 #define TR_SWITCH                      TR("Schalt.", "Schalter")
 #define TR_TRIMS                       "Trimmer"
@@ -359,9 +359,9 @@
 #define TR_FADEOUT                     "Langs. Aus"
 #define TR_DEFAULT                     "(Normal)"
 #if defined(COLORLCD)
-  #define TR_CHECKTRIMS                "Check FM Trims"
+  #define TR_CHECKTRIMS                "Prüfe Flugphasen-Trimmung"
 #else
-  #define TR_CHECKTRIMS                CENTER"\006Check\012Trims"
+  #define TR_CHECKTRIMS                CENTER"\006Prüfe\012Trimmung"
 #endif
 #define OFS_CHECKTRIMS                 CENTER_OFS+(9*FW)
 #define TR_SWASHTYPE                   TR("Typ Taumelsch", "Typ  Taumelscheibe")

--- a/radio/src/translations/en.h
+++ b/radio/src/translations/en.h
@@ -352,7 +352,11 @@
 #define TR_FADEIN                      "Fade in"
 #define TR_FADEOUT                     "Fade out"
 #define TR_DEFAULT                     "(default)"
-#define TR_CHECKTRIMS                  CENTER "\006Check\012trims"
+#if defined(COLORLCD)
+  #define TR_CHECKTRIMS                "Check FM Trims"
+#else
+  #define TR_CHECKTRIMS                CENTER "\006Check\012trims"
+#endif
 #define OFS_CHECKTRIMS                 CENTER_OFS+(9*FW)
 #define TR_SWASHTYPE                   "Swash Type"
 #define TR_COLLECTIVE                  TR("Collective", "Coll. pitch source")

--- a/radio/src/translations/es.h
+++ b/radio/src/translations/es.h
@@ -354,7 +354,11 @@
 #define TR_FADEIN              "Inicio"
 #define TR_FADEOUT             "Final"
 #define TR_DEFAULT             "(defecto)"
-#define TR_CHECKTRIMS          CENTER "\006Check\012Trims"
+#if defined(COLORLCD)
+  #define TR_CHECKTRIMS        "Check FM Trims"
+#else
+  #define TR_CHECKTRIMS        CENTER "\006Check\012trims"
+#endif
 #define OFS_CHECKTRIMS         CENTER_OFS+(9*FW)
 #define TR_SWASHTYPE           "Tipo cíclico"
 #define TR_COLLECTIVE          TR("Colectivo", "Fuente colectivo")

--- a/radio/src/translations/fi.h
+++ b/radio/src/translations/fi.h
@@ -380,7 +380,11 @@
 #define TR_FADEIN                      "Fade In"
 #define TR_FADEOUT                     "Fade Out"
 #define TR_DEFAULT                     "(default)"
-#define TR_CHECKTRIMS                  CENTER "\006Check\012Trims"
+#if defined(COLORLCD)
+  #define TR_CHECKTRIMS                "Check FM Trims"
+#else
+  #define TR_CHECKTRIMS                CENTER "\006Check\012Trims"
+#endif
 #define OFS_CHECKTRIMS                 CENTER_OFS+(9*FW)
 #define TR_SWASHTYPE                   "Swash Type"
 #define TR_COLLECTIVE                  TR("Collective", "Coll. pitch source")

--- a/radio/src/translations/fr.h
+++ b/radio/src/translations/fr.h
@@ -375,7 +375,11 @@
 #define TR_FADEIN                      "Fondu ON"
 #define TR_FADEOUT                     "Fondu OFF"
 #define TR_DEFAULT                     "(défaut)"
-#define TR_CHECKTRIMS                  "\006Vérif\012Trims"
+#if defined(COLORLCD)
+  #define TR_CHECKTRIMS                "Vérif Trims"
+#else
+  #define TR_CHECKTRIMS                "\006Vérif\012Trims"
+#endif
 #define OFS_CHECKTRIMS                 (9*FW)
 #define TR_SWASHTYPE                   TR("Type de Plat.", "Type de plateau")
 #define TR_COLLECTIVE                  TR("Collectif", "Source collectif")

--- a/radio/src/translations/it.h
+++ b/radio/src/translations/it.h
@@ -359,7 +359,11 @@
 #define TR_FADEIN              "Diss.In"
 #define TR_FADEOUT             "Diss.Out"
 #define TR_DEFAULT             "(Predefinita)"
-#define TR_CHECKTRIMS          CENTER "\006Contr.\012Trims"
+#if defined(COLORLCD)
+  #define TR_CHECKTRIMS        "Contr. Trims"
+#else
+  #define TR_CHECKTRIMS        CENTER "\006Contr.\012Trims"
+#endif
 #define OFS_CHECKTRIMS         CENTER_OFS+(9*FW)
 #define TR_SWASHTYPE           "Tipo Ciclico"
 #define TR_COLLECTIVE          TR("Collettivo", "Origine Collettivo")

--- a/radio/src/translations/jp.h
+++ b/radio/src/translations/jp.h
@@ -368,7 +368,7 @@
 #if defined(COLORLCD)
   #define TR_CHECKTRIMS                "現在の飛行モードのトリムをチェック"
 #else
-  #define TR_CHECKTRIMS CENTER         "\006チェック\012トリム"
+  #define TR_CHECKTRIMS                CENTER "\006チェック\012トリム"
 #endif#endif
 #define OFS_CHECKTRIMS                 CENTER_OFS+(9*FW)
 #define TR_SWASHTYPE                   "スワッシュタイプ"

--- a/radio/src/translations/jp.h
+++ b/radio/src/translations/jp.h
@@ -368,7 +368,7 @@
 #if defined(COLORLCD)
   #define TR_CHECKTRIMS                "現在の飛行モードのトリムをチェック"
 #else
-  #define TR_CHECKTRIMS                "\006チェック\012トリム"
+  #define TR_CHECKTRIMS CENTER         "\006チェック\012トリム"
 #endif#endif
 #define OFS_CHECKTRIMS                 CENTER_OFS+(9*FW)
 #define TR_SWASHTYPE                   "スワッシュタイプ"

--- a/radio/src/translations/jp.h
+++ b/radio/src/translations/jp.h
@@ -364,7 +364,11 @@
 #define TR_FADEIN                      "フェードイン"
 #define TR_FADEOUT                     "フェードアウト"
 #define TR_DEFAULT                     "(デフォルト)"
-#define TR_CHECKTRIMS                  CENTER "\006チェック\012トリム"
+#if defined(COLORLCD)
+  #define TR_CHECKTRIMS                "チェック トリム"
+#else
+  #define TR_CHECKTRIMS                CENTER "\006チェック\012トリム"
+#endif
 #define OFS_CHECKTRIMS                 CENTER_OFS+(9*FW)
 #define TR_SWASHTYPE                   "スワッシュタイプ"
 #define TR_COLLECTIVE                  TR("Collective", "Coll. pitch ソース")

--- a/radio/src/translations/jp.h
+++ b/radio/src/translations/jp.h
@@ -365,10 +365,11 @@
 #define TR_FADEOUT                     "フェードアウト"
 #define TR_DEFAULT                     "(デフォルト)"
 #if defined(COLORLCD)
-  #define TR_CHECKTRIMS                "チェック トリム"
+#if defined(COLORLCD)
+  #define TR_CHECKTRIMS                "現在の飛行モードのトリムをチェック"
 #else
-  #define TR_CHECKTRIMS                CENTER "\006チェック\012トリム"
-#endif
+  #define TR_CHECKTRIMS                "\006チェック\012トリム"
+#endif#endif
 #define OFS_CHECKTRIMS                 CENTER_OFS+(9*FW)
 #define TR_SWASHTYPE                   "スワッシュタイプ"
 #define TR_COLLECTIVE                  TR("Collective", "Coll. pitch ソース")

--- a/radio/src/translations/nl.h
+++ b/radio/src/translations/nl.h
@@ -357,7 +357,11 @@
 #define TR_FADEIN              "Fade in"
 #define TR_FADEOUT             "Fade out"
 #define TR_DEFAULT             "(default)"
-#define TR_CHECKTRIMS          CENTER "\006Check\012Trims"
+#if defined(COLORLCD)
+  #define TR_CHECKTRIMS        "Check FM Trims"
+#else
+  #define TR_CHECKTRIMS        CENTER "\006Check\012Trims"
+#endif
 #define OFS_CHECKTRIMS         CENTER_OFS+(9*FW)
 #define TR_SWASHTYPE           "Swash Type"
 #define TR_COLLECTIVE          TR("Collective", "Coll. pitch source")

--- a/radio/src/translations/pl.h
+++ b/radio/src/translations/pl.h
@@ -354,7 +354,11 @@
 #define TR_FADEIN              "Pojawia"
 #define TR_FADEOUT             "Zanik   "
 #define TR_DEFAULT             "(Bazowa) "
-#define TR_CHECKTRIMS          CENTER "\006Spr  \012Trymy"
+#if defined(COLORLCD)
+  #define TR_CHECKTRIMS        "Spr Trymy"
+#else
+  #define TR_CHECKTRIMS        CENTER "\006Spr  \012Trymy"
+#endif
 #define OFS_CHECKTRIMS         CENTER_OFS+(9*FW)
 #define TR_SWASHTYPE           "Typ tarczy"
 #define TR_COLLECTIVE          TR("Kolektyw", "Źródło Kolektywu")

--- a/radio/src/translations/pl.h
+++ b/radio/src/translations/pl.h
@@ -355,7 +355,7 @@
 #define TR_FADEOUT             "Zanik   "
 #define TR_DEFAULT             "(Bazowa) "
 #if defined(COLORLCD)
-  #define TR_CHECKTRIMS        "Spr Trymy"
+  #define TR_CHECKTRIMS        "Sprawdź trymy"
 #else
   #define TR_CHECKTRIMS        CENTER "\006Spr  \012Trymy"
 #endif

--- a/radio/src/translations/pt.h
+++ b/radio/src/translations/pt.h
@@ -356,7 +356,11 @@
 #define TR_FADEIN              "Aparecer"
 #define TR_FADEOUT             "Ocultar"
 #define TR_DEFAULT             "(default)"
-#define TR_CHECKTRIMS          "\006Check\012Trims"
+#if defined(COLORLCD)
+  #define TR_CHECKTRIMS        "Check FM Trims"
+#else
+  #define TR_CHECKTRIMS        "\006Check\012Trims"
+#endif
 #define OFS_CHECKTRIMS         (9*FW)
 #define TR_SWASHTYPE           "Ciclico Tipo"
 #define TR_COLLECTIVE          "Coletivo"

--- a/radio/src/translations/se.h
+++ b/radio/src/translations/se.h
@@ -382,7 +382,11 @@
 #define TR_FADEIN                       "Tona in"
 #define TR_FADEOUT                      "Tona ut"
 #define TR_DEFAULT                      "Default"
-#define TR_CHECKTRIMS                   CENTER "\006Kolla\012trimmar"
+#if defined(COLORLCD)
+  #define TR_CHECKTRIMS                 "Kolla FL-trimmar"
+#else
+  #define TR_CHECKTRIMS                 CENTER "\006Kolla\012trimmar"
+#endif 
 #define OFS_CHECKTRIMS                  CENTER_OFS+(9*FW)
 #define TR_SWASHTYPE                    "Swashtyp"
 #define TR_COLLECTIVE                   "Kollektiv"
@@ -1087,6 +1091,7 @@
 #define TR_GVAR_HEADERS_FM6             "Värde för FL6"
 #define TR_GVAR_HEADERS_FM7             "Värde för FL7"
 #define TR_GVAR_HEADERS_FM8             "Värde för FL8"
+//#define TR_CHECK_FM_TRIMS               "Kolla FL-trimmar"
 
 // Horus footer descriptions
 #define TR_LSW_DESCRIPTIONS             { "Comparison type or function", "First variable", "Second variable or constant", "Second variable or constant", "Additional condition for line to be enabled", "Minimum ON duration of the logical switch", "Minimum TRUE duration for the switch to become ON" }

--- a/radio/src/translations/se.h
+++ b/radio/src/translations/se.h
@@ -161,7 +161,7 @@
 #endif
 
 #if defined(OVERRIDE_CHANNEL_FUNCTION) && LCD_W >= 212
-  #define TR_SF_SAFETY                  "Åsidosätt "
+  #define TR_SF_SAFETY                  "Lås "
 #elif defined(OVERRIDE_CHANNEL_FUNCTION)
   #define TR_SF_SAFETY                  "Lås "
 #else

--- a/radio/src/translations/tw.h
+++ b/radio/src/translations/tw.h
@@ -353,9 +353,9 @@
 #define TR_FADEOUT                     "漸出"
 #define TR_DEFAULT                     "(默認)"
 #if defined(COLORLCD)
-  #define TR_CHECKTRIMS                "Check FM Trims"
+  #define TR_CHECKTRIMS                "檢查當前飛行模式微調"
 #else
-  #define TR_CHECKTRIMS                "\006Check\012trims"
+  #define TR_CHECKTRIMS                "\006檢查\012微調"
 #endif
 #define OFS_CHECKTRIMS                 CENTER_OFS+(9*FW)
 #define TR_SWASHTYPE                   "斜盤類型"

--- a/radio/src/translations/tw.h
+++ b/radio/src/translations/tw.h
@@ -352,7 +352,11 @@
 #define TR_FADEIN                      "漸入"
 #define TR_FADEOUT                     "漸出"
 #define TR_DEFAULT                     "(默認)"
-#define TR_CHECKTRIMS                  "\006Check\012trims"
+#if defined(COLORLCD)
+  #define TR_CHECKTRIMS                "Check FM Trims"
+#else
+  #define TR_CHECKTRIMS                "\006Check\012trims"
+#endif
 #define OFS_CHECKTRIMS                 CENTER_OFS+(9*FW)
 #define TR_SWASHTYPE                   "斜盤類型"
 #define TR_COLLECTIVE                  TR("螺距源", "螺距混控源")


### PR DESCRIPTION
Fixes #2797

Summary of changes:
Added translation for Check FM Trims button for color radios and separated the button text string for BW and color radios in the firmware translation files.
