### PR TITLE
chore: fix STM32 HAL headers

### DIFF
--- a/radio/src/targets/common/arm/stm32/stm32_hal.h
+++ b/radio/src/targets/common/arm/stm32/stm32_hal.h
@@ -25,14 +25,8 @@ extern "C" {
   #if defined(STM32F4)
     #include "CMSIS/Device/ST/STM32F4xx/Include/stm32f4xx.h"
     #include "stm32f4xx_hal.h"
-    #include "stm32f4xx_hal_rcc.h"
-    #include "stm32f4xx_hal_rtc.h"
-    #include "stm32f4xx_hal_pwr.h"
   #elif defined(STM32F2)
     #include "CMSIS/Device/ST/STM32F2xx/Include/stm32f2xx.h"
     #include "stm32f2xx_hal.h"
-    #include "stm32f2xx_hal_rcc.h"
-    #include "stm32f2xx_hal_rtc.h"
-    #include "stm32f2xx_hal_pwr.h"
   #endif
 }


### PR DESCRIPTION
Single HAL headers/modules are enabled by changing the defines in `stm32f2xx_hal_conf.h` / `stm32f2xx_hal_conf.h` rather than being directly included into this file.