### PR TITLE
fix(ui) - Fix update of V3 when V2 is modified whilst editing a logical switch.

### DIFF
--- a/radio/src/gui/colorlcd/model_logical_switches.cpp
+++ b/radio/src/gui/colorlcd/model_logical_switches.cpp
@@ -123,10 +123,9 @@ class LogicalSwitchEditPage: public Page
         auto edit2 = new NumberEdit(logicalSwitchOneWindow, grid.getFieldSlot(2, 1), -1, 222 - cs->v2, GET_SET_DEFAULT(cs->v3));
         edit1->setSetValueHandler([=](int32_t newValue) {
           cs->v2 = newValue;
-          cs->v3 = min<uint8_t>(cs->v3, 222 - cs->v2);
           SET_DIRTY();
           edit2->setMax(222 - cs->v2);
-          edit2->invalidate();
+          edit2->setValue(cs->v3);
         });
         edit1->setDisplayHandler([](int32_t value) {
           return formatNumberAsString(lswTimerValue(value), PREC1);


### PR DESCRIPTION
Fixes #3048 (#3035)

Summary of changes:

Fix to correctly update the second time value (V3) for 'Edge' switches when V2 is updated, and also display the new V3 value immediately.
