### PR TITLE
fix(sim): Consistent steps for 6POS

### DIFF
--- a/companion/src/simulation/widgets/radioknobwidget.h
+++ b/companion/src/simulation/widgets/radioknobwidget.h
@@ -100,7 +100,7 @@ class RadioKnobWidget : public RadioWidget
         void setValue(int value)
         {
           if (m_stepSize > 1) {
-            value = value / m_stepSize * m_stepSize;
+            value = ((value + m_stepSize / 2) / m_stepSize) * m_stepSize;
           }
           QDial::setValue(value);
         }

--- a/companion/src/simulation/widgets/radioknobwidget.h
+++ b/companion/src/simulation/widgets/radioknobwidget.h
@@ -101,6 +101,10 @@ class RadioKnobWidget : public RadioWidget
         {
           if (m_stepSize > 1) {
             value = ((value + m_stepSize / 2) / m_stepSize) * m_stepSize;
+            // Fix values to account for lack of precision from using integer step size
+            // This makes the values more symmetrical around the center point
+            // Note: this is specific to the TX16 6 position switch which is currently the only use case here
+            if (value > 1024) value += 3;
           }
           QDial::setValue(value);
         }

--- a/companion/src/simulation/widgets/radiowidget.cpp
+++ b/companion/src/simulation/widgets/radiowidget.cpp
@@ -66,8 +66,13 @@ void RadioWidget::setValue(const int & value)
   if (value != m_value || m_valueReset) {
     m_value = value;
     m_valueReset = false;
+    // This 'emit valueChanged()' call can trigger another call into this function if the value is altered.
+    // This can happen with the TX16 6 Position switch control.
     emit valueChanged(value);
-    emit valueChange(m_type, m_index, value);
+    // If actual value was changed by the 'emit valueChanged()' call above, then 
+    // skip the 'valueChange' signal that would send the original value. We have already sent the signal with the updated value.
+    if (value == getValue())
+        emit valueChange(m_type, m_index, value);
   }
 }
 


### PR DESCRIPTION
Ensure consistent values for the TX16, 6 position switch, in the simulator.

<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #2827

Summary of changes:

- Round value to nearest step size in KnobWidget::setValue
- Prevent second call to 'emit valueChange()' with old 'value' in RadioWidget::setValue when value is rounded to nearest step size for 6 position switch.