### PR TITLE
fix: various issues related to IMU sensor

### DIFF
--- a/radio/src/gyro.cpp
+++ b/radio/src/gyro.cpp
@@ -54,6 +54,11 @@ void Gyro::wakeup()
     return;
   }
 
+  // reset error count on each
+  // successful query to avoid
+  // stopping the sensor forever
+  errors = 0;
+
   int16_t gx = values[0];
   int16_t gy = values[1];
   // int16_t gz = values[2];

--- a/radio/src/tasks.cpp
+++ b/radio/src/tasks.cpp
@@ -56,10 +56,6 @@ TASK_FUNCTION(menusTask)
   touchPanelInit();
 #endif
 
-#if defined(IMU)
-  gyroInit();
-#endif
-  
   opentxInit();
 
 #if defined(PWR_BUTTON_PRESS)

--- a/radio/src/tasks/mixer_task.cpp
+++ b/radio/src/tasks/mixer_task.cpp
@@ -133,6 +133,10 @@ void execMixerFrequentActions()
 
 TASK_FUNCTION(mixerTask)
 {
+#if defined(IMU)
+  gyroInit();
+#endif
+
   mixerSchedulerInit();
   mixerSchedulerStart();
 


### PR DESCRIPTION
Summary of changes:
- fixed a lock-up issue with touch sensor and IMU on the same I2C bus
  - Please note that the HAL already handles busy I2C bus, so that we should not run into the case where the bus is used and another query is started. However, if that happens, HAL_BUSY will be returned, which leads to -1 being returned in our functions, thus increasing the error count until the sensor stops working.
- fixed a race condition between init and usage of the IMU sensor
  - Init was placed in the UI task, while the sensor was queried in the mixer task.

Fixes #2786