### PR TITLE
feat(radio) - Add 'repeat' option to 'Lua Script' special function.

### DIFF
--- a/companion/src/firmwares/customfunctiondata.cpp
+++ b/companion/src/firmwares/customfunctiondata.cpp
@@ -212,10 +212,6 @@ QString CustomFunctionData::repeatToString(const int value, const AssignFunc fun
 //  static
 QString CustomFunctionData::repeatToString(const int value, const bool abbrev)
 {
-  if (func == FuncPlayScript) {
-    return (value == 0) ? tr("50ms") : tr("1x");
-  }
-
   if (value == -1) {
     return abbrev ? tr("!1x") : tr("Played once, not during startup");
   }
@@ -393,6 +389,19 @@ AbstractStaticItemModel * CustomFunctionData::repeatItemModel()
   for (int i = -1; i <= 60; i++) {
     mdl->appendToItemList(repeatToString(i, false), i);
   }
+
+  mdl->loadItemList();
+  return mdl;
+}
+
+//  static
+AbstractStaticItemModel * CustomFunctionData::repeatLuaItemModel()
+{
+  AbstractStaticItemModel * mdl = new AbstractStaticItemModel();
+  mdl->setName("customfunctiondata.repeatLua");
+
+  mdl->appendToItemList("On", 0);
+  mdl->appendToItemList("1x", 1);
 
   mdl->loadItemList();
   return mdl;

--- a/companion/src/firmwares/customfunctiondata.cpp
+++ b/companion/src/firmwares/customfunctiondata.cpp
@@ -400,8 +400,8 @@ AbstractStaticItemModel * CustomFunctionData::repeatLuaItemModel()
   AbstractStaticItemModel * mdl = new AbstractStaticItemModel();
   mdl->setName("customfunctiondata.repeatLua");
 
-  mdl->appendToItemList("On", 0);
-  mdl->appendToItemList("1x", 1);
+  mdl->appendToItemList(tr("On"), 0);
+  mdl->appendToItemList(tr("1x"), 1);
 
   mdl->loadItemList();
   return mdl;

--- a/companion/src/firmwares/customfunctiondata.cpp
+++ b/companion/src/firmwares/customfunctiondata.cpp
@@ -212,6 +212,10 @@ QString CustomFunctionData::repeatToString(const int value, const AssignFunc fun
 //  static
 QString CustomFunctionData::repeatToString(const int value, const bool abbrev)
 {
+  if (func == FuncPlayScript) {
+    return (value == 0) ? tr("50ms") : tr("1x");
+  }
+
   if (value == -1) {
     return abbrev ? tr("!1x") : tr("Played once, not during startup");
   }

--- a/companion/src/firmwares/customfunctiondata.h
+++ b/companion/src/firmwares/customfunctiondata.h
@@ -136,6 +136,7 @@ class CustomFunctionData {
     static QStringList gvarAdjustModeStringList();
     static QString gvarAdjustModeToString(const int value);
     static AbstractStaticItemModel * repeatItemModel();
+    static AbstractStaticItemModel * repeatLuaItemModel();
     static AbstractStaticItemModel * playSoundItemModel();
     static AbstractStaticItemModel * harpicItemModel();
     static AbstractStaticItemModel * gvarAdjustModeItemModel();

--- a/companion/src/firmwares/edgetx/yaml_customfunctiondata.cpp
+++ b/companion/src/firmwares/edgetx/yaml_customfunctiondata.cpp
@@ -37,7 +37,8 @@ static bool fnHasRepeat(AssignFunc fn)
     || (fn == FuncPlayValue)
     || (fn == FuncPlayHaptic)
     || (fn == FuncPlaySound)
-    || (fn == FuncSetScreen);
+    || (fn == FuncSetScreen)
+    || (fn == FuncPlayScript);
 }
 
 static const YamlLookupTable customFnLut = {
@@ -225,7 +226,9 @@ Node convert<CustomFunctionData>::encode(const CustomFunctionData& rhs)
     if (add_comma) {
       def += ",";
     }
-    if (rhs.repeatParam == 0) {
+    if (rhs.func == FuncPlayScript) {
+      def += ((rhs.repeatParam == 0) ? "50ns" : "1x");
+    } else if (rhs.repeatParam == 0) {
       def += "1x";
     } else if (rhs.repeatParam == -1) {
       def += "!1x";
@@ -374,7 +377,9 @@ bool convert<CustomFunctionData>::decode(const Node& node,
   } else if(fnHasRepeat(rhs.func)) {
     std::string repeat;
     getline(def, repeat);
-    if (repeat == "1x") {
+    if (rhs.func == FuncPlayScript) {
+      rhs.repeatParam = (repeat == "1x") ? 1 : 0;
+    } else if (repeat == "1x") {
       rhs.repeatParam = 0;
     } else if (repeat == "!1x") {
       rhs.repeatParam = -1;

--- a/companion/src/firmwares/edgetx/yaml_customfunctiondata.cpp
+++ b/companion/src/firmwares/edgetx/yaml_customfunctiondata.cpp
@@ -227,7 +227,7 @@ Node convert<CustomFunctionData>::encode(const CustomFunctionData& rhs)
       def += ",";
     }
     if (rhs.func == FuncPlayScript) {
-      def += ((rhs.repeatParam == 0) ? "50ns" : "1x");
+      def += ((rhs.repeatParam == 0) ? "On" : "1x");
     } else if (rhs.repeatParam == 0) {
       def += "1x";
     } else if (rhs.repeatParam == -1) {

--- a/companion/src/modeledit/customfunctions.cpp
+++ b/companion/src/modeledit/customfunctions.cpp
@@ -39,6 +39,7 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
   playSoundId = tabModelFactory->registerItemModel(CustomFunctionData::playSoundItemModel());
   harpicId = tabModelFactory->registerItemModel(CustomFunctionData::harpicItemModel());
   repeatId = tabModelFactory->registerItemModel(CustomFunctionData::repeatItemModel());
+  repeatLuaId = tabModelFactory->registerItemModel(CustomFunctionData::repeatLuaItemModel());
   gvarAdjustModeId = tabModelFactory->registerItemModel(CustomFunctionData::gvarAdjustModeItemModel());
 
   tabFilterFactory = new FilteredItemModelFactory();
@@ -193,7 +194,10 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
     tableLayout->addLayout(i, 4, repeatLayout);
     fswtchRepeat[i] = new QComboBox(this);
     fswtchRepeat[i]->setProperty("index", i);
-    fswtchRepeat[i]->setModel(tabModelFactory->getItemModel(repeatId));
+    if (functions[i].func == FuncPlayScript)
+      fswtchRepeat[i]->setModel(tabModelFactory->getItemModel(repeatLuaId));
+    else
+      fswtchRepeat[i]->setModel(tabModelFactory->getItemModel(repeatId));
     fswtchRepeat[i]->setSizePolicy(QSizePolicy::Maximum, QSizePolicy::Fixed);
     fswtchRepeat[i]->setSizeAdjustPolicy(QComboBox::AdjustToContents);
     repeatLayout->addWidget(fswtchRepeat[i], i + 1);
@@ -324,6 +328,10 @@ void CustomFunctionsPanel::functionEdited()
     functions[index].clear();
     functions[index].swtch = swtch;
     functions[index].func = (AssignFunc)fswtchFunc[index]->currentData().toInt();
+    if (functions[index].func == FuncPlayScript)
+      fswtchRepeat[index]->setModel(tabModelFactory->getItemModel(repeatLuaId));
+    else
+      fswtchRepeat[index]->setModel(tabModelFactory->getItemModel(repeatId));
     refreshCustomFunction(index);
     emit modified();
     lock = false;
@@ -523,11 +531,13 @@ void CustomFunctionsPanel::refreshCustomFunction(int i, bool modified)
       }
     }
     else if (func == FuncPlayScript) {
-      widgetsMask |= CUSTOM_FUNCTION_FILE_PARAM;
+      widgetsMask |= CUSTOM_FUNCTION_FILE_PARAM | CUSTOM_FUNCTION_REPEAT;
       if (modified) {
         Helpers::getFileComboBoxValue(fswtchParamArmT[i], cfn.paramarm, 8);
+        cfn.repeatParam = fswtchRepeat[i]->currentData().toInt();
       }
       Helpers::populateFileComboBox(fswtchParamArmT[i], scriptsSet, cfn.paramarm);
+      fswtchRepeat[i]->setCurrentIndex(fswtchRepeat[i]->findData(cfn.repeatParam));
     }
     else {
       if (modified)

--- a/companion/src/modeledit/customfunctions.h
+++ b/companion/src/modeledit/customfunctions.h
@@ -87,6 +87,7 @@ class CustomFunctionsPanel : public GenericPanel
     int playSoundId;
     int harpicId;
     int repeatId;
+    int repeatLuaId;
     int gvarAdjustModeId;
 
     QSet<QString> tracksSet;

--- a/radio/src/gui/128x64/model_special_functions.cpp
+++ b/radio/src/gui/128x64/model_special_functions.cpp
@@ -307,7 +307,7 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
 #if defined(SDCARD)
           else if (func == FUNC_PLAY_TRACK || func == FUNC_BACKGND_MUSIC || func == FUNC_PLAY_SCRIPT) {
             if (ZEXIST(cfn->play.name))
-              lcdDrawSizedText(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, cfn->play.name, sizeof(cfn->play.name), attr);
+              lcdDrawSizedText(MODEL_SPECIAL_FUNC_3RD_COLUMN-6, y, cfn->play.name, sizeof(cfn->play.name), attr);
             else
               lcdDrawTextAtIndex(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, STR_VCSWFUNC, 0, attr);
             if (active && event==EVT_KEY_BREAK(KEY_ENTER)) {
@@ -439,18 +439,21 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
           }
           else if (HAS_REPEAT_PARAM(func)) {
             if (func == FUNC_PLAY_SCRIPT) {
-              lcdDrawChar(MODEL_SPECIAL_FUNC_4TH_COLUMN_ONOFF+3, y, (CFN_PLAY_REPEAT(cfn) == 0) ? '+' : '-', attr);
-            }
-            else if (CFN_PLAY_REPEAT(cfn) == 0) {
-              lcdDrawChar(MODEL_SPECIAL_FUNC_4TH_COLUMN_ONOFF+3, y, '-', attr);
-            }
-            else if (CFN_PLAY_REPEAT(cfn) == CFN_PLAY_REPEAT_NOSTART) {
-              lcdDrawText(MODEL_SPECIAL_FUNC_4TH_COLUMN_ONOFF+1, y, "!-", attr);
+              lcdDrawText(MODEL_SPECIAL_FUNC_4TH_COLUMN_ONOFF-3, y, (CFN_PLAY_REPEAT(cfn) == 0) ? "On" : "1x", attr);
+              if (active) CFN_PLAY_REPEAT(cfn) = checkIncDec(event, CFN_PLAY_REPEAT(cfn), 0, 1, eeFlags);
             }
             else {
-              lcdDrawNumber(MODEL_SPECIAL_FUNC_4TH_COLUMN+2+FW, y, CFN_PLAY_REPEAT(cfn)*CFN_PLAY_REPEAT_MUL, RIGHT | attr);
+              if (CFN_PLAY_REPEAT(cfn) == 0) {
+                lcdDrawChar(MODEL_SPECIAL_FUNC_4TH_COLUMN_ONOFF+3, y, '-', attr);
+              }
+              else if (CFN_PLAY_REPEAT(cfn) == CFN_PLAY_REPEAT_NOSTART) {
+                lcdDrawText(MODEL_SPECIAL_FUNC_4TH_COLUMN_ONOFF+1, y, "!-", attr);
+              }
+              else {
+                lcdDrawNumber(MODEL_SPECIAL_FUNC_4TH_COLUMN+2+FW, y, CFN_PLAY_REPEAT(cfn)*CFN_PLAY_REPEAT_MUL, RIGHT | attr);
+              }
+              if (active) CFN_PLAY_REPEAT(cfn) = checkIncDec(event, CFN_PLAY_REPEAT(cfn)==CFN_PLAY_REPEAT_NOSTART?-1:CFN_PLAY_REPEAT(cfn), -1, 60/CFN_PLAY_REPEAT_MUL, eeFlags);
             }
-            if (active) CFN_PLAY_REPEAT(cfn) = checkIncDec(event, CFN_PLAY_REPEAT(cfn)==CFN_PLAY_REPEAT_NOSTART?-1:CFN_PLAY_REPEAT(cfn), -1, 60/CFN_PLAY_REPEAT_MUL, eeFlags);
           }
           else if (attr) {
             REPEAT_LAST_CURSOR_MOVE();

--- a/radio/src/gui/128x64/model_special_functions.cpp
+++ b/radio/src/gui/128x64/model_special_functions.cpp
@@ -438,7 +438,10 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
             if (active) CFN_ACTIVE(cfn) = checkIncDec(event, CFN_ACTIVE(cfn), 0, 1, eeFlags);
           }
           else if (HAS_REPEAT_PARAM(func)) {
-            if (CFN_PLAY_REPEAT(cfn) == 0) {
+            if (func == FUNC_PLAY_SCRIPT) {
+              lcdDrawChar(MODEL_SPECIAL_FUNC_4TH_COLUMN_ONOFF+3, y, (CFN_PLAY_REPEAT(cfn) == 0) ? '+' : '-', attr);
+            }
+            else if (CFN_PLAY_REPEAT(cfn) == 0) {
               lcdDrawChar(MODEL_SPECIAL_FUNC_4TH_COLUMN_ONOFF+3, y, '-', attr);
             }
             else if (CFN_PLAY_REPEAT(cfn) == CFN_PLAY_REPEAT_NOSTART) {

--- a/radio/src/gui/212x64/model_special_functions.cpp
+++ b/radio/src/gui/212x64/model_special_functions.cpp
@@ -416,7 +416,10 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
             if (active) CFN_ACTIVE(cfn) = checkIncDec(event, CFN_ACTIVE(cfn), 0, 1, eeFlags);
           }
           else if (HAS_REPEAT_PARAM(func)) {
-            if (CFN_PLAY_REPEAT(cfn) == 0) {
+            if (func == FUNC_PLAY_SCRIPT) {
+              lcdDrawText(MODEL_SPECIAL_FUNC_4TH_COLUMN+2, y, (CFN_PLAY_REPEAT(cfn) == 0) ? "On" : "1x", attr);
+            }
+            else if (CFN_PLAY_REPEAT(cfn) == 0) {
               lcdDrawText(MODEL_SPECIAL_FUNC_4TH_COLUMN+2, y, "1x", attr);
             }
             else if (CFN_PLAY_REPEAT(cfn) == CFN_PLAY_REPEAT_NOSTART) {

--- a/radio/src/gui/212x64/model_special_functions.cpp
+++ b/radio/src/gui/212x64/model_special_functions.cpp
@@ -418,19 +418,22 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
           else if (HAS_REPEAT_PARAM(func)) {
             if (func == FUNC_PLAY_SCRIPT) {
               lcdDrawText(MODEL_SPECIAL_FUNC_4TH_COLUMN+2, y, (CFN_PLAY_REPEAT(cfn) == 0) ? "On" : "1x", attr);
-            }
-            else if (CFN_PLAY_REPEAT(cfn) == 0) {
-              lcdDrawText(MODEL_SPECIAL_FUNC_4TH_COLUMN+2, y, "1x", attr);
-            }
-            else if (CFN_PLAY_REPEAT(cfn) == CFN_PLAY_REPEAT_NOSTART) {
-              lcdDrawChar(MODEL_SPECIAL_FUNC_4TH_COLUMN-1, y, '!', attr);
-              lcdDrawText(MODEL_SPECIAL_FUNC_4TH_COLUMN+2, y, "1x", attr);
+              if (active) CFN_PLAY_REPEAT(cfn) = checkIncDec(event, CFN_PLAY_REPEAT(cfn), 0, 1, eeFlags);
             }
             else {
-              lcdDrawNumber(MODEL_SPECIAL_FUNC_4TH_COLUMN+2+FW, y, CFN_PLAY_REPEAT(cfn)*CFN_PLAY_REPEAT_MUL, attr|RIGHT);
-              lcdDrawChar(MODEL_SPECIAL_FUNC_4TH_COLUMN+2+FW, y, 's', attr);
+              if (CFN_PLAY_REPEAT(cfn) == 0) {
+                lcdDrawText(MODEL_SPECIAL_FUNC_4TH_COLUMN+2, y, "1x", attr);
+              }
+              else if (CFN_PLAY_REPEAT(cfn) == CFN_PLAY_REPEAT_NOSTART) {
+                lcdDrawChar(MODEL_SPECIAL_FUNC_4TH_COLUMN-1, y, '!', attr);
+                lcdDrawText(MODEL_SPECIAL_FUNC_4TH_COLUMN+2, y, "1x", attr);
+              }
+              else {
+                lcdDrawNumber(MODEL_SPECIAL_FUNC_4TH_COLUMN+2+FW, y, CFN_PLAY_REPEAT(cfn)*CFN_PLAY_REPEAT_MUL, attr|RIGHT);
+                lcdDrawChar(MODEL_SPECIAL_FUNC_4TH_COLUMN+2+FW, y, 's', attr);
+              }
+              if (active) CFN_PLAY_REPEAT(cfn) = checkIncDec(event, CFN_PLAY_REPEAT(cfn)==CFN_PLAY_REPEAT_NOSTART?-1:CFN_PLAY_REPEAT(cfn), -1, 60/CFN_PLAY_REPEAT_MUL, eeFlags);
             }
-            if (active) CFN_PLAY_REPEAT(cfn) = checkIncDec(event, CFN_PLAY_REPEAT(cfn)==CFN_PLAY_REPEAT_NOSTART?-1:CFN_PLAY_REPEAT(cfn), -1, 60/CFN_PLAY_REPEAT_MUL, eeFlags);
           }
           else if (attr) {
             REPEAT_LAST_CURSOR_MOVE();

--- a/radio/src/gui/colorlcd/special_functions.cpp
+++ b/radio/src/gui/colorlcd/special_functions.cpp
@@ -337,7 +337,7 @@ class SpecialFunctionEditPage : public Page
                                  SET_DEFAULT(CFN_PLAY_REPEAT(cfn)));
         repeat->setTextHandler([](int32_t value) {
             // 0 == repeat at 50ms interval for backward compatibility
-            return (value == 0) ? std::string("50ms") : std::string("1x");
+            return (value == 0) ? std::string("On") : std::string("1x");
         });
       } else {
         auto repeat = new NumberEdit(line, rect_t{}, 0, 60 / CFN_PLAY_REPEAT_MUL,
@@ -662,7 +662,7 @@ class SpecialFunctionButton : public Button
       lv_obj_clear_flag(sfEnable, LV_OBJ_FLAG_HIDDEN);
     } else if (HAS_REPEAT_PARAM(func)) {
       if (func == FUNC_PLAY_SCRIPT) {
-        sprintf(s, "(%s)", (CFN_PLAY_REPEAT(cfn) == 0) ? "50ms" : "1x");
+        sprintf(s, "(%s)", (CFN_PLAY_REPEAT(cfn) == 0) ? "On" : "1x");
       } else {
         sprintf(s, "(%s)",
           (CFN_PLAY_REPEAT(cfn) == 0) ? "1x" :

--- a/radio/src/myeeprom.h
+++ b/radio/src/myeeprom.h
@@ -63,7 +63,7 @@
 #if defined(COLORLCD)
 #define HAS_REPEAT_PARAM(func)         (IS_PLAY_FUNC(func) || IS_HAPTIC_FUNC(func) || func == FUNC_PLAY_SCRIPT || func == FUNC_SET_SCREEN)
 #else
-#define HAS_REPEAT_PARAM(func)         (IS_PLAY_FUNC(func) || IS_HAPTIC_FUNC(func) || func == FUNC_PLAY_SCRIPT )
+#define HAS_REPEAT_PARAM(func)         (IS_PLAY_FUNC(func) || IS_HAPTIC_FUNC(func) || func == FUNC_PLAY_SCRIPT)
 #endif
 
 #define CFN_EMPTY(p)                   (!(p)->swtch)

--- a/radio/src/myeeprom.h
+++ b/radio/src/myeeprom.h
@@ -61,9 +61,9 @@
 
 #define HAS_ENABLE_PARAM(func)         ((func) < FUNC_FIRST_WITHOUT_ENABLE || (func == FUNC_BACKLIGHT))
 #if defined(COLORLCD)
-#define HAS_REPEAT_PARAM(func)         (IS_PLAY_FUNC(func) || IS_HAPTIC_FUNC(func) || func == FUNC_SET_SCREEN)
+#define HAS_REPEAT_PARAM(func)         (IS_PLAY_FUNC(func) || IS_HAPTIC_FUNC(func) || func == FUNC_PLAY_SCRIPT || func == FUNC_SET_SCREEN)
 #else
-#define HAS_REPEAT_PARAM(func)         (IS_PLAY_FUNC(func) || IS_HAPTIC_FUNC(func) )
+#define HAS_REPEAT_PARAM(func)         (IS_PLAY_FUNC(func) || IS_HAPTIC_FUNC(func) || func == FUNC_PLAY_SCRIPT )
 #endif
 
 #define CFN_EMPTY(p)                   (!(p)->swtch)

--- a/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
@@ -1477,7 +1477,12 @@ static void r_customFn(void* user, uint8_t* data, uint32_t bitoffs,
       }
     }
   } else if (HAS_REPEAT_PARAM(func)) {
-    if (val_len == 2
+    if (func == FUNC_PLAY_SCRIPT) {
+      if (val_len == 2 && val[0] == '1' && val[1] == 'x')
+        CFN_PLAY_REPEAT(cfn) = 1;
+      else
+        CFN_PLAY_REPEAT(cfn) = 0;
+    } else if (val_len == 2
         && val[0] == '1'
         && val[1] == 'x') {
       CFN_PLAY_REPEAT(cfn) = 0;
@@ -1629,7 +1634,9 @@ static bool w_customFn(void* user, uint8_t* data, uint32_t bitoffs,
       // ","
       if (!wf(opaque,",",1)) return false;
     }
-    if (CFN_PLAY_REPEAT(cfn) == 0) {
+    if (func == FUNC_PLAY_SCRIPT) {
+      if (!wf(opaque,(CFN_PLAY_REPEAT(cfn) == 0) ? "On" : "1x",2)) return false;
+    } else if (CFN_PLAY_REPEAT(cfn) == 0) {
       // "1x"
       if (!wf(opaque,"1x",2)) return false;
     } else if (CFN_PLAY_REPEAT(cfn) == CFN_PLAY_REPEAT_NOSTART) {


### PR DESCRIPTION
Fixes #3321 

Adds the 'repeat' option to the 'Lua Script' special function.
The options are:
- 'On' = current functionality where script runs repeatedly while SF switch is active.
- '1x' = script is run only once for each activation the SF switch

Companion, Color and B&W radios supported.
Some minor layout adjustment needed for 128x64 B&W radios.

![Screen Shot 2023-03-10 at 4 48 06 pm](https://user-images.githubusercontent.com/9474356/224234736-9462702b-46b0-4491-9741-252c54923b09.png)

![Screen Shot 2023-03-10 at 4 47 32 pm](https://user-images.githubusercontent.com/9474356/224234761-04ba73d4-0d0d-4fff-89aa-36fb832b2f5e.png)

![Screen Shot 2023-03-10 at 4 48 58 pm](https://user-images.githubusercontent.com/9474356/224234806-2e36d59a-755d-4022-8cad-26340db36dd6.png)
