### PR TITLE
fix: UI - not all detected sensors displayed at detection time

### DIFF
--- a/radio/src/gui/colorlcd/model_telemetry.cpp
+++ b/radio/src/gui/colorlcd/model_telemetry.cpp
@@ -524,8 +524,11 @@ ModelTelemetryPage::ModelTelemetryPage() :
 
 void ModelTelemetryPage::checkEvents()
 {
-  if (lastKnownIndex >= 0 && lastKnownIndex != availableTelemetryIndex()) {
+  int _lastKnownIndex = availableTelemetryIndex();
+
+  if (lastKnownIndex >= 0 && lastKnownIndex != _lastKnownIndex) {
     rebuild(window);
+    lastKnownIndex = _lastKnownIndex;
   }
 
   PageTab::checkEvents();


### PR DESCRIPTION
Fixes https://github.com/EdgeTX/edgetx/issues/3327

Summary of changes:

The problem is due to a classical race condition. `void ModelTelemetryPage::checkEvents()` is called cyclically and uses `int availableTelemetryIndex()` to determine if the model telemetry screen needs to be rebuilt due to a changed list of telemetry sensors using `void ModelTelemetryPage::rebuild()`. 

The last known index into the the telemetry sensor list memorized `int ModelTelemetryPage::lastKnownIndex` is compared to the number of available sensors. If different the screen needs to be updated (rebuilt). But `rebuild()` updates `lastKnownIndex` by calling `availableTelemetryIndex()` again when finished redrawing the screen. In time frame between the comparison if a rebuild is necessary until rebuild() finishes and updates the last `lastKnownIndex` by calling `availableTelemetryIndex()` the number of available sensors has changed due to further incoming sensors in the background. Hence `lastKnownIndex` can be ahead of what was actually drawn. This leads to the missing sensors on display.

Saving the status of available sensors at entry to `checkEvents()` and updating `lastKnownIndex `vafter rebuilding the screen solves this race condition and keeps `lastKnownIndex` consistent with what was actually drawn in order to allow the next call to 'rebuild()' to correctly determine if the screen needs to be updated again.

 
