### PR TITLE
fix(ui) - UI is not updated when using the 'Add trims to subtrims' button on the Outputs page.

### DIFF
--- a/radio/src/gui/colorlcd/model_outputs.cpp
+++ b/radio/src/gui/colorlcd/model_outputs.cpp
@@ -83,7 +83,12 @@ class OutputLineButton : public ListLineButton
   {
     lv_obj_t* target = lv_event_get_target(e);
     auto line = (OutputLineButton*)lv_obj_get_user_data(target);
-    if (line && !line->init) line->delayed_init(e);
+    if (line) {
+      if (!line->init)
+        line->delayed_init(e);
+      else
+        line->refresh();
+    }
   }
   
   void delayed_init(lv_event_t* e)


### PR DESCRIPTION
Fixes #2906

Summary of changes:

Call the 'refresh' method when redrawing the Output buttons to get the updated trim value.