### PR TITLE
fix(color) - Fix memory leak when disconnecting USB in SD card mode.

### DIFF
--- a/radio/src/gui/colorlcd/themes/480_default.cpp
+++ b/radio/src/gui/colorlcd/themes/480_default.cpp
@@ -156,7 +156,7 @@ class Theme480: public OpenTxTheme
     void setBackgroundImageFileName(const char *fileName) override
     {
       // ensure you delete old bitmap
-      if (strcmp(backgroundImageFileName, fileName) != 0 && backgroundBitmap != nullptr)
+      if (backgroundBitmap != nullptr)
         delete backgroundBitmap;
       OpenTxTheme::setBackgroundImageFileName(fileName);  // set the filename
       backgroundBitmap = BitmapBuffer::loadBitmap(backgroundImageFileName);


### PR DESCRIPTION
When USB is connected in SD card mode, everything is shut down.
When USB is disconnected, everything is re-loaded including the background image.

The background image name had not been changed, so the old bitmap buffer was not deleted, even though the image was re-loaded into a new bitmap buffer.

The old buffer is now always deleted.
The user may have copied a new image file to the SD card so can't just assume the old buffer is valid.
