### PR TITLE
fix(color) - Fix scroll wheel behaviour on inputs, mixes and outputs pages.

### DIFF
--- a/radio/src/gui/colorlcd/model_inputs.cpp
+++ b/radio/src/gui/colorlcd/model_inputs.cpp
@@ -445,14 +445,6 @@ void ModelInputsPage::build(FormWindow *window)
   auto form_obj = form->getLvObj();
   lv_obj_set_width(form_obj, lv_pct(100));
 
-  auto btn = new TextButton(window, rect_t{}, LV_SYMBOL_PLUS, [=]() {
-    uint8_t input, index;
-    if (getFreeInput(input, index)) insertInput(input, index);
-    return 0;
-  });
-  auto btn_obj = btn->getLvObj();
-  lv_obj_set_width(btn_obj, lv_pct(100));
-
   groups.clear();
   lines.clear();
 
@@ -479,5 +471,13 @@ void ModelInputsPage::build(FormWindow *window)
       break;
     }
   }
+
+  auto btn = new TextButton(window, rect_t{}, LV_SYMBOL_PLUS, [=]() {
+    uint8_t input, index;
+    if (getFreeInput(input, index)) insertInput(input, index);
+    return 0;
+  });
+  auto btn_obj = btn->getLvObj();
+  lv_obj_set_width(btn_obj, lv_pct(100));
 }
 

--- a/radio/src/gui/colorlcd/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model_mixes.cpp
@@ -522,27 +522,6 @@ void ModelMixesPage::build(FormWindow * window)
   auto form_obj = form->getLvObj();
   lv_obj_set_width(form_obj, lv_pct(100));
 
-  auto box = new FormGroup(window, rect_t{});
-  box->setFlexLayout(LV_FLEX_FLOW_ROW, lv_dpx(8));
-  box->padLeft(lv_dpx(8));
-
-  auto box_obj = box->getLvObj();
-  lv_obj_set_width(box_obj, lv_pct(100));
-  lv_obj_set_style_flex_cross_place(box_obj, LV_FLEX_ALIGN_CENTER, 0);
-
-  new StaticText(box, rect_t{}, STR_SHOW_MIXER_MONITORS, 0, COLOR_THEME_PRIMARY1);
-  new CheckBox(
-      box, rect_t{}, [=]() { return showMonitors; },
-      [=](uint8_t val) { enableMonitors(val); });
-
-  auto btn = new TextButton(window, rect_t{}, LV_SYMBOL_PLUS, [=]() {
-    newMix();
-    return 0;
-  });
-  auto btn_obj = btn->getLvObj();
-  lv_obj_set_width(btn_obj, lv_pct(100));
-  lv_group_focus_obj(btn_obj);
-
   groups.clear();
   lines.clear();
 
@@ -567,6 +546,26 @@ void ModelMixesPage::build(FormWindow * window)
       }
     }
   }
+
+  auto box = new FormGroup(window, rect_t{});
+  box->setFlexLayout(LV_FLEX_FLOW_ROW, lv_dpx(8));
+  box->padLeft(lv_dpx(8));
+
+  auto box_obj = box->getLvObj();
+  lv_obj_set_width(box_obj, lv_pct(100));
+  lv_obj_set_style_flex_cross_place(box_obj, LV_FLEX_ALIGN_CENTER, 0);
+
+  new StaticText(box, rect_t{}, STR_SHOW_MIXER_MONITORS, 0, COLOR_THEME_PRIMARY1);
+  new CheckBox(
+      box, rect_t{}, [=]() { return showMonitors; },
+      [=](uint8_t val) { enableMonitors(val); });
+
+  auto btn = new TextButton(window, rect_t{}, LV_SYMBOL_PLUS, [=]() {
+    newMix();
+    return 0;
+  });
+  auto btn_obj = btn->getLvObj();
+  lv_obj_set_width(btn_obj, lv_pct(100));
 }
 
 void ModelMixesPage::enableMonitors(bool enabled)

--- a/radio/src/gui/colorlcd/model_outputs.cpp
+++ b/radio/src/gui/colorlcd/model_outputs.cpp
@@ -322,7 +322,10 @@ void ModelOutputsPage::build(FormWindow *window)
 
     // Channel settings
     auto btn = new OutputLineButton(window, ch);
-    // btn->refresh();
+#if LCD_W > LCD_H
+    // Initial scroll height is incorrect without this??? (Issue #3186)
+    btn->setHeight(35);
+#endif
 
     LimitData* output = limitAddress(ch);
     btn->setPressHandler([=]() -> uint8_t {


### PR DESCRIPTION
Fixes #3186

Summary of changes:
- Move button creation on inputs and mixes pages so the '+' button is not the first selected button.
- Force line height on outputs page so initial scroll height works.