### PR TITLE
fix(color,fr) - Fix missing comma in FR translation.

### DIFF
--- a/radio/src/translations/fr.h
+++ b/radio/src/translations/fr.h
@@ -747,7 +747,7 @@
 #define TR_MAXBAUDRATE                 "Max bauds"
 #define TR_BAUDRATE                    "Baudrate"
 #define TR_SAMPLE_MODE                 "Sample Mode"
-#define TR_SAMPLE_MODES                "Normal""OneBit"
+#define TR_SAMPLE_MODES                "Normal","OneBit"
 #define TR_LOADING                     "Loading..."
 #define TR_DELETE_THEME                "Delete Theme?"
 #define TR_SAVE_THEME                  "Save Theme?"


### PR DESCRIPTION
Fixes #3266 
