### PR TITLE
Various soft serial fixes

### DIFF
--- a/radio/src/io/multi_firmware_update.cpp
+++ b/radio/src/io/multi_firmware_update.cpp
@@ -233,6 +233,8 @@ const char * MultiFirmwareUpdateDriver::waitForInitialSync()
 
 const char * MultiFirmwareUpdateDriver::getDeviceSignature(uint8_t * signature) const
 {
+  clear();
+
   // Read signature
   sendByte(STK_READ_SIGN);
   sendByte(CRC_EOP);

--- a/radio/src/targets/common/arm/stm32/stm32_pulse_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_pulse_driver.cpp
@@ -70,7 +70,11 @@ void stm32_pulse_init(const stm32_pulse_timer_t* tim, uint32_t freq)
   }
   
   timInit.Prescaler = __LL_TIM_CALC_PSC(tim->TIM_Freq, freq);
-  timInit.Autoreload = STM32_DEFAULT_TIMER_AUTORELOAD;
+  if (IS_TIM_32B_COUNTER_INSTANCE(tim->TIMx)) {
+    timInit.Autoreload = 0xFFFFFFFFUL;
+  } else {
+    timInit.Autoreload = STM32_DEFAULT_TIMER_AUTORELOAD;
+  }
 
   enable_tim_clock(tim->TIMx);
   LL_TIM_Init(tim->TIMx, &timInit);

--- a/radio/src/targets/common/arm/stm32/stm32_softserial_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_softserial_driver.cpp
@@ -43,14 +43,21 @@ static const stm32_softserial_rx_port* _softserialPort;
 static void _softserial_exti()
 {
   if (rxBitCount == 0) {
+    auto port = _softserialPort;
+
+    // cheap debouncing...
+    for (uint8_t i = 0; i < 16; ++i) {
+      if (LL_GPIO_IsInputPinSet(port->GPIOx, port->GPIO_Pin) == 0)
+        return;
+    }
 
     // enable timer counter
-    auto TIMx = _softserialPort->TIMx;
+    auto TIMx = port->TIMx;
     LL_TIM_SetAutoReload(TIMx, (BITLEN + BITLEN/2) - 1);
     LL_TIM_EnableCounter(TIMx);
     
     // disable start bit interrupt
-    LL_EXTI_DisableIT_0_31(_softserialPort->EXTI_Line);
+    LL_EXTI_DisableIT_0_31(port->EXTI_Line);
   }
 }
 

--- a/radio/src/targets/common/arm/stm32/stm32_usart_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_usart_driver.cpp
@@ -557,14 +557,15 @@ void stm32_usart_isr(const stm32_usart_t* usart, etx_serial_callbacks_t* cb)
     // Drain RX
     while (status & (LL_USART_SR_RXNE | USART_FLAG_ERRORS)) {
 
-      // This will clear the RXNE bit in USART_DR register
-      uint8_t data = LL_USART_ReadReg(usart->USARTx, DR);
-
       if (status & USART_FLAG_ERRORS) {
         if (cb->on_error)
           cb->on_error();
       }
-      else {
+
+      if (status & LL_USART_SR_RXNE) {
+        // This will clear the RXNE bit in USART_DR register
+        uint8_t data = LL_USART_ReadReg(usart->USARTx, DR);
+
         if (cb->on_receive)
           cb->on_receive(data);
       }


### PR DESCRIPTION
Summary of changes:
- fixes for sending pulses/soft-serial using 32bit timers (X10E; mostly impacting MPM, DSM and similar)
- fixes for soft-serial RX (mostly X10E; caused by coupling btw. PPM & S.PORT lines)
- fix for USART driver RX side
