### PR TITLE
Set center position for highlighting (fix #2859)

### DIFF
--- a/radio/src/gui/colorlcd/output_edit.h
+++ b/radio/src/gui/colorlcd/output_edit.h
@@ -36,7 +36,7 @@ class OutputEditWindow : public Page
  protected:
   uint8_t channel;
   int value = 0;
-  int chanZero = 0;
+
   StaticText *minText;
   GVarNumberEdit* minEdit;
   StaticText *maxText;


### PR DESCRIPTION
Set center position for highlighting MAX and MIN fields in the outputEditWindow 

Fixes #2859 

Summary of changes: compute channel center position based on the limits and offset rather than stick position at the moment of entering.
Also dynamically update central position when offsets and limits are changed.
