### PR TITLE
fix (ui) - Fix crash on model inputs and model mixes pages if limit on mixes/expos reached.

### DIFF
--- a/radio/src/gui/colorlcd/model_inputs.cpp
+++ b/radio/src/gui/colorlcd/model_inputs.cpp
@@ -47,15 +47,6 @@ uint8_t getExposCount()
   return count;
 }
 
-bool reachExposLimit()
-{
-  if (getExposCount() >= MAX_EXPOS) {
-    POPUP_WARNING(STR_NOFREEEXPO);
-    return true;
-  }
-  return false;
-}
-
 // TODO: these functions need to be added to the generic API
 //       used by all radios, and be removed from UI code
 //
@@ -179,6 +170,15 @@ ModelInputsPage::ModelInputsPage():
     // reset clipboard
     _copyMode = 0;
   });
+}
+
+bool ModelInputsPage::reachExposLimit()
+{
+  if (getExposCount() >= MAX_EXPOS) {
+    new MessageDialog(form, STR_WARNING, STR_NOFREEEXPO);
+    return true;
+  }
+  return false;
 }
 
 InputMixGroup* ModelInputsPage::getGroupBySrc(mixsrc_t src)

--- a/radio/src/gui/colorlcd/model_inputs.h
+++ b/radio/src/gui/colorlcd/model_inputs.h
@@ -59,4 +59,6 @@ class ModelInputsPage : public PageTab
   void pasteInput(uint8_t dst_idx, uint8_t input);
   void pasteInputBefore(uint8_t dst_idx);
   void pasteInputAfter(uint8_t dst_idx);
+
+  bool reachExposLimit();
 };

--- a/radio/src/gui/colorlcd/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model_mixes.cpp
@@ -64,15 +64,6 @@ uint8_t getMixesCount()
   return count;
 }
 
-bool reachMixesLimit()
-{
-  if (getMixesCount() >= MAX_MIXERS) {
-    POPUP_WARNING(STR_NOFREEMIXER);
-    return true;
-  }
-  return false;
-}
-
 void insertMix(uint8_t idx, uint8_t channel)
 {
   pauseMixerCalculations();
@@ -310,6 +301,15 @@ ModelMixesPage::ModelMixesPage() :
 {
   setTitle(STR_MIXES);
   setIcon(ICON_MODEL_MIXER);
+}
+
+bool ModelMixesPage::reachMixesLimit()
+{
+  if (getMixesCount() >= MAX_MIXERS) {
+    new MessageDialog(form, STR_WARNING, STR_NOFREEMIXER);
+    return true;
+  }
+  return false;
 }
 
 InputMixGroup* ModelMixesPage::getGroupByIndex(uint8_t index)

--- a/radio/src/gui/colorlcd/model_mixes.h
+++ b/radio/src/gui/colorlcd/model_mixes.h
@@ -53,4 +53,6 @@ class ModelMixesPage : public ModelInputsPage
   void pasteMixAfter(uint8_t dst_idx);
 
   void enableMonitors(bool enabled);
+
+  bool reachMixesLimit();
 };


### PR DESCRIPTION
Fixes #2981

Summary of changes:

The _run_popup_dialog function crashes on the model inputs and model mixes pages (I don't know why).

This change replaces the POPUP_WARNING call with a MessageDialog popup on the current window - it seems to achieve the same result without the crash.

It also uses the translated string for the warning popup title instead of a hard wired english string.
