### PR TITLE
fix(color) - Fix update of 'end' value in ChannelRange class.

### DIFF
--- a/radio/src/gui/colorlcd/channel_range.cpp
+++ b/radio/src/gui/colorlcd/channel_range.cpp
@@ -68,7 +68,8 @@ void ChannelRange::updateEnd()
   chEnd->setMax(max_ch);
   chEnd->setDefault(max_ch);
 
-  chEnd->update();
+  // Force value to fit between new min and max
+  chEnd->setValue(chEnd->getValue());
 }
 
 void ChannelRange::updateStart()


### PR DESCRIPTION
Fixes #3236 