### PR TITLE
fix: Building TX16s firmware with -DDEBUG=YES -DCMAKE_BUILD_TYPE=Debug fails

### DIFF
--- a/radio/src/serial.cpp
+++ b/radio/src/serial.cpp
@@ -29,16 +29,16 @@
 
 #include "hal/serial_port.h"
 
+#if defined(CONFIGURABLE_MODULE_PORT) and !defined(BOOT)
+  #include "hal/module_port.h"
+  #include "tasks/mixer_task.h"
+#endif
+
 #if !defined(BOOT)
   #include "opentx.h"
   #include "lua/lua_api.h"
 #else
   #include "dataconstants.h"
-#endif
-
-#if defined(CONFIGURABLE_MODULE_PORT)
-  #include "hal/module_port.h"
-  #include "tasks/mixer_task.h"
 #endif
 
 #if defined(CROSSFIRE)
@@ -256,7 +256,7 @@ static void serialSetCallBacks(int mode, void* ctx, const etx_serial_port_t* por
     break;
 #endif
 
-#if defined(CONFIGURABLE_MODULE_PORT)
+#if defined(CONFIGURABLE_MODULE_PORT) and !defined(BOOT)
   case UART_MODE_EXT_MODULE:
     if (port && !ctx) { // de-init
       etx_module_port_t mod_port;
@@ -400,7 +400,7 @@ void serialInit(uint8_t port_nr, int mode)
     memset(state, 0, sizeof(SerialPortState));
   }
 
-#if defined(CONFIGURABLE_MODULE_PORT)
+#if defined(CONFIGURABLE_MODULE_PORT) and !defined(BOOT)
   if (mode == UART_MODE_EXT_MODULE) {
     etx_module_port_t mod_port = {
       .port = ETX_MOD_PORT_UART,

--- a/radio/src/serial.cpp
+++ b/radio/src/serial.cpp
@@ -29,16 +29,15 @@
 
 #include "hal/serial_port.h"
 
-#if defined(CONFIGURABLE_MODULE_PORT)
-  #include "hal/module_port.h"
-  #include "tasks/mixer_task.h"
-#endif
-
 #if !defined(BOOT)
   #include "opentx.h"
   #include "lua/lua_api.h"
 #else
   #include "dataconstants.h"
+#endif
+
+#if defined(CONFIGURABLE_MODULE_PORT)
+  #include "hal/module_port.h"
 #endif
 
 #if defined(CROSSFIRE)

--- a/radio/src/serial.cpp
+++ b/radio/src/serial.cpp
@@ -38,6 +38,7 @@
 
 #if defined(CONFIGURABLE_MODULE_PORT)
   #include "hal/module_port.h"
+  #include "tasks/mixer_task.h"
 #endif
 
 #if defined(CROSSFIRE)


### PR DESCRIPTION
fixes #3509

This problem shows for target bootloader and is caused by CONFIGURABLE_MODULE_PORT including header files into `radio\src\gui\colorlcd\mpm_settings.cpp` which are not meant to be part of bootloader code.

Changes:
- include CONFIGURABLE_MODULE_PORT code only if compiled not for bootloader
