### PR TITLE
fix(cpn) - Fix handling of the 'show splash' setting for B&W radios in Companion.

### DIFF
--- a/companion/src/firmwares/edgetx/yaml_generalsettings.cpp
+++ b/companion/src/firmwares/edgetx/yaml_generalsettings.cpp
@@ -146,9 +146,11 @@ Node convert<GeneralSettings>::encode(const GeneralSettings& rhs)
 {
   Node node;
 
+  auto fw = getCurrentFirmware();
+
   node["semver"] = VERSION;
 
-  std::string board = getCurrentFirmware()->getFlavour().toStdString();
+  std::string board = fw->getFlavour().toStdString();
   node["board"] = board;
 
   YamlCalibData calib(rhs.calibMid, rhs.calibSpanNeg, rhs.calibSpanPos);
@@ -184,7 +186,9 @@ Node convert<GeneralSettings>::encode(const GeneralSettings& rhs)
   node["internalModuleBaudrate"] = internalModuleBaudrate.value;
 
   node["internalModule"] = LookupValue(internalModuleLut, rhs.internalModule);
-  node["splashMode"] = rhs.splashMode;                // TODO: B&W only
+  if (!IS_FAMILY_HORUS_OR_T16(fw->getBoard())) {
+    node["splashMode"] = rhs.splashMode;
+  }
   node["lightAutoOff"] = rhs.backlightDelay;
   node["templateSetup"] = rhs.templateSetup;
   node["hapticLength"] = rhs.hapticLength + 2;
@@ -214,7 +218,7 @@ Node convert<GeneralSettings>::encode(const GeneralSettings& rhs)
   node["varioRange"] = rhs.varioRange * 15;
   node["varioRepeat"] = rhs.varioRepeat;
   node["backgroundVolume"] = rhs.backgroundVolume + 2;
-  if (Boards::getCapability(getCurrentFirmware()->getBoard(), Board::HasColorLcd)) {
+  if (Boards::getCapability(fw->getBoard(), Board::HasColorLcd)) {
     node["modelQuickSelect"] = (int)rhs.modelQuickSelect;
   }
 
@@ -380,7 +384,9 @@ bool convert<GeneralSettings>::decode(const Node& node, GeneralSettings& rhs)
     rhs.internalModule = Boards::getDefaultInternalModules(fw->getBoard());
   }
 
-  node["splashMode"] >> rhs.splashMode;                // TODO: B&W only
+  if (!IS_FAMILY_HORUS_OR_T16(fw->getBoard())) {
+    node["splashMode"] >> rhs.splashMode;
+  }
   node["lightAutoOff"] >> rhs.backlightDelay;
   node["templateSetup"] >> rhs.templateSetup;
   node["hapticLength"] >> ioffset_int(rhs.hapticLength, 2);

--- a/companion/src/firmwares/generalsettings.h
+++ b/companion/src/firmwares/generalsettings.h
@@ -218,8 +218,7 @@ class GeneralSettings {
     bool minuteBeep;
     bool preBeep;
     bool flashBeep;
-    unsigned int splashMode;
-    int splashDuration;
+    int splashMode;
     unsigned int backlightDelay;
     unsigned int templateSetup;  //RETA order according to chout_ar array
     int PPM_Multiplier;

--- a/companion/src/firmwares/opentx/opentxeeprom.cpp
+++ b/companion/src/firmwares/opentx/opentxeeprom.cpp
@@ -3088,10 +3088,8 @@ OpenTxGeneralData::OpenTxGeneralData(GeneralSettings & generalData, Board::Type 
   internalField.Append(new UnsignedField<3>(this, generalData.internalModuleBaudrate));
   if (IS_FAMILY_HORUS_OR_T16(board))
     internalField.Append(new SpareBitsField<3>(this));
-  else if (IS_TARANIS(board))
-    internalField.Append(new SignedField<3>(this, generalData.splashDuration));
   else
-    internalField.Append(new UnsignedField<3>(this, generalData.splashMode)); // TODO
+    internalField.Append(new SignedField<3>(this, generalData.splashMode)); // TODO
   internalField.Append(new SignedField<2>(this, (int &)generalData.hapticMode));
 
   internalField.Append(new SignedField<8>(this, generalData.switchesDelay));

--- a/companion/src/firmwares/opentx/opentxeeprom.cpp
+++ b/companion/src/firmwares/opentx/opentxeeprom.cpp
@@ -3089,7 +3089,7 @@ OpenTxGeneralData::OpenTxGeneralData(GeneralSettings & generalData, Board::Type 
   if (IS_FAMILY_HORUS_OR_T16(board))
     internalField.Append(new SpareBitsField<3>(this));
   else
-    internalField.Append(new SignedField<3>(this, generalData.splashMode)); // TODO
+    internalField.Append(new SignedField<3>(this, generalData.splashMode));
   internalField.Append(new SignedField<2>(this, (int &)generalData.hapticMode));
 
   internalField.Append(new SignedField<8>(this, generalData.switchesDelay));

--- a/companion/src/generaledit/generalsetup.cpp
+++ b/companion/src/generaledit/generalsetup.cpp
@@ -251,17 +251,11 @@ ui(new Ui::GeneralSetup)
   ui->rssiPowerOffWarnChkB->setChecked(!generalSettings.disableRssiPoweroffAlarm); // Default is zero=checked
 
   if (IS_FAMILY_HORUS_OR_T16(firmware->getBoard())) {
-    ui->splashScreenChkB->hide();
     ui->splashScreenDuration->hide();
     ui->splashScreenLabel->hide();
   }
-  if (IS_TARANIS(firmware->getBoard())) {
-    ui->splashScreenChkB->hide();
-    ui->splashScreenDuration->setCurrentIndex(3-generalSettings.splashDuration);
-  }
   else {
-    ui->splashScreenDuration->hide();
-    ui->splashScreenChkB->setChecked(!generalSettings.splashMode);
+    ui->splashScreenDuration->setCurrentIndex(3-generalSettings.splashMode);
   }
 
   if (!firmware->getCapability(PwrButtonPress)) {
@@ -542,16 +536,9 @@ void GeneralSetupPanel::on_soundModeCB_currentIndexChanged(int index)
   emit modified();
 }
 
-
-void GeneralSetupPanel::on_splashScreenChkB_stateChanged(int )
-{
-  generalSettings.splashMode = ui->splashScreenChkB->isChecked() ? 0 : 1;
-  emit modified();
-}
-
 void GeneralSetupPanel::on_splashScreenDuration_currentIndexChanged(int index)
 {
-  generalSettings.splashDuration = 3-index;
+  generalSettings.splashMode = 3-index;
   emit modified();
 }
 

--- a/companion/src/generaledit/generalsetup.h
+++ b/companion/src/generaledit/generalsetup.h
@@ -37,7 +37,6 @@ class GeneralSetupPanel : public GeneralPanel
     virtual ~GeneralSetupPanel();
 
   private slots:
-    void on_splashScreenChkB_stateChanged(int);
     void on_splashScreenDuration_currentIndexChanged(int index);
     void on_alarmwarnChkB_stateChanged(int);
     void on_rssiPowerOffWarnChkB_stateChanged(int);

--- a/companion/src/generaledit/generalsetup.ui
+++ b/companion/src/generaledit/generalsetup.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>809</width>
+    <width>810</width>
     <height>880</height>
    </rect>
   </property>
@@ -1850,31 +1850,6 @@ p, li { white-space: pre-wrap; }
      </item>
      <item row="10" column="1" colspan="2">
       <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="QCheckBox" name="splashScreenChkB">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string>Show splash screen on startup</string>
-         </property>
-         <property name="whatsThis">
-          <string>Show splash screen on startup</string>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
        <item>
         <widget class="QComboBox" name="splashScreenDuration">
          <property name="sizePolicy">


### PR DESCRIPTION
Fixes #3331 

Summary of changes:
- Change Companion logic for the splash screen settings to match the firmware logic.
- Only save/load splash screen settings for b&W radios.