### PR TITLE
fix(yaml): the string compare only matched the number of characters f…

### DIFF
--- a/radio/src/storage/yaml/yaml_tree_walker.cpp
+++ b/radio/src/storage/yaml/yaml_tree_walker.cpp
@@ -45,7 +45,8 @@ uint32_t yaml_parse_enum(const struct YamlIdStr* choices, const char* val, uint8
     while (choices->str) {
 
         // we have a match!
-        if (!strncmp(val, choices->str, val_len))
+        if( strncmp(val, choices->str, val_len) == 0
+          && strlen(choices->str) == val_len)
             break;
 
         choices++;


### PR DESCRIPTION
…ound in the yaml file, so "SLIDER1" matched "SL" on the X9E


Fixes #3107 

It might make sense to port this also to 2.8, in case we make another patch release for 2.8