### PR TITLE
fix(lua) - Store and update the 'zone' rectangle for Lua widgets.

### DIFF
--- a/radio/src/gui/colorlcd/widget.cpp
+++ b/radio/src/gui/colorlcd/widget.cpp
@@ -135,9 +135,10 @@ void Widget::setFullscreen(bool enable)
   // Enter Fullscreen Mode
   else {
 
-    // Set window opaque (inhibits redraw from windows bellow)
+    // Set window opaque (inhibits redraw from windows below)
     setWindowFlags(getWindowFlags() | OPAQUE);
     lv_obj_set_style_bg_opa(lvobj, LV_OPA_MAX, LV_PART_MAIN);
+    updateZoneRect(parent->getRect());
     setRect(parent->getRect());
     fullscreen = true;
 

--- a/radio/src/gui/colorlcd/widget.cpp
+++ b/radio/src/gui/colorlcd/widget.cpp
@@ -98,10 +98,6 @@ void Widget::onCancel()
 
 void Widget::update()
 {
-  auto container = dynamic_cast<WidgetsContainer*>(parent);
-  if (container) {
-    container->updateZones();
-  }
 }
 
 void Widget::setFullscreen(bool enable)
@@ -113,7 +109,10 @@ void Widget::setFullscreen(bool enable)
   if (!enable) {
 
     // Reset all zones in container
-    Widget::update();
+    auto container = dynamic_cast<WidgetsContainer*>(parent);
+    if (container)
+      container->updateZones();
+
     setWindowFlags(getWindowFlags() & ~OPAQUE);
     lv_obj_set_style_bg_opa(lvobj, LV_OPA_0, LV_PART_MAIN);
 

--- a/radio/src/gui/colorlcd/widget.h
+++ b/radio/src/gui/colorlcd/widget.h
@@ -106,6 +106,9 @@ class Widget : public Button
     // Called at regular time interval, even if the widget cannot be seen
     virtual void background() {}
 
+    // Update widget 'zone' data (for Lua widgets)
+    virtual void updateZoneRect(rect_t rect) {}
+
   protected:
     const WidgetFactory * factory;
     PersistentData * persistentData;

--- a/radio/src/gui/colorlcd/widgets/widgets_container_impl.h
+++ b/radio/src/gui/colorlcd/widgets/widgets_container_impl.h
@@ -135,8 +135,8 @@ class WidgetsContainerImpl : public WidgetsContainer
     for (int i = 0; i < N; i++) {
       if (widgets[i]) {
         auto zone = getZone(i);
-        widgets[i]->updateZoneRect(zone);
         widgets[i]->setRect(zone);
+        widgets[i]->updateZoneRect(zone);
       }
     }
   }

--- a/radio/src/gui/colorlcd/widgets/widgets_container_impl.h
+++ b/radio/src/gui/colorlcd/widgets/widgets_container_impl.h
@@ -135,6 +135,7 @@ class WidgetsContainerImpl : public WidgetsContainer
     for (int i = 0; i < N; i++) {
       if (widgets[i]) {
         auto zone = getZone(i);
+        widgets[i]->updateZoneRect(zone);
         widgets[i]->setRect(zone);
       }
     }

--- a/radio/src/lua/lua_widget.cpp
+++ b/radio/src/lua/lua_widget.cpp
@@ -196,9 +196,10 @@ void LuaEventHandler::removeHandler(Window* w)
 
 LuaWidget::LuaWidget(const WidgetFactory* factory, Window* parent,
                      const rect_t& rect, WidgetPersistentData* persistentData,
-                     int luaWidgetDataRef) :
+                     int luaWidgetDataRef,int zoneRectDataRef) :
     Widget(factory, parent, rect, persistentData),
     luaWidgetDataRef(luaWidgetDataRef),
+    zoneRectDataRef(zoneRectDataRef),
     errorMessage(nullptr)
 {
 }
@@ -206,6 +207,7 @@ LuaWidget::LuaWidget(const WidgetFactory* factory, Window* parent,
 LuaWidget::~LuaWidget()
 {
   luaL_unref(lsWidgets, LUA_REGISTRYINDEX, luaWidgetDataRef);
+  luaL_unref(lsWidgets, LUA_REGISTRYINDEX, zoneRectDataRef);
   free(errorMessage);
 }
 
@@ -285,6 +287,27 @@ void LuaWidget::update()
 
   if (lua_pcall(lsWidgets, 2, 0, 0) != 0) {
     setErrorMessage("update()");
+  }
+}
+
+void LuaWidget::updateZoneRect(rect_t rect)
+{
+  if (lsWidgets)
+  {
+    // Update widget zone with current size and position
+
+    lua_rawgeti(lsWidgets, LUA_REGISTRYINDEX, zoneRectDataRef);
+
+    lua_pushinteger(lsWidgets, rect.w);
+    lua_setfield(lsWidgets, -2, "w");
+    lua_pushinteger(lsWidgets, rect.h);
+    lua_setfield(lsWidgets, -2, "h");
+    lua_pushinteger(lsWidgets, rect.x);
+    lua_setfield(lsWidgets, -2, "xabs");
+    lua_pushinteger(lsWidgets, rect.y);
+    lua_setfield(lsWidgets, -2, "yabs");
+
+    lua_pop(lsWidgets, 1);
   }
 }
 

--- a/radio/src/lua/lua_widget.h
+++ b/radio/src/lua/lua_widget.h
@@ -76,6 +76,7 @@ class LuaWidget : public Widget, public LuaEventHandler
 
   // Update 'zone' data
   void updateZoneRect(rect_t rect) override;
+  bool updateTable(const char* idx, int val);
 
  public:
   LuaWidget(const WidgetFactory* factory, Window* parent, const rect_t& rect,

--- a/radio/src/lua/lua_widget.h
+++ b/radio/src/lua/lua_widget.h
@@ -60,6 +60,7 @@ class LuaWidget : public Widget, public LuaEventHandler
   friend class LuaWidgetFactory;
 
   int luaWidgetDataRef;
+  int zoneRectDataRef;
   char* errorMessage;
   bool refreshed = false;
 
@@ -73,9 +74,12 @@ class LuaWidget : public Widget, public LuaEventHandler
     
   void setErrorMessage(const char* funcName);
 
+  // Update 'zone' data
+  void updateZoneRect(rect_t rect) override;
+
  public:
   LuaWidget(const WidgetFactory* factory, Window* parent, const rect_t& rect,
-            WidgetPersistentData* persistentData, int luaWidgetDataRef);
+            WidgetPersistentData* persistentData, int luaWidgetDataRef, int zoneRectDataRef);
   ~LuaWidget() override;
 
 #if defined(DEBUG_WINDOWS)

--- a/radio/src/lua/lua_widget_factory.cpp
+++ b/radio/src/lua/lua_widget_factory.cpp
@@ -70,6 +70,7 @@ Widget* LuaWidgetFactory::create(Window* parent, const rect_t& rect,
   luaSetInstructionsLimit(lsWidgets, MAX_INSTRUCTIONS);
   lua_rawgeti(lsWidgets, LUA_REGISTRYINDEX, createFunction);
 
+  // Make 'zone' table for 'create' call
   lua_newtable(lsWidgets);
   l_pushtableint("x", 0);
   l_pushtableint("y", 0);
@@ -77,6 +78,11 @@ Widget* LuaWidgetFactory::create(Window* parent, const rect_t& rect,
   l_pushtableint("h", rect.h);
   l_pushtableint("xabs", rect.x);
   l_pushtableint("yabs", rect.y);
+
+  // Store the zone data in registry for later updates
+  int zoneRectDataRef = luaL_ref(lsWidgets, LUA_REGISTRYINDEX);
+  // Push stored zone for 'create' call
+  lua_rawgeti(lsWidgets, LUA_REGISTRYINDEX, zoneRectDataRef);
 
   lua_newtable(lsWidgets);
   int i = 0;
@@ -100,7 +106,7 @@ Widget* LuaWidgetFactory::create(Window* parent, const rect_t& rect,
 
   bool err = lua_pcall(lsWidgets, 2, 1, 0);
   int widgetData = err ? LUA_NOREF : luaL_ref(lsWidgets, LUA_REGISTRYINDEX);
-  LuaWidget* lw = new LuaWidget(this, parent, rect, persistentData, widgetData);
+  LuaWidget* lw = new LuaWidget(this, parent, rect, persistentData, widgetData, zoneRectDataRef);
   if (err) lw->setErrorMessage("create()");
   return lw;
 }


### PR DESCRIPTION
Fixes #2598

Summary of changes:

Implements solution from @jfrickmann in issue 2598:
- Store the widget zone rectangle data in the Lua registry.
- Updates the zone data when the layout changes.

Also calls the widget 'update' function if the zone has been altered.
