### PR TITLE
fix(cpn): MacOS not saving unless `.etx` in filename

### DIFF
--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1250,11 +1250,7 @@ bool MdiChild::saveAs(bool isNew)
 {
   forceNewFilename();
   QFileInfo fi(curFile);
-#ifdef __APPLE__
-  QString filter;
-#else
   QString filter(ETX_FILES_FILTER % YML_FILES_FILTER);
-#endif
 
   QString fileName = QFileDialog::getSaveFileName(this, tr("Save As"), g.eepromDir() + "/" + fi.fileName(), filter);
   if (fileName.isEmpty())


### PR DESCRIPTION
MacOS companion does not save models if ".etx" extension not in filename.
Tested on MacOS 10, 11, 12 and 13.

<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #2809

Summary of changes:

Use the same filter in call to QFileDialog::getSaveFileName (in MdiChild::saveAs) for MacOS as other platforms.
