### PR TITLE
feat(ui): "Missing or bad radio data"

### DIFF
--- a/radio/src/translations/cn.h
+++ b/radio/src/translations/cn.h
@@ -520,7 +520,7 @@
 #define TR_ALARMSDISABLED              "已禁用报警"
 #define TR_PRESSANYKEY                 TR("\010按任意键", "按任意键")
 #define TR_BADEEPROMDATA               "存储数据错误"
-#define TR_BAD_RADIO_DATA              "系统数据错误"
+#define TR_BAD_RADIO_DATA              "无法读取系统设置参数, 请检查SD卡"
 #define TR_RADIO_DATA_RECOVERED        TR3("Using backup radio data","Using backup radio settings","Radio settings recovered from backup")
 #define TR_RADIO_DATA_UNRECOVERABLE    TR3("Radio settings invalid","Radio settings not valid", "Unable to read valid radio settings")
 #define TR_EEPROMFORMATTING            "格式化存储"

--- a/radio/src/translations/cz.h
+++ b/radio/src/translations/cz.h
@@ -525,7 +525,7 @@
 #define TR_ALARMSDISABLED              "Alarmy jsou zakázány"
 #define TR_PRESSANYKEY                 TR("\006Stiskni klávesu", "Stiskni klávesu")
 #define TR_BADEEPROMDATA               TR("\006Chyba dat EEPROM", "Chyba dat EEPROM")
-#define TR_BAD_RADIO_DATA              "Chybná data rádia"
+#define TR_BAD_RADIO_DATA              "Chybějící nebo poškozená data vysílače"
 #define TR_RADIO_DATA_RECOVERED        TR3("Použití zálohy dat TX","Použití zálohy dat vysílače","Nastavení vysílače bylo obnoveno ze zálohy")
 #define TR_RADIO_DATA_UNRECOVERABLE    TR3("Neplatné nastavení TX","Neplatné nastavení vysílače", "Nelze načíst platné nastavení vysílače")
 #define TR_EEPROMFORMATTING            TR("\004Formatování EEPROM", "Formatování EEPROM")

--- a/radio/src/translations/da.h
+++ b/radio/src/translations/da.h
@@ -525,7 +525,7 @@
 #define TR_ALARMSDISABLED              "Alarmer afkoblet"
 #define TR_PRESSANYKEY                 TR("\010Tryk en tast", "Tryk en tast")
 #define TR_BADEEPROMDATA               "Dårlig EEprom data"
-#define TR_BAD_RADIO_DATA              "Dårlig radio data"
+#define TR_BAD_RADIO_DATA              "Manglende eller dårlig radio data"
 #define TR_RADIO_DATA_RECOVERED        TR3("Anvender radio data fra backup","Anvender radio indstillinger fra backup","Radio indstillinger genskabt fra backup")
 #define TR_RADIO_DATA_UNRECOVERABLE    TR3("Radio indstillinger fejlagtige","Radio indstillinger ikke gyyldige", "Ikke muligt at indlæse gyyldige radio indstillinger")
 #define TR_EEPROMFORMATTING            "Formaterer EEPROM"

--- a/radio/src/translations/de.h
+++ b/radio/src/translations/de.h
@@ -524,7 +524,7 @@
 #define TR_ALARMSDISABLED              "Alarme ausgeschaltet"
 #define TR_PRESSANYKEY                 TR("Taste drücken",CENTER"Taste drücken")
 #define TR_BADEEPROMDATA               "EEPROM ungültig"
-#define TR_BAD_RADIO_DATA              "Bad Radio Data"
+#define TR_BAD_RADIO_DATA              "Fehlende oder fehlerhafte Daten"
 #define TR_RADIO_DATA_RECOVERED        TR3("Using backup radio data","Using backup radio settings","Radio settings recovered from backup")
 #define TR_RADIO_DATA_UNRECOVERABLE    TR3("Radio settings invalid","Radio settings not valid", "Unable to read valid radio settings")
 #define TR_EEPROMFORMATTING            "EEPROM Initialisieren"

--- a/radio/src/translations/en.h
+++ b/radio/src/translations/en.h
@@ -518,7 +518,7 @@
 #define TR_ALARMSDISABLED              "Alarms disabled"
 #define TR_PRESSANYKEY                 TR("\010Press any Key", "Press any key")
 #define TR_BADEEPROMDATA               "Bad EEprom data"
-#define TR_BAD_RADIO_DATA              "Bad radio data"
+#define TR_BAD_RADIO_DATA              "Missing or bad radio data"
 #define TR_RADIO_DATA_RECOVERED        TR3("Using backup radio data","Using backup radio settings","Radio settings recovered from backup")
 #define TR_RADIO_DATA_UNRECOVERABLE    TR3("Radio settings invalid","Radio settings not valid", "Unable to read valid radio settings")
 #define TR_EEPROMFORMATTING            "Formatting EEPROM"

--- a/radio/src/translations/fi.h
+++ b/radio/src/translations/fi.h
@@ -527,7 +527,7 @@
 #define TR_ALARMSDISABLED              "Alarms Disabled"
 #define TR_PRESSANYKEY                 TR("\010Press any Key", "Press any Key")
 #define TR_BADEEPROMDATA               "Bad EEPROM Data"
-#define TR_BAD_RADIO_DATA              "Bad Radio Data"
+#define TR_BAD_RADIO_DATA              "Puuttuvat tai virheelliset asetukset"
 #define TR_RADIO_DATA_RECOVERED        TR3("Using backup radio data","Using backup radio settings","Radio settings recovered from backup")
 #define TR_RADIO_DATA_UNRECOVERABLE    TR3("Radio settings invalid","Radio settings not valid", "Unable to read valid radio settings")
 #define TR_EEPROMFORMATTING            "Formatting EEPROM"

--- a/radio/src/translations/fr.h
+++ b/radio/src/translations/fr.h
@@ -532,7 +532,7 @@
 #define TR_ALARMSDISABLED              "Alarmes désactivées"
 #define TR_PRESSANYKEY                 TR("Toucher pour continuer", "Toucher pour continuer")
 #define TR_BADEEPROMDATA               "EEPROM corrompue"
-#define TR_BAD_RADIO_DATA              "Réglages radio corrompus"
+#define TR_BAD_RADIO_DATA              "Absence ou erreur de donnée"
 #define TR_RADIO_DATA_RECOVERED        TR3("Utilisation des données radio sauvegardées","Utilisation des paramètres radio sauvegardées","Réglages Radio restaurés de la Sauvegarde")
 #define TR_RADIO_DATA_UNRECOVERABLE    TR3("Réglages Radio invalides","Réglages Radio invalides", "Impossible lire réglages radio valides")
 #define TR_EEPROMFORMATTING            "Formatage EEPROM"

--- a/radio/src/translations/it.h
+++ b/radio/src/translations/it.h
@@ -523,7 +523,7 @@
 #define TR_ALARMSDISABLED               "Allarmi Disattivati!"
 #define TR_PRESSANYKEY                  TR("\010Premi un tasto", "Premi un tasto")
 #define TR_BADEEPROMDATA                "Dati corrotti!"
-#define TR_BAD_RADIO_DATA               "Dati radio errati"
+#define TR_BAD_RADIO_DATA               "Dati nella cartella RADIO/nerrati o assenti"
 #define TR_RADIO_DATA_RECOVERED         TR3("Uso i dati radio di backup","Uso i settaggi radio di backup","Settaggi Radio ripresi da un backup")
 #define TR_RADIO_DATA_UNRECOVERABLE     TR3("Radio settings invalid","Radio settings not valid", "Unable to read valid radio settings")
 #define TR_EEPROMFORMATTING             "Formatto EEPROM..."

--- a/radio/src/translations/jp.h
+++ b/radio/src/translations/jp.h
@@ -518,7 +518,7 @@
 #define TR_ALARMSDISABLED              "アラーム無効"
 #define TR_PRESSANYKEY                 TR("\010Press any Key", "任意のキーを押してください")
 #define TR_BADEEPROMDATA               "EEPROMデータが不良です"
-#define TR_BAD_RADIO_DATA              "送信機データが不良です"
+#define TR_BAD_RADIO_DATA              "送信機データ不具合、もしくは存在しません"
 #define TR_RADIO_DATA_RECOVERED        TR3("バックアップした送信機データを使用","バックアップした送信機設定を使用","バックアップから送信機設定を復元")
 #define TR_RADIO_DATA_UNRECOVERABLE    TR3("送信機設定が無効です","送信機設定が有効ではありません", "有効な送信機設定を読み込めません")
 #define TR_EEPROMFORMATTING            "EEPROMをフォーマットします"

--- a/radio/src/translations/pl.h
+++ b/radio/src/translations/pl.h
@@ -520,7 +520,7 @@
 #define TR_ALARMSDISABLED      "Alarmy wyłączone"
 #define TR_PRESSANYKEY         TR("\010Wciśnij jakiś klawisz","Wciśnij jakiś klawisz")
 #define TR_BADEEPROMDATA       "\006Błąd danych EEPROM"
-#define TR_BAD_RADIO_DATA      "Bad Radio Data"
+#define TR_BAD_RADIO_DATA      "Brak lub nieprawidłowe dane radia"
 #define TR_RADIO_DATA_RECOVERED        TR3("Using backup radio data","Using backup radio settings","Radio settings recovered from backup")
 #define TR_RADIO_DATA_UNRECOVERABLE    TR3("Radio settings invalid","Radio settings not valid", "Unable to read valid radio settings")
 #define TR_EEPROMFORMATTING    "\004Formatowanie EEPROM"

--- a/radio/src/translations/se.h
+++ b/radio/src/translations/se.h
@@ -546,7 +546,7 @@
 #define TR_ALARMSDISABLED               "Alarmen avstängda!"
 #define TR_PRESSANYKEY                  TR("\010Tryck på en knapp", "Tryck på valfri knapp")
 #define TR_BADEEPROMDATA                "Minnet kan inte tolkas"
-#define TR_BAD_RADIO_DATA               "Data från radion kan inte tolkas"
+#define TR_BAD_RADIO_DATA               "Radiodata felaktig eller saknas"
 #define TR_RADIO_DATA_RECOVERED         TR3("Anv. backupradiodata","Anv. backupradioinställningar","Radioinställningar återställda från backup")
 #define TR_RADIO_DATA_UNRECOVERABLE     TR3("Ogiltiga radioinställn.","Ogiltiga radioinställningar", "Kan inte läsa giltiga radioinställningar")
 #define TR_EEPROMFORMATTING             "Minnet formateras"

--- a/radio/src/translations/tw.h
+++ b/radio/src/translations/tw.h
@@ -518,7 +518,7 @@
 #define TR_ALARMSDISABLED              "已禁用報警"
 #define TR_PRESSANYKEY                 TR("\010按任意鍵", "按任意鍵")
 #define TR_BADEEPROMDATA               "存儲數據錯誤"
-#define TR_BAD_RADIO_DATA              "系統數據錯誤"
+#define TR_BAD_RADIO_DATA              "無法讀取系統設置參數, 請檢查SD卡"
 #define TR_RADIO_DATA_RECOVERED        TR3("Using backup radio data","Using backup radio settings","Radio settings recovered from backup")
 #define TR_RADIO_DATA_UNRECOVERABLE    TR3("Radio settings invalid","Radio settings not valid", "Unable to read valid radio settings")
 #define TR_EEPROMFORMATTING            "格式化存儲"


### PR DESCRIPTION
Changes to less daunting label "Missing or bad radio data" if \RADIO folder on SD card is non-existent:

![grafik](https://github.com/EdgeTX/edgetx/assets/21011587/6c57cef6-5e28-4b33-ad08-bb6f3281a11b)

Previously "Bad radio data" was used, causing unnecessary negative emotions on many users, who created a clean SD card content.

Needs translation of the TR_BAD_RADIO_DATA string. I am herewith pinging directly - thx!

- [x] @zyren CN / TW
- [x] @Eldenroot CZ
- [x] @HThuren DA
- [x] @ParkerEde DE
- [x] @Pat6874 FR
- [x] @robustini IT
- [x] @ToshihiroMakuuchi JP
- [x] @ajjjjjjjj PL
- [x] @ulfhedlund SE

 Please feel to use the phrase in your language what makes most sense - does not need to be a direct translation.