### PR TITLE
fix(color) - Make radio and model setup UI more responsive when switching tabs.

### DIFF
--- a/radio/src/gui/colorlcd/tabsgroup.cpp
+++ b/radio/src/gui/colorlcd/tabsgroup.cpp
@@ -243,7 +243,7 @@ void TabsGroup::setVisibleTab(PageTab* tab)
     tab->build(form);
 
     header.setTitle(tab->title.c_str());
-    invalidate();
+    header.invalidate();
 
 #if defined(DEBUG)
     TRACE("tab time: %d ms", RTOS_GET_MS() - start_ms);


### PR DESCRIPTION
A small change that improves the performance when switching tabs in the radio and model setup views.