### PR TITLE
fix(color) - Fix issue where popup telemetry warning can crash radio.

### DIFF
--- a/radio/src/gui/colorlcd/popups.cpp
+++ b/radio/src/gui/colorlcd/popups.cpp
@@ -21,6 +21,7 @@
 
 #include "popups.h"
 #include "libopenui.h"
+#include "pwr.h"
 
 static void _run_popup_dialog(const char* title, const char* msg,
                               const char* info = nullptr)
@@ -37,6 +38,19 @@ static void _run_popup_dialog(const char* title, const char* msg,
     md->setInfoText(std::string(info));
   }
   while (running) {
+    // Allow power off while showing popup
+    auto check = pwrCheck();
+    if (check == e_power_off) {
+      boardOff();
+#if defined(SIMU)
+      // Required so simulator exits cleanly when window closed
+      return;
+#endif
+    } else if (check == e_power_press) {
+      WDG_RESET();
+      RTOS_WAIT_MS(1);
+      continue;
+    } 
     WDG_RESET();
     MainWindow::instance()->run();
     LvglWrapper::runNested();
@@ -52,4 +66,34 @@ void POPUP_INFORMATION(const char * message)
 void POPUP_WARNING(const char * message, const char * info)
 {
   _run_popup_dialog("Warning", message, info);
+}
+
+static const char* ui_popup_title = nullptr;
+static const char* ui_popup_msg = nullptr;
+static const char* ui_popup_info = nullptr;
+static bool ui_popup_active = false;
+
+// Allow UI task to show a popup deferred from another task.
+void show_ui_popup()
+{
+  if (ui_popup_active) {
+    _run_popup_dialog(ui_popup_title, ui_popup_msg, ui_popup_info);
+    ui_popup_active = false;
+  }
+}
+
+void POPUP_WARNING_ON_UI_TASK(const char * message, const char * info)
+{
+  // Wait in case already in popup.
+  while (ui_popup_active) {
+    RTOS_WAIT_MS(20);
+  }
+  ui_popup_title = "Warning";
+  ui_popup_msg = message;
+  ui_popup_info = info;
+  ui_popup_active = true;
+  // Wait until closed
+  while (ui_popup_active) {
+    RTOS_WAIT_MS(20);
+  }
 }

--- a/radio/src/gui/colorlcd/popups.h
+++ b/radio/src/gui/colorlcd/popups.h
@@ -27,3 +27,6 @@ typedef std::function<void(const char *, const char *, int, int)> ProgressHandle
 
 void POPUP_INFORMATION(const char * message);
 void POPUP_WARNING(const char * message, const char * info = nullptr);
+void POPUP_WARNING_ON_UI_TASK(const char * message, const char * info = nullptr);
+
+void show_ui_popup();

--- a/radio/src/gui/common/stdlcd/popups.h
+++ b/radio/src/gui/common/stdlcd/popups.h
@@ -187,4 +187,7 @@ inline void POPUP_MENU_START(PopupMenuHandler handler)
   }
 }
 
+// For compatability with color LCD code base, not (currently) required for B&W
+#define POPUP_WARNING_ON_UI_TASK POPUP_WARNING
+
 #endif // _STDLCD_POPUPS_H_

--- a/radio/src/main.cpp
+++ b/radio/src/main.cpp
@@ -580,6 +580,8 @@ void perMain()
   DEBUG_TIMER_START(debugTimerGuiMain);
 #if defined(LIBOPENUI)
   guiMain(0);
+  // For color screens show a popup deferred from another task
+  show_ui_popup();
 #else
   guiMain(evt);
 #endif

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -269,7 +269,7 @@ void telemetryWakeup()
 #if defined(PCBFRSKY)
     if (isBadAntennaDetected()) {
       AUDIO_RAS_RED();
-      POPUP_WARNING(STR_WARNING, STR_ANTENNAPROBLEM);
+      POPUP_WARNING_ON_UI_TASK(STR_WARNING, STR_ANTENNAPROBLEM);
       SCHEDULE_NEXT_ALARMS_CHECK(10/*seconds*/);
     }
 #endif


### PR DESCRIPTION
Fixes #3424 

The antenna warning from the telemetry task is handed off to the UI task for display.

Also fixes an issue where the simulator does not close cleanly if a popup is showing.
