### PR TITLE
safeguard RTC backup memory

### DIFF
--- a/radio/src/debug.h
+++ b/radio/src/debug.h
@@ -24,7 +24,11 @@
 
 #include <float.h>
 #include "definitions.h"
+
+#if defined(RTCLOCK)
 #include "rtc.h"
+#endif
+
 #include "dump.h"
 
 #define CRLF "\r\n"

--- a/radio/src/rtc.h
+++ b/radio/src/rtc.h
@@ -52,6 +52,8 @@ extern uint8_t g_ms100; // global to allow time set function to reset to zero
 
 void rtcInit();
 void rtcSetTime(const struct gtm * tm);
+uint32_t getRTCBKPR(uint8_t register);
+void setRTCBKPR(uint8_t register, uint32_t value);
 gtime_t gmktime (struct gtm *tm);
 uint8_t rtcAdjust(uint16_t year, uint8_t mon, uint8_t day, uint8_t hour, uint8_t min, uint8_t sec);
 

--- a/radio/src/rtc.h
+++ b/radio/src/rtc.h
@@ -52,8 +52,8 @@ extern uint8_t g_ms100; // global to allow time set function to reset to zero
 
 void rtcInit();
 void rtcSetTime(const struct gtm * tm);
-uint32_t getRTCBKPR(uint8_t register);
-void setRTCBKPR(uint8_t register, uint32_t value);
+uint32_t getRTCBKPR(uint8_t r);
+void setRTCBKPR(uint8_t r, uint32_t value);
 gtime_t gmktime (struct gtm *tm);
 uint8_t rtcAdjust(uint16_t year, uint8_t mon, uint8_t day, uint8_t hour, uint8_t min, uint8_t sec);
 

--- a/radio/src/storage/modelslist.h
+++ b/radio/src/storage/modelslist.h
@@ -40,7 +40,10 @@
 #endif
 
 #include "dataconstants.h"
+
+#if defined(RTCLOCK)
 #include "rtc.h"
+#endif
 
 // modelXXXXXXX.bin F,FF F,3F,FF\r\n
 #define LEN_MODELS_IDX_LINE \

--- a/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
+++ b/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
@@ -584,7 +584,7 @@ int  bootloaderMain()
 #if !defined(SIMU)
 #if defined(RTC_BACKUP_RAM)
       rtcInit();
-      RTC->BKP0R = SOFTRESET_REQUEST;
+      setRTCBKPR(0, SOFTRESET_REQUEST);
 #endif
       blExit();
       NVIC_SystemReset();

--- a/radio/src/targets/common/arm/stm32/rtc_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/rtc_driver.cpp
@@ -21,6 +21,56 @@
 
 #include "stm32_hal.h"
 #include "rtc.h"
+#include "hal.h"
+
+//
+// EdgeTX NV14 and Horus types use the first 2 out of the 20 
+// RTC backup registers to hold data about startup reason 
+// and tpye.
+
+//
+// calculate the RTC backup memory checksum to be stored in 
+// the last of the 20 backup registers
+//
+#define RTCCHKSUM() ((RTC->BKP0R ^ RTC->BKP1R) + 0x4d484131)
+
+//  
+// resets RTC backup registers if data is corrupt
+// and returns the requested backup register
+// 
+uint32_t getRTCBKPR(uint8_t r) {
+  uint32_t prim = __get_PRIMASK();
+  
+  __disable_irq();
+  
+  if(RTC->BKP19R != RTCCHKSUM()) {
+    RTC->BKP0R = 0;
+    RTC->BKP1R = 0;
+    RTC->BKP19R = RTCCHKSUM();
+  }
+
+  if(!prim) 
+    __enable_irq();
+
+  return ((uint32_t *)RTC)[r];
+}
+
+//  
+// writes data to the specified RTC backup register
+// and updates the checksum
+// 
+void setRTCBKPR(uint8_t r, uint32_t value) {
+  ((uint32_t *)RTC)[r] = value;
+
+  uint32_t prim = __get_PRIMASK();
+  
+  __disable_irq();
+
+  RTC->BKP19R = RTCCHKSUM();
+
+  if(!prim) 
+    __enable_irq();
+}
 
 RTC_HandleTypeDef rtc = {};
 

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -227,7 +227,7 @@ void boardOff()
   PWR_BackupRegulatorCmd(DISABLE);
 #endif
 
-  RTC->BKP0R = SHUTDOWN_REQUEST;
+  setRTCBKPR(0, SHUTDOWN_REQUEST);
 
   pwrOff();
 

--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -34,7 +34,9 @@
 
 #include "watchdog_driver.h"
 
+#if defined(RTCLOCK)
 #include "rtc.h"
+#endif
 
 #if defined(HARDWARE_TOUCH)
 #include "tp_gt911.h"

--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -34,6 +34,8 @@
 
 #include "watchdog_driver.h"
 
+#include "rtc.h"
+
 #if defined(HARDWARE_TOUCH)
 #include "tp_gt911.h"
 #endif
@@ -457,16 +459,16 @@ inline bool UNEXPECTED_SHUTDOWN()
   if (WAS_RESET_BY_WATCHDOG())
     return true;
   else if (WAS_RESET_BY_SOFTWARE())
-    return RTC->BKP0R != SOFTRESET_REQUEST;
+    return getRTCBKPR(0) != SOFTRESET_REQUEST;
   else
-    return RTC->BKP1R == POWER_REASON_SIGNATURE && RTC->BKP0R != SHUTDOWN_REQUEST;
+    return getRTCBKPR(1) == POWER_REASON_SIGNATURE && getRTCBKPR(0) != SHUTDOWN_REQUEST;
 #endif
 }
 
 inline void SET_POWER_REASON(uint32_t value)
 {
-  RTC->BKP0R = value;
-  RTC->BKP1R = POWER_REASON_SIGNATURE;
+  setRTCBKPR(0, value);
+  setRTCBKPR(1, POWER_REASON_SIGNATURE);
 }
 #endif
 

--- a/radio/src/targets/nv14/board.cpp
+++ b/radio/src/targets/nv14/board.cpp
@@ -283,12 +283,12 @@ void boardOff()
   if (usbPlugged())
   {
     delay_ms(100);  // Add a delay to wait for lcdOff
-    RTC->BKP0R = SOFTRESET_REQUEST;
+    setRTCBKPR(0, SOFTRESET_REQUEST);
     NVIC_SystemReset();
   }
   else
   {
-    RTC->BKP0R = SHUTDOWN_REQUEST;
+    setRTCBKPR(0, SHUTDOWN_REQUEST);
     pwrOff();
   }
 

--- a/radio/src/targets/nv14/board.h
+++ b/radio/src/targets/nv14/board.h
@@ -40,7 +40,9 @@
 #include "battery_driver.h"
 #include "watchdog_driver.h"
 
+#if defined(RTCLOCK)
 #include "rtc.h"
+#endif
 
 #define FLASHSIZE                       0x200000
 #define BOOTLOADER_SIZE                 0x20000

--- a/radio/src/targets/nv14/board.h
+++ b/radio/src/targets/nv14/board.h
@@ -40,7 +40,7 @@
 #include "battery_driver.h"
 #include "watchdog_driver.h"
 
-#include "hal.h"
+#include "rtc.h"
 
 #define FLASHSIZE                       0x200000
 #define BOOTLOADER_SIZE                 0x20000

--- a/radio/src/targets/nv14/board.h
+++ b/radio/src/targets/nv14/board.h
@@ -40,6 +40,8 @@
 #include "battery_driver.h"
 #include "watchdog_driver.h"
 
+#include "hal.h"
+
 #define FLASHSIZE                       0x200000
 #define BOOTLOADER_SIZE                 0x20000
 #define FIRMWARE_ADDRESS                0x08000000
@@ -365,16 +367,16 @@ inline bool UNEXPECTED_SHUTDOWN()
   if (WAS_RESET_BY_WATCHDOG())
     return true;
   else if (WAS_RESET_BY_SOFTWARE())
-    return RTC->BKP0R != SOFTRESET_REQUEST;
+    return getRTCBKPR(0) != SOFTRESET_REQUEST;
   else
-    return RTC->BKP1R == POWER_REASON_SIGNATURE && RTC->BKP0R != SHUTDOWN_REQUEST;
+    return getRTCBKPR(1) == POWER_REASON_SIGNATURE && getRTCBKPR(0) != SHUTDOWN_REQUEST;
 #endif
 }
 
 inline void SET_POWER_REASON(uint32_t value)
 {
-  RTC->BKP0R = value;
-  RTC->BKP1R = POWER_REASON_SIGNATURE;
+  setRTCBKPR(0, value);
+  setRTCBKPR(1, POWER_REASON_SIGNATURE);
 }
 #endif
 

--- a/radio/src/targets/simu/simpgmspace.h
+++ b/radio/src/targets/simu/simpgmspace.h
@@ -202,6 +202,9 @@ extern char * main_thread_error;
 
 inline void getADC() { }
 
+inline uint32_t getRTCBKPR(uint8_t r) { return 0; };
+inline void setRTCBKPR(uint8_t r, uint32_t value) {};
+
 uint64_t simuTimerMicros(void);
 uint8_t simuSleep(uint32_t ms);  // returns true if thread shutdown requested
 

--- a/radio/src/targets/simu/simpgmspace.h
+++ b/radio/src/targets/simu/simpgmspace.h
@@ -202,9 +202,7 @@ extern char * main_thread_error;
 
 inline void getADC() { }
 
-// Taranis targets include SIMU code for tests. 
-// avoid redefinition
-#if defined(SIMU)                                     
+#if defined(RTCLOCK)              
 inline uint32_t getRTCBKPR(uint8_t r) { return 0; };
 inline void setRTCBKPR(uint8_t r, uint32_t value) {};
 #endif

--- a/radio/src/targets/simu/simpgmspace.h
+++ b/radio/src/targets/simu/simpgmspace.h
@@ -202,8 +202,12 @@ extern char * main_thread_error;
 
 inline void getADC() { }
 
+// Taranis targets include SIMU code for tests. 
+// avoid redefinition
+#if defined(SIMU)                                     
 inline uint32_t getRTCBKPR(uint8_t r) { return 0; };
 inline void setRTCBKPR(uint8_t r, uint32_t value) {};
+#endif
 
 uint64_t simuTimerMicros(void);
 uint8_t simuSleep(uint32_t ms);  // returns true if thread shutdown requested

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -24,7 +24,10 @@
 #include "boards/generic_stm32/intmodule_heartbeat.h"
 
 #include "debug.h"
+
+#if defined(RTCLOCK)
 #include "rtc.h"
+#endif
 
 #include "hal/adc_driver.h"
 #include "hal/module_port.h"


### PR DESCRIPTION
This PR introduces a checksum for the RTC backup memory preventing boot hangs due to corrupt RTC backup memory.

Changes:
- setter and getter for checksum protected RTC backup register access 