### PR TITLE
feat(radio,cpn): Support all current timezones.

### DIFF
--- a/companion/src/firmwares/edgetx/yaml_generalsettings.cpp
+++ b/companion/src/firmwares/edgetx/yaml_generalsettings.cpp
@@ -182,6 +182,7 @@ Node convert<GeneralSettings>::encode(const GeneralSettings& rhs)
   node["hapticMode"] = rhs.hapticMode;
   node["stickMode"] = rhs.stickMode;
   node["timezone"] = rhs.timezone;
+  node["timezoneMinutes"] = rhs.timezoneMinutes;
   node["adjustRTC"] = (int)rhs.adjustRTC;
   node["inactivityTimer"] = rhs.inactivityTimer;
 
@@ -390,6 +391,7 @@ bool convert<GeneralSettings>::decode(const Node& node, GeneralSettings& rhs)
   node["hapticMode"] >> rhs.hapticMode;
   node["stickMode"] >> rhs.stickMode;
   node["timezone"] >> rhs.timezone;
+  node["timezoneMinutes"] >> rhs.timezoneMinutes;
   node["adjustRTC"] >> rhs.adjustRTC;
   node["inactivityTimer"] >> rhs.inactivityTimer;
 

--- a/companion/src/firmwares/generalsettings.h
+++ b/companion/src/firmwares/generalsettings.h
@@ -212,6 +212,7 @@ class GeneralSettings {
     BeeperMode hapticMode;
     unsigned int stickMode; // TODO enum
     int timezone;
+    unsigned int timezoneMinutes;
     bool adjustRTC;
     bool optrexDisplay;
     unsigned int inactivityTimer;

--- a/companion/src/firmwares/generalsettings.h
+++ b/companion/src/firmwares/generalsettings.h
@@ -212,7 +212,7 @@ class GeneralSettings {
     BeeperMode hapticMode;
     unsigned int stickMode; // TODO enum
     int timezone;
-    unsigned int timezoneMinutes;
+    int timezoneMinutes;
     bool adjustRTC;
     bool optrexDisplay;
     unsigned int inactivityTimer;

--- a/companion/src/generaledit/CMakeLists.txt
+++ b/companion/src/generaledit/CMakeLists.txt
@@ -1,4 +1,4 @@
-include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
+include_directories(${CMAKE_SOURCE_DIR} ${CMAKE_CURRENT_SOURCE_DIR} ${CMAKE_CURRENT_BINARY_DIR})
 
 set(generaledit_NAMES
   generaledit
@@ -10,6 +10,7 @@ set(generaledit_SRCS
   hardware.cpp
   trainer.cpp
   generaloptions.cpp
+  timezoneedit.cpp
 )
 
 set(generaledit_HDRS
@@ -17,6 +18,7 @@ set(generaledit_HDRS
   hardware.h
   trainer.h
   generaloptions.h
+  timezoneedit.h
 )
 
 set(generaledit_UIS

--- a/companion/src/generaledit/generalsetup.cpp
+++ b/companion/src/generaledit/generalsetup.cpp
@@ -25,39 +25,39 @@
 // For backward compatibility timezone is stored as two separate values:
 //   timezone = hour value
 //   timezoneMinutes - minute value / 15
-static int8_t timezoneHours[] = { -12, -11, -10, -9, -9, -8, -7, -6, -5, -4, -3, -3, -2, -1 , 0, 1, 2, 3,  3, 4,  4, 5,  5,  5, 6,  6, 7, 8,  8, 9,  9, 10, 10, 11, 12, 12, 13, 14 };
-static uint8_t timezoneMins[] = {   0,   0,   0, 30,  0,  0,  0,  0,  0,  0, 30,  0,  0,  0,  0, 0, 0, 0, 30, 0, 30, 0, 30, 45, 0, 30, 0, 0, 45, 0, 30,  0, 30,  0,  0, 45,  0,  0 };
 
-uint8_t maxTimezone()
+int minTimezone()
 {
-  return sizeof(timezoneHours) - 1;
+  return -12 * 4;
+}
+
+int maxTimezone()
+{
+  return 14 * 4;
 }
 
 std::string timezoneDisplay(int tz)
 {
   char s[10];
-  sprintf(s,"%d:%02d", timezoneHours[tz], timezoneMins[tz]);
+  int h = abs(tz / 4);
+  int m = abs(tz % 4) * 15;
+  sprintf(s,"%s%d:%02d", (tz < 0) ? "-" : "", h, m);
   return std::string(s);
 }
 
-int timezoneIndex(int8_t tzHour, uint8_t tzMinute)
+int timezoneIndex(int tzHour, int tzMinute)
 {
-  tzMinute = tzMinute * 15;
-  for (int i = 0; i <= maxTimezone(); i += 1) {
-    if (timezoneHours[i] == tzHour && timezoneMins[i] == tzMinute)
-      return i;
-  }
-  return 0;
+  return (tzHour * 4) + tzMinute;
 }
 
-int8_t timezoneHour(int tz)
+int timezoneHour(int tz)
 {
-  return timezoneHours[tz];
+  return tz / 4;
 }
 
-uint8_t timezoneMinute(int tz)
+int timezoneMinute(int tz)
 {
-  return timezoneMins[tz] / 15;
+  return tz % 4;
 }
 
 GeneralSetupPanel::GeneralSetupPanel(QWidget * parent, GeneralSettings & generalSettings, Firmware * firmware):
@@ -375,7 +375,7 @@ void GeneralSetupPanel::populateTimezoneCB()
 
   int tzIndex = timezoneIndex(generalSettings.timezone, generalSettings.timezoneMinutes);
 
-  for (int i = 0; i <= maxTimezone(); i += 1) {
+  for (int i = minTimezone(); i <= maxTimezone(); i += 1) {
     b->addItem(timezoneDisplay(i).c_str(), 0);
     if (tzIndex == i) {
       b->setCurrentIndex(b->count()-1);
@@ -386,6 +386,7 @@ void GeneralSetupPanel::populateTimezoneCB()
 void GeneralSetupPanel::on_timezoneCB_currentIndexChanged(int index)
 {
   if (!lock) {
+    index += minTimezone();
     generalSettings.timezone = timezoneHour(index);
     generalSettings.timezoneMinutes = timezoneMinute(index);
     emit modified();

--- a/companion/src/generaledit/generalsetup.h
+++ b/companion/src/generaledit/generalsetup.h
@@ -50,7 +50,7 @@ class GeneralSetupPanel : public GeneralPanel
     void on_faimode_CB_stateChanged(int );
     void on_rotEncMode_CB_currentIndexChanged(int index);
     void on_speakerPitchSB_editingFinished();
-    void on_timezoneSB_editingFinished();
+    void on_timezoneCB_currentIndexChanged(int index);
     void on_adjustRTC_stateChanged(int);
     void on_hapticStrength_valueChanged();
     void on_soundModeCB_currentIndexChanged(int index);
@@ -98,6 +98,7 @@ class GeneralSetupPanel : public GeneralPanel
     Ui::GeneralSetup *ui;
 
     void setValues();
+    void populateTimezoneCB();
     void populateBacklightCB();
     void populateVoiceLangCB();
     void populateRotEncCB(int reCount);

--- a/companion/src/generaledit/generalsetup.h
+++ b/companion/src/generaledit/generalsetup.h
@@ -50,7 +50,7 @@ class GeneralSetupPanel : public GeneralPanel
     void on_faimode_CB_stateChanged(int );
     void on_rotEncMode_CB_currentIndexChanged(int index);
     void on_speakerPitchSB_editingFinished();
-    void on_timezoneCB_currentIndexChanged(int index);
+    void on_timezoneLE_textEdited(const QString &text);
     void on_adjustRTC_stateChanged(int);
     void on_hapticStrength_valueChanged();
     void on_soundModeCB_currentIndexChanged(int index);
@@ -98,7 +98,6 @@ class GeneralSetupPanel : public GeneralPanel
     Ui::GeneralSetup *ui;
 
     void setValues();
-    void populateTimezoneCB();
     void populateBacklightCB();
     void populateVoiceLangCB();
     void populateRotEncCB(int reCount);

--- a/companion/src/generaledit/generalsetup.ui
+++ b/companion/src/generaledit/generalsetup.ui
@@ -927,7 +927,7 @@
      <item row="18" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout_2">
        <item>
-        <widget class="QComboBox" name="timezoneCB"/>
+        <widget class="TimezoneEdit" name="timezoneLE"/>
        </item>
        <item>
         <widget class="QCheckBox" name="adjustRTC">
@@ -2491,6 +2491,13 @@ p, li { white-space: pre-wrap; }
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>TimezoneEdit</class>
+   <extends>QLineEdit</extends>
+   <header>timezoneedit.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/companion/src/generaledit/generalsetup.ui
+++ b/companion/src/generaledit/generalsetup.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>810</width>
+    <width>858</width>
     <height>880</height>
    </rect>
   </property>
@@ -927,17 +927,7 @@
      <item row="18" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout_2">
        <item>
-        <widget class="QSpinBox" name="timezoneSB">
-         <property name="minimum">
-          <number>-14</number>
-         </property>
-         <property name="maximum">
-          <number>12</number>
-         </property>
-         <property name="value">
-          <number>0</number>
-         </property>
-        </widget>
+        <widget class="QComboBox" name="timezoneCB"/>
        </item>
        <item>
         <widget class="QCheckBox" name="adjustRTC">

--- a/companion/src/generaledit/timezoneedit.cpp
+++ b/companion/src/generaledit/timezoneedit.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "timezoneedit.h"
+
+TimezoneEdit::TimezoneEdit(QWidget * parent) :
+  TimerEdit(parent)
+{
+  setShowSeconds(false);
+  setMinimumTime(-12 * 60 * 60);
+  setMaximumTime(14 * 60 * 60);
+  setSingleStep(15 * 60);
+  setPageStep(60 * 60);
+}
+
+void TimezoneEdit::setupFormat()
+{
+	QString inputRe  = "^(?<pol>-|\\+|\\s)?(?<hrs>[0-9]*[0-9]):(?<mins>00|15|30|45)";
+	m_validator->setRegularExpression(QRegularExpression(inputRe));
+
+	setInputMask("#99:99");
+	setValidator(m_validator);
+}

--- a/companion/src/generaledit/timezoneedit.h
+++ b/companion/src/generaledit/timezoneedit.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include <TimerEdit>
+
+class TimezoneEdit : public TimerEdit
+{
+  Q_OBJECT
+
+  public:
+    explicit TimezoneEdit(QWidget * parent = Q_NULLPTR);
+    virtual ~TimezoneEdit() {}
+
+  protected:
+		void setupFormat() override;
+};

--- a/companion/src/thirdparty/maxlibqt/src/widgets/TimerEdit.h
+++ b/companion/src/thirdparty/maxlibqt/src/widgets/TimerEdit.h
@@ -86,7 +86,7 @@ class TimerEdit : public QLineEdit
 
 	protected:
 		void textEditedHandler();
-		void setupFormat();
+		virtual void setupFormat();
 		void emitValueChanged();
 		void keyPressEvent(QKeyEvent *event) Q_DECL_OVERRIDE;
 		void wheelEvent(QWheelEvent *event) Q_DECL_OVERRIDE;

--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -855,7 +855,8 @@ PACK(struct RadioData {
 
   // Real attributes
   NOBACKUP(uint8_t manuallyEdited:1);
-  NOBACKUP(int8_t spare0:7 SKIP);
+  uint8_t timezoneMinutes:2;    // 0 = 0, 1 = 15, 2 = 30, 3 = 45
+  NOBACKUP(int8_t spare0:5 SKIP);
   CUST_ATTR(semver,nullptr,w_semver);
   CUST_ATTR(board,nullptr,w_board);
   CalibData calib[MAX_CALIB_ANALOG_INPUTS] NO_IDX;

--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -855,8 +855,8 @@ PACK(struct RadioData {
 
   // Real attributes
   NOBACKUP(uint8_t manuallyEdited:1);
-  uint8_t timezoneMinutes:2;    // 0 = 0, 1 = 15, 2 = 30, 3 = 45
-  NOBACKUP(int8_t spare0:5 SKIP);
+  int8_t timezoneMinutes:3;    // -3 to +3 ==> (-45 to 45 minutes in 15 minute increments)
+  NOBACKUP(int8_t spare0:4 SKIP);
   CUST_ATTR(semver,nullptr,w_semver);
   CUST_ATTR(board,nullptr,w_board);
   CalibData calib[MAX_CALIB_ANALOG_INPUTS] NO_IDX;

--- a/radio/src/gui/128x64/radio_setup.cpp
+++ b/radio/src/gui/128x64/radio_setup.cpp
@@ -599,9 +599,18 @@ void menuRadioSetup(event_t event)
 
 #if defined(GPS)
       case ITEM_RADIO_SETUP_TIMEZONE:
-        lcdDrawTextAlignedLeft(y, STR_TIMEZONE);
-        lcdDrawNumber(RADIO_SETUP_2ND_COLUMN, y, g_eeGeneral.timezone, attr|LEFT);
-        if (attr) CHECK_INCDEC_GENVAR(event, g_eeGeneral.timezone, -12, 12);
+        {
+          lcdDrawTextAlignedLeft(y, STR_TIMEZONE);
+          int tzIndex = timezoneIndex(g_eeGeneral.timezone, g_eeGeneral.timezoneMinutes);
+          lcdDrawText(RADIO_SETUP_2ND_COLUMN, y, timezoneDisplay(tzIndex).c_str(), attr);
+          if (attr) {
+            tzIndex = checkIncDec(event, tzIndex, 0, maxTimezone(), EE_GENERAL);
+            if (checkIncDec_Ret) {
+              g_eeGeneral.timezone = timezoneHour(tzIndex);
+              g_eeGeneral.timezoneMinutes = timezoneMinute(tzIndex);
+            }
+          }
+        }
         break;
 
       case ITEM_RADIO_SETUP_ADJUST_RTC:

--- a/radio/src/gui/128x64/radio_setup.cpp
+++ b/radio/src/gui/128x64/radio_setup.cpp
@@ -604,7 +604,7 @@ void menuRadioSetup(event_t event)
           int tzIndex = timezoneIndex(g_eeGeneral.timezone, g_eeGeneral.timezoneMinutes);
           lcdDrawText(RADIO_SETUP_2ND_COLUMN, y, timezoneDisplay(tzIndex).c_str(), attr);
           if (attr) {
-            tzIndex = checkIncDec(event, tzIndex, 0, maxTimezone(), EE_GENERAL);
+            tzIndex = checkIncDec(event, tzIndex, minTimezone(), maxTimezone(), EE_GENERAL);
             if (checkIncDec_Ret) {
               g_eeGeneral.timezone = timezoneHour(tzIndex);
               g_eeGeneral.timezoneMinutes = timezoneMinute(tzIndex);

--- a/radio/src/gui/212x64/radio_setup.cpp
+++ b/radio/src/gui/212x64/radio_setup.cpp
@@ -547,9 +547,18 @@ void menuRadioSetup(event_t event)
         break;
 
       case ITEM_RADIO_SETUP_TIMEZONE:
-        lcdDrawText(INDENT_WIDTH, y, STR_TIMEZONE);
-        lcdDrawNumber(RADIO_SETUP_2ND_COLUMN, y, g_eeGeneral.timezone, attr|LEFT);
-        if (attr) CHECK_INCDEC_GENVAR(event, g_eeGeneral.timezone, -12, 12);
+        {
+          lcdDrawText(INDENT_WIDTH, y, STR_TIMEZONE);
+          int tzIndex = timezoneIndex(g_eeGeneral.timezone, g_eeGeneral.timezoneMinutes);
+          lcdDrawText(RADIO_SETUP_2ND_COLUMN, y, timezoneDisplay(tzIndex).c_str(), attr);
+          if (attr) {
+            tzIndex = checkIncDec(event, tzIndex, 0, maxTimezone(), EE_GENERAL);
+            if (checkIncDec_Ret) {
+              g_eeGeneral.timezone = timezoneHour(tzIndex);
+              g_eeGeneral.timezoneMinutes = timezoneMinute(tzIndex);
+            }
+          }
+        }
         break;
 
       case ITEM_RADIO_SETUP_ADJUST_RTC:

--- a/radio/src/gui/212x64/radio_setup.cpp
+++ b/radio/src/gui/212x64/radio_setup.cpp
@@ -552,7 +552,7 @@ void menuRadioSetup(event_t event)
           int tzIndex = timezoneIndex(g_eeGeneral.timezone, g_eeGeneral.timezoneMinutes);
           lcdDrawText(RADIO_SETUP_2ND_COLUMN, y, timezoneDisplay(tzIndex).c_str(), attr);
           if (attr) {
-            tzIndex = checkIncDec(event, tzIndex, 0, maxTimezone(), EE_GENERAL);
+            tzIndex = checkIncDec(event, tzIndex, minTimezone(), maxTimezone(), EE_GENERAL);
             if (checkIncDec_Ret) {
               g_eeGeneral.timezone = timezoneHour(tzIndex);
               g_eeGeneral.timezoneMinutes = timezoneMinute(tzIndex);

--- a/radio/src/gui/colorlcd/radio_setup.cpp
+++ b/radio/src/gui/colorlcd/radio_setup.cpp
@@ -556,10 +556,22 @@ class GpsPage : public SubPage {
     {
       FlexGridLayout grid(col_two_dsc, row_dsc, 4);
 
+      tzIndex = timezoneIndex(g_eeGeneral.timezone, g_eeGeneral.timezoneMinutes);
+
       auto line = body.newLine(&grid);
       // Timezone
       new StaticText(line, rect_t{}, STR_TIMEZONE, 0, COLOR_THEME_PRIMARY1);
-      new NumberEdit(line, rect_t{}, -12, 12, GET_SET_DEFAULT(g_eeGeneral.timezone));
+      auto tz = new NumberEdit(line, rect_t{}, 0, maxTimezone(),
+                               GET_DEFAULT(tzIndex),
+                               [=](int newTz) {
+                                 tzIndex = newTz;
+                                 g_eeGeneral.timezone = timezoneHour(newTz);
+                                 g_eeGeneral.timezoneMinutes = timezoneMinute(newTz);
+                                 SET_DIRTY();
+                               });
+      tz->setDisplayHandler([](int32_t tz) {
+        return timezoneDisplay(tz);
+      });
       line = body.newLine(&grid);
 
       // Adjust RTC (from telemetry)
@@ -572,6 +584,9 @@ class GpsPage : public SubPage {
       new Choice(line, rect_t{}, STR_GPSFORMAT, 0, 1, GET_SET_DEFAULT(g_eeGeneral.gpsFormat));
       line = body.newLine(&grid);
     }
+
+  protected:
+    int tzIndex;
 };
 
 class ViewOptionsPage : public Page

--- a/radio/src/gui/colorlcd/radio_setup.cpp
+++ b/radio/src/gui/colorlcd/radio_setup.cpp
@@ -561,7 +561,7 @@ class GpsPage : public SubPage {
       auto line = body.newLine(&grid);
       // Timezone
       new StaticText(line, rect_t{}, STR_TIMEZONE, 0, COLOR_THEME_PRIMARY1);
-      auto tz = new NumberEdit(line, rect_t{}, 0, maxTimezone(),
+      auto tz = new NumberEdit(line, rect_t{}, minTimezone(), maxTimezone(),
                                GET_DEFAULT(tzIndex),
                                [=](int newTz) {
                                  tzIndex = newTz;

--- a/radio/src/rtc.cpp
+++ b/radio/src/rtc.cpp
@@ -471,7 +471,7 @@ uint8_t rtcAdjust(uint16_t year, uint8_t mon, uint8_t day, uint8_t hour, uint8_t
     t.tm_hour = hour;
     t.tm_min  = min;
     t.tm_sec  = sec;
-    gtime_t newTime = gmktime(&t) + g_eeGeneral.timezone * 3600;
+    gtime_t newTime = gmktime(&t) + timezoneOffsetMinutes(g_eeGeneral.timezone, g_eeGeneral.timezoneMinutes);
     gtime_t diff = (g_rtcTime > newTime) ? (g_rtcTime - newTime) : (newTime - g_rtcTime);
 
 #if defined(DEBUG) && defined (PCBTARANIS)

--- a/radio/src/rtc.cpp
+++ b/radio/src/rtc.cpp
@@ -471,7 +471,7 @@ uint8_t rtcAdjust(uint16_t year, uint8_t mon, uint8_t day, uint8_t hour, uint8_t
     t.tm_hour = hour;
     t.tm_min  = min;
     t.tm_sec  = sec;
-    gtime_t newTime = gmktime(&t) + timezoneOffsetMinutes(g_eeGeneral.timezone, g_eeGeneral.timezoneMinutes);
+    gtime_t newTime = gmktime(&t) + timezoneOffsetSeconds(g_eeGeneral.timezone, g_eeGeneral.timezoneMinutes);
     gtime_t diff = (g_rtcTime > newTime) ? (g_rtcTime - newTime) : (newTime - g_rtcTime);
 
 #if defined(DEBUG) && defined (PCBTARANIS)

--- a/radio/src/storage/yaml/yaml_datastructs_128x64.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_128x64.cpp
@@ -263,7 +263,8 @@ static const struct YamlNode struct_CustomFunctionData[] = {
 };
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "timezoneMinutes", 2 ),
+  YAML_PADDING( 5 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 12, struct_CalibData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_128x64.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_128x64.cpp
@@ -263,8 +263,8 @@ static const struct YamlNode struct_CustomFunctionData[] = {
 };
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
-  YAML_UNSIGNED( "timezoneMinutes", 2 ),
-  YAML_PADDING( 5 ),
+  YAML_SIGNED( "timezoneMinutes", 3 ),
+  YAML_PADDING( 4 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 12, struct_CalibData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
@@ -293,7 +293,8 @@ static const struct YamlNode struct_OpenTxTheme__PersistentData[] = {
 };
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "timezoneMinutes", 2 ),
+  YAML_PADDING( 5 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 22, struct_CalibData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
@@ -293,8 +293,8 @@ static const struct YamlNode struct_OpenTxTheme__PersistentData[] = {
 };
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
-  YAML_UNSIGNED( "timezoneMinutes", 2 ),
-  YAML_PADDING( 5 ),
+  YAML_SIGNED( "timezoneMinutes", 3 ),
+  YAML_PADDING( 4 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 22, struct_CalibData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_t20.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t20.cpp
@@ -263,7 +263,8 @@ static const struct YamlNode struct_CustomFunctionData[] = {
 };
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_SIGNED( "timezoneMinutes", 3 ),
+  YAML_PADDING( 4 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 12, struct_CalibData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_tpro.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tpro.cpp
@@ -263,7 +263,8 @@ static const struct YamlNode struct_CustomFunctionData[] = {
 };
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "timezoneMinutes", 2 ),
+  YAML_PADDING( 5 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 12, struct_CalibData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_tpro.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tpro.cpp
@@ -263,8 +263,8 @@ static const struct YamlNode struct_CustomFunctionData[] = {
 };
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
-  YAML_UNSIGNED( "timezoneMinutes", 2 ),
-  YAML_PADDING( 5 ),
+  YAML_SIGNED( "timezoneMinutes", 3 ),
+  YAML_PADDING( 4 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 12, struct_CalibData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_x10.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x10.cpp
@@ -301,7 +301,8 @@ static const struct YamlNode struct_OpenTxTheme__PersistentData[] = {
 };
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "timezoneMinutes", 2 ),
+  YAML_PADDING( 5 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 22, struct_CalibData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_x10.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x10.cpp
@@ -301,8 +301,8 @@ static const struct YamlNode struct_OpenTxTheme__PersistentData[] = {
 };
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
-  YAML_UNSIGNED( "timezoneMinutes", 2 ),
-  YAML_PADDING( 5 ),
+  YAML_SIGNED( "timezoneMinutes", 3 ),
+  YAML_PADDING( 4 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 22, struct_CalibData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
@@ -301,7 +301,8 @@ static const struct YamlNode struct_OpenTxTheme__PersistentData[] = {
 };
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "timezoneMinutes", 2 ),
+  YAML_PADDING( 5 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 22, struct_CalibData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
@@ -301,8 +301,8 @@ static const struct YamlNode struct_OpenTxTheme__PersistentData[] = {
 };
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
-  YAML_UNSIGNED( "timezoneMinutes", 2 ),
-  YAML_PADDING( 5 ),
+  YAML_SIGNED( "timezoneMinutes", 3 ),
+  YAML_PADDING( 4 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 22, struct_CalibData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
@@ -263,7 +263,8 @@ static const struct YamlNode struct_CustomFunctionData[] = {
 };
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "timezoneMinutes", 2 ),
+  YAML_PADDING( 5 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 12, struct_CalibData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
@@ -263,8 +263,8 @@ static const struct YamlNode struct_CustomFunctionData[] = {
 };
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
-  YAML_UNSIGNED( "timezoneMinutes", 2 ),
-  YAML_PADDING( 5 ),
+  YAML_SIGNED( "timezoneMinutes", 3 ),
+  YAML_PADDING( 4 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 12, struct_CalibData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
@@ -263,7 +263,8 @@ static const struct YamlNode struct_CustomFunctionData[] = {
 };
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "timezoneMinutes", 2 ),
+  YAML_PADDING( 5 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 12, struct_CalibData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
@@ -263,8 +263,8 @@ static const struct YamlNode struct_CustomFunctionData[] = {
 };
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
-  YAML_UNSIGNED( "timezoneMinutes", 2 ),
-  YAML_PADDING( 5 ),
+  YAML_SIGNED( "timezoneMinutes", 3 ),
+  YAML_PADDING( 4 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 12, struct_CalibData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_x9lite.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9lite.cpp
@@ -263,7 +263,8 @@ static const struct YamlNode struct_CustomFunctionData[] = {
 };
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "timezoneMinutes", 2 ),
+  YAML_PADDING( 5 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 12, struct_CalibData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_x9lite.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9lite.cpp
@@ -263,8 +263,8 @@ static const struct YamlNode struct_CustomFunctionData[] = {
 };
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
-  YAML_UNSIGNED( "timezoneMinutes", 2 ),
-  YAML_PADDING( 5 ),
+  YAML_SIGNED( "timezoneMinutes", 3 ),
+  YAML_PADDING( 4 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 12, struct_CalibData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
@@ -265,8 +265,8 @@ static const struct YamlNode struct_CustomFunctionData[] = {
 };
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
-  YAML_UNSIGNED( "timezoneMinutes", 2 ),
-  YAML_PADDING( 5 ),
+  YAML_SIGNED( "timezoneMinutes", 3 ),
+  YAML_PADDING( 4 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 12, struct_CalibData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
@@ -265,7 +265,8 @@ static const struct YamlNode struct_CustomFunctionData[] = {
 };
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "timezoneMinutes", 2 ),
+  YAML_PADDING( 5 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 12, struct_CalibData, NULL),

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -1045,3 +1045,50 @@ char *strAppendDate(char *str, bool time)
 
 #if !defined(BOOT)
 #endif
+
+// Manage timezones
+// For backward compatibility timezone is stored as two separate values:
+//   timezone = hour value
+//   timezoneMinutes - minute value / 15
+static int8_t timezoneHours[] = { -12, -11, -10, -9, -9, -8, -7, -6, -5, -4, -3, -3, -2, -1 , 0, 1, 2, 3,  3, 4,  4, 5,  5,  5, 6,  6, 7, 8,  8, 9,  9, 10, 10, 11, 12, 12, 13, 14 };
+static uint8_t timezoneMins[] = {   0,   0,   0, 30,  0,  0,  0,  0,  0,  0, 30,  0,  0,  0,  0, 0, 0, 0, 30, 0, 30, 0, 30, 45, 0, 30, 0, 0, 45, 0, 30,  0, 30,  0,  0, 45,  0,  0 };
+
+uint8_t maxTimezone()
+{
+  return sizeof(timezoneHours) - 1;
+}
+
+std::string timezoneDisplay(int tz)
+{
+  char s[10];
+  sprintf(s,"%d:%02d", timezoneHours[tz], timezoneMins[tz]);
+  return std::string(s);
+}
+
+int timezoneIndex(int8_t tzHour, uint8_t tzMinute)
+{
+  tzMinute = tzMinute * 15;
+  for (int i = 0; i <= maxTimezone(); i += 1) {
+    if (timezoneHours[i] == tzHour && timezoneMins[i] == tzMinute)
+      return i;
+  }
+  return 0;
+}
+
+int8_t timezoneHour(int tz)
+{
+  return timezoneHours[tz];
+}
+
+uint8_t timezoneMinute(int tz)
+{
+  return timezoneMins[tz] / 15;
+}
+
+int timezoneOffsetMinutes(int8_t tzHour, uint8_t tzMinute)
+{
+  tzMinute = tzMinute * 15;
+  if (tzHour < 0)
+    return (tzHour * 3600) - tzMinute;
+  return (tzHour * 3600) + tzMinute;
+}

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -1085,10 +1085,11 @@ uint8_t timezoneMinute(int tz)
   return timezoneMins[tz] / 15;
 }
 
-int timezoneOffsetMinutes(int8_t tzHour, uint8_t tzMinute)
+int timezoneOffsetSeconds(int8_t tzHour, uint8_t tzMinute)
 {
-  tzMinute = tzMinute * 15;
+  tzHour = tzHour * 3600;
+  tzMinute = tzMinute * 15 * 60;
   if (tzHour < 0)
-    return (tzHour * 3600) - tzMinute;
-  return (tzHour * 3600) + tzMinute;
+    return tzHour - tzMinute;
+  return tzHour + tzMinute;
 }

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -1063,7 +1063,7 @@ int8_t maxTimezone()
 
 std::string timezoneDisplay(int tz)
 {
-  char s[10];
+  char s[16];
   int h = abs(tz / 4);
   int m = abs(tz % 4) * 15;
   sprintf(s,"%s%d:%02d", (tz < 0) ? "-" : "", h, m);

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -1050,46 +1050,42 @@ char *strAppendDate(char *str, bool time)
 // For backward compatibility timezone is stored as two separate values:
 //   timezone = hour value
 //   timezoneMinutes - minute value / 15
-static int8_t timezoneHours[] = { -12, -11, -10, -9, -9, -8, -7, -6, -5, -4, -3, -3, -2, -1 , 0, 1, 2, 3,  3, 4,  4, 5,  5,  5, 6,  6, 7, 8,  8, 9,  9, 10, 10, 11, 12, 12, 13, 14 };
-static uint8_t timezoneMins[] = {   0,   0,   0, 30,  0,  0,  0,  0,  0,  0, 30,  0,  0,  0,  0, 0, 0, 0, 30, 0, 30, 0, 30, 45, 0, 30, 0, 0, 45, 0, 30,  0, 30,  0,  0, 45,  0,  0 };
 
-uint8_t maxTimezone()
+int8_t minTimezone()
 {
-  return sizeof(timezoneHours) - 1;
+  return -12 * 4;
+}
+
+int8_t maxTimezone()
+{
+  return 14 * 4;
 }
 
 std::string timezoneDisplay(int tz)
 {
   char s[10];
-  sprintf(s,"%d:%02d", timezoneHours[tz], timezoneMins[tz]);
+  int h = abs(tz / 4);
+  int m = abs(tz % 4) * 15;
+  sprintf(s,"%s%d:%02d", (tz < 0) ? "-" : "", h, m);
   return std::string(s);
 }
 
-int timezoneIndex(int8_t tzHour, uint8_t tzMinute)
+int timezoneIndex(int8_t tzHour, int8_t tzMinute)
 {
-  tzMinute = tzMinute * 15;
-  for (int i = 0; i <= maxTimezone(); i += 1) {
-    if (timezoneHours[i] == tzHour && timezoneMins[i] == tzMinute)
-      return i;
-  }
-  return 0;
+  return (tzHour * 4) + tzMinute;
 }
 
 int8_t timezoneHour(int tz)
 {
-  return timezoneHours[tz];
+  return tz / 4;
 }
 
-uint8_t timezoneMinute(int tz)
+int8_t timezoneMinute(int tz)
 {
-  return timezoneMins[tz] / 15;
+  return tz % 4;
 }
 
-int timezoneOffsetSeconds(int8_t tzHour, uint8_t tzMinute)
+int timezoneOffsetSeconds(int8_t tzHour, int8_t tzMinute)
 {
-  tzHour = tzHour * 3600;
-  tzMinute = tzMinute * 15 * 60;
-  if (tzHour < 0)
-    return tzHour - tzMinute;
-  return tzHour + tzMinute;
+  return (tzHour * 3600) + (tzMinute * 15 * 60);
 }

--- a/radio/src/strhelpers.h
+++ b/radio/src/strhelpers.h
@@ -175,11 +175,12 @@ std::string getValueWithUnit(int val, uint8_t unit, LcdFlags flags);
 std::string getGVarValue(uint8_t gvar, gvar_t value, LcdFlags flags);
 
 // Timezone handling
-extern uint8_t maxTimezone();
+extern int8_t minTimezone();
+extern int8_t maxTimezone();
 extern std::string timezoneDisplay(int tz);
-extern int timezoneIndex(int8_t tzHour, uint8_t tzMinute);
+extern int timezoneIndex(int8_t tzHour, int8_t tzMinute);
 extern int8_t timezoneHour(int tz);
-extern uint8_t timezoneMinute(int tz);
-extern int timezoneOffsetSeconds(int8_t tzHour, uint8_t tzMinute);
+extern int8_t timezoneMinute(int tz);
+extern int timezoneOffsetSeconds(int8_t tzHour, int8_t tzMinute);
 
 #endif  // _STRHELPERS_H_

--- a/radio/src/strhelpers.h
+++ b/radio/src/strhelpers.h
@@ -180,6 +180,6 @@ extern std::string timezoneDisplay(int tz);
 extern int timezoneIndex(int8_t tzHour, uint8_t tzMinute);
 extern int8_t timezoneHour(int tz);
 extern uint8_t timezoneMinute(int tz);
-extern int timezoneOffsetMinutes(int8_t tzHour, uint8_t tzMinute);
+extern int timezoneOffsetSeconds(int8_t tzHour, uint8_t tzMinute);
 
 #endif  // _STRHELPERS_H_

--- a/radio/src/strhelpers.h
+++ b/radio/src/strhelpers.h
@@ -174,4 +174,12 @@ int strncasecmp(char (&s1)[L1], const char *const s2)
 std::string getValueWithUnit(int val, uint8_t unit, LcdFlags flags);
 std::string getGVarValue(uint8_t gvar, gvar_t value, LcdFlags flags);
 
+// Timezone handling
+extern uint8_t maxTimezone();
+extern std::string timezoneDisplay(int tz);
+extern int timezoneIndex(int8_t tzHour, uint8_t tzMinute);
+extern int8_t timezoneHour(int tz);
+extern uint8_t timezoneMinute(int tz);
+extern int timezoneOffsetMinutes(int8_t tzHour, uint8_t tzMinute);
+
 #endif  // _STRHELPERS_H_

--- a/radio/src/telemetry/spektrum.cpp
+++ b/radio/src/telemetry/spektrum.cpp
@@ -934,7 +934,7 @@ static void adjustTimeFromUTC(uint8_t hour, uint8_t min, uint8_t sec,
                               struct gtm *tp)
 {
   // Get current UTC date/time
-  __offtime(&g_rtcTime, -g_eeGeneral.timezone * 3600, tp);
+  __offtime(&g_rtcTime, -timezoneOffsetMinutes(g_eeGeneral.timezone, g_eeGeneral.timezoneMinutes), tp);
 
   tp->tm_hour = hour;
   tp->tm_min = min;

--- a/radio/src/telemetry/spektrum.cpp
+++ b/radio/src/telemetry/spektrum.cpp
@@ -934,7 +934,7 @@ static void adjustTimeFromUTC(uint8_t hour, uint8_t min, uint8_t sec,
                               struct gtm *tp)
 {
   // Get current UTC date/time
-  __offtime(&g_rtcTime, -timezoneOffsetMinutes(g_eeGeneral.timezone, g_eeGeneral.timezoneMinutes), tp);
+  __offtime(&g_rtcTime, -timezoneOffsetSeconds(g_eeGeneral.timezone, g_eeGeneral.timezoneMinutes), tp);
 
   tp->tm_hour = hour;
   tp->tm_min = min;


### PR DESCRIPTION
Add support for all current timezones to radios and Companion.

Fixes #3398 

Summary of changes:
- Add a 'timezoneMinutes' field to the radio settings to store the minutes offset.
- Add +13:00 and +14:00 timezones.
- Update the radio and Companion UI to allow selection of any valid timezone.

![Screen Shot 2023-03-26 at 9 37 08 pm](https://user-images.githubusercontent.com/9474356/227770212-592e25c3-520f-4962-ad52-381148e31315.png)

![Screen Shot 2023-03-26 at 9 37 54 pm](https://user-images.githubusercontent.com/9474356/227770221-6d3f3331-d21d-40e6-88c7-408cdf82640d.png)

![Screen Shot 2023-03-26 at 9 36 51 pm](https://user-images.githubusercontent.com/9474356/227770230-250ff148-5d8a-4c0d-b7eb-296b3c0915a7.png)

