### PR TITLE
feat(color) - Skip model switch delay if mixer not running (e.g. on startup).

### DIFF
--- a/radio/src/storage/storage_common.cpp
+++ b/radio/src/storage/storage_common.cpp
@@ -61,8 +61,10 @@ void preModelLoad()
   logsClose();
 #endif
 
+  bool needDelay = false;
   if (mixerTaskStarted()) {
     pulsesStop();
+    needDelay = true;
   }
 
   stopTrainer();
@@ -70,7 +72,8 @@ void preModelLoad()
   deleteCustomScreens();
 #endif
 
-  RTOS_WAIT_MS(200);
+  if (needDelay)
+    RTOS_WAIT_MS(200);
 }
 
 void postRadioSettingsLoad()


### PR DESCRIPTION
There is a 200ms delay built in when switching models to ensure the RF module initialises properly when stopped and restarted.

This is not needed on radio startup so this PR skips it to reduce startup time.
