### PR TITLE
fix(cpn) - Delete old models from radio before saving new models

### DIFF
--- a/companion/src/storage/labeled.cpp
+++ b/companion/src/storage/labeled.cpp
@@ -312,25 +312,21 @@ bool LabelsStorageFormat::writeYaml(const RadioData & radioData)
 
   bool hasLabels = getCurrentFirmware()->getCapability(HasModelLabels);
 
-  //  B&W radios do not use the models.yml file and scan the MODELS folder for modelxx.yml files
-  //  models have been deleted or reordered in Companion so delete all old modelxx.yml and just in case models.yml files
-  //  from radio MODELS folder before writing new modelxx.yml files
-  if (!hasLabels) {
-    // fetch "MODELS/modelXX.yml"
-    std::list<std::string> filelist;
-    if (!getFileList(filelist)) {
-      setError(tr("Cannot list files"));
-      return false;
-    }
+  // Delete all old modelxx.yml from radio MODELS folder before writing new modelxx.yml files
+  // fetch "MODELS/modelXX.yml"
+  std::list<std::string> filelist;
+  if (!getFileList(filelist)) {
+    setError(tr("Cannot list files"));
+    return false;
+  }
 
-    const std::regex yml_regex("MODELS/(model([0-9s]+)\\.yml)");
-    for(const auto& f : filelist) {
-      std::smatch match;
-      if (std::regex_match(f, match, yml_regex)) {
-        if (match.size() == 3) {
-          if (!deleteFile(QString(f.c_str()))) {
-            return false;
-          }
+  const std::regex yml_regex("MODELS/(model([0-9s]+)\\.yml)");
+  for(const auto& f : filelist) {
+    std::smatch match;
+    if (std::regex_match(f, match, yml_regex)) {
+      if (match.size() == 3) {
+        if (!deleteFile(QString(f.c_str()))) {
+          return false;
         }
       }
     }

--- a/companion/src/storage/labeled.cpp
+++ b/companion/src/storage/labeled.cpp
@@ -312,7 +312,6 @@ bool LabelsStorageFormat::writeYaml(const RadioData & radioData)
 
   bool hasLabels = getCurrentFirmware()->getCapability(HasModelLabels);
 
-  // Delete all old modelxx.yml from radio MODELS folder before writing new modelxx.yml files
   // fetch "MODELS/modelXX.yml"
   std::list<std::string> filelist;
   if (!getFileList(filelist)) {
@@ -320,12 +319,14 @@ bool LabelsStorageFormat::writeYaml(const RadioData & radioData)
     return false;
   }
 
+  // Delete all old modelxx.yml from radio MODELS folder before writing new modelxx.yml files
   const std::regex yml_regex("MODELS/(model([0-9s]+)\\.yml)");
   for(const auto& f : filelist) {
     std::smatch match;
     if (std::regex_match(f, match, yml_regex)) {
       if (match.size() == 3) {
         if (!deleteFile(QString(f.c_str()))) {
+          setError(tr("Error deleting files"));
           return false;
         }
       }


### PR DESCRIPTION
Fixes #2817 #3011 

Summary of changes:

Make companion work the same on color LCD radios as on B&W - delete all model files from the radio before saving new models.
