### PR TITLE
fix(color): EM triggered when checking if modelID unique in certain instances

### DIFF
--- a/radio/src/storage/modelslist.cpp
+++ b/radio/src/storage/modelslist.cpp
@@ -1521,7 +1521,7 @@ bool ModelsList::isModelIdUnique(uint8_t moduleIdx, char *warn_buf,
 
       // you cannot rely exactly on WARNING_LINE_LEN so using WARNING_LINE_LEN-2
       // (-2 for the ",")
-      if ((warn_buf_len - 2 - (curr - warn_buf)) > LEN_MODEL_NAME) {
+      if ((int)(warn_buf_len - 2 - (curr - warn_buf)) > LEN_MODEL_NAME) {
         if (warn_buf[0] != 0) curr = strAppend(curr, ", ");
         if (modelName[0] == 0) {
           size_t len = min<size_t>(strlen(modelFilename), LEN_MODEL_NAME);


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #2844

Summary of changes:

In ModelsList::isModelIdUnique function:
 - cast comparison value to int to avoid signed / unsigned comparison error if (curr - warn_buf) > 48.

Note: only tested in the simulator; but should fix issue in affected radios.