### PR TITLE
feat(cpn): Force light mode UI on MacOS for legibility

### DIFF
--- a/companion/targets/mac/MacOSXBundleInfo.plist.in
+++ b/companion/targets/mac/MacOSXBundleInfo.plist.in
@@ -30,6 +30,8 @@
 	<true/>
 	<key>NSHumanReadableCopyright</key>
 	<string>${MACOSX_BUNDLE_COPYRIGHT}</string>
+	<key>NSRequiresAquaSystemAppearance</key>
+	<true/>
 
     <!-- added since cmake/qt do not add these by default -->
     <key>NSPrincipalClass</key>


### PR DESCRIPTION
Force companion and simulator to use light mode on MacOS as workaround to make the UI more readable, when user has selected dark mode on their Mac.

<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #2459

Summary of changes:

Add NSRequiresAquaSystemAppearance = true to the info.plist for MacOS to force light mode UI.