### PR TITLE
fix(cpn): write sort order and selected labels

### DIFF
--- a/companion/src/firmwares/edgetx/edgetxinterface.h
+++ b/companion/src/firmwares/edgetx/edgetxinterface.h
@@ -38,6 +38,7 @@ struct EtxModelMetadata {
 typedef std::list<EtxModelMetadata> EtxModelfiles;
 
 bool loadLabelsListFromYaml(QStringList& labels,
+                            int& sortOrder,
                             EtxModelfiles& modelFiles,
                             const QByteArray& data);
 

--- a/companion/src/firmwares/edgetx/edgetxinterface.h
+++ b/companion/src/firmwares/edgetx/edgetxinterface.h
@@ -37,7 +37,7 @@ struct EtxModelMetadata {
 
 typedef std::list<EtxModelMetadata> EtxModelfiles;
 
-bool loadLabelsListFromYaml(QStringList& labels,
+bool loadLabelsListFromYaml(RadioData::ModelLabels& labels,
                             int& sortOrder,
                             EtxModelfiles& modelFiles,
                             const QByteArray& data);

--- a/companion/src/firmwares/radiodata.cpp
+++ b/companion/src/firmwares/radiodata.cpp
@@ -121,8 +121,11 @@ void RadioData::addLabel(QString label)
       output.truncate(truncateAt);
   }
   label = QString(output);
-  if (labels.indexOf(label) == -1)
-    labels.append(label);
+
+  if (indexOfLabel(label) < 0) {
+    LabelData ld = { label, false };
+    labels.append(ld);
+  }
 }
 
 bool RadioData::deleteLabel(QString label)
@@ -140,7 +143,9 @@ bool RadioData::deleteLabel(QString label)
   }
 
   // Remove the label from the global list
-  labels.removeAll(label);
+  int index = indexOfLabel(label);
+  if (index > -1)
+    labels.remove(index);
 
   // If no labels remain, add a Favorites one
   if (!labels.size()) {
@@ -152,7 +157,7 @@ bool RadioData::deleteLabel(QString label)
 bool RadioData::deleteLabel(int index)
 {
   if (index >= labels.size()) return false;
-  QString modelLabel = labels.at(index);
+  QString modelLabel = labels.at(index).name;
   return deleteLabel(modelLabel);
 }
 
@@ -189,9 +194,9 @@ bool RadioData::renameLabel(QString from, QString to)
         }
       }
     }
-    int ind = labels.indexOf(from);
+    int ind = indexOfLabel(from);
     if (ind != -1) {
-      labels.replace(ind, to);
+      labels[ind].name = to;
     }
   }
   return success;
@@ -200,7 +205,7 @@ bool RadioData::renameLabel(QString from, QString to)
 bool RadioData::renameLabel(int index, QString to)
 {
   if (index >= labels.size()) return false;
-  QString from = labels.at(index);
+  QString from = labels.at(index).name;
   return renameLabel(from, to);
 }
 
@@ -212,7 +217,7 @@ void RadioData::swapLabel(int indFrom, int indTo)
       indFrom < 0 ||
       indTo < 0)
     return;
-  QString tmplbl = labels.at(indFrom);
+  LabelData tmplbl = labels.at(indFrom);
   labels.replace(indFrom, labels.at(indTo));
   labels.replace(indTo, tmplbl);
 }
@@ -257,6 +262,20 @@ void RadioData::addLabelsFromModels()
       addLabel(label);
     }
   }
+}
+
+int RadioData::indexOfLabel(QString & label) const
+{
+  int index = -1;
+
+  for (int i = 0; i < labels.size(); i++) {
+    if (labels.at(i).name == label) {
+      index = i;
+      break;
+    }
+  }
+
+  return index;
 }
 
 QStringList RadioData::fromCSV(const QString &csv)

--- a/companion/src/firmwares/radiodata.cpp
+++ b/companion/src/firmwares/radiodata.cpp
@@ -22,7 +22,8 @@
 #include "radiodataconversionstate.h"
 #include "eeprominterface.h"
 
-RadioData::RadioData()
+RadioData::RadioData() :
+  sortOrder(0)
 {
   models.resize(getCurrentFirmware()->getCapability(Models));
 }

--- a/companion/src/firmwares/radiodata.h
+++ b/companion/src/firmwares/radiodata.h
@@ -18,6 +18,7 @@ class RadioData {
 
     GeneralSettings generalSettings;
     QStringList labels;
+    int sortOrder;
     std::vector<ModelData> models;
 
     void convert(RadioDataConversionState & cstate);

--- a/companion/src/firmwares/radiodata.h
+++ b/companion/src/firmwares/radiodata.h
@@ -17,7 +17,16 @@ class RadioData {
     RadioData();
 
     GeneralSettings generalSettings;
-    QStringList labels;
+
+    struct LabelData {
+      QString name;
+      bool selected;
+    };
+
+    typedef QVector<LabelData> ModelLabels;
+
+    ModelLabels labels;
+
     int sortOrder;
     std::vector<ModelData> models;
 
@@ -32,6 +41,7 @@ class RadioData {
     bool addLabelToModel(int index, QString label);
     bool removeLabelFromModel(int index, QString label);
     void addLabelsFromModels();
+    int indexOfLabel(QString & label) const;
 
     static QStringList fromCSV(const QString &csv);
     static QString toCSV(QStringList lbls);

--- a/companion/src/storage/labeled.cpp
+++ b/companion/src/storage/labeled.cpp
@@ -218,15 +218,19 @@ bool LabelsStorageFormat::loadYaml(RadioData & radioData)
   //        - Update possible labels with all found in models too
 
   QByteArray labelslistBuffer;
+  int sortOrder = 0;
   if (loadFile(labelslistBuffer, "MODELS/labels.yml")) {
     try {
-      if (!loadLabelsListFromYaml(radioData.labels, modelFiles, labelslistBuffer)) {
+      if (!loadLabelsListFromYaml(radioData.labels, sortOrder, modelFiles, labelslistBuffer)) {
         setError(tr("Can't load MODELS/labels.yml"));
       }
     } catch(const std::runtime_error& e) {
       setError(tr("Can't load MODELS/labels.yml") + ":\n" + QString(e.what()));
     }
   }
+
+  // Save Sort Order
+  radioData.sortOrder = sortOrder;
 
   // Scan for all models
   std::list<std::string> filelist;

--- a/companion/src/storage/labeled.cpp
+++ b/companion/src/storage/labeled.cpp
@@ -140,7 +140,8 @@ bool LabelsStorageFormat::loadBin(RadioData & radioData)
 
   // Add a Favorites label
   if(getCurrentFirmware()->getCapability(HasModelLabels)) {
-   radioData.labels.append(tr("Favorites"));
+   RadioData::LabelData ld = { tr("Favorites"), false };
+   radioData.labels.append(ld);
   }
   return true;
 }
@@ -312,8 +313,10 @@ bool LabelsStorageFormat::loadYaml(RadioData & radioData)
     radioData.addLabelsFromModels();
 
     // If no labels, add a Favorites
-    if(!radioData.labels.size())
-      radioData.labels.append(tr("Favorites"));
+    if(!radioData.labels.size()) {
+      RadioData::LabelData ld = { tr("Favorites"), false };
+      radioData.labels.append(ld);
+    }
   }
 
   return true;


### PR DESCRIPTION
Fixes #2899

Summary of changes:
- based on work by @dlktdr 
- extend radio data structures
- read and write sort order and selected labels

Note: This PR does not support changing these within Companion. That will be included in a separate PR along with some other features. The primary objective here is for Companion not to lose settings.