### PR TITLE
fix(cpn) - Fix throttle initialisation in Companion after changes in PR 3111.

### DIFF
--- a/companion/src/simulation/widgets/virtualjoystickwidget.cpp
+++ b/companion/src/simulation/widgets/virtualjoystickwidget.cpp
@@ -300,7 +300,7 @@ void VirtualJoystickWidget::loadDefaultsForMode(const unsigned mode)
 {
   if (((mode & 1) && stickSide == 'L') || (!(mode & 1) && stickSide == 'R')) {
     setStickConstraint(HOLD_Y, true);
-    setStickY(1.0);
+    setStickY(-1.0);
     onNodeYChanged();
   }
 }


### PR DESCRIPTION
I missed one change after fixing the vertical axis logic in PR 3111
The throttle initial position needs to be set to -1 (down).
