### PR TITLE
fix(radio) - Fix SF 'Play Sound' not working on startup.

### DIFF
--- a/radio/src/functions.cpp
+++ b/radio/src/functions.cpp
@@ -297,9 +297,7 @@ void evalFunctions(const CustomFunctionData * functions, CustomFunctionsContext 
             if (isRepeatDelayElapsed(functions, functionsContext, i)) {
               if (!IS_PLAYING(PLAY_INDEX)) {
                 if (CFN_FUNC(cfn) == FUNC_PLAY_SOUND) {
-                  if (audioQueue.isEmpty()) {
-                    AUDIO_PLAY(AU_SPECIAL_SOUND_FIRST + CFN_PARAM(cfn));
-                  }
+                  AUDIO_PLAY(AU_SPECIAL_SOUND_FIRST + CFN_PARAM(cfn));
                 } else if (CFN_FUNC(cfn) == FUNC_PLAY_VALUE) {
                   PLAY_VALUE(CFN_PARAM(cfn), PLAY_INDEX);
                 }


### PR DESCRIPTION
Fixes #2967 

Remove the check on the audio queue state from the 'Play Sound' code.
