### PR TITLE
fix(ui,cpn) - Fix error in value conversion when loading logical switch data.

### DIFF
--- a/companion/src/firmwares/edgetx/yaml_logicalswitchdata.cpp
+++ b/companion/src/firmwares/edgetx/yaml_logicalswitchdata.cpp
@@ -47,7 +47,7 @@ static int timerValue2lsw(uint32_t t)
 {
   if (t < 20) {
     return t - 129;
-  } else if (600) {
+  } else if (t < 600) {
     return t / 5 - 113;
   } else {
     return t / 10 - 53;

--- a/companion/src/firmwares/edgetx/yaml_rawswitch.cpp
+++ b/companion/src/firmwares/edgetx/yaml_rawswitch.cpp
@@ -71,7 +71,7 @@ std::string YamlRawSwitchEncode(const RawSwitch& rhs)
 
   case SWITCH_TYPE_SENSOR:
     sw_str += "T";
-    sw_str += std::to_string(sval + 1);
+    sw_str += std::to_string(sval);
     break;
 
   default:
@@ -131,7 +131,7 @@ RawSwitch YamlRawSwitchDecode(const std::string& sw_str)
     // starts at T1
     int sensor_idx = std::stoi(sw_str_tmp.substr(1, val_len - 1));
     if ((sensor_idx > 0) && (sensor_idx <= CPN_MAX_SENSORS)) {
-      rhs = RawSwitch(SWITCH_TYPE_SENSOR, sensor_idx - 1);
+      rhs = RawSwitch(SWITCH_TYPE_SENSOR, sensor_idx);
     }
 
   } else if (sw_str_tmp.substr(0, 4) == std::string("Trim")) {

--- a/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
@@ -1647,7 +1647,7 @@ static delayval_t timerValue2lsw(uint32_t t)
 {
   if (t < 20) {
     return t - 129;
-  } else if (600) {
+  } else if (t < 600) {
     return t / 5 - 113;
   } else {
     return t / 10 - 53;
@@ -1708,6 +1708,7 @@ static void r_logicSw(void* user, uint8_t* data, uint32_t bitoffs,
     if (!val_len || val[0] != ',') return;
     val++; val_len--;
     ls->v2 = timerValue2lsw(yaml_str2uint(val, val_len));
+  fprintf(stderr,">>>>> TIMER %s %d %d\n", val,ls->v1,ls->v2);
     break;
     
   default:

--- a/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
@@ -1708,7 +1708,6 @@ static void r_logicSw(void* user, uint8_t* data, uint32_t bitoffs,
     if (!val_len || val[0] != ',') return;
     val++; val_len--;
     ls->v2 = timerValue2lsw(yaml_str2uint(val, val_len));
-  fprintf(stderr,">>>>> TIMER %s %d %d\n", val,ls->v1,ls->v2);
     break;
     
   default:


### PR DESCRIPTION
Fixes #3022 

Summary of changes:

Fixes a logic error in the timerValue2lsw function when converting YAML values for 'Edge' and 'Timer' logical switches.

The existing version will corrupt the saved values for these logical switch functions when the model is re-loaded. Unfortunately there is no way to undo this and restore the original value.