### PR TITLE
fix(cpn) - paste model to empty slot on B&W radios

### DIFF
--- a/companion/src/apppreferencesdialog.ui
+++ b/companion/src/apppreferencesdialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>864</width>
+    <width>865</width>
     <height>673</height>
    </rect>
   </property>
@@ -45,7 +45,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>3</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="profileTab">
       <attribute name="title">
@@ -936,7 +936,7 @@ Mode 4:
             <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option  maintains the behaviour from older OpenTx versions where empty model slots are preserved when a model is deleted or moved. &lt;/p&gt;&lt;p&gt;When this option is de-selected, the other models may be re-arranged to fill the gap left by the removed  model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
            </property>
            <property name="text">
-            <string>Remove empty model slots when deleting models (only applies for radios w/out categories)</string>
+            <string>Remove empty model slots when deleting models (only applies for radios w/out labels)</string>
            </property>
           </widget>
          </item>

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -865,7 +865,7 @@ void MdiChild::pasteModelData(const QMimeData * mimeData, const QModelIndex row,
   bool hasOwnData = modelsListModel->hasOwnMimeData(mimeData);
   move = (move && hasOwnData);
 
-  qDebug().nospace() << "row: " << row << "; ins: " << insert << "; mv: " << move << "; row modelIdx: " << modelIdx;
+  //qDebug().nospace() << "row: " << row << "; ins: " << insert << "; mv: " << move << "; row modelIdx: " << modelIdx;
 
   // Model data
   for (int i=0; i < modelsList.size(); ++i) {
@@ -935,7 +935,7 @@ void MdiChild::pasteModelData(const QMimeData * mimeData, const QModelIndex row,
       }
       radioData.addLabelsFromModels();
     }
-    qDebug().nospace() << "i: " << i << "; modelIdx:" << modelIdx << "; origMdlIdx: " << origMdlIdx << "; doMove: " << doMove << "; inserts:" << inserts << "; deletes: " << deletesList;
+    //qDebug().nospace() << "i: " << i << "; modelIdx:" << modelIdx << "; origMdlIdx: " << origMdlIdx << "; doMove: " << doMove << "; inserts:" << inserts << "; deletes: " << deletesList;
 
     ++modelIdx;
   }

--- a/companion/src/mdichild.h
+++ b/companion/src/mdichild.h
@@ -53,8 +53,8 @@ class MdiChild : public QWidget
       ACT_GEN_CPY,
       ACT_GEN_PST,
       ACT_GEN_SIM,
-      ACT_ITM_EDT,  // edit model/rename category
-      ACT_ITM_DEL,  // delete model or cat
+      ACT_ITM_EDT,
+      ACT_ITM_DEL,
       ACT_LBL_ADD,
       ACT_LBL_DEL,
       ACT_LBL_MVU,  // Move up
@@ -81,7 +81,6 @@ class MdiChild : public QWidget
 
     QString currentFile() const;
     QString userFriendlyCurrentFile() const;
-    QVector<int> getSelectedCategories() const;
     QVector<int> getSelectedModels() const;
     QList<QAction *> getGeneralActions();
     QList<QAction *> getEditActions();

--- a/companion/src/modelslist.h
+++ b/companion/src/modelslist.h
@@ -31,15 +31,15 @@ class ModelListItem
     enum ModelListItemFlags { MarkedForCut = 0x01 };
 
     explicit ModelListItem(const QVector<QVariant> & itemData);
-    explicit ModelListItem(ModelListItem * parent, int categoryIndex, int modelIndex);
+    explicit ModelListItem(ModelListItem * parent, int modelIndex);
     ~ModelListItem();
 
     ModelListItem * child(int number);
     int childCount() const;
     int columnCount() const;
     QVariant data(int column) const;
-    ModelListItem * appendChild(int categoryIndex, int modelIndex);
-    ModelListItem * insertChild(const int row, int categoryIndex, int modelIndex);
+    ModelListItem * appendChild( int modelIndex);
+    ModelListItem * insertChild(const int row, int modelIndex);
     bool removeChildren(int position, int count);
     bool insertChildren(int row, int count);
 
@@ -50,8 +50,6 @@ class ModelListItem
     void setParent(ModelListItem * p) { parentItem = p; }
     int getModelIndex() const { return modelIndex; }
     void setModelIndex(int value) { modelIndex = value; }
-    int getCategoryIndex() const { return categoryIndex; }
-    void setCategoryIndex(int value) { categoryIndex = value; }
     void setHighlightRX(int value) { highlightRX = value; }
     bool isHighlightRX() const { return highlightRX; }
 
@@ -59,14 +57,12 @@ class ModelListItem
     void setFlags(const quint16 & value) { flags = value; }
     void setFlag(const quint16 & flag, const bool on = true);
 
-    bool isCategory() const;
     bool isModel() const;
 
   private:
     QList<ModelListItem*> childItems;
     QVector<QVariant> itemData;
     ModelListItem * parentItem;
-    int categoryIndex;
     int modelIndex;
     quint16 flags;
     bool highlightRX;
@@ -92,7 +88,7 @@ class ModelsListModel : public QAbstractItemModel
 
     virtual QModelIndex index(int row, int column, const QModelIndex &parent = QModelIndex()) const Q_DECL_OVERRIDE;
     virtual QModelIndex parent(const QModelIndex &index) const Q_DECL_OVERRIDE;
-    virtual Qt::ItemFlags flags(const QModelIndex &index) const Q_DECL_OVERRIDE;    
+    virtual Qt::ItemFlags flags(const QModelIndex &index) const Q_DECL_OVERRIDE;
 
     virtual int rowCount(const QModelIndex &parent = QModelIndex()) const Q_DECL_OVERRIDE;
     virtual int columnCount(const QModelIndex &parent = QModelIndex()) const Q_DECL_OVERRIDE;
@@ -124,11 +120,8 @@ class ModelsListModel : public QAbstractItemModel
     static int countModelsInMimeData(const QMimeData * mimeData);
 
     QModelIndex getIndexForModel(const int modelIndex, QModelIndex parent = QModelIndex());
-    QModelIndex getIndexForCategory(const int categoryIndex);
     int getModelIndex(const QModelIndex & index) const;
-    int getCategoryIndex(const QModelIndex & index) const;
     int rowNumber(const QModelIndex & index = QModelIndex()) const;
-    bool isCategoryType(const QModelIndex & index) const;
     bool isModelType(const QModelIndex & index) const;
 
   public slots:


### PR DESCRIPTION
Fixes #3370

Summary of changes:
- fix paste
- housekeeping remove traces of old categories code