### PR TITLE
Fix attempt for boot issue

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1689,6 +1689,8 @@ int main()
 #endif
 
   boardInit();
+
+  modulePortInit();
   pulsesInit();
 
   checkValidMCU();

--- a/radio/src/storage/storage_common.cpp
+++ b/radio/src/storage/storage_common.cpp
@@ -21,6 +21,7 @@
 
 #include "opentx.h"
 #include "timers_driver.h"
+#include "tasks/mixer_task.h"
 
 #if defined(MULTIMODULE)
   #include "pulses/multi.h"
@@ -56,7 +57,10 @@ void preModelLoad()
   logsClose();
 #endif
 
-  pulsesStop();
+  if (mixerTaskStarted()) {
+    pulsesStop();
+  }
+
   stopTrainer();
 #if defined(COLORLCD)
   deleteCustomScreens();
@@ -165,7 +169,13 @@ void postModelLoad(bool alarms)
     PLAY_MODEL_NAME();
   }
 #endif
-  pulsesStart();
+
+  // Mixer should only be restarted
+  // if we are switching between models,
+  // not on first boot (started later on)
+  if (mixerTaskStarted()) {
+    pulsesStart();
+  }
 
 #if defined(SDCARD)
   referenceModelAudioFiles();

--- a/radio/src/targets/common/arm/stm32/bluetooth_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/bluetooth_driver.cpp
@@ -97,6 +97,7 @@ void bluetoothDisable()
   LL_GPIO_SetOutputPin(BT_EN_GPIO, BT_EN_GPIO_PIN);
   if (_bt_usart_ctx) {
     STM32SerialDriver.deinit(_bt_usart_ctx);
+    _bt_usart_ctx = nullptr;
   }
 }
 

--- a/radio/src/tasks/mixer_task.cpp
+++ b/radio/src/tasks/mixer_task.cpp
@@ -35,6 +35,7 @@ static RTOS_MUTEX_HANDLE mixerMutex;
 // The mixer will start in 'paused' mode
 // and start working properly once
 // mixerTaskStart() has been called.
+static bool _mixer_started = false;
 static bool _mixer_running = false;
 static bool _mixer_exit = false;
 
@@ -61,8 +62,14 @@ void mixerTaskInit()
                    MIXER_STACK_SIZE, MIXER_TASK_PRIO);
 }
 
+bool mixerTaskStarted()
+{
+  return _mixer_started;
+}
+
 void mixerTaskStart()
 {
+  _mixer_started = true;
   _mixer_running = true;
 }
 

--- a/radio/src/tasks/mixer_task.h
+++ b/radio/src/tasks/mixer_task.h
@@ -30,6 +30,10 @@ TASK_FUNCTION(mixerTask);
 // init, create and start the OS task itself
 void mixerTaskInit();
 
+// return true if the mixer has
+// already started at least once since boot
+bool mixerTaskStarted();
+
 // start the main computations
 // and pushing channels out
 //


### PR DESCRIPTION
I must admit I'm not quite sure why this is an issue at this point, but we used to have the mixer (and thus sending stuff to modules / initialising telemetry, etc) running at a later point than today. This PR re-establishes the *status quo ante*.