### PR TITLE
Hal tick fix

### DIFF
--- a/radio/src/targets/common/arm/stm32/stm32_hal.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_hal.cpp
@@ -20,9 +20,9 @@
  */
 
 #include "stm32_hal.h"
-#include "rtos.h"
+#include "timers_driver.h"
 
 extern "C" uint32_t HAL_GetTick(void)
 {
-    return RTOS_GET_MS();
+    return timersGetMsTick();
 }

--- a/radio/src/targets/common/arm/stm32/timers_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/timers_driver.cpp
@@ -21,7 +21,7 @@
 
 #include "opentx.h"
 
-static volatile uint32_t msTickCount; // Used to get 10 Hz counter
+static volatile uint32_t msTickCount; // Used to get 1 kHz counter
 
 // Start TIMER at 2000000Hz
 void init2MhzTimer()
@@ -32,7 +32,7 @@ void init2MhzTimer()
   TIMER_2MHz_TIMER->CR1 = TIM_CR1_CEN;
 }
 
-// Start TIMER at 200Hz
+// Start TIMER at 1000Hz
 void init1msTimer()
 {
   msTickCount = 0;
@@ -75,14 +75,13 @@ static void interrupt1ms()
 
 
   // 5ms loop
+  if(pre_scale == 5 || pre_scale == 10) {
 #if defined(HAPTIC)
-  if(pre_scale == 5 || pre_scale == 10)
-  {
     DEBUG_TIMER_START(debugTimerHaptic);
     HAPTIC_HEARTBEAT();
     DEBUG_TIMER_STOP(debugTimerHaptic);
-  }
 #endif
+  }
   
   // 10ms loop
   if (pre_scale == 10) {

--- a/radio/src/targets/common/arm/stm32/timers_driver.h
+++ b/radio/src/targets/common/arm/stm32/timers_driver.h
@@ -31,8 +31,8 @@ uint16_t getTmr2MHz();
 #include "hal.h"
 
 void init2MhzTimer();
-void init5msTimer();
-void stop5msTimer();
+void init1msTimer();
+void stop1msTimer();
 
 static inline uint16_t getTmr2MHz() { return TIMER_2MHz_TIMER->CNT; }
 
@@ -48,3 +48,5 @@ static inline tmr10ms_t get_tmr10ms()
 {
   return g_tmr10ms;
 }
+
+uint32_t timersGetMsTick();

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -168,7 +168,7 @@ void boardInit()
     TRACE("adcInit failed");
 
   init2MhzTimer();
-  init5msTimer();
+  init1msTimer();
 
   usbInit();
   hapticInit();

--- a/radio/src/targets/nv14/board.cpp
+++ b/radio/src/targets/nv14/board.cpp
@@ -185,7 +185,7 @@ void boardInit()
   battery_charge_init();
   globalData.flyskygimbals = flysky_gimbal_init();
   init2MhzTimer();
-  init5msTimer();
+  init1msTimer();
   TouchInit();
   usbInit();
 

--- a/radio/src/targets/nv14/hal.h
+++ b/radio/src/targets/nv14/hal.h
@@ -37,7 +37,7 @@
  * TIM7 = 2MHz counter
  *
  *
- * TIM14 = 5ms counter
+ * TIM14 = 1ms counter
  */
 
 /* DMA Allocation:

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -218,7 +218,7 @@ void boardInit()
   lcdInit(); // delaysInit() must be called before
   audioInit();
   init2MhzTimer();
-  init5msTimer();
+  init1msTimer();
   __enable_irq();
   usbInit();
 


### PR DESCRIPTION
Fixes #3155 in main

Summary of changes:
use a HW timer to generate a 1ms tick count instead of using the RTOS tick counter, which is not available during initialization