### PR TITLE
fix(color) - Adjust page padding for pre-flight checks, trims and throttle setup pages.

### DIFF
--- a/radio/src/gui/colorlcd/radio_setup.cpp
+++ b/radio/src/gui/colorlcd/radio_setup.cpp
@@ -451,22 +451,21 @@ class BacklightPage : public SubPage {
       blMode->setAvailableHandler(
           [=](int newValue) { return newValue != e_backlight_mode_off; });
 
-      line = body.newLine(&grid);
+      backlightTimeout = body.newLine(&grid);
 
       // Delay
-      new StaticText(line, rect_t{}, STR_BACKLIGHT_TIMER, 0, COLOR_THEME_PRIMARY1);
-      auto edit = new NumberEdit(line, rect_t{}, 5, 600,
+      new StaticText(backlightTimeout, rect_t{}, STR_BACKLIGHT_TIMER, 0, COLOR_THEME_PRIMARY1);
+      auto edit = new NumberEdit(backlightTimeout, rect_t{}, 5, 600,
                                  GET_DEFAULT(g_eeGeneral.lightAutoOff * 5),
                                  SET_VALUE(g_eeGeneral.lightAutoOff, newValue / 5));
       edit->setStep(5);
       edit->setSuffix("s");
-      backlightTimeout = edit;
 
-      line = body.newLine(&grid);
+      backlightOnBright = body.newLine(&grid);
 
       // Backlight ON bright
-      new StaticText(line, rect_t{}, STR_BLONBRIGHTNESS, 0, COLOR_THEME_PRIMARY1);
-      backlightOnBright = new Slider(line, rect_t{0,0,lv_pct(50),PAGE_LINE_HEIGHT}, BACKLIGHT_LEVEL_MIN, BACKLIGHT_LEVEL_MAX,
+      new StaticText(backlightOnBright, rect_t{}, STR_BLONBRIGHTNESS, 0, COLOR_THEME_PRIMARY1);
+      new Slider(backlightOnBright, rect_t{0,0,lv_pct(50),PAGE_LINE_HEIGHT}, BACKLIGHT_LEVEL_MIN, BACKLIGHT_LEVEL_MAX,
                  [=]() -> int32_t {
                    return BACKLIGHT_LEVEL_MAX - g_eeGeneral.backlightBright;
                  },
@@ -476,18 +475,20 @@ class BacklightPage : public SubPage {
                    else
                      g_eeGeneral.backlightBright = BACKLIGHT_LEVEL_MAX - g_eeGeneral.blOffBright;
                  });
-      line = body.newLine(&grid);
+
+      backlightOffBright = body.newLine(&grid);
 
       // Backlight OFF bright
-      new StaticText(line, rect_t{}, STR_BLOFFBRIGHTNESS, 0, COLOR_THEME_PRIMARY1);
-      backlightOffBright = new Slider(line, rect_t{0,0,lv_pct(50),PAGE_LINE_HEIGHT}, BACKLIGHT_LEVEL_MIN, BACKLIGHT_LEVEL_MAX, GET_DEFAULT(g_eeGeneral.blOffBright),
-          [=](int32_t newValue) {
-            int32_t onBright = BACKLIGHT_LEVEL_MAX - g_eeGeneral.backlightBright;
-            if(newValue <= onBright || g_eeGeneral.backlightMode == e_backlight_mode_off)
-              g_eeGeneral.blOffBright = newValue;
-            else
-              g_eeGeneral.blOffBright = onBright;
-          });
+      new StaticText(backlightOffBright, rect_t{}, STR_BLOFFBRIGHTNESS, 0, COLOR_THEME_PRIMARY1);
+      new Slider(backlightOffBright, rect_t{0,0,lv_pct(50),PAGE_LINE_HEIGHT}, BACKLIGHT_LEVEL_MIN, BACKLIGHT_LEVEL_MAX, GET_DEFAULT(g_eeGeneral.blOffBright),
+                 [=](int32_t newValue) {
+                   int32_t onBright = BACKLIGHT_LEVEL_MAX - g_eeGeneral.backlightBright;
+                   if(newValue <= onBright || g_eeGeneral.backlightMode == e_backlight_mode_off)
+                     g_eeGeneral.blOffBright = newValue;
+                   else
+                     g_eeGeneral.blOffBright = onBright;
+                 });
+
       line = body.newLine(&grid);
 
   #if defined(KEYS_BACKLIGHT_GPIO)
@@ -506,36 +507,36 @@ class BacklightPage : public SubPage {
     }
 
   protected:
-    FormField* backlightTimeout = nullptr;
-    FormField* backlightOnBright = nullptr;
-    FormField* backlightOffBright = nullptr;
+    Window* backlightTimeout = nullptr;
+    Window* backlightOnBright = nullptr;
+    Window* backlightOffBright = nullptr;
 
     void updateBacklightControls()
     {
       switch(g_eeGeneral.backlightMode)
       {
       case e_backlight_mode_off:
-        backlightTimeout->enable(false);
-        backlightOnBright->enable(false);
-        backlightOffBright->enable(true);
+        lv_obj_add_flag(backlightTimeout->getLvObj(), LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(backlightOnBright->getLvObj(), LV_OBJ_FLAG_HIDDEN);
+        lv_obj_clear_flag(backlightOffBright->getLvObj(), LV_OBJ_FLAG_HIDDEN);
         break;
       case e_backlight_mode_keys:
       case e_backlight_mode_sticks:
       case e_backlight_mode_all:
       default:
       {
-        backlightTimeout->enable(true);
-        backlightOnBright->enable(true);
-        backlightOffBright->enable(true);
+        lv_obj_clear_flag(backlightTimeout->getLvObj(), LV_OBJ_FLAG_HIDDEN);
+        lv_obj_clear_flag(backlightOnBright->getLvObj(), LV_OBJ_FLAG_HIDDEN);
+        lv_obj_clear_flag(backlightOffBright->getLvObj(), LV_OBJ_FLAG_HIDDEN);
         int32_t onBright = BACKLIGHT_LEVEL_MAX - g_eeGeneral.backlightBright;
         if(onBright < g_eeGeneral.blOffBright)
           g_eeGeneral.backlightBright = BACKLIGHT_LEVEL_MAX - g_eeGeneral.blOffBright;
         break;
       }
       case e_backlight_mode_on:
-        backlightTimeout->enable(false);
-        backlightOnBright->enable(true);
-        backlightOffBright->enable(false);
+        lv_obj_add_flag(backlightTimeout->getLvObj(), LV_OBJ_FLAG_HIDDEN);
+        lv_obj_clear_flag(backlightOnBright->getLvObj(), LV_OBJ_FLAG_HIDDEN);
+        lv_obj_add_flag(backlightOffBright->getLvObj(), LV_OBJ_FLAG_HIDDEN);
         break;
       }
       resetBacklightTimeout();

--- a/radio/src/gui/colorlcd/radio_setup.cpp
+++ b/radio/src/gui/colorlcd/radio_setup.cpp
@@ -29,11 +29,9 @@
 
 #define SET_DIRTY()     storageDirty(EE_GENERAL)
 
-static const lv_coord_t col_two_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1),
+static const lv_coord_t col_two_dsc[] = {LV_GRID_FR(19), LV_GRID_FR(21),
                                      LV_GRID_TEMPLATE_LAST};
-static const lv_coord_t col_three_dsc[] = {LV_GRID_FR(2), LV_GRID_FR(1), LV_GRID_FR(1),
-                                     LV_GRID_TEMPLATE_LAST};
-static const lv_coord_t col_four_dsc[] = {LV_GRID_FR(3), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1),
+static const lv_coord_t col_four_dsc[] = {LV_GRID_FR(19), LV_GRID_FR(7), LV_GRID_FR(7), LV_GRID_FR(7),
                                      LV_GRID_TEMPLATE_LAST};
 static const lv_coord_t row_dsc[] = {LV_GRID_CONTENT, LV_GRID_CONTENT,
                                      LV_GRID_TEMPLATE_LAST};
@@ -240,23 +238,23 @@ class WindowButtonGroup : public FormGroup
   PageDefs pages;
 };
 
-class SoundPage : public Page {
+class SubPage : public Page
+{
   public:
-  SoundPage() :
-      Page(ICON_RADIO_SETUP)
+    SubPage(MenuIcons icon, const char* title) : Page(icon)
     {
-      build();
-    }
-
-  protected:
-
-    void build()
-    {
-      header.setTitle(STR_SOUND_LABEL);
+      header.setTitle(title);
 
       body.setFlexLayout();
-      FlexGridLayout grid(col_two_dsc, row_dsc, 2);
-      lv_obj_set_style_pad_column(lvobj, 10, 0);
+      body.padAll(8);
+    }
+};
+
+class SoundPage : public SubPage {
+  public:
+    SoundPage() : SubPage(ICON_RADIO_SETUP, STR_SOUND_LABEL)
+    {
+      FlexGridLayout grid(col_two_dsc, row_dsc, 3);
 
       auto line = body.newLine(&grid);
 
@@ -306,27 +304,16 @@ class SoundPage : public Page {
 };
 
 #if defined(VARIO)
-class VarioPage : public Page {
+class VarioPage : public SubPage {
   public:
-  VarioPage() :
-      Page(ICON_RADIO_SETUP)
+    VarioPage() : SubPage(ICON_RADIO_SETUP, STR_VARIO)
     {
-      build();
-    }
-
-  protected:
-
-    void build()
-    {
-      header.setTitle(STR_VARIO);
-
-      body.setFlexLayout();
-      FlexGridLayout grid(col_two_dsc, row_dsc, 2);
+      FlexGridLayout grid(col_two_dsc, row_dsc, 4);
 
       auto line = body.newLine(&grid);
 
       // Vario volume
-      new StaticText(line, rect_t{}, TR_VOLUME, 0, COLOR_THEME_PRIMARY1);
+      new StaticText(line, rect_t{}, STR_VOLUME, 0, COLOR_THEME_PRIMARY1);
       new Slider(line, rect_t{0,0,lv_pct(50),PAGE_LINE_HEIGHT}, -2, +2, GET_SET_DEFAULT(g_eeGeneral.varioVolume));
       line = body.newLine(&grid);
 
@@ -358,22 +345,11 @@ class VarioPage : public Page {
 #endif
 
 #if defined(HAPTIC)
-class HapticPage : public Page {
+class HapticPage : public SubPage {
   public:
-	HapticPage() :
-      Page(ICON_RADIO_SETUP)
+    HapticPage() : SubPage(ICON_RADIO_SETUP, STR_HAPTIC_LABEL)
     {
-      build();
-    }
-
-  protected:
-
-    void build()
-    {
-      header.setTitle(STR_HAPTIC_LABEL);
-
-      body.setFlexLayout();
-      FlexGridLayout grid(col_two_dsc, row_dsc, 2);
+      FlexGridLayout grid(col_two_dsc, row_dsc, 4);
 
       auto line = body.newLine(&grid);
 
@@ -395,22 +371,11 @@ class HapticPage : public Page {
 };
 #endif
 
-class AlarmsPage : public Page {
+class AlarmsPage : public SubPage {
   public:
-	AlarmsPage() :
-      Page(ICON_RADIO_SETUP)
+    AlarmsPage() : SubPage(ICON_RADIO_SETUP, STR_ALARMS_LABEL)
     {
-      build();
-    }
-
-  protected:
-
-    void build()
-    {
-      header.setTitle(STR_ALARMS_LABEL);
-
-      body.setFlexLayout();
-      FlexGridLayout grid(col_two_dsc, row_dsc, 2);
+      FlexGridLayout grid(col_two_dsc, row_dsc, 4);
 
       auto line = body.newLine(&grid);
       // Battery warning
@@ -464,25 +429,11 @@ class AlarmsPage : public Page {
     }
 };
 
-class BacklightPage : public Page {
+class BacklightPage : public SubPage {
   public:
-	BacklightPage() :
-      Page(ICON_RADIO_SETUP)
+    BacklightPage() : SubPage(ICON_RADIO_SETUP, STR_BACKLIGHT_LABEL)
     {
-      build();
-    }
-
-  protected:
-    FormField* backlightTimeout = nullptr;
-    FormField* backlightOnBright = nullptr;
-    FormField* backlightOffBright = nullptr;
-
-    void build()
-    {
-      header.setTitle(STR_BACKLIGHT_LABEL);
-
-      body.setFlexLayout();
-      FlexGridLayout grid(col_three_dsc, row_dsc, 2);
+      FlexGridLayout grid(col_two_dsc, row_dsc, 4);
 
       auto line = body.newLine(&grid);
 
@@ -500,7 +451,10 @@ class BacklightPage : public Page {
       blMode->setAvailableHandler(
           [=](int newValue) { return newValue != e_backlight_mode_off; });
 
+      line = body.newLine(&grid);
+
       // Delay
+      new StaticText(line, rect_t{}, STR_BACKLIGHT_TIMER, 0, COLOR_THEME_PRIMARY1);
       auto edit = new NumberEdit(line, rect_t{}, 5, 600,
                                  GET_DEFAULT(g_eeGeneral.lightAutoOff * 5),
                                  SET_VALUE(g_eeGeneral.lightAutoOff, newValue / 5));
@@ -512,7 +466,6 @@ class BacklightPage : public Page {
 
       // Backlight ON bright
       new StaticText(line, rect_t{}, STR_BLONBRIGHTNESS, 0, COLOR_THEME_PRIMARY1);
-      grid.setColSpan(2);
       backlightOnBright = new Slider(line, rect_t{0,0,lv_pct(50),PAGE_LINE_HEIGHT}, BACKLIGHT_LEVEL_MIN, BACKLIGHT_LEVEL_MAX,
                  [=]() -> int32_t {
                    return BACKLIGHT_LEVEL_MAX - g_eeGeneral.backlightBright;
@@ -523,12 +476,10 @@ class BacklightPage : public Page {
                    else
                      g_eeGeneral.backlightBright = BACKLIGHT_LEVEL_MAX - g_eeGeneral.blOffBright;
                  });
-      grid.setColSpan(1);
       line = body.newLine(&grid);
 
       // Backlight OFF bright
       new StaticText(line, rect_t{}, STR_BLOFFBRIGHTNESS, 0, COLOR_THEME_PRIMARY1);
-      grid.setColSpan(2);
       backlightOffBright = new Slider(line, rect_t{0,0,lv_pct(50),PAGE_LINE_HEIGHT}, BACKLIGHT_LEVEL_MIN, BACKLIGHT_LEVEL_MAX, GET_DEFAULT(g_eeGeneral.blOffBright),
           [=](int32_t newValue) {
             int32_t onBright = BACKLIGHT_LEVEL_MAX - g_eeGeneral.backlightBright;
@@ -537,7 +488,6 @@ class BacklightPage : public Page {
             else
               g_eeGeneral.blOffBright = onBright;
           });
-      grid.setColSpan(1);
       line = body.newLine(&grid);
 
   #if defined(KEYS_BACKLIGHT_GPIO)
@@ -554,6 +504,11 @@ class BacklightPage : public Page {
 
       updateBacklightControls();
     }
+
+  protected:
+    FormField* backlightTimeout = nullptr;
+    FormField* backlightOnBright = nullptr;
+    FormField* backlightOffBright = nullptr;
 
     void updateBacklightControls()
     {
@@ -587,22 +542,11 @@ class BacklightPage : public Page {
     }
 };
 
-class GpsPage : public Page {
+class GpsPage : public SubPage {
   public:
-	GpsPage() :
-      Page(ICON_RADIO_SETUP)
+    GpsPage() : SubPage(ICON_RADIO_SETUP, STR_GPS)
     {
-      build();
-    }
-
-  protected:
-
-    void build()
-    {
-      header.setTitle(STR_GPS);
-
-      body.setFlexLayout();
-      FlexGridLayout grid(col_two_dsc, row_dsc, 2);
+      FlexGridLayout grid(col_two_dsc, row_dsc, 4);
 
       auto line = body.newLine(&grid);
       // Timezone
@@ -629,7 +573,7 @@ RadioSetupPage::RadioSetupPage():
 
 void RadioSetupPage::build(FormWindow * window)
 {
-  FlexGridLayout grid(col_three_dsc, row_dsc, 2);
+  FlexGridLayout grid(col_two_dsc, row_dsc, 2);
   window->setFlexLayout();
 
   // Date & time picker including labels
@@ -718,12 +662,10 @@ void RadioSetupPage::build(FormWindow * window)
   // Switches delay
   line = window->newLine(&grid);
   new StaticText(line, rect_t{}, STR_SWITCHES_DELAY, 0, COLOR_THEME_PRIMARY1);
-  grid.setColSpan(2);
   auto edit =
       new NumberEdit(line, rect_t{}, -15, 100 - 15,
                      GET_SET_VALUE_WITH_OFFSET(g_eeGeneral.switchesDelay, 15));
   edit->setSuffix(std::string("0") + STR_MS);
-  grid.setColSpan(1);
 
   // USB mode
   line = window->newLine(&grid);
@@ -743,7 +685,6 @@ void RadioSetupPage::build(FormWindow * window)
   line = window->newLine(&grid);
   new StaticText(line, rect_t{}, STR_RXCHANNELORD, 0,
                  COLOR_THEME_PRIMARY1);  // RAET->AETR
-  grid.setColSpan(2);
   choice = new Choice(line, rect_t{}, 0, 4 * 3 * 2 - 1,
                       GET_SET_DEFAULT(g_eeGeneral.templateSetup));
   choice->setTextHandler([](uint8_t value) {
@@ -753,12 +694,10 @@ void RadioSetupPage::build(FormWindow * window)
     }
     return s;
   });
-  grid.setColSpan(1);
 
   // Stick mode
   line = window->newLine(&grid);
   new StaticText(line, rect_t{}, STR_MODE, 0, COLOR_THEME_PRIMARY1);
-  grid.setColSpan(2);
   choice = new Choice(line, rect_t{}, 0, 3, GET_DEFAULT(g_eeGeneral.stickMode),
                       [=](uint8_t newValue) {
                         mixerTaskStop();
@@ -774,7 +713,6 @@ void RadioSetupPage::build(FormWindow * window)
            std::string(
                &getSourceString(MIXSRC_Rud + modn12x3[4 * value + 1])[1]);
   });
-  grid.setColSpan(1);
 
   // Model quick select
   line = window->newLine(&grid);

--- a/radio/src/gui/colorlcd/throttle_params.cpp
+++ b/radio/src/gui/colorlcd/throttle_params.cpp
@@ -58,7 +58,8 @@ ThrottleParams::ThrottleParams() : Page(ICON_MODEL_SETUP)
   header.setTitle(STR_THROTTLE_LABEL);
 
   body.setFlexLayout();
-  FlexGridLayout grid(line_col_dsc, line_row_dsc, 2);
+  body.padAll(8);
+  FlexGridLayout grid(line_col_dsc, line_row_dsc, 4);
 
   // Throttle reversed
   auto line = body.newLine(&grid);

--- a/radio/src/gui/colorlcd/trims_setup.cpp
+++ b/radio/src/gui/colorlcd/trims_setup.cpp
@@ -41,11 +41,12 @@ TrimsSetup::TrimsSetup() : Page(ICON_MODEL_SETUP)
   header.setTitle(STR_TRIMS);
 
   body.setFlexLayout();
-  FlexGridLayout grid(line_col_dsc, line_row_dsc, 2);
+  body.padAll(8);
+  FlexGridLayout grid(line_col_dsc, line_row_dsc, 4);
 
   // Reset trims
   auto line = body.newLine();
-  lv_obj_set_style_pad_all(line->getLvObj(), lv_dpx(8), 0);
+  line->padBottom(4);
   auto btn = new TextButton(line, rect_t{}, STR_RESET_BTN, []() -> uint8_t {
     resetTrims();
     return 0;

--- a/radio/src/translations.cpp
+++ b/radio/src/translations.cpp
@@ -727,6 +727,7 @@ const char STR_DELETE_THEME[] = TR_DELETE_THEME;
 const char STR_SAVE_THEME[] = TR_SAVE_THEME;
 const char STR_EDIT_COLOR[] = TR_EDIT_COLOR;
 const char STR_NO_THEME_IMAGE[] = TR_NO_THEME_IMAGE;
+const char STR_BACKLIGHT_TIMER[] = TR_BACKLIGHT_TIMER;
 #endif
 
 #if !defined(COLORLCD)

--- a/radio/src/translations.h
+++ b/radio/src/translations.h
@@ -747,6 +747,7 @@ extern const char STR_DELETE_THEME[];
 extern const char STR_SAVE_THEME[];
 extern const char STR_EDIT_COLOR[];
 extern const char STR_NO_THEME_IMAGE[];
+extern const char STR_BACKLIGHT_TIMER[];
 #endif
 extern const char STR_EXECUTE_FILE[];
 extern const char STR_DELETE_FILE[];

--- a/radio/src/translations/cn.h
+++ b/radio/src/translations/cn.h
@@ -745,6 +745,7 @@
 #define TR_SAVE_THEME                  "保存主题?"
 #define TR_EDIT_COLOR                  "编辑颜色"
 #define TR_NO_THEME_IMAGE              "没有预览图"
+#define TR_BACKLIGHT_TIMER             "Inactivity timeout"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "快速选择模型"

--- a/radio/src/translations/cn.h
+++ b/radio/src/translations/cn.h
@@ -745,7 +745,7 @@
 #define TR_SAVE_THEME                  "保存主题?"
 #define TR_EDIT_COLOR                  "编辑颜色"
 #define TR_NO_THEME_IMAGE              "没有预览图"
-#define TR_BACKLIGHT_TIMER             "Inactivity timeout"
+#define TR_BACKLIGHT_TIMER             "持续时间"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "快速选择模型"

--- a/radio/src/translations/cz.h
+++ b/radio/src/translations/cz.h
@@ -745,6 +745,7 @@
 #define TR_SAVE_THEME                  "Uložit motiv?"
 #define TR_EDIT_COLOR                  "Upravit barvu"
 #define TR_NO_THEME_IMAGE              "Náhled motivu nedostupný"
+#define TR_BACKLIGHT_TIMER             "Inactivity timeout"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "Rychlý výběr modelu"

--- a/radio/src/translations/cz.h
+++ b/radio/src/translations/cz.h
@@ -745,7 +745,7 @@
 #define TR_SAVE_THEME                  "Uložit motiv?"
 #define TR_EDIT_COLOR                  "Upravit barvu"
 #define TR_NO_THEME_IMAGE              "Náhled motivu nedostupný"
-#define TR_BACKLIGHT_TIMER             "Čas zhasnutí"
+#define TR_BACKLIGHT_TIMER             "Čas zhasnutí displeje"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "Rychlý výběr modelu"

--- a/radio/src/translations/cz.h
+++ b/radio/src/translations/cz.h
@@ -745,7 +745,7 @@
 #define TR_SAVE_THEME                  "Uložit motiv?"
 #define TR_EDIT_COLOR                  "Upravit barvu"
 #define TR_NO_THEME_IMAGE              "Náhled motivu nedostupný"
-#define TR_BACKLIGHT_TIMER             "Inactivity timeout"
+#define TR_BACKLIGHT_TIMER             "Čas zhasnutí"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "Rychlý výběr modelu"

--- a/radio/src/translations/da.h
+++ b/radio/src/translations/da.h
@@ -750,7 +750,7 @@
 #define TR_SAVE_THEME                  "Gem tema?"
 #define TR_EDIT_COLOR                  "Rediger farve"
 #define TR_NO_THEME_IMAGE              "Ingen billede for tema"
-#define TR_BACKLIGHT_TIMER             "Inactivity timeout"
+#define TR_BACKLIGHT_TIMER             TR2("Inaktivitet", "Ved inaktivitet dæmp efter")
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "Hurtigvalg af model"

--- a/radio/src/translations/da.h
+++ b/radio/src/translations/da.h
@@ -750,6 +750,7 @@
 #define TR_SAVE_THEME                  "Gem tema?"
 #define TR_EDIT_COLOR                  "Rediger farve"
 #define TR_NO_THEME_IMAGE              "Ingen billede for tema"
+#define TR_BACKLIGHT_TIMER             "Inactivity timeout"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "Hurtigvalg af model"

--- a/radio/src/translations/de.h
+++ b/radio/src/translations/de.h
@@ -742,7 +742,7 @@
 #define TR_SAVE_THEME                  "Theme speichern?"
 #define TR_EDIT_COLOR                  "Farbe bearbeiten"
 #define TR_NO_THEME_IMAGE              "Kein Theme Bild"
-#define TR_BACKLIGHT_TIMER             "Inactivity timeout"
+#define TR_BACKLIGHT_TIMER             "Inaktivitäts Timeout"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "schnelle Modellauswahl"

--- a/radio/src/translations/de.h
+++ b/radio/src/translations/de.h
@@ -742,6 +742,7 @@
 #define TR_SAVE_THEME                  "Theme speichern?"
 #define TR_EDIT_COLOR                  "Farbe bearbeiten"
 #define TR_NO_THEME_IMAGE              "Kein Theme Bild"
+#define TR_BACKLIGHT_TIMER             "Inactivity timeout"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "schnelle Modellauswahl"

--- a/radio/src/translations/en.h
+++ b/radio/src/translations/en.h
@@ -743,6 +743,7 @@
 #define TR_SAVE_THEME                  "Save Theme?"
 #define TR_EDIT_COLOR                  "Edit Color"
 #define TR_NO_THEME_IMAGE              "No theme image"
+#define TR_BACKLIGHT_TIMER             "Inactivity timeout"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "Model quick select"

--- a/radio/src/translations/es.h
+++ b/radio/src/translations/es.h
@@ -744,6 +744,7 @@
 #define TR_SAVE_THEME                  "Save Theme?"
 #define TR_EDIT_COLOR                  "Edit Color"
 #define TR_NO_THEME_IMAGE              "No theme image"
+#define TR_BACKLIGHT_TIMER             "Inactivity timeout"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "Model quick select"

--- a/radio/src/translations/fi.h
+++ b/radio/src/translations/fi.h
@@ -756,6 +756,7 @@
 #define TR_SAVE_THEME                  "Save Theme?"
 #define TR_EDIT_COLOR                  "Edit Color"
 #define TR_NO_THEME_IMAGE              "No theme image"
+#define TR_BACKLIGHT_TIMER             "Inactivity timeout"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "Mallin pikavalinta"

--- a/radio/src/translations/fr.h
+++ b/radio/src/translations/fr.h
@@ -753,6 +753,7 @@
 #define TR_SAVE_THEME                  "Save Theme?"
 #define TR_EDIT_COLOR                  "Edit Color"
 #define TR_NO_THEME_IMAGE              "No theme image"
+#define TR_BACKLIGHT_TIMER             "Inactivity timeout"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "Model quick select"

--- a/radio/src/translations/it.h
+++ b/radio/src/translations/it.h
@@ -745,7 +745,7 @@
 #define TR_SAVE_THEME          "Salvo Tema?"
 #define TR_EDIT_COLOR          "Edita colore"
 #define TR_NO_THEME_IMAGE      "Nessuna immagine trovata"
-#define TR_BACKLIGHT_TIMER             "Inactivity timeout"
+#define TR_BACKLIGHT_TIMER             "Tempo d'inattività"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT "Selezione veloce modello"

--- a/radio/src/translations/it.h
+++ b/radio/src/translations/it.h
@@ -745,6 +745,7 @@
 #define TR_SAVE_THEME          "Salvo Tema?"
 #define TR_EDIT_COLOR          "Edita colore"
 #define TR_NO_THEME_IMAGE      "Nessuna immagine trovata"
+#define TR_BACKLIGHT_TIMER             "Inactivity timeout"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT "Selezione veloce modello"

--- a/radio/src/translations/jp.h
+++ b/radio/src/translations/jp.h
@@ -744,7 +744,7 @@
 #define TR_SAVE_THEME                  "テーマを保存しますか？"
 #define TR_EDIT_COLOR                  "カラー編集"
 #define TR_NO_THEME_IMAGE              "テーマ画像はありません"
-#define TR_BACKLIGHT_TIMER             "Inactivity timeout"
+#define TR_BACKLIGHT_TIMER             "持続時間"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "モデル クイックセレクト"

--- a/radio/src/translations/jp.h
+++ b/radio/src/translations/jp.h
@@ -744,6 +744,7 @@
 #define TR_SAVE_THEME                  "テーマを保存しますか？"
 #define TR_EDIT_COLOR                  "カラー編集"
 #define TR_NO_THEME_IMAGE              "テーマ画像はありません"
+#define TR_BACKLIGHT_TIMER             "Inactivity timeout"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "モデル クイックセレクト"

--- a/radio/src/translations/nl.h
+++ b/radio/src/translations/nl.h
@@ -748,6 +748,7 @@
 #define TR_SAVE_THEME                  "Save Theme?"
 #define TR_EDIT_COLOR                  "Edit Color"
 #define TR_NO_THEME_IMAGE              "No theme image"
+#define TR_BACKLIGHT_TIMER             "Inactivity timeout"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "Model quick select"

--- a/radio/src/translations/pl.h
+++ b/radio/src/translations/pl.h
@@ -741,7 +741,7 @@
 #define TR_SAVE_THEME          "Zapisać motyw?"
 #define TR_EDIT_COLOR                  "Edit Color"
 #define TR_NO_THEME_IMAGE              "No theme image"
-#define TR_BACKLIGHT_TIMER             "Inactivity timeout"
+#define TR_BACKLIGHT_TIMER             "Czas bezczynności"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT "Szybki wybór modelu"

--- a/radio/src/translations/pl.h
+++ b/radio/src/translations/pl.h
@@ -741,6 +741,7 @@
 #define TR_SAVE_THEME          "Zapisać motyw?"
 #define TR_EDIT_COLOR                  "Edit Color"
 #define TR_NO_THEME_IMAGE              "No theme image"
+#define TR_BACKLIGHT_TIMER             "Inactivity timeout"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT "Szybki wybór modelu"

--- a/radio/src/translations/pt.h
+++ b/radio/src/translations/pt.h
@@ -748,6 +748,7 @@
 #define TR_SAVE_THEME                  "Save Theme?"
 #define TR_EDIT_COLOR                  "Edit Color"
 #define TR_NO_THEME_IMAGE              "No theme image"
+#define TR_BACKLIGHT_TIMER             "Inactivity timeout"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "Model quick select"

--- a/radio/src/translations/tw.h
+++ b/radio/src/translations/tw.h
@@ -743,6 +743,7 @@
 #define TR_SAVE_THEME                  "保存主題?"
 #define TR_EDIT_COLOR                  "编辑颜色"
 #define TR_NO_THEME_IMAGE              "没有预览图"
+#define TR_BACKLIGHT_TIMER             "Inactivity timeout"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "快速選擇模型"

--- a/radio/src/translations/tw.h
+++ b/radio/src/translations/tw.h
@@ -743,7 +743,7 @@
 #define TR_SAVE_THEME                  "保存主題?"
 #define TR_EDIT_COLOR                  "编辑颜色"
 #define TR_NO_THEME_IMAGE              "没有预览图"
-#define TR_BACKLIGHT_TIMER             "Inactivity timeout"
+#define TR_BACKLIGHT_TIMER             "持續時間"
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "快速選擇模型"


### PR DESCRIPTION
Fixes #2534 

Also made the button size consistent and display better pot/slider name in the center beeps buttons in the pre-flight checks page.

![Screen Shot 2023-03-03 at 8 11 55 am](https://user-images.githubusercontent.com/9474356/222557243-98963588-453c-4216-bdb4-ba2d47e37d8b.png)

![Screen Shot 2023-03-03 at 8 06 38 am](https://user-images.githubusercontent.com/9474356/222557299-1a26edce-9e53-450f-9d67-488fe85ef4f5.png)
