### PR TITLE
fix(yaml): potential unaligned access when reading and writing switch…

### DIFF
--- a/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
@@ -952,7 +952,6 @@ static void r_swtchWarn(void* user, uint8_t* data, uint32_t bitoffs,
                         const char* val, uint8_t val_len)
 {
   data += (bitoffs >> 3UL);
-  swarnstate_t& swtchWarn = *(swarnstate_t*)data;
 
   // Read from string like 'AdBuC-':
   //
@@ -963,12 +962,13 @@ static void r_swtchWarn(void* user, uint8_t* data, uint32_t bitoffs,
   //
   // -> switches not in the list shall not be checked
   //
-  swtchWarn = 0;
+  swarnstate_t swtchWarn = 0;
+
   while (val_len--) {
     signed swtch = getRawSwitchIdx(*(val++));
     if (swtch < 0) break;
 
-    unsigned state = 0;
+    swarnstate_t state = 0;
     switch (*(val++)) {
       case 'u':
         state = 1;
@@ -987,13 +987,17 @@ static void r_swtchWarn(void* user, uint8_t* data, uint32_t bitoffs,
     // 3 bits per switch
     swtchWarn |= (state << (3 * swtch));
   }
+  memcpy(data, &swtchWarn, sizeof(swtchWarn));
+
 }
 
 static bool w_swtchWarn(void* user, uint8_t* data, uint32_t bitoffs,
                         yaml_writer_func wf, void* opaque)
 {
   data += (bitoffs >> 3UL);
-  swarnstate_t states = *(swarnstate_t*)data;
+
+  swarnstate_t states;
+  memcpy(&states, data, sizeof(states));
 
   for (int i = 0; i < NUM_SWITCHES; i++) {
     // TODO: SWITCH_EXISTS() uses the g_eeGeneral stucture, which might not be


### PR DESCRIPTION
… warning positions. It IS unaligned for the X9E

Fixes #2855 
and potentially #2855 and #2165

Summary of changes:
prevent the compiler from generating code for aligned access to a variable that might be unaligned

This also should be merged to 2.8