### PR TITLE
fix(color) - Fix telemetry checks not running in simulator due to inverted logic.

### DIFF
--- a/radio/src/tasks/mixer_task.cpp
+++ b/radio/src/tasks/mixer_task.cpp
@@ -123,7 +123,7 @@ void execMixerFrequentActions()
 #endif
 
 #if defined(SIMU)
-  if (!_mixer_running) {
+  if (_mixer_running) {
     DEBUG_TIMER_START(debugTimerTelemetryWakeup);
     telemetryWakeup();
     DEBUG_TIMER_STOP(debugTimerTelemetryWakeup);


### PR DESCRIPTION
Fixes #3242 
