### PR TITLE
fix: MPM protocol options missing in various protocols

### DIFF
--- a/radio/src/gui/colorlcd/mpm_settings.cpp
+++ b/radio/src/gui/colorlcd/mpm_settings.cpp
@@ -153,10 +153,8 @@ struct MPMSubtype : public FormGroup::Line
   void checkEvents();
 
   protected:                                 
-    const uint8_t invalidSubTypeIndex = MODULE_SUBTYPE_MULTI_FIRST-1;
-
     uint8_t moduleIdx;
-    uint8_t lastSubType = invalidSubTypeIndex;
+    uint8_t lastSubType = MODULE_SUBTYPE_MULTI_FIRST-1;   // init with invalid subType
     uint8_t lastRfProtocol = MODULE_TYPE_NONE;
 };
 
@@ -199,11 +197,6 @@ void MPMSubtype::update(const MultiRfProtocols::RfProto* rfProto, uint8_t module
   }
 
   ModuleData* md = &g_model.moduleData[moduleIdx];
-
-  // always force subType update for DSM2 auto mode with MPM status data
-  if(md->multi.rfProtocol == MODULE_SUBTYPE_MULTI_DSM2 && md->subType == MM_RF_DSM2_SUBTYPE_AUTO) {
-    lastSubType = invalidSubTypeIndex;        
-  }
 
   // check if protocol or subtype has changed
   if(md->multi.rfProtocol == lastRfProtocol && md->subType == lastSubType)

--- a/radio/src/gui/colorlcd/mpm_settings.cpp
+++ b/radio/src/gui/colorlcd/mpm_settings.cpp
@@ -152,8 +152,7 @@ struct MPMSubtype : public FormGroup::Line
   void update(const MultiRfProtocols::RfProto* rfProto, uint8_t moduleIdx);
   void checkEvents();
 
-  protected:
-    const uint8_t DSM_AUTO_SUBTYPE = 4;                                      
+  protected:                                 
     const uint8_t invalidSubTypeIndex = MODULE_SUBTYPE_MULTI_FIRST-1;
 
     uint8_t moduleIdx;
@@ -201,16 +200,9 @@ void MPMSubtype::update(const MultiRfProtocols::RfProto* rfProto, uint8_t module
 
   ModuleData* md = &g_model.moduleData[moduleIdx];
 
-  // adjust subType for DSM2 auto mode with MPM status data
-  if(md->multi.rfProtocol == MODULE_SUBTYPE_MULTI_DSM2) {
-    MultiModuleStatus &status = getMultiModuleStatus(moduleIdx);
-
-    if(status.isValid() && md->subType == DSM_AUTO_SUBTYPE) {   // DSM Auto mode
-      md->subType = status.protocolSubNbr;                      // set subType MPM has chosen
-      lastSubType = invalidSubTypeIndex;                        // force update in the next step
-
-      SET_DIRTY();
-    }
+  // always force subType update for DSM2 auto mode with MPM status data
+  if(md->multi.rfProtocol == MODULE_SUBTYPE_MULTI_DSM2 && md->subType == MM_RF_DSM2_SUBTYPE_AUTO) {
+    lastSubType = invalidSubTypeIndex;        
   }
 
   // check if protocol or subtype has changed

--- a/radio/src/gui/colorlcd/mpm_settings.cpp
+++ b/radio/src/gui/colorlcd/mpm_settings.cpp
@@ -22,7 +22,6 @@
 #include "mpm_settings.h"
 #include "opentx.h"
 
-#include "telemetry/multi.h"
 #include "multi_rfprotos.h"
 #include "io/multi_protolist.h"
 
@@ -67,7 +66,7 @@ MPMProtoOption::MPMProtoOption(FormGroup* form, FlexGridLayout *layout) :
 
 void MPMProtoOption::update(const MultiRfProtocols::RfProto* rfProto, ModuleData* md, uint8_t moduleIdx)
 {
-    if (!rfProto || !getMultiOptionTitle(moduleIdx)) {
+  if (!rfProto || !getMultiOptionTitle(moduleIdx)) {
     lv_obj_add_flag(lvobj, LV_OBJ_FLAG_HIDDEN);
     return;
   }

--- a/radio/src/gui/colorlcd/mpm_settings.cpp
+++ b/radio/src/gui/colorlcd/mpm_settings.cpp
@@ -45,7 +45,7 @@ struct MPMProtoOption : public FormGroup::Line
   DynamicNumber<uint16_t>* rssi;
 
   MPMProtoOption(FormGroup* form, FlexGridLayout *layout);
-  void update(const MultiRfProtocols::RfProto* rfProto, ModuleData* md);
+  void update(const MultiRfProtocols::RfProto* rfProto, ModuleData* md, uint8_t moduleIdx);
 };
 
 MPMProtoOption::MPMProtoOption(FormGroup* form, FlexGridLayout *layout) :
@@ -64,16 +64,16 @@ MPMProtoOption::MPMProtoOption(FormGroup* form, FlexGridLayout *layout) :
       box, rect_t{}, [] { return (uint16_t)TELEMETRY_RSSI(); }, 0, "RSSI: ", " db");
 }
 
-void MPMProtoOption::update(const MultiRfProtocols::RfProto* rfProto, ModuleData* md)
+void MPMProtoOption::update(const MultiRfProtocols::RfProto* rfProto, ModuleData* md, uint8_t moduleIdx)
 {
-  if (!rfProto || !rfProto->getOptionStr()) {
+    if (!rfProto || !getMultiOptionTitle(moduleIdx)) {
     lv_obj_add_flag(lvobj, LV_OBJ_FLAG_HIDDEN);
     return;
   }
 
   lv_obj_clear_flag(lvobj, LV_OBJ_FLAG_HIDDEN);
 
-  const char *title = rfProto->getOptionStr();
+  const char *title = getMultiOptionTitle(moduleIdx);
   label->setText(title);
 
   lv_obj_add_flag(choice->getLvObj(), LV_OBJ_FLAG_HIDDEN);
@@ -322,7 +322,7 @@ void MultimoduleSettings::update()
   auto rfProto = mpm_rfprotos->getProto(md->multi.rfProtocol);
 
   st_line->update(rfProto, md);
-  opt_line->update(rfProto, md);
+  opt_line->update(rfProto, md, moduleIdx);
 
   auto multi_proto = md->multi.rfProtocol;
   if (multi_proto == MODULE_SUBTYPE_MULTI_DSM2) {

--- a/radio/src/gui/colorlcd/mpm_settings.cpp
+++ b/radio/src/gui/colorlcd/mpm_settings.cpp
@@ -199,6 +199,7 @@ MPMSubtype::MPMSubtype(FormGroup* form, FlexGridLayout *layout, uint8_t moduleId
         md->subType = newValue;
         if(!DSM2autoUpdated)                        // reset MPM options only if user triggered
           resetMultiProtocolsOptions(moduleIdx);
+        DSM2autoUpdated = false; 
         SET_DIRTY();
       });
 

--- a/radio/src/io/multi_protolist.cpp
+++ b/radio/src/io/multi_protolist.cpp
@@ -136,20 +136,6 @@ void MultiRfProtocols::RfProto::fillSubProtoList(const char *const *str, int n)
   }
 }
 
-uint8_t MultiRfProtocols::RfProto::getOption() const
-{
-  uint8_t opt = flags >> 4;
-  if (opt >= getMaxMultiOptions()) {
-    opt = 1; // Unknown options are defaulted to type 1 (basic option)
-  }
-  return opt;
-}
-
-const char* MultiRfProtocols::RfProto::getOptionStr() const
-{
-  return mm_options_strings::options[getOption()];
-}
-
 MultiRfProtocols* MultiRfProtocols::instance(unsigned int moduleIdx)
 {
   if (moduleIdx >= NUM_MODULES) return nullptr;

--- a/radio/src/io/multi_protolist.h
+++ b/radio/src/io/multi_protolist.h
@@ -73,9 +73,6 @@ class MultiRfProtocols
 
     // fixed length strings concatenated
     void fillSubProtoList(const char* str, int n, int len);
-
-    uint8_t getOption() const;
-    const char* getOptionStr() const;
     
     bool supportsFailsafe() const { return flags & 0x01; }
     bool supportsDisableMapping() const { return flags & 0x02; }


### PR DESCRIPTION
Fixes #2713, fixes #3046 (partly #3500), and fixes #1470

Summary of changes:
- use getMultiOptionTitle() instead of rfproto->getOptionStr() as getMultiOptionTitle() takes updated MPM status in account
- changes to mpm_settings.cpp to check for MPM changing subtype for DSM auto