### PR TITLE
Fix configurable port, solved R9M Access problem and support FRM303 via mod

### DIFF
--- a/radio/src/hal/module_port.cpp
+++ b/radio/src/hal/module_port.cpp
@@ -31,6 +31,16 @@ extern const uint8_t _n_modules;
 static etx_module_state_t _module_states[MAX_MODULES];
 static uint8_t _module_power;
 
+#if defined(CONFIGURABLE_MODULE_PORT)
+// supplemental configurable port
+static etx_module_port_t _extra_module_port;
+
+void modulePortConfigExtra(const etx_module_port_t* port)
+{
+  memcpy(&_extra_module_port, port, sizeof(_extra_module_port));
+}
+#endif
+
 void modulePortInit()
 {
   memset(_module_states, 0, sizeof(_module_states));
@@ -41,16 +51,6 @@ void modulePortInit()
   _extra_module_port.type = 0xFF; // some invalid type
 #endif
 }
-
-#if defined(CONFIGURABLE_MODULE_PORT)
-// supplemental configurable port
-static etx_module_port_t _extra_module_port;
-
-void modulePortConfigExtra(const etx_module_port_t* port)
-{
-  memcpy(&_extra_module_port, port, sizeof(_extra_module_port));
-}
-#endif
 
 static void modulePortClear(etx_module_state_t* st)
 {

--- a/radio/src/pulses/afhds3.cpp
+++ b/radio/src/pulses/afhds3.cpp
@@ -881,10 +881,18 @@ static void* initModule(uint8_t module)
     module == INTERNAL_MODULE ? ETX_Pol_Normal : ETX_Pol_Inverted;
   mod_st = modulePortInitSerial(module, ETX_MOD_PORT_UART, &params);
 
-  if (module == EXTERNAL_MODULE && !mod_st) {
+#if defined(CONFIGURABLE_MODULE_PORT)
+  if (!mod_st && module == EXTERNAL_MODULE) {
+    // Try Connect using aux serial mod
+    params.polarity = ETX_Pol_Normal;
+    mod_st = modulePortInitSerial(module, ETX_MOD_PORT_UART, &params);
+  }
+#endif
+
+  if (!mod_st && module == EXTERNAL_MODULE) {
     // soft-serial fallback
     params.baudrate = AFHDS3_SOFTSERIAL_BAUDRATE;
-    params.direction = ETX_Dir_RX;
+    params.direction = ETX_Dir_TX;
     period = AFHDS3_SOFTSERIAL_COMMAND_TIMEOUT * 1000 /* us */;
     mod_st = modulePortInitSerial(module, ETX_MOD_PORT_SOFT_INV, &params);
     // TODO: telemetry RX ???

--- a/radio/src/pulses/pulses.cpp
+++ b/radio/src/pulses/pulses.cpp
@@ -470,7 +470,7 @@ static void pulsesEnableModule(uint8_t module, uint8_t protocol)
       break;
 #endif
 
-#if defined(INTERNAL_MODULE_AFHDS3)
+#if defined(INTERNAL_MODULE_AFHDS3) || defined(AFHDS3)
     case PROTOCOL_CHANNELS_AFHDS3:
       _init_module(module, &afhds3::ProtoDriver);
       break;

--- a/radio/src/targets/horus/CMakeLists.txt
+++ b/radio/src/targets/horus/CMakeLists.txt
@@ -193,6 +193,10 @@ if(IMU_LSM6DS33)
   set(AUX_SERIAL OFF)
 endif()
 
+if(AUX_SERIAL)
+  add_definitions(-DCONFIGURABLE_MODULE_PORT)
+endif()
+
 if(NOT INTERNAL_MODULE_PXX1)
   option(ALLOW_TRAINER_MULTI "Allow multimodule to be use as trainer input" OFF)
 endif()


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #3337
Fixes #3413

Summary of changes:
1. Fix configurable port problems
2. Resolved R9M Access MOD unusable
3. Support FRM303 in TX16S via AUX1 mod (similar to R9M mod but no need inverters.

Documentation for mod: https://github.com/EdgeTX/edgetx/wiki/Flysky-FRM303-Mod-for-TX16S