### PR TITLE
fix(color) - Fix GVAR edit page to show GV value in header on first load.

### DIFF
--- a/radio/src/gui/colorlcd/model_gvars.cpp
+++ b/radio/src/gui/colorlcd/model_gvars.cpp
@@ -185,7 +185,7 @@ class GVarEditWindow : public Page
  protected:
   uint8_t index;
   gvar_t lastGVar = 0;
-  uint8_t lastFlightMode = 0;
+  uint8_t lastFlightMode = 255; // Force initial setting of header title
   NumberEdit* min = nullptr;
   NumberEdit* max = nullptr;
   NumberEdit* values[MAX_FLIGHT_MODES] = {};


### PR DESCRIPTION
The global var edit page was not showing the GV value in the header on first load.
