### PR TITLE
Workaround for 'lastopened' value not loaded on startup if stored hash not up to date.

### DIFF
--- a/radio/src/storage/yaml/yaml_labelslist.cpp
+++ b/radio/src/storage/yaml/yaml_labelslist.cpp
@@ -194,17 +194,19 @@ static void set_attr(void* ctx, char* buf, uint16_t len)
       }
     }
 
-    // Don't bother filling in values below if hash didn't match
-    if(mi->modeldatavalid) {
+    // Last Opened
+    // Hack: Always load this as the hash value is (currently) not in synch with the saved model file
+    // TODO: Ensure stored hash is up to date.
+    if (!strcasecmp(mi->current_attr, "lastopen")) {
+        mi->curmodel->lastOpened = (gtime_t)strtol(value, NULL, 0);
+        TRACE_LABELS_YAML(" Last Opened %lu", value);
+    } else if (mi->modeldatavalid) {
+      // Don't bother filling in values below if hash didn't match
+
       // Model Name
       if(!strcasecmp(mi->current_attr, "name")) {
         mi->curmodel->setModelName(value);
         TRACE_LABELS_YAML(" Set the models name");
-
-      // Last Opened
-      } else if(!strcasecmp(mi->current_attr, "lastopen")) {
-        mi->curmodel->lastOpened = (gtime_t)strtol(value, NULL, 0);
-        TRACE_LABELS_YAML(" Last Opened %lu", value);
 
       // Model Bitmap
   #if LEN_BITMAP_NAME > 0


### PR DESCRIPTION
Fixes #3518 

The hash value stored in the labels.yml file does not get updated when model files are saved.
On restart the values stored in labels.yml are ignored because the hash is not correct.

This workaround forces loading of the 'lastopened' value regardless of the hash. All other ignored values are re-created correctly.

This is a quick and dirty workaround to fix the issue.
