### PR TITLE
fix(color): Display of model notes when selecting model

### DIFF
--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -371,10 +371,6 @@ ModelsPageBody::ModelsPageBody(Window *parent, const rect_t &rect) :
 
 void ModelsPageBody::selectModel(ModelCell *model)
 {
-  // Exit to main view
-  auto w = Layer::back();
-  if (w) w->onCancel();
-
   bool modelConnected =
       TELEMETRY_STREAMING() && !g_eeGeneral.disableRssiPoweroffAlarm;
   if (modelConnected) {
@@ -389,6 +385,10 @@ void ModelsPageBody::selectModel(ModelCell *model)
       return;  // stop if connected but not confirmed
     }
   }
+
+  // Exit to main view
+  auto w = Layer::back();
+  if (w) w->onCancel();
 
   // store changes (if any) and load selected model
   storageFlushCurrentModel();

--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -371,6 +371,10 @@ ModelsPageBody::ModelsPageBody(Window *parent, const rect_t &rect) :
 
 void ModelsPageBody::selectModel(ModelCell *model)
 {
+  // Exit to main view
+  auto w = Layer::back();
+  if (w) w->onCancel();
+
   bool modelConnected =
       TELEMETRY_STREAMING() && !g_eeGeneral.disableRssiPoweroffAlarm;
   if (modelConnected) {
@@ -397,10 +401,6 @@ void ModelsPageBody::selectModel(ModelCell *model)
 
   storageDirty(EE_GENERAL);
   storageCheck(true);
-
-  // Exit to main view
-  auto w = Layer::back();
-  if (w) w->onCancel();
 }
 
 void ModelsPageBody::duplicateModel(ModelCell* model)


### PR DESCRIPTION
Alternate solution to the one in PR #2792

My testing on TX16S and in the simulator has no issues; but if there are reasons why doing it this way won't work please let me know.

Fixes #2722 and #2921

Summary of changes:

Close model select page before loading model so notes window is not hidden.
