### PR TITLE
fix: `loadRadioSettingsYaml` not honoring checks flag

### DIFF
--- a/radio/src/storage/sdcard_yaml.cpp
+++ b/radio/src/storage/sdcard_yaml.cpp
@@ -131,13 +131,16 @@ static const char * attemptLoad(const char *filename, ChecksumResult* checksum_s
   return readYamlFile(filename, YamlTreeWalker::get_parser_calls(), &tree, checksum_status);
 }
 
-const char * loadRadioSettingsYaml()
+const char * loadRadioSettingsYaml(bool checks)
 {
     // YAML reader
     TRACE("YAML radio settings reader");
 
     ChecksumResult checksum_status;
     const char* p = attemptLoad(RADIO_SETTINGS_YAML_PATH, &checksum_status);
+
+    if(!checks)
+      return p;
 
     if((p != NULL) || (checksum_status != ChecksumResult::Success) ) {
       // Read failed or checksum check failed
@@ -182,7 +185,7 @@ const char * loadRadioSettings()
     g_eeGeneral.internalModule = DEFAULT_INTERNAL_MODULE;
 #endif
 
-    const char* error = loadRadioSettingsYaml();
+    const char* error = loadRadioSettingsYaml(true);
     if (!error) {
       g_eeGeneral.chkSum = evalChkSum();
     }
@@ -598,5 +601,5 @@ const char * restoreModel(uint8_t idx, char *model_name)
 bool storageReadRadioSettings(bool checks)
 {
   if (!sdMounted()) sdInit();
-  return loadRadioSettingsYaml() == nullptr;
+  return loadRadioSettingsYaml(checks) == nullptr;
 }

--- a/radio/src/storage/sdcard_yaml.h
+++ b/radio/src/storage/sdcard_yaml.h
@@ -26,7 +26,7 @@ enum class ChecksumResult {Success, Failed, None};
 
 constexpr uint8_t MODELIDX_STRLEN = sizeof(MODEL_FILENAME_PREFIX "00");
 
-const char * loadRadioSettingsYaml();
+const char * loadRadioSettingsYaml(bool checks);
 const char * writeModelYaml(const char* filename);
 const char * readModelYaml(const char * filename, uint8_t * buffer, uint32_t size, const char* pathName = STR_MODELS_PATH);
 bool YamlFileChecksum(const YamlNode* root_node, uint8_t* data, uint16_t* checksum);


### PR DESCRIPTION
Fixes issue whereby no `RADIO/radio.yml` would trigger radio to power off rather than to initalise new files. 

The radio settings are loaded twice (i.e. B&W that show startup animation) or sometimes three times for some radios (i.e. TPro). It's only the final load that really needs to verify the checksum. The other times, checks are allowed to be ignored. 

Summary of changes:
- allow `loadRadioSettingsYaml` to skip checks, primarily when `storageReadRadioSettings` is called with the `false` flag


Was first detected on the RM Boxer after deleting the radio folder. I have tested this on this radio, and it now correctly starts and alerts if files are missing, and still performs checksum validation if the files are present. Will check behaviour on the T-Pro as that radio uniquely uses `storageReadRadioSettings` as part of using the LEDs to indicate charge status. 

edit: Have now checkd TPro and that is fine also.

This is going into the 2.8.1 on short notice as you can't even turn the radio on with a blank SD card as it stands 😮 