### PR TITLE
fix(gh): Mac Cpn action dependency reorder

### DIFF
--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -70,13 +70,6 @@ jobs:
       - name: Install dependencies
         run: python3 -m pip install --upgrade pip Pillow lz4 clang
 
-      - name: Install dfu-util
-        run:   wget https://downloads.sourceforge.net/project/dfu-util/dfu-util-0.9.tar.gz &&
-          tar xfv dfu-util-0.9.tar.gz &&
-          cd dfu-util-0.9 &&
-          ./configure &&
-          make install
-
       - name: Install libusb
         run:   wget https://github.com/libusb/libusb/releases/download/v1.0.20/libusb-1.0.20.tar.bz2 &&
           export MACOSX_DEPLOYMENT_TARGET=10.9 &&
@@ -85,6 +78,13 @@ jobs:
           ./configure &&
           make install &&
           cd ..
+
+      - name: Install dfu-util
+        run:   wget https://downloads.sourceforge.net/project/dfu-util/dfu-util-0.9.tar.gz &&
+          tar xfv dfu-util-0.9.tar.gz &&
+          cd dfu-util-0.9 &&
+          ./configure &&
+          make install
 
       - name: Install libsdl
         run:   wget https://www.libsdl.org/release/SDL-1.2.15.tar.gz &&

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -70,6 +70,9 @@ jobs:
       - name: Install dependencies
         run: python3 -m pip install --upgrade pip Pillow lz4 clang
 
+      - name: Patch GitHub macOS build
+        run: brew install pkg-config
+
       - name: Install libusb
         run:   wget https://github.com/libusb/libusb/releases/download/v1.0.20/libusb-1.0.20.tar.bz2 &&
           export MACOSX_DEPLOYMENT_TARGET=10.9 &&


### PR DESCRIPTION
Summary of changes:

~~Seems that the MacOS Companion build now needs libusb before dfu-util?~ 

Seems to be a bug introduced by a new github-action runner image whereby `pkg-config` is missing
https://github.com/actions/runner-images/pull/7125
