### PR TITLE
fix(color) - Fix file handle leak in theme manager.

### DIFF
--- a/radio/src/gui/colorlcd/theme_manager.cpp
+++ b/radio/src/gui/colorlcd/theme_manager.cpp
@@ -345,6 +345,7 @@ void ThemePersistance::scanThemeFolder(char *fullPath)
   FRESULT result = f_open(&file, fullPath, FA_OPEN_EXISTING | FA_READ);
   if (result != FR_OK) return;
 
+  f_close(&file);
   TRACE("scanForThemes: found file %s", fullPath);
   themes.emplace_back(new ThemeFile(fullPath));
 }


### PR DESCRIPTION
The ThemePersistance::scanThemeFolder method was not closing the file it opened, leaking a file handle for each theme on the SD card.

The themes are only scanned once on startup so not a huge issue on a radio. 
However, at least on MacOS, this eventually crashes the simulator / companion if the radio is reloaded in the simulator or the simulator is closed and opened multiple times.

Summary of changes:

Close the file handle in ThemePersistance::scanThemeFolder.
