### PR TITLE
feat(ui) - Change dialog background color to make buttons more visible.

### DIFF
--- a/radio/src/gui/colorlcd/color_picker.cpp
+++ b/radio/src/gui/colorlcd/color_picker.cpp
@@ -66,6 +66,8 @@ class ColorEditorPopup : public Dialog
     Dialog(parent, std::string(), rect_t{}),
       _setValue(std::move(_setValue))
   {
+    lv_obj_set_style_bg_color(content->getLvObj(), makeLvColor(COLOR_THEME_SECONDARY3), 0);
+
     setCloseWhenClickOutside(true);
     auto form = &content->form;
 

--- a/radio/src/gui/colorlcd/confirm_dialog.cpp
+++ b/radio/src/gui/colorlcd/confirm_dialog.cpp
@@ -34,6 +34,8 @@ ConfirmDialog::ConfirmDialog(Window* parent, const char* title,
   auto msg = new StaticText(form, rect_t{}, message);
   msg->padAll(lv_dpx(16));
 
+  lv_obj_set_style_bg_color(content->getLvObj(), makeLvColor(COLOR_THEME_SECONDARY3), 0);
+
   auto box = new FormGroup(form, rect_t{});
   box->setFlexLayout(LV_FLEX_FLOW_ROW);
 


### PR DESCRIPTION
Summary of changes:

Change the background color of the ConfirmDialog and ColorEditorPopup dialogs.

Before:
![Screen Shot 2022-12-19 at 7 49 25 pm](https://user-images.githubusercontent.com/9474356/208409912-3dabf277-d82b-4f74-8f22-450ccafb4f28.png)
![Screen Shot 2022-12-19 at 8 14 04 pm](https://user-images.githubusercontent.com/9474356/208409932-9732cbe7-d83d-418e-9e72-d9c2727578e9.png)

After:
![Screen Shot 2022-12-19 at 7 44 41 pm](https://user-images.githubusercontent.com/9474356/208409956-1c06da1e-767d-4f37-b177-b1e3fcf7bbf0.png)
![Screen Shot 2022-12-19 at 8 13 36 pm](https://user-images.githubusercontent.com/9474356/208409974-fabcc39e-ea78-4b5a-be37-ded141a5cdf9.png)

