### PR TITLE
feat(LUA): adds delete command to filesystem API

### DIFF
--- a/radio/src/lua/api_filesystem.cpp
+++ b/radio/src/lua/api_filesystem.cpp
@@ -151,6 +151,36 @@ int luaFstat(lua_State* L)
   return 1;
 }
 
+/*luadoc
+@function del(file or directory)
+
+ Returns FRESULT (e.g. 0=OK, 4=File not found, 5=Path not found, 6=Path invalid)
+
+@status current Introduced in 2.9.0
+
+### Example
+
+```lua
+  if del("/SCRIPTS/TOOLS/deleteme.txt") == 0 then
+     -- successfully deleted file
+  else
+     -- failed to delete file
+  end
+
+*/
+int luaDelete(lua_State* L)
+{
+  const char* filename = luaL_optstring(L, 1, nullptr);
+
+  FRESULT res = f_unlink(filename);
+  if (res != FR_OK) {
+    printf("luaDelete cannot delete file/folder %s\n", filename);
+  }
+
+  lua_pushunsigned(L, res);
+  return 1;
+}
+
 
 LROT_BEGIN(dir_handle, NULL, LROT_MASK_GC)
   LROT_FUNCENTRY( __gc, dir_gc )
@@ -159,6 +189,7 @@ LROT_END(dir_handle, NULL, LROT_MASK_GC)
 LROT_BEGIN(etxdir, NULL, 0)
   LROT_FUNCENTRY( dir, luaDir )
   LROT_FUNCENTRY( fstat, luaFstat )
+  LROT_FUNCENTRY( del, luaDelete )
 LROT_END(etxdir, NULL, 0)
 
 extern "C" {


### PR DESCRIPTION
Usage in LUA:
```lua
if del("/SCRIPTS/TOOLS/deleteme.txt") == 0 then
   -- successfully deleted file
else
   -- failed to deleted file
end
```

`del()` returns FRESULT:
https://github.com/EdgeTX/edgetx/blob/60cdb897ee8fe8d7fd4a44a5c4fef7e969ccac63/radio/src/thirdparty/FatFs/ff.h#L251-L272

Tested with simulator under Win10.