### PR TITLE
fix(ui) - Close menu popup on main view when switching to other views.

### DIFF
--- a/radio/src/gui/colorlcd/view_main.cpp
+++ b/radio/src/gui/colorlcd/view_main.cpp
@@ -250,11 +250,13 @@ void ViewMain::onEvent(event_t event)
 #if defined(HARDWARE_KEYS)
   switch (event) {
     case EVT_KEY_BREAK(KEY_MODEL):
+      if (viewMainMenu) viewMainMenu->onCancel();
       new ModelMenu();
       break;
 
     case EVT_KEY_LONG(KEY_MODEL):
       killEvents(KEY_MODEL);
+      if (viewMainMenu) viewMainMenu->onCancel();
       new ModelLabelsWindow();
       break;
 
@@ -263,10 +265,12 @@ void ViewMain::onEvent(event_t event)
     // - use LONG for "Tools" page
     //
     case EVT_KEY_FIRST(KEY_RADIO):
+      if (viewMainMenu) viewMainMenu->onCancel();
       new RadioMenu();
       break;
 
     case EVT_KEY_FIRST(KEY_TELEM):
+      if (viewMainMenu) viewMainMenu->onCancel();
       new ScreenMenu();
       break;
 
@@ -275,7 +279,10 @@ void ViewMain::onEvent(event_t event)
 #else
     case EVT_KEY_BREAK(KEY_PGDN):
 #endif
-      if (!widget_select) nextMainView();
+      if (!widget_select) {
+        if (viewMainMenu) viewMainMenu->onCancel();
+        nextMainView();
+      }
       break;
 
 //TODO: these need to go away!
@@ -286,7 +293,10 @@ void ViewMain::onEvent(event_t event)
     case EVT_KEY_LONG(KEY_PGDN):
 #endif
       killEvents(event);
-      if (!widget_select) previousMainView();
+      if (!widget_select) {
+        if (viewMainMenu) viewMainMenu->onCancel();
+        previousMainView();
+      }
       break;
   }
 #endif
@@ -362,7 +372,9 @@ bool ViewMain::enableWidgetSelect(bool enable)
 
 void ViewMain::openMenu()
 {
-  new ViewMainMenu(this);
+  viewMainMenu = new ViewMainMenu(this, [=]() {
+    viewMainMenu = nullptr;
+  });
 }
 
 void ViewMain::paint(BitmapBuffer * dc)

--- a/radio/src/gui/colorlcd/view_main.h
+++ b/radio/src/gui/colorlcd/view_main.h
@@ -29,6 +29,7 @@
 
 class SetupWidgetsPage;
 class SetupTopBarWidgetsPage;
+class ViewMainMenu;
 
 class ViewMain: public Window
 {
@@ -89,6 +90,7 @@ class ViewMain: public Window
     TopbarImpl* topbar = nullptr;
     bool        widget_select = false;
     lv_timer_t* widget_select_timer = nullptr;
+    ViewMainMenu* viewMainMenu = nullptr;
 
     void paint(BitmapBuffer * dc) override;
     void deleteLater(bool detach = true, bool trash = true) override;

--- a/radio/src/gui/colorlcd/view_main_menu.cpp
+++ b/radio/src/gui/colorlcd/view_main_menu.cpp
@@ -33,9 +33,11 @@
 #include "select_fab_carousel.h"
 #include "view_text.h"
 
-ViewMainMenu::ViewMainMenu(Window* parent) :
+ViewMainMenu::ViewMainMenu(Window* parent, std::function<void()> closeHandler) :
     Window(parent->getFullScreenWindow(), rect_t{})
 {
+  this->closeHandler = std::move(closeHandler);
+
   // Save focus
   Layer::push(this);
 
@@ -131,6 +133,7 @@ void ViewMainMenu::paint(BitmapBuffer* dc)
 
 void ViewMainMenu::deleteLater(bool detach, bool trash)
 {
+  if (closeHandler) closeHandler();
   Layer::pop(this);
   Window::deleteLater(detach, trash);
 }

--- a/radio/src/gui/colorlcd/view_main_menu.h
+++ b/radio/src/gui/colorlcd/view_main_menu.h
@@ -26,7 +26,7 @@
 class ViewMainMenu : public Window
 {
  public:
-  ViewMainMenu(Window* parent);
+  ViewMainMenu(Window* parent, std::function<void()> closeHandler);
 
   void onCancel() override;
   void paint(BitmapBuffer* dc) override;
@@ -49,4 +49,5 @@ class ViewMainMenu : public Window
 
  protected:
   rect_t carouselRect;
+  std::function<void()> closeHandler = nullptr;
 };


### PR DESCRIPTION
Fixes #3087 

Summary of changes:

Close the menu popup on the main view before navigating to other pages.