### PR TITLE
feat(fw): Only attach SD card in USB storage mode

### DIFF
--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -58,6 +58,7 @@ option(TBS_RELEASE "Used to build TBS released firmware" OFF)
 option(IMRC_RELEASE "Used to build IMRC released firmware" OFF)
 option(HARDWARE_TRAINER_MULTI "Allow multi trainer" OFF)
 option(BOOTLOADER "Include Bootloader" ON)
+option(FWDRIVE "Attach also firmware drive with USB" OFF)
 
 # since we reset all default CMAKE compiler flags for firmware builds, provide an alternate way for user to specify additional flags.
 set(FIRMWARE_C_FLAGS "" CACHE STRING "Additional flags for firmware target c compiler (note: all CMAKE_C_FLAGS[_*] are ignored for firmware/bootloader).")
@@ -446,6 +447,10 @@ else()
   set(DEFAULT_TEMPLATE_SETUP 0 CACHE STRING "")
 endif()
 add_definitions(-DDEFAULT_TEMPLATE_SETUP=${DEFAULT_TEMPLATE_SETUP})
+
+if(FWDRIVE)
+  add_definitions(-DFWDRIVE)
+endif()
 
 set(SRC
   ${SRC}

--- a/radio/src/targets/common/arm/stm32/usbd_desc.c
+++ b/radio/src/targets/common/arm/stm32/usbd_desc.c
@@ -58,7 +58,7 @@
 #define USBD_VID_PID_CODES                  0x1209    // https://pid.codes
 
 #define USBD_LANGID_STRING                  0x409
-#define USBD_MANUFACTURER_STRING            "OpenTX"
+#define USBD_MANUFACTURER_STRING            "EdgeTX"
 #define USBD_SERIALNUMBER_FS_STRING         "00000000001B"
 
 #if defined(BOOT)

--- a/radio/src/targets/common/arm/stm32/usbd_storage_msd.cpp
+++ b/radio/src/targets/common/arm/stm32/usbd_storage_msd.cpp
@@ -44,12 +44,11 @@ extern "C" {
 
 enum MassstorageLuns {
   STORAGE_SDCARD_LUN,
-  STORAGE_EEPROM_LUN,
   STORAGE_LUN_NBR
 };
 
 /* USB Mass storage Standard Inquiry Data */
-const unsigned char STORAGE_Inquirydata[] = { //36
+const unsigned char STORAGE_Inquirydata[] = { //18
   /* LUN 0 */
   0x00,		
   0x80,		
@@ -63,25 +62,9 @@ const unsigned char STORAGE_Inquirydata[] = { //36
   USB_PRODUCT,                             /* Product      : 16 Bytes */
   'R', 'a', 'd', 'i', 'o', ' ', ' ', ' ',
   '1', '.', '0', '0',                      /* Version      : 4 Bytes */
-  /* LUN 1 */
-  0x00,		
-  0x80,		
-  0x02,		
-  0x02,
-  (USBD_STD_INQUIRY_LENGTH - 5),
-  0x00,
-  0x00,	
-  0x00,
-  USB_MANUFACTURER,                        /* Manufacturer : 8 bytes */
-  USB_PRODUCT,                             /* Product      : 16 Bytes */
-  'R', 'a', 'd', 'i', 'o', ' ', ' ', ' ',
-  '1', '.', '0' ,'0',                      /* Version      : 4 Bytes */
 };
 
 #define RESERVED_SECTORS (1 /*Boot*/ + 2 /*Fat table */ + 1 /*Root dir*/ + 8 /* one cluster for firmware.txt */)
-
-int32_t fat12Write(const uint8_t * buffer, uint16_t sector, uint16_t count);
-int32_t fat12Read(uint8_t * buffer, uint16_t sector, uint16_t count );
 
 int8_t STORAGE_Init (uint8_t lun);
 
@@ -89,9 +72,9 @@ int8_t STORAGE_GetCapacity (uint8_t lun,
                            uint32_t *block_num, 
                            uint32_t *block_size);
 
-int8_t  STORAGE_IsReady (uint8_t lun);
+int8_t STORAGE_IsReady (uint8_t lun);
 
-int8_t  STORAGE_IsWriteProtected (uint8_t lun);
+int8_t STORAGE_IsWriteProtected (uint8_t lun);
 
 int8_t STORAGE_Read (uint8_t lun, 
                         uint8_t *buf, 
@@ -149,16 +132,6 @@ int8_t STORAGE_Init (uint8_t lun)
   */
 int8_t STORAGE_GetCapacity (uint8_t lun, uint32_t *block_num, uint32_t *block_size)
 {
-  if (lun == STORAGE_EEPROM_LUN) {
-    *block_size = BLOCK_SIZE;
-#if defined(EEPROM)
-    *block_num  = RESERVED_SECTORS + EEPROM_SIZE/BLOCK_SIZE + FLASHSIZE/BLOCK_SIZE;
-#else
-    *block_num  = RESERVED_SECTORS + FLASHSIZE/BLOCK_SIZE;
-#endif
-    return 0;
-  }
-
   if (!SD_CARD_PRESENT())
     return -1;
   
@@ -182,7 +155,6 @@ uint8_t lunReady[STORAGE_LUN_NBR];
 void usbInitLUNs()
 {
   lunReady[STORAGE_SDCARD_LUN] = 1;
-  lunReady[STORAGE_EEPROM_LUN] = 1;
 }
 
 /**
@@ -192,12 +164,6 @@ void usbInitLUNs()
   */
 int8_t  STORAGE_IsReady (uint8_t lun)
 { 
-#if defined(EEPROM)
-  if (lun == STORAGE_EEPROM_LUN) {
-    return (lunReady[STORAGE_EEPROM_LUN] != 0) ? 0 : -1;
-  }
-#endif
-
   return (lunReady[STORAGE_SDCARD_LUN] != 0 && SD_CARD_PRESENT()) ? 0 : -1;
 }
 
@@ -227,10 +193,6 @@ int8_t STORAGE_Read (uint8_t lun,
 {
   WATCHDOG_SUSPEND(100/*1s*/);
   
-  if (lun == STORAGE_EEPROM_LUN) {
-    return (fat12Read(buf, blk_addr, blk_len) == 0) ? 0 : -1;
-  }
-
   // read without cache
   return (__disk_read(0, buf, blk_addr, blk_len) == RES_OK) ? 0 : -1;
 }
@@ -250,10 +212,6 @@ int8_t STORAGE_Write (uint8_t lun,
 {
   WATCHDOG_SUSPEND(100/*1s*/);
   
-  if (lun == STORAGE_EEPROM_LUN)	{
-    return (fat12Write(buf, blk_addr, blk_len) == 0) ? 0 : -1;
-  }
-
   // write without cache
   return (__disk_write(0, buf, blk_addr, blk_len) == RES_OK) ? 0 : -1;
 }
@@ -267,358 +225,4 @@ int8_t STORAGE_Write (uint8_t lun,
 int8_t STORAGE_GetMaxLun (void)
 {
   return STORAGE_LUN_NBR - 1;
-}
-
-
-/* Firmware.txt */
-const char firmware_txt[] =
-#if defined(BOOT)
-  "EdgeTX Bootloader"
-#else
-  "EdgeTX Firmware"
-#endif
-  " for " FLAVOUR "\r\n\r\n"
-#if defined(BOOT)
-  "BOOTVER    "
-#else
-  "FWVERSION  "
-#endif
-  "edgetx-" FLAVOUR "-" VERSION " (" GIT_STR ")\r\n"
-  "DATE       " DATE "\r\n"
-  "TIME       " TIME "\r\n"
-#if !defined(BOOT)
-  "BOOTVER   "
-#else
-  "FWVERSION "
-#endif
-  ;
-
-//------------------------------------------------------------------------------
-/**
- * FAT12 boot sector partition.
- */
-#if defined(EEPROM)
-#define TOTALSECTORS  (RESERVED_SECTORS + (EEPROM_SIZE/BLOCK_SIZE) +  (FLASHSIZE/BLOCK_SIZE))
-#else
-#define TOTALSECTORS  (RESERVED_SECTORS + (FLASHSIZE/BLOCK_SIZE))
-#endif
-const char g_FATboot[BLOCK_SIZE] =
-{
-  0xeb, 0x3c, 0x90, // Jump instruction.
-  'O', 'p', 'e', 'n', 'T', 'x', 0x00, 0x00, // OEM Name
-  0x00, 0x02, // Bytes per sector
-  0x08, // Sectors per FS cluster.
-  0x01, 0x00, // Reserved sector count
-
-  0x01, // Number of FATs
-  0x10, 0x00, // Number of root directory entries
-  TOTALSECTORS & 0x00ff,  (TOTALSECTORS & 0xff00) >> 8, // Total sectors
-  0xf8, // Media descriptor
-  0x02, 0x00, // Sectors per FAT table
-  0x20, 0x00, // Sectors per track
-  0x40, 0x00, // Number of heads
-  0x00, 0x00, 0x00, 0x00, // Number of hidden sectors
-
-  0x00, 0x00, 0x00, 0x00, // Large number of sectors.
-  0x00, // Physical drive number
-  0x00, // Reserved
-  0x29, // Extended boot signature
-  'O', 'T', 'x', 0xD1, // Disk ID (serial number)
-  'V', 'I', 'R', 'T', 'F', 'S', ' ', ' ', ' ', ' ', ' ', // Volume label
-  'F', 'A', 'T', '1', '2', ' ', ' ', ' ', // FAT file system type
-  0x00, 0x00, // OS boot code
-
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x55, 0xaa
-};
-
-
-//	File Attributes
-//	0 	0x01 	Read Only.
-//	1 	0x02 	Hidden.
-//	2 	0x04 	System.
-//	3 	0x08 	Volume Label.
-//	4 	0x10 	Subdirectory.
-//	5 	0x20 	Archive.
-//	6 	0x40 	Device.
-//	7 	0x80 	Reserved.
-
-typedef struct
-{
-    uint8_t name[8];
-    uint8_t ext[3];
-    uint8_t attribute;
-    uint8_t reserved;
-    uint8_t create_time_ms;
-    uint16_t create_time;
-    uint16_t create_date;
-    uint16_t access_date;
-    uint16_t ea_index;
-    uint16_t modify_time;
-    uint16_t modify_date;
-    uint16_t start_cluster;
-    uint32_t file_size;
-} FATDirEntry_t;
-
-// First 16 FAT root directory entries (1 sector)
-const FATDirEntry_t g_DIRroot[] =
-{
-    {
-        { USB_PRODUCT },
-        { ' ', ' ', ' '},
-        0x08,		// Volume
-        0x00,
-        0x00,
-        0x0000,
-        0x0000,
-        0x0000,
-        0x0000,
-        0x0000,
-        0x0000,
-        0x0000,
-        0x00000000
-    },
-    {
-      { 'F', 'I', 'R', 'M', 'W', 'A', 'R', 'E'},
-      { 'T', 'X', 'T'},
-      0x21,          // Readonly+Archive
-      0x00,
-      0x3E,
-      0xA301,
-      0x3D55,
-      0x3D55,
-      0x0000,
-      0xA302,
-      0x3D55,
-      0x0002,
-      sizeof(firmware_txt) + strlen(getFirmwareVersion())
-    },
-    {
-      { 'F', 'I', 'R', 'M', 'W', 'A', 'R', 'E'},
-      { 'B', 'I', 'N'},
-#if defined(BOOT)
-      0x20,          // Archive
-#else
-      0x21,          // Readonly+Archive
-#endif
-      0x00,
-      0x3E,
-      0xA301,
-      0x3D55,
-      0x3D55,
-      0x0000,
-      0xA302,
-      0x3D55,
-      0x0003,
-      FLASHSIZE
-  },
-#if defined(EEPROM)
-    {
-        { 'E', 'E', 'P', 'R', 'O', 'M', ' ', ' '},
-        { 'B', 'I', 'N'},
-        0x20,		// Archive
-        0x00,
-        0x3E,
-        0xA301,
-        0x3D55,
-        0x3D55,
-        0x0000,
-        0xA302,
-        0x3D55,
-        0x0003 + (FLASHSIZE/BLOCK_SIZE)/8,
-        EEPROM_SIZE
-    },
-#endif
-  // Emty entries are 0x00, omitted here. Up to 16 entries can be defined here
-};
-
-static void writeByte(uint8_t *buffer, uint16_t sector, int byte, uint8_t value)
-{
-  if (byte >= sector* BLOCK_SIZE && byte < (sector+1)* BLOCK_SIZE)
-    buffer[byte - sector*BLOCK_SIZE] = value;
-}
-
-static void pushCluster(uint8_t *buffer, uint16_t sector, uint16_t & cluster, int & rest, uint16_t value)
-{
-  // boot sector is in front of FAT
-  sector= sector-1;
-
-  // First byte of the cluster
-  int startbyte = cluster *3/2;
-  if (cluster % 2 == 0) {
-    // First 12 bit half
-    rest = value >> 8;
-    writeByte(buffer, sector, startbyte, value & 0xff);
-  } else {
-    // second 12 bit half, write rest and next byte
-    writeByte(buffer, sector, startbyte, value << 4 | rest );
-    writeByte(buffer, sector, startbyte+1, (value >> 4) & 0xff);
-  }
-  cluster++;
-}
-
-// count is number of 512 byte sectors
-int32_t fat12Read(uint8_t * buffer, uint16_t sector, uint16_t count)
-{
-  while(count) {
-    memset(buffer, 0x00, BLOCK_SIZE);
-    if (sector == 0) {
-      memcpy(buffer, g_FATboot, sizeof(g_FATboot) ) ;
-    }
-    else if (sector == 1 || sector == 2) {
-      // FAT table. Generate on the fly to save the 1024 byte flash space
-      uint16_t cluster=0;
-      int rest;
-      pushCluster (buffer, sector, cluster, rest, (uint16_t) 0xFF8);
-      pushCluster (buffer, sector, cluster, rest, (uint16_t) 0xFFF);
-
-      // Entry for firmware.txt, exactly one cluster
-      pushCluster (buffer, sector, cluster, rest, (uint16_t) 0xFFF);
-
-      // Entry for firmware.bin
-      for (int i=0;i<FLASHSIZE/BLOCK_SIZE/8 -1;i++)
-        pushCluster (buffer, sector, cluster, rest, cluster+1);
-      pushCluster (buffer, sector, cluster, rest, (uint16_t) 0xFFF);
-
-#if defined(EEPROM)
-      // Entry for eeprom.bin
-      for (int i=0;i<EEPROM_SIZE/BLOCK_SIZE/8 -1;i++)
-        pushCluster (buffer, sector, cluster, rest, cluster+1);
-      pushCluster (buffer, sector, cluster, rest, (uint16_t) 0xFFF);
-#endif
-
-      // Ensure last cluster is written if it is the first half
-      pushCluster (buffer, sector, cluster, rest, (uint16_t)  0x000);
-
-      // Rest is 0x0 as per memset
-    }
-    else if (sector == 3) {
-      memcpy(buffer, g_DIRroot, sizeof(g_DIRroot) ) ;
-    }
-    else if (sector == 4) {
-      memcpy(buffer, firmware_txt, sizeof(firmware_txt));
-      strcpy((char *)(buffer + sizeof(firmware_txt)), getFirmwareVersion());
-    }
-    else if (sector < RESERVED_SECTORS) {
-      // allocated to firmware.txt
-    }
-    else if (sector < RESERVED_SECTORS + (FLASHSIZE/BLOCK_SIZE )) {
-      uint32_t address;
-      address = sector - RESERVED_SECTORS;
-      address *= BLOCK_SIZE;
-      address += FIRMWARE_ADDRESS;
-      memcpy(buffer, (uint8_t *)address, BLOCK_SIZE);
-    }
-#if defined(EEPROM)
-    else if (sector < RESERVED_SECTORS + (EEPROM_SIZE/BLOCK_SIZE) + (FLASHSIZE/BLOCK_SIZE)) {
-      eepromReadBlock(buffer, (sector - RESERVED_SECTORS - (FLASHSIZE/BLOCK_SIZE))*BLOCK_SIZE, BLOCK_SIZE);
-    }
-#endif
-    buffer += BLOCK_SIZE ;
-    sector++ ;
-    count-- ;
-  }
-  return 0;
-}
-
-
-
-int32_t fat12Write(const uint8_t * buffer, uint16_t sector, uint16_t count)
-{
-  enum FatWriteOperation {
-    FATWRITE_NONE,
-    FATWRITE_EEPROM,
-    FATWRITE_FIRMWARE
-  };
-
-  // Silence compiler warning that this is not used on X10
-  __attribute__((unused)) static uint8_t operation = FATWRITE_NONE;
-
-  TRACE("FAT12 Write(sector=%d, count=%d)", sector, count);
-
-  if (sector < RESERVED_SECTORS) {
-    // reserved, read-only
-  }
-  else if (sector < RESERVED_SECTORS + (FLASHSIZE/BLOCK_SIZE)) {
-#if !defined(BOOT) // Don't allow overwrite of running firmware
-    return -1;
-#else
-    // firmware
-    uint32_t address;
-    address = sector - RESERVED_SECTORS;
-    address *= BLOCK_SIZE;
-    address += FIRMWARE_ADDRESS;
-    while (count) {
-      for (uint32_t i=0; i<BLOCK_SIZE/FLASH_PAGESIZE; i++) {
-        if (address >= FIRMWARE_ADDRESS+BOOTLOADER_SIZE/*protect bootloader*/ && address <= FIRMWARE_ADDRESS+FLASHSIZE-FLASH_PAGESIZE) {
-          if (address == FIRMWARE_ADDRESS+BOOTLOADER_SIZE && isFirmwareStart(buffer)) {
-            TRACE("FIRMWARE start found in sector %d", sector);
-            operation = FATWRITE_FIRMWARE;
-          }
-          if (operation == FATWRITE_FIRMWARE) {
-            flashWrite((uint32_t *)address, (uint32_t *)buffer);
-          }
-        }
-        address += FLASH_PAGESIZE;
-        buffer += FLASH_PAGESIZE;
-      }
-      sector++;
-      count--;
-      if (sector-RESERVED_SECTORS >= (FLASHSIZE/BLOCK_SIZE)) {
-        TRACE("FIRMWARE end written at sector %d", sector-1);
-        operation = FATWRITE_NONE;
-      }
-    }
-#endif
-  }
-#if defined(EEPROM)
-  else if (sector < RESERVED_SECTORS + (EEPROM_SIZE/BLOCK_SIZE) + (FLASHSIZE/BLOCK_SIZE)) {
-    // eeprom
-    while (count) {
-      if (operation == FATWRITE_NONE && isEepromStart(buffer)) {
-        TRACE("EEPROM start found in sector %d", sector);
-        operation = FATWRITE_EEPROM;
-      }
-      if (operation == FATWRITE_EEPROM) {
-        eepromWriteBlock((uint8_t *)buffer, (sector-RESERVED_SECTORS-(FLASHSIZE/BLOCK_SIZE))*BLOCK_SIZE, BLOCK_SIZE);
-      }
-      buffer += BLOCK_SIZE;
-      sector++;
-      count--;
-      if (sector-RESERVED_SECTORS >= (EEPROM_SIZE/BLOCK_SIZE)+(FLASHSIZE/BLOCK_SIZE)) {
-        TRACE("EEPROM end written at sector %d", sector-1);
-        operation = FATWRITE_NONE;
-      }
-    }
-  }
-#endif
-  return 0 ;
 }

--- a/radio/src/targets/common/arm/stm32/usbd_storage_msd.cpp
+++ b/radio/src/targets/common/arm/stm32/usbd_storage_msd.cpp
@@ -44,11 +44,14 @@ extern "C" {
 
 enum MassstorageLuns {
   STORAGE_SDCARD_LUN,
+#if defined(FWDRIVE)
+  STORAGE_EEPROM_LUN,
+#endif  
   STORAGE_LUN_NBR
 };
 
 /* USB Mass storage Standard Inquiry Data */
-const unsigned char STORAGE_Inquirydata[] = { //18
+const unsigned char STORAGE_Inquirydata[] = {
   /* LUN 0 */
   0x00,		
   0x80,		
@@ -62,9 +65,29 @@ const unsigned char STORAGE_Inquirydata[] = { //18
   USB_PRODUCT,                             /* Product      : 16 Bytes */
   'R', 'a', 'd', 'i', 'o', ' ', ' ', ' ',
   '1', '.', '0', '0',                      /* Version      : 4 Bytes */
+#if defined(FWDRIVE)
+  /* LUN 1 */
+  0x00,		
+  0x80,		
+  0x02,		
+  0x02,
+  (USBD_STD_INQUIRY_LENGTH - 5),
+  0x00,
+  0x00,	
+  0x00,
+  USB_MANUFACTURER,                        /* Manufacturer : 8 bytes */
+  USB_PRODUCT,                             /* Product      : 16 Bytes */
+  'R', 'a', 'd', 'i', 'o', ' ', ' ', ' ',
+  '1', '.', '0' ,'0',                      /* Version      : 4 Bytes */
+#endif  
 };
 
-#define RESERVED_SECTORS (1 /*Boot*/ + 2 /*Fat table */ + 1 /*Root dir*/ + 8 /* one cluster for firmware.txt */)
+#if defined(FWDRIVE)
+ #define RESERVED_SECTORS (1 /*Boot*/ + 2 /*Fat table */ + 1 /*Root dir*/ + 8 /* one cluster for firmware.txt */)
+
+ int32_t fat12Write(const uint8_t * buffer, uint16_t sector, uint16_t count);
+ int32_t fat12Read(uint8_t * buffer, uint16_t sector, uint16_t count );
+#endif
 
 int8_t STORAGE_Init (uint8_t lun);
 
@@ -132,6 +155,18 @@ int8_t STORAGE_Init (uint8_t lun)
   */
 int8_t STORAGE_GetCapacity (uint8_t lun, uint32_t *block_num, uint32_t *block_size)
 {
+#if defined(FWDRIVE)
+  if (lun == STORAGE_EEPROM_LUN) {
+    *block_size = BLOCK_SIZE;
+ #if defined(EEPROM)
+    *block_num  = RESERVED_SECTORS + EEPROM_SIZE/BLOCK_SIZE + FLASHSIZE/BLOCK_SIZE;
+ #else
+    *block_num  = RESERVED_SECTORS + FLASHSIZE/BLOCK_SIZE;
+ #endif
+    return 0;
+  }
+#endif
+
   if (!SD_CARD_PRESENT())
     return -1;
   
@@ -155,6 +190,9 @@ uint8_t lunReady[STORAGE_LUN_NBR];
 void usbInitLUNs()
 {
   lunReady[STORAGE_SDCARD_LUN] = 1;
+#if defined(FWDRIVE)
+  lunReady[STORAGE_EEPROM_LUN] = 1;
+#endif  
 }
 
 /**
@@ -164,6 +202,11 @@ void usbInitLUNs()
   */
 int8_t  STORAGE_IsReady (uint8_t lun)
 { 
+#if defined(FWDRIVE) && defined(EEPROM)
+  if (lun == STORAGE_EEPROM_LUN) {
+    return (lunReady[STORAGE_EEPROM_LUN] != 0) ? 0 : -1;
+  }
+#endif
   return (lunReady[STORAGE_SDCARD_LUN] != 0 && SD_CARD_PRESENT()) ? 0 : -1;
 }
 
@@ -192,7 +235,13 @@ int8_t STORAGE_Read (uint8_t lun,
                  uint16_t blk_len)
 {
   WATCHDOG_SUSPEND(100/*1s*/);
-  
+
+#if defined(FWDRIVE)
+  if (lun == STORAGE_EEPROM_LUN) {
+    return (fat12Read(buf, blk_addr, blk_len) == 0) ? 0 : -1;
+  }
+#endif
+
   // read without cache
   return (__disk_read(0, buf, blk_addr, blk_len) == RES_OK) ? 0 : -1;
 }
@@ -212,6 +261,12 @@ int8_t STORAGE_Write (uint8_t lun,
 {
   WATCHDOG_SUSPEND(100/*1s*/);
   
+#if defined(FWDRIVE)
+  if (lun == STORAGE_EEPROM_LUN)	{
+    return (fat12Write(buf, blk_addr, blk_len) == 0) ? 0 : -1;
+  }
+#endif
+
   // write without cache
   return (__disk_write(0, buf, blk_addr, blk_len) == RES_OK) ? 0 : -1;
 }
@@ -226,3 +281,358 @@ int8_t STORAGE_GetMaxLun (void)
 {
   return STORAGE_LUN_NBR - 1;
 }
+
+#if defined(FWDRIVE)
+/* Firmware.txt */
+const char firmware_txt[] =
+ #if defined(BOOT)
+  "EdgeTX Bootloader"
+ #else
+  "EdgeTX Firmware"
+ #endif
+  " for " FLAVOUR "\r\n\r\n"
+ #if defined(BOOT)
+  "BOOTVER    "
+ #else
+  "FWVERSION  "
+ #endif
+  "edgetx-" FLAVOUR "-" VERSION " (" GIT_STR ")\r\n"
+  "DATE       " DATE "\r\n"
+  "TIME       " TIME "\r\n"
+ #if !defined(BOOT)
+  "BOOTVER   "
+ #else
+  "FWVERSION "
+ #endif
+  ;
+
+//------------------------------------------------------------------------------
+/**
+ * FAT12 boot sector partition.
+ */
+ #if defined(EEPROM)
+  #define TOTALSECTORS  (RESERVED_SECTORS + (EEPROM_SIZE/BLOCK_SIZE) +  (FLASHSIZE/BLOCK_SIZE))
+ #else
+  #define TOTALSECTORS  (RESERVED_SECTORS + (FLASHSIZE/BLOCK_SIZE))
+ #endif
+const char g_FATboot[BLOCK_SIZE] =
+{
+  0xeb, 0x3c, 0x90, // Jump instruction.
+  'O', 'p', 'e', 'n', 'T', 'x', 0x00, 0x00, // OEM Name
+  0x00, 0x02, // Bytes per sector
+  0x08, // Sectors per FS cluster.
+  0x01, 0x00, // Reserved sector count
+
+  0x01, // Number of FATs
+  0x10, 0x00, // Number of root directory entries
+  TOTALSECTORS & 0x00ff,  (TOTALSECTORS & 0xff00) >> 8, // Total sectors
+  0xf8, // Media descriptor
+  0x02, 0x00, // Sectors per FAT table
+  0x20, 0x00, // Sectors per track
+  0x40, 0x00, // Number of heads
+  0x00, 0x00, 0x00, 0x00, // Number of hidden sectors
+
+  0x00, 0x00, 0x00, 0x00, // Large number of sectors.
+  0x00, // Physical drive number
+  0x00, // Reserved
+  0x29, // Extended boot signature
+  'O', 'T', 'x', 0xD1, // Disk ID (serial number)
+  'V', 'I', 'R', 'T', 'F', 'S', ' ', ' ', ' ', ' ', ' ', // Volume label
+  'F', 'A', 'T', '1', '2', ' ', ' ', ' ', // FAT file system type
+  0x00, 0x00, // OS boot code
+
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+  0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x55, 0xaa
+};
+
+
+//	File Attributes
+//	0 	0x01 	Read Only.
+//	1 	0x02 	Hidden.
+//	2 	0x04 	System.
+//	3 	0x08 	Volume Label.
+//	4 	0x10 	Subdirectory.
+//	5 	0x20 	Archive.
+//	6 	0x40 	Device.
+//	7 	0x80 	Reserved.
+
+typedef struct
+{
+    uint8_t name[8];
+    uint8_t ext[3];
+    uint8_t attribute;
+    uint8_t reserved;
+    uint8_t create_time_ms;
+    uint16_t create_time;
+    uint16_t create_date;
+    uint16_t access_date;
+    uint16_t ea_index;
+    uint16_t modify_time;
+    uint16_t modify_date;
+    uint16_t start_cluster;
+    uint32_t file_size;
+} FATDirEntry_t;
+
+// First 16 FAT root directory entries (1 sector)
+const FATDirEntry_t g_DIRroot[] =
+{
+    {
+        { USB_PRODUCT },
+        { ' ', ' ', ' '},
+        0x08,		// Volume
+        0x00,
+        0x00,
+        0x0000,
+        0x0000,
+        0x0000,
+        0x0000,
+        0x0000,
+        0x0000,
+        0x0000,
+        0x00000000
+    },
+    {
+      { 'F', 'I', 'R', 'M', 'W', 'A', 'R', 'E'},
+      { 'T', 'X', 'T'},
+      0x21,          // Readonly+Archive
+      0x00,
+      0x3E,
+      0xA301,
+      0x3D55,
+      0x3D55,
+      0x0000,
+      0xA302,
+      0x3D55,
+      0x0002,
+      sizeof(firmware_txt) + strlen(getFirmwareVersion())
+    },
+    {
+      { 'F', 'I', 'R', 'M', 'W', 'A', 'R', 'E'},
+      { 'B', 'I', 'N'},
+ #if defined(BOOT)
+      0x20,          // Archive
+ #else
+      0x21,          // Readonly+Archive
+ #endif
+      0x00,
+      0x3E,
+      0xA301,
+      0x3D55,
+      0x3D55,
+      0x0000,
+      0xA302,
+      0x3D55,
+      0x0003,
+      FLASHSIZE
+  },
+ #if defined(EEPROM)
+    {
+        { 'E', 'E', 'P', 'R', 'O', 'M', ' ', ' '},
+        { 'B', 'I', 'N'},
+        0x20,		// Archive
+        0x00,
+        0x3E,
+        0xA301,
+        0x3D55,
+        0x3D55,
+        0x0000,
+        0xA302,
+        0x3D55,
+        0x0003 + (FLASHSIZE/BLOCK_SIZE)/8,
+        EEPROM_SIZE
+    },
+ #endif
+  // Emty entries are 0x00, omitted here. Up to 16 entries can be defined here
+};
+
+static void writeByte(uint8_t *buffer, uint16_t sector, int byte, uint8_t value)
+{
+  if (byte >= sector* BLOCK_SIZE && byte < (sector+1)* BLOCK_SIZE)
+    buffer[byte - sector*BLOCK_SIZE] = value;
+}
+
+static void pushCluster(uint8_t *buffer, uint16_t sector, uint16_t & cluster, int & rest, uint16_t value)
+{
+  // boot sector is in front of FAT
+  sector= sector-1;
+
+  // First byte of the cluster
+  int startbyte = cluster *3/2;
+  if (cluster % 2 == 0) {
+    // First 12 bit half
+    rest = value >> 8;
+    writeByte(buffer, sector, startbyte, value & 0xff);
+  } else {
+    // second 12 bit half, write rest and next byte
+    writeByte(buffer, sector, startbyte, value << 4 | rest );
+    writeByte(buffer, sector, startbyte+1, (value >> 4) & 0xff);
+  }
+  cluster++;
+}
+
+// count is number of 512 byte sectors
+int32_t fat12Read(uint8_t * buffer, uint16_t sector, uint16_t count)
+{
+  while(count) {
+    memset(buffer, 0x00, BLOCK_SIZE);
+    if (sector == 0) {
+      memcpy(buffer, g_FATboot, sizeof(g_FATboot) ) ;
+    }
+    else if (sector == 1 || sector == 2) {
+      // FAT table. Generate on the fly to save the 1024 byte flash space
+      uint16_t cluster=0;
+      int rest;
+      pushCluster (buffer, sector, cluster, rest, (uint16_t) 0xFF8);
+      pushCluster (buffer, sector, cluster, rest, (uint16_t) 0xFFF);
+
+      // Entry for firmware.txt, exactly one cluster
+      pushCluster (buffer, sector, cluster, rest, (uint16_t) 0xFFF);
+
+      // Entry for firmware.bin
+      for (int i=0;i<FLASHSIZE/BLOCK_SIZE/8 -1;i++)
+        pushCluster (buffer, sector, cluster, rest, cluster+1);
+      pushCluster (buffer, sector, cluster, rest, (uint16_t) 0xFFF);
+
+ #if defined(EEPROM)
+      // Entry for eeprom.bin
+      for (int i=0;i<EEPROM_SIZE/BLOCK_SIZE/8 -1;i++)
+        pushCluster (buffer, sector, cluster, rest, cluster+1);
+      pushCluster (buffer, sector, cluster, rest, (uint16_t) 0xFFF);
+ #endif
+
+      // Ensure last cluster is written if it is the first half
+      pushCluster (buffer, sector, cluster, rest, (uint16_t)  0x000);
+
+      // Rest is 0x0 as per memset
+    }
+    else if (sector == 3) {
+      memcpy(buffer, g_DIRroot, sizeof(g_DIRroot) ) ;
+    }
+    else if (sector == 4) {
+      memcpy(buffer, firmware_txt, sizeof(firmware_txt));
+      strcpy((char *)(buffer + sizeof(firmware_txt)), getFirmwareVersion());
+    }
+    else if (sector < RESERVED_SECTORS) {
+      // allocated to firmware.txt
+    }
+    else if (sector < RESERVED_SECTORS + (FLASHSIZE/BLOCK_SIZE )) {
+      uint32_t address;
+      address = sector - RESERVED_SECTORS;
+      address *= BLOCK_SIZE;
+      address += FIRMWARE_ADDRESS;
+      memcpy(buffer, (uint8_t *)address, BLOCK_SIZE);
+    }
+ #if defined(EEPROM)
+    else if (sector < RESERVED_SECTORS + (EEPROM_SIZE/BLOCK_SIZE) + (FLASHSIZE/BLOCK_SIZE)) {
+      eepromReadBlock(buffer, (sector - RESERVED_SECTORS - (FLASHSIZE/BLOCK_SIZE))*BLOCK_SIZE, BLOCK_SIZE);
+    }
+ #endif
+    buffer += BLOCK_SIZE ;
+    sector++ ;
+    count-- ;
+  }
+  return 0;
+}
+
+
+
+int32_t fat12Write(const uint8_t * buffer, uint16_t sector, uint16_t count)
+{
+  enum FatWriteOperation {
+    FATWRITE_NONE,
+    FATWRITE_EEPROM,
+    FATWRITE_FIRMWARE
+  };
+
+  // Silence compiler warning that this is not used on X10
+  __attribute__((unused)) static uint8_t operation = FATWRITE_NONE;
+
+  TRACE("FAT12 Write(sector=%d, count=%d)", sector, count);
+
+  if (sector < RESERVED_SECTORS) {
+    // reserved, read-only
+  }
+  else if (sector < RESERVED_SECTORS + (FLASHSIZE/BLOCK_SIZE)) {
+ #if !defined(BOOT) // Don't allow overwrite of running firmware
+    return -1;
+ #else
+    // firmware
+    uint32_t address;
+    address = sector - RESERVED_SECTORS;
+    address *= BLOCK_SIZE;
+    address += FIRMWARE_ADDRESS;
+    while (count) {
+      for (uint32_t i=0; i<BLOCK_SIZE/FLASH_PAGESIZE; i++) {
+        if (address >= FIRMWARE_ADDRESS+BOOTLOADER_SIZE/*protect bootloader*/ && address <= FIRMWARE_ADDRESS+FLASHSIZE-FLASH_PAGESIZE) {
+          if (address == FIRMWARE_ADDRESS+BOOTLOADER_SIZE && isFirmwareStart(buffer)) {
+            TRACE("FIRMWARE start found in sector %d", sector);
+            operation = FATWRITE_FIRMWARE;
+          }
+          if (operation == FATWRITE_FIRMWARE) {
+            flashWrite((uint32_t *)address, (uint32_t *)buffer);
+          }
+        }
+        address += FLASH_PAGESIZE;
+        buffer += FLASH_PAGESIZE;
+      }
+      sector++;
+      count--;
+      if (sector-RESERVED_SECTORS >= (FLASHSIZE/BLOCK_SIZE)) {
+        TRACE("FIRMWARE end written at sector %d", sector-1);
+        operation = FATWRITE_NONE;
+      }
+    }
+ #endif
+  }
+ #if defined(EEPROM)
+  else if (sector < RESERVED_SECTORS + (EEPROM_SIZE/BLOCK_SIZE) + (FLASHSIZE/BLOCK_SIZE)) {
+    // eeprom
+    while (count) {
+      if (operation == FATWRITE_NONE && isEepromStart(buffer)) {
+        TRACE("EEPROM start found in sector %d", sector);
+        operation = FATWRITE_EEPROM;
+      }
+      if (operation == FATWRITE_EEPROM) {
+        eepromWriteBlock((uint8_t *)buffer, (sector-RESERVED_SECTORS-(FLASHSIZE/BLOCK_SIZE))*BLOCK_SIZE, BLOCK_SIZE);
+      }
+      buffer += BLOCK_SIZE;
+      sector++;
+      count--;
+      if (sector-RESERVED_SECTORS >= (EEPROM_SIZE/BLOCK_SIZE)+(FLASHSIZE/BLOCK_SIZE)) {
+        TRACE("EEPROM end written at sector %d", sector-1);
+        operation = FATWRITE_NONE;
+      }
+    }
+  }
+ #endif
+  return 0 ;
+}
+#endif

--- a/radio/src/targets/common/arm/stm32/usbd_storage_msd.cpp
+++ b/radio/src/targets/common/arm/stm32/usbd_storage_msd.cpp
@@ -46,20 +46,20 @@ enum MassstorageLuns {
   STORAGE_SDCARD_LUN,
 #if defined(FWDRIVE)
   STORAGE_EEPROM_LUN,
-#endif  
+#endif
   STORAGE_LUN_NBR
 };
 
 /* USB Mass storage Standard Inquiry Data */
 const unsigned char STORAGE_Inquirydata[] = {
   /* LUN 0 */
-  0x00,		
-  0x80,		
-  0x02,		
+  0x00,
+  0x80,
+  0x02,
   0x02,
   (USBD_STD_INQUIRY_LENGTH - 5),
   0x00,
-  0x00,	
+  0x00,
   0x00,
   USB_MANUFACTURER,                        /* Manufacturer : 8 bytes */
   USB_PRODUCT,                             /* Product      : 16 Bytes */
@@ -67,19 +67,19 @@ const unsigned char STORAGE_Inquirydata[] = {
   '1', '.', '0', '0',                      /* Version      : 4 Bytes */
 #if defined(FWDRIVE)
   /* LUN 1 */
-  0x00,		
-  0x80,		
-  0x02,		
+  0x00,
+  0x80,
+  0x02,
   0x02,
   (USBD_STD_INQUIRY_LENGTH - 5),
   0x00,
-  0x00,	
+  0x00,
   0x00,
   USB_MANUFACTURER,                        /* Manufacturer : 8 bytes */
   USB_PRODUCT,                             /* Product      : 16 Bytes */
   'R', 'a', 'd', 'i', 'o', ' ', ' ', ' ',
   '1', '.', '0' ,'0',                      /* Version      : 4 Bytes */
-#endif  
+#endif
 };
 
 #if defined(FWDRIVE)
@@ -91,21 +91,21 @@ const unsigned char STORAGE_Inquirydata[] = {
 
 int8_t STORAGE_Init (uint8_t lun);
 
-int8_t STORAGE_GetCapacity (uint8_t lun, 
-                           uint32_t *block_num, 
+int8_t STORAGE_GetCapacity (uint8_t lun,
+                           uint32_t *block_num,
                            uint32_t *block_size);
 
 int8_t STORAGE_IsReady (uint8_t lun);
 
 int8_t STORAGE_IsWriteProtected (uint8_t lun);
 
-int8_t STORAGE_Read (uint8_t lun, 
-                        uint8_t *buf, 
+int8_t STORAGE_Read (uint8_t lun,
+                        uint8_t *buf,
                         uint32_t blk_addr,
                         uint16_t blk_len);
 
-int8_t STORAGE_Write (uint8_t lun, 
-                        uint8_t *buf, 
+int8_t STORAGE_Write (uint8_t lun,
+                        uint8_t *buf,
                         uint32_t blk_addr,
                         uint16_t blk_len);
 
@@ -140,8 +140,8 @@ int8_t STORAGE_Init (uint8_t lun)
 
 /* TODO if no SD ... if( SD_Init() != 0)
   {
-    return (-1); 
-  } 
+    return (-1);
+  }
 */
   return (0);
 }
@@ -169,7 +169,7 @@ int8_t STORAGE_GetCapacity (uint8_t lun, uint32_t *block_num, uint32_t *block_si
 
   if (!SD_CARD_PRESENT())
     return -1;
-  
+
   *block_size = BLOCK_SIZE;
 
   static DWORD sector_count = 0;
@@ -192,7 +192,7 @@ void usbInitLUNs()
   lunReady[STORAGE_SDCARD_LUN] = 1;
 #if defined(FWDRIVE)
   lunReady[STORAGE_EEPROM_LUN] = 1;
-#endif  
+#endif
 }
 
 /**
@@ -201,7 +201,7 @@ void usbInitLUNs()
   * @retval Status
   */
 int8_t  STORAGE_IsReady (uint8_t lun)
-{ 
+{
 #if defined(FWDRIVE) && defined(EEPROM)
   if (lun == STORAGE_EEPROM_LUN) {
     return (lunReady[STORAGE_EEPROM_LUN] != 0) ? 0 : -1;
@@ -229,9 +229,9 @@ int8_t  STORAGE_IsWriteProtected (uint8_t lun)
   * @retval Status
   */
 
-int8_t STORAGE_Read (uint8_t lun, 
-                 uint8_t *buf, 
-                 uint32_t blk_addr,                       
+int8_t STORAGE_Read (uint8_t lun,
+                 uint8_t *buf,
+                 uint32_t blk_addr,
                  uint16_t blk_len)
 {
   WATCHDOG_SUSPEND(100/*1s*/);
@@ -254,13 +254,13 @@ int8_t STORAGE_Read (uint8_t lun,
   * @retval Status
   */
 
-int8_t STORAGE_Write (uint8_t lun, 
-                  uint8_t *buf, 
+int8_t STORAGE_Write (uint8_t lun,
+                  uint8_t *buf,
                   uint32_t blk_addr,
                   uint16_t blk_len)
 {
   WATCHDOG_SUSPEND(100/*1s*/);
-  
+
 #if defined(FWDRIVE)
   if (lun == STORAGE_EEPROM_LUN)	{
     return (fat12Write(buf, blk_addr, blk_len) == 0) ? 0 : -1;

--- a/radio/src/targets/common/arm/stm32/usbd_storage_msd.cpp
+++ b/radio/src/targets/common/arm/stm32/usbd_storage_msd.cpp
@@ -111,7 +111,7 @@ int8_t STORAGE_Write (uint8_t lun,
 
 int8_t STORAGE_GetMaxLun (void);
 
-const USBD_STORAGE_cb_TypeDef USBD_MICRO_SDIO_fops =    // modified my OpenTX
+const USBD_STORAGE_cb_TypeDef USBD_MICRO_SDIO_fops =
 {
   STORAGE_Init,
   STORAGE_GetCapacity,
@@ -123,7 +123,7 @@ const USBD_STORAGE_cb_TypeDef USBD_MICRO_SDIO_fops =    // modified my OpenTX
   (int8_t *)STORAGE_Inquirydata,
 };
 
-const USBD_STORAGE_cb_TypeDef  * const USBD_STORAGE_fops = &USBD_MICRO_SDIO_fops;    // modified my OpenTX
+const USBD_STORAGE_cb_TypeDef  * const USBD_STORAGE_fops = &USBD_MICRO_SDIO_fops;
 
 #if defined(__cplusplus) && !defined(SIMU)
 }


### PR DESCRIPTION
Skips creating the "FIRMWARE" drive, when attaching radio in mass storage mode to the computer. Tested with RM TX16S.