### PR TITLE
fix(color): Fix top bar timer widget names sometimes having garbage characters

### DIFF
--- a/radio/src/gui/colorlcd/widgets/timer.cpp
+++ b/radio/src/gui/colorlcd/widgets/timer.cpp
@@ -112,7 +112,7 @@ class TimerWidget : public Widget
       }
       // name
       if (ZLEN(timerData.name) > 0) {  // user name exist
-        dc->drawText(2, 0, timerData.name, FONT(XS) | COLOR_THEME_PRIMARY2);
+        dc->drawSizedText(2, 0, timerData.name, LEN_TIMER_NAME, FONT(XS) | COLOR_THEME_PRIMARY2);
       } else {  // user name not exist "TMRn"
         drawStringWithIndex(dc, 2, 0, "TMR", index + 1,
                             FONT(XS) | COLOR_THEME_PRIMARY2);


### PR DESCRIPTION
Limit length of name text drawn in small size timer widget to prevent random characters appearing.

<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #2807

Summary of changes:

Use 'drawSizedText' instead of 'drawText' as suggested by schnupperm in the issue description.