### PR TITLE
fix(color) - Fix issue where top menu bar still active when widget popup menu is opened

### DIFF
--- a/radio/src/gui/colorlcd/widget.cpp
+++ b/radio/src/gui/colorlcd/widget.cpp
@@ -57,7 +57,10 @@ Widget::Widget(const WidgetFactory* factory, Window* parent,
 
 void Widget::openMenu()
 {
-  Menu* menu = new Menu(this);
+  // Widgets are placed on a full screen window which is underneath the main view menu bar
+  // Find the parent of this so that when the popup loads it covers the main view menu
+  Window* w = parent->getFullScreenWindow()->getParent();
+  Menu* menu = new Menu(w ? w : this);
   if (fsAllowed) {
     menu->addLine(STR_WIDGET_FULLSCREEN, [&]() { setFullscreen(true); });
   }


### PR DESCRIPTION
Fixes #3412 

The Menu popup dialog tries to find the parent full screen window to display the modal window over which should block all the other on-screen buttons.

The widgets are displayed on a child full screen window which sits under the main view menu bar, so the widget Menu popup does not block the top bar buttons.

This change tries to find the real top level full screen window to prevent this problem.