### PR TITLE
feat(color) - Return actual free memory available from 'malloc/new' calls in the 'availableMemory' function.

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -37,6 +37,9 @@
   #include "gui/colorlcd/LvglWrapper.h"
 #endif
 
+#if !defined(SIMU)
+#include <malloc.h>
+#endif
 
 RadioData  g_eeGeneral;
 ModelData  g_model;
@@ -1926,3 +1929,17 @@ uint32_t pwrCheck()
 }
 #endif  // defined(PWR_BUTTON_PRESS)
 #endif  // !defined(SIMU)
+
+uint32_t availableMemory()
+{
+#if defined(SIMU)
+  return 1000;
+#else
+  extern unsigned char *heap;
+  extern int _heap_end;
+
+  struct mallinfo info = mallinfo();
+
+  return ((uint32_t)((unsigned char *)&_heap_end - heap)) + info.fordblks;
+#endif
+}

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -469,14 +469,7 @@ extern uint8_t mixerCurrentFlightMode;
 extern uint8_t lastFlightMode;
 extern uint8_t flightModeTransitionLast;
 
-#if defined(SIMU)
-  inline int availableMemory() { return 1000; }
-#else
-  extern unsigned char *heap;
-  extern int _end;
-  extern int _heap_end;
-  #define availableMemory() ((unsigned int)((unsigned char *)&_heap_end - heap))
-#endif
+extern uint32_t availableMemory();
 
 
 void evalFlightModeMixes(uint8_t mode, uint8_t tick10ms);


### PR DESCRIPTION
The current implementation of 'availableMemory' only returns the free heap space.

Memory already allocated from the heap by the 'malloc/new' memory management system is not considered.

This change adds the amount of free memory already taken from the heap; but not used, to the total.
