### PR TITLE
Fixes for various issues (3038-rebase).

### DIFF
--- a/companion/src/modeledit/customfunctions.cpp
+++ b/companion/src/modeledit/customfunctions.cpp
@@ -100,7 +100,7 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
   playIcon.addImage("stop.png", QIcon::Normal, QIcon::On);
 
   QStringList headerLabels;
-  headerLabels << "#" << tr("Switch") << tr("Action") << tr("Parameters") << tr("Repeat") << tr("Enable") << "";
+  headerLabels << "#" << tr("Switch") << tr("Action") << tr("Parameters") << tr("Repeat") << tr("Enable");
   TableLayout * tableLayout = new TableLayout(this, fswCapability, headerLabels);
 
   for (int i = 0; i < fswCapability; i++) {

--- a/radio/src/functions.cpp
+++ b/radio/src/functions.cpp
@@ -154,12 +154,9 @@ void evalFunctions(const CustomFunctionData * functions, CustomFunctionsContext 
     if (swtch) {
       MASK_CFN_TYPE switch_mask = ((MASK_CFN_TYPE)1 << i);
 
-      bool active = getSwitch(
-          swtch, IS_PLAY_FUNC(CFN_FUNC(cfn)) ? GETSWITCH_MIDPOS_DELAY : 0);
-
-      if (HAS_ENABLE_PARAM(CFN_FUNC(cfn))) {
-        active &= (bool)CFN_ACTIVE(cfn);
-      }
+      bool active = getSwitch(swtch, IS_PLAY_FUNC(CFN_FUNC(cfn)) ? GETSWITCH_MIDPOS_DELAY : 0);
+      if (CFN_ACTIVE(cfn) == 0)
+        active = false;
 
       if (active) {
         switch (CFN_FUNC(cfn)) {

--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -1097,15 +1097,16 @@ static bool resumeLua(bool init, bool allowLcdUsage)
             functionsContext = &globalFunctionsContext;
           }
 
-          tmr10ms_t tmr10ms = get_tmr10ms();
-
-          if (getSwitch(fn->swtch) && (functionsContext->lastFunctionTime[idx] == 0 || CFN_PLAY_REPEAT(fn) == 0)) {
-            lua_rawgeti(lsScripts, LUA_REGISTRYINDEX, sid.run);
-            functionsContext->lastFunctionTime[idx] = tmr10ms;
-          }
-          else {
-            if (sid.background == LUA_NOREF) continue;
-            lua_rawgeti(lsScripts, LUA_REGISTRYINDEX, sid.background);
+          if (CFN_ACTIVE(fn)) {
+            tmr10ms_t tmr10ms = get_tmr10ms();
+            if (getSwitch(fn->swtch) && (functionsContext->lastFunctionTime[idx] == 0 || CFN_PLAY_REPEAT(fn) == 0)) {
+              lua_rawgeti(lsScripts, LUA_REGISTRYINDEX, sid.run);
+              functionsContext->lastFunctionTime[idx] = tmr10ms;
+            }
+            else {
+              if (sid.background == LUA_NOREF) continue;
+              lua_rawgeti(lsScripts, LUA_REGISTRYINDEX, sid.background);
+            }
           }
         }
 #if defined(PCBTARANIS)

--- a/radio/src/myeeprom.h
+++ b/radio/src/myeeprom.h
@@ -59,7 +59,6 @@
   #define IS_HAPTIC_FUNC(func)         (0)
 #endif
 
-#define HAS_ENABLE_PARAM(func)         ((func) < FUNC_FIRST_WITHOUT_ENABLE || (func == FUNC_BACKLIGHT))
 #if defined(COLORLCD)
 #define HAS_REPEAT_PARAM(func)         (IS_PLAY_FUNC(func) || IS_HAPTIC_FUNC(func) || func == FUNC_PLAY_SCRIPT || func == FUNC_SET_SCREEN)
 #else


### PR DESCRIPTION
Make 'active' flag work for all functions.
Fix loading and saving of 'active' flag and 'repeat' param in YAML file.
Add missing logic for 'Lua Script' repeat param.
Remove redundant HAS_ENABLE_PARAM macro.
Remove empty column from Companion special/custom functions page.
