### PR TITLE
fix(color) - Fix flight mode name display in global variables overview.

### DIFF
--- a/radio/src/gui/colorlcd/model_gvars.cpp
+++ b/radio/src/gui/colorlcd/model_gvars.cpp
@@ -121,6 +121,8 @@ void GVarButton::updateValueText(uint8_t flightMode)
 
   if (value > GVAR_MAX) {
     uint8_t fm = value - GVAR_MAX - 1;
+    if (fm >= flightMode)
+      fm += 1;
     char label[16] = {};
     getFlightModeString(label, fm + 1);
 


### PR DESCRIPTION
The flight mode names were displaying incorrectly for global variables in the GV overview page.
E.G. edit GV 1 and change the option for FM1 to be FM2 instead of FM0.
On the overview page it would show FM1 as FM1 instead of FM2.
