### PR TITLE
fix(build): packaged openssl files

### DIFF
--- a/.github/workflows/win-cpn-32.yml
+++ b/.github/workflows/win-cpn-32.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           mkdir output && \
           CMAKE_PREFIX_PATH=$RUNNER_WORKSPACE/Qt/$QT_VERSION/$MINGW_PATH \
-          export QT_TOOLS_OPENSSL_ROOT_PATH=$RUNNER_WORKSPACE/Qt/Tools/OpenSSL/Win_x86 \
+          QT_TOOLS_OPENSSL_ROOT_PATH=$RUNNER_WORKSPACE/Qt/Tools/OpenSSL/Win_x86 \
           tools/build-companion.sh "$(pwd)" "$(pwd)/output/"
       - name: Compose release filename
         # https://stackoverflow.com/questions/58033366/how-to-get-current-branch-within-github-actions

--- a/.github/workflows/win-cpn-32.yml
+++ b/.github/workflows/win-cpn-32.yml
@@ -56,8 +56,7 @@ jobs:
                                 mingw-w64-i686-libraqm \
                                 mingw-w64-i686-SDL \
                                 mingw-w64-i686-clang \
-                                mingw-w64-i686-nsis \
-                                mingw-w64-i686-openssl
+                                mingw-w64-i686-nsis
           python -m pip install clang
 
       - name: Install Qt
@@ -67,6 +66,7 @@ jobs:
           cache-key-prefix: 'install-qt-action-win32'
           version: ${{ env.QT_VERSION }}
           arch: ${{ env.MINGW_VERSION }}
+          tools: 'tools_openssl_x86'
 
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -79,6 +79,7 @@ jobs:
         run: |
           mkdir output && \
           CMAKE_PREFIX_PATH=$RUNNER_WORKSPACE/Qt/$QT_VERSION/$MINGW_PATH \
+          QT_TOOLS_OPENSSL_ROOT_PATH=$RUNNER_WORKSPACE/Qt/Tools/OpenSSL/binary \
           tools/build-companion.sh "$(pwd)" "$(pwd)/output/"
       - name: Compose release filename
         # https://stackoverflow.com/questions/58033366/how-to-get-current-branch-within-github-actions

--- a/.github/workflows/win-cpn-32.yml
+++ b/.github/workflows/win-cpn-32.yml
@@ -79,7 +79,7 @@ jobs:
         run: |
           mkdir output && \
           CMAKE_PREFIX_PATH=$RUNNER_WORKSPACE/Qt/$QT_VERSION/$MINGW_PATH \
-          QT_TOOLS_OPENSSL_ROOT_PATH=$RUNNER_WORKSPACE/Qt/Tools/OpenSSL/binary \
+          export QT_TOOLS_OPENSSL_ROOT_PATH=$RUNNER_WORKSPACE/Qt/Tools/OpenSSL/Win_x86 \
           tools/build-companion.sh "$(pwd)" "$(pwd)/output/"
       - name: Compose release filename
         # https://stackoverflow.com/questions/58033366/how-to-get-current-branch-within-github-actions

--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           mkdir output && \
           CMAKE_PREFIX_PATH=$RUNNER_WORKSPACE/Qt/$QT_VERSION/$MINGW_PATH \
-          export QT_TOOLS_OPENSSL_ROOT_PATH=$RUNNER_WORKSPACE/Qt/Tools/OpenSSL/Win_x64/bin \
+          export QT_TOOLS_OPENSSL_ROOT_PATH=$RUNNER_WORKSPACE/Qt/Tools/OpenSSL/Win_x64 \
           tools/build-companion.sh "$(pwd)" "$(pwd)/output/"
 
       - name: Compose release filename

--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           mkdir output && \
           CMAKE_PREFIX_PATH=$RUNNER_WORKSPACE/Qt/$QT_VERSION/$MINGW_PATH \
-          QT_TOOLS_OPENSSL_ROOT_PATH=$RUNNER_WORKSPACE/Qt/Tools/OpenSSL/binary \
+          export QT_TOOLS_OPENSSL_ROOT_PATH=$RUNNER_WORKSPACE/Qt/Tools/OpenSSL/Win_x64/bin \
           tools/build-companion.sh "$(pwd)" "$(pwd)/output/"
 
       - name: Compose release filename

--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -93,7 +93,7 @@ jobs:
         run: |
           mkdir output && \
           CMAKE_PREFIX_PATH=$RUNNER_WORKSPACE/Qt/$QT_VERSION/$MINGW_PATH \
-          export QT_TOOLS_OPENSSL_ROOT_PATH=$RUNNER_WORKSPACE/Qt/Tools/OpenSSL/Win_x64 \
+          QT_TOOLS_OPENSSL_ROOT_PATH=$RUNNER_WORKSPACE/Qt/Tools/OpenSSL/Win_x64 \
           tools/build-companion.sh "$(pwd)" "$(pwd)/output/"
 
       - name: Compose release filename

--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -70,8 +70,7 @@ jobs:
                                 mingw-w64-x86_64-libraqm \
                                 mingw-w64-x86_64-SDL \
                                 mingw-w64-x86_64-clang \
-                                mingw-w64-x86_64-nsis \
-                                mingw-w64-x86_64-openssl
+                                mingw-w64-x86_64-nsis
           python -m pip install clang
 
       - name: Install Qt
@@ -81,6 +80,7 @@ jobs:
           cache-key-prefix: 'install-qt-action-win64'
           version: ${{ env.QT_VERSION }}
           arch: ${{ env.MINGW_VERSION }}
+          tools: 'tools_openssl_x64'
 
       - name: Check out the repo
         uses: actions/checkout@v3
@@ -93,6 +93,7 @@ jobs:
         run: |
           mkdir output && \
           CMAKE_PREFIX_PATH=$RUNNER_WORKSPACE/Qt/$QT_VERSION/$MINGW_PATH \
+          QT_TOOLS_OPENSSL_ROOT_PATH=$RUNNER_WORKSPACE/Qt/Tools/OpenSSL/binary \
           tools/build-companion.sh "$(pwd)" "$(pwd)/output/"
 
       - name: Compose release filename

--- a/companion/src/CMakeLists.txt
+++ b/companion/src/CMakeLists.txt
@@ -346,7 +346,14 @@ if(POLICY CMP0026)
   cmake_policy(SET CMP0026 OLD)  # https://cmake.org/cmake/help/v3.0/policy/CMP0026.html
 endif()
 
-set(OPENSSL_ROOT_DIR "$ENV{QT_TOOLS_OPENSSL_ROOT_PATH}")
+# OpenSSL
+# environment variable set in github workflows and build-edgetx Dockerfile
+if (DEFINED ENV{QT_TOOLS_OPENSSL_ROOT_PATH})
+  set(OPENSSL_ROOT_DIR "$ENV{QT_TOOLS_OPENSSL_ROOT_PATH}")
+else()
+  message(STATUS "Environment variable QT_TOOLS_OPENSSL_ROOT_PATH not defined. Performing default OpenSSL library search.")
+endif()
+
 find_package(OpenSSL)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
@@ -371,6 +378,13 @@ if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   install(FILES images/linuxicons/scalable/companion.svg DESTINATION ${INSTALL_TEMP_SHR_PFX}share/icons/hicolor/scalable/apps RENAME companion${C9X_NAME_SUFFIX}.svg)
   install(FILES ../targets/linux/45-companion-taranis.rules DESTINATION ${INSTALL_TEMP_LIB_PFX}lib/udev/rules.d RENAME 45-companion${C9X_NAME_SUFFIX}-taranis.rules)
   install(FILES ../targets/linux/45-usbasp.rules DESTINATION ${INSTALL_TEMP_LIB_PFX}lib/udev/rules.d RENAME 45-companion${C9X_NAME_SUFFIX}-usbasp.rules)
+
+  if (OPENSSL_FOUND)
+    get_filename_component(OPENSSL_SSL_LIBRARY_DIR ${OPENSSL_SSL_LIBRARY} DIRECTORY)
+    # install only files Qt networking requires
+    install(DIRECTORY ${OPENSSL_SSL_LIBRARY_DIR}/ DESTINATION ${CMAKE_INSTALL_PREFIX}/lib FILES_MATCHING PATTERN "engines*" EXCLUDE PATTERN "pkg*" EXCLUDE PATTERN "*.so*")
+  endif()
+
   # Linux specific code
   set(OperatingSystem "Linux")
   # Shortcut target
@@ -409,9 +423,15 @@ elseif(WIN32)
     message(WARNING "Installer: SDL.dll not found, set SDL_LIBRARY_PATH manually.")
   endif()
 
-  # OpendSSL dlls
   if (OPENSSL_FOUND)
-    install(DIRECTORY ${OPENSSL_SSL_LIBRARY}/ DESTINATION ${INSTALL_DESTINATION} FILES_MATCHING PATTERN "*.dll")
+    get_filename_component(OPENSSL_SSL_LIBRARY_DIR ${OPENSSL_SSL_LIBRARY} DIRECTORY)
+    set(OPENSSL_BIN_DIR "${OPENSSL_SSL_LIBRARY_DIR}/../bin")
+    if (EXISTS "${OPENSSL_BIN_DIR}")
+      # install only files Qt networking requires
+      install(DIRECTORY ${OPENSSL_BIN_DIR}/ DESTINATION ${INSTALL_DESTINATION} FILES_MATCHING PATTERN "*.dll")
+    else()
+  	  message(STATUS "Installer: OpenSSL bin directory not found, dlls not bundled.")
+    endif()
   endif()
 endif() # WIN32 install
 

--- a/companion/src/CMakeLists.txt
+++ b/companion/src/CMakeLists.txt
@@ -409,7 +409,7 @@ elseif(WIN32)
   # SSL dlls (used by QtNetwork)
   file(TO_CMAKE_PATH "$ENV{PROGRAMFILES}" WIN_PROGRAM_FILES)
   # try 64-bit
-  find_path(SSL_LIB_DIR libssl-1_1-x64.dll libssl-1_1-x86.dll HINTS
+  find_path(SSL_LIB_DIR libssl-1_1-x64.dll libssl-1_1.dll HINTS
     "${WIN_PROGRAM_FILES}/OpenSSL" "${WIN_PROGRAM_FILES}/OpenSSL-Win32"
     "C:/OpenSSL/" "C:/OpenSSL-Win32/"
     "${WIN_EXTRA_LIBS_PATH}" "${WIN_EXTRA_LIBS_PATH}/OpenSSL" "${WIN_EXTRA_LIBS_PATH}/OpenSSL-Win32"
@@ -420,7 +420,7 @@ elseif(WIN32)
   )
   if (SSL_LIB_DIR)
     install(FILES "${SSL_LIB_DIR}/libssl-1_1-x64.dll" "${SSL_LIB_DIR}/libcrypto-1_1-x64.dll" DESTINATION ${INSTALL_DESTINATION} OPTIONAL)
-    install(FILES "${SSL_LIB_DIR}/libssl-1_1-x86.dll" "${SSL_LIB_DIR}/libcrypto-1_1-x86.dll" DESTINATION ${INSTALL_DESTINATION} OPTIONAL)
+    install(FILES "${SSL_LIB_DIR}/libssl-1_1.dll" "${SSL_LIB_DIR}/libcrypto-1_1.dll" DESTINATION ${INSTALL_DESTINATION} OPTIONAL)
   else()
     message(WARNING "Installer: SSL libs not found, set SSL_LIB_DIR manually.")
   endif()

--- a/companion/src/CMakeLists.txt
+++ b/companion/src/CMakeLists.txt
@@ -346,11 +346,14 @@ if(POLICY CMP0026)
   cmake_policy(SET CMP0026 OLD)  # https://cmake.org/cmake/help/v3.0/policy/CMP0026.html
 endif()
 
+set(OPENSSL_ROOT_DIR "$ENV{QT_TOOLS_OPENSSL_ROOT_PATH}")
+find_package(OpenSSL)
+
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
   message(STATUS "install " ${CMAKE_BINARY_DIR} " to " ${CMAKE_INSTALL_PREFIX}/bin)
   install(TARGETS ${COMPANION_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
   install(TARGETS ${SIMULATOR_NAME} DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
-  install(DIRECTORY ${CMAKE_BINARY_DIR}/plugins/ DESTINATION "${SIMULATOR_LIB_INSTALL_PATH}")
+  install(DIRECTORY ${CMAKE_BINARY_DIR}/plugins/ DESTINATION ${SIMULATOR_LIB_INSTALL_PATH})
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/companion.desktop DESTINATION share/applications RENAME companion${C9X_NAME_SUFFIX}.desktop)
   install(FILES ${CMAKE_CURRENT_BINARY_DIR}/simulator.desktop DESTINATION share/applications RENAME simulator${C9X_NAME_SUFFIX}.desktop)
   if(${CMAKE_INSTALL_PREFIX} MATCHES "/usr/local")
@@ -406,23 +409,9 @@ elseif(WIN32)
     message(WARNING "Installer: SDL.dll not found, set SDL_LIBRARY_PATH manually.")
   endif()
 
-  # SSL dlls (used by QtNetwork)
-  file(TO_CMAKE_PATH "$ENV{PROGRAMFILES}" WIN_PROGRAM_FILES)
-  # try 64-bit
-  find_path(SSL_LIB_DIR libssl-1_1-x64.dll libssl-1_1.dll HINTS
-    "${WIN_PROGRAM_FILES}/OpenSSL" "${WIN_PROGRAM_FILES}/OpenSSL-Win32"
-    "C:/OpenSSL/" "C:/OpenSSL-Win32/"
-    "${WIN_EXTRA_LIBS_PATH}" "${WIN_EXTRA_LIBS_PATH}/OpenSSL" "${WIN_EXTRA_LIBS_PATH}/OpenSSL-Win32"
-    "${MINGW_DIR}/../opt/bin"
-    "${PYTHON_DIRECTORY}/lib/site-packages/PyQt4"
-    PATH_SUFFIXES bin
-    DOC "Path to OpenSSL for Windows 1.1"
-  )
-  if (SSL_LIB_DIR)
-    install(FILES "${SSL_LIB_DIR}/libssl-1_1-x64.dll" "${SSL_LIB_DIR}/libcrypto-1_1-x64.dll" DESTINATION ${INSTALL_DESTINATION} OPTIONAL)
-    install(FILES "${SSL_LIB_DIR}/libssl-1_1.dll" "${SSL_LIB_DIR}/libcrypto-1_1.dll" DESTINATION ${INSTALL_DESTINATION} OPTIONAL)
-  else()
-    message(WARNING "Installer: SSL libs not found, set SSL_LIB_DIR manually.")
+  # OpendSSL dlls
+  if (OPENSSL_FOUND)
+    install(DIRECTORY ${OPENSSL_SSL_LIBRARY}/ DESTINATION ${INSTALL_DESTINATION} FILES_MATCHING PATTERN "*.dll")
   endif()
 endif() # WIN32 install
 


### PR DESCRIPTION
Fixes #2929 #2758

Summary of changes:
- modify the github workflows including installing Qt tools openssl for each OS
- change the Companion installer processes to bundle the Qt versions of the openssl libs

Dependencies:
For linux builds https://github.com/EdgeTX/build-edgetx/pull/14 needs to be merged

TODO:
- [x] Win x86
- [x] Win x64
- [x] linux
- [ ] MacOS