### PR TITLE
feat(color) - New switch choice dialog

### DIFF
--- a/radio/src/gui/colorlcd/input_edit.cpp
+++ b/radio/src/gui/colorlcd/input_edit.cpp
@@ -138,9 +138,9 @@ void InputEditWindow::buildBody(FormWindow* form)
   line = form->newLine(&grid);
   new StaticText(line, rect_t{}, STR_SWITCH, 0, COLOR_THEME_PRIMARY1);
   new SwitchChoice(line, rect_t{}, SWSRC_FIRST_IN_MIXES, SWSRC_LAST_IN_MIXES,
-                   GET_DEFAULT(inputData->swtch),
+                   GET_DEFAULT(input->swtch),
                    [=](int32_t newValue) {
-                       inputData->swtch = newValue;
+                       input->swtch = newValue;
                        preview->invalidate();
                        SET_DIRTY();
                    });

--- a/radio/src/gui/colorlcd/input_edit.cpp
+++ b/radio/src/gui/colorlcd/input_edit.cpp
@@ -137,8 +137,13 @@ void InputEditWindow::buildBody(FormWindow* form)
   // Switch
   line = form->newLine(&grid);
   new StaticText(line, rect_t{}, STR_SWITCH, 0, COLOR_THEME_PRIMARY1);
-  new SwitchChoice(line, rect_t{}, SWSRC_FIRST_IN_MIXES,
-                   SWSRC_LAST_IN_MIXES, GET_SET_DEFAULT(input->swtch));
+  new SwitchChoice(line, rect_t{}, SWSRC_FIRST_IN_MIXES, SWSRC_LAST_IN_MIXES,
+                   GET_DEFAULT(inputData->swtch),
+                   [=](int32_t newValue) {
+                       inputData->swtch = newValue;
+                       preview->invalidate();
+                       SET_DIRTY();
+                   });
 
   // Curve
   line = form->newLine(&grid);

--- a/radio/src/gui/colorlcd/switchchoice.cpp
+++ b/radio/src/gui/colorlcd/switchchoice.cpp
@@ -320,12 +320,7 @@ class SwitchMatrix : public Window
         }
       }
 
-      for (int i = 0; i < btnsCnt; i += 1) {
-        if (btns[i]->hasActive()) {
-          setFocus(i);
-          break;
-        }
-      }
+      checkFocus();
     }
 
     ~SwitchMatrix()
@@ -339,6 +334,16 @@ class SwitchMatrix : public Window
     {
       for (int i = 0; i < btnsCnt; i += 1)
         btns[i]->updateBtns();
+    }
+
+    void checkFocus()
+    {
+      for (int i = 0; i < btnsCnt; i += 1) {
+        if (btns[i]->hasActive()) {
+          setFocus(i);
+          return;
+        }
+      }
     }
 
     void setInverted(bool state)
@@ -628,6 +633,25 @@ class SwitchDialog : public ModalWindow
         m_onSave(isLongPressed);
         deleteLater();
       }
+      swsrc_t val = 0;
+      swsrc_t swtch = getMovedSwitch();
+      if (swtch) {
+        div_t info = switchInfo(swtch);
+        if (IS_CONFIG_TOGGLE(info.quot)) {
+          if (info.rem != 0) {
+            val = (val == swtch ? swtch - 2 : swtch);
+          }
+        } else {
+          val = swtch;
+        }
+        if (val && m_isValueAvailable(val)) {
+          setSwitchValue(val, false);
+          for (int i = 0; i < maxSection; i += 1) {
+            if (sectionBtn[i])
+              sectionBtn[i]->checkFocus();
+          }
+        }
+      }
     }
 
     void setTitle()
@@ -651,7 +675,7 @@ class SwitchDialog : public ModalWindow
       } else {
         m_setValue(newValue);
         setTitle();
-        for (int i = 0; i < 4; i += 1) {
+        for (int i = 0; i < maxSection; i += 1) {
           if (sectionBtn[i])
             sectionBtn[i]->updateBtns();
         }

--- a/radio/src/gui/colorlcd/switchchoice.cpp
+++ b/radio/src/gui/colorlcd/switchchoice.cpp
@@ -111,7 +111,7 @@ class SwitchButtons : public ButtonMatrix
 
     void updateBtns()
     {
-      update();
+      refresh();
     }
 
     void setInverted(bool state)
@@ -172,8 +172,9 @@ class SwitchButtons : public ButtonMatrix
       if (inverted)
         s = "!";
       s += getSwitchPositionName(sw);
-      setText(b, s.c_str());
       btnValues[b] = sw;
+      setText(b, s.c_str());
+      setChecked(b);
     }
 
     void setButtonText(int firstIdx, int lastIdx)

--- a/radio/src/gui/colorlcd/switchchoice.cpp
+++ b/radio/src/gui/colorlcd/switchchoice.cpp
@@ -27,6 +27,584 @@
 #include "opentx.h"
 #include "strhelpers.h"
 #include "switches.h"
+#include "modal_window.h"
+#include "button_matrix.h"
+
+#if LCD_W > LCD_H
+#define DLG_W (LCD_W - 96)
+#define DLG_H (LCD_H - 32)
+#define SW_INDENT 20
+#define MAX_COLS 4
+#define MAX_ROWS 3
+#else
+#define DLG_W (LCD_W - 20)
+#define DLG_H (LCD_H - 96)
+#define SW_INDENT 10
+#define MAX_COLS 3
+#define MAX_ROWS 5
+#endif
+
+class SwitchButtonMatrix : public ButtonMatrix
+{
+  public:
+    SwitchButtonMatrix(Window* parent, int firstIdx, int lastIdx,
+                       std::function<int16_t()> getValue, std::function<void(int16_t)> setValue,
+                       bool invert, int cols, int rows, int btn_cnt, bool isSwitches) :
+        ButtonMatrix(parent, rect_t{}),
+        m_getValue(std::move(getValue)),
+        m_setValue(std::move(setValue)),
+        firstIdx(firstIdx),
+        lastIdx(lastIdx),
+        inverted(invert),
+        btnCnt(btn_cnt),
+        isSwitches(isSwitches)
+    {
+      int max_btns = rows * cols;
+
+      lv_obj_set_width(lvobj, cols * 75);
+      lv_obj_set_height(lvobj, rows * 38);
+
+      lv_obj_set_style_bg_opa(lvobj, LV_OPA_0, LV_PART_MAIN);
+
+      lv_obj_set_style_pad_all(lvobj, lv_dpx(4), LV_PART_MAIN);
+      lv_obj_set_style_pad_row(lvobj, lv_dpx(4), LV_PART_MAIN);
+      lv_obj_set_style_pad_column(lvobj, lv_dpx(4), LV_PART_MAIN);
+
+      lv_obj_remove_style(lvobj, nullptr, LV_PART_MAIN | LV_STATE_FOCUSED);
+      lv_obj_remove_style(lvobj, nullptr, LV_PART_MAIN | LV_STATE_EDITED);
+
+      initBtnMap(cols, max_btns);
+
+      update();
+
+      for (int i = btn_cnt; i < max_btns; i += 1) {
+        hide(i);
+      }
+
+      btnValues = new int16_t[btn_cnt];
+      for (int i = 0; i < btn_cnt; i +=1)
+        btnValues[i] = -1;
+
+      refresh();
+    }
+
+    ~SwitchButtonMatrix()
+    {
+     if (btnValues) {
+       delete btnValues;
+       btnValues = nullptr;
+     }
+    }
+
+    void updateBtns()
+    {
+      update();
+    }
+
+    void setInverted(bool state)
+    {
+      inverted = state;
+      refresh();
+    }
+
+    bool hasActive()
+    {
+      for (int i = 0; i < btnCnt; i += 1) {
+        if (isActive(i)) {
+          return true;
+        }
+      }
+      return false;
+    }
+
+  protected:
+    int16_t* btnValues = nullptr;
+    std::function<void(int16_t)> m_setValue;
+    std::function<int16_t()> m_getValue;
+    bool inverted;
+    int firstIdx;
+    int lastIdx;
+    int btnCnt;
+    bool isSwitches;
+
+    void hide(int n)
+    {
+      lv_btnmatrix_set_btn_ctrl(lvobj, n, LV_BTNMATRIX_CTRL_HIDDEN);
+    }
+
+    void refresh()
+    {
+      if (isSwitches) {
+        setSwitchText(firstIdx, lastIdx);
+      } else {
+        setButtonText(firstIdx, lastIdx);
+      }
+
+      update();
+    }
+
+    void setBtnText(int b, int sw)
+    {
+      std::string s("");
+      if (inverted)
+        s = "!";
+      s += getSwitchPositionName(sw);
+      setText(b, s.c_str());
+      btnValues[b] = sw;
+    }
+
+    void setButtonText(int firstIdx, int lastIdx, int b = 0)
+    {
+      for (int i = firstIdx; i <= lastIdx; i += 1) {
+        if (isSwitchAvailableInMixes(i)) {
+          setBtnText(b, i);
+          b += 1;
+        }
+      }
+    }
+
+    void setSwitchText(int firstIdx, int lastIdx)
+    {
+      int b = 0;
+      for (int i = firstIdx; i <= lastIdx; i += 3) {
+        if (isSwitchAvailableInMixes(i) || isSwitchAvailableInMixes(i+1) || isSwitchAvailableInMixes(i+2)) {
+          if (isSwitchAvailableInMixes(i)) {
+            setBtnText(b, i);
+          } else {
+            hide(b);
+          }
+          b += 1;
+          if (isSwitchAvailableInMixes(i+1)) {
+            setBtnText(b, i+1);
+          } else {
+            hide(b);
+          }
+          b += 1;
+          if (isSwitchAvailableInMixes(i+2)) {
+            setBtnText(b, i+2);
+          } else {
+            hide(b);
+          }
+          b += 1;
+        }
+      }
+    }
+
+    void onPress(uint8_t btn_id)
+    {
+      m_setValue(inverted ? -btnValues[btn_id] : btnValues[btn_id]);
+    }
+
+    bool isActive(uint8_t btn_id)
+    {
+      return btnValues[btn_id] == abs(m_getValue());
+    }
+};
+
+class SwitchMatrix : public Window
+{
+  public:
+    SwitchMatrix(Window* parent, int firstIdx, int lastIdx,
+                 std::function<int16_t()> getValue, std::function<void(int16_t)> setValue,
+                 bool invert) :
+        Window(parent, rect_t{})
+    {
+      setWidth(LV_SIZE_CONTENT);
+      setHeight(LV_SIZE_CONTENT);
+      padAll(0);
+      padLeft(SW_INDENT);
+
+      auto form = new FormWindow(this, rect_t{});
+      form->setFlexLayout(LV_FLEX_FLOW_COLUMN, 0);
+      form->padAll(0);
+      form->setWidth(LV_SIZE_CONTENT);
+      form->setHeight(LV_SIZE_CONTENT);
+
+      isSwitches = (firstIdx == SWSRC_FIRST_SWITCH);
+
+      int cols = MAX_COLS;
+#if LCD_H > LCD_W
+      if (firstIdx == SWSRC_FIRST_TRIM)
+        cols = 2;
+#endif
+      int btn_cnt = 0;
+      int multiPos_cnt = 0;
+
+      if (isSwitches) {
+        cols = 3;
+        btn_cnt = switchButtonCount(firstIdx, lastIdx);
+      } else {
+        btn_cnt = buttonCount(firstIdx, lastIdx);
+      }
+
+      int rows = (btn_cnt + cols - 1) / cols;
+      int max_btns = rows * cols;
+
+      if (isSwitches) {
+        btnsCnt = rows;
+#if NUM_XPOTS > 0
+        btnsCnt += 1;
+#endif
+      } else {
+        if (rows <= MAX_ROWS)
+          btnsCnt = 1;
+        else
+          btnsCnt = rows;
+      }
+
+      btns = new SwitchButtonMatrix*[btnsCnt];
+
+      if (isSwitches) {
+        int n = 0;
+        for (int i = firstIdx; i <= lastIdx; i += 3) {
+          if (isSwitchAvailableInMixes(i) || isSwitchAvailableInMixes(i+1) || isSwitchAvailableInMixes(i+2)) {
+            btns[n] = new SwitchButtonMatrix(form, i, i+2, getValue, setValue, invert, cols, 1, cols, true);
+            n += 1;
+          }
+        }
+#if NUM_XPOTS > 0
+        int r = (buttonCount(SWSRC_FIRST_MULTIPOS_SWITCH, SWSRC_LAST_MULTIPOS_SWITCH) + cols - 1) / cols;
+        btns[n] = new SwitchButtonMatrix(form, SWSRC_FIRST_MULTIPOS_SWITCH, SWSRC_LAST_MULTIPOS_SWITCH, getValue, setValue, invert, cols, r, r * cols, false);
+#endif
+      } else {
+        if (btnsCnt == 1) {
+          btns[0] = new SwitchButtonMatrix(form, firstIdx, lastIdx, getValue, setValue, invert, cols, rows, btn_cnt, false);
+        } else {
+          int sw = firstIdx;
+          for (int i = 0; i <= rows; i += 1) {
+            int lw = sw + cols - 1;
+            if (lw > lastIdx) lw = lastIdx;
+            btns[i] = new SwitchButtonMatrix(form, sw, lw, getValue, setValue, invert, cols, 1, cols, false);
+          }
+        }
+      }
+
+      for (int i = 0; i < btnsCnt; i += 1) {
+        if (btns[i]->hasActive()) {
+          lv_group_focus_obj(btns[i]->getLvObj());
+          break;
+        }
+      }
+    }
+
+    ~SwitchMatrix()
+    {
+      if (btns)
+        delete btns;
+      btns = nullptr;
+    }
+
+    void updateBtns()
+    {
+      for (int i = 0; i < btnsCnt; i += 1)
+        btns[i]->updateBtns();
+    }
+
+    void setInverted(bool state)
+    {
+      for (int i = 0; i < btnsCnt; i += 1)
+        btns[i]->setInverted(state);
+    }
+
+  protected:
+    SwitchButtonMatrix** btns = nullptr;
+    int btnsCnt = 0;
+    bool isSwitches = false;
+
+    int buttonCount(int firstIdx, int lastIdx)
+    {
+      int n = 0;
+      for (int i = firstIdx; i <= lastIdx; i += 1) {
+        if (isSwitchAvailableInMixes(i)) {
+          n += 1;
+        }
+      }
+      return n;
+    }
+
+    int switchButtonCount(int firstIdx, int lastIdx)
+    {
+      int n = 0;
+      for (int i = firstIdx; i <= lastIdx; i += 3) {
+        if (isSwitchAvailableInMixes(i) || isSwitchAvailableInMixes(i+1) || isSwitchAvailableInMixes(i+2)) {
+          n += 3;
+        }
+      }
+      return n;
+    }
+};
+
+class SwitchDialog : public ModalWindow
+{
+  protected:
+    std::function<int16_t()> m_getValue;
+    std::function<void(int16_t)> m_setValue;
+    std::function<void()> m_onSave;
+    StaticText* title = nullptr;
+    FormWindow* tabsForm = nullptr;
+    Window* switches = nullptr;
+    FormWindow* switchesForm = nullptr;
+    int filterSection = -1;
+    StaticText* sectionTitle[4] = {};
+    SwitchMatrix* sectionBtn[4] = {};
+    TextButton* sectionCtrl[4] = {};
+    bool inverted = false;
+
+    void setTitle()
+    {
+      int value = m_getValue();
+      std::string s = std::string(STR_SWITCH) + ": ";
+
+      if (value == 0)
+        s += "---";
+      else
+        s += getSwitchPositionName(value);
+      title->setText(s);
+    }
+
+    void setSwitchValue(int16_t newValue)
+    {
+      if (m_getValue() == newValue) {
+        m_onSave();
+        deleteLater();
+      } else {
+        m_setValue(newValue);
+        setTitle();
+        for (int i = 0; i < 4; i += 1) {
+          if (sectionBtn[i])
+            sectionBtn[i]->updateBtns();
+        }
+      }
+    }
+
+    void applyFilter(int section)
+    {
+      filterSection = section;
+      for (int i = 0; i < 4; i += 1) {
+        if (sectionTitle[i]) {
+          sectionCtrl[i]->check(filterSection == i);
+          if ((filterSection == i) || (filterSection == -1)) {
+            lv_obj_clear_flag(sectionTitle[i]->getLvObj(), LV_OBJ_FLAG_HIDDEN);
+            lv_obj_clear_flag(sectionBtn[i]->getLvObj(), LV_OBJ_FLAG_HIDDEN);
+          } else {
+            lv_obj_add_flag(sectionTitle[i]->getLvObj(), LV_OBJ_FLAG_HIDDEN);
+            lv_obj_add_flag(sectionBtn[i]->getLvObj(), LV_OBJ_FLAG_HIDDEN);
+          }
+        }
+      }
+      lv_obj_scroll_to_y(switches->getLvObj(), 0, LV_ANIM_OFF);
+    }
+
+    void addSectionCtrl(const char* iconChar, int section)
+    {
+      sectionCtrl[section] = new TextButton(tabsForm, rect_t{0, 0, 24, 24}, iconChar, [=]() -> uint8_t {
+                       if (filterSection == section)
+                         applyFilter(-1);
+                       else
+                         applyFilter(section);
+                       return filterSection == section;
+                     });
+    }
+
+    void addSection(const char* title, int firstIdx, int lastIdx, int section)
+    {
+      sectionTitle[section] = new StaticText(switchesForm, rect_t{}, title, 0, COLOR_THEME_PRIMARY1);
+      sectionBtn[section] = new SwitchMatrix(switchesForm, firstIdx, lastIdx, m_getValue, [=](int16_t n) { setSwitchValue(n); }, inverted);
+    }
+
+  public:
+    SwitchDialog(Window* parent, int vmax,
+                 std::function<int16_t()> getValue,
+                 std::function<void(int16_t)> setValue,
+                 std::function<void()> onSave,
+                 std::function<void()> onCancel) :
+        ModalWindow(parent, true),
+        m_getValue(std::move(getValue)),
+        m_setValue(std::move(setValue)),
+        m_onSave(std::move(onSave))
+    {
+      inverted = getValue() < 0;
+
+      auto window = new Window(this, rect_t{(LCD_W-DLG_W)/2, (LCD_H-DLG_H)/2, DLG_W, DLG_H});
+      window->padAll(0);
+      lv_obj_set_style_bg_color(window->getLvObj(), makeLvColor(COLOR_THEME_SECONDARY3), 0);
+      lv_obj_set_style_bg_opa(window->getLvObj(), LV_OPA_100, 0);
+      lv_obj_set_style_border_width(window->getLvObj(), 1, 0);
+      lv_obj_set_style_border_color(window->getLvObj(), makeLvColor(COLOR_THEME_SECONDARY2), 0);
+      lv_obj_set_style_border_opa(window->getLvObj(), LV_OPA_100, 0);
+
+      auto form = new FormWindow(window, rect_t{});
+      form->setFlexLayout(LV_FLEX_FLOW_COLUMN, 0);
+      form->padAll(0);
+
+      auto hdr = new Window(form, rect_t{0, 0, DLG_W-2, 22});
+      hdr->padAll(0);
+      hdr->padLeft(4);
+      lv_obj_set_style_bg_color(hdr->getLvObj(), makeLvColor(COLOR_THEME_SECONDARY1), 0);
+      lv_obj_set_style_bg_opa(hdr->getLvObj(), LV_OPA_100, 0);
+      lv_obj_set_style_border_width(hdr->getLvObj(), 1, 0);
+      lv_obj_set_style_border_color(hdr->getLvObj(), makeLvColor(COLOR_THEME_SECONDARY2), 0);
+      lv_obj_set_style_border_opa(hdr->getLvObj(), LV_OPA_100, 0);
+
+      title = new StaticText(hdr, rect_t{}, STR_SWITCH, 0, COLOR_THEME_PRIMARY2);
+      setTitle();
+
+      auto content = new Window(form, rect_t{0, 0, DLG_W-2, DLG_H-64});
+      content->padAll(0);
+
+      auto contentForm = new FormWindow(content, rect_t{});
+      contentForm->setFlexLayout(LV_FLEX_FLOW_ROW, 0);
+      contentForm->padAll(0);
+
+      auto tabs = new Window(contentForm, rect_t{0, 0, 40, DLG_H-64});
+      tabs->padAll(0);
+      lv_obj_set_style_border_width(tabs->getLvObj(), 1, 0);
+      lv_obj_set_style_border_color(tabs->getLvObj(), makeLvColor(COLOR_THEME_SECONDARY2), 0);
+      lv_obj_set_style_border_opa(tabs->getLvObj(), LV_OPA_100, 0);
+
+      tabsForm = new FormWindow(tabs, rect_t{});
+      tabsForm->setFlexLayout(LV_FLEX_FLOW_COLUMN, 4);
+      tabsForm->padAll(0);
+      tabsForm->padTop(4);
+      lv_obj_set_flex_align(tabsForm->getLvObj(), LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_SPACE_AROUND);
+
+      addSectionCtrl(STR_CHAR_SWITCH, 0);
+
+      if (vmax >= SWSRC_FIRST_TRIM) {
+        addSectionCtrl(STR_CHAR_TRIM, 1);
+      }
+
+      if (vmax >= SWSRC_FIRST_LOGICAL_SWITCH) {
+        addSectionCtrl(STR_CHAR_SWITCH, 2);
+      }
+
+      if (vmax >= SWSRC_TELEMETRY_STREAMING) {
+        addSectionCtrl(STR_CHAR_TELEMETRY, 3);
+      }
+
+      auto body = new Window(contentForm, rect_t{0, 0, DLG_W-42, DLG_H-64});
+      body->padAll(0);
+
+      auto bodyForm = new FormWindow(body, rect_t{});
+      bodyForm->setFlexLayout(LV_FLEX_FLOW_COLUMN, 0);
+      bodyForm->padAll(0);
+
+      switches = new Window(bodyForm, rect_t{0, 0, DLG_W-42, DLG_H-64});
+      switches->padAll(0);
+      lv_obj_set_style_border_width(switches->getLvObj(), 1, 0);
+      lv_obj_set_style_border_color(switches->getLvObj(), makeLvColor(COLOR_THEME_SECONDARY2), 0);
+      lv_obj_set_style_border_opa(switches->getLvObj(), LV_OPA_100, 0);
+      lv_obj_set_scrollbar_mode(switches->getLvObj(), LV_SCROLLBAR_MODE_AUTO);
+  
+      switchesForm = new FormWindow(switches, rect_t{});
+      switchesForm->setFlexLayout(LV_FLEX_FLOW_COLUMN, 4);
+      switchesForm->padAll(4);
+      lv_obj_set_flex_align(tabsForm->getLvObj(), LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_SPACE_AROUND);
+
+      addSection(STR_MENU_SWITCHES, SWSRC_FIRST_SWITCH, SWSRC_LAST_SWITCH, 0);
+
+      if (vmax >= SWSRC_FIRST_TRIM) {
+        addSection(STR_MENU_TRIMS, SWSRC_FIRST_TRIM, SWSRC_LAST_TRIM, 1);
+      }
+
+      if (vmax >= SWSRC_FIRST_LOGICAL_SWITCH) {
+        addSection(STR_MENU_LOGICAL_SWITCHES, SWSRC_FIRST_LOGICAL_SWITCH, SWSRC_LAST_LOGICAL_SWITCH, 2);
+      }
+
+      if (vmax >= SWSRC_TELEMETRY_STREAMING) {
+        addSection(STR_MENU_TELEMETRY, SWSRC_TELEMETRY_STREAMING, SWSRC_RADIO_ACTIVITY, 3);
+      }
+
+      auto ftr = new Window(form, rect_t{0, 0, DLG_W-2, 40});
+      ftr->padAll(0);
+      lv_obj_set_style_border_width(ftr->getLvObj(), 1, 0);
+      lv_obj_set_style_border_color(ftr->getLvObj(), makeLvColor(COLOR_THEME_SECONDARY2), 0);
+      lv_obj_set_style_border_opa(ftr->getLvObj(), LV_OPA_100, 0);
+
+      auto ftrForm = new FormWindow(ftr, rect_t{});
+      ftrForm->setFlexLayout(LV_FLEX_FLOW_ROW, 2);
+      ftrForm->padAll(0);
+      lv_obj_set_flex_align(ftrForm->getLvObj(), LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_SPACE_AROUND);
+
+      auto ftrL = new Window(ftrForm, rect_t{0, 0, (DLG_W-10)/2-20, 40});
+      ftrL->padAll(0);
+
+      auto ftrFormL = new FormWindow(ftrL, rect_t{});
+      ftrFormL->setFlexLayout(LV_FLEX_FLOW_ROW, 2);
+      ftrFormL->padAll(4);
+      ftrFormL->padTop(6);
+      lv_obj_set_flex_align(ftrFormL->getLvObj(), LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_SPACE_AROUND);
+
+      auto btn = new TextButton(ftrFormL, rect_t{0, 0, 50, 28}, "!", [=]() -> uint8_t {
+                       setInverted();
+                       return inverted;
+                     });
+      btn->check(inverted);
+
+      new TextButton(ftrFormL, rect_t{0, 0, 50, 28}, "---", [=]() -> uint8_t {
+                       setSwitchValue(0);
+                       return 0;
+                     });
+
+      auto ftrR = new Window(ftrForm, rect_t{0, 0, (DLG_W-10)/2+20, 40});
+      ftrR->padAll(0);
+
+      auto ftrFormR = new FormWindow(ftrR, rect_t{});
+      ftrFormR->setFlexLayout(LV_FLEX_FLOW_ROW, 2);
+      ftrFormR->padAll(4);
+      ftrFormR->padTop(6);
+      lv_obj_set_flex_align(ftrFormR->getLvObj(), LV_FLEX_ALIGN_END, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_SPACE_AROUND);
+
+      new TextButton(ftrFormR, rect_t{0, 0, 80, 28}, STR_CANCEL, [=]() -> uint8_t {
+                       onCancel();
+                       deleteLater();
+                       return 0;
+                     });
+
+      new TextButton(ftrFormR, rect_t{0, 0, 80, 28}, STR_SAVE, [=]() -> uint8_t {
+                       onSave();
+                       deleteLater();
+                       return 0;
+                     });
+    }
+
+    void setInverted()
+    {
+      inverted = !inverted;
+      for (int i = 0; i < 4; i += 1) {
+        if (sectionBtn[i])
+          sectionBtn[i]->setInverted(inverted);
+      }
+      m_setValue(-m_getValue());
+      setTitle();
+    }
+
+    void onCancel() override
+    {
+      deleteLater();
+    }
+
+    void onEvent(event_t event) override
+    {
+      if (event == EVT_KEY_BREAK(KEY_PGDN)) {
+        filterSection += 1;
+        if (filterSection > 3)
+          filterSection = -1;
+        applyFilter(filterSection);
+      }
+#if defined(KEYS_GPIO_REG_PGUP)
+      else if (event == EVT_KEY_BREAK(KEY_PGUP)) {
+#else
+      else if (event == EVT_KEY_LONG(KEY_PGDN)) {
+        killEvents(event);
+#endif
+        filterSection -= 1;
+        if (filterSection < -1)
+          filterSection = 3;
+        applyFilter(filterSection);
+      }
+    }
+};
 
 class SwitchChoiceMenuToolbar : public MenuToolbar
 {
@@ -43,13 +621,8 @@ class SwitchChoiceMenuToolbar : public MenuToolbar
 
 void SwitchChoice::LongPressHandler(void* data)
 {
-  SwitchChoice* swch = (SwitchChoice*)data;
-  if (!swch) return;
-  int16_t val = swch->_getValue();
-  if (swch->isValueAvailable && swch->isValueAvailable(-val)) {
-    swch->setValue(-val);
-    swch->invalidate();
-  }
+  SwitchChoice* sc = (SwitchChoice*)data;
+  sc->setValue(-sc->getIntValue());
 }
 
 SwitchChoice::SwitchChoice(Window* parent, const rect_t& rect, int vmin,
@@ -57,41 +630,33 @@ SwitchChoice::SwitchChoice(Window* parent, const rect_t& rect, int vmin,
                            std::function<void(int16_t)> setValue) :
     Choice(parent, rect, vmin, vmax, getValue, setValue)
 {
-  setBeforeDisplayMenuHandler([=](Menu* menu) {
-    auto tb = new SwitchChoiceMenuToolbar(this, menu);
-    menu->setToolbar(tb);
-
-#if defined(AUTOSWITCH)
-    menu->setWaitHandler([menu, this, setValue, tb]() {
-      swsrc_t val = 0;
-      swsrc_t swtch = getMovedSwitch();
-      if (swtch) {
-        div_t info = switchInfo(swtch);
-        if (IS_CONFIG_TOGGLE(info.quot)) {
-          if (info.rem != 0) {
-            val = (val == swtch ? swtch - 2 : swtch);
-          }
-        } else {
-          val = swtch;
-        }
-        if (val && (!isValueAvailable || isValueAvailable(val))) {
-          // if (filtered) fillMenu(menu);
-          tb->resetFilter();
-          menu->select(getIndexFromValue(val));
-        }
-      }
-    });
-#endif
-  });
+  switchValue = _getValue();
 
   setTextHandler([=](int value) {
-    if (isValueAvailable && !isValueAvailable(value))
+    if (!isSwitchAvailableInMixes(value))
       return std::to_string(0);  // we will fix this later
 
     return std::string(getSwitchPositionName(value));
   });
-
+ 
   set_lv_LongPressHandler(LongPressHandler, this);
+}
 
-  setAvailableHandler(isSwitchAvailableInMixes);
+void SwitchChoice::openMenu()
+{
+  switchValue = _getValue();
+  new SwitchDialog(this, vmax,
+                   [=]() -> int16_t {
+                     return switchValue;
+                   },
+                   [=](int16_t newValue) {
+                     switchValue = newValue;
+                   },
+                   [=]() {
+                     setValue(switchValue);
+                   },
+                   [=]() {
+                     switchValue = _getValue();
+                   }
+                  );
 }

--- a/radio/src/gui/colorlcd/switchchoice.cpp
+++ b/radio/src/gui/colorlcd/switchchoice.cpp
@@ -739,16 +739,16 @@ class SwitchDialog : public ModalWindow
 
     void onEvent(event_t event) override
     {
-      if (event == EVT_KEY_BREAK(KEY_PGDN)) {
+      if (event == EVT_KEY_BREAK(KEY_PAGEDN)) {
         filterSection += 1;
         if (filterSection >= maxSection)
           filterSection = -1;
         applyFilter(filterSection);
       }
 #if defined(KEYS_GPIO_REG_PGUP)
-      else if (event == EVT_KEY_BREAK(KEY_PGUP)) {
+      else if (event == EVT_KEY_BREAK(KEY_PAGEUP)) {
 #else
-      else if (event == EVT_KEY_LONG(KEY_PGDN)) {
+      else if (event == EVT_KEY_LONG(KEY_PAGEDN)) {
         killEvents(event);
 #endif
         actionSel -= 1;

--- a/radio/src/gui/colorlcd/switchchoice.cpp
+++ b/radio/src/gui/colorlcd/switchchoice.cpp
@@ -408,7 +408,7 @@ class SwitchDialog : public ModalWindow
                  std::function<void(bool)> onSave,
                  std::function<void()> onCancel,
                  std::function<bool(int)> isValueAvailable) :
-        ModalWindow(parent, true),
+        ModalWindow(parent, false),
         m_getValue(std::move(getValue)),
         m_setValue(std::move(setValue)),
         m_onSave(std::move(onSave)),

--- a/radio/src/gui/colorlcd/switchchoice.cpp
+++ b/radio/src/gui/colorlcd/switchchoice.cpp
@@ -276,9 +276,6 @@ class SwitchMatrix : public Window
 
       if (isSwitches) {
         btnsCnt = rows;
-#if NUM_XPOTS > 0
-        btnsCnt += 1;
-#endif
       } else {
         if (rows <= MAX_ROWS)
           btnsCnt = 1;
@@ -299,19 +296,13 @@ class SwitchMatrix : public Window
             n += 1;
           }
         }
-#if NUM_XPOTS > 0
-        // Add multi-position switch
-        int r = (buttonCount(SWSRC_FIRST_MULTIPOS_SWITCH, SWSRC_LAST_MULTIPOS_SWITCH) + cols - 1) / cols;
-        btns[n] = new SwitchButtons(form, SWSRC_FIRST_MULTIPOS_SWITCH, SWSRC_LAST_MULTIPOS_SWITCH, m_getValue, m_setValue, m_isValueAvailable, invert, cols, r, r * cols, false);
-        lv_obj_add_event_cb(btns[n]->getLvObj(), longPressHandler, LV_EVENT_LONG_PRESSED, this);
-#endif
       } else {
         if (btnsCnt == 1) {
           btns[0] = new SwitchButtons(form, firstIdx, lastIdx, m_getValue, m_setValue, m_isValueAvailable, invert, cols, rows, btn_cnt, false);
           lv_obj_add_event_cb(btns[0]->getLvObj(), longPressHandler, LV_EVENT_LONG_PRESSED, this);
         } else {
-          int sw = firstIdx;
-          for (int i = 0; i <= rows; i += 1) {
+          for (int i = 0; i < rows; i += 1) {
+            int sw = firstIdx + cols * i;
             int lw = sw + cols - 1;
             if (lw > lastIdx) lw = lastIdx;
             btns[i] = new SwitchButtons(form, sw, lw, m_getValue, m_setValue, m_isValueAvailable, invert, cols, 1, cols, false);
@@ -531,7 +522,7 @@ class SwitchDialog : public ModalWindow
 
       // Switch sections
       maxSection = 0;
-      addSection(switchesForm, STR_MENU_SWITCHES, SWSRC_FIRST_SWITCH, SWSRC_LAST_SWITCH, maxSection);
+      addSection(switchesForm, STR_MENU_SWITCHES, SWSRC_FIRST_SWITCH, SWSRC_LAST_MULTIPOS_SWITCH, maxSection);
       maxSection += 1;
 
       if (vmax >= SWSRC_FIRST_TRIM) {

--- a/radio/src/gui/colorlcd/switchchoice.h
+++ b/radio/src/gui/colorlcd/switchchoice.h
@@ -32,7 +32,7 @@ class SwitchChoice : public Choice
                  std::function<int16_t()> getValue,
                  std::function<void(int16_t)> setValue);
 
-    static void LongPressHandler(void* data);
+    static void longPressHandler(void* data);
 
   protected:
 #if defined(DEBUG_WINDOWS)

--- a/radio/src/gui/colorlcd/switchchoice.h
+++ b/radio/src/gui/colorlcd/switchchoice.h
@@ -27,17 +27,21 @@
 
 class SwitchChoice : public Choice
 {
- public:
-  SwitchChoice(Window* parent, const rect_t& rect, int vmin, int vmax,
-               std::function<int16_t()> getValue,
-               std::function<void(int16_t)> setValue);
+  public:
+    SwitchChoice(Window* parent, const rect_t& rect, int vmin, int vmax,
+                 std::function<int16_t()> getValue,
+                 std::function<void(int16_t)> setValue);
 
-  static void LongPressHandler(void* data);
+    static void LongPressHandler(void* data);
 
- protected:
+  protected:
 #if defined(DEBUG_WINDOWS)
-  std::string getName() const override { return "SwitchChoice"; }
+    std::string getName() const override { return "SwitchChoice"; }
 #endif
+
+    int16_t switchValue;
+
+    void openMenu() override;
 };
 
 #endif  // _SWITCHCHOICE_H_


### PR DESCRIPTION
I've always found the switch choice popup difficult to use and prone to error (accidentally selecting a value when scrolling with the touch screen).

Here is a revised switch choice dialog for consideration.

I've tried to make it both touch and button/scrollwheel friendly as well as more intuitive to use.

Resolves #1538,  and resolves #3106 

Some screenshots:
![Screen Shot 2023-04-13 at 4 44 25 pm](https://user-images.githubusercontent.com/9474356/231950181-372fde66-dcf7-4252-b326-ab2a7729f49e.png)
![Screen Shot 2023-04-13 at 4 44 39 pm](https://user-images.githubusercontent.com/9474356/231950209-c638cf17-1dd0-43a9-90d3-506f774197c6.png)
![Screen Shot 2023-04-13 at 4 45 02 pm](https://user-images.githubusercontent.com/9474356/231950230-ff55799c-453f-4a79-b844-0fca6cba5126.png)
![Screen Shot 2023-04-13 at 4 45 56 pm](https://user-images.githubusercontent.com/9474356/231950253-ee3ad58c-be95-460e-832b-3182c223fce7.png)
