### PR TITLE
feat(color) - Update long press handler on model select page.

### DIFF
--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -570,6 +570,7 @@ void ModelsPageBody::update()
     // Long Press Handler for Models
     button->setLongPressHandler([=]() -> uint8_t {
       button->setFocused();
+      focusedModel = model;
       openMenu();
       return 0;
     });

--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -569,9 +569,8 @@ void ModelsPageBody::update()
 
     // Long Press Handler for Models
     button->setLongPressHandler([=]() -> uint8_t {
-      if (model == focusedModel) {
-        openMenu();
-      }
+      button->setFocused();
+      openMenu();
       return 0;
     });
   }


### PR DESCRIPTION
Currently a long press on the touch screen on  any model other than the selected one does nothing.

With this change, a long touch press on any model will select it and open the menu.
