### PR TITLE
fixes hex2char() returning wrong characters for 0xa..0xf

### DIFF
--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -29,7 +29,7 @@ const char s_charTab[] = "_-.,";
 
 char hex2zchar(uint8_t hex) { return (hex >= 10 ? hex - 9 : 27 + hex); }
 
-char hex2char(uint8_t hex) { return (hex >= 10 ? hex - 9 + 'A' : hex + '0'); }
+char hex2char(uint8_t hex) { return (hex >= 10 ? hex - 10 + 'A' : hex + '0'); }
 
 char zchar2char(int8_t idx)
 {


### PR DESCRIPTION
Fixes #3301

Summary of changes: 
subtract 10 instead of 9 in case hex value is in [0xa..0xf]
