### PR TITLE
feat(cpn): Status dialog when writing models and settings to radio

### DIFF
--- a/companion/src/helpers.cpp
+++ b/companion/src/helpers.cpp
@@ -929,3 +929,25 @@ bool SemanticVersion::fromInt(const unsigned int val)
   version.preReleaseNumber = Helpers::getBitmappedValue(val, 0, 4);
   return isValid();
 }
+
+StatusDialog::StatusDialog(QWidget * parent, const QString title, QString msgtext, const int width) :
+  QDialog(parent)
+{
+  setWindowTitle(title);
+  QVBoxLayout *layout = new QVBoxLayout(this);
+  msg = new QLabel(this);
+  msg->setFixedWidth(width);
+  msg->setContentsMargins(50, 50, 50, 50);
+  update(msgtext);
+  layout->addWidget(msg);
+  show();
+}
+
+StatusDialog::~StatusDialog()
+{
+}
+
+void StatusDialog::update(QString text)
+{
+  msg->setText(text);
+}

--- a/companion/src/helpers.h
+++ b/companion/src/helpers.h
@@ -29,6 +29,7 @@
 #include <QTime>
 #include <QElapsedTimer>
 #include <QStandardItemModel>
+#include <QDialog>
 
 extern const QColor colors[CPN_MAX_CURVES];
 
@@ -310,4 +311,18 @@ class SemanticVersion
     inline QString preReleaseTypeToString() const { return PreReleaseTypesStringList.value(version.preReleaseType, ""); }
     inline int preReleaseTypeToInt(QString preRelType) const { return PreReleaseTypesStringList.indexOf(preRelType); }
 
+};
+
+class StatusDialog: public QDialog
+{
+    Q_OBJECT
+
+  public:
+    StatusDialog(QWidget * parent = nullptr, const QString title = "", QString msgtext = "", const int width = 200);
+    virtual ~StatusDialog();
+
+    void update(QString text);
+
+  private:
+    QLabel *msg;
 };

--- a/companion/src/mainwindow.cpp
+++ b/companion/src/mainwindow.cpp
@@ -530,8 +530,12 @@ void MainWindow::customizeSplash()
 
 void MainWindow::writeSettings()
 {
+  StatusDialog *status = new StatusDialog(this, tr("Writing models and settings to radio"), tr("In progress..."), 400);
+
   if (activeMdiChild())
-    activeMdiChild()->writeSettings();
+    activeMdiChild()->writeSettings(status);
+
+  delete status;
 }
 
 void MainWindow::readSettings()

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1402,7 +1402,7 @@ int MdiChild::askQuestion(const QString & msg, QMessageBox::StandardButtons butt
   return QMessageBox::question(this, CPN_STR_APP_NAME, msg, buttons, defaultButton);
 }
 
-void MdiChild::writeSettings()  // write to Tx
+void MdiChild::writeSettings(StatusDialog * status)  // write to Tx
 {
   if (g.confirmWriteModelsAndSettings()) {
     QMessageBox msgbox;
@@ -1412,7 +1412,7 @@ void MdiChild::writeSettings()  // write to Tx
     msgbox.setStandardButtons(QMessageBox::Yes | QMessageBox::Abort);
     msgbox.setDefaultButton(QMessageBox::Abort);
 
-    QCheckBox *cb = new QCheckBox(tr("Don't show this message again"));
+    QCheckBox *cb = new QCheckBox(tr("Do not show this message again"));
     msgbox.setCheckBox(cb);
     connect(cb, &QCheckBox::stateChanged, [=](const int &state){ g.confirmWriteModelsAndSettings(!state); });
 
@@ -1430,12 +1430,15 @@ void MdiChild::writeSettings()  // write to Tx
       QMessageBox::critical(this, CPN_STR_TTL_ERROR, tr("Unable to find radio SD card!"));
       return;
     }
+
     if (saveFile(radioPath, false)) {
-      QMessageBox::information(this, CPN_STR_TTL_INFO, tr("Saved models and settings to radio"));
+      status->hide();
+      QMessageBox::information(this, CPN_STR_TTL_INFO, tr("Models and settings written to radio"));
     }
     else {
       qDebug() << "MdiChild::writeEeprom(): saveFile error";
-      QMessageBox::critical(this, CPN_STR_TTL_ERROR, tr("Error saving models and settings to radio!"));
+      status->hide();
+      QMessageBox::critical(this, CPN_STR_TTL_ERROR, tr("Error writing models and settings to radio!"));
     }
   }
   else {

--- a/companion/src/mdichild.h
+++ b/companion/src/mdichild.h
@@ -34,6 +34,7 @@
 #include <QListWidget>
 
 class QToolBar;
+class StatusDialog;
 
 namespace Ui {
 class MdiChild;
@@ -95,7 +96,7 @@ class MdiChild : public QWidget
     bool saveAs(bool isNew=false);
     bool saveFile(const QString & fileName, bool setCurrent=true);
     void closeFile(bool force = false);
-    void writeSettings();
+    void writeSettings(StatusDialog * status);
     void print(int model=-1, const QString & filename="");
     void onFirmwareChanged();
 


### PR DESCRIPTION
Fixes #2932

Summary of changes:
- display a static progress message whilst writing

The ideal solution would be a progress bar however the refactoring is not insignificant.