### PR TITLE
Addressing error: 'uint32_t' has not been declared

### DIFF
--- a/radio/src/gui/colorlcd/str_functions.h
+++ b/radio/src/gui/colorlcd/str_functions.h
@@ -19,6 +19,7 @@
  * GNU General Public License for more details.
  */
 #pragma once
+#include <cstdint>
 #include <wctype.h>
 #include <string>
 #include <iostream>


### PR DESCRIPTION

<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #3222.

Summary of changes:

Addressing
```
In file included from /builddir/build/BUILD/edgetx-2.8.1/radio/src/gui/colorlcd/str_functions.cpp:25: /builddir/build/BUILD/edgetx-2.8.1/radio/src/gui/colorlcd/str_functions.h:30:42: error: 'uint32_t' has not been declared
   30 | extern std::string wrap(std::string str, uint32_t width);
      |                                          ^~~~~~~~
```

The change helps compilation with gcc 13 while does not negatively affect gcc 12.