### PR TITLE
Fix display of 6POS display. (#2943)

### DIFF
--- a/radio/src/gui/colorlcd/layouts/sliders.cpp
+++ b/radio/src/gui/colorlcd/layouts/sliders.cpp
@@ -105,7 +105,7 @@ void MainView6POS::checkEvents()
 {
   Window::checkEvents();
 #if NUM_XPOTS > 0 // prevent compiler warning
-  int16_t newValue = 1 + (potsPos[idx] & 0x0f);
+  int16_t newValue = (potsPos[idx] & 0x0f);
   if (value != newValue) {
     value = newValue;
     invalidate();


### PR DESCRIPTION

Fixes #2943

Summary of changes: fix mismatch in value definition between checkEvents() and paint(0 for MainView6POS.
