### PR TITLE
feat(color) - Sort the widget list by display name.

### DIFF
--- a/radio/src/gui/colorlcd/widget.cpp
+++ b/radio/src/gui/colorlcd/widget.cpp
@@ -205,7 +205,13 @@ void registerWidget(const WidgetFactory * factory)
   if (oldWidget) {
     unregisterWidget(oldWidget);
   }
-  TRACE("register widget %s", name);
+  TRACE("register widget %s %s", name, factory->getDisplayName());
+  for (auto it = getRegisteredWidgets().cbegin(); it != getRegisteredWidgets().cend(); ++it) {
+    if (strcmp((*it)->getDisplayName(), factory->getDisplayName()) > 0) {
+      getRegisteredWidgets().insert(it, factory);
+      return;
+    }
+  }
   getRegisteredWidgets().push_back(factory);
 }
 


### PR DESCRIPTION
It always annoys me when selecting widgets that the list is not sorted so I have to scroll around to find the one I want.

This PR sorts the list of widgets by the display name.