### PR TITLE
fix: wrong TX polarity at CCPM pin for external PPM, DSM2 and LemonDSMP modules

### DIFF
--- a/radio/src/pulses/dsm2.cpp
+++ b/radio/src/pulses/dsm2.cpp
@@ -175,7 +175,7 @@ const etx_serial_init dsmUartParams = {
     .baudrate = 0,
     .encoding = ETX_Encoding_8N1,
     .direction = ETX_Dir_TX,
-    .polarity = ETX_Pol_Inverted,
+    .polarity = ETX_Pol_Normal,
 };
 
 static void* dsmInit(uint8_t module, uint32_t baudrate,  uint16_t period, bool telemetry)

--- a/radio/src/pulses/dsm2.cpp
+++ b/radio/src/pulses/dsm2.cpp
@@ -175,7 +175,7 @@ const etx_serial_init dsmUartParams = {
     .baudrate = 0,
     .encoding = ETX_Encoding_8N1,
     .direction = ETX_Dir_TX,
-    .polarity = ETX_Pol_Normal,
+    .polarity = ETX_Pol_Inverted,
 };
 
 static void* dsmInit(uint8_t module, uint32_t baudrate,  uint16_t period, bool telemetry)
@@ -188,12 +188,14 @@ static void* dsmInit(uint8_t module, uint32_t baudrate,  uint16_t period, bool t
   auto mod_st = modulePortInitSerial(module, ETX_MOD_PORT_UART, &params);
   if (!mod_st) {
     // inverted soft-serial fallback
+    params.polarity = ETX_Pol_Normal;
     mod_st = modulePortInitSerial(module, ETX_MOD_PORT_SOFT_INV, &params);
     if (!mod_st) return nullptr;
   }
 
   if (telemetry) {
     params.direction = ETX_Dir_RX;
+    params.polarity = ETX_Pol_Inverted;
     if (!modulePortInitSerial(module, ETX_MOD_PORT_SPORT, &params)) {
       // inverted soft-serial fallback
       modulePortInitSerial(module, ETX_MOD_PORT_SPORT_INV, &params);

--- a/radio/src/pulses/ppm.cpp
+++ b/radio/src/pulses/ppm.cpp
@@ -106,7 +106,7 @@ static void* ppmInit(uint8_t module)
   auto delay = GET_MODULE_PPM_DELAY(module) * 2;
   etx_timer_config_t cfg = {
     .type = ETX_PWM,
-    .polarity = GET_MODULE_PPM_POLARITY(module),
+    .polarity = !GET_MODULE_PPM_POLARITY(module),
     .cmp_val = (uint16_t)delay,
   };
 
@@ -141,7 +141,7 @@ static void ppmSendPulses(void* ctx, uint8_t* buffer, int16_t* channels, uint8_t
   auto delay = GET_MODULE_PPM_DELAY(module) * 2;
   etx_timer_config_t cfg = {
     .type = ETX_PWM,
-    .polarity = GET_MODULE_PPM_POLARITY(module),
+    .polarity = !GET_MODULE_PPM_POLARITY(module),
     .cmp_val = (uint16_t)delay,
   };
 

--- a/radio/src/pulses/ppm.cpp
+++ b/radio/src/pulses/ppm.cpp
@@ -106,7 +106,7 @@ static void* ppmInit(uint8_t module)
   auto delay = GET_MODULE_PPM_DELAY(module) * 2;
   etx_timer_config_t cfg = {
     .type = ETX_PWM,
-    .polarity = !GET_MODULE_PPM_POLARITY(module),
+    .polarity = GET_MODULE_PPM_POLARITY(module),
     .cmp_val = (uint16_t)delay,
   };
 
@@ -141,7 +141,7 @@ static void ppmSendPulses(void* ctx, uint8_t* buffer, int16_t* channels, uint8_t
   auto delay = GET_MODULE_PPM_DELAY(module) * 2;
   etx_timer_config_t cfg = {
     .type = ETX_PWM,
-    .polarity = !GET_MODULE_PPM_POLARITY(module),
+    .polarity = GET_MODULE_PPM_POLARITY(module),
     .cmp_val = (uint16_t)delay,
   };
 

--- a/radio/src/targets/common/arm/stm32/module_timer_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/module_timer_driver.cpp
@@ -46,10 +46,13 @@ static void module_timer_send(void* ctx, const etx_timer_config_t* cfg,
                               const void* pulses, uint16_t length)
 {
   auto timer = (const stm32_pulse_timer_t*)ctx;
-  if (!stm32_pulse_if_not_running_disable(timer)) return;
+  if (!stm32_pulse_if_not_running_disable(timer)) {
+    LL_DMA_DeInit(timer->DMAx, timer->DMA_Stream);
+    return;
+  }
 
   // Set polarity
-  stm32_pulse_set_polarity(timer, cfg->polarity);
+  stm32_pulse_set_polarity(timer, !cfg->polarity);
   
   // Start DMA request and re-enable timer
   uint32_t ocmode = (cfg->type == ETX_PWM) ? LL_TIM_OCMODE_PWM1 : LL_TIM_OCMODE_TOGGLE;


### PR DESCRIPTION
Fixes https://github.com/EdgeTX/edgetx/issues/3413

Summary of changes:
- PPM: As neither g_model.moduleData[].ppm.pulsePol nor the yaml representation has changed over 2.8.1 I figured changing the logic at port initialization is the right place for PPM.
- DSM2 and LemonDSMP: changed initialization of serial port TX to normal 

Tested on TX16s ok.