### PR TITLE
fix(cpn): Ignore 'Quit' event in main window on MacOS simulator running

### DIFF
--- a/companion/src/helpers.cpp
+++ b/companion/src/helpers.cpp
@@ -324,6 +324,12 @@ void Helpers::setBitmappedValue(unsigned int & field, unsigned int value, unsign
   field = (field & ~fieldmask) | (value << (numbits * index + offset));
 }
 
+#ifdef __APPLE__
+// Flag when simulator is running
+static bool simulatorRunning = false;
+bool isSimulatorRunning() { return simulatorRunning; }
+#endif
+
 void startSimulation(QWidget * parent, RadioData & radioData, int modelIdx)
 {
   QString fwId = SimulatorLoader::findSimulatorByFirmwareName(getCurrentFirmware()->getId());
@@ -347,6 +353,9 @@ void startSimulation(QWidget * parent, RadioData & radioData, int modelIdx)
   dialog->setAttribute(Qt::WA_DeleteOnClose);
 
   QObject::connect(dialog, &SimulatorMainWindow::destroyed, [simuData] (void) {
+#ifdef __APPLE__
+    simulatorRunning = false;
+#endif
     // TODO simuData and Horus tmp directory is deleted on simulator close OR we could use it to get back data from the simulation
     delete simuData;
   });
@@ -359,6 +368,9 @@ void startSimulation(QWidget * parent, RadioData & radioData, int modelIdx)
     dialog->deleteLater();
   }
    else if (dialog->setRadioData(simuData)) {
+#ifdef __APPLE__
+    simulatorRunning = true;
+#endif
     dialog->show();
   }
   else {

--- a/companion/src/helpers.h
+++ b/companion/src/helpers.h
@@ -122,6 +122,11 @@ namespace Helpers
 
 void startSimulation(QWidget * parent, RadioData & radioData, int modelIdx);
 
+#ifdef __APPLE__
+// Flag when simulator is running
+bool isSimulatorRunning();
+#endif
+
 // Format a pixmap to fit on the current firmware
 QPixmap makePixMap(const QImage & image);
 

--- a/companion/src/mainwindow.cpp
+++ b/companion/src/mainwindow.cpp
@@ -197,6 +197,14 @@ void MainWindow::displayWarnings()
 
 void MainWindow::closeEvent(QCloseEvent *event)
 {
+#ifdef __APPLE__
+  // If simulator is running ignore this Quit event (simulator will still be closed)
+  // - prevents app crash on exit
+  if (isSimulatorRunning()) {
+    event->ignore();
+    return;
+  }
+#endif
   g.mainWinGeo(saveGeometry());
   g.mainWinState(saveState());
   g.tabbedMdi(actTabbedWindows->isChecked());


### PR DESCRIPTION
Prevents Companion app crashing on exit while the simulator is open.

In MacOS 10 the user cannot exit the app when the simulator window is open.
On MacOS 11, 12 and 13, the user can exit the app - from the Quit menu option or by pressing Command+Q.
However the app crashes while closing, prompting the user to send a bug report to apple.

This change stops the main window from closing, allowing the quit event to just close the simulator window.
Pressing Command+Q (or selecting Quit) a second time will close the Companion app.

I suspect there is a timing issue at play; but I have so far not been able to find it. 
This change is probably not ideal; but I think is a reasonable work around for now.

Summary of changes:

Add a function to test if the simulator is running to helpers.cpp.
Ignore the quit event in MainWindow if the simulator is running.
The changes are limited to MacOS only.
