### PR TITLE
fix(color) - Fix '!1x' repeat option broken in PR 3338.

### DIFF
--- a/radio/src/gui/colorlcd/special_functions.cpp
+++ b/radio/src/gui/colorlcd/special_functions.cpp
@@ -340,7 +340,7 @@ class SpecialFunctionEditPage : public Page
             return (value == 0) ? std::string("On") : std::string("1x");
         });
       } else {
-        auto repeat = new NumberEdit(line, rect_t{}, 0, 60 / CFN_PLAY_REPEAT_MUL,
+        auto repeat = new NumberEdit(line, rect_t{}, -1, 60 / CFN_PLAY_REPEAT_MUL,
                                      GET_DEFAULT((int8_t)CFN_PLAY_REPEAT(cfn)),
                                      SET_DEFAULT(CFN_PLAY_REPEAT(cfn)));
         repeat->setDisplayHandler([](int32_t value) {


### PR DESCRIPTION
Fixes #3519 

Fix incorrect minimum value for repeat option edit box on color LCD radios.
Checked B&W and they are not affected.