### PR TITLE
feat(sim): Forced style for POT/6POS knobs on MacOS for legibility

### DIFF
--- a/companion/src/simulation/widgets/radioknobwidget.h
+++ b/companion/src/simulation/widgets/radioknobwidget.h
@@ -27,6 +27,9 @@
 #include <QDial>
 #include <QMouseEvent>
 #include <QToolTip>
+#ifdef __APPLE__
+#include <QStyleFactory>
+#endif
 #include <math.h>
 
 class RadioKnobWidget : public RadioWidget
@@ -72,6 +75,11 @@ class RadioKnobWidget : public RadioWidget
         explicit KnobWidget(Board::PotType type, QWidget * parent = 0):
           QDial(parent)
         {
+#ifdef __APPLE__
+          // Set style for dial to show dot instead of arrow pointer for selected position
+          setStyle(QStyleFactory::create("fusion"));
+#endif
+
           m_toolTip = tr("<p>Value (input): <b>%1</b></p>");
 
           setSizePolicy(QSizePolicy::Fixed, QSizePolicy::Fixed);


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #

Summary of changes:

The default dial widget display on MacOS simulator is hard to see. This change forces the dial to use the 'fusion' style to make it display better.

Current style:
![Screen Shot 2022-12-10 at 9 04 46 am](https://user-images.githubusercontent.com/9474356/206803917-c6f56dac-0476-49c5-8d81-3f99a68e7264.png)

New style:
![Screen Shot 2022-12-10 at 9 04 16 am](https://user-images.githubusercontent.com/9474356/206803944-f4af5b78-7a64-44d2-9e0e-fc29923ac530.png)
