### PR TITLE
fix(radio) - Fix key names for Boxer.

### DIFF
--- a/radio/src/translations/cn.h
+++ b/radio/src/translations/cn.h
@@ -230,7 +230,7 @@
   #define TR_VKEYS                     "Exit","Enter","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(RADIO_T8) || defined(RADIO_COMMANDO8)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","UP","DOWN"
-#elif defined(RADIO_ZORRO)
+#elif defined(RADIO_ZORRO) || defined(RADIO_BOXER)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(PCBTARANIS)
   #define TR_VKEYS                     "Menu","Exit","Enter","Page","Plus","Minus"

--- a/radio/src/translations/cz.h
+++ b/radio/src/translations/cz.h
@@ -231,7 +231,7 @@
   #define TR_VKEYS                     "Exit","Enter","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(RADIO_T8) || defined(RADIO_COMMANDO8)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","UP","DOWN"
-#elif defined(RADIO_ZORRO)
+#elif defined(RADIO_ZORRO) || defined(RADIO_BOXER)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(PCBTARANIS)
   #define TR_VKEYS                     "Menu","Exit","Enter","Page","Plus","Minus"

--- a/radio/src/translations/da.h
+++ b/radio/src/translations/da.h
@@ -233,7 +233,7 @@
   #define TR_VKEYS                     "Exit","Enter","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(RADIO_T8) || defined(RADIO_COMMANDO8)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","OP","NED"
-#elif defined(RADIO_ZORRO)
+#elif defined(RADIO_ZORRO) || defined(RADIO_BOXER)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(PCBTARANIS)
   #define TR_VKEYS                     "Menu","Exit","Enter","Page","Plus","Minus"

--- a/radio/src/translations/de.h
+++ b/radio/src/translations/de.h
@@ -230,7 +230,7 @@
   #define TR_VKEYS                     "Exit","Enter","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(RADIO_T8) || defined(RADIO_COMMANDO8)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","UP","DOWN"
-#elif defined(RADIO_ZORRO)
+#elif defined(RADIO_ZORRO) || defined(RADIO_BOXER)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(PCBTARANIS)
   #define TR_VKEYS                     "Menu","Exit","Enter","Page","Plus","Minus"

--- a/radio/src/translations/en.h
+++ b/radio/src/translations/en.h
@@ -228,7 +228,7 @@
   #define TR_VKEYS                     "Exit","Enter","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(RADIO_T8) || defined(RADIO_COMMANDO8)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","UP","DOWN"
-#elif defined(RADIO_ZORRO)
+#elif defined(RADIO_ZORRO) || defined(RADIO_BOXER)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(PCBTARANIS)
   #define TR_VKEYS                     "Menu","Exit","Enter","Page","Plus","Minus"

--- a/radio/src/translations/es.h
+++ b/radio/src/translations/es.h
@@ -228,7 +228,7 @@
   #define TR_VKEYS                     "Exit","Enter","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(RADIO_T8) || defined(RADIO_COMMANDO8)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","UP","DOWN"
-#elif defined(RADIO_ZORRO)
+#elif defined(RADIO_ZORRO) || defined(RADIO_BOXER)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(PCBTARANIS)
   #define TR_VKEYS                     "Menu","Exit","Enter","Page","Plus","Minus"

--- a/radio/src/translations/fi.h
+++ b/radio/src/translations/fi.h
@@ -237,7 +237,7 @@
   #define TR_VKEYS                     "Exit","Enter","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(RADIO_T8) || defined(RADIO_COMMANDO8)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","UP","DOWN"
-#elif defined(RADIO_ZORRO)
+#elif defined(RADIO_ZORRO) || defined(RADIO_BOXER)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(PCBTARANIS)
   #define TR_VKEYS                     "Menu","Exit","Enter","Page","Plus","Minus"

--- a/radio/src/translations/fr.h
+++ b/radio/src/translations/fr.h
@@ -239,7 +239,7 @@
   #define TR_VKEYS                     "Exit","Enter","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(RADIO_T8) || defined(RADIO_COMMANDO8)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","UP","DOWN"
-#elif defined(RADIO_ZORRO)
+#elif defined(RADIO_ZORRO) || defined(RADIO_BOXER)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(PCBTARANIS)
   #define TR_VKEYS                     "Menu","Exit","Enter","Page","Plus","Minus"

--- a/radio/src/translations/it.h
+++ b/radio/src/translations/it.h
@@ -233,7 +233,7 @@
   #define TR_VKEYS                     "Exit","Enter","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(RADIO_T8) || defined(RADIO_COMMANDO8)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","UP","DOWN"
-#elif defined(RADIO_ZORRO)
+#elif defined(RADIO_ZORRO) || defined(RADIO_BOXER)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(PCBTARANIS)
   #define TR_VKEYS                     "Menu","Exit","Enter","Page","Plus","Minus"

--- a/radio/src/translations/jp.h
+++ b/radio/src/translations/jp.h
@@ -228,7 +228,7 @@
   #define TR_VKEYS                     "Exit","Enter","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(RADIO_T8) || defined(RADIO_COMMANDO8)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","UP","DOWN"
-#elif defined(RADIO_ZORRO)
+#elif defined(RADIO_ZORRO) || defined(RADIO_BOXER)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(PCBTARANIS)
   #define TR_VKEYS                     "Menu","Exit","Enter","Page","Plus","Minus"

--- a/radio/src/translations/nl.h
+++ b/radio/src/translations/nl.h
@@ -231,7 +231,7 @@
   #define TR_VKEYS                     "Exit","Enter","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(RADIO_T8) || defined(RADIO_COMMANDO8)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","UP","DOWN"
-#elif defined(RADIO_ZORRO)
+#elif defined(RADIO_ZORRO) || defined(RADIO_BOXER)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(PCBTARANIS)
   #define TR_VKEYS                     "Menu","Exit","Enter","Page","Plus","Minus"

--- a/radio/src/translations/pl.h
+++ b/radio/src/translations/pl.h
@@ -229,7 +229,7 @@
   #define TR_VKEYS                     "Exit","Enter","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(RADIO_T8) || defined(RADIO_COMMANDO8)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","UP","DOWN"
-#elif defined(RADIO_ZORRO)
+#elif defined(RADIO_ZORRO) || defined(RADIO_BOXER)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(PCBTARANIS)
   #define TR_VKEYS                     "Menu","Exit","Enter","Page","Plus","Minus"

--- a/radio/src/translations/pt.h
+++ b/radio/src/translations/pt.h
@@ -228,7 +228,7 @@
   #define TR_VKEYS                     "Exit","Enter","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(RADIO_T8) || defined(RADIO_COMMANDO8)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","UP","DOWN"
-#elif defined(RADIO_ZORRO)
+#elif defined(RADIO_ZORRO) || defined(RADIO_BOXER)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(PCBTARANIS)
   #define TR_VKEYS                     "Menu","Exit","Enter","Page","Plus","Minus"

--- a/radio/src/translations/se.h
+++ b/radio/src/translations/se.h
@@ -246,7 +246,7 @@
   #define TR_VKEYS                     "Avbryt","Enter","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(RADIO_T8) || defined(RADIO_COMMANDO8)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","UPP","NER"
-#elif defined(RADIO_ZORRO)
+#elif defined(RADIO_ZORRO) || defined(RADIO_BOXER)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(PCBTARANIS)
   #define TR_VKEYS                     "Meny","Avbryt","Enter","Sida","Plus","Minus"

--- a/radio/src/translations/tw.h
+++ b/radio/src/translations/tw.h
@@ -229,7 +229,7 @@
   #define TR_VKEYS                     "Exit","Enter","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(RADIO_T8) || defined(RADIO_COMMANDO8)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","UP","DOWN"
-#elif defined(RADIO_ZORRO)
+#elif defined(RADIO_ZORRO) || defined(RADIO_BOXER)
   #define TR_VKEYS                     "RTN","ENTER","PGUP","PGDN","SYS","MDL","TELE"
 #elif defined(PCBTARANIS)
   #define TR_VKEYS                     "Menu","Exit","Enter","Page","Plus","Minus"


### PR DESCRIPTION
Fixes #3533 

Update translation files - use same key names as Zorro.