### PR TITLE
Changes to date/time setting on color LCD radios.

### DIFF
--- a/radio/src/gui/colorlcd/radio_setup.cpp
+++ b/radio/src/gui/colorlcd/radio_setup.cpp
@@ -119,7 +119,7 @@ class DateTimeWindow : public FormGroup {
       FlexGridLayout grid(col_four_dsc, row_dsc, 2);
 
       gettime(&m_tm);
-      memcpy(&m_last_tm, &m_tm, sizeof(m_tm));
+      m_last_tm = m_tm;
 
       // Date
       auto line = newLine(&grid);


### PR DESCRIPTION
Summary of changes:

- Limits the max value for the day field to the actual number of days in the selected month and year
- If the month or year is updated, and the day value is out of range, reset day value to max value for month & year
- Only update UI values on screen if the RTC value is different to the displayed value (assumes screen update is expensive compared to value comparison)
- Limit the range for the hour value to 0..23 (was 0..24)

