### PR TITLE
RX stat type "Rqly %" for PPM MLINK

### DIFF
--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -121,6 +121,13 @@ rxStatStruct *getRxStatLabels() {
         }
       }
       break;
+    
+    case MODULE_TYPE_PPM:
+      if(moduleState[moduleToUse].protocol == PROTOCOL_CHANNELS_PPM_MLINK) {
+        rxStat.label = STR_RXSTAT_LABEL_RQLY;
+        rxStat.unit  = STR_RXSTAT_UNIT_PERCENT;
+      }
+      break;
 
     case MODULE_TYPE_CROSSFIRE:
     case MODULE_TYPE_GHOST:


### PR DESCRIPTION
Summary of changes:
- added rx stat type Rqly % for PPM MLINK telemetry protocol

Tested ok on TX16s