### PR TITLE
feat(ui) - Add long press for SYS button on main screen.

### DIFF
--- a/radio/src/gui/colorlcd/view_main.cpp
+++ b/radio/src/gui/colorlcd/view_main.cpp
@@ -260,13 +260,18 @@ void ViewMain::onEvent(event_t event)
       new ModelLabelsWindow();
       break;
 
-    // TODO:
-    // - use BREAK instead
-    // - use LONG for "Tools" page
-    //
-    case EVT_KEY_FIRST(KEY_RADIO):
+    case EVT_KEY_BREAK(KEY_RADIO):
       if (viewMainMenu) viewMainMenu->onCancel();
       new RadioMenu();
+      break;
+
+    case EVT_KEY_LONG(KEY_RADIO):
+      {
+        killEvents(KEY_RADIO);
+        // Radio setup
+        auto m = new RadioMenu();
+        m->setCurrentTab(2);
+      }
       break;
 
     case EVT_KEY_FIRST(KEY_TELEM):


### PR DESCRIPTION
Long press on SYS button jumps to the radio setup tab.

Partially addresses #169 
