### PR TITLE
fix(X9lite): Chan. monitor, other display glitches

### DIFF
--- a/radio/src/gui/128x64/model_failsafe.cpp
+++ b/radio/src/gui/128x64/model_failsafe.cpp
@@ -112,7 +112,7 @@ void menuModelFailsafe(event_t event)
     }
 
     // Gauge
-#if !defined(PCBX7) // X7 LCD doesn't like too many horizontal lines
+#if !(defined(PCBX7) || defined(PCBX9LITE) || defined(PCBX9LITES)) // X7/X9 LCD doesn't like too many horizontal lines
     lcdDrawRect(x+LCD_W-3-wbar, y, wbar+1, 6);
 #endif
     const uint8_t lenChannel = limit<uint8_t>(1, (abs(channelValue) * wbar/2 + lim/2) / lim, wbar/2);

--- a/radio/src/gui/128x64/widgets.cpp
+++ b/radio/src/gui/128x64/widgets.cpp
@@ -68,7 +68,7 @@ void drawVerticalScrollbar(coord_t x, coord_t y, coord_t h, uint16_t offset, uin
 
 void drawGauge(coord_t x, coord_t y, coord_t w, coord_t h, int32_t val, int32_t max)
 {
-#if defined(PCBX7) || defined(PCBX9LITES) // X7 LCD doesn't like too many horizontal lines
+#if defined(PCBX7) || defined(PCBX9LITE) || defined(PCBX9LITES) // X7/X9 LCD doesn't like too many horizontal lines
   h++;
 #else
   lcdDrawRect(x, y, w+1, h);

--- a/radio/src/gui/common/stdlcd/model_receiver_options.cpp
+++ b/radio/src/gui/common/stdlcd/model_receiver_options.cpp
@@ -238,7 +238,7 @@ void menuModelReceiverOptions(event_t event)
             // Bargraph
             if (channel <= channelMax) {
               int32_t channelValue = channelOutputs[channel];
-  #if !defined(PCBX7) // X7 LCD doesn't like too many horizontal lines
+  #if !(defined(PCBX7) || defined(PCBX9LITE) || defined(PCBX9LITES)) // X7/X9 LCD doesn't like too many horizontal lines
               lcdDrawRect(RECEIVER_OPTIONS_2ND_COLUMN, y + 2, wbar + 1, 4);
   #endif
               auto lenChannel = limit<uint8_t>(1, (abs(channelValue) * wbar / 2 + lim / 2) / lim, wbar / 2);


### PR DESCRIPTION
It seems the display used on these TX doesn't like too many horizontal lines.

Fixes #3450

Summary of changes:
 - Apply X7/X9 Lite S fix to X9 Lite also, consistently