### PR TITLE
fix(cpn): Fix the size of the YamlStickConfig struct in companion.

### DIFF
--- a/companion/src/firmwares/edgetx/yaml_switchconfig.h
+++ b/companion/src/firmwares/edgetx/yaml_switchconfig.h
@@ -46,7 +46,7 @@ struct YamlNameConfig {
   }
 };
 
-typedef YamlNameConfig<CPN_MAX_SWITCHES, YamlStickLookup> YamlStickConfig;
+typedef YamlNameConfig<CPN_MAX_STICKS, YamlStickLookup> YamlStickConfig;
 
 template <unsigned int N, class name_lookup, const YamlLookupTable& cfg_lut>
 struct YamlKnobConfig : public YamlNameConfig<N, name_lookup> {


### PR DESCRIPTION
The YamlStickConfig definition was defined and sized with CPN_MAX_SWITCHES (32) instead of CPN_MAX_STICKS (4).
When loading radio.yml this would overwrite 112 bytes past the end of the stickName array in the GeneralSettings class.
