### PR TITLE
fix(EL18): Crash when you touch the screen while charging

### DIFF
--- a/radio/src/targets/nv14/board.cpp
+++ b/radio/src/targets/nv14/board.cpp
@@ -181,7 +181,7 @@ void boardInit()
   flysky_hall_stick_init();
   init2MhzTimer();
   init1msTimer();
-  TouchInit();
+  TouchEventInit();
   usbInit();
 
   uint32_t press_start = 0;
@@ -206,7 +206,7 @@ void boardInit()
       } else {
         uint32_t press_end_touch = press_end;
         if (touchPanelEventOccured()) {
-          touchPanelRead();
+          CleanTouchPanelEvent();
           press_end_touch = get_tmr10ms();
         }
         press_start = 0;

--- a/radio/src/targets/nv14/touch_driver.h
+++ b/radio/src/targets/nv14/touch_driver.h
@@ -357,8 +357,9 @@ typedef struct
 #define LCD_WIDTH                         ( 320 )
 #define LCD_HEIGHT                        ( 480 )
 
-extern void TouchInit( void );
-extern void TouchDriver( void );
+extern void touchPanelInit( void );
+extern void TouchEventInit( void );
+extern void CleanTouchPanelEvent( void );
 
 
 #ifdef __cplusplus

--- a/radio/src/tasks.cpp
+++ b/radio/src/tasks.cpp
@@ -192,7 +192,7 @@ TASK_FUNCTION(menusTask)
   }
 #endif
 
-#if defined(HARDWARE_TOUCH) && !defined(PCBFLYSKY) && !defined(SIMU)
+#if (defined(HARDWARE_TOUCH) || defined(PCBFLYSKY)) && !defined(SIMU)
   touchPanelInit();
 #endif
 


### PR DESCRIPTION
Because FREERTOS does not enable scheduling, the function HAL_GetTick always returns 0, and the program may never return in the function I2C_WaitOnFlagUntilTimeout.

Fixes #3155 