### PR TITLE
fix: more precise pulse timings

### DIFF
--- a/radio/src/targets/common/arm/stm32/extmodule_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/extmodule_driver.cpp
@@ -111,7 +111,7 @@ void extmoduleSendNextFramePpm(void* pulses, uint16_t length,
 void extmodulePxx1PulsesStart()
 {
   EXTERNAL_MODULE_ON();
-  stm32_pulse_config_output(&extmoduleTimer, false, LL_TIM_OCMODE_PWM1, 9 * 2);
+  stm32_pulse_config_output(&extmoduleTimer, false, LL_TIM_OCMODE_PWM1, 8 * 2);
   stm32_pulse_init(&extmoduleTimer);
 }
 
@@ -121,7 +121,7 @@ void extmoduleSendNextFramePxx1(const void* pulses, uint16_t length)
 
   // Start DMA request and re-enable timer
   stm32_pulse_start_dma_req(&extmoduleTimer, pulses, length, LL_TIM_OCMODE_PWM1,
-                            9 * 2);
+                            8 * 2);
 }
 #endif
 

--- a/radio/src/targets/taranis/intmodule_pulses_driver.cpp
+++ b/radio/src/targets/taranis/intmodule_pulses_driver.cpp
@@ -75,7 +75,7 @@ void intmoduleStop()
 void intmodulePxx1PulsesStart()
 {
   INTERNAL_MODULE_ON();
-  stm32_pulse_config_output(&intmoduleTimer, false, LL_TIM_OCMODE_PWM1, 9 * 2);
+  stm32_pulse_config_output(&intmoduleTimer, false, LL_TIM_OCMODE_PWM1, 8 * 2);
   stm32_pulse_init(&intmoduleTimer);
 }
 
@@ -85,6 +85,6 @@ void intmoduleSendNextFramePxx1(const uint16_t* data, uint8_t size)
 
   // Start DMA request and re-enable timer
   stm32_pulse_start_dma_req(&intmoduleTimer, data, size, LL_TIM_OCMODE_PWM1,
-                            9 * 2);
+                            8 * 2);
 }
 #endif


### PR DESCRIPTION
This PR fixes some timing issues for the pulse drivers that might otherwise causes trouble with picky PXX1 modules. The issue is probably that the timing have been tuned to work with older radios, which had much slower raise time on the inverters. Newer harder has inverters with a faster raise time (to support higher bitrates).

- X10 (the old one, not the Express):
<img width="186" alt="PXX1 X10 external" src="https://user-images.githubusercontent.com/1050031/220394278-b7cafb1a-e1f2-4b1b-962b-160282e1baae.png">

- X9D+ (legacy):
<img width="250" alt="Screenshot 2023-02-22 at 09 34 51" src="https://user-images.githubusercontent.com/1050031/220566219-88e98f02-9f29-404c-8ef7-cd67d06d79d4.png">

- TX16S MKII:
<img width="190" alt="PXX1 TX16S external" src="https://user-images.githubusercontent.com/1050031/220394386-db8badf3-0d4b-4ce9-9c31-3bd8331f6834.png">

- RM Boxer:
<img width="189" alt="Screenshot 2023-02-21 at 17 01 08" src="https://user-images.githubusercontent.com/1050031/220396431-f7af3135-3e57-4e80-8588-637885fb6b68.png">

Please note that the measurements above have been done with a pulse length set to `8 us`.