### PR TITLE
fix(cpn) - Joystick preferences in Companion.

### DIFF
--- a/companion/src/apppreferencesdialog.cpp
+++ b/companion/src/apppreferencesdialog.cpp
@@ -78,6 +78,7 @@ void AppPreferencesDialog::accept()
   g.showSplash(ui->showSplash->isChecked());
   g.promptProfile(ui->chkPromptProfile->isChecked());
   g.simuSW(ui->simuSW->isChecked());
+  g.disableJoystickWarning(ui->joystickWarningCB->isChecked());
   g.removeModelSlots(ui->opt_removeBlankSlots->isChecked());
   g.newModelAction((AppData::NewModelAction)ui->cboNewModelAction->currentIndex());
   g.historySize(ui->historySize->value());
@@ -237,6 +238,7 @@ void AppPreferencesDialog::initSettings()
   }
 
   ui->simuSW->setChecked(g.simuSW());
+  ui->joystickWarningCB->setChecked(g.disableJoystickWarning());
   ui->opt_removeBlankSlots->setChecked(g.removeModelSlots());
   ui->cboNewModelAction->addItems(AppData::newModelActionsList());
   ui->cboNewModelAction->setCurrentIndex(g.newModelAction());

--- a/companion/src/apppreferencesdialog.cpp
+++ b/companion/src/apppreferencesdialog.cpp
@@ -94,9 +94,11 @@ void AppPreferencesDialog::accept()
   g.appLogsDir(ui->appLogsDir->text());
   g.runAppInstaller(ui->chkPromptInstall->isChecked());
 
-  if (ui->joystickChkB ->isChecked() && ui->joystickCB->isEnabled()) {
+  if (ui->joystickChkB ->isChecked()) {
     g.jsSupport(ui->joystickChkB ->isChecked());
-    g.jsCtrl(ui->joystickCB ->currentIndex());
+    // Don't overwrite selected joystick if not connected. Avoid surprising the user.
+    if (ui->joystickCB->isEnabled())
+      g.jsCtrl(ui->joystickCB ->currentIndex());
   }
   else {
     g.jsSupport(false);

--- a/companion/src/apppreferencesdialog.ui
+++ b/companion/src/apppreferencesdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>864</width>
-    <height>668</height>
+    <height>673</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -45,7 +45,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>3</number>
+      <number>2</number>
      </property>
      <widget class="QWidget" name="profileTab">
       <attribute name="title">
@@ -1284,7 +1284,7 @@ Mode 4:
          </property>
         </widget>
        </item>
-       <item row="12" column="1">
+       <item row="11" column="1">
         <spacer name="verticalSpacer">
          <property name="orientation">
           <enum>Qt::Vertical</enum>
@@ -1385,6 +1385,13 @@ Mode 4:
         <widget class="QPushButton" name="btnClearPos">
          <property name="text">
           <string>Clear saved positions</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QCheckBox" name="joystickWarningCB">
+         <property name="text">
+          <string>Disable 'Cannot open joystick, joystick disabled' warning</string>
          </property>
         </widget>
        </item>

--- a/companion/src/apppreferencesdialog.ui
+++ b/companion/src/apppreferencesdialog.ui
@@ -45,7 +45,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>2</number>
+      <number>3</number>
      </property>
      <widget class="QWidget" name="profileTab">
       <attribute name="title">
@@ -481,7 +481,6 @@ Mode 4:
          </property>
          <property name="font">
           <font>
-           <family>Ubuntu</family>
            <weight>75</weight>
            <bold>true</bold>
           </font>

--- a/companion/src/simulation/simulatorwidget.cpp
+++ b/companion/src/simulation/simulatorwidget.cpp
@@ -691,7 +691,8 @@ void SimulatorWidget::setupJoysticks()
       joysticksEnabled = true;
     }
     else {
-      QMessageBox::critical(this, CPN_STR_TTL_WARNING, tr("Cannot open joystick, joystick disabled"));
+      if (!g.disableJoystickWarning())
+        QMessageBox::critical(this, CPN_STR_TTL_WARNING, tr("Cannot open joystick, joystick disabled"));
     }
   }
   else if (joystick) {

--- a/companion/src/storage/appdata.h
+++ b/companion/src/storage/appdata.h
@@ -687,6 +687,7 @@ class AppData: public CompStoreObj
     PROPERTY(int, backLight,       0)
     PROPERTY(int, simuLastProfId, -1)
     PROPERTY(bool, simuSW,      true)
+    PROPERTY(bool, disableJoystickWarning, false)
 
     // Message box confirmations
     PROPERTY(bool, confirmWriteModelsAndSettings, true)


### PR DESCRIPTION
Made the following changes to the Companion preferences:
- Don't wipe the user joystick settings if preferences dialog opened when radio is not connected as a joystick.
- Add an option to disable the alert popup when starting the simulator with no joystick connected.
- Remove reference to the "Ubuntu" font family for the 'Radio Type' label (showed a warning on MacOS).
