### PR TITLE
fix(ui) - Update date & time in top bar on model and radio setup pages.

### DIFF
--- a/radio/src/gui/colorlcd/tabsgroup.cpp
+++ b/radio/src/gui/colorlcd/tabsgroup.cpp
@@ -247,6 +247,13 @@ void TabsGroup::checkEvents()
   if (currentTab) {
     currentTab->checkEvents();
   }
+
+  static uint32_t lastRefresh = 0;
+  uint32_t now = RTOS_GET_MS();
+  if (now - lastRefresh >= 5000) {
+    lastRefresh = now;
+    header.invalidate();
+  }
 }
 
 void TabsGroup::onEvent(event_t event)


### PR DESCRIPTION
Fixes #3031 

Summary of changes:

Periodically refresh header to update date/time value.

Note: header refresh also redraws all the icons. To avoid too much overhead the header is only refreshed once every 5 seconds. The time does not display seconds so this should be adequate.