### PR TITLE
feat(color): Add alignment option for text widget

### DIFF
--- a/radio/src/gui/colorlcd/widgets/text.cpp
+++ b/radio/src/gui/colorlcd/widgets/text.cpp
@@ -40,13 +40,33 @@ class TextWidget: public Widget
       // get font size from options[2]
       LcdFlags fontsize = persistentData->options[2].value.unsignedValue << 8u;
 
+      // get alignment from options[4]
+      LcdFlags alignment = persistentData->options[4].value.unsignedValue;
+
+      coord_t x;
+      LcdFlags attributes = fontsize;
+
+      switch (alignment) {
+        case ALIGN_RIGHT:
+          x = width();
+          attributes |= RIGHT;
+          break;
+        case ALIGN_CENTER:
+          x = width()/2;
+          attributes |= CENTERED;
+          break;
+        default: // ALIGN_LEFT:
+          x = 0;
+          attributes |= LEFT;
+      }
+
       // draw shadow
       if (persistentData->options[3].value.boolValue) {
-        dc->drawText(1, 1, persistentData->options[0].value.stringValue, fontsize | BLACK);
+        dc->drawText(x+1, 1, persistentData->options[0].value.stringValue, attributes | BLACK);
       }
 
       // draw text
-      dc->drawText(0, 0, persistentData->options[0].value.stringValue, fontsize | CUSTOM_COLOR);
+      dc->drawText(x, 0, persistentData->options[0].value.stringValue, attributes | CUSTOM_COLOR);
     }
 
     static const ZoneOption options[];
@@ -57,6 +77,7 @@ const ZoneOption TextWidget::options[] = {
   { STR_COLOR, ZoneOption::Color, OPTION_VALUE_UNSIGNED(COLOR_THEME_SECONDARY1>>16) },
   { STR_SIZE, ZoneOption::TextSize, OPTION_VALUE_UNSIGNED(0) },
   { STR_SHADOW, ZoneOption::Bool, OPTION_VALUE_BOOL(false)  },
+  { STR_ALIGNMENT, ZoneOption::Align, OPTION_VALUE_UNSIGNED(ALIGN_LEFT) },
   { nullptr, ZoneOption::Bool }
 };
 

--- a/radio/src/translations.cpp
+++ b/radio/src/translations.cpp
@@ -761,6 +761,7 @@ const char STR_INVALID_FILE[] = TR_INVALID_FILE;
 const char STR_TIMER_SOURCE[] = TR_TIMER_SOURCE;
 const char STR_SIZE[] = TR_SIZE;
 const char STR_SHADOW[] = TR_SHADOW;
+const char STR_ALIGNMENT[] = TR_ALIGNMENT;
 const char STR_ALIGN_LABEL[] = TR_ALIGN_LABEL;
 const char STR_ALIGN_VALUE[] = TR_ALIGN_VALUE;
 const char* const STR_ALIGN_OPTS[] = TR_ALIGN_OPTS;

--- a/radio/src/translations.h
+++ b/radio/src/translations.h
@@ -768,6 +768,7 @@ extern const char* const STR_TEXT_SIZE[];
 extern const char* const STR_SUBTRIMMODES[];
 extern const char STR_SIZE[];
 extern const char STR_SHADOW[];
+extern const char STR_ALIGNMENT[];
 extern const char STR_ALIGN_LABEL[];
 extern const char STR_ALIGN_VALUE[];
 extern const char* const STR_ALIGN_OPTS[];

--- a/radio/src/translations/cn.h
+++ b/radio/src/translations/cn.h
@@ -960,7 +960,7 @@
   #define TR_TIMER_SOURCE              "计时器选择"
   #define TR_SIZE                      "尺寸"
   #define TR_SHADOW                    "阴影"
-  #define TR_ALIGNMENT                 "Alignment"
+  #define TR_ALIGNMENT                 "对齐"
   #define TR_ALIGN_LABEL               "对齐名称"
   #define TR_ALIGN_VALUE               "对齐值"
   #define TR_ALIGN_OPTS                { "左", "中", "右" }

--- a/radio/src/translations/cn.h
+++ b/radio/src/translations/cn.h
@@ -960,6 +960,7 @@
   #define TR_TIMER_SOURCE              "计时器选择"
   #define TR_SIZE                      "尺寸"
   #define TR_SHADOW                    "阴影"
+  #define TR_ALIGNMENT                 "Alignment"
   #define TR_ALIGN_LABEL               "对齐名称"
   #define TR_ALIGN_VALUE               "对齐值"
   #define TR_ALIGN_OPTS                { "左", "中", "右" }

--- a/radio/src/translations/cz.h
+++ b/radio/src/translations/cz.h
@@ -980,7 +980,7 @@
   #define TR_TIMER_SOURCE              "Časovač zdroj"
   #define TR_SIZE                      "Velikost"
   #define TR_SHADOW                    "Stíny"
-  #define TR_ALIGNMENT                 "Zarovnat"
+  #define TR_ALIGNMENT                 "Zarovnání"
   #define TR_ALIGN_LABEL               "Zarovnat název"
   #define TR_ALIGN_VALUE               "Zarovnat hodnotu"
   #define TR_ALIGN_OPTS                { "Vlevo", "Uprostřed", "Vpravo" }

--- a/radio/src/translations/cz.h
+++ b/radio/src/translations/cz.h
@@ -980,6 +980,7 @@
   #define TR_TIMER_SOURCE              "Časovač zdroj"
   #define TR_SIZE                      "Velikost"
   #define TR_SHADOW                    "Stíny"
+  #define TR_ALIGNMENT                 "Zarovnat"
   #define TR_ALIGN_LABEL               "Zarovnat název"
   #define TR_ALIGN_VALUE               "Zarovnat hodnotu"
   #define TR_ALIGN_OPTS                { "Vlevo", "Uprostřed", "Vpravo" }

--- a/radio/src/translations/da.h
+++ b/radio/src/translations/da.h
@@ -974,6 +974,7 @@
   #define TR_TIMER_SOURCE              "Tidtagning kilde"
   #define TR_SIZE                      "Størrelse"
   #define TR_SHADOW                    "Skygge"
+  #define TR_ALIGNMENT                 "Justere"
   #define TR_ALIGN_LABEL               "Justere navn"
   #define TR_ALIGN_VALUE               "Justere værdi"
   #define TR_ALIGN_OPTS                { "Venstre", "Center", "Højre" }

--- a/radio/src/translations/da.h
+++ b/radio/src/translations/da.h
@@ -974,7 +974,7 @@
   #define TR_TIMER_SOURCE              "Tidtagning kilde"
   #define TR_SIZE                      "Størrelse"
   #define TR_SHADOW                    "Skygge"
-  #define TR_ALIGNMENT                 "Justere"
+  #define TR_ALIGNMENT                 "Justering"
   #define TR_ALIGN_LABEL               "Justere navn"
   #define TR_ALIGN_VALUE               "Justere værdi"
   #define TR_ALIGN_OPTS                { "Venstre", "Center", "Højre" }

--- a/radio/src/translations/de.h
+++ b/radio/src/translations/de.h
@@ -955,6 +955,7 @@
   #define TR_TIMER_SOURCE              "Timer Quelle"
   #define TR_SIZE                      "Größe"
   #define TR_SHADOW                    "Schatten"
+  #define TR_ALIGNMENT                 "Ausrichtung"
   #define TR_ALIGN_LABEL               "Name ausrichten"
   #define TR_ALIGN_VALUE               "Wert ausrichten"
   #define TR_ALIGN_OPTS                { "Links", "Mitte", "Rechts" }

--- a/radio/src/translations/en.h
+++ b/radio/src/translations/en.h
@@ -969,6 +969,7 @@
   #define TR_TIMER_SOURCE              "Timer source"
   #define TR_SIZE                      "Size"
   #define TR_SHADOW                    "Shadow"
+  #define TR_ALIGNMENT                 "Alignment"
   #define TR_ALIGN_LABEL               "Align label"
   #define TR_ALIGN_VALUE               "Align value"
   #define TR_ALIGN_OPTS                { "Left", "Center", "Right" }

--- a/radio/src/translations/es.h
+++ b/radio/src/translations/es.h
@@ -972,6 +972,7 @@
   #define TR_TIMER_SOURCE              "Entrada timer"
   #define TR_SIZE                      "Tamaño"
   #define TR_SHADOW                    "Sombra"
+  #define TR_ALIGNMENT                 "Alinear"
   #define TR_ALIGN_LABEL               "Alinear marbete"
   #define TR_ALIGN_VALUE               "Alinear valor"
   #define TR_ALIGN_OPTS                { "Lzquierdo", "Centro", "Derecho" }

--- a/radio/src/translations/fi.h
+++ b/radio/src/translations/fi.h
@@ -984,6 +984,7 @@
   #define TR_TIMER_SOURCE              "Timer source"
   #define TR_SIZE                      "Size"
   #define TR_SHADOW                    "Shadow"
+  #define TR_ALIGNMENT                 "Kohdistus"
   #define TR_ALIGN_LABEL               "Kohdista merkki"
   #define TR_ALIGN_VALUE               "Kohdista arvo"
   #define TR_ALIGN_OPTS                { "Vasen", "Keski", "Oikea" }

--- a/radio/src/translations/fr.h
+++ b/radio/src/translations/fr.h
@@ -988,6 +988,7 @@
   #define TR_TIMER_SOURCE              "Source Chrono"
   #define TR_SIZE                      "Taille"
   #define TR_SHADOW                    "Ombre"
+  #define TR_ALIGNMENT                 "Aligner"
   #define TR_ALIGN_LABEL               "Aligner Catégorie"
   #define TR_ALIGN_VALUE               "Aligner Valeur"
   #define TR_ALIGN_OPTS                { "Gauche", "Centre", "Droite" }

--- a/radio/src/translations/fr.h
+++ b/radio/src/translations/fr.h
@@ -988,7 +988,7 @@
   #define TR_TIMER_SOURCE              "Source Chrono"
   #define TR_SIZE                      "Taille"
   #define TR_SHADOW                    "Ombre"
-  #define TR_ALIGNMENT                 "Aligner"
+  #define TR_ALIGNMENT                 "Alignement"
   #define TR_ALIGN_LABEL               "Aligner Catégorie"
   #define TR_ALIGN_VALUE               "Aligner Valeur"
   #define TR_ALIGN_OPTS                { "Gauche", "Centre", "Droite" }

--- a/radio/src/translations/he.h
+++ b/radio/src/translations/he.h
@@ -1050,6 +1050,7 @@
   #define TR_TIMER_SOURCE              "מקור השעון"
   #define TR_SIZE                      "גודל"
   #define TR_SHADOW                    "הצללה"
+  #define TR_ALIGNMENT                 "יישור"
   #define TR_ALIGN_LABEL               "Align label"
   #define TR_ALIGN_VALUE               "Align value"
   #define TR_ALIGN_OPTS                { "שמאל", "מרכז", "ימין" }

--- a/radio/src/translations/it.h
+++ b/radio/src/translations/it.h
@@ -968,6 +968,7 @@
   #define TR_TIMER_SOURCE              "Sorgente timer"
   #define TR_SIZE                      "Dimensione"
   #define TR_SHADOW                    "Ombra"
+  #define TR_ALIGNMENT                 "Allineare"
   #define TR_ALIGN_LABEL               "Allineare il cartellino"
   #define TR_ALIGN_VALUE               "Allineare il valore"
   #define TR_ALIGN_OPTS                { "Sinistra", "Mezzo", "Destra" }

--- a/radio/src/translations/it.h
+++ b/radio/src/translations/it.h
@@ -968,7 +968,7 @@
   #define TR_TIMER_SOURCE              "Sorgente timer"
   #define TR_SIZE                      "Dimensione"
   #define TR_SHADOW                    "Ombra"
-  #define TR_ALIGNMENT                 "Allineare"
+  #define TR_ALIGNMENT                 "Allineamento"
   #define TR_ALIGN_LABEL               "Allineare il cartellino"
   #define TR_ALIGN_VALUE               "Allineare il valore"
   #define TR_ALIGN_OPTS                { "Sinistra", "Mezzo", "Destra" }

--- a/radio/src/translations/jp.h
+++ b/radio/src/translations/jp.h
@@ -965,6 +965,7 @@
   #define TR_TIMER_SOURCE              "タイマーソース"
   #define TR_SIZE                      "サイズ"
   #define TR_SHADOW                    "影"
+  #define TR_ALIGNMENT                 "Alignment"
   #define TR_ALIGN_LABEL               "ラベルを揃える"
   #define TR_ALIGN_VALUE               "値を揃える"
   #define TR_ALIGN_OPTS                { "左", "中央", "右" }

--- a/radio/src/translations/jp.h
+++ b/radio/src/translations/jp.h
@@ -965,7 +965,7 @@
   #define TR_TIMER_SOURCE              "タイマーソース"
   #define TR_SIZE                      "サイズ"
   #define TR_SHADOW                    "影"
-  #define TR_ALIGNMENT                 "Alignment"
+  #define TR_ALIGNMENT                 "アライメント"
   #define TR_ALIGN_LABEL               "ラベルを揃える"
   #define TR_ALIGN_VALUE               "値を揃える"
   #define TR_ALIGN_OPTS                { "左", "中央", "右" }

--- a/radio/src/translations/nl.h
+++ b/radio/src/translations/nl.h
@@ -977,6 +977,7 @@
   #define TR_TIMER_SOURCE              "Timer source"
   #define TR_SIZE                      "Size"
   #define TR_SHADOW                    "Shadow"
+  #define TR_ALIGNMENT                 "Uitlijnen"
   #define TR_ALIGN_LABEL               "Label uitlijnen"
   #define TR_ALIGN_VALUE               "Waarde uitlijnen"
   #define TR_ALIGN_OPTS                { "Links", "Midden", "Rechts" }

--- a/radio/src/translations/pl.h
+++ b/radio/src/translations/pl.h
@@ -966,6 +966,7 @@
   #define TR_TIMER_SOURCE              "Timer source"
   #define TR_SIZE                      "Rozmiar"
   #define TR_SHADOW                    "Cień"
+  #define TR_ALIGNMENT                 "Wyrównaj"
   #define TR_ALIGN_LABEL               "Wyrównaj przywieszka"
   #define TR_ALIGN_VALUE               "Wyrównać wartość"
   #define TR_ALIGN_OPTS                { "Lewy", "Centrum", "Prawe" }

--- a/radio/src/translations/pt.h
+++ b/radio/src/translations/pt.h
@@ -972,6 +972,7 @@
   #define TR_TIMER_SOURCE              "Timer source"
   #define TR_SIZE                      "Size"
   #define TR_SHADOW                    "Shadow"
+  #define TR_ALIGNMENT                 "Alinhar"
   #define TR_ALIGN_LABEL               "Alinhar etiqueta"
   #define TR_ALIGN_VALUE               "Alinhar valor"
   #define TR_ALIGN_OPTS                { "Esquerda", "Centro", "Direita" }

--- a/radio/src/translations/tw.h
+++ b/radio/src/translations/tw.h
@@ -964,6 +964,7 @@
   #define TR_TIMER_SOURCE              "計時器選擇"
   #define TR_SIZE                      "尺寸"
   #define TR_SHADOW                    "陰影"
+  #define TR_ALIGNMENT                 "Alignment"
   #define TR_ALIGN_LABEL               "对齐名称"
   #define TR_ALIGN_VALUE               "对齐值"
   #define TR_ALIGN_OPTS                { "左", "中", "右" }

--- a/radio/src/translations/tw.h
+++ b/radio/src/translations/tw.h
@@ -964,7 +964,7 @@
   #define TR_TIMER_SOURCE              "計時器選擇"
   #define TR_SIZE                      "尺寸"
   #define TR_SHADOW                    "陰影"
-  #define TR_ALIGNMENT                 "Alignment"
+  #define TR_ALIGNMENT                 "對齊"
   #define TR_ALIGN_LABEL               "对齐名称"
   #define TR_ALIGN_VALUE               "对齐值"
   #define TR_ALIGN_OPTS                { "左", "中", "右" }


### PR DESCRIPTION
Adds text alignment option for the text widget.
Here the results, as tested with TX16S simulator:

![grafik](https://user-images.githubusercontent.com/21011587/237037435-296d83dc-0aee-4632-a52d-eecc23fbc0c8.png)

![grafik](https://user-images.githubusercontent.com/21011587/237037491-fe0a6f1d-05a0-4f88-91ae-1b2cc0afb847.png)

![grafik](https://user-images.githubusercontent.com/21011587/237037525-746ef411-1349-468e-8c7c-15adaa1e48a0.png)

![grafik](https://user-images.githubusercontent.com/21011587/237037550-5e349807-3248-4dd3-b2f2-f37513476f43.png)

![grafik](https://user-images.githubusercontent.com/21011587/237037587-b761d2a0-a5b7-4602-bc35-b3ef7391e3c5.png)

![grafik](https://user-images.githubusercontent.com/21011587/237037618-fe58f300-2721-4104-80d5-a40247e7beea.png)

Translators, please double check the translation TR_ALIGNMENT - thanks!