### PR TITLE
Fix: first channel omitted in PPM stream

### DIFF
--- a/radio/src/targets/common/arm/stm32/module_timer_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/module_timer_driver.cpp
@@ -46,7 +46,10 @@ static void module_timer_send(void* ctx, const etx_timer_config_t* cfg,
                               const void* pulses, uint16_t length)
 {
   auto timer = (const stm32_pulse_timer_t*)ctx;
-  if (!stm32_pulse_if_not_running_disable(timer)) return;
+  if (!stm32_pulse_if_not_running_disable(timer)) {
+    LL_DMA_DeInit(timer->DMAx, timer->DMA_Stream);
+    return;
+  }
 
   // Set polarity
   stm32_pulse_set_polarity(timer, cfg->polarity);

--- a/radio/src/targets/common/arm/stm32/stm32_pulse_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_pulse_driver.cpp
@@ -298,12 +298,12 @@ void stm32_pulse_start_dma_req(const stm32_pulse_timer_t* tim,
   // Enable TC IRQ
   LL_DMA_EnableIT_TC(tim->DMAx, tim->DMA_Stream);
 
-  // Reset counter close to overflow
-  if (IS_TIM_32B_COUNTER_INSTANCE(tim->TIMx)) {
-    LL_TIM_SetCounter(tim->TIMx, 0xFFFFFFFF);
-  } else {
-    LL_TIM_SetCounter(tim->TIMx, 0xFFFF);
-  }
+  // Reset counter
+  LL_TIM_SetCounter(tim->TIMx, 0x00);
+
+  // only on PWM (preloads the first period)
+  if (ocmode == LL_TIM_OCMODE_PWM1)
+    LL_TIM_GenerateEvent_UPDATE(tim->TIMx);
 
   LL_TIM_EnableDMAReq_UPDATE(tim->TIMx);
   LL_DMA_EnableStream(tim->DMAx, tim->DMA_Stream);


### PR DESCRIPTION
fixes #3597

PPM settings for external module:

![image](https://github.com/EdgeTX/edgetx/assets/5615068/f7ddfc07-65b9-4561-b651-180be0ff76dd)

PPM stream with internal RF set to OFF and external RF set to PPM with above settings - `OK`
All sticks at neutral except CH1 set to Min. Channel monitor confirms all channel 1 at 988us, channels 2 to 8 at 1500us. Notice  all 8 channels correctly transmitted, timing as expected.

![image](https://github.com/EdgeTX/edgetx/assets/5615068/b5a0b0a1-bfe0-44fe-a13c-dc3f789f6a74)

PPM OFF to PPM ON without glitches -  - `OK`
![image](https://github.com/EdgeTX/edgetx/assets/5615068/5b8365ba-cc82-41b3-b297-fdfea6b1f878)





