### PR TITLE
fix(boxer): Power LED sequence

### DIFF
--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -869,7 +869,7 @@ constexpr uint8_t OPENTX_START_NO_CHECKS = 0x04;
 // Green is preferred "ready to use" color for these radios
 #if defined(RADIO_T8) || defined(RADIO_COMMANDO8) || defined(RADIO_TLITE) || \
     defined(RADIO_TPRO) || defined(RADIO_TX12) || defined(RADIO_TX12MK2) ||  \
-    defined(RADIO_ZORRO)
+    defined(RADIO_ZORRO) || defined(RADIO_BOXER)
 #define LED_ERROR_END() ledGreen()
 #define LED_BIND() ledBlue()
 #else

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -153,7 +153,7 @@ void boardInit()
   ledInit();
 #if defined(RADIO_T8) || defined(RADIO_COMMANDO8) || defined(RADIO_TLITE) || \
     defined(RADIO_TPRO) || defined(RADIO_TX12) || defined(RADIO_TX12MK2) ||  \
-    defined(RADIO_ZORRO)
+    defined(RADIO_ZORRO) || defined(RADIO_BOXER)
   ledBlue();
 #else
   ledGreen();


### PR DESCRIPTION
Fixes issue whereby RM Boxer is not following convention of blue during startup, green once operational in cases where radio has RGB power LED and manufacturer has not requested it be different. 
