### PR TITLE
Fix CRSF GPS heading precision

### DIFF
--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -46,7 +46,7 @@ const CrossfireSensor crossfireSensors[] = {
   {GPS_ID,         0, STR_SENSOR_GPS,           UNIT_GPS_LATITUDE,      0},
   {GPS_ID,         0, STR_SENSOR_GPS,           UNIT_GPS_LONGITUDE,     0},
   {GPS_ID,         2, STR_SENSOR_GSPD,          UNIT_KMH,               1},
-  {GPS_ID,         3, STR_SENSOR_HDG,           UNIT_DEGREE,            3},
+  {GPS_ID,         3, STR_SENSOR_HDG,           UNIT_DEGREE,            2},
   {GPS_ID,         4, STR_SENSOR_ALT,           UNIT_METERS,            0},
   {GPS_ID,         5, STR_SENSOR_SATELLITES,    UNIT_RAW,               0},
   {ATTITUDE_ID,    0, STR_SENSOR_PITCH,         UNIT_RADIANS,           3},


### PR DESCRIPTION
Looking at the code there seems something  wrong with CRSF GPS heading. I do not think it has been reported, nor do I have the necessary equipment to confirm, but looking at 

![image](https://user-images.githubusercontent.com/5167938/218250204-ed53ba9e-f74b-473d-99e7-80afd401f5a7.png)

or betaflight code

/*
0x02 GPS
Payload:
int32_t     Latitude ( degree / 10000000 )
int32_t     Longitude (degree / 10000000 )
uint16_t    Groundspeed ( km/h / 10 )
uint16_t    GPS heading ( degree / 100 )
uint16      Altitude ( meter ­1000m offset )
uint8_t     Satellites in use ( counter )
*/

the current code cannot be right (and in addition, a 16bits uint cannot store 360 * 1000, so a 3 digits precision cannot work)

I would really appreciate if someone with a craft with GPS using CRSF could report