### PR TITLE
fix(color): Rework rotary encoder acceleration calculation removing double handling

### DIFF
--- a/radio/src/gui/colorlcd/LvglWrapper.cpp
+++ b/radio/src/gui/colorlcd/LvglWrapper.cpp
@@ -254,21 +254,11 @@ static void rotaryDriverRead(lv_indev_drv_t *drv, lv_indev_data_t *data)
   if (diff != 0) {
     reset_inactivity();
 
-    bool use_accel = false;
-    auto i = lv_indev_get_act();
-    if (i) {
-      auto g = i->group;
-      if (g && lv_group_get_editing(g)) {
-        auto obj = lv_group_get_focused(g);
-        use_accel = obj && lv_obj_has_flag(obj, LV_OBJ_FLAG_ENCODER_ACCEL);
-      }
-    }
-    
     int8_t dir = 0;
     if (diff < 0) dir = -1;
     else if (diff > 0) dir = 1;
 
-    if (use_accel && (dir == prevDir)) {
+    if (dir == prevDir) {
       auto dt = rotencDt - lastDt;
       dt = max(dt, (uint32_t)1);
 
@@ -279,6 +269,9 @@ static void rotaryDriverRead(lv_indev_drv_t *drv, lv_indev_data_t *data)
     } else {
       _rotary_enc_accel = 0;
     }
+
+    // For Lua getRotEncSpeed() function
+    rotencSpeed = max(_rotary_enc_accel, (int8_t)1);
 
     prevDir = dir;
     lastDt = rotencDt;

--- a/radio/src/gui/colorlcd/LvglWrapper.cpp
+++ b/radio/src/gui/colorlcd/LvglWrapper.cpp
@@ -272,7 +272,7 @@ static void rotaryDriverRead(lv_indev_drv_t *drv, lv_indev_data_t *data)
       auto dt = rotencDt - lastDt;
       dt = max(dt, (uint32_t)1);
 
-      auto dx_dt = (diff * diff * 100) / dt;
+      auto dx_dt = (diff * diff * 50) / dt;
       dx_dt = min(dx_dt, (uint32_t)100);
 
       _rotary_enc_accel = (int8_t)dx_dt;

--- a/radio/src/gui/colorlcd/LvglWrapper.cpp
+++ b/radio/src/gui/colorlcd/LvglWrapper.cpp
@@ -270,12 +270,12 @@ static void rotaryDriverRead(lv_indev_drv_t *drv, lv_indev_data_t *data)
 
     if (use_accel && (dir == prevDir)) {
       auto dt = rotencDt - lastDt;
-      auto dx_dt = (abs(diff) * 50) / max(dt, (uint32_t)1);
+      dt = max(dt, (uint32_t)1);
+
+      auto dx_dt = (diff * diff * 100) / dt;
+      dx_dt = min(dx_dt, (uint32_t)100);
 
       _rotary_enc_accel = (int8_t)dx_dt;
-      if (_rotary_enc_accel > 0) {
-        data->enc_diff = (int16_t)diff * (int16_t)_rotary_enc_accel;
-      }
     } else {
       _rotary_enc_accel = 0;
     }


### PR DESCRIPTION
Fixes #3428 

Only tested on TX16S Mk2 so far; but this seems to work better in my testing.