### PR TITLE
fix(color) - Fix for custom failsafe settings not being saved to SD card on color LCD radios.

### DIFF
--- a/radio/src/gui/colorlcd/custom_failsafe.cpp
+++ b/radio/src/gui/colorlcd/custom_failsafe.cpp
@@ -110,6 +110,7 @@ public:
     if (value != FAILSAFE_CHANNEL_HOLD && value != FAILSAFE_CHANNEL_NOPULSE) {
       setSetValueHandler([=](int value) {
         g_model.failsafeChannels[channel] = calc1000toRESX(value);
+        SET_DIRTY();
       });
       lv_obj_clear_state(lvobj, LV_STATE_DISABLED);
     } else {
@@ -117,6 +118,7 @@ public:
       setSetValueHandler(nullptr);
       lv_obj_add_state(lvobj, LV_STATE_DISABLED);
     }
+    SET_DIRTY();
     NumberEdit::update();
   }
 


### PR DESCRIPTION
Fixes #3462 

Add missing calls to SET_DIRTY() when values changed.