### PR TITLE
fix:EL18 power-on backlight before screen content.

### DIFF
--- a/radio/src/targets/common/arm/stm32/f4/system_stm32f4xx.c
+++ b/radio/src/targets/common/arm/stm32/f4/system_stm32f4xx.c
@@ -214,6 +214,9 @@ static void SetSysClock(void);
   */
 void SystemInit(void)
 {
+#if defined(PCBFLYSKY)
+  backlightLowInit();
+#endif
   /* FPU settings ------------------------------------------------------------*/
   #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
     SCB->CPACR |= ((3UL << 10*2)|(3UL << 11*2));  /* set CP10 and CP11 Full Access */

--- a/radio/src/targets/nv14/backlight_driver.cpp
+++ b/radio/src/targets/nv14/backlight_driver.cpp
@@ -24,6 +24,19 @@
 
 #include "globals.h"
 
+void backlightLowInit( void )
+{
+    RCC_AHB1PeriphClockCmd(BACKLIGHT_RCC_AHB1Periph, ENABLE);
+    GPIO_InitTypeDef GPIO_InitStructure;
+    GPIO_InitStructure.GPIO_Pin = BACKLIGHT_GPIO_PIN;
+    GPIO_InitStructure.GPIO_Mode = GPIO_Mode_OUT;
+    GPIO_InitStructure.GPIO_Speed = GPIO_Speed_2MHz;
+    GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
+    GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_UP;
+    GPIO_Init(BACKLIGHT_GPIO, &GPIO_InitStructure);
+    GPIO_WriteBit( BACKLIGHT_GPIO, BACKLIGHT_GPIO_PIN, Bit_RESET );
+}
+
 void backlightInit()
 {
   // PIN init
@@ -41,7 +54,7 @@ void backlightInit()
   BACKLIGHT_TIMER->PSC = BACKLIGHT_TIMER_FREQ / 1000000 - 1; // 10kHz (same as FrOS)
   BACKLIGHT_TIMER->CCMR1 = TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2 | TIM_CCMR1_OC1PE; // PWM mode 1
   BACKLIGHT_TIMER->CCER = TIM_CCER_CC1E | TIM_CCER_CC1NE;
-  BACKLIGHT_TIMER->CCR1 = 100; // 100% on init
+  BACKLIGHT_TIMER->CCR1 = 0;
   BACKLIGHT_TIMER->EGR = TIM_EGR_UG;
   BACKLIGHT_TIMER->CR1 |= TIM_CR1_CEN; // Counter enable
   BACKLIGHT_TIMER->BDTR |= TIM_BDTR_MOE;

--- a/radio/src/targets/nv14/board.h
+++ b/radio/src/targets/nv14/board.h
@@ -430,6 +430,7 @@ void lcdOn();
 #define BACKLIGHT_LEVEL_MIN             1
 
 extern bool boardBacklightOn;
+void backlightLowInit( void );
 void backlightInit();
 void backlightEnable(uint8_t dutyCycle);
 void backlightFullOn();

--- a/radio/src/targets/nv14/bootloader/boot_menu.cpp
+++ b/radio/src/targets/nv14/bootloader/boot_menu.cpp
@@ -66,6 +66,8 @@ static bool rfUsbAccess = false;
 void bootloaderInitScreen()
 {
   lcdInitDisplayDriver();
+  backlightInit();
+  backlightEnable(100);
 }
 
 static void bootloaderDrawTitle(const char* text)


### PR DESCRIPTION
Fixes #3199
![backlight](https://user-images.githubusercontent.com/46518305/219844188-c81fbfc9-8563-43d5-973d-5f6cc694394e.png)
Because the resistance value of the pull-down resistor(R5) of the backlight pin is too large, the backlight will be turned on when the pin is not initialized at power-on.