### PR TITLE
Cleanup title display logic on various pages.

### DIFF
--- a/radio/src/gui/colorlcd/curveedit.cpp
+++ b/radio/src/gui/colorlcd/curveedit.cpp
@@ -374,10 +374,7 @@ CurveEditWindow::CurveEditWindow(uint8_t index):
 
 void CurveEditWindow::buildHeader(Window * window)
 {
-  new StaticText(window,
-                 {PAGE_TITLE_LEFT, PAGE_TITLE_TOP, LCD_W - PAGE_TITLE_LEFT,
-                  PAGE_LINE_HEIGHT},
-                 STR_MENUCURVE, 0, COLOR_THEME_PRIMARY2);
+  header.setTitle(STR_MENUCURVE);
   char s[16];
   strAppendStringWithIndex(s, STR_CV, index + 1);
   new StaticText(window,

--- a/radio/src/gui/colorlcd/model_gvars.cpp
+++ b/radio/src/gui/colorlcd/model_gvars.cpp
@@ -201,10 +201,7 @@ bool GVarRenderer::isUpdated()
 
 void GVarEditWindow::buildHeader(Window * window)
 {
-  new StaticText(window,
-                 {PAGE_TITLE_LEFT, PAGE_TITLE_TOP, LCD_W - PAGE_TITLE_LEFT,
-                  PAGE_LINE_HEIGHT},
-                 STR_GLOBAL_VAR, 0, COLOR_THEME_PRIMARY2);
+  header.setTitle(STR_GLOBAL_VAR);
   gVarInHeader =
       new GVarRenderer(window,
                        {PAGE_TITLE_LEFT, PAGE_TITLE_TOP + PAGE_LINE_HEIGHT,

--- a/radio/src/gui/colorlcd/model_logical_switches.cpp
+++ b/radio/src/gui/colorlcd/model_logical_switches.cpp
@@ -80,10 +80,7 @@ class LogicalSwitchEditPage: public Page
 
     void buildHeader(Window * window)
     {
-      new StaticText(window,
-                     {PAGE_TITLE_LEFT, PAGE_TITLE_TOP, LCD_W - PAGE_TITLE_LEFT,
-                      PAGE_LINE_HEIGHT},
-                     STR_MENULOGICALSWITCHES, 0, COLOR_THEME_PRIMARY2);
+      header.setTitle(STR_MENULOGICALSWITCHES);
       headerSwitchName = new StaticText(
           window,
           {PAGE_TITLE_LEFT, PAGE_TITLE_TOP + PAGE_LINE_HEIGHT,

--- a/radio/src/gui/colorlcd/model_mixer_scripts.cpp
+++ b/radio/src/gui/colorlcd/model_mixer_scripts.cpp
@@ -60,10 +60,7 @@ class ScriptEditWindow : public Page {
 
     void buildHeader(Window * window)
     {
-      new StaticText(window,
-                     {PAGE_TITLE_LEFT, PAGE_TITLE_TOP, LCD_W - PAGE_TITLE_LEFT,
-                      PAGE_LINE_HEIGHT},
-                     STR_MENUCUSTOMSCRIPTS, 0, COLOR_THEME_PRIMARY2);
+      header.setTitle(STR_MENUCUSTOMSCRIPTS);
       new StaticText(window,
                      {PAGE_TITLE_LEFT, PAGE_TITLE_TOP + PAGE_LINE_HEIGHT,
                       LCD_W - PAGE_TITLE_LEFT, PAGE_LINE_HEIGHT},

--- a/radio/src/gui/colorlcd/model_telemetry.cpp
+++ b/radio/src/gui/colorlcd/model_telemetry.cpp
@@ -181,11 +181,7 @@ class SensorEditWindow : public Page {
 
     void buildHeader(Window * window)
     {
-      new StaticText(window,
-                     {PAGE_TITLE_LEFT, PAGE_TITLE_TOP, LCD_W - PAGE_TITLE_LEFT,
-                      PAGE_LINE_HEIGHT},
-                     STR_SENSOR + std::to_string(index + 1), 0,
-                     COLOR_THEME_PRIMARY2);
+      header.setTitle(STR_SENSOR + std::to_string(index + 1));
 
       new SensorLiveValue(window,
           {PAGE_TITLE_LEFT, PAGE_TITLE_TOP + PAGE_LINE_HEIGHT,

--- a/radio/src/gui/colorlcd/radio_calibration.cpp
+++ b/radio/src/gui/colorlcd/radio_calibration.cpp
@@ -67,10 +67,7 @@ RadioCalibrationPage::RadioCalibrationPage(bool initial):
 
 void RadioCalibrationPage::buildHeader(Window * window)
 {
-  new StaticText(window,
-                 {PAGE_TITLE_LEFT, PAGE_TITLE_TOP, LCD_W - PAGE_TITLE_LEFT,
-                  PAGE_LINE_HEIGHT},
-                 STR_MENUCALIBRATION, 0, COLOR_THEME_PRIMARY2);
+  header.setTitle(STR_MENUCALIBRATION);
 
   text = new StaticText(window,
                         {PAGE_TITLE_LEFT, PAGE_TITLE_TOP + PAGE_LINE_HEIGHT,

--- a/radio/src/gui/colorlcd/special_functions.cpp
+++ b/radio/src/gui/colorlcd/special_functions.cpp
@@ -79,11 +79,7 @@ class SpecialFunctionEditPage : public Page
 
   void buildHeader(Window *window)
   {
-    new StaticText(
-        window, {PAGE_TITLE_LEFT, PAGE_TITLE_TOP, LCD_W - PAGE_TITLE_LEFT, 20},
-        functions == g_model.customFn ? STR_MENUCUSTOMFUNC
-                                      : STR_MENUSPECIALFUNCS,
-        0, COLOR_THEME_PRIMARY2);
+    header.setTitle(functions == g_model.customFn ? STR_MENUCUSTOMFUNC : STR_MENUSPECIALFUNCS);
     headerSF = new StaticText(
         window,
         {PAGE_TITLE_LEFT, PAGE_TITLE_TOP + PAGE_LINE_HEIGHT,


### PR DESCRIPTION
Use 'Page' class 'header' property to display the title where possible (instead of creating a new object).
