### PR TITLE
Fixes an extra string that was included.

### DIFF
--- a/radio/src/translations/jp.h
+++ b/radio/src/translations/jp.h
@@ -365,11 +365,10 @@
 #define TR_FADEOUT                     "フェードアウト"
 #define TR_DEFAULT                     "(デフォルト)"
 #if defined(COLORLCD)
-#if defined(COLORLCD)
   #define TR_CHECKTRIMS                "現在の飛行モードのトリムをチェック"
 #else
   #define TR_CHECKTRIMS                CENTER "\006チェック\012トリム"
-#endif#endif
+#endif
 #define OFS_CHECKTRIMS                 CENTER_OFS+(9*FW)
 #define TR_SWASHTYPE                   "スワッシュタイプ"
 #define TR_COLLECTIVE                  TR("Collective", "Coll. pitch ソース")


### PR DESCRIPTION
Fixing an extra string in jp.h that was included.
(PR #2800 content transcription error)