### PR TITLE
fix(radio) - Include internal module type in backup data for EM so radio re-connects to receiver.

### DIFF
--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -871,7 +871,7 @@ PACK(struct RadioData {
   uint8_t disableRtcWarning:1;
   uint8_t keysBacklight:1;
   NOBACKUP(uint8_t spare1:1 SKIP);
-  NOBACKUP(uint8_t internalModule ENUM(ModuleType));
+  uint8_t internalModule ENUM(ModuleType);
   NOBACKUP(TrainerData trainer);
   NOBACKUP(uint8_t view);            // index of view in main screen
   NOBACKUP(BUZZER_FIELD); /* 2bits */


### PR DESCRIPTION
Fixes #3599 
