### PR TITLE
fix(ui) - Fix flight mode color on startup, or when theme is edited or active theme is changed.

### DIFF
--- a/radio/src/gui/colorlcd/layouts/layout_factory_impl.cpp
+++ b/radio/src/gui/colorlcd/layouts/layout_factory_impl.cpp
@@ -81,6 +81,14 @@ void Layout::setFlightModeVisible(bool visible)
   decoration->setFlightModeVisible(visible);
 }
 
+void Layout::updateFromTheme()
+{
+  // Hack to fix flight mode color on main view
+  // Required because theme is loaded after the main view has been created
+  if (decoration)
+    decoration->setFlightModeColor();
+}
+
 void Layout::adjustLayout()
 {
   // Check if deco setting are still up-to-date

--- a/radio/src/gui/colorlcd/layouts/layout_factory_impl.h
+++ b/radio/src/gui/colorlcd/layouts/layout_factory_impl.h
@@ -95,6 +95,9 @@ class Layout: public LayoutBase
     void setSlidersVisible(bool visible);
     void setFlightModeVisible(bool visible);
 
+    // Update from theme settings
+    void updateFromTheme() override;
+
     // Updates settings for trims, sliders, pots, etc...
     void adjustLayout() override;
 

--- a/radio/src/gui/colorlcd/theme_manager.cpp
+++ b/radio/src/gui/colorlcd/theme_manager.cpp
@@ -19,6 +19,7 @@
  * GNU General Public License for more details.
  */
 #include "theme_manager.h"
+#include "view_main.h"
 
 #define MAX_FILES 9
 ThemePersistance themePersistance;
@@ -327,6 +328,12 @@ void ThemeFile::applyTheme()
   applyColors();
   applyBackground();
   OpenTxTheme::instance()->update(false);
+
+  // Update views with new theme
+  // Currently, on startup, active theme is loaded after ViewMain is created so ViewMain instance is defined
+  // In case this changes, we call getInstance() here to avoid creating ViewMain
+  if (ViewMain::getInstance())
+    ViewMain::getInstance()->updateFromTheme();
 }
 
 // avoid leaking memory

--- a/radio/src/gui/colorlcd/view_main.cpp
+++ b/radio/src/gui/colorlcd/view_main.cpp
@@ -236,6 +236,15 @@ void ViewMain::updateTopbarVisibility()
   }
 }
 
+// Update screens after theme loaded / changed
+void ViewMain::updateFromTheme()
+{
+  for (int i = 0; i < MAX_CUSTOM_SCREENS; i += 1) {
+    if (customScreens[i])
+      customScreens[i]->updateFromTheme();
+  }
+}
+
 void ViewMain::onEvent(event_t event)
 {
 #if defined(HARDWARE_KEYS)

--- a/radio/src/gui/colorlcd/view_main.h
+++ b/radio/src/gui/colorlcd/view_main.h
@@ -46,6 +46,8 @@ class ViewMain: public Window
       return _instance;
     }
 
+    static ViewMain* getInstance() { return _instance; }
+
 #if defined(DEBUG_WINDOWS)
     std::string getName() const override
     {
@@ -59,6 +61,9 @@ class ViewMain: public Window
     void disableTopbar();
     void updateTopbarVisibility();
     bool enableWidgetSelect(bool enable);
+    
+    // Update after theme loaded / changed
+    void updateFromTheme();
 
     // Get the available space in the middle of the screen
     // (without topbar)

--- a/radio/src/gui/colorlcd/view_main_decoration.cpp
+++ b/radio/src/gui/colorlcd/view_main_decoration.cpp
@@ -98,6 +98,16 @@ void ViewMainDecoration::setFlightModeVisible(bool visible)
   }
 }
 
+void ViewMainDecoration::setFlightModeColor()
+{
+  // Hack to fix flight mode color on main view
+  // Required because theme is loaded after the main view has been created
+  if (flightMode) {
+    lv_obj_set_style_text_color(flightMode->getLvObj(), makeLvColor(COLOR_THEME_SECONDARY1), 0);
+    flightMode->invalidate();
+  }
+}
+
 rect_t ViewMainDecoration::getMainZone() const
 {
   // update layout first

--- a/radio/src/gui/colorlcd/view_main_decoration.h
+++ b/radio/src/gui/colorlcd/view_main_decoration.h
@@ -34,7 +34,7 @@ class ViewMainDecoration
     void setTrimsVisible(bool visible);
     void setSlidersVisible(bool visible);
     void setFlightModeVisible(bool visible);
-
+    void setFlightModeColor();
 
     // Get the available space in the middle of the screen
     // (without decoration)

--- a/radio/src/gui/colorlcd/widgets/widgets_container_impl.h
+++ b/radio/src/gui/colorlcd/widgets/widgets_container_impl.h
@@ -141,6 +141,7 @@ class WidgetsContainerImpl : public WidgetsContainer
   }
 
   void adjustLayout() override {}
+  void updateFromTheme() override {};
 
  protected:
   PersistentData* persistentData;

--- a/radio/src/gui/colorlcd/widgets_container.h
+++ b/radio/src/gui/colorlcd/widgets_container.h
@@ -88,6 +88,7 @@ class WidgetsContainer: public Window
     virtual void removeWidget(unsigned int index) = 0;
     virtual void adjustLayout() = 0;
     virtual void updateZones() = 0;
+    virtual void updateFromTheme() = 0;
 };
 
 


### PR DESCRIPTION
Fixes #2688

Summary of changes:

Add methods to allow the theme manager to trigger updates of the main view screens after a theme is loaded or changed.

Most screen elements redraw after a theme change; but the flight mode text color is not automatically updated so has to be manually changed to the new theme color.