### PR TITLE
2.8 hal tick fix

### DIFF
--- a/radio/src/targets/common/arm/stm32/stm32_hal.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_hal.cpp
@@ -20,9 +20,9 @@
  */
 
 #include "stm32_hal.h"
-#include "rtos.h"
+#include "timers_driver.h"
 
 extern "C" uint32_t HAL_GetTick(void)
 {
-    return RTOS_GET_MS();
+    return timersGetMsTick();
 }

--- a/radio/src/targets/common/arm/stm32/timers_driver.h
+++ b/radio/src/targets/common/arm/stm32/timers_driver.h
@@ -48,3 +48,5 @@ static inline tmr10ms_t get_tmr10ms()
 {
   return g_tmr10ms;
 }
+
+uint32_t timersGetMsTick();


### PR DESCRIPTION
Fixes #3155 in 2.8

Summary of changes:
use a HW timer to generate a 1ms tick count instead of using the RTOS tick counter, which is not available during initialization