### PR TITLE
feat(cpn): Delete extra models from radio when saving models and settings in companion. (V2)

### DIFF
--- a/companion/src/firmwares/radiodata.cpp
+++ b/companion/src/firmwares/radiodata.cpp
@@ -75,15 +75,19 @@ QString RadioData::getNextModelFilename()
   bool found = true;
   while (found) {
     sprintf(filename, "model%d.%s", ++index, hasSDCard ? "yml" : "bin");
-    found = false;
-    for (unsigned int i=0; i<models.size(); i++) {
-      if (strcmp(filename, models[i].filename) == 0) {
-        found = true;
-        break;
-      }
-    }
+    found = hasModelWithFilename(filename);
   }
   return filename;
+}
+
+bool RadioData::hasModelWithFilename(const char * filename) const
+{
+  for (unsigned int i=0; i<models.size(); i++) {
+    if (strcmp(filename, models[i].filename) == 0) {
+      return true;
+    }
+  }
+  return false;
 }
 
 void RadioData::convert(RadioDataConversionState & cstate)

--- a/companion/src/firmwares/radiodata.h
+++ b/companion/src/firmwares/radiodata.h
@@ -40,6 +40,7 @@ class RadioData {
     void setCurrentModel(unsigned int index);
     void fixModelFilenames();
     QString getNextModelFilename();
+    bool hasModelWithFilename(const char * filename) const;
 
     // leave here until all calls repointed
     static QString getElementName(const QString & prefix, unsigned int index, const char * name = 0, bool padding = false)

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1269,6 +1269,9 @@ bool MdiChild::saveFile(const QString & filename, bool setCurrent)
     return false;
   }
 
+  // Check for extra models on radio after saving - asks user if they want to delete any extras
+  storage.deleteExtraRadioModels(radioData);
+
   if (setCurrent) {
     setCurrentFile(filename);
   }

--- a/companion/src/storage/sdcard.h
+++ b/companion/src/storage/sdcard.h
@@ -35,14 +35,15 @@ class SdcardFormat : public LabelsStorageFormat
     {
     }
 
-    virtual QString name() { return "sdcard"; }
-    virtual bool write(const RadioData & radioData);
+    virtual QString name() override { return "sdcard"; }
+    virtual bool write(const RadioData & radioData) override;
+    virtual void deleteExtraRadioModels(const RadioData & radioData) override;
 
   protected:
-    virtual bool loadFile(QByteArray & fileData, const QString & fileName);
-    virtual bool writeFile(const QByteArray & fileData, const QString & fileName);
-    virtual bool getFileList(std::list<std::string>& filelist);
-    virtual bool deleteFile(const QString & fileName);
+    virtual bool loadFile(QByteArray & fileData, const QString & fileName) override;
+    virtual bool writeFile(const QByteArray & fileData, const QString & fileName) override;
+    virtual bool getFileList(std::list<std::string>& filelist) override;
+    virtual bool deleteFile(const QString & fileName) override;
 };
 
 class SdcardStorageFactory : public DefaultStorageFactory<SdcardFormat>

--- a/companion/src/storage/storage.cpp
+++ b/companion/src/storage/storage.cpp
@@ -135,6 +135,19 @@ bool Storage::writeModel(const RadioData & radioData, const int modelIndex)
   return ret;
 }
 
+// Delete extra models from radio
+void Storage::deleteExtraRadioModels(const RadioData & radioData)
+{
+  foreach(StorageFactory * factory, registeredStorageFactories) {
+    if (factory->probe(filename)) {
+      StorageFormat * format = factory->instance(filename);
+      format->deleteExtraRadioModels(radioData);
+      delete format;
+      break;
+    }
+  }
+}
+
 bool convertEEprom(const QString & sourceEEprom, const QString & destinationEEprom, const QString & firmwareFilename)
 {
   FirmwareInterface firmware(firmwareFilename);

--- a/companion/src/storage/storage.h
+++ b/companion/src/storage/storage.h
@@ -58,6 +58,7 @@ class StorageFormat
     virtual bool load(RadioData & radioData) = 0;
     virtual bool write(const RadioData & radioData) = 0;
     virtual bool writeModel(const RadioData & radioData, const int modelIndex) { return false; }
+    virtual void deleteExtraRadioModels(const RadioData & radioData) { }
 
     QString error() {
       return _error;
@@ -159,6 +160,7 @@ class Storage : public StorageFormat
     virtual bool load(RadioData & radioData);
     virtual bool write(const RadioData & radioData);
     virtual bool writeModel(const RadioData & radioData, const int modelIndex);
+    virtual void deleteExtraRadioModels(const RadioData & radioData);
 };
 
 void registerStorageFactories();


### PR DESCRIPTION
Add logic to support deletion of model files from the radio if there are extra models on the radio after saving models and settings in companion.
- only applies to YAML model files that are stored on an SD card in the radio
- this can happen if a model is deleted in companion then saved to the radio
- prompts the user asking if they want to delete all extra models on the radio

Fixes #2817

Summary of changes:

Add logic to:
- check if the radio has more models than the set saved from companion to the radio
- prompt user if they want to delete extra models
- delete extra models from radio

This change also sorts the model file list loaded from the SD card in natural order (model10 now comes after model9 instead of model1). This keeps the companion model list in the same order the models were created on, or written to, the radio. Previously the order would change in companion when the model data was loaded from the radio, if there were more than 9 models.