### PR TITLE
[2.8] fix: FLASH overflow detection

### DIFF
--- a/radio/src/targets/horus/stm32f4_flash.ld
+++ b/radio/src/targets/horus/stm32f4_flash.ld
@@ -106,7 +106,7 @@ SECTIONS
   _sidata = .;
 
   /* Initialized data sections goes into RAM, load LMA copy after code */
-  .data : AT ( _sidata )
+  .data :
   {
     . = ALIGN(4);
     _sdata = .;        /* create a global symbol at data start */
@@ -114,7 +114,7 @@ SECTIONS
     *(.data*)          /* .data* sections */
     . = ALIGN(4);
     _edata = .;        /* define a global symbol at data end */
-  } >CCM
+  } >CCM AT> FLASH
 
   /* Uninitialized data section */
   . = ALIGN(4);

--- a/radio/src/targets/taranis/stm32f2_flash.ld
+++ b/radio/src/targets/taranis/stm32f2_flash.ld
@@ -106,7 +106,7 @@ SECTIONS
   _sidata = .;
 
   /* Initialized data sections goes into RAM, load LMA copy after code */
-  .data : AT ( _sidata )
+  .data :
   {
     . = ALIGN(4);
     _sdata = .;        /* create a global symbol at data start */
@@ -115,7 +115,7 @@ SECTIONS
 
     . = ALIGN(4);
     _edata = .;        /* define a global symbol at data end */
-  } >RAM
+  } >RAM AT> FLASH
 
   /* Uninitialized data section */
   . = ALIGN(4);

--- a/radio/src/targets/taranis/stm32f4_flash.ld
+++ b/radio/src/targets/taranis/stm32f4_flash.ld
@@ -106,7 +106,7 @@ SECTIONS
   _sidata = .;
 
   /* Initialized data sections goes into RAM, load LMA copy after code */
-  .data : AT ( _sidata )
+  .data :
   {
     . = ALIGN(4);
     _sdata = .;        /* create a global symbol at data start */
@@ -115,7 +115,7 @@ SECTIONS
 
     . = ALIGN(4);
     _edata = .;        /* define a global symbol at data end */
-  } >CCM
+  } >CCM AT> FLASH
 
   /* Uninitialized data section */
   . = ALIGN(4);


### PR DESCRIPTION
Prior to this PR, FLASH overflow detection would fail if `.text` segment would be small enough, but the firmware would overflow once `.data` is added.

Summary of changes:
- explicitly locate `.data` segment in `FLASH` instead of using `_sidata` marker.
