### PR TITLE
Fix  for issue 2703 - mixer layout on color lcd screens

### DIFF
--- a/radio/src/gui/colorlcd/input_mix_button.cpp
+++ b/radio/src/gui/colorlcd/input_mix_button.cpp
@@ -34,9 +34,9 @@ STATIC_LZ4_BITMAP(mask_textline_fm);
 
 #if LCD_W > LCD_H // Landscape
 static const lv_coord_t col_dsc[] = {
-  LV_GRID_FR(1),   // weigth
-  LV_GRID_FR(1),   // source
-  LV_GRID_FR(4),   // opts
+  LV_GRID_FR(7),   // weight
+  LV_GRID_FR(12),   // source
+  LV_GRID_FR(29),   // opts
   FM_CANVAS_WIDTH, // flight modes
   LV_GRID_TEMPLATE_LAST
 };
@@ -56,8 +56,6 @@ static const lv_coord_t row_dsc[] = {LV_GRID_CONTENT,
                                      LV_GRID_TEMPLATE_LAST};
 #endif
 
-static const char _empty_txt[] = "";
-
 InputMixButton::InputMixButton(Window* parent, uint8_t index) :
     ListLineButton(parent, index)
 {
@@ -65,7 +63,7 @@ InputMixButton::InputMixButton(Window* parent, uint8_t index) :
   lv_obj_set_grid_dsc_array(lvobj, col_dsc, row_dsc);
 
   weight = lv_label_create(lvobj);
-  lv_obj_set_grid_cell(weight, LV_GRID_ALIGN_END, 0, 1, LV_GRID_ALIGN_START, 0, 1);
+  lv_obj_set_grid_cell(weight, LV_GRID_ALIGN_START, 0, 1, LV_GRID_ALIGN_START, 0, 1);
   
   source = lv_label_create(lvobj);
   lv_obj_set_grid_cell(source, LV_GRID_ALIGN_START, 1, 1, LV_GRID_ALIGN_START, 0, 1);

--- a/radio/src/gui/colorlcd/input_mix_button.cpp
+++ b/radio/src/gui/colorlcd/input_mix_button.cpp
@@ -45,9 +45,9 @@ static const lv_coord_t row_dsc[] = {LV_GRID_CONTENT,
                                      LV_GRID_TEMPLATE_LAST};
 #else // Portrait
 static const lv_coord_t col_dsc[] = {
-  LV_GRID_FR(1),   // weigth
-  LV_GRID_FR(1),   // source
-  LV_GRID_FR(2),   // opts
+  LV_GRID_FR(13),   // weight
+  LV_GRID_FR(21),   // source
+  LV_GRID_FR(32),   // opts
   LV_GRID_TEMPLATE_LAST
 };
 

--- a/radio/src/gui/colorlcd/input_mix_group.cpp
+++ b/radio/src/gui/colorlcd/input_mix_group.cpp
@@ -29,7 +29,7 @@
 #include <algorithm>
 
 static const lv_coord_t col_dsc[] = {
-  lv_coord_t(LV_DPI_DEF * 0.65), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST,
+  lv_coord_t(LV_DPI_DEF * 0.55), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST,
 };
 
 static const lv_coord_t row_dsc[] = {


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #2703

Summary of changes:
- Adjust LVGL layout to reduce the chance of text overlap on the mixer screen for color lcd radios.

Note: it is still possible to get a small amount of overlap if input and mix names are max length using a lot of wide characters; but this change should remove overlap for most cases.

Screenshots:

Existing layout
![Screen Shot 2022-12-12 at 9 50 34 am](https://user-images.githubusercontent.com/9474356/206934015-ef5aeb66-bb7f-4736-b914-b045f478e17b.png)

New layout
![Screen Shot 2022-12-12 at 9 46 06 am](https://user-images.githubusercontent.com/9474356/206934019-4edc34e6-8725-47f3-b0bc-0a919dcf2a0a.png)
