### PR TITLE
Added turning the red LED before RTC data and blue LED afterwards

### DIFF
--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -236,11 +236,13 @@ void boardInit()
   sportUpdateInit();
 #endif
 
-  ledBlue();
+  ledRed();
 
 #if defined(RTCLOCK) && !defined(COPROCESSOR)
   rtcInit(); // RTC must be initialized before rambackupRestore() is called
 #endif
+
+  ledBlue();
 }
 
 void boardOff()
@@ -276,8 +278,8 @@ void boardOff()
   RTC->BKP0R = SHUTDOWN_REQUEST;
 
   pwrOff();
-  
-  // We reach here only in forced power situations, such as hw-debugging with external power  
+
+  // We reach here only in forced power situations, such as hw-debugging with external power
   // Enter STM32 stop mode / deep-sleep
   // Code snippet from ST Nucleo PWR_EnterStopMode example
 #define PDMode             0x00000000U
@@ -291,7 +293,7 @@ void boardOff()
 
 /* Set SLEEPDEEP bit of Cortex System Control Register */
   SET_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SLEEPDEEP_Msk));
-  
+
   // To avoid HardFault at return address, end in an endless loop
   while (1) {
 

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -236,9 +236,8 @@ void boardInit()
   sportUpdateInit();
 #endif
 
-  ledRed();
-
 #if defined(RTCLOCK) && !defined(COPROCESSOR)
+  ledRed();
   rtcInit(); // RTC must be initialized before rambackupRestore() is called
 #endif
 


### PR DESCRIPTION
With the LED turned RED if the RTC data retrieval fails it will stay red. This will at least be an indication that the RTC startup encountered a problem. For now there is no indication that this problem occurred.

<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

It doesn't really fix #3005, but helps in diagnostics.

Summary of changes:

Added red LED before initializing RTC and blue LED afterward.