### PR TITLE
fix(lua) - Add missing switch and countdownStart properties to timer functions

### DIFF
--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -292,6 +292,8 @@ static int luaModelGetTimer(lua_State *L)
     lua_pushtableinteger(L, "persistent", timer.persistent);
     lua_pushtablenstring(L, "name", timer.name);
     lua_pushtableboolean(L, "showElapsed", timer.showElapsed);
+    lua_pushtableinteger(L, "switch", timer.swtch);
+    lua_pushtableinteger(L, "countdownStart", timer.countdownStart);
   }
   else {
     lua_pushnil(L);
@@ -347,6 +349,12 @@ static int luaModelSetTimer(lua_State *L)
       }
       else if (!strcmp(key, "showElapsed")) {
         timer.showElapsed = lua_toboolean(L, -1);
+      }
+      else if (!strcmp(key, "switch")) {
+        timer.swtch = luaL_checkinteger(L, -1);
+      }
+      else if (!strcmp(key, "countdownStart")) {
+        timer.countdownStart = luaL_checkinteger(L, -1);
       }
     }
     storageDirty(EE_MODEL);


### PR DESCRIPTION
Fixes #2960 

Summary of changes:

Add the switch and countdownStart properties to the getTimer and setTimer Lua functions.
