### PR TITLE
fix(color) - Fixes and layout updates for theme pages.

### DIFF
--- a/radio/src/gui/colorlcd/confirm_dialog.cpp
+++ b/radio/src/gui/colorlcd/confirm_dialog.cpp
@@ -47,14 +47,22 @@ ConfirmDialog::ConfirmDialog(Window* parent, const char* title,
     onCancel();
     return 0;
   });
+#if LCD_W > LCD_H
   btn->setWidth(LV_DPI_DEF);
+#else
+  btn->setWidth(LV_DPI_DEF * 3 / 4);
+#endif
 
   btn = new TextButton(box, rect_t{}, STR_YES, [=]() -> int8_t {
     this->deleteLater();
     this->confirmHandler();
     return 0;
   });
+#if LCD_W > LCD_H
   btn->setWidth(LV_DPI_DEF);
+#else
+  btn->setWidth(LV_DPI_DEF * 3 / 4);
+#endif
 
   content->setWidth(LCD_W * 0.8);
   content->updateSize();

--- a/radio/src/gui/colorlcd/listbox.cpp
+++ b/radio/src/gui/colorlcd/listbox.cpp
@@ -83,12 +83,7 @@ void ListBase::setAutoEdit(bool enable)
 
 void ListBase::setName(uint16_t idx, const std::string& name)
 {
-  std::string s = name;
-  // Truncate string to fit without running under the 'selected' tick symbol
-  // Todo: find a better way to do this 
-  while (getTextWidth(s.c_str(), 0, FONT(STD)) > (rect.w - 40))
-    s.pop_back();
-  lv_table_set_cell_value(lvobj, idx, 0, s.c_str());
+  lv_table_set_cell_value(lvobj, idx, 0, name.c_str());  
 }
 
 void ListBase::setNames(const std::vector<std::string>& names)

--- a/radio/src/gui/colorlcd/listbox.cpp
+++ b/radio/src/gui/colorlcd/listbox.cpp
@@ -83,7 +83,12 @@ void ListBase::setAutoEdit(bool enable)
 
 void ListBase::setName(uint16_t idx, const std::string& name)
 {
-  lv_table_set_cell_value(lvobj, idx, 0, name.c_str());  
+  std::string s = name;
+  // Truncate string to fit without running under the 'selected' tick symbol
+  // Todo: find a better way to do this 
+  while (getTextWidth(s.c_str(), 0, FONT(STD)) > (rect.w - 40))
+    s.pop_back();
+  lv_table_set_cell_value(lvobj, idx, 0, s.c_str());
 }
 
 void ListBase::setNames(const std::vector<std::string>& names)

--- a/radio/src/gui/colorlcd/listbox.h
+++ b/radio/src/gui/colorlcd/listbox.h
@@ -97,9 +97,9 @@ class ListBase : public TableField
 
 class ListBox : public ListBase
 {
-  std::string title;
+//   std::string title;
 
  public:
   using ListBase::ListBase;
-  inline void setTitle(std::string title) { this->title = title; }
+//   inline void setTitle(std::string title) { this->title = title; }
 };

--- a/radio/src/gui/colorlcd/page.cpp
+++ b/radio/src/gui/colorlcd/page.cpp
@@ -58,6 +58,8 @@ Page::Page(unsigned icon):
   body(this, _get_body_rect(), FORM_FORWARD_FOCUS)
 {
   Layer::push(this);
+
+  lv_obj_set_style_bg_color(lvobj, makeLvColor(COLOR_THEME_SECONDARY3), 0);
 }
 
 void Page::deleteLater(bool detach, bool trash)
@@ -69,15 +71,9 @@ void Page::deleteLater(bool detach, bool trash)
   Window::deleteLater(detach, trash);
 }
 
-void Page::paint(BitmapBuffer * dc)
-{
-  dc->clear(COLOR_THEME_SECONDARY3);
-}
-
 void Page::onCancel()
 {
-  if (canCancel())
-    deleteLater();
+  deleteLater();
 }
 
 void Page::onClicked()

--- a/radio/src/gui/colorlcd/page.h
+++ b/radio/src/gui/colorlcd/page.h
@@ -55,10 +55,7 @@ class Page : public Window
   void onCancel() override;
   void onClicked() override;
 
-  void paint(BitmapBuffer* dc) override;
   void deleteLater(bool detach = true, bool trash = true) override;
-
-  virtual bool canCancel() { return true; }
 
  protected:
   PageHeader header;

--- a/radio/src/gui/colorlcd/radio_theme.cpp
+++ b/radio/src/gui/colorlcd/radio_theme.cpp
@@ -608,25 +608,33 @@ void ThemeSetupPage::displayThemeMenu(Window *window, ThemePersistance *tp)
   }
 }
 
+void ThemeSetupPage::setSelected(ThemePersistance *tp)
+{
+  auto value = listBox->getSelected();
+  if (themeColorPreview && authorText && nameText && fileCarosell) {
+    ThemeFile *theme = tp->getThemeByIndex(value);
+    if (theme) {
+      themeColorPreview->setColorList(theme->getColorList());
+      setAuthor(theme);
+      setName(theme);
+      fileCarosell->setFileNames(theme->getThemeImageFileNames());
+    }
+  currentTheme = value;
+  }
+}
+
 void ThemeSetupPage::setupListbox(Window *window, rect_t r, ThemePersistance *tp)
 {
   listBox = new ListBox(window, r, tp->getNames());
   listBox->setAutoEdit(true);
   listBox->setSelected(currentTheme);
   listBox->setActiveItem(tp->getThemeIndex());
-  listBox->setTitle(STR_THEME + std::string("s")); // TODO: fix this!
-  listBox->setLongPressHandler([=] () { displayThemeMenu(window, tp); });
+  listBox->setLongPressHandler([=] () {
+      setSelected(tp);
+      displayThemeMenu(window, tp);
+    });
   listBox->setPressHandler([=] () {
-      auto value = listBox->getSelected();
-      if (themeColorPreview && authorText && nameText && fileCarosell) {
-        ThemeFile *theme = tp->getThemeByIndex(value);
-        if (!theme) return;
-        themeColorPreview->setColorList(theme->getColorList());
-        setAuthor(theme);
-        setName(theme);
-        fileCarosell->setFileNames(theme->getThemeImageFileNames());
-      }
-      currentTheme = value;
+      setSelected(tp);
     });
 }
 

--- a/radio/src/gui/colorlcd/radio_theme.cpp
+++ b/radio/src/gui/colorlcd/radio_theme.cpp
@@ -288,7 +288,7 @@ class ColorEditPage : public Page
 
       FormWindow *colBoxForm = new FormWindow(colForm, r);
       colBoxForm->padAll(0);
-      colBoxForm->setFlexLayout(LV_FLEX_FLOW_ROW, 4);
+      colBoxForm->setFlexLayout(LV_FLEX_FLOW_ROW, 2);
 
       r.h = colForm->height() - COLOR_BOX_HEIGHT - 4;
 
@@ -313,7 +313,7 @@ class ColorEditPage : public Page
       _colorSquare = new ColorSquare(colBoxForm, r, _theme.getColorEntryByIndex(_indexOfColor)->colorValue);
 
       // hexBox
-      r.w = 90;
+      r.w = 95;
       _hexBox = new StaticText(colBoxForm, r, "", 0, COLOR_THEME_PRIMARY1 | FONT(L) | RIGHT);
       setHexStr(_theme.getColorEntryByIndex(_indexOfColor)->colorValue);
     }

--- a/radio/src/gui/colorlcd/radio_theme.cpp
+++ b/radio/src/gui/colorlcd/radio_theme.cpp
@@ -551,10 +551,10 @@ void ThemeSetupPage::displayThemeMenu(Window *window, ThemePersistance *tp)
         // if the theme info currently displayed
         // were changed, update the UI
         if (themeIdx == currentTheme) {
-          setAuthor(&theme);
-          setName(&theme);
-          listBox->setName(currentTheme, theme.getName());
-          themeColorPreview->setColorList(theme.getColorList());
+          setAuthor(theme);
+          setName(theme);
+          listBox->setName(currentTheme, theme->getName());
+          themeColorPreview->setColorList(theme->getColorList());
         }
 
         // if the active theme changed, re-apply it

--- a/radio/src/gui/colorlcd/radio_theme.h
+++ b/radio/src/gui/colorlcd/radio_theme.h
@@ -45,4 +45,5 @@ class ThemeSetupPage: public PageTab {
     void displayThemeMenu(Window *window, ThemePersistance *tp);
     void setAuthor(ThemeFile *theme);
     void setName(ThemeFile *theme);
+    void setSelected(ThemePersistance *tp);
 };

--- a/radio/src/gui/colorlcd/radio_theme.h
+++ b/radio/src/gui/colorlcd/radio_theme.h
@@ -26,7 +26,6 @@ class ThemeColorPreview;
 class ThemeSetupPage: public PageTab {
   public:
     ThemeSetupPage();
-    ~ThemeSetupPage();
 
     void build(FormWindow * window) override;
     void checkEvents() override;
@@ -40,7 +39,10 @@ class ThemeSetupPage: public PageTab {
     StaticText *authorText = nullptr;
     StaticText *nameText = nullptr;
     int currentTheme = 0;
-    void setupListbox(FormWindow *window, rect_t r, ThemePersistance *tp);
+    bool started = false;
+
+    void setupListbox(Window *window, rect_t r, ThemePersistance *tp);
     void displayThemeMenu(Window *window, ThemePersistance *tp);
     void setAuthor(ThemeFile *theme);
+    void setName(ThemeFile *theme);
 };

--- a/radio/src/gui/colorlcd/tabsgroup.cpp
+++ b/radio/src/gui/colorlcd/tabsgroup.cpp
@@ -139,6 +139,8 @@ static constexpr rect_t _get_body_rect()
   return { 0, MENU_BODY_TOP, LCD_W, MENU_BODY_HEIGHT };
 }
 
+TabsGroup* TabsGroup::activeTabsGroup = nullptr;
+
 TabsGroup::TabsGroup(uint8_t icon):
   Window(Layer::back(), { 0, 0, LCD_W, LCD_H }, OPAQUE),
   header(this, icon),
@@ -147,13 +149,24 @@ TabsGroup::TabsGroup(uint8_t icon):
   Layer::push(this);
 
   lv_obj_set_style_bg_color(lvobj, makeLvColor(COLOR_THEME_SECONDARY3), 0);
+
+  activeTabsGroup = this;
 }
 
 TabsGroup::~TabsGroup()
 {
+  if (activeTabsGroup == this)
+    activeTabsGroup = nullptr;
+
   for (auto tab: tabs) {
     delete tab;
   }
+}
+
+void TabsGroup::refreshTheme()
+{
+  if (activeTabsGroup)
+    lv_obj_set_style_bg_color(activeTabsGroup->getLvObj(), makeLvColor(COLOR_THEME_SECONDARY3), 0);
 }
 
 void TabsGroup::deleteLater(bool detach, bool trash)

--- a/radio/src/gui/colorlcd/tabsgroup.cpp
+++ b/radio/src/gui/colorlcd/tabsgroup.cpp
@@ -145,6 +145,8 @@ TabsGroup::TabsGroup(uint8_t icon):
   body(this, _get_body_rect(), NO_FOCUS | FORM_FORWARD_FOCUS)
 {
   Layer::push(this);
+
+  lv_obj_set_style_bg_color(lvobj, makeLvColor(COLOR_THEME_SECONDARY3), 0);
 }
 
 TabsGroup::~TabsGroup()
@@ -290,11 +292,6 @@ void TabsGroup::onClicked()
 void TabsGroup::onCancel()
 {
   deleteLater();
-}
-
-void TabsGroup::paint(BitmapBuffer * dc)
-{
-  dc->clear(COLOR_THEME_SECONDARY3);
 }
 
 #if defined(HARDWARE_TOUCH)

--- a/radio/src/gui/colorlcd/tabsgroup.h
+++ b/radio/src/gui/colorlcd/tabsgroup.h
@@ -213,8 +213,6 @@ class TabsGroup: public Window
     void onClicked() override;
     void onCancel() override;
 
-    void paint(BitmapBuffer * dc) override;
-
 #if defined(HARDWARE_TOUCH)
     bool onTouchEnd(coord_t x, coord_t y) override;
 #endif

--- a/radio/src/gui/colorlcd/tabsgroup.h
+++ b/radio/src/gui/colorlcd/tabsgroup.h
@@ -217,12 +217,14 @@ class TabsGroup: public Window
     bool onTouchEnd(coord_t x, coord_t y) override;
 #endif
 
+    static void refreshTheme();
 
    protected:
     TabsGroupHeader header;
     FormWindow body;
     std::vector<PageTab *> tabs;
     PageTab * currentTab = nullptr;
+    static TabsGroup* activeTabsGroup;
 
     void setVisibleTab(PageTab * tab);
 };

--- a/radio/src/gui/colorlcd/theme_manager.cpp
+++ b/radio/src/gui/colorlcd/theme_manager.cpp
@@ -295,7 +295,6 @@ void ThemeFile::applyBackground()
   auto instance = OpenTxTheme::instance();
   std::string backgroundImageFileName(getPath());
   auto pos = backgroundImageFileName.rfind('/');
-  fprintf(stderr,">>>>>> applyBackground %s\n", backgroundImageFileName.c_str());
   if (pos != std::string::npos) {
     auto rootDir = backgroundImageFileName.substr(0, pos + 1);
     rootDir = rootDir + "background_" + std::to_string(LCD_W) + "x" +

--- a/radio/src/gui/colorlcd/theme_manager.h
+++ b/radio/src/gui/colorlcd/theme_manager.h
@@ -61,12 +61,9 @@ class ThemeFile
         _imageFileNames(theme._imageFileNames)
     {
         path = theme.path;
-        strncpy(name, theme.name, NAME_LENGTH);
-        name[NAME_LENGTH] = '\0';
-        strncpy(author, theme.author, AUTHOR_LENGTH);
-        author[AUTHOR_LENGTH] = '\0';
-        strncpy(info, theme.info, INFO_LENGTH);
-        info[INFO_LENGTH] = '\0';
+        strAppend(name, theme.name, NAME_LENGTH);
+        strAppend(author, theme.author, AUTHOR_LENGTH);
+        strAppend(info, theme.info, INFO_LENGTH);
     }
     virtual ~ThemeFile() {}
 
@@ -101,9 +98,9 @@ class ThemeFile
         return 0;
     }
     
-    void setName(std::string name) { strncpy(this->name, name.c_str(), NAME_LENGTH); }
-    void setAuthor(std::string author) { strncpy(this->author, author.c_str(), AUTHOR_LENGTH); }
-    void setInfo(std::string info) { strncpy(this->info, info.c_str(), INFO_LENGTH); }
+    void setName(std::string name) { strAppend(this->name, name.c_str(), NAME_LENGTH); }
+    void setAuthor(std::string author) { strAppend(this->author, author.c_str(), AUTHOR_LENGTH); }
+    void setInfo(std::string info) { strAppend(this->info, info.c_str(), INFO_LENGTH); }
     void setPath(std::string path) { this->path = path; }
 
     std::vector<ColorEntry>& getColorList() { return colorList; }

--- a/radio/src/gui/colorlcd/theme_manager.h
+++ b/radio/src/gui/colorlcd/theme_manager.h
@@ -147,7 +147,6 @@ class ThemePersistance
 
     void loadDefaultTheme();
     void setDefaultTheme(int index);
-    void deleteDefaultTheme();
     static char **getColorNames();
     bool deleteThemeByIndex(int index);
     bool createNewTheme(std::string name, ThemeFile &theme);

--- a/radio/src/translations.cpp
+++ b/radio/src/translations.cpp
@@ -723,6 +723,7 @@ const char STR_MODEL_QUICK_SELECT[] = TR_MODEL_QUICK_SELECT;
 const char STR_LOADING[] = TR_LOADING;
 const char STR_DELETE_THEME[] = TR_DELETE_THEME;
 const char STR_SAVE_THEME[] = TR_SAVE_THEME;
+const char STR_EDIT_COLOR[] = TR_EDIT_COLOR;
 #endif
 
 #if !defined(COLORLCD)

--- a/radio/src/translations.h
+++ b/radio/src/translations.h
@@ -744,6 +744,7 @@ extern const char STR_MODEL_QUICK_SELECT[];
 extern const char STR_LOADING[];
 extern const char STR_DELETE_THEME[];
 extern const char STR_SAVE_THEME[];
+extern const char STR_EDIT_COLOR[];
 #endif
 extern const char STR_EXECUTE_FILE[];
 extern const char STR_DELETE_FILE[];

--- a/radio/src/translations/cn.h
+++ b/radio/src/translations/cn.h
@@ -742,6 +742,7 @@
 #define TR_LOADING                     "加载中..."
 #define TR_DELETE_THEME                "删除主题?"
 #define TR_SAVE_THEME                  "保存主题?"
+#define TR_EDIT_COLOR                  "Edit Color"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "快速选择模型"

--- a/radio/src/translations/cz.h
+++ b/radio/src/translations/cz.h
@@ -742,6 +742,7 @@
 #define TR_LOADING                     "Načítání..."
 #define TR_DELETE_THEME                "Smazat motiv?"
 #define TR_SAVE_THEME                  "Uložit motiv?"
+#define TR_EDIT_COLOR                  "Edit Color"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "Rychlý výběr modelu"

--- a/radio/src/translations/da.h
+++ b/radio/src/translations/da.h
@@ -748,6 +748,7 @@
 #define TR_LOADING                     "Indlæser..."
 #define TR_DELETE_THEME                "Slet tema?"
 #define TR_SAVE_THEME                  "Gem tema?"
+#define TR_EDIT_COLOR                  "Edit Color"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "Hurtigvalg af model"

--- a/radio/src/translations/de.h
+++ b/radio/src/translations/de.h
@@ -740,6 +740,7 @@
 #define TR_LOADING                     "Wird geladen..."
 #define TR_DELETE_THEME                "Theme löschen?"
 #define TR_SAVE_THEME                  "Theme speichern?"
+#define TR_EDIT_COLOR                  "Edit Color"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "schnelle Modellauswahl"

--- a/radio/src/translations/en.h
+++ b/radio/src/translations/en.h
@@ -741,6 +741,7 @@
 #define TR_LOADING                     "Loading..."
 #define TR_DELETE_THEME                "Delete Theme?"
 #define TR_SAVE_THEME                  "Save Theme?"
+#define TR_EDIT_COLOR                  "Edit Color"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "Model quick select"

--- a/radio/src/translations/es.h
+++ b/radio/src/translations/es.h
@@ -742,6 +742,7 @@
 #define TR_LOADING                     "Loading..."
 #define TR_DELETE_THEME                "Delete Theme?"
 #define TR_SAVE_THEME                  "Save Theme?"
+#define TR_EDIT_COLOR                  "Edit Color"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "Model quick select"

--- a/radio/src/translations/fi.h
+++ b/radio/src/translations/fi.h
@@ -754,6 +754,7 @@
 #define TR_LOADING                     "Loading..."
 #define TR_DELETE_THEME                "Delete Theme?"
 #define TR_SAVE_THEME                  "Save Theme?"
+#define TR_EDIT_COLOR                  "Edit Color"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "Mallin pikavalinta"

--- a/radio/src/translations/fr.h
+++ b/radio/src/translations/fr.h
@@ -751,6 +751,7 @@
 #define TR_LOADING                     "Loading..."
 #define TR_DELETE_THEME                "Delete Theme?"
 #define TR_SAVE_THEME                  "Save Theme?"
+#define TR_EDIT_COLOR                  "Edit Color"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "Model quick select"

--- a/radio/src/translations/it.h
+++ b/radio/src/translations/it.h
@@ -743,6 +743,7 @@
 #define TR_LOADING             "Caricamento..."
 #define TR_DELETE_THEME        "Cancello Tema?"
 #define TR_SAVE_THEME          "Salvo Tema?"
+#define TR_EDIT_COLOR                  "Edit Color"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT "Selezione veloce modello"

--- a/radio/src/translations/jp.h
+++ b/radio/src/translations/jp.h
@@ -742,6 +742,7 @@
 #define TR_LOADING                     "読み込み中..."
 #define TR_DELETE_THEME                "テーマを削除しますか？"
 #define TR_SAVE_THEME                  "テーマを保存しますか？"
+#define TR_EDIT_COLOR                  "Edit Color"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "モデル クイックセレクト"

--- a/radio/src/translations/nl.h
+++ b/radio/src/translations/nl.h
@@ -746,6 +746,7 @@
 #define TR_LOADING                     "Loading..."
 #define TR_DELETE_THEME                "Delete Theme?"
 #define TR_SAVE_THEME                  "Save Theme?"
+#define TR_EDIT_COLOR                  "Edit Color"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "Model quick select"

--- a/radio/src/translations/pl.h
+++ b/radio/src/translations/pl.h
@@ -739,6 +739,7 @@
 #define TR_LOADING             "Ładowanie..."
 #define TR_DELETE_THEME        "Usunąć motyw?"
 #define TR_SAVE_THEME          "Zapisać motyw?"
+#define TR_EDIT_COLOR                  "Edit Color"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT "Szybki wybór modelu"

--- a/radio/src/translations/pt.h
+++ b/radio/src/translations/pt.h
@@ -746,6 +746,7 @@
 #define TR_LOADING                     "Loading..."
 #define TR_DELETE_THEME                "Delete Theme?"
 #define TR_SAVE_THEME                  "Save Theme?"
+#define TR_EDIT_COLOR                  "Edit Color"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "Model quick select"

--- a/radio/src/translations/se.h
+++ b/radio/src/translations/se.h
@@ -763,6 +763,7 @@
 #define TR_LOADING                      "Laddar..."
 #define TR_DELETE_THEME                 "Radera tema?"
 #define TR_SAVE_THEME                   "Spara tema?"
+#define TR_EDIT_COLOR                  "Edit Color"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT         "Snabbval av modell"

--- a/radio/src/translations/tw.h
+++ b/radio/src/translations/tw.h
@@ -741,6 +741,7 @@
 #define TR_LOADING                     "加載中..."
 #define TR_DELETE_THEME                "刪除主題?"
 #define TR_SAVE_THEME                  "保存主題?"
+#define TR_EDIT_COLOR                  "Edit Color"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "快速選擇模型"


### PR DESCRIPTION
Changes to theme related pages:
- Convert theme select, theme edit and color edit pages to LVGL flex.
- Add 'Edit Color' string to language files (requires translations).
- Simplify theme edit 'onCancel' logic.
- Replace strncpy and strncat in theme manager with strAppend - avoid possible unterminated strings and string overrun.
- Truncate display of long name and author strings in theme pages.

Change to other files to fix issues found:
- Fix size of buttons in ConfirmDialog for portrait layout.
- Truncate item strings in ListBox to fit available space.
- Set window background color on Page and TabsGroup classes instead of using 'paint' function.
