### PR TITLE
feat(radio,cpn) - Updates for new joystick system.

### DIFF
--- a/companion/src/apppreferencesdialog.cpp
+++ b/companion/src/apppreferencesdialog.cpp
@@ -97,12 +97,13 @@ void AppPreferencesDialog::accept()
   if (ui->joystickChkB ->isChecked()) {
     g.jsSupport(ui->joystickChkB ->isChecked());
     // Don't overwrite selected joystick if not connected. Avoid surprising the user.
-    if (ui->joystickCB->isEnabled())
-      g.jsCtrl(ui->joystickCB ->currentIndex());
+    if (ui->joystickCB->isEnabled()) {
+      profile.jsName(ui->joystickCB->currentText());
+      g.loadNamedJS();
+    }
   }
   else {
     g.jsSupport(false);
-    g.jsCtrl(0);
   }
 
   //  Updates tab
@@ -287,7 +288,8 @@ void AppPreferencesDialog::initSettings()
     }
     ui->joystickCB->clear();
     ui->joystickCB->insertItems(0, joystickNames);
-    ui->joystickCB->setCurrentIndex(g.jsCtrl());
+    int stick = joystick->findCurrent(g.currentProfile().jsName());
+    ui->joystickCB->setCurrentIndex(stick);
   }
   else {
     ui->joystickCB->clear();
@@ -614,8 +616,9 @@ void AppPreferencesDialog::on_joystickChkB_clicked() {
 }
 
 void AppPreferencesDialog::on_joystickcalButton_clicked() {
-   joystickDialog * jd=new joystickDialog(this, ui->joystickCB->currentIndex());
-   jd->exec();
+  g.currentProfile().jsName(ui->joystickCB->currentText());
+  joystickDialog * jd = new joystickDialog(this);
+  jd->exec();
 }
 #endif
 

--- a/companion/src/simulation/joystick.cpp
+++ b/companion/src/simulation/joystick.cpp
@@ -167,3 +167,13 @@ int Joystick::getAxisValue(int axis)
   } else
     return 0;
 }
+
+int Joystick::findCurrent(QString jsName)
+{
+  for (int i = 0; i < joystickNames.size(); i += 1) {
+    if (joystickNames[i] == jsName) {
+      return i;
+    }
+  }
+  return 0;
+}

--- a/companion/src/simulation/joystick.h
+++ b/companion/src/simulation/joystick.h
@@ -62,6 +62,8 @@ class Joystick : public QObject
     }
     int getAxisValue(int);
 
+    int findCurrent(QString jsName);
+
   private:
     QMap<int, Sint16> axes;
     QMap<int, Uint8> buttons;

--- a/companion/src/simulation/joystickdialog.cpp
+++ b/companion/src/simulation/joystickdialog.cpp
@@ -264,7 +264,6 @@ void joystickDialog::joystickOpen(int stick)
   else {
     QMessageBox::critical(this, CPN_STR_TTL_ERROR, tr("Cannot open joystick."));
   }
-fprintf(stderr,">>>>>> JSO %d %d\n",numAxes,numButtons);
   g.currentProfile().jsName(ui->joystickCB->currentText());
   g.loadNamedJS();
   loadGrid();

--- a/companion/src/simulation/joystickdialog.cpp
+++ b/companion/src/simulation/joystickdialog.cpp
@@ -209,11 +209,11 @@ void joystickDialog::populateButtonCombo(QComboBox * cb)
   for (i = 0; i < ttlTrims; i += 1) {
     wname = RawSource(RawSourceType::SOURCE_TYPE_TRIM, i).toString(nullptr, &radioSettings);
     if ((i == 0) || (i == 3)) {
-      cb->addItem(wname + " Left", i + ttlSwitches | JS_BUTTON_3POS_DN);
-      cb->addItem(wname + " Right", i + ttlSwitches | JS_BUTTON_3POS_UP);
+      cb->addItem(wname + " Left", (i + ttlSwitches) | JS_BUTTON_3POS_DN);
+      cb->addItem(wname + " Right", (i + ttlSwitches) | JS_BUTTON_3POS_UP);
     } else {
-      cb->addItem(wname + " Down", i + ttlSwitches | JS_BUTTON_3POS_DN);
-      cb->addItem(wname + " Up", i + ttlSwitches | JS_BUTTON_3POS_UP);
+      cb->addItem(wname + " Down", (i + ttlSwitches) | JS_BUTTON_3POS_DN);
+      cb->addItem(wname + " Up", (i + ttlSwitches) | JS_BUTTON_3POS_UP);
     }
   }
 }

--- a/companion/src/simulation/joystickdialog.cpp
+++ b/companion/src/simulation/joystickdialog.cpp
@@ -96,14 +96,14 @@ void joystickDialog::loadGrid()
       QSlider *s = new QSlider(Qt::Horizontal);
       s->setMinimum(-32767);
       s->setMaximum(32767);
-      sliders[row] = s;
+      sliders[i] = s;
       grid->addWidget(s, row/2, col+1, 1, 1);
       QCheckBox *c = new QCheckBox("");
-      invert[row] = c;
+      invert[i] = c;
       grid->addWidget(c, row/2, col+2, 1, 1);
       QComboBox *d = new QComboBox();
       populateSourceCombo(d);
-      sticks[row] = d;
+      sticks[i] = d;
       grid->addWidget(d, row/2, col+3, 1, 1);
     }
     if (row & 1) row += 1;
@@ -115,11 +115,11 @@ void joystickDialog::loadGrid()
       QSlider *s = new QSlider(Qt::Horizontal);
       s->setMinimum(0);
       s->setMaximum(1);
-      sliders[row] = s;
+      sliders[i+numAxes] = s;
       grid->addWidget(s, row/2, col+1, 1, 1);
       QComboBox *d = new QComboBox();
       populateButtonCombo(d);
-      sticks[row] = d;
+      sticks[i+numAxes] = d;
       grid->addWidget(d, row/2, col+3, 1, 1);
     }
   }

--- a/companion/src/simulation/joystickdialog.h
+++ b/companion/src/simulation/joystickdialog.h
@@ -58,6 +58,7 @@ class joystickDialog : public QDialog
     QSlider * sliders[MAX_JS_AXES + MAX_JS_BUTTONS];
     int step;
     int numAxes;
+    int numButtons;
     bool started;
 
     void loadGrid();

--- a/companion/src/simulation/joystickdialog.h
+++ b/companion/src/simulation/joystickdialog.h
@@ -46,7 +46,7 @@ class joystickDialog : public QDialog
     Q_OBJECT
 
   public:
-    explicit joystickDialog(QWidget *parent = 0, int stick=-1);
+    explicit joystickDialog(QWidget *parent = 0);
     ~joystickDialog();
     Joystick *joystick;
 
@@ -60,10 +60,12 @@ class joystickDialog : public QDialog
     int numAxes;
     bool started;
 
+    void loadGrid();
+
   private slots:
     void populateSourceCombo(QComboBox * cb);
     void populateButtonCombo(QComboBox * cb);
-    bool loadJoysticks(int stick = -1);
+    bool loadJoysticks();
     void joystickOpen(int stick);
     void joystickSetEnabled(bool enable);
     void onjoystickAxisValueChanged(int axis, int value);

--- a/companion/src/simulation/simulatorwidget.cpp
+++ b/companion/src/simulation/simulatorwidget.cpp
@@ -670,13 +670,15 @@ void SimulatorWidget::setupJoysticks()
 #ifdef JOYSTICKS
   bool joysticksEnabled = false;
 
-  if (g.jsSupport() && g.jsCtrl() > -1) {
+  if (g.jsSupport()) {
     if (!joystick)
       joystick = new Joystick(this, SDL_JOYSTICK_DEFAULT_EVENT_TIMEOUT, false, SDL_JOYSTICK_DEFAULT_AUTOREPEAT_DELAY);
     else
       joystick->close();
 
-    if (joystick && joystick->open(g.jsCtrl())) {
+    int stick = joystick->findCurrent(g.currentProfile().jsName());
+
+    if (joystick && joystick->open(stick)) {
       int numAxes = std::min(joystick->numAxes, MAX_JS_AXES);
       for (int j=0; j<numAxes; j++) {
         joystick->sensitivities[j] = 0;
@@ -860,8 +862,8 @@ void SimulatorWidget::onjoystickAxisValueChanged(int axis, int value)
 {
 #ifdef JOYSTICKS
   static const int ttlSticks = 4;
-  static const int ttlKnobs = Boards::getCapability(m_board, Board::Pots);
-  static const int ttlFaders = Boards::getCapability(m_board, Board::Sliders);
+  const int ttlKnobs = Boards::getCapability(m_board, Board::Pots);
+  const int ttlFaders = Boards::getCapability(m_board, Board::Sliders);
   static const int valueRange = 1024;
 
   if (!joystick || axis >= MAX_JS_AXES)
@@ -915,9 +917,6 @@ void SimulatorWidget::onjoystickButtonValueChanged(int button, bool state)
   int ttlSwitches = Boards::getCapability(m_board, Board::Switches);
 
   int btn = g.jsButton[button].button_idx();
-
-  if (g.jsButton[button].button_inv())
-    state = !state;
 
   int swtch = btn & JS_BUTTON_SWITCH_MASK;
  

--- a/companion/src/storage/appdata.cpp
+++ b/companion/src/storage/appdata.cpp
@@ -490,7 +490,7 @@ void AppData::saveNamedJS()
     }
   }
   
-  int oldestTime = namedJS[0].jsLastUsed();
+  unsigned int oldestTime = namedJS[0].jsLastUsed();
   int oldestN = 0;
   for (int i = 1; i < MAX_NAMED_JOYSTICKS; i += 1) {
     if (namedJS[i].jsLastUsed() < oldestTime) {

--- a/companion/src/storage/appdata.cpp
+++ b/companion/src/storage/appdata.cpp
@@ -266,6 +266,36 @@ bool JButtonData::existsOnDisk()
   return (m_settings.value(settingsPath() % button_idx_key(), -1).toInt() > -1);
 }
 
+NamedJStickData::NamedJStickData() : CompStoreObj(), index(-1)
+{
+  CompStoreObj::addObjectMapping(propertyGroup(), this);
+}
+
+bool NamedJStickData::existsOnDisk()
+{
+  return (m_settings.value(settingsPath() % stick_axe_key(), -1).toInt() > -1);
+}
+
+NamedJButtonData::NamedJButtonData() : CompStoreObj(), index(-1)
+{
+  CompStoreObj::addObjectMapping(propertyGroup(), this);
+}
+
+bool NamedJButtonData::existsOnDisk()
+{
+  return (m_settings.value(settingsPath() % button_idx_key(), -1).toInt() > -1);
+}
+
+NamedJSData::NamedJSData() : CompStoreObj(), index(-1)
+{
+  CompStoreObj::addObjectMapping(propertyGroup(), this);
+}
+
+bool NamedJSData::existsOnDisk()
+{
+  return (m_settings.value(settingsPath() % jsName(), -1).toInt() > -1);
+}
+
 
 // ** Profile class********************
 
@@ -411,12 +441,87 @@ AppData::AppData() :
     joystick[i].setIndex(i);
   for (int i = 0; i < MAX_JS_BUTTONS; i++)
     jsButton[i].setIndex(i);
+  for (int i = 0; i < MAX_NAMED_JOYSTICKS; i++) {
+    namedJS[i].setIndex(i);
+    for (int a = 0; a < MAX_JS_AXES; a += 1)
+      namedJS[i].joystick[a].setIndex(a, i);
+    for (int b = 0; b < MAX_JS_BUTTONS; b += 1)
+      namedJS[i].jsButton[b].setIndex(b, i);
+  }
 
   // Configure the updates
   for (int i = 0; i < MAX_COMPONENTS; i++) {
     component[i].setIndex(i);
     for (int j = 0; j < MAX_COMPONENT_ASSETS; j++) {
       component[i].asset[j].setIndexes(i, j);
+    }
+  }
+}
+
+void AppData::saveNamedJS(int i)
+{
+  namedJS[i].jsName(currentProfile().jsName());
+  for (int a = 0; a < MAX_JS_AXES; a += 1) {
+    namedJS[i].joystick[a].stick_axe(joystick[a].stick_axe());
+    namedJS[i].joystick[a].stick_max(joystick[a].stick_max());
+    namedJS[i].joystick[a].stick_med(joystick[a].stick_med());
+    namedJS[i].joystick[a].stick_min(joystick[a].stick_min());
+    namedJS[i].joystick[a].stick_min(joystick[a].stick_min());
+  }
+  for (int b = 0; b < MAX_JS_BUTTONS; b += 1) {
+    namedJS[i].jsButton[b].button_idx(jsButton[b].button_idx());
+  }
+  namedJS[i].jsLastUsed(time(NULL));
+}
+
+void AppData::saveNamedJS()
+{
+  for (int i = 0; i < MAX_NAMED_JOYSTICKS; i += 1) {
+    if (namedJS[i].jsName() == currentProfile().jsName()) {
+      saveNamedJS(i);
+      return;
+    }
+  }
+
+  for (int i = 0; i < MAX_NAMED_JOYSTICKS; i += 1) {
+    if (namedJS[i].jsName() == "") {
+      saveNamedJS(i);
+      return;
+    }
+  }
+  
+  int oldestTime = namedJS[0].jsLastUsed();
+  int oldestN = 0;
+  for (int i = 1; i < MAX_NAMED_JOYSTICKS; i += 1) {
+    if (namedJS[i].jsLastUsed() < oldestTime) {
+      oldestTime = namedJS[i].jsLastUsed();
+      oldestN = i;
+    }
+  }
+  saveNamedJS(oldestN);
+}
+
+void AppData::loadNamedJS(int i)
+{
+  for (int a = 0; a < MAX_JS_AXES; a += 1) {
+    joystick[a].stick_axe(namedJS[i].joystick[a].stick_axe());
+    joystick[a].stick_max(namedJS[i].joystick[a].stick_max());
+    joystick[a].stick_med(namedJS[i].joystick[a].stick_med());
+    joystick[a].stick_min(namedJS[i].joystick[a].stick_min());
+    joystick[a].stick_min(namedJS[i].joystick[a].stick_min());
+  }
+  for (int b = 0; b < MAX_JS_BUTTONS; b += 1) {
+    jsButton[b].button_idx(namedJS[i].jsButton[b].button_idx());
+  }
+  namedJS[i].jsLastUsed(time(NULL));
+}
+
+void AppData::loadNamedJS()
+{
+  for (int i = 0; i < MAX_NAMED_JOYSTICKS; i += 1) {
+    if (namedJS[i].jsName() == currentProfile().jsName()) {
+      loadNamedJS(i);
+      return;
     }
   }
 }
@@ -452,7 +557,14 @@ void AppData::initAll()
     joystick[i].init();
   for (int i = 0; i < MAX_JS_BUTTONS; i++)
     jsButton[i].init();
-  // Initialize the updatess
+  for (int i = 0; i < MAX_NAMED_JOYSTICKS; i++) {
+    namedJS[i].init();
+    for (int a = 0; a < MAX_JS_AXES; a += 1)
+      namedJS[i].joystick[a].init();
+    for (int b = 0; b < MAX_JS_BUTTONS; b += 1)
+      namedJS[i].jsButton[b].init();
+  }
+  // Initialize the updates
   for (int i = 0; i < MAX_COMPONENTS; i++) {
     component[i].init();
     for (int j = 0; j < MAX_COMPONENT_ASSETS; j++) {
@@ -471,6 +583,13 @@ void AppData::resetAllSettings()
     joystick[i].resetAll();
   for (int i = 0; i < MAX_JS_BUTTONS; i++)
     jsButton[i].resetAll();
+  for (int i = 0; i < MAX_NAMED_JOYSTICKS; i++) {
+    namedJS[i].resetAll();
+    for (int a = 0; a < MAX_JS_AXES; a += 1)
+      namedJS[i].joystick[a].resetAll();
+    for (int b = 0; b < MAX_JS_BUTTONS; b += 1)
+      namedJS[i].jsButton[b].resetAll();
+  }
   for (int i = 0; i < MAX_COMPONENTS; i++) {
     component[i].resetAll();
     for (int j = 0; j < MAX_COMPONENT_ASSETS; j++) {
@@ -489,6 +608,13 @@ void AppData::storeAllSettings()
     joystick[i].storeAll();
   for (int i = 0; i < MAX_JS_BUTTONS; i++)
     jsButton[i].storeAll();
+  for (int i = 0; i < MAX_NAMED_JOYSTICKS; i++) {
+    namedJS[i].storeAll();
+    for (int a = 0; a < MAX_JS_AXES; a += 1)
+      namedJS[i].joystick[a].storeAll();
+    for (int b = 0; b < MAX_JS_BUTTONS; b += 1)
+      namedJS[i].jsButton[b].storeAll();
+  }
   for (int i = 0; i < MAX_COMPONENTS; i++) {
     component[i].storeAll();
     for (int j = 0; j < MAX_COMPONENT_ASSETS; j++)
@@ -506,6 +632,7 @@ void AppData::sessionId(int index)
   if (index < 0 || index >= MAX_PROFILES || index == m_sessionId)
     return;
   m_sessionId = index;
+  loadNamedJS();
   emit sessionIdChanged(index);
   emit currentProfileChanged();
 }

--- a/companion/src/storage/appdata.h
+++ b/companion/src/storage/appdata.h
@@ -332,6 +332,15 @@ class JStickData: public CompStoreObj
   public slots:
     bool existsOnDisk();
 
+  public:
+    void clear() {
+      stick_axe(-1);
+      stick_med(-32768);
+      stick_max(32767);
+      stick_med(0);
+      stick_inv(0);
+    }
+
   protected:
     explicit JStickData();
     void setIndex(int idx) { index = idx; }
@@ -350,12 +359,17 @@ class JStickData: public CompStoreObj
     int index;
 };
 
-//! \brief JStickData class stores properties related to each joystick button (button number).
+//! \brief JButtonData class stores properties related to each joystick button (button number).
 class JButtonData: public CompStoreObj
 {
   Q_OBJECT
   public slots:
     bool existsOnDisk();
+
+  public:
+    void clear() {
+      button_idx(-1);
+    }
 
   protected:
     explicit JButtonData();
@@ -371,7 +385,7 @@ class JButtonData: public CompStoreObj
     int index;
 };
 
-//! \brief JStickData class stores properties related to each joystick axis (calibration/assignment/direction).
+//! \brief NamedJStickData class stores properties related to each joystick axis (calibration/assignment/direction).
 class NamedJStickData: public CompStoreObj
 {
   Q_OBJECT
@@ -397,7 +411,7 @@ class NamedJStickData: public CompStoreObj
     int index;
 };
 
-//! \brief JStickData class stores properties related to each joystick button (button number).
+//! \brief NamedJButtonData class stores properties related to each joystick button (button number).
 class NamedJButtonData: public CompStoreObj
 {
   Q_OBJECT
@@ -696,6 +710,12 @@ class AppData: public CompStoreObj
     FwRevision fwRev;
     ComponentData component[MAX_COMPONENTS];
 
+    void clearJSData() {
+      for (int i = 0; i < MAX_JS_AXES; i += 1)
+        joystick[i].clear();
+      for (int i = 0; i < MAX_JS_BUTTONS; i += 1)
+        jsButton[i].clear();
+    }
     void saveNamedJS();
     void loadNamedJS();
 

--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -638,6 +638,12 @@ PACK(struct USBJoystickChData {
 
 #if defined(USBJ_EX)
   NOBACKUP(
+    uint8_t btnCount() {
+      // Use one less joystick button for 2POS and 3POS switches for Companion mode
+      if ((param == USBJOYS_BTN_MODE_COMPANION) && (switch_npos > 0) && (switch_npos < 3))
+        return switch_npos;
+      return switch_npos + 1;
+    }
     uint8_t lastBtnNumNoCLip() {
       uint8_t last = btn_num + switch_npos;
       // Use one less joystick button for 2POS and 3POS switches for Companion mode

--- a/radio/src/usb_joystick.cpp
+++ b/radio/src/usb_joystick.cpp
@@ -318,7 +318,7 @@ int setupUSBJoystick()
     else if (_usbJoystickIfMode == USBJOYS_MULTIAXIS) joystickType = 0x08;
 
     _hidReportDesc[3] = joystickType;
-    _hidReportDesc[13] = buttonCount;
+    _hidReportDesc[13] = buttonCount ? buttonCount : 1;
     _hidReportDesc[19] = USBJ_BUTTON_SIZE;
 
     // generic axis types

--- a/radio/src/usb_joystick.cpp
+++ b/radio/src/usb_joystick.cpp
@@ -96,7 +96,7 @@ static const uint8_t HID_JOYSTICK_ReportDesc[] =
     0x09, 0x34,                    //         USAGE (Ry)
     0x09, 0x35,                    //         USAGE (Rz)
     0x09, 0x36,                    //         USAGE (Slider)
-    0x09, 0x36,                    //         USAGE (Slider)
+    0x09, 0x37,                    //         USAGE (Dial)
     0x16, 0x00, 0x00,              //         LOGICAL_MINIMUM (0)
     0x26, 0xFF, 0x07,              //         LOGICAL_MAXIMUM (2047)
     0x75, 0x10,                    //         REPORT_SIZE (16)

--- a/radio/src/usb_joystick.cpp
+++ b/radio/src/usb_joystick.cpp
@@ -209,6 +209,7 @@ int setupUSBJoystick()
 
     uint8_t genAxisCount = 0;
     uint8_t simAxisCount = 0;
+    uint8_t buttonCount = 0;
 
     // sort channels by type
     uint8_t typeCount[USBJOYS_CH_LAST + 1] = { };
@@ -222,6 +223,7 @@ int setupUSBJoystick()
       mode = g_model.usbJoystickCh[i].mode;
 
       if (g_model.usbJoystickCh[i].mode == USBJOYS_CH_BUTTON) {
+        buttonCount += g_model.usbJoystickCh[i].btnCount();
         typeCount[mode]++;
       }
       else if (g_model.usbJoystickCh[i].mode == USBJOYS_CH_AXIS) {
@@ -316,7 +318,7 @@ int setupUSBJoystick()
     else if (_usbJoystickIfMode == USBJOYS_MULTIAXIS) joystickType = 0x08;
 
     _hidReportDesc[3] = joystickType;
-    _hidReportDesc[13] = USBJ_BUTTON_SIZE;
+    _hidReportDesc[13] = buttonCount;
     _hidReportDesc[19] = USBJ_BUTTON_SIZE;
 
     // generic axis types


### PR DESCRIPTION
Reduce RAM usage for advanced joystick system on radio:
- Don't allocate memory blocks unless joystick mode is actually being used.

Support multiple radio joystick configurations in Companion:
- Save configured joystick settings by joystick name in Companion settings.
- Save last joystick name used in each profile.
- Reload joystick settings by name when profile is changed.

This allows the configuration for multiple radios to be saved individually in the Companion settings, and stores the radio that was last used for each profile. On profile load/switch the appropriate joystick settings are restored.

Previously only one configuration was available so switching radios required redoing all the configuration settings.