### PR TITLE
 fix: X10access - no PPM output on CPPM pin

### DIFF
--- a/radio/src/targets/common/arm/stm32/stm32_pulse_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_pulse_driver.cpp
@@ -70,11 +70,7 @@ void stm32_pulse_init(const stm32_pulse_timer_t* tim, uint32_t freq)
   }
   
   timInit.Prescaler = __LL_TIM_CALC_PSC(tim->TIM_Freq, freq);
-  if (IS_TIM_32B_COUNTER_INSTANCE(tim->TIMx)) {
-    timInit.Autoreload = 0xFFFFFFFFUL;
-  } else {
-    timInit.Autoreload = STM32_DEFAULT_TIMER_AUTORELOAD;
-  }
+  timInit.Autoreload = STM32_DEFAULT_TIMER_AUTORELOAD;
 
   enable_tim_clock(tim->TIMx);
   LL_TIM_Init(tim->TIMx, &timInit);


### PR DESCRIPTION
Fixes #3418 

Summary of changes:
- revert changes made to pulse driver in commit e016598
- tested successfully on X10access

Notes:
I suspect the change was made under a wrong assumption. Struct `LL_TIM_InitTypeDef` member `.Autoreload ` is of unsigende 32 bit (uint32_t) type . Setting `.Autoreload` to `STM32_DEFAULT_TIMER_AUTORELOAD` which is defined as value 65535 (= 0xffff) most likely tricked the author into thinking of 0xffff as a signed value. Hence the author extended the initialization code to distinguish between 16 and 32 bit timers and setting .Autoreload to 0xffffffff in case the timer is a 32bit timer. 0xffff is not a signed value so 32 bit timers should also be initialized with 0xffff to load the same countdown value as for 16 bit timers. This is what the original code did. Reverting to the original code fixes #3418
