### PR TITLE
feat(cpn) - Companion startup changes

### DIFF
--- a/companion/src/companion.cpp
+++ b/companion/src/companion.cpp
@@ -237,27 +237,24 @@ int main(int argc, char *argv[])
     profile.fwName("");
   }
 
-  QString splashScreen;
-  splashScreen = ":/images/splash.png";
-
-  QPixmap pixmap = QPixmap(splashScreen);
-  QSplashScreen *splash = new QSplashScreen(pixmap);
-
   Firmware::setCurrentVariant(Firmware::getFirmwareForId(g.profile[g.id()].fwType()));
 
   MainWindow *mainWin = new MainWindow();
+  mainWin->show();
+
   if (g.showSplash()) {
-    splash->show();
-    QTimer::singleShot(1000*SPLASH_TIME, splash, SLOT(close()));
-    QTimer::singleShot(1000*SPLASH_TIME, mainWin, SLOT(show()));
-  }
-  else {
-    mainWin->show();
+    QSplashScreen *splash = new QSplashScreen(QPixmap(":/images/splash.png"));
+    QTimer::singleShot(1, [=] {
+      splash->show();
+    });
+    QTimer::singleShot(1000*SPLASH_TIME, [=] {
+      splash->close();
+      delete splash;
+    });
   }
 
   int result = app.exec();
 
-  delete splash;
   delete mainWin;
 
   SimulatorLoader::unregisterSimulators();


### PR DESCRIPTION
This fixes some issues on MacOS Companion startup.

1. Show the main window before showing the splash screen:
- Fixes MacOS issue where the main window size and position is not restored if the splash screen is displayed first.
- Splash screen can be dismissed before the timeout (click on splash) and the main window can be used without having to wait for the timeout to finish.

2. Delay showing splash until after app.exec() started:
- Prevents lockup due to splash->show() call not returning. Note this only happen on my self-build versions; but happens on both Big Sur and Monterey.

4. Don't create splash objects unless needed (general optimisation).
