### PR TITLE
fix(ui) - Fix layout size issue (#2961) and improve code readability.

### DIFF
--- a/radio/src/gui/colorlcd/layouts/layout_factory_impl.cpp
+++ b/radio/src/gui/colorlcd/layouts/layout_factory_impl.cpp
@@ -93,11 +93,11 @@ void Layout::adjustLayout()
 {
   // Check if deco setting are still up-to-date
   uint8_t checkSettings =
-    (hasTopbar() ? 1 << 0 : 0) |
-    (hasSliders() ? 1 << 1 : 0) |
-    (hasTrims() ? 1 << 2 : 0) |
-    (hasFlightMode() ? 1 << 3 : 0) |
-    (isMirrored() ? 1 << 4 : 0);
+    (hasTopbar() ? DECORATION_TOPBAR : 0) |
+    (hasSliders() ? DECORATION_SLIDERS : 0) |
+    (hasTrims() ? DECORATION_TRIMS : 0) |
+    (hasFlightMode() ? DECORATION_FLIGHTMODE : 0) |
+    (isMirrored() ? DECORATION_MIRRORED : 0);
 
   if (checkSettings == decorationSettings) {
     // everything ok, exit!
@@ -119,7 +119,7 @@ void Layout::adjustLayout()
 rect_t Layout::getMainZone() const
 {
   rect_t zone = decoration->getMainZone();
-  if (decorationSettings & 0x7) {
+  if (decorationSettings & (DECORATION_SLIDERS|DECORATION_TRIMS|DECORATION_FLIGHTMODE)) {
     // some decoration activated
     zone.x += MAIN_ZONE_BORDER;
     zone.y += MAIN_ZONE_BORDER;

--- a/radio/src/gui/colorlcd/layouts/layout_factory_impl.h
+++ b/radio/src/gui/colorlcd/layouts/layout_factory_impl.h
@@ -105,8 +105,18 @@ class Layout: public LayoutBase
     const LayoutFactory * factory  = nullptr;
     std::unique_ptr<ViewMainDecoration> decoration;
 
+    enum DecorationSettings {
+        DECORATION_NONE       = 0x00,
+        DECORATION_TOPBAR     = 0x01,
+        DECORATION_SLIDERS    = 0x02,
+        DECORATION_TRIMS      = 0x04,
+        DECORATION_FLIGHTMODE = 0x08,
+        DECORATION_MIRRORED   = 0x10,
+        DECORATION_UNKNOWN    = 0xFF
+    };
+
     // Decoration settings bitmask to detect updates
-    uint8_t  decorationSettings = 255;
+    uint8_t  decorationSettings = DECORATION_UNKNOWN;
 
     // Last time we refreshed the window
     uint32_t lastRefresh = 0;


### PR DESCRIPTION
Fixes #2961 

Summary of changes:

Add enum for the 'decorationSettings' bits to make the code more understandable.
Fix the size check in 'getMainZone'.