### PR TITLE
feat(color) Add haptic startup buzz for radios with no startup animation

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1531,6 +1531,7 @@ void opentxInit()
   }
 #else // defined(PWR_BUTTON_PRESS)
   pwrOn();
+  haptic.play(15, 3, PLAY_NOW);
 #endif
 
   // Radios handle UNEXPECTED_SHUTDOWN() differently:


### PR DESCRIPTION
Add haptic startup buzz for radios with no startup animation, which may or may not be just colorlcd radios?

### Details
It is difficult to tell when my TX16S finally turns on after holding the power button when outdoors. The LED is not visible in direct sunlight and my polarized sunglasses make the LCD itself completely black when held in the normal orientation (both my head and the radio in their respective normal orientations). B&W radios such as the Zorro give a satisfying buzz as they power on so why not everyone else?

### Not Sure
Hardware with physical on/off switches may also buzz with this? Not sure if this is a good or a bad thing or if this code path runs for those fancy snowflakes.

### Tested
TX16S with 2.8.2 + this line, also tested compiling `main` with it as well, as this patch is against main
Zorro with 2.8.2 + this line, still does what it did before which is ROCK... oh I mean buzzes