### PR TITLE
fix(ui) - Ignore hidden file when iterating SD card contents.

### DIFF
--- a/radio/src/gui/colorlcd/file_browser.cpp
+++ b/radio/src/gui/colorlcd/file_browser.cpp
@@ -145,8 +145,8 @@ static int scan_files(std::list<std::string>& files,
       break; // Break on error or end of dir
     // if (strlen((const char*)fno.fname) > SD_SCREEN_FILE_LENGTH)
     //   continue;
-    if (fno.fname[0] == '.' && fno.fname[1] != '.')
-      continue; // Ignore hidden files under UNIX, but not ..
+    if (fno.fattrib & (AM_HID|AM_SYS)) continue;     /* Ignore hidden and system files */
+    if (fno.fname[0] == '.' && fno.fname[1] != '.') continue; // Ignore hidden files under UNIX, but not ..
 
     if (fno.fattrib & AM_DIR) {
       directories.push_back((char*)fno.fname);

--- a/radio/src/gui/colorlcd/model_templates.cpp
+++ b/radio/src/gui/colorlcd/model_templates.cpp
@@ -86,7 +86,6 @@ SelectTemplate::SelectTemplate(TemplatePage* tp)
     // read all entries
     for (;;) {
       res = f_readdir(&dir, &fno);
-      firstTime = false;
       if (res != FR_OK || fno.fname[0] == 0)
         break; // Break on error or end of dir
       if (strlen((const char*)fno.fname) > SD_SCREEN_FILE_LENGTH)
@@ -203,7 +202,6 @@ SelectTemplateFolder::SelectTemplateFolder(std::function<void(void)> update)
     // read all entries
     for (;;) {
       res = f_readdir(&dir, &fno);
-      firstTime = false;
       if (res != FR_OK || fno.fname[0] == 0)
         break; // Break on error or end of dir
       if (strlen((const char*)fno.fname) > SD_SCREEN_FILE_LENGTH)

--- a/radio/src/gui/colorlcd/model_templates.cpp
+++ b/radio/src/gui/colorlcd/model_templates.cpp
@@ -84,25 +84,23 @@ SelectTemplate::SelectTemplate(TemplatePage* tp)
 
   if (res == FR_OK) {
     // read all entries
-    bool firstTime = true;
     for (;;) {
-      res = sdReadDir(&dir, &fno, firstTime);
+      res = f_readdir(&dir, &fno);
       firstTime = false;
       if (res != FR_OK || fno.fname[0] == 0)
         break; // Break on error or end of dir
       if (strlen((const char*)fno.fname) > SD_SCREEN_FILE_LENGTH)
         continue;
-      if (fno.fname[0] == '.')
-        continue;
-      if (!(fno.fattrib & AM_DIR)) {
-        const char *ext = getFileExtension(fno.fname);
-        if(ext && !strcasecmp(ext, YAML_EXT)) {
-          int len = ext - fno.fname;
-          if (len < FF_MAX_LFN) {
-            char name[FF_MAX_LFN] = { 0 };
-            strncpy(name, fno.fname, len);
-            files.push_back(name);
-          }
+      if (fno.fattrib & (AM_DIR|AM_HID|AM_SYS)) continue;   /* Ignore folders, hidden and system files */
+      if (fno.fname[0] == '.') continue;                    /* Ignore UNIX hidden files */
+
+      const char *ext = getFileExtension(fno.fname);
+      if(ext && !strcasecmp(ext, YAML_EXT)) {
+        int len = ext - fno.fname;
+        if (len < FF_MAX_LFN) {
+          char name[FF_MAX_LFN] = { 0 };
+          strncpy(name, fno.fname, len);
+          files.push_back(name);
         }
       }
     }
@@ -203,16 +201,15 @@ SelectTemplateFolder::SelectTemplateFolder(std::function<void(void)> update)
 
   if (res == FR_OK) {
     // read all entries
-    bool firstTime = true;
     for (;;) {
-      res = sdReadDir(&dir, &fno, firstTime);
+      res = f_readdir(&dir, &fno);
       firstTime = false;
       if (res != FR_OK || fno.fname[0] == 0)
         break; // Break on error or end of dir
       if (strlen((const char*)fno.fname) > SD_SCREEN_FILE_LENGTH)
         continue;
-      if (fno.fname[0] == '.')
-        continue;
+      if (fno.fattrib & (AM_HID|AM_SYS)) continue;  /* Ignore hidden and system files */
+      if (fno.fname[0] == '.') continue;            /* Ignore UNIX hidden files */
       if (fno.fattrib & AM_DIR)
         directories.push_back((char*)fno.fname);
     }

--- a/radio/src/gui/colorlcd/radio_tools.cpp
+++ b/radio/src/gui/colorlcd/radio_tools.cpp
@@ -111,9 +111,8 @@ static void scanLuaTools(std::list<ToolEntry>& scripts)
       TCHAR path[FF_MAX_LFN+1] = SCRIPTS_TOOLS_PATH "/";
       res = f_readdir(&dir, &fno);                   /* Read a directory item */
       if (res != FR_OK || fno.fname[0] == 0) break;  /* Break on error or end of dir */
-      if (fno.fattrib & AM_DIR) continue;            /* Skip subfolders */
-      if (fno.fattrib & AM_HID) continue;            /* Skip hidden files */
-      if (fno.fattrib & AM_SYS) continue;            /* Skip system files */
+      if (fno.fattrib & (AM_DIR|AM_HID|AM_SYS)) continue;  // skip subfolders, hidden files and system files
+      if (fno.fname[0] == '.') continue;  /* Ignore UNIX hidden files */
 
       strcat(path, fno.fname);
       if (isRadioScriptTool(fno.fname)) {

--- a/radio/src/gui/common/stdlcd/radio_sdmanager.cpp
+++ b/radio/src/gui/common/stdlcd/radio_sdmanager.cpp
@@ -523,7 +523,7 @@ void menuRadioSdManager(event_t _event)
           res = sdReadDir(&dir, &fno, firstTime);
           if (res != FR_OK || fno.fname[0] == 0) break;              /* Break on error or end of dir */
           if (strlen(fno.fname) > SD_SCREEN_FILE_LENGTH) continue;
-          if (fno.fattrib & AM_HID) continue;                        /* Ignore Windows hidden files */
+          if (fno.fattrib & (AM_HID|AM_SYS)) continue;               /* Ignore hidden and system files */
           if (fno.fname[0] == '.' && fno.fname[1] != '.') continue;  /* Ignore UNIX hidden files, but not .. */
 
           reusableBuffer.sdManager.count++;

--- a/radio/src/gui/common/stdlcd/radio_tools.cpp
+++ b/radio/src/gui/common/stdlcd/radio_tools.cpp
@@ -128,9 +128,8 @@ void menuRadioTools(event_t event)
 
       res = f_readdir(&dir, &fno);                   /* Read a directory item */
       if (res != FR_OK || fno.fname[0] == 0) break;  /* Break on error or end of dir */
-      if (fno.fattrib & AM_DIR) continue;            /* Skip subfolders */
-      if (fno.fattrib & AM_HID) continue;            /* Skip hidden files */
-      if (fno.fattrib & AM_SYS) continue;            /* Skip system files */
+      if (fno.fattrib & (AM_DIR|AM_HID|AM_SYS)) continue;  // skip subfolders, hidden files and system files
+      if (fno.fname[0] == '.') continue;  /* Ignore UNIX hidden files */
 
       strcat(path, fno.fname);
       if (isRadioScriptTool(fno.fname)) {

--- a/radio/src/sdcard.cpp
+++ b/radio/src/sdcard.cpp
@@ -276,9 +276,8 @@ bool sdListFiles(const char * path, const char * extension, const uint8_t maxlen
     for (;;) {
       res = f_readdir(&dir, &fno);                   /* Read a directory item */
       if (res != FR_OK || fno.fname[0] == 0) break;  /* Break on error or end of dir */
-      if (fno.fattrib & AM_DIR) continue;            /* Skip subfolders */
-      if (fno.fattrib & AM_HID) continue;            /* Skip hidden files */
-      if (fno.fattrib & AM_SYS) continue;            /* Skip system files */
+      if (fno.fattrib & (AM_DIR|AM_HID|AM_SYS)) continue;  // skip subfolders, hidden files and system files
+      if (fno.fname[0] == '.') continue;  /* Ignore UNIX hidden files */
 
       fnExt = getFileExtension(fno.fname, 0, 0, &fnLen, &extLen);
       fnLen -= extLen;


### PR DESCRIPTION
Fixes #2852 

Summary of changes:

Add hidden file filter to various places where the SD card files and folders are being iterated over.
