### PR TITLE
fix(cpn) - Fix joystick slider mappings in companion.

### DIFF
--- a/companion/src/simulation/simulatorwidget.cpp
+++ b/companion/src/simulation/simulatorwidget.cpp
@@ -884,7 +884,7 @@ void SimulatorWidget::onjoystickAxisValueChanged(int axis, int value)
     if (stick < ttlKnobs)
       emit widgetValueChange(RadioWidget::RADIO_WIDGET_KNOB, stick, stickval);
     else
-      emit widgetValueChange(RadioWidget::RADIO_WIDGET_FADER, stick, stickval);
+      emit widgetValueChange(RadioWidget::RADIO_WIDGET_FADER, stick - ttlKnobs, stickval);
   }
 
 #endif


### PR DESCRIPTION
On my TX16S the sliders could be seen in the companion joystick setup; but would not connect to the simulator widgets regardless of the mapping option selected in the dropdown.

The index being passed to the widgetValueChanged event was incorrect.

Note: On the TX16S the LS and RS sliders should be mapped to Knob/Slider 8 and Knob/Slider 9 respectively. They will then control the simulator widgets correctly.

For some reason the companion code setup thinks the TX16S has 7 pots ???
