### PR TITLE
fix: corrupt data using soft serial driver

### DIFF
--- a/radio/src/mixer_scheduler.h
+++ b/radio/src/mixer_scheduler.h
@@ -40,9 +40,6 @@ void mixerSchedulerStart();
 // Stop the scheduler timer
 void mixerSchedulerStop();
 
-// Set the timer counter to 0
-void mixerSchedulerResetTimer();
-
 // Set the scheduling period for a given module
 void mixerSchedulerSetPeriod(uint8_t moduleIdx, uint16_t periodUs);
 
@@ -55,6 +52,9 @@ void mixerSchedulerEnableTrigger();
 // Disable the timer trigger
 void mixerSchedulerDisableTrigger();
 
+// Trigger mixer from heartbeat interrupt 
+void mixerSchedulerSoftTrigger();
+
 // Fetch the current scheduling period
 uint16_t getMixerSchedulerPeriod();
 
@@ -66,13 +66,13 @@ void mixerSchedulerISRTrigger();
 #define mixerSchedulerInit()
 #define mixerSchedulerStart()
 #define mixerSchedulerStop()
-#define mixerSchedulerResetTimer()
 #define mixerSchedulerSetPeriod(m,p) ((void)(p))
 #define mixerSchedulerGetPeriod(m) ((uint16_t)MIXER_SCHEDULER_DEFAULT_PERIOD_US)
-#define mixerSchedulerClearTrigger()
 
 #define mixerSchedulerEnableTrigger()
 #define mixerSchedulerDisableTrigger()
+
+#define mixerSchedulerSoftTrigger()
 
 #define getMixerSchedulerPeriod() (MIXER_SCHEDULER_DEFAULT_PERIOD_US)
 #define mixerSchedulerISRTrigger()

--- a/radio/src/targets/common/arm/stm32/heartbeat_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/heartbeat_driver.cpp
@@ -41,8 +41,12 @@ static void trigger_intmodule_heartbeat()
   heartbeatCapture.count++;
 #endif
 
-  mixerSchedulerResetTimer();
-  mixerSchedulerISRTrigger();
+  // Generate an timer update event (TIM_EGR_UG) to reload the Prescaler and the repetition 
+  // counter value immediately to avoid making FreeRTOS calls within this ISR:
+  // - fires MIXER_SCHEDULER_TIMER interrupt after returning from this ISR
+  // - MIXER_SCHEDULER_TIMER_IRQHandler(void) takes care of making FreeRTOS calls
+  //   to ensure switching to highest priority task.
+  MIXER_SCHEDULER_TIMER->EGR = TIM_EGR_UG;  
 }
 
 void init_intmodule_heartbeat()

--- a/radio/src/targets/common/arm/stm32/heartbeat_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/heartbeat_driver.cpp
@@ -41,14 +41,7 @@ static void trigger_intmodule_heartbeat()
   heartbeatCapture.count++;
 #endif
 
-  mixerSchedulerResetTimer();
-
-  // Generate a timer update event (TIM_EGR_UG) to reload the Prescaler and the repetition 
-  // counter value immediately to avoid making FreeRTOS calls within this ISR:
-  // - fires MIXER_SCHEDULER_TIMER interrupt after returning from this ISR
-  // - MIXER_SCHEDULER_TIMER_IRQHandler(void) takes care of making FreeRTOS calls
-  //   to ensure switching to highest priority task.
-  MIXER_SCHEDULER_TIMER->EGR = TIM_EGR_UG;  
+  mixerSchedulerSoftTrigger();
 }
 
 void init_intmodule_heartbeat()

--- a/radio/src/targets/common/arm/stm32/heartbeat_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/heartbeat_driver.cpp
@@ -41,7 +41,9 @@ static void trigger_intmodule_heartbeat()
   heartbeatCapture.count++;
 #endif
 
-  // Generate an timer update event (TIM_EGR_UG) to reload the Prescaler and the repetition 
+  mixerSchedulerResetTimer();
+
+  // Generate a timer update event (TIM_EGR_UG) to reload the Prescaler and the repetition 
   // counter value immediately to avoid making FreeRTOS calls within this ISR:
   // - fires MIXER_SCHEDULER_TIMER interrupt after returning from this ISR
   // - MIXER_SCHEDULER_TIMER_IRQHandler(void) takes care of making FreeRTOS calls

--- a/radio/src/targets/common/arm/stm32/mixer_scheduler_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/mixer_scheduler_driver.cpp
@@ -30,13 +30,11 @@
 void mixerSchedulerStart()
 {
   MIXER_SCHEDULER_TIMER->CR1 &= ~TIM_CR1_CEN;
-
-  MIXER_SCHEDULER_TIMER->CR1   = TIM_CR1_URS; // do not generate interrupt on soft update
   MIXER_SCHEDULER_TIMER->PSC   = MIXER_SCHEDULER_TIMER_FREQ / 1000000 - 1; // 1uS (1Mhz)
   MIXER_SCHEDULER_TIMER->CCER  = 0;
   MIXER_SCHEDULER_TIMER->CCMR1 = 0;
   MIXER_SCHEDULER_TIMER->ARR   = getMixerSchedulerPeriod() - 1;
-  MIXER_SCHEDULER_TIMER->EGR   = TIM_EGR_UG;   // reset timer
+  MIXER_SCHEDULER_TIMER->CNT   = 0;   // reset counter
 
   NVIC_EnableIRQ(MIXER_SCHEDULER_TIMER_IRQn);
   NVIC_SetPriority(MIXER_SCHEDULER_TIMER_IRQn,

--- a/radio/src/targets/horus/hal.h
+++ b/radio/src/targets/horus/hal.h
@@ -521,7 +521,7 @@
 // TELEMETRY_EXTI IRQ
 #if !defined(USE_EXTI9_5_IRQ)
   #define USE_EXTI9_5_IRQ
-  #define EXTI9_5_IRQ_Priority 5
+  #define EXTI9_5_IRQ_Priority 0
 #endif
 
 #define TELEMETRY_TIMER                 TIM11

--- a/radio/src/targets/horus/hal.h
+++ b/radio/src/targets/horus/hal.h
@@ -523,8 +523,10 @@
 // TELEMETRY_EXTI IRQ
 #if !defined(USE_EXTI9_5_IRQ)
   #define USE_EXTI9_5_IRQ
-  #define EXTI9_5_IRQ_Priority          TELEMETRY_EXTI_PRIO
 #endif
+// overwrite priority
+#undef EXTI9_5_IRQ_Priority
+#define EXTI9_5_IRQ_Priority            TELEMETRY_EXTI_PRIO
 
 #define TELEMETRY_TIMER                 TIM11
 #define TELEMETRY_TIMER_IRQn            TIM1_TRG_COM_TIM11_IRQn

--- a/radio/src/targets/horus/hal.h
+++ b/radio/src/targets/horus/hal.h
@@ -28,6 +28,8 @@
 #define TIMER_MULT_APB1                 2
 #define TIMER_MULT_APB2                 2
 
+#define TELEMETRY_EXTI_PRIO             0 // required for soft serial
+
 // Keys
 #define KEYS_RCC_AHB1Periph             (RCC_AHB1Periph_GPIOB | RCC_AHB1Periph_GPIOC | RCC_AHB1Periph_GPIOD | RCC_AHB1Periph_GPIOE | RCC_AHB1Periph_GPIOG | RCC_AHB1Periph_GPIOH | RCC_AHB1Periph_GPIOI | RCC_AHB1Periph_GPIOJ)
 #if defined(PCBX12S)
@@ -521,7 +523,7 @@
 // TELEMETRY_EXTI IRQ
 #if !defined(USE_EXTI9_5_IRQ)
   #define USE_EXTI9_5_IRQ
-  #define EXTI9_5_IRQ_Priority 0
+  #define EXTI9_5_IRQ_Priority          TELEMETRY_EXTI_PRIO
 #endif
 
 #define TELEMETRY_TIMER                 TIM11

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -1962,7 +1962,7 @@
 // TELEMETRY_EXTI IRQ
 #if !defined(USE_EXTI9_5_IRQ)
   #define USE_EXTI9_5_IRQ
-  #define EXTI9_5_IRQ_Priority 5
+  #define EXTI9_5_IRQ_Priority 0
 #endif
 
 #define TELEMETRY_TIMER                 TIM11

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -223,7 +223,7 @@
   // ROTARY_ENCODER_EXTI_LINE1 IRQ
   #if !defined(USE_EXTI9_5_IRQ)
     #define USE_EXTI9_5_IRQ
-    #define EXTI9_5_IRQ_Priority 5
+    #define EXTI9_5_IRQ_Priority 0
   #endif
   // ROTARY_ENCODER_EXTI_LINE2 IRQ
   #if !defined(USE_EXTI15_10_IRQ)
@@ -263,7 +263,7 @@
   // ROTARY_ENCODER_EXTI_LINE1 IRQ
   #if !defined(USE_EXTI9_5_IRQ)
     #define USE_EXTI9_5_IRQ
-    #define EXTI9_5_IRQ_Priority 5
+    #define EXTI9_5_IRQ_Priority 0
   #endif
   // ROTARY_ENCODER_EXTI_LINE2 IRQ
   #if !defined(USE_EXTI15_10_IRQ)
@@ -2062,7 +2062,7 @@
   // INTMODULE_HEARTBEAT_EXTI IRQ
   #if !defined(USE_EXTI9_5_IRQ)
     #define USE_EXTI9_5_IRQ
-    #define EXTI9_5_IRQ_Priority 5
+    #define EXTI9_5_IRQ_Priority 0
   #endif
 #elif defined(RADIO_X9DP2019)
   #define INTMODULE_HEARTBEAT
@@ -2090,7 +2090,7 @@
   // INTMODULE_HEARTBEAT_EXTI IRQ
   #if !defined(USE_EXTI9_5_IRQ)
     #define USE_EXTI9_5_IRQ
-    #define EXTI9_5_IRQ_Priority 5
+    #define EXTI9_5_IRQ_Priority 0
   #endif
 #endif
 

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -35,6 +35,8 @@
 #define TIMER_MULT_APB1                 2
 #define TIMER_MULT_APB2                 2
 
+#define TELEMETRY_EXTI_PRIO             0 // required for soft serial
+
 // Keys
 #if defined(PCBX9E)
   #define KEYS_GPIO_REG_MENU            GPIOD->IDR
@@ -223,7 +225,7 @@
   // ROTARY_ENCODER_EXTI_LINE1 IRQ
   #if !defined(USE_EXTI9_5_IRQ)
     #define USE_EXTI9_5_IRQ
-    #define EXTI9_5_IRQ_Priority 0
+    #define EXTI9_5_IRQ_Priority        TELEMETRY_EXTI_PRIO
   #endif
   // ROTARY_ENCODER_EXTI_LINE2 IRQ
   #if !defined(USE_EXTI15_10_IRQ)
@@ -263,7 +265,7 @@
   // ROTARY_ENCODER_EXTI_LINE1 IRQ
   #if !defined(USE_EXTI9_5_IRQ)
     #define USE_EXTI9_5_IRQ
-    #define EXTI9_5_IRQ_Priority 0
+    #define EXTI9_5_IRQ_Priority           TELEMETRY_EXTI_PRIO
   #endif
   // ROTARY_ENCODER_EXTI_LINE2 IRQ
   #if !defined(USE_EXTI15_10_IRQ)
@@ -1962,7 +1964,7 @@
 // TELEMETRY_EXTI IRQ
 #if !defined(USE_EXTI9_5_IRQ)
   #define USE_EXTI9_5_IRQ
-  #define EXTI9_5_IRQ_Priority 0
+  #define EXTI9_5_IRQ_Priority          TELEMETRY_EXTI_PRIO
 #endif
 
 #define TELEMETRY_TIMER                 TIM11
@@ -2062,7 +2064,7 @@
   // INTMODULE_HEARTBEAT_EXTI IRQ
   #if !defined(USE_EXTI9_5_IRQ)
     #define USE_EXTI9_5_IRQ
-    #define EXTI9_5_IRQ_Priority 0
+    #define EXTI9_5_IRQ_Priority                  TELEMETRY_EXTI_PRIO
   #endif
 #elif defined(RADIO_X9DP2019)
   #define INTMODULE_HEARTBEAT
@@ -2090,7 +2092,7 @@
   // INTMODULE_HEARTBEAT_EXTI IRQ
   #if !defined(USE_EXTI9_5_IRQ)
     #define USE_EXTI9_5_IRQ
-    #define EXTI9_5_IRQ_Priority 0
+    #define EXTI9_5_IRQ_Priority                  TELEMETRY_EXTI_PRIO
   #endif
 #endif
 

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -225,8 +225,10 @@
   // ROTARY_ENCODER_EXTI_LINE1 IRQ
   #if !defined(USE_EXTI9_5_IRQ)
     #define USE_EXTI9_5_IRQ
-    #define EXTI9_5_IRQ_Priority        TELEMETRY_EXTI_PRIO
   #endif
+  // overwrite priority
+  #undef EXTI9_5_IRQ_Priority
+  #define EXTI9_5_IRQ_Priority          TELEMETRY_EXTI_PRIO
   // ROTARY_ENCODER_EXTI_LINE2 IRQ
   #if !defined(USE_EXTI15_10_IRQ)
     #define USE_EXTI15_10_IRQ
@@ -265,8 +267,10 @@
   // ROTARY_ENCODER_EXTI_LINE1 IRQ
   #if !defined(USE_EXTI9_5_IRQ)
     #define USE_EXTI9_5_IRQ
-    #define EXTI9_5_IRQ_Priority           TELEMETRY_EXTI_PRIO
   #endif
+  // overwrite priority
+  #undef EXTI9_5_IRQ_Priority
+  #define EXTI9_5_IRQ_Priority             TELEMETRY_EXTI_PRIO
   // ROTARY_ENCODER_EXTI_LINE2 IRQ
   #if !defined(USE_EXTI15_10_IRQ)
     #define USE_EXTI15_10_IRQ
@@ -1964,8 +1968,10 @@
 // TELEMETRY_EXTI IRQ
 #if !defined(USE_EXTI9_5_IRQ)
   #define USE_EXTI9_5_IRQ
-  #define EXTI9_5_IRQ_Priority          TELEMETRY_EXTI_PRIO
 #endif
+// overwrite priority
+#undef EXTI9_5_IRQ_Priority
+#define EXTI9_5_IRQ_Priority            TELEMETRY_EXTI_PRIO
 
 #define TELEMETRY_TIMER                 TIM11
 #define TELEMETRY_TIMER_PRESCALER       ()
@@ -2064,8 +2070,10 @@
   // INTMODULE_HEARTBEAT_EXTI IRQ
   #if !defined(USE_EXTI9_5_IRQ)
     #define USE_EXTI9_5_IRQ
-    #define EXTI9_5_IRQ_Priority                  TELEMETRY_EXTI_PRIO
   #endif
+  // overwrite priority
+  #undef EXTI9_5_IRQ_Priority
+  #define EXTI9_5_IRQ_Priority                    TELEMETRY_EXTI_PRIO
 #elif defined(RADIO_X9DP2019)
   #define INTMODULE_HEARTBEAT
   #define INTMODULE_HEARTBEAT_RCC_AHB1Periph      RCC_AHB1Periph_GPIOB
@@ -2092,8 +2100,10 @@
   // INTMODULE_HEARTBEAT_EXTI IRQ
   #if !defined(USE_EXTI9_5_IRQ)
     #define USE_EXTI9_5_IRQ
-    #define EXTI9_5_IRQ_Priority                  TELEMETRY_EXTI_PRIO
   #endif
+  // overwrite priority
+  #undef EXTI9_5_IRQ_Priority
+  #define EXTI9_5_IRQ_Priority                    TELEMETRY_EXTI_PRIO
 #endif
 
 // Trainer / Trainee from the module bay

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -225,10 +225,8 @@
   // ROTARY_ENCODER_EXTI_LINE1 IRQ
   #if !defined(USE_EXTI9_5_IRQ)
     #define USE_EXTI9_5_IRQ
+    #define EXTI9_5_IRQ_Priority 5
   #endif
-  // overwrite priority
-  #undef EXTI9_5_IRQ_Priority
-  #define EXTI9_5_IRQ_Priority          TELEMETRY_EXTI_PRIO
   // ROTARY_ENCODER_EXTI_LINE2 IRQ
   #if !defined(USE_EXTI15_10_IRQ)
     #define USE_EXTI15_10_IRQ
@@ -267,10 +265,8 @@
   // ROTARY_ENCODER_EXTI_LINE1 IRQ
   #if !defined(USE_EXTI9_5_IRQ)
     #define USE_EXTI9_5_IRQ
+    #define EXTI9_5_IRQ_Priority 5
   #endif
-  // overwrite priority
-  #undef EXTI9_5_IRQ_Priority
-  #define EXTI9_5_IRQ_Priority             TELEMETRY_EXTI_PRIO
   // ROTARY_ENCODER_EXTI_LINE2 IRQ
   #if !defined(USE_EXTI15_10_IRQ)
     #define USE_EXTI15_10_IRQ
@@ -2070,10 +2066,8 @@
   // INTMODULE_HEARTBEAT_EXTI IRQ
   #if !defined(USE_EXTI9_5_IRQ)
     #define USE_EXTI9_5_IRQ
+    #define EXTI9_5_IRQ_Priority 5
   #endif
-  // overwrite priority
-  #undef EXTI9_5_IRQ_Priority
-  #define EXTI9_5_IRQ_Priority                    TELEMETRY_EXTI_PRIO
 #elif defined(RADIO_X9DP2019)
   #define INTMODULE_HEARTBEAT
   #define INTMODULE_HEARTBEAT_RCC_AHB1Periph      RCC_AHB1Periph_GPIOB
@@ -2100,10 +2094,8 @@
   // INTMODULE_HEARTBEAT_EXTI IRQ
   #if !defined(USE_EXTI9_5_IRQ)
     #define USE_EXTI9_5_IRQ
+    #define EXTI9_5_IRQ_Priority 5
   #endif
-  // overwrite priority
-  #undef EXTI9_5_IRQ_Priority
-  #define EXTI9_5_IRQ_Priority                    TELEMETRY_EXTI_PRIO
 #endif
 
 // Trainer / Trainee from the module bay


### PR DESCRIPTION
Fixes https://github.com/EdgeTX/edgetx/issues/3285

Summary of changes after discussion with @raphaelcoeffic:
This sets the bit start detection IRQ priority to the value used before the major serial/port API change. Tested on TX16s and 
X10express. Logic analyzer confirms great performance and spot on timing of the soft serial driver introduced with the serial/port API change.

TODO: the same or similar fix must be applied for targets Taranis and NV14 as at least external telemetry protocol LemonDSP uses soft serial. Need discussion how to go about this in a follow up PR.