### PR TITLE
Fix carryTrim in LUA

### DIFF
--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -96,7 +96,7 @@ PACK(struct ExpoData {
   uint16_t mode:2;
   uint16_t scale:14;
   uint16_t srcRaw:10 ENUM(MixSources) CUST(r_mixSrcRaw,w_mixSrcRaw);
-  int16_t  carryTrim:6;
+  int16_t  trimSource:6;
   uint32_t chn:5;
   int32_t  swtch:9 CUST(r_swtchSrc,w_swtchSrc);
   uint32_t flightModes:9 CUST(r_flightModes, w_flightModes);

--- a/radio/src/gui/128x64/model_input_edit.cpp
+++ b/radio/src/gui/128x64/model_input_edit.cpp
@@ -151,11 +151,11 @@ void menuModelExpoOne(event_t event)
 
       case EXPO_FIELD_TRIM:
         uint8_t notStick = (ed->srcRaw > MIXSRC_Ail);
-        int8_t carryTrim = -ed->carryTrim;
+        int8_t trimSource = -ed->trimSource;
         lcdDrawTextAlignedLeft(y, STR_TRIM);
-        lcdDrawTextAtIndex(EXPO_ONE_2ND_COLUMN, y, STR_VMIXTRIMS, (notStick && carryTrim == 0) ? 0 : carryTrim+1, RIGHT | (menuHorizontalPosition==0 ? attr : 0));
+        lcdDrawTextAtIndex(EXPO_ONE_2ND_COLUMN, y, STR_VMIXTRIMS, (notStick && trimSource == 0) ? 0 : trimSource + 1, RIGHT | (menuHorizontalPosition==0 ? attr : 0));
         if (attr)
-          ed->carryTrim = -checkIncDecModel(event, carryTrim, notStick ? TRIM_ON : -TRIM_OFF, -TRIM_LAST);
+          ed->trimSource = -checkIncDecModel(event, trimSource, notStick ? TRIM_ON : -TRIM_OFF, -TRIM_LAST);
         break;
     }
     y += FH;

--- a/radio/src/gui/212x64/model_input_edit.cpp
+++ b/radio/src/gui/212x64/model_input_edit.cpp
@@ -142,10 +142,10 @@ void menuModelExpoOne(event_t event)
 
       case EXPO_FIELD_TRIM:
         uint8_t not_stick = (ed->srcRaw > MIXSRC_Ail);
-        int8_t carryTrim = -ed->carryTrim;
+        int8_t trimSource = -ed->trimSource;
         lcdDrawTextAlignedLeft(y, STR_TRIM);
-        lcdDrawTextAtIndex(EXPO_ONE_2ND_COLUMN, y, STR_VMIXTRIMS, (not_stick && carryTrim == 0) ? 0 : carryTrim+1, menuHorizontalPosition==0 ? attr : 0);
-        if (attr) ed->carryTrim = -checkIncDecModel(event, carryTrim, not_stick ? TRIM_ON : -TRIM_OFF, -TRIM_LAST);
+        lcdDrawTextAtIndex(EXPO_ONE_2ND_COLUMN, y, STR_VMIXTRIMS, (not_stick && trimSource == 0) ? 0 : trimSource + 1, menuHorizontalPosition==0 ? attr : 0);
+        if (attr) ed->trimSource = -checkIncDecModel(event, trimSource, not_stick ? TRIM_ON : -TRIM_OFF, -TRIM_LAST);
         break;
     }
     y += FH;

--- a/radio/src/gui/colorlcd/input_edit_adv.cpp
+++ b/radio/src/gui/colorlcd/input_edit_adv.cpp
@@ -61,8 +61,8 @@ InputEditAdvanced::InputEditAdvanced(uint8_t input_n, uint8_t index) :
   line = form->newLine(&grid);
   new StaticText(line, rect_t{}, STR_TRIM, 0, COLOR_THEME_PRIMARY1);
   auto c = new Choice(line, rect_t{}, STR_VMIXTRIMS, -TRIM_OFF,
-                          -TRIM_LAST, GET_VALUE(-input->carryTrim),
-                          SET_VALUE(input->carryTrim, -newValue));
+                          -TRIM_LAST, GET_VALUE(-input->trimSource),
+                          SET_VALUE(input->trimSource, -newValue));
   c->setAvailableHandler([=](int value) {
     return value != TRIM_ON || input->srcRaw <= MIXSRC_Ail;
   });

--- a/radio/src/gui/colorlcd/input_source.cpp
+++ b/radio/src/gui/colorlcd/input_source.cpp
@@ -143,8 +143,8 @@ InputSource::InputSource(Window* parent, ExpoData* input) :
 
 void InputSource::update()
 {
-  if (input->srcRaw > MIXSRC_Ail && input->carryTrim == TRIM_ON) {
-    input->carryTrim = TRIM_OFF;
+  if (input->srcRaw > MIXSRC_Ail && input->trimSource == TRIM_ON) {
+    input->trimSource = TRIM_OFF;
   }
 
   if (!sensor_form) return;

--- a/radio/src/gui/common/stdlcd/model_inputs.cpp
+++ b/radio/src/gui/common/stdlcd/model_inputs.cpp
@@ -181,8 +181,8 @@ void displayExpoLine(coord_t y, ExpoData * ed)
 {
   drawSource(EXPO_LINE_SRC_POS, y, ed->srcRaw, 0);
 
-  if (ed->carryTrim != TRIM_ON) {
-    lcdDrawChar(EXPO_LINE_TRIM_POS, y, ed->carryTrim > 0 ? '-' : STR_RETA123[-ed->carryTrim][0]);
+  if (ed->trimSource != TRIM_ON) {
+    lcdDrawChar(EXPO_LINE_TRIM_POS, y, ed->trimSource > 0 ? '-' : STR_RETA123[-ed->trimSource][0]);
   }
 
   if (!ed->flightModes || ((ed->curve.value || ed->swtch) && ((get_tmr10ms() / 200) & 1)))

--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -578,7 +578,7 @@ Return input data for given input and line number
  * 'trimSource' (number) a positive number representing trim source
  * 'flightModes' (number) bit-mask of active flight modes
 
-@status current Introduced in 2.0.0, curveType/curveValue/carryTrim added in 2.3, inputName added 2.3.10, flighmode reworked in 2.3.11
+@status current Introduced in 2.0.0, curveType/curveValue/carryTrim added in 2.3, inputName added 2.3.10, flighmode reworked in 2.3.11, broken carryTrim replaced by trimSource in 2.8.1
 */
 static int luaModelGetInput(lua_State *L)
 {
@@ -597,7 +597,6 @@ static int luaModelGetInput(lua_State *L)
     lua_pushtableinteger(L, "switch", expo->swtch);
     lua_pushtableinteger(L, "curveType", expo->curve.type);
     lua_pushtableinteger(L, "curveValue", expo->curve.value);
-    lua_pushtableinteger(L, "carryTrim", expo->trimSource);
     lua_pushtableinteger(L, "trimSource", - expo->trimSource);
     lua_pushtableinteger(L, "flightModes", expo->flightModes);
   }
@@ -618,7 +617,7 @@ Insert an Input at specified line
 
 @param value (table) input data, see model.getInput()
 
-@status current Introduced in 2.0.0, curveType/curveValue/carryTrim added in 2.3, inputName added 2.3.10
+@status current Introduced in 2.0.0, curveType/curveValue/carryTrim added in 2.3, inputName added 2.3.10, broken carryTrim replaced by trimSource in EdgeTX 2.8.1
 */
 static int luaModelInsertInput(lua_State *L)
 {
@@ -666,9 +665,6 @@ static int luaModelInsertInput(lua_State *L)
       }
       else if (!strcmp(key, "curveValue")) {
         expo->curve.value = luaL_checkinteger(L, -1);
-      }
-      else if (!strcmp(key, "carryTrim")) { // deprecated, remove in 2024
-        expo->trimSource = luaL_checkinteger(L, -1);
       }
       else if (!strcmp(key, "trimSource")) {
         expo->trimSource = - luaL_checkinteger(L, -1);

--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -574,7 +574,8 @@ Return input data for given input and line number
  * `switch` (number) input switch index
  * `curveType` (number) curve type (function, expo, custom curve)
  * `curveValue` (number) curve index
- * `carryTrim` (boolean) input trims applied
+ * `carryTrim` deprecated, please use trimSource instead. WARNING: carryTrim was getting negative values (carryTrim = - trimSource)
+ * 'trimSource' (number) a positive number representing trim source
  * 'flightModes' (number) bit-mask of active flight modes
 
 @status current Introduced in 2.0.0, curveType/curveValue/carryTrim added in 2.3, inputName added 2.3.10, flighmode reworked in 2.3.11
@@ -596,7 +597,8 @@ static int luaModelGetInput(lua_State *L)
     lua_pushtableinteger(L, "switch", expo->swtch);
     lua_pushtableinteger(L, "curveType", expo->curve.type);
     lua_pushtableinteger(L, "curveValue", expo->curve.value);
-    lua_pushtableinteger(L, "carryTrim", expo->carryTrim);
+    lua_pushtableinteger(L, "carryTrim", expo->trimSource);
+    lua_pushtableinteger(L, "trimSource", - expo->trimSource);
     lua_pushtableinteger(L, "flightModes", expo->flightModes);
   }
   else {
@@ -665,8 +667,11 @@ static int luaModelInsertInput(lua_State *L)
       else if (!strcmp(key, "curveValue")) {
         expo->curve.value = luaL_checkinteger(L, -1);
       }
-      else if (!strcmp(key, "carryTrim")) {
-        expo->carryTrim = lua_toboolean(L, -1);
+      else if (!strcmp(key, "carryTrim")) { // deprecated, remove in 2024
+        expo->trimSource = luaL_checkinteger(L, -1);
+      }
+      else if (!strcmp(key, "trimSource")) {
+        expo->trimSource = - luaL_checkinteger(L, -1);
       }
       else if (!strcmp(key, "flightModes")) {
         expo->flightModes = luaL_checkinteger(L, -1);

--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -189,9 +189,9 @@ void applyExpos(int16_t * anas, uint8_t mode, uint8_t ovwrIdx, int16_t ovwrValue
         if (offset) v += divRoundClosest(calc100toRESX(offset), 10);
 
         //========== TRIMS ================
-        if (ed->carryTrim < TRIM_ON)
-          virtualInputsTrims[cur_chn] = -ed->carryTrim - 1;
-        else if (ed->carryTrim == TRIM_ON && ed->srcRaw >= MIXSRC_Rud && ed->srcRaw <= MIXSRC_Ail)
+        if (ed->trimSource < TRIM_ON)
+          virtualInputsTrims[cur_chn] = -ed->trimSource - 1;
+        else if (ed->trimSource == TRIM_ON && ed->srcRaw >= MIXSRC_Rud && ed->srcRaw <= MIXSRC_Ail)
           virtualInputsTrims[cur_chn] = ed->srcRaw - MIXSRC_Rud;
         else
           virtualInputsTrims[cur_chn] = -1;

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1480,7 +1480,7 @@ void instantTrim()
         if (!EXPO_VALID(expo))
           break; // end of list
         if (stick == expo->srcRaw - MIXSRC_FIRST_STICK) {
-          if (expo->carryTrim < 0) {
+          if (expo->trimSource < 0) {
             // only default trims will be taken into account
             addTrim = false;
             break;

--- a/radio/src/tests/mixer.cpp
+++ b/radio/src/tests/mixer.cpp
@@ -395,9 +395,9 @@ TEST_F(TrimsTest, MoveTrimsToOffsetsWithCrossTrims)
   g_model.limitData[1].offset = 0;
   g_model.thrTrimSw = MIXSRC_TrimEle - MIXSRC_FIRST_TRIM;
   ExpoData *expo = expoAddress(THR_STICK);
-  expo->carryTrim = TRIM_ELE;
+  expo->trimSource = TRIM_ELE;
   expo = expoAddress(ELE_STICK);
-  expo->carryTrim = TRIM_THR;
+  expo->trimSource = TRIM_THR;
 
   anaInValues[THR_STICK] = 0;
   setTrimValue(0, MIXSRC_TrimEle - MIXSRC_FIRST_TRIM, 100);
@@ -422,9 +422,9 @@ TEST_F(TrimsTest, MoveTrimsToOffsetsWithCrosstrimsAndTrimIdle)
   g_model.thrTrim = 1;
   g_model.thrTrimSw = MIXSRC_TrimEle - MIXSRC_FIRST_TRIM;
   ExpoData *expo = expoAddress(THR_STICK);
-  expo->carryTrim = TRIM_ELE;
+  expo->trimSource = TRIM_ELE;
   expo = expoAddress(ELE_STICK);
-  expo->carryTrim = TRIM_THR;
+  expo->trimSource = TRIM_THR;
 
   anaInValues[THR_STICK] = -1024;  // Min stick
   setTrimValue(0, MIXSRC_TrimEle - MIXSRC_FIRST_TRIM, 100);
@@ -834,9 +834,9 @@ TEST_F(TrimsTest, throttleTrimWithCrossTrims)
   g_model.thrTrim = 1;
   g_model.thrTrimSw = MIXSRC_TrimEle - MIXSRC_FIRST_TRIM;
   ExpoData *expo = expoAddress(THR_STICK);
-  expo->carryTrim = TRIM_ELE;
+  expo->trimSource = TRIM_ELE;
   expo = expoAddress(ELE_STICK);
-  expo->carryTrim = TRIM_THR;
+  expo->trimSource = TRIM_THR;
 
   // stick max + trim max
   anaInValues[THR_STICK] = +1024;
@@ -909,9 +909,9 @@ TEST_F(TrimsTest, invertedThrottlePlusThrottleTrimWithCrossTrims)
   g_model.thrTrim = 1;
   g_model.thrTrimSw = MIXSRC_TrimEle - MIXSRC_FIRST_TRIM;
   ExpoData *expo = expoAddress(THR_STICK);
-  expo->carryTrim = TRIM_ELE;
+  expo->trimSource = TRIM_ELE;
   expo = expoAddress(ELE_STICK);
-  expo->carryTrim = TRIM_THR;
+  expo->trimSource = TRIM_THR;
 
   // stick max + trim max
   anaInValues[THR_STICK] = +1024;


### PR DESCRIPTION
- rename the carryTrim in ExpoData to trimSource, and fix it's lua casting
- trimSource is using positive values, where carryTrim was using negative ones

This fixes https://github.com/opentx/opentx/issues/8995 also existing in EdgeTX

There is no Companion impact, as data model is untouched.