### PR TITLE
feat(lua): add 'intensity' parameter to playHaptic

### DIFF
--- a/radio/src/haptic.cpp
+++ b/radio/src/haptic.cpp
@@ -81,7 +81,9 @@ void hapticQueue::heartbeat()
 
 void hapticQueue::play(uint8_t tLen, uint8_t tPause, uint8_t tFlags)
 {
-  tLen = getHapticLength(tLen);
+  if(tLen > 0){
+    tLen = getHapticLength(tLen);
+  }
 
   if ((tFlags & PLAY_NOW) || (!busy() && empty())) {
     if (tLen == 0) {

--- a/radio/src/haptic.cpp
+++ b/radio/src/haptic.cpp
@@ -51,7 +51,7 @@ void hapticQueue::heartbeat()
     if (intensity < 255) {
       hapticOn(intensity);
     } else {
-    hapticOn(HAPTIC_STRENGTH() * 20);
+      hapticOn(HAPTIC_STRENGTH() * 20);
     }
 #else
     if (hapticTick-- > 0) {

--- a/radio/src/haptic.cpp
+++ b/radio/src/haptic.cpp
@@ -27,8 +27,6 @@
 extern uint32_t simuHapticValue;
 #endif
 
-constexpr uint8_t fullHaptic = 255;
-
 hapticQueue::hapticQueue()
 {
   buzzTimeLeft = 0;
@@ -39,7 +37,7 @@ hapticQueue::hapticQueue()
 
   hapticTick = 0;
 
-  intensity = fullHaptic;
+  intensity = userHapticStrength;
 }
 
 void hapticQueue::heartbeat()
@@ -50,7 +48,7 @@ void hapticQueue::heartbeat()
   if (buzzTimeLeft > 0) {
     buzzTimeLeft--; // time gets counted down
 #if defined(HAPTIC_PWM)
-    if (intensity < fullHaptic) {
+    if (intensity < userHapticStrength) {
       hapticOn(intensity);
     } else {
       hapticOn(HAPTIC_STRENGTH() * 20);
@@ -73,6 +71,7 @@ void hapticQueue::heartbeat()
     else if (t_queueRidx != t_queueWidx) {
       buzzTimeLeft = queueHapticLength[t_queueRidx];
       buzzPause = queueHapticPause[t_queueRidx];
+      intensity = queueHapticIntensity[t_queueRidx];
       if (!queueHapticRepeat[t_queueRidx]--) {
         t_queueRidx = (t_queueRidx + 1) & (HAPTIC_QUEUE_LENGTH-1);
       }
@@ -81,22 +80,16 @@ void hapticQueue::heartbeat()
 #endif // defined(SIMU)
 }
 
-void hapticQueue::play(uint8_t tLen, uint8_t tPause, uint8_t tFlags)
+void hapticQueue::play(uint8_t tLen, uint8_t tPause, uint8_t tFlags, uint8_t tIntensity)
 {
   if(tLen > 0){
     tLen = getHapticLength(tLen);
   }
 
   if ((tFlags & PLAY_NOW) || (!busy() && empty())) {
-    if (tLen == 0) {
-      buzzTimeLeft = 250;
-      intensity = tPause;
-      buzzPause = 100;
-    } else {
-      buzzTimeLeft = tLen;
-      buzzPause = tPause;
-      intensity = fullHaptic;
-    }
+    buzzTimeLeft = tLen;
+    buzzPause = tPause;
+    intensity = tIntensity;
     t_queueWidx = t_queueRidx;
   }
   else {
@@ -110,6 +103,7 @@ void hapticQueue::play(uint8_t tLen, uint8_t tPause, uint8_t tFlags)
       queueHapticLength[t_queueWidx] = tLen;
       queueHapticPause[t_queueWidx] = tPause;
       queueHapticRepeat[t_queueWidx] = tFlags-1;
+      queueHapticIntensity[t_queueWidx] = tIntensity;
       t_queueWidx = next_queueWidx;
     }
   }

--- a/radio/src/haptic.cpp
+++ b/radio/src/haptic.cpp
@@ -27,6 +27,8 @@
 extern uint32_t simuHapticValue;
 #endif
 
+constexpr uint8_t fullHaptic = 255;
+
 hapticQueue::hapticQueue()
 {
   buzzTimeLeft = 0;
@@ -36,8 +38,8 @@ hapticQueue::hapticQueue()
   t_queueWidx = 0;
 
   hapticTick = 0;
-  
-  intensity = 255;
+
+  intensity = fullHaptic;
 }
 
 void hapticQueue::heartbeat()
@@ -48,7 +50,7 @@ void hapticQueue::heartbeat()
   if (buzzTimeLeft > 0) {
     buzzTimeLeft--; // time gets counted down
 #if defined(HAPTIC_PWM)
-    if (intensity < 255) {
+    if (intensity < fullHaptic) {
       hapticOn(intensity);
     } else {
       hapticOn(HAPTIC_STRENGTH() * 20);
@@ -93,7 +95,7 @@ void hapticQueue::play(uint8_t tLen, uint8_t tPause, uint8_t tFlags)
     } else {
       buzzTimeLeft = tLen;
       buzzPause = tPause;
-      intensity = 255;
+      intensity = fullHaptic;
     }
     t_queueWidx = t_queueRidx;
   }

--- a/radio/src/haptic.cpp
+++ b/radio/src/haptic.cpp
@@ -36,6 +36,8 @@ hapticQueue::hapticQueue()
   t_queueWidx = 0;
 
   hapticTick = 0;
+  
+  intensity = 255;
 }
 
 void hapticQueue::heartbeat()
@@ -46,7 +48,11 @@ void hapticQueue::heartbeat()
   if (buzzTimeLeft > 0) {
     buzzTimeLeft--; // time gets counted down
 #if defined(HAPTIC_PWM)
+    if (intensity < 255) {
+      hapticOn(intensity);
+    } else {
     hapticOn(HAPTIC_STRENGTH() * 20);
+    }
 #else
     if (hapticTick-- > 0) {
       hapticOn();
@@ -78,8 +84,15 @@ void hapticQueue::play(uint8_t tLen, uint8_t tPause, uint8_t tFlags)
   tLen = getHapticLength(tLen);
 
   if ((tFlags & PLAY_NOW) || (!busy() && empty())) {
-    buzzTimeLeft = tLen;
-    buzzPause = tPause;
+    if (tLen == 0) {
+      buzzTimeLeft = 250;
+      intensity = tPause;
+      buzzPause = 100;
+    } else {
+      buzzTimeLeft = tLen;
+      buzzPause = tPause;
+      intensity = 255;
+    }
     t_queueWidx = t_queueRidx;
   }
   else {

--- a/radio/src/haptic.h
+++ b/radio/src/haptic.h
@@ -61,6 +61,8 @@ class hapticQueue
 
     uint8_t hapticTick;
 
+    uint8_t intensity;
+  
     // queue arrays
     uint8_t queueHapticLength[HAPTIC_QUEUE_LENGTH];
     uint8_t queueHapticPause[HAPTIC_QUEUE_LENGTH];

--- a/radio/src/haptic.h
+++ b/radio/src/haptic.h
@@ -23,6 +23,9 @@
 
 #define HAPTIC_QUEUE_LENGTH  4
 
+// sentinel: use HAPTIC_STRENGTH() setting instead of an explicit intensity
+constexpr uint8_t userHapticStrength = 255;
+
 class hapticQueue
 {
   public:
@@ -31,9 +34,11 @@ class hapticQueue
 
     // only difference between these two functions is that one does the
     // interupt queue (Now) and the other queues for playing ASAP.
-    void play(uint8_t tLen, uint8_t tPause, uint8_t tRepeat=0);
+    void play(uint8_t tLen, uint8_t tPause, uint8_t tFlags=0, uint8_t tIntensity=userHapticStrength);
 
     inline bool busy() { return (buzzTimeLeft > 0); }
+
+    inline uint8_t getIntensity() { return intensity; }
 
     void event(uint8_t e);
 
@@ -67,6 +72,7 @@ class hapticQueue
     uint8_t queueHapticLength[HAPTIC_QUEUE_LENGTH];
     uint8_t queueHapticPause[HAPTIC_QUEUE_LENGTH];
     uint8_t queueHapticRepeat[HAPTIC_QUEUE_LENGTH];
+    uint8_t queueHapticIntensity[HAPTIC_QUEUE_LENGTH];
 };
 
 extern hapticQueue haptic;

--- a/radio/src/haptic.h
+++ b/radio/src/haptic.h
@@ -32,8 +32,8 @@ class hapticQueue
 
     hapticQueue();
 
-    // only difference between these two functions is that one does the
-    // interupt queue (Now) and the other queues for playing ASAP.
+    // The PLAY_NOW flag interrupts and plays immediately; otherwise this
+    // queues to play as soon as the current buzz finishes.
     void play(uint8_t tLen, uint8_t tPause, uint8_t tFlags=0, uint8_t tIntensity=userHapticStrength);
 
     inline bool busy() { return (buzzTimeLeft > 0); }

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1658,7 +1658,7 @@ static int luaScreenshot(lua_State * L)
 }
 
 /*luadoc
-@function playHaptic(duration, pause [, flags])
+@function playHaptic(duration, pause [, flags [, intensity]])
 
 Generate haptic feedback
 
@@ -1670,7 +1670,11 @@ Generate haptic feedback
  * `0 or not present` play with normal priority
  * `PLAY_NOW` play immediately
 
-@status current Introduced in 2.2.0
+@param intensity (number) [optional] haptic motor strength, 0-100 (only
+effective on boards with PWM-driven haptic support); defaults to the user's
+configured haptic strength setting
+
+@status current Introduced in 2.2.0, intensity added in 3.0
 */
 static int luaPlayHaptic(lua_State * L)
 {
@@ -1678,7 +1682,12 @@ static int luaPlayHaptic(lua_State * L)
   int length = luaL_checkinteger(L, 1);
   int pause = luaL_checkinteger(L, 2);
   int flags = luaL_optinteger(L, 3, 0);
-  haptic.play(length, pause, flags);
+  int intensity = luaL_optinteger(L, 4, userHapticStrength);
+  if (intensity != userHapticStrength) {
+    if (intensity < 0) intensity = 0;
+    else if (intensity > 100) intensity = 100;
+  }
+  haptic.play(length, pause, flags, intensity);
 #else
   UNUSED(L);
 #endif

--- a/radio/src/tests/haptic.cpp
+++ b/radio/src/tests/haptic.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "gtests.h"
+
+TEST(Haptic, DefaultIntensityUsesUserStrength)
+{
+  hapticQueue hq;
+  EXPECT_EQ(userHapticStrength, hq.getIntensity());
+}
+
+TEST(Haptic, PlayWithoutIntensityKeepsUserStrength)
+{
+  hapticQueue hq;
+  hq.play(15, 3, PLAY_NOW);
+  EXPECT_EQ(userHapticStrength, hq.getIntensity());
+}
+
+TEST(Haptic, PlayAcceptsCustomIntensityWithCustomDuration)
+{
+  hapticQueue hq;
+  hq.play(15, 3, PLAY_NOW, 50);
+  EXPECT_TRUE(hq.busy());
+  EXPECT_EQ(50, hq.getIntensity());
+}
+
+TEST(Haptic, PlayAcceptsMinAndMaxIntensity)
+{
+  hapticQueue hq;
+  hq.play(15, 3, PLAY_NOW, 0);
+  EXPECT_EQ(0, hq.getIntensity());
+
+  hq.play(15, 3, PLAY_NOW, 100);
+  EXPECT_EQ(100, hq.getIntensity());
+}
+
+TEST(Haptic, QueuedPlayDoesNotChangeCurrentIntensity)
+{
+  hapticQueue hq;
+  hq.play(15, 3, PLAY_NOW, 50);
+  ASSERT_TRUE(hq.busy());
+  ASSERT_EQ(50, hq.getIntensity());
+
+  // queue busy -> gets queued rather than applied immediately
+  hq.play(5, 1, PLAY_REPEAT(1), 80);
+  EXPECT_EQ(50, hq.getIntensity());
+}


### PR DESCRIPTION
- [x] Change haptic playback function to accept an “intensity” argument
- [x] Change lua playHaptic function to accept an “intensity” argument, or add function…

Standalone Lua demo that has been tested on TX12MK2 hardware... walks through using old and new playHaptic() forms to ensure no change in behaviour. Even plays a 15 note beat at the end using the haptic and intensity 🤣 Step 7 demonstrates a way to get around the playHaptic queue being limited to 4 events. 

```lua
-- Haptic intensity demo
--
-- Standalone script: put in SCRIPTS/TOOLS/, launch from the radio's Tools
-- menu. Press [ENTER] to step through a series of haptic patterns - the
-- first three use only the classic (duration, pause, flags) API, the rest
-- add the new 4th "intensity" (0-100) argument.
--
-- Steps are debounced: presses are ignored until the haptic queue has had
-- time to fully drain, otherwise a fast double-press can make one step's
-- tail bleed into the next one's pulses.

local step = 0
local nextAllowed = 0
local COOLDOWN = 150 -- 10ms ticks (1.5s) - longer than any single-call step takes

-- Fires one playHaptic call per note, always via PLAY_NOW so it doesn't
-- depend on the haptic queue's own (4-slot) capacity. Each note is
-- { duration, intensity, gap } - gap is how long (in 10ms ticks) to wait
-- after firing this note before firing the next one.
local seq = nil
local seqIndex = 0
local seqNext = 0

local function startSeq(notes)
  seq = notes
  seqIndex = 0
  seqNext = 0
end

local function seqTotalTicks(notes)
  local total = 0
  for i = 1, #notes do
    total = total + notes[i][3]
  end
  return total
end

local RAMP = { { 10, 20, 30 }, { 10, 40, 30 }, { 10, 60, 30 }, { 10, 80, 30 }, { 10, 100, 30 } }

-- 15-note rock beat
local KICK  = { 12, 100, 15 }
local HAT   = { 4, 30, 15 }
local SNARE = { 8, 80, 15 }
local MELODY = {
  KICK, HAT, HAT, SNARE,
  KICK, HAT, HAT, SNARE,
  KICK, HAT, HAT, SNARE,
  KICK, HAT, { 16, 100, 0 },
}

local steps = {
  {
    "1: single buzz",
    "(classic)",
    function() playHaptic(15, 3) end,
  },
  {
    "2: PLAY_NOW buzz",
    "played immediately",
    function() playHaptic(10, 3, PLAY_NOW) end,
  },
  {
    "3: double-tap",
    "2nd call queues",
    function()
      playHaptic(8, 2, PLAY_NOW)
      playHaptic(8, 25)
    end,
  },
  {
    "4: NEW intensity",
    "buzz at 25%",
    function() playHaptic(15, 3, PLAY_NOW, 25) end,
  },
  {
    "5: NEW intensity",
    "same buzz at 100%",
    function() playHaptic(15, 3, PLAY_NOW, 100) end,
  },
  {
    "6: NEW intensity",
    "4 queued levels",
    function()
      playHaptic(10, 15, PLAY_NOW, 25)
      playHaptic(10, 15, 0, 50)
      playHaptic(10, 15, 0, 75)
      playHaptic(10, 15, 0, 100)
    end,
  },
  {
    "7: NEW intensity",
    "5-step ramp up",
    function() startSeq(RAMP) end,
  },
  {
    "8: NEW intensity",
    "15-note drum beat",
    function() startSeq(MELODY) end,
  },
}

local function init()
  step = 0
  nextAllowed = 0
end

local function run(event)
  if event == EVT_VIRTUAL_EXIT then
    return 2
  end

  local now = getTime()

  if seq and now >= seqNext then
    seqIndex = seqIndex + 1
    local note = seq[seqIndex]
    playHaptic(note[1], 3, PLAY_NOW, note[2])
    if seqIndex >= #seq then
      seq = nil
    else
      seqNext = now + note[3]
    end
  end

  if (event == EVT_VIRTUAL_ENTER or event == EVT_VIRTUAL_NEXT_PAGE)
      and now >= nextAllowed then
    step = (step % #steps) + 1
    steps[step][3]()
    if seq then
      nextAllowed = now + seqTotalTicks(seq) + COOLDOWN
    else
      nextAllowed = now + COOLDOWN
    end
  end

  lcd.clear()
  lcd.drawScreenTitle("Haptic demo", 0, 0)
  if step == 0 then
    lcd.drawText(1, 20, "ENTER to start", SMLSIZE)
  else
    lcd.drawText(1, 20, steps[step][1], SMLSIZE)
    lcd.drawText(1, 30, steps[step][2], SMLSIZE)
    lcd.drawText(1, 45, step.."/"..#steps.." ENTER=next", SMLSIZE)
  end

  return 0
end

return { init = init, run = run }
```