### PR TITLE
fix(ui): Clean up the UI for the 6POS switch on the radio/simulator

### DIFF
--- a/radio/src/gui/colorlcd/layouts/sliders.cpp
+++ b/radio/src/gui/colorlcd/layouts/sliders.cpp
@@ -88,18 +88,18 @@ void MainView6POS::paint(BitmapBuffer * dc)
 {
 #if NUM_XPOTS > 0 // prevent compiler warning
   // The ticks
-  int delta = (width() - TRIM_SQUARE_SIZE) / (XPOTS_MULTIPOS_COUNT - 1);
-  coord_t x = TRIM_SQUARE_SIZE / 2;
-  for (uint8_t i = 0; i <= XPOTS_MULTIPOS_COUNT; i++) {
+  int delta = (TRIM_SQUARE_SIZE / 2 + 1);
+  coord_t x = 2 + (TRIM_SQUARE_SIZE / 2);
+  for (uint8_t i = 0; i < XPOTS_MULTIPOS_COUNT; i++) {
     dc->drawSolidVerticalLine(x, 4, 9, COLOR_THEME_SECONDARY1);
     x += delta;
   }
 
   // The square
   value = 1 + (potsPos[idx] & 0x0f);
-  x = TRIM_SQUARE_SIZE / 2 + divRoundClosest((width() - TRIM_SQUARE_SIZE) * (value -1) , 6);
+  x = 2 + (value - 1) * delta;
   drawTrimSquare(dc, x, 0, COLOR_THEME_FOCUS);
-  dc->drawNumber(x + 1, 0, value, FONT(XS) | COLOR_THEME_PRIMARY2);
+  dc->drawNumber(x + 4, 0, value, FONT(XS) | COLOR_THEME_PRIMARY2);
 #endif
 }
 

--- a/radio/src/gui/colorlcd/layouts/sliders.h
+++ b/radio/src/gui/colorlcd/layouts/sliders.h
@@ -32,7 +32,7 @@ constexpr uint8_t SLIDER_TICKS_COUNT = 40;
 constexpr coord_t HMARGIN = 5;
 constexpr coord_t HORIZONTAL_SLIDERS_WIDTH = SLIDER_TICKS_COUNT * 4 + TRIM_SQUARE_SIZE;
 constexpr coord_t MULTIPOS_H = 18;
-constexpr coord_t MULTIPOS_W = 50;
+constexpr coord_t MULTIPOS_W = (TRIM_SQUARE_SIZE / 2) + (XPOTS_MULTIPOS_COUNT - 1) * (TRIM_SQUARE_SIZE / 2 + 1) + XPOTS_MULTIPOS_COUNT + (TRIM_SQUARE_SIZE / 2);
 constexpr coord_t VERTICAL_SLIDERS_HEIGHT = SLIDER_TICKS_COUNT * 4 + TRIM_SQUARE_SIZE;
 
 class MainViewSlider : public Window

--- a/radio/src/gui/colorlcd/view_main_decoration.cpp
+++ b/radio/src/gui/colorlcd/view_main_decoration.cpp
@@ -63,6 +63,9 @@ ViewMainDecoration::ViewMainDecoration(Window* parent) :
   w_bc = create_layout_box(parent, LV_ALIGN_BOTTOM_MID, LV_FLEX_FLOW_COLUMN);
   w_br = create_layout_box(parent, LV_ALIGN_BOTTOM_RIGHT, LV_FLEX_FLOW_COLUMN);
 
+  // Ensure flight mode and 6POS switch UI are centered
+  lv_obj_set_flex_align(w_bc->getLvObj(), LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_SPACE_AROUND);
+
   createTrims(w_ml, w_mr, w_bl, w_br);
   createFlightMode(w_bc);
   createSliders(w_ml, w_mr, w_bl, w_bc, w_br);


### PR DESCRIPTION
Change 6POS switch UI:
- Box for selected position fits between the tick lines
- Center the position number in the box

Before:
![Screen Shot 2022-12-18 at 8 03 41 am](https://user-images.githubusercontent.com/9474356/208266091-fbe313ba-c378-42d3-a681-c09ebf8213fd.png)

After:
![Screen Shot 2022-12-18 at 8 03 08 am](https://user-images.githubusercontent.com/9474356/208266094-1f141226-82dd-41d8-81f0-5da7d99a5a3e.png)
