### PR TITLE
fix: signal polarity for soft-serial & timer based protocols

### DIFF
--- a/radio/src/pulses/multi.cpp
+++ b/radio/src/pulses/multi.cpp
@@ -222,7 +222,6 @@ static void* multiInit(uint8_t module)
     mod_st = modulePortInitSerial(module, ETX_MOD_PORT_UART, &cfg);
 
     if (!mod_st) {
-      cfg.polarity = ETX_Pol_Normal;
       mod_st = modulePortInitSerial(module, ETX_MOD_PORT_SOFT_INV, &cfg);
     }
 

--- a/radio/src/pulses/ppm.cpp
+++ b/radio/src/pulses/ppm.cpp
@@ -106,7 +106,7 @@ static void* ppmInit(uint8_t module)
   auto delay = GET_MODULE_PPM_DELAY(module) * 2;
   etx_timer_config_t cfg = {
     .type = ETX_PWM,
-    .polarity = GET_MODULE_PPM_POLARITY(module),
+    .polarity = !GET_MODULE_PPM_POLARITY(module),
     .cmp_val = (uint16_t)delay,
   };
 
@@ -141,7 +141,7 @@ static void ppmSendPulses(void* ctx, uint8_t* buffer, int16_t* channels, uint8_t
   auto delay = GET_MODULE_PPM_DELAY(module) * 2;
   etx_timer_config_t cfg = {
     .type = ETX_PWM,
-    .polarity = GET_MODULE_PPM_POLARITY(module),
+    .polarity = !GET_MODULE_PPM_POLARITY(module),
     .cmp_val = (uint16_t)delay,
   };
 

--- a/radio/src/targets/common/arm/stm32/module_timer_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/module_timer_driver.cpp
@@ -28,7 +28,7 @@ static void* module_timer_init(void* hw_def, const etx_timer_config_t* cfg)
 
   bool polarity = cfg->polarity;
   uint32_t ocval = cfg->cmp_val;
-  uint32_t ocmode = (cfg->type == ETX_PWM) ? LL_TIM_OCMODE_PWM1 : LL_TIM_OCMODE_TOGGLE;
+  uint32_t ocmode = (cfg->type == ETX_PWM) ? LL_TIM_OCMODE_FORCED_INACTIVE : LL_TIM_OCMODE_TOGGLE;
 
   stm32_pulse_init(timer, 0);
   stm32_pulse_config_output(timer, polarity, ocmode, ocval);

--- a/radio/src/targets/common/arm/stm32/stm32_pulse_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_pulse_driver.cpp
@@ -305,10 +305,6 @@ void stm32_pulse_start_dma_req(const stm32_pulse_timer_t* tim,
     LL_TIM_SetCounter(tim->TIMx, 0xFFFF);
   }
 
-  // only on PWM (preloads the first period)
-  if (ocmode == LL_TIM_OCMODE_PWM1)
-    LL_TIM_GenerateEvent_UPDATE(tim->TIMx);
-  
   LL_TIM_EnableDMAReq_UPDATE(tim->TIMx);
   LL_DMA_EnableStream(tim->DMAx, tim->DMA_Stream);
 

--- a/radio/src/targets/common/arm/stm32/stm32_softserial_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_softserial_driver.cpp
@@ -340,7 +340,7 @@ static void* stm32_softserial_tx_init(void* hw_def, const etx_serial_init* param
   auto st = port->st;
   memset(port->st, 0, sizeof(stm32_softserial_tx_state));
 
-  bool polarity = params->polarity == ETX_Pol_Normal;
+  bool polarity = params->polarity;
   uint32_t freq = params->baudrate * 16;
   uint32_t ocmode = LL_TIM_OCMODE_TOGGLE;
   uint32_t cmp_val = 0;

--- a/radio/src/targets/common/arm/stm32/stm32_softserial_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_softserial_driver.cpp
@@ -359,7 +359,7 @@ static void* stm32_softserial_tx_init(void* hw_def, const etx_serial_init* param
     st->conv_byte = _conv_byte_pxx1;
     freq = PXX1_FREQ;
     polarity = false;
-    ocmode = LL_TIM_OCMODE_PWM1;
+    ocmode = LL_TIM_OCMODE_FORCED_INACTIVE;
     cmp_val = PXX1_PWM_ON;
     break;
 


### PR DESCRIPTION
✅ Tested side-by-side with TX16S & Boxer for all external module protocols.

Fixes #3413 