### PR TITLE
feat(color) - Use generic YAML parser to save/load Theme yaml files.

### DIFF
--- a/companion/src/firmwares/edgetx/yaml_generalsettings.cpp
+++ b/companion/src/firmwares/edgetx/yaml_generalsettings.cpp
@@ -148,6 +148,8 @@ Node convert<GeneralSettings>::encode(const GeneralSettings& rhs)
 
   auto fw = getCurrentFirmware();
 
+  bool hasColorLcd = Boards::getCapability(fw->getBoard(), Board::HasColorLcd);
+
   node["semver"] = VERSION;
 
   std::string board = fw->getFlavour().toStdString();
@@ -281,7 +283,8 @@ Node convert<GeneralSettings>::encode(const GeneralSettings& rhs)
   // OneBit sampling (X9D only?)
   node["uartSampleMode"] = rhs.uartSampleMode;
 
-  node["selectedTheme"] = rhs.selectedTheme;
+  if (hasColorLcd)
+    node["selectedTheme"] = rhs.selectedTheme;
 
   return node;
 }

--- a/companion/src/firmwares/edgetx/yaml_generalsettings.cpp
+++ b/companion/src/firmwares/edgetx/yaml_generalsettings.cpp
@@ -281,6 +281,8 @@ Node convert<GeneralSettings>::encode(const GeneralSettings& rhs)
   // OneBit sampling (X9D only?)
   node["uartSampleMode"] = rhs.uartSampleMode;
 
+  node["selectedTheme"] = rhs.selectedTheme;
+
   return node;
 }
 
@@ -495,6 +497,8 @@ bool convert<GeneralSettings>::decode(const Node& node, GeneralSettings& rhs)
   //  TODO: for consistency move up call stack to use existing eeprom and profile conversions
   if (needsConversion)
     rhs.init();
+
+  node["selectedTheme"] >> rhs.selectedTheme;
 
   return true;
 }

--- a/companion/src/firmwares/generalsettings.h
+++ b/companion/src/firmwares/generalsettings.h
@@ -101,6 +101,7 @@ constexpr int BLUETOOTH_NAME_LEN      {10};
 constexpr int TTS_LANGUAGE_LEN        {2};
 constexpr int HARDWARE_NAME_LEN       {3};
 constexpr int REGISTRATION_ID_LEN     {8};
+constexpr int SELECTED_THEME_NAME_LEN {26};
 
 class GeneralSettings {
   Q_DECLARE_TR_FUNCTIONS(GeneralSettings)
@@ -282,6 +283,8 @@ class GeneralSettings {
 
     int pwrOnSpeed;
     int pwrOffSpeed;
+
+    char selectedTheme[SELECTED_THEME_NAME_LEN + 1];
 
     bool switchPositionAllowedTaranis(int index) const;
     bool switchSourceAllowedTaranis(int index) const;

--- a/radio/src/dataconstants.h
+++ b/radio/src/dataconstants.h
@@ -934,4 +934,6 @@ enum ModelOverridableEnable {
   OVERRIDE_ON
 };
 
+#define SELECTED_THEME_NAME_LEN 26
+
 #endif // _DATACONSTANTS_H_

--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -139,14 +139,14 @@ static inline void check_struct()
   CHKSIZE(ModelData, 6661);
 #elif defined(PCBHORUS)
   #if defined(PCBX10)
-    CHKSIZE(RadioData, 924);
+    CHKSIZE(RadioData, 950);
     CHKSIZE(ModelData, 15431);
   #else
-    CHKSIZE(RadioData, 906);
+    CHKSIZE(RadioData, 932);
     CHKSIZE(ModelData, 15429);
   #endif
 #elif defined(PCBNV14)
-  CHKSIZE(RadioData, 852);
+  CHKSIZE(RadioData, 878);
   CHKSIZE(ModelData, 15245);
 #endif
 

--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -948,6 +948,10 @@ PACK(struct RadioData {
   NOBACKUP(int8_t imuMax);
   NOBACKUP(int8_t imuOffset);
 #endif
+
+#if defined(COLORLCD)
+  NOBACKUP(char selectedTheme[SELECTED_THEME_NAME_LEN]);
+#endif
 });
 
 #undef SWITCHES_WARNING_DATA

--- a/radio/src/gui/colorlcd/radio_theme.cpp
+++ b/radio/src/gui/colorlcd/radio_theme.cpp
@@ -143,7 +143,7 @@ class ThemeDetailsDialog: public Dialog
       auto line = form->newLine(&grid);
 
       new StaticText(line, rect_t{}, STR_NAME, 0, COLOR_THEME_PRIMARY1);
-      auto te = new TextEdit(line, rect_t{}, this->theme.getName(), NAME_LENGTH);
+      auto te = new TextEdit(line, rect_t{}, this->theme.getName(), SELECTED_THEME_NAME_LEN);
       lv_obj_set_grid_cell(te->getLvObj(), LV_GRID_ALIGN_STRETCH, 1, 1, LV_GRID_ALIGN_CENTER, 0, 1);
 
       line = form->newLine(&grid);
@@ -564,8 +564,8 @@ void ThemeSetupPage::displayThemeMenu(Window *window, ThemePersistance *tp)
 
     new ThemeDetailsDialog(window, newTheme, [=](ThemeFile theme) {
       if (strlen(theme.getName()) != 0) {
-        char name[NAME_LENGTH + 20];
-        strncpy(name, theme.getName(), NAME_LENGTH + 19);
+        char name[SELECTED_THEME_NAME_LEN + 20];
+        strncpy(name, theme.getName(), SELECTED_THEME_NAME_LEN + 19);
         removeAllWhiteSpace(name);
 
         // use the selected themes color list to make the new theme

--- a/radio/src/gui/colorlcd/radio_theme.cpp
+++ b/radio/src/gui/colorlcd/radio_theme.cpp
@@ -540,7 +540,7 @@ void ThemeSetupPage::displayThemeMenu(Window *window, ThemePersistance *tp)
         *theme = editedTheme;
 
         theme->serialize();
-        
+
         // if the theme info currently displayed
         // were changed, update the UI
         if (themeIdx == currentTheme) {
@@ -552,6 +552,8 @@ void ThemeSetupPage::displayThemeMenu(Window *window, ThemePersistance *tp)
 
         // if the active theme changed, re-apply it
         if (themeIdx == tp->getThemeIndex()) {
+          // Update saved them name in case it was changed.
+          tp->setDefaultTheme(themeIdx);
           theme->applyTheme();
           TabsGroup::refreshTheme();
         }

--- a/radio/src/gui/colorlcd/theme_manager.cpp
+++ b/radio/src/gui/colorlcd/theme_manager.cpp
@@ -31,7 +31,8 @@ constexpr const char *RGBSTRING = "RGB(";
 
 ThemePersistance themePersistance;
 
-// read a YAML file - TODO: should this be in sdcard header file?
+// prototype for SD card function to read a YAML file
+// TODO: should this be in sdcard header file?
 enum class ChecksumResult;
 extern const char* readYamlFile(const char* fullpath, const YamlParserCalls* calls, void* parser_ctx, ChecksumResult* checksum_result);
 

--- a/radio/src/gui/colorlcd/theme_manager.cpp
+++ b/radio/src/gui/colorlcd/theme_manager.cpp
@@ -25,6 +25,8 @@
 #include "../../storage/yaml/yaml_bits.h"
 #include "../../storage/sdcard_common.h"
 
+#define SET_DIRTY() storageDirty(EE_GENERAL)
+
 #define MAX_FILES 9
 
 constexpr const char *RGBSTRING = "RGB(";
@@ -69,7 +71,7 @@ static bool w_color(const YamlNode* node, uint32_t val, yaml_writer_func wf,
 
 PACK(struct YAMLThemeSummary
 {
-  char name[NAME_LENGTH + 1];
+  char name[SELECTED_THEME_NAME_LEN + 1];
   char author[AUTHOR_LENGTH + 1];
   char info[INFO_LENGTH+1];
 });
@@ -90,7 +92,7 @@ PACK(struct YAMLTheme
 });
 
 static const struct YamlNode struct_YAMLThemeSummary[] = {
-  YAML_STRING("name", (NAME_LENGTH + 1)),
+  YAML_STRING("name", (SELECTED_THEME_NAME_LEN + 1)),
   YAML_STRING("author", (AUTHOR_LENGTH + 1)),
   YAML_STRING("info", (INFO_LENGTH + 1)),
   YAML_END
@@ -115,12 +117,12 @@ static const struct YamlNode struct_YAMLThemeColors[] = {
 // the old parser. Otherwise older versions of EdgeTX will not load the theme files.
 // TODO: Remove this sometime in the future
 static const struct YamlNode w_struct_YAMLTheme[] = {
-  YAML_STRUCT("---\r\nsummary", (NAME_LENGTH + AUTHOR_LENGTH + INFO_LENGTH + 3) * 8, struct_YAMLThemeSummary, NULL),
+  YAML_STRUCT("---\r\nsummary", (SELECTED_THEME_NAME_LEN + AUTHOR_LENGTH + INFO_LENGTH + 3) * 8, struct_YAMLThemeSummary, NULL),
   YAML_STRUCT("colors", (COLOR_COUNT - 2) * 32, struct_YAMLThemeColors, NULL),
   YAML_END
 };
 static const struct YamlNode r_struct_YAMLTheme[] = {
-  YAML_STRUCT("summary", (NAME_LENGTH + AUTHOR_LENGTH + INFO_LENGTH + 3) * 8, struct_YAMLThemeSummary, NULL),
+  YAML_STRUCT("summary", (SELECTED_THEME_NAME_LEN + AUTHOR_LENGTH + INFO_LENGTH + 3) * 8, struct_YAMLThemeSummary, NULL),
   YAML_STRUCT("colors", (COLOR_COUNT - 2) * 32, struct_YAMLThemeColors, NULL),
   YAML_END
 };
@@ -130,8 +132,6 @@ static const char *colorNames[COLOR_COUNT] = {
     "SECONDARY1", "SECONDARY2", "SECONDARY3", "FOCUS",
     "EDIT",       "ACTIVE",     "WARNING",    "DISABLED", "CUSTOM",
 };
-
-constexpr const char* SELECTED_THEME_FILE = THEMES_PATH "/selectedtheme.txt";
 
 ThemeFile::ThemeFile(std::string themePath, bool loadYAML) :
   path(themePath)
@@ -162,7 +162,7 @@ ThemeFile& ThemeFile::operator= (const ThemeFile& theme)
     return *this;
 
   path = theme.path;
-  strAppend(name, theme.name, NAME_LENGTH);
+  strAppend(name, theme.name, SELECTED_THEME_NAME_LEN);
   strAppend(author, theme.author, AUTHOR_LENGTH);
   strAppend(info, theme.info, INFO_LENGTH);
   colorList.assign(theme.colorList.begin(), theme.colorList.end());
@@ -181,7 +181,7 @@ void ThemeFile::serialize()
   struct YAMLTheme yt;
   struct YamlNode themeRootNode = YAML_ROOT(w_struct_YAMLTheme);
 
-  strAppend(yt.summary.name, name, NAME_LENGTH);
+  strAppend(yt.summary.name, name, SELECTED_THEME_NAME_LEN);
   strAppend(yt.summary.author, author, AUTHOR_LENGTH);
   strAppend(yt.summary.info, info, INFO_LENGTH);
   for (auto colorEntry : colorList) {
@@ -204,7 +204,7 @@ void ThemeFile::deSerialize()
   auto err = readYamlFile(path.c_str(), YamlTreeWalker::get_parser_calls(), &tree, nullptr);
 
   if (err == nullptr) {
-    strAppend(name, yt.summary.name, NAME_LENGTH);
+    strAppend(name, yt.summary.name, SELECTED_THEME_NAME_LEN);
     strAppend(author, yt.summary.author, AUTHOR_LENGTH);
     strAppend(info, yt.summary.info, INFO_LENGTH);
     for (int i = 0; i < COLOR_COUNT - 2; i += 1) {
@@ -336,37 +336,66 @@ void ThemePersistance::loadDefaultTheme()
 {
   refresh();
 
-  FIL file;
-  FRESULT status = f_open(&file, SELECTED_THEME_FILE, FA_READ);
-  if (status != FR_OK) return;
+  int index = 0;
+  bool found = false;
 
-  char line[256];
-  unsigned int len;
+  // Load theme from 'selectedtheme.txt' file, if not set in radio settings
+  // TODO: remove this sometime in the future
+  if (g_eeGeneral.selectedTheme[0] == 0) {
+    constexpr const char* SELECTED_THEME_FILE = THEMES_PATH "/selectedtheme.txt";
 
-  status = f_read(&file, line, 256, &len);
-  if (status == FR_OK) {
+    FIL file;
+    FRESULT status = f_open(&file, SELECTED_THEME_FILE, FA_READ);
 
-    line[len] = '\0';
+    if (status == FR_OK) {
+      char line[256];
+      unsigned int len;
 
-    int index = 0;
-    bool found = false;
-    for (auto theme : themes) {
-      if (theme->getPath() == std::string(line)) {
-        found = true;
-        break;
+      status = f_read(&file, line, 256, &len);
+      if (status == FR_OK) {
+        line[len] = '\0';
+
+        for (auto theme : themes) {
+          if (theme->getPath() == std::string(line)) {
+            found = true;
+            break;
+          }
+          index++;
+        }
+
+        // Force default if no match for last selected theme
+        if (!found)
+          index = 0;
       }
-      index++;
+
+      f_close(&file);
+
+      // Delete old file
+      f_unlink(SELECTED_THEME_FILE);
     }
 
-    // Force default if no match for last selected theme
-    if (!found)
-      index = 0;
+    // Save selected theme (sets to default if nothing found)
+    setDefaultTheme(index);
 
-    applyTheme(index);
-    setThemeIndex(index);
+    // Reset values (used below);
+    index = 0;
+    found = false;
   }
 
-  f_close(&file);
+  for (auto theme : themes) {
+    if (strncmp(theme->getName(), g_eeGeneral.selectedTheme, SELECTED_THEME_NAME_LEN) == 0) {
+      found = true;
+      break;
+    }
+    index++;
+  }
+
+  // Force default if no match for last selected theme
+  if (!found)
+    index = 0;
+
+  applyTheme(index);
+  setThemeIndex(index);
 }
 
 char ** ThemePersistance::getColorNames()
@@ -415,16 +444,10 @@ bool ThemePersistance::createNewTheme(std::string name, ThemeFile &theme)
 
 void ThemePersistance::setDefaultTheme(int index)
 {
-  FIL file;
   if (index >= 0 && index < (int) themes.size()) {
-    auto theme = themes[index];
-    FRESULT status = f_open(&file, SELECTED_THEME_FILE, FA_CREATE_ALWAYS | FA_WRITE);
-    if (status != FR_OK) return;
-
+    strAppend(g_eeGeneral.selectedTheme, themes[index]->getName(), SELECTED_THEME_NAME_LEN);
+    SET_DIRTY();
     currentTheme = index;
-    if (index > 0)
-      f_printf(&file, theme->getPath().c_str());
-    f_close(&file);
   }
 }
 

--- a/radio/src/gui/colorlcd/theme_manager.cpp
+++ b/radio/src/gui/colorlcd/theme_manager.cpp
@@ -111,13 +111,19 @@ static const struct YamlNode struct_YAMLThemeColors[] = {
   YAML_END
 };
 
-static const struct YamlNode struct_YAMLTheme[] = {
+// This hack is required to ensure the YAML file written is backward compatible with
+// the old parser. Otherwise older versions of EdgeTX will not load the theme files.
+// TODO: Remove this sometime in the future
+static const struct YamlNode w_struct_YAMLTheme[] = {
+  YAML_STRUCT("---\r\nsummary", (NAME_LENGTH + AUTHOR_LENGTH + INFO_LENGTH + 3) * 8, struct_YAMLThemeSummary, NULL),
+  YAML_STRUCT("colors", (COLOR_COUNT - 2) * 32, struct_YAMLThemeColors, NULL),
+  YAML_END
+};
+static const struct YamlNode r_struct_YAMLTheme[] = {
   YAML_STRUCT("summary", (NAME_LENGTH + AUTHOR_LENGTH + INFO_LENGTH + 3) * 8, struct_YAMLThemeSummary, NULL),
   YAML_STRUCT("colors", (COLOR_COUNT - 2) * 32, struct_YAMLThemeColors, NULL),
   YAML_END
 };
-
-static const struct YamlNode themeRootNode = YAML_ROOT(struct_YAMLTheme);
 
 static const char *colorNames[COLOR_COUNT] = {
     "DEFAULT",    "PRIMARY1",   "PRIMARY2",   "PRIMARY3",
@@ -173,6 +179,7 @@ std::vector<std::string> ThemeFile::getThemeImageFileNames()
 void ThemeFile::serialize()
 {
   struct YAMLTheme yt;
+  struct YamlNode themeRootNode = YAML_ROOT(w_struct_YAMLTheme);
 
   strAppend(yt.summary.name, name, NAME_LENGTH);
   strAppend(yt.summary.author, author, AUTHOR_LENGTH);
@@ -190,6 +197,7 @@ void ThemeFile::serialize()
 void ThemeFile::deSerialize()
 {
   struct YAMLTheme yt;
+  struct YamlNode themeRootNode = YAML_ROOT(r_struct_YAMLTheme);
 
   YamlTreeWalker tree;
   tree.reset(&themeRootNode, (uint8_t*)&yt);

--- a/radio/src/gui/colorlcd/theme_manager.cpp
+++ b/radio/src/gui/colorlcd/theme_manager.cpp
@@ -183,7 +183,7 @@ void ThemeFile::serialize()
 
   auto err = writeFileYaml(path.c_str(), &themeRootNode, (uint8_t*)&yt, 0);
   if (err != nullptr) {
-    ALERT(STR_WARNING, err, nullptr);
+    ALERT(STR_WARNING, err, AU_WARNING1);
   }
 }
 
@@ -203,7 +203,7 @@ void ThemeFile::deSerialize()
       colorList.emplace_back(ColorEntry{(LcdColorIndex)(i+1), yt.colors.colors[i]});
     }
   } else {
-    ALERT(STR_WARNING, err, nullptr);
+    ALERT(STR_WARNING, err, AU_WARNING1);
   }
 }
 

--- a/radio/src/gui/colorlcd/theme_manager.h
+++ b/radio/src/gui/colorlcd/theme_manager.h
@@ -29,10 +29,14 @@
 #include "sdcard.h"
 #include "str_functions.h"
 
+#define COLOR_COUNT 13
+
+#define AUTHOR_LENGTH 50
+#define INFO_LENGTH 255
+#define NAME_LENGTH 26
+
 class ThemePersistance;
 extern ThemePersistance themePersistance;
-
-#define COLOR_COUNT 13
 
 struct ColorEntry
 {
@@ -42,10 +46,6 @@ struct ColorEntry
     bool operator== (const ColorEntry &a) { return this->colorNumber == a.colorNumber; }
 };
 
-
-#define AUTHOR_LENGTH 50
-#define INFO_LENGTH 255
-#define NAME_LENGTH 26
 class ThemeFile
 {
  public:
@@ -55,16 +55,8 @@ class ThemeFile
       info[0] = '\0';
     }
     
-    ThemeFile(std::string themePath);
-    ThemeFile(const ThemeFile &theme) :
-        colorList(theme.colorList),
-        _imageFileNames(theme._imageFileNames)
-    {
-        path = theme.path;
-        strAppend(name, theme.name, NAME_LENGTH);
-        strAppend(author, theme.author, AUTHOR_LENGTH);
-        strAppend(info, theme.info, INFO_LENGTH);
-    }
+    ThemeFile(std::string themePath, bool loadYAML = true);
+
     virtual ~ThemeFile() {}
 
     ThemeFile& operator= (const ThemeFile& theme);
@@ -86,17 +78,6 @@ class ThemeFile
 
         return nullptr;
     }
-
-    uint32_t getColorByName(std::string colorName) {
-
-        auto colorIndex = findColorIndex(colorName.c_str());
-        ColorEntry a = {colorIndex, 0};
-        auto colorEntry = std::find(colorList.begin(), colorList.end(), a);
-        if (colorEntry != colorList.end())
-            return colorEntry->colorValue;
-        
-        return 0;
-    }
     
     void setName(std::string name) { strAppend(this->name, name.c_str(), NAME_LENGTH); }
     void setAuthor(std::string author) { strAppend(this->author, author.c_str(), AUTHOR_LENGTH); }
@@ -105,7 +86,6 @@ class ThemeFile
 
     std::vector<ColorEntry>& getColorList() { return colorList; }
     void setColor(LcdColorIndex colorIndex, uint32_t color);
-    void setColorByIndex(int index, uint32_t color);
 
     virtual std::vector<std::string> getThemeImageFileNames();
     void applyTheme();
@@ -120,17 +100,7 @@ class ThemeFile
     void applyColors();
     virtual void applyBackground();
 
-    enum ScanState
-    {
-        none,
-        summary,
-        colors
-    };
-
     void deSerialize();
-    bool convertRGB(char *pColorRGB, uint32_t &color);
-    LcdColorIndex findColorIndex(const char *name);
-    bool readNextLine(FIL &file, char *line, int maxlen);
 };
 
 

--- a/radio/src/gui/colorlcd/theme_manager.h
+++ b/radio/src/gui/colorlcd/theme_manager.h
@@ -33,7 +33,6 @@
 
 #define AUTHOR_LENGTH 50
 #define INFO_LENGTH 255
-#define NAME_LENGTH 26
 
 class ThemePersistance;
 extern ThemePersistance themePersistance;
@@ -79,7 +78,7 @@ class ThemeFile
         return nullptr;
     }
     
-    void setName(std::string name) { strAppend(this->name, name.c_str(), NAME_LENGTH); }
+    void setName(std::string name) { strAppend(this->name, name.c_str(), SELECTED_THEME_NAME_LEN); }
     void setAuthor(std::string author) { strAppend(this->author, author.c_str(), AUTHOR_LENGTH); }
     void setInfo(std::string info) { strAppend(this->info, info.c_str(), INFO_LENGTH); }
     void setPath(std::string path) { this->path = path; }
@@ -92,7 +91,7 @@ class ThemeFile
 
   protected:
     std::string path;
-    char name[NAME_LENGTH + 1];
+    char name[SELECTED_THEME_NAME_LEN + 1];
     char author[AUTHOR_LENGTH + 1];
     char info[INFO_LENGTH + 1];
     std::vector<ColorEntry> colorList;

--- a/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
@@ -458,6 +458,7 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_SIGNED( "uartSampleMode", 2 ),
   YAML_UNSIGNED( "stickDeadZone", 3 ),
   YAML_PADDING( 1 ),
+  YAML_STRING("selectedTheme", 26),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_x10.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x10.cpp
@@ -489,6 +489,7 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_PADDING( 1 ),
   YAML_SIGNED( "imuMax", 8 ),
   YAML_SIGNED( "imuOffset", 8 ),
+  YAML_STRING("selectedTheme", 26),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
@@ -487,6 +487,7 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_PADDING( 1 ),
   YAML_SIGNED( "imuMax", 8 ),
   YAML_SIGNED( "imuOffset", 8 ),
+  YAML_STRING("selectedTheme", 26),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_labelslist.cpp
+++ b/radio/src/storage/yaml/yaml_labelslist.cpp
@@ -165,7 +165,7 @@ static bool find_node(void* ctx, char* buf, uint8_t len)
     return true;
 }
 
-static void set_attr(void* ctx, char* buf, uint8_t len)
+static void set_attr(void* ctx, char* buf, uint16_t len)
 {
   char value[LABELS_LENGTH + 1];
   if(len > LABELS_LENGTH) {

--- a/radio/src/storage/yaml/yaml_modelslist.cpp
+++ b/radio/src/storage/yaml/yaml_modelslist.cpp
@@ -95,7 +95,7 @@ static bool find_node(void* ctx, char* buf, uint8_t len)
     return true;
 }
 
-static void set_attr(void* ctx, char* buf, uint8_t len)
+static void set_attr(void* ctx, char* buf, uint16_t len)
 {
   char fnamebuf[LEN_MODEL_FILENAME + 1];
   modelslist_iter* mi = (modelslist_iter*)ctx;

--- a/radio/src/storage/yaml/yaml_parser.cpp
+++ b/radio/src/storage/yaml/yaml_parser.cpp
@@ -110,12 +110,6 @@ YamlParser::parse(const char* buffer, unsigned int size)
                 break;
             }
 
-            if (*c == '\r' || *c == '\n') {
-                saved_state = state;
-                state = ps_CRLF;
-                continue;
-            }
-            
             if (indent < getLastIndent()) {
                 // go up as many levels as necessary
                 do {
@@ -146,6 +140,12 @@ YamlParser::parse(const char* buffer, unsigned int size)
                 if (!calls->to_next_elmt(ctx)) {
                     return DONE_PARSING;
                 }
+            }
+
+            if (*c == '\r' || *c == '\n') {
+                saved_state = state;
+                state = ps_CRLF;
+                continue;
             }
 
             state = ps_Attr;

--- a/radio/src/storage/yaml/yaml_parser.cpp
+++ b/radio/src/storage/yaml/yaml_parser.cpp
@@ -110,6 +110,12 @@ YamlParser::parse(const char* buffer, unsigned int size)
                 break;
             }
 
+            if (*c == '\r' || *c == '\n') {
+                saved_state = state;
+                state = ps_CRLF;
+                continue;
+            }
+
             if (indent < getLastIndent()) {
                 // go up as many levels as necessary
                 do {
@@ -140,12 +146,6 @@ YamlParser::parse(const char* buffer, unsigned int size)
                 if (!calls->to_next_elmt(ctx)) {
                     return DONE_PARSING;
                 }
-            }
-
-            if (*c == '\r' || *c == '\n') {
-                saved_state = state;
-                state = ps_CRLF;
-                continue;
             }
 
             state = ps_Attr;
@@ -302,11 +302,12 @@ YamlParser::parse(const char* buffer, unsigned int size)
             break;
                 
         case ps_CRLF:
-            if (*c == '\n') {
-                // reset state at EOL
-                reset();
-            }
-            break;
+            // Skip EOL chars and blank lines
+            while (c < end && (*c == '\r' || *c == '\n'))
+              c += 1;
+            // reset state at EOL
+            reset();
+            continue;
         }
 
         c++;

--- a/radio/src/storage/yaml/yaml_parser.cpp
+++ b/radio/src/storage/yaml/yaml_parser.cpp
@@ -302,12 +302,15 @@ YamlParser::parse(const char* buffer, unsigned int size)
             break;
                 
         case ps_CRLF:
-            // Skip EOL chars and blank lines
-            while (c < end && (*c == '\r' || *c == '\n'))
-              c += 1;
-            // reset state at EOL
-            reset();
-            continue;
+            if (*c == '\n') {
+                // Skip blank lines
+                while (c < end && (*c == '\r' || *c == '\n'))
+                  c += 1;
+                // reset state at EOL
+                reset();
+                continue;
+            }
+            break;
         }
 
         c++;

--- a/radio/src/storage/yaml/yaml_parser.h
+++ b/radio/src/storage/yaml/yaml_parser.h
@@ -24,7 +24,7 @@
 
 #include <stdint.h>
 
-#define MAX_STR 100
+#define MAX_STR 256
 #define MAX_DEPTH 16 // 12 real + 4 virtual
 
 struct YamlParserCalls
@@ -33,7 +33,7 @@ struct YamlParserCalls
     bool (*to_child)     (void* ctx);
     bool (*to_next_elmt) (void* ctx);
     bool (*find_node)    (void* ctx, char* buf, uint8_t len);
-    void (*set_attr)     (void* ctx, char* buf, uint8_t len);
+    void (*set_attr)     (void* ctx, char* buf, uint16_t len);
 };
 
 class YamlParser
@@ -70,7 +70,7 @@ class YamlParser
     // scratch buffer w/ 16 bytes
     // used for attribute and values
     char    scratch_buf[MAX_STR];
-    uint8_t scratch_len;
+    uint16_t scratch_len;
 
     bool node_found;
     bool eof;

--- a/radio/src/storage/yaml/yaml_tree_walker.cpp
+++ b/radio/src/storage/yaml/yaml_tree_walker.cpp
@@ -29,7 +29,7 @@
 
 #define MIN(a,b) (a < b ? a : b)
 
-static void copy_string(char* dst, uint8_t dst_len, const char* src,
+static void copy_string(char* dst, uint16_t dst_len, const char* src,
                         uint8_t src_len)
 {
   if (src_len < dst_len) {
@@ -57,7 +57,7 @@ uint32_t yaml_parse_enum(const struct YamlIdStr* choices, const char* val, uint8
 
 static void yaml_set_attr(void* user, uint8_t* ptr, uint32_t bit_ofs,
                           const YamlNode* node, const char* val,
-                          uint8_t val_len)
+                          uint16_t val_len)
 {
   uint32_t i = 0;
 
@@ -265,7 +265,7 @@ bool YamlTreeWalker::findNode(const char* tag, uint8_t tag_len)
         setAttrValue((char*)tag, tag_len);
         return true;
     }
-            
+
     while(attr && attr->type != YDT_NONE) {
 
         if ((tag_len == attr->tag_len)
@@ -442,7 +442,7 @@ void YamlTreeWalker::toNextAttr()
     }
 }
 
-void YamlTreeWalker::setAttrValue(char* buf, uint8_t len)
+void YamlTreeWalker::setAttrValue(char* buf, uint16_t len)
 {
     if (!buf || !len || isIdxInvalid())
         return;
@@ -684,7 +684,7 @@ static bool find_node(void* ctx, char* buf, uint8_t len)
     return ((YamlTreeWalker*)ctx)->findNode(buf,len);
 }
 
-static void set_attr(void* ctx, char* buf, uint8_t len)
+static void set_attr(void* ctx, char* buf, uint16_t len)
 {
     ((YamlTreeWalker*)ctx)->setAttrValue(buf,len);
 }

--- a/radio/src/storage/yaml/yaml_tree_walker.h
+++ b/radio/src/storage/yaml/yaml_tree_walker.h
@@ -156,7 +156,7 @@ public:
 
     bool isElmtEmpty(uint8_t* data);
 
-    void setAttrValue(char* buf, uint8_t len);
+    void setAttrValue(char* buf, uint16_t len);
 
     bool generate(yaml_writer_func wf, void* opaque);
 


### PR DESCRIPTION
Summary of changes:
- Remove hard wired code and use YAML parser for theme files.
- Fix handling of empty input lines in YAML parser.
- Increase size of YAML parser variables to handle theme 'info' property length.
