### PR TITLE
lua: fix drawHudRectangle for roll = 0

### DIFF
--- a/radio/src/lua/api_colorlcd.cpp
+++ b/radio/src/lua/api_colorlcd.cpp
@@ -1331,7 +1331,7 @@ static void drawHudRectangle(BitmapBuffer * dc, float pitch, float roll, coord_t
   if (roll == 0.0f) { // prevent divide by zero
     dc->drawSolidFilledRect(
         xmin, max(ymin, ymin + (ywidth/2 + (coord_t)dy)),
-        xmax - xmin, min(ywidth, ywidth/2 - (coord_t)dy + (dy != 0.0f ? 1 : 0)), flags);
+        xmax - xmin, max(0,min(ywidth, ywidth/2 - (coord_t)dy)), flags);
   }
   else if (fabs(roll) >= 180.0f) {
     dc->drawSolidFilledRect(xmin, ymin, xmax - xmin, min(ywidth, ywidth/2 + (coord_t)fabsf(dy)), flags);


### PR DESCRIPTION
- removed an extra line at the bottom of the hud rectangle
- fixed overflowing hud rectangle for horizon outside (below) viewport (pitch > 0)

The C++ code is a direct port of my original LUA hud drawing code which had the same bug hidden by OpenTX not drawing rectangles with a negative height.
Lua code required an extra bottom line to be drawn to fill the rectangle when roll was 0 that is not necessary in C++