### PR TITLE
fix(radio) - Fix crash when editing multi module type on 212x64 LCD B&W radios.

### DIFF
--- a/radio/src/gui/212x64/model_setup.cpp
+++ b/radio/src/gui/212x64/model_setup.cpp
@@ -1543,6 +1543,7 @@ void menuModelSetup(event_t event)
        if (MULTIMODULE_PROTOCOL_KNOWN(moduleIdx)) {
          const char * title = getMultiOptionTitle(moduleIdx);
 
+         if (!title) break;
          lcdDrawText(INDENT_WIDTH, y, title);
          if (title == STR_MULTI_RFTUNE) {
            lcdDrawText(MODEL_SETUP_2ND_COLUMN + 23, y, "RSSI(", LEFT);


### PR DESCRIPTION
Fixes #3458 

Add missing test for empty 'title' value.
