### PR TITLE
fix(ui) - Prevent infinite loop and crash in popups.

### DIFF
--- a/radio/src/gui/colorlcd/popups.cpp
+++ b/radio/src/gui/colorlcd/popups.cpp
@@ -26,6 +26,11 @@ static void _run_popup_dialog(const char* title, const char* msg,
                               const char* info = nullptr)
 {
   bool running = true;
+
+  // reset input devices to avoid
+  // RELEASED/CLICKED to be called in a loop
+  lv_indev_reset(nullptr, nullptr);
+  
   auto md = new MessageDialog(MainWindow::instance(), title, msg);
   md->setCloseHandler([&]() { running = false; });
   if (info) {


### PR DESCRIPTION
Fixes the underlying problem with the popups from issue #2981 

PR #2985 fixed the issue by not using the POPUP_WARNING function - this change fixes the root cause in case there are any other places that might be affected.
