### PR TITLE
fix: undesired MPM protocol selection changes

### DIFF
--- a/radio/src/storage/storage_common.cpp
+++ b/radio/src/storage/storage_common.cpp
@@ -142,16 +142,24 @@ void postModelLoad(bool alarms)
   }
 
   // fix colorLCD radios not writing yaml tag receivers
-  ModuleData *intModule = &g_model.moduleData[INTERNAL_MODULE];
-  ModuleData *extModule = &g_model.moduleData[EXTERNAL_MODULE];
+  if(isModulePXX2(INTERNAL_MODULE)) {
+    ModuleData *intModule = &g_model.moduleData[INTERNAL_MODULE];
 
-  for(uint8_t receiverIdx = 0; receiverIdx < 3; receiverIdx++) {
-    if(intModule->pxx2.receiverName[receiverIdx][0])
+    for(uint8_t receiverIdx = 0; receiverIdx < 3; receiverIdx++) {
+      if(intModule->pxx2.receiverName[receiverIdx][0])
         intModule->pxx2.receivers |= (1 << receiverIdx);
-
-    if(extModule->pxx2.receiverName[receiverIdx][0])
-        extModule->pxx2.receivers |= (1 << receiverIdx);
+    }
   }
+
+  if(isModulePXX2(EXTERNAL_MODULE)) {
+    ModuleData *extModule = &g_model.moduleData[EXTERNAL_MODULE];
+
+    for(uint8_t receiverIdx = 0; receiverIdx < 3; receiverIdx++) {
+      if(extModule->pxx2.receiverName[receiverIdx][0])
+        extModule->pxx2.receivers |= (1 << receiverIdx);
+    }
+  }
+
   storageDirty(EE_MODEL);
 #endif
 


### PR DESCRIPTION
Fixes #3434

Summary of changes:
This fixes the shortcomings of [PR #3355](https://github.com/EdgeTX/edgetx/pull/3355) where ACCESS receiver name data was corrected to fix https://github.com/EdgeTX/edgetx/issues/3273
Added checking module types of the currently loaded model. If there is no PXX2 module selected there is nothing to correct. 
The problem finder confirmed this to fix his problem.

Note of shame:
Dummy me created a major mess with https://github.com/EdgeTX/edgetx/pull/3355 which showed it's ugly face in 2.8.2 (https://github.com/EdgeTX/edgetx/issues/3434) and is also present in 2.9. My fudge up causes under very specific conditions (which makes it look random) an index shift to Multi protocols (firmware and simulator). The reason is writing to the PXX2 module data struct via PXX2 union  without checking if PXX2 is actually an active module of the loaded model. This semi-randomly overwrites parts of the active modules data. For Multi this can result in an index shift in in the .yml file of the active model. I apologize for the inconvenience.

@pfeerick as this is ugly for 2.8.2. can we think about 2.8.3 which should include at least this PR and the fix for crashing Companion if Multi is selected as internal or external module (https://github.com/EdgeTX/edgetx/pull/3426).