### PR TITLE
fix: Companion X10s Express, ISRM receiver name missing

### DIFF
--- a/companion/src/firmwares/edgetx/yaml_moduledata.cpp
+++ b/companion/src/firmwares/edgetx/yaml_moduledata.cpp
@@ -419,6 +419,7 @@ bool convert<ModuleData>::decode(const Node& node, ModuleData& rhs)
               if (rcvrname.IsMap()) {
                 if (rcvrname["val"]) {
                   rcvrname["val"] >> rhs.access.receiverName[i];
+                  rhs.access.receivers |= (1 << i);       // fix colorLCD radios not writing tag receivers
                 }
               }
             }

--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -695,6 +695,12 @@ void ModulePanel::update()
   ui->registrationIdLabel->setVisible(mask & MASK_ACCESS);
   ui->registrationId->setVisible(mask & MASK_ACCESS);
 
+  // fix 2.8 not writing yaml tag receiver:
+  for(uint8_t receiverIdx = 0; receiverIdx < 3; receiverIdx++) {
+    if(module.access.receiverName[receiverIdx][0])
+      module.access.receivers |= (1 << receiverIdx);
+  }
+
   ui->rx1Label->setVisible((mask & MASK_ACCESS) && (module.access.receivers & (1 << 0)));
   ui->clearRx1->setVisible((mask & MASK_ACCESS) && (module.access.receivers & (1 << 0)));
   ui->rx1->setVisible((mask & MASK_ACCESS) && (module.access.receivers & (1 << 0)));

--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -695,12 +695,6 @@ void ModulePanel::update()
   ui->registrationIdLabel->setVisible(mask & MASK_ACCESS);
   ui->registrationId->setVisible(mask & MASK_ACCESS);
 
-  // fix 2.8 not writing yaml tag receiver:
-  for(uint8_t receiverIdx = 0; receiverIdx < 3; receiverIdx++) {
-    if(module.access.receiverName[receiverIdx][0])
-      module.access.receivers |= (1 << receiverIdx);
-  }
-
   ui->rx1Label->setVisible((mask & MASK_ACCESS) && (module.access.receivers & (1 << 0)));
   ui->clearRx1->setVisible((mask & MASK_ACCESS) && (module.access.receivers & (1 << 0)));
   ui->rx1->setVisible((mask & MASK_ACCESS) && (module.access.receivers & (1 << 0)));

--- a/radio/src/gui/colorlcd/access_settings.cpp
+++ b/radio/src/gui/colorlcd/access_settings.cpp
@@ -38,8 +38,8 @@ static void startBindWaitDialog(Window* parent, uint8_t moduleIdx,
       bindInfo.candidateReceiversNames[bindInfo.selectedReceiverIndex];
   memcpy(g_model.moduleData[moduleIdx].pxx2.receiverName[receiverIdx],
          receiverName, PXX2_LEN_RX_NAME);
-  storageDirty(EE_MODEL);
   bindInfo.step = BIND_OK;
+  setPXX2ReceiverUsed(moduleIdx, receiverIdx);
   moduleState[moduleIdx].mode = MODULE_MODE_NORMAL;
   new MessageDialog(parent, STR_BIND, STR_BIND_OK);
 #else
@@ -161,6 +161,7 @@ void BindWaitDialog::checkEvents()
       deleteLater();
       if (bindInfo.step == BIND_OK) {
         POPUP_INFORMATION(STR_REG_OK);
+        setPXX2ReceiverUsed(moduleIdx, receiverIdx);
       }
       return;
     }

--- a/radio/src/pulses/modules_helpers.h
+++ b/radio/src/pulses/modules_helpers.h
@@ -740,6 +740,7 @@ inline bool isPXX2ReceiverUsed(uint8_t moduleIdx, uint8_t receiverIdx)
 inline void setPXX2ReceiverUsed(uint8_t moduleIdx, uint8_t receiverIdx)
 {
   g_model.moduleData[moduleIdx].pxx2.receivers |= (1 << receiverIdx);
+  storageDirty(EE_MODEL);
 }
 
 inline bool isPXX2ReceiverEmpty(uint8_t moduleIdx, uint8_t receiverIdx)

--- a/radio/src/storage/storage_common.cpp
+++ b/radio/src/storage/storage_common.cpp
@@ -133,7 +133,7 @@ void postModelLoad(bool alarms)
     memcpy(g_model.modelRegistrationID, g_eeGeneral.ownerRegistrationID, PXX2_LEN_REGISTRATION_ID);
   }
 
-  // fix yaml tag receiver: not written in 2.8
+  // fix colorLCD radios not writing yaml tag receivers
   ModuleData *intModule = &g_model.moduleData[INTERNAL_MODULE];
   ModuleData *extModule = &g_model.moduleData[EXTERNAL_MODULE];
 

--- a/radio/src/storage/storage_common.cpp
+++ b/radio/src/storage/storage_common.cpp
@@ -132,6 +132,19 @@ void postModelLoad(bool alarms)
   if (is_memclear(g_model.modelRegistrationID, PXX2_LEN_REGISTRATION_ID)) {
     memcpy(g_model.modelRegistrationID, g_eeGeneral.ownerRegistrationID, PXX2_LEN_REGISTRATION_ID);
   }
+
+  // fix yaml tag receiver: not written in 2.8
+  ModuleData *intModule = &g_model.moduleData[INTERNAL_MODULE];
+  ModuleData *extModule = &g_model.moduleData[EXTERNAL_MODULE];
+
+  for(uint8_t receiverIdx = 0; receiverIdx < 3; receiverIdx++) {
+    if(intModule->pxx2.receiverName[receiverIdx][0])
+        intModule->pxx2.receivers |= (1 << receiverIdx);
+
+    if(extModule->pxx2.receiverName[receiverIdx][0])
+        extModule->pxx2.receivers |= (1 << receiverIdx);
+  }
+  storageDirty(EE_MODEL);
 #endif
 
 #if defined(MULTIMODULE) && defined(MULTI_PROTOLIST)


### PR DESCRIPTION
fixes https://github.com/EdgeTX/edgetx/issues/3273

The reason Companion doesn't show any registered ACCESS receivers is simply because color LCD radios don't populate the pxx2.receivers bit field after successfully binding receivers. Companion checks the bit field in yaml tag receivers: and as the bit filed results to no bit set it doesn't show the receiver names. Which in turn leads to the situation that all receivers are lost when playing back the model.yml file to the radio, forcing users to bind their receivers again.

Changes:
1. Color LCD (and simu) now set the correct bit in the pxx2.receivers bit field after a successful (or simulated) bind
2. Companion and radio firmware check after loading model.yml if pxx2 receiver names are given. If so it updates the pxx2.receivers bit field accordingly to spare users having to rebind their receivers.

As this is not only a 2.9 problem (it's present at least in 2.8.1 too) I think a similar fix (or a better one) should be worked out for 2.8.2 as well.

Edit: actually this can be cherry picked into 2.8.2 if desired

Edit2: don't know why the checks are failing with:
```
 Error response from daemon: received unexpected HTTP status: 503 Service Unavailable
  Warning: Docker pull failed with exit code 1, back off 1.551 seconds before retry.
```