### PR TITLE
fix(color) - Fix colors when theme is changed.

### DIFF
--- a/radio/src/gui/colorlcd/model_flightmodes.cpp
+++ b/radio/src/gui/colorlcd/model_flightmodes.cpp
@@ -237,32 +237,27 @@ class FMStyle
 
         lv_style_init(&fmIdStyle);
         lv_style_set_text_font(&fmIdStyle, getFont(FONT(STD)));
-        lv_style_set_text_color(&fmIdStyle, makeLvColor(COLOR_THEME_SECONDARY1));
         lv_style_set_text_align(&fmIdStyle, LV_TEXT_ALIGN_LEFT);
         lv_style_set_width(&fmIdStyle, FMID_W);
         lv_style_set_pad_left(&fmIdStyle, 2);
 
         lv_style_init(&fmNameStyle);
         lv_style_set_text_font(&fmNameStyle, getFont(FONT(XS)));
-        lv_style_set_text_color(&fmNameStyle, makeLvColor(COLOR_THEME_SECONDARY1));
         lv_style_set_text_align(&fmNameStyle, LV_TEXT_ALIGN_LEFT);
         lv_style_set_width(&fmNameStyle, NAME_W);
 
         lv_style_init(&fmSwitchStyle);
         lv_style_set_text_font(&fmSwitchStyle, getFont(FONT(STD)));
-        lv_style_set_text_color(&fmSwitchStyle, makeLvColor(COLOR_THEME_SECONDARY1));
         lv_style_set_text_align(&fmSwitchStyle, LV_TEXT_ALIGN_LEFT);
         lv_style_set_width(&fmSwitchStyle, SWTCH_W);
 
         lv_style_init(&fmFadeStyle);
         lv_style_set_text_font(&fmFadeStyle, getFont(FONT(STD)));
-        lv_style_set_text_color(&fmFadeStyle, makeLvColor(COLOR_THEME_SECONDARY1));
         lv_style_set_text_align(&fmFadeStyle, LV_TEXT_ALIGN_RIGHT);
         lv_style_set_width(&fmFadeStyle, FADE_W);
 
         lv_style_init(&fmTrimModeStyle);
         lv_style_set_text_font(&fmTrimModeStyle, getFont(FONT(STD)));
-        lv_style_set_text_color(&fmTrimModeStyle, makeLvColor(COLOR_THEME_SECONDARY1));
         lv_style_set_text_align(&fmTrimModeStyle, LV_TEXT_ALIGN_CENTER);
         lv_style_set_width(&fmTrimModeStyle, TRIM_W);
         lv_style_set_height(&fmTrimModeStyle, 16);
@@ -270,53 +265,90 @@ class FMStyle
         fmTrimValueStyle = fmTrimModeStyle;
         lv_style_init(&fmTrimValueStyle);
         lv_style_set_text_font(&fmTrimValueStyle, getFont(FONT(XS)));
-        lv_style_set_text_color(&fmTrimValueStyle, makeLvColor(COLOR_THEME_SECONDARY1));
         lv_style_set_text_align(&fmTrimValueStyle, LV_TEXT_ALIGN_CENTER);
         lv_style_set_width(&fmTrimValueStyle, TRIM_W);
         lv_style_set_height(&fmTrimValueStyle, 16);
       }
+
+      // Always update colors in case theme changes
+      lv_style_set_text_color(&fmIdStyle, makeLvColor(COLOR_THEME_SECONDARY1));
+      lv_style_set_text_color(&fmNameStyle, makeLvColor(COLOR_THEME_SECONDARY1));
+      lv_style_set_text_color(&fmSwitchStyle, makeLvColor(COLOR_THEME_SECONDARY1));
+      lv_style_set_text_color(&fmFadeStyle, makeLvColor(COLOR_THEME_SECONDARY1));
+      lv_style_set_text_color(&fmTrimModeStyle, makeLvColor(COLOR_THEME_SECONDARY1));
+      lv_style_set_text_color(&fmTrimValueStyle, makeLvColor(COLOR_THEME_SECONDARY1));
     }
 
-    void setTrimContStyle(lv_obj_t* obj)
+    lv_obj_t* newId(lv_obj_t* parent)
     {
-      init();
-      lv_obj_add_style(obj, &fmTrimContStyle, LV_PART_MAIN);
-    }
-
-    void setIdStyle(lv_obj_t* obj)
-    {
-      init();
+      auto obj = lv_label_create(parent);
       lv_obj_add_style(obj, &fmIdStyle, LV_PART_MAIN);
+
+      return obj;
     }
 
-    void setNameStyle(lv_obj_t* obj)
+    lv_obj_t* newGroup(lv_obj_t* parent)
     {
-      init();
+      lv_obj_t* obj = lv_obj_create(parent);
+      lv_obj_set_flex_flow(obj, LV_FLEX_FLOW_ROW_WRAP);
+      lv_obj_set_style_flex_grow(obj, 2, LV_PART_MAIN);
+      lv_obj_set_style_pad_all(obj, 0, LV_PART_MAIN);
+      lv_obj_set_height(obj, LV_SIZE_CONTENT);
+      lv_obj_add_flag(obj, LV_OBJ_FLAG_EVENT_BUBBLE);
+      lv_obj_set_flex_align(obj, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_SPACE_AROUND);
+
+      return obj;
+    }
+
+    lv_obj_t* newName(lv_obj_t* parent)
+    {
+      auto obj = lv_label_create(parent);
       lv_obj_add_style(obj, &fmNameStyle, LV_PART_MAIN);
+
+      return obj;
     }
 
-    void setSwitchStyle(lv_obj_t* obj)
+    lv_obj_t* newSwitch(lv_obj_t* parent)
     {
-      init();
+      auto obj = lv_label_create(parent);
       lv_obj_add_style(obj, &fmSwitchStyle, LV_PART_MAIN);
+
+      return obj;
     }
 
-    void setFadeStyle(lv_obj_t* obj)
+    lv_obj_t* newTrimCont(lv_obj_t* parent)
     {
-      init();
-      lv_obj_add_style(obj, &fmFadeStyle, LV_PART_MAIN);
+      auto obj = lv_obj_create(parent);
+      lv_obj_add_style(obj, &fmTrimContStyle, LV_PART_MAIN);
+      lv_obj_add_flag(obj, LV_OBJ_FLAG_EVENT_BUBBLE);
+
+      return obj;
     }
 
-    void setTrimModeStyle(lv_obj_t* obj)
+    lv_obj_t* newTrimMode(lv_obj_t* parent, int n)
     {
-      init();
+      auto obj = lv_label_create(parent);
       lv_obj_add_style(obj, &fmTrimModeStyle, LV_PART_MAIN);
+      lv_obj_set_pos(obj, n * TRIM_W, 0);
+
+      return obj;
     }
 
-    void setTrimValueStyle(lv_obj_t* obj)
+    lv_obj_t* newTrimValue(lv_obj_t* parent, int n)
     {
-      init();
+      auto obj = lv_label_create(parent);
       lv_obj_add_style(obj, &fmTrimValueStyle, LV_PART_MAIN);
+      lv_obj_set_pos(obj, n * TRIM_W, 16);
+
+      return obj;
+    }
+
+    lv_obj_t* newFade(lv_obj_t* parent)
+    {
+      auto obj = lv_label_create(parent);
+      lv_obj_add_style(obj, &fmFadeStyle, LV_PART_MAIN);
+
+      return obj;
     }
 
   private:
@@ -370,44 +402,24 @@ class FlightModeBtn : public Button
   {
     lv_obj_enable_style_refresh(false);
 
-    fmID = lv_label_create(lvobj);
-    fmStyle.setIdStyle(fmID);
+    fmID = fmStyle.newId(lvobj);
 
-    lv_obj_t* container = lv_obj_create(lvobj);
-    lv_obj_set_flex_flow(container, LV_FLEX_FLOW_ROW_WRAP);
-    lv_obj_set_style_flex_grow(container, 2, LV_PART_MAIN);
-    lv_obj_set_style_pad_all(container, 0, LV_PART_MAIN);
-    lv_obj_set_height(container, LV_SIZE_CONTENT);
+    lv_obj_t* container = fmStyle.newGroup(lvobj);
     lv_obj_set_user_data(container, this);
-    lv_obj_add_flag(container, LV_OBJ_FLAG_EVENT_BUBBLE);
-    lv_obj_set_flex_align(container, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_SPACE_AROUND);
 
-    fmName = lv_label_create(container);
-    fmStyle.setNameStyle(fmName);
+    fmName = fmStyle.newName(container);
+    fmSwitch = fmStyle.newSwitch(container);
 
-    fmSwitch = lv_label_create(container);
-    fmStyle.setSwitchStyle(fmSwitch);
-
-    lv_obj_t* trims_cont = lv_obj_create(container);
-    fmStyle.setTrimContStyle(trims_cont);
+    lv_obj_t* trims_cont = fmStyle.newTrimCont(container);
     lv_obj_set_user_data(trims_cont, this);
-    lv_obj_add_flag(trims_cont, LV_OBJ_FLAG_EVENT_BUBBLE);
 
     for (int i = 0; i < NUM_TRIMS; i += 1) {
-      fmTrimMode[i] = lv_label_create(trims_cont);
-      fmStyle.setTrimModeStyle(fmTrimMode[i]);
-      lv_obj_set_pos(fmTrimMode[i], i*TRIM_W, 0);
-
-      fmTrimValue[i] = lv_label_create(trims_cont);
-      fmStyle.setTrimValueStyle(fmTrimValue[i]);
-      lv_obj_set_pos(fmTrimValue[i], i*TRIM_W, 16);
+      fmTrimMode[i] = fmStyle.newTrimMode(trims_cont, i);
+      fmTrimValue[i] = fmStyle.newTrimValue(trims_cont, i);
     }
 
-    fmFadeIn = lv_label_create(container);
-    fmStyle.setFadeStyle(fmFadeIn);
-
-    fmFadeOut = lv_label_create(container);
-    fmStyle.setFadeStyle(fmFadeOut);
+    fmFadeIn = fmStyle.newFade(container);
+    fmFadeOut = fmStyle.newFade(container);
 
     init = true;
     refresh();
@@ -508,6 +520,7 @@ class FlightModeBtn : public Button
 ModelFlightModesPage::ModelFlightModesPage():
   PageTab(STR_MENUFLIGHTMODES, ICON_MODEL_FLIGHT_MODES)
 {
+  fmStyle.init();
 }
 
 static const lv_coord_t fmt_col_dsc[] = {LV_GRID_FR(1),

--- a/radio/src/gui/colorlcd/model_gvars.h
+++ b/radio/src/gui/colorlcd/model_gvars.h
@@ -28,7 +28,7 @@
 class ModelGVarsPage : public PageTab
 {
  public:
-  ModelGVarsPage() : PageTab(STR_MENU_GLOBAL_VARS, ICON_MODEL_GVARS) {}
+  ModelGVarsPage();
 
  protected:
   void build(FormWindow* window) override;

--- a/radio/src/gui/colorlcd/model_telemetry.cpp
+++ b/radio/src/gui/colorlcd/model_telemetry.cpp
@@ -80,72 +80,100 @@ class TSStyle
 
         lv_style_init(&tsNumStyle);
         lv_style_set_text_font(&tsNumStyle, getFont(FONT(STD)));
-        lv_style_set_text_color(&tsNumStyle, makeLvColor(COLOR_THEME_SECONDARY1));
         lv_style_set_text_align(&tsNumStyle, LV_TEXT_ALIGN_CENTER);
         lv_style_set_width(&tsNumStyle, NUM_W);
 
         lv_style_init(&tsNameStyle);
         lv_style_set_text_font(&tsNameStyle, getFont(FONT(STD)));
-        lv_style_set_text_color(&tsNameStyle, makeLvColor(COLOR_THEME_SECONDARY1));
         lv_style_set_text_align(&tsNameStyle, LV_TEXT_ALIGN_LEFT);
         lv_style_set_width(&tsNameStyle, NAME_W);
 
         lv_style_init(&tsFreshStyle);
-        lv_style_set_text_color(&tsFreshStyle, makeLvColor(COLOR_THEME_SECONDARY1));
         lv_style_set_width(&tsFreshStyle, 8);
         lv_style_set_height(&tsFreshStyle, 8);
-        lv_style_set_img_recolor(&tsFreshStyle, makeLvColor(COLOR_THEME_SECONDARY1));
         lv_style_set_img_recolor_opa(&tsFreshStyle, LV_OPA_COVER);
 
         lv_style_init(&tsValueStyle);
         lv_style_set_text_font(&tsValueStyle, getFont(FONT(STD)));
-        lv_style_set_text_color(&tsValueStyle, makeLvColor(COLOR_THEME_SECONDARY1));
         lv_style_set_text_align(&tsValueStyle, LV_TEXT_ALIGN_LEFT);
         lv_style_set_width(&tsValueStyle, LV_SIZE_CONTENT);
 
         lv_style_init(&tsIdStyle);
         lv_style_set_text_font(&tsIdStyle, getFont(FONT(XXS)));
-        lv_style_set_text_color(&tsIdStyle, makeLvColor(COLOR_THEME_SECONDARY1));
         lv_style_set_text_align(&tsIdStyle, LV_TEXT_ALIGN_CENTER);
         lv_style_set_width(&tsIdStyle, NUM_W);
         lv_style_set_height(&tsIdStyle, 11);
       }
+
+      // Always update colors in case theme changes
+      lv_style_set_text_color(&tsNumStyle, makeLvColor(COLOR_THEME_SECONDARY1));
+      lv_style_set_text_color(&tsNameStyle, makeLvColor(COLOR_THEME_SECONDARY1));
+      lv_style_set_text_color(&tsFreshStyle, makeLvColor(COLOR_THEME_SECONDARY1));
+      lv_style_set_img_recolor(&tsFreshStyle, makeLvColor(COLOR_THEME_SECONDARY1));
+      lv_style_set_text_color(&tsValueStyle, makeLvColor(COLOR_THEME_SECONDARY1));
+      lv_style_set_text_color(&tsIdStyle, makeLvColor(COLOR_THEME_SECONDARY1));
     }
 
-    void setContStyle(lv_obj_t* obj)
+    lv_obj_t* newGroup(lv_obj_t* parent)
     {
-      init();
+      auto obj = lv_obj_create(parent);
       lv_obj_add_style(obj, &tsContStyle, LV_PART_MAIN);
+      lv_obj_set_flex_flow(obj, LV_FLEX_FLOW_COLUMN);
+      lv_obj_set_flex_align(obj, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_SPACE_AROUND);
+
+      return obj;
     }
 
-    void setNumStyle(lv_obj_t* obj)
+    lv_obj_t* newNum(lv_obj_t* parent, uint8_t index)
     {
-      init();
+      auto obj = lv_label_create(parent);
       lv_obj_add_style(obj, &tsNumStyle, LV_PART_MAIN);
+      lv_label_set_text(obj, std::to_string(index+1).c_str());
+
+      return obj;
     }
 
-    void setNameStyle(lv_obj_t* obj)
+    lv_obj_t* newId(lv_obj_t* parent, const char* id)
     {
-      init();
-      lv_obj_add_style(obj, &tsNameStyle, LV_PART_MAIN);
-    }
-
-    void setValueStyle(lv_obj_t* obj)
-    {
-      init();
-      lv_obj_add_style(obj, &tsValueStyle, LV_PART_MAIN);
-    }
-
-    void setFreshStyle(lv_obj_t* obj)
-    {
-      init();
-      lv_obj_add_style(obj, &tsFreshStyle, LV_PART_MAIN);
-    }
-
-    void setIdStyle(lv_obj_t* obj)
-    {
-      init();
+      auto obj = lv_label_create(parent);
       lv_obj_add_style(obj, &tsIdStyle, LV_PART_MAIN);
+      lv_label_set_text(obj, id);
+
+      return obj;
+    }
+
+    lv_obj_t* newName(lv_obj_t* parent, const char* name)
+    {
+      auto obj = lv_label_create(parent);
+      lv_obj_add_style(obj, &tsNameStyle, LV_PART_MAIN);
+      lv_label_set_text(obj, name);
+
+      return obj;
+    }
+
+    lv_obj_t* newFreshCont(lv_obj_t* parent)
+    {
+      auto obj = lv_obj_create(parent);
+      lv_obj_add_style(obj, &tsFreshStyle, LV_PART_MAIN);
+
+      return obj;
+    }
+
+    lv_obj_t* newFreshIcon(lv_obj_t* parent)
+    {
+      auto obj = lv_canvas_create(parent);
+      lv_obj_add_style(obj, &tsFreshStyle, LV_PART_MAIN);
+
+      return obj;
+    }
+
+    lv_obj_t* newValue(lv_obj_t* parent)
+    {
+      auto obj = lv_label_create(parent);
+      lv_obj_add_style(obj, &tsValueStyle, LV_PART_MAIN);
+      lv_label_set_text(obj, "");
+
+      return obj;
     }
 
   private:
@@ -243,18 +271,9 @@ class SensorButton : public Button {
     {
       char s[20];
 
-      auto box = lv_obj_create(lvobj);
-      tsStyle.setContStyle(box);
-      lv_obj_set_flex_flow(box, LV_FLEX_FLOW_COLUMN);
-      lv_obj_set_flex_align(box, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_SPACE_AROUND);
+      auto box = tsStyle.newGroup(lvobj);
 
-      numLabel = lv_label_create(box);
-      tsStyle.setNumStyle(numLabel);
-
-      lv_label_set_text(numLabel, std::to_string(index+1).c_str());
-
-      idLabel = lv_label_create(box);
-      tsStyle.setIdStyle(idLabel);
+      numLabel = tsStyle.newNum(box, index);
 
       TelemetrySensor * sensor = & g_model.telemetrySensors[index];
       if (sensor->type == TELEM_TYPE_CUSTOM) {
@@ -263,26 +282,19 @@ class SensorButton : public Button {
         s[0] = 0;
       }
 
-      lv_label_set_text(idLabel, s);
+      idLabel = tsStyle.newId(box, s);
+
       setNumIdState();
 
-      auto lbl = lv_label_create(lvobj);
-      tsStyle.setNameStyle(lbl);
-
       strAppend(s, g_model.telemetrySensors[index].label, TELEM_LABEL_LEN);
-      lv_label_set_text(lbl, s);
+      auto lbl = tsStyle.newName(lvobj, s);
 
-      box = lv_obj_create(lvobj);
-      tsStyle.setFreshStyle(box);
-
-      fresh = lv_canvas_create(box);
-      tsStyle.setFreshStyle(fresh);
+      box = tsStyle.newFreshCont(lvobj);
+      fresh = tsStyle.newFreshIcon(box);
       lv_canvas_set_buffer(fresh, freshBitmap, 8, 8, LV_IMG_CF_ALPHA_8BIT);
       lv_obj_add_flag(fresh, LV_OBJ_FLAG_HIDDEN);
 
-      valLabel = lv_label_create(lvobj);
-      tsStyle.setValueStyle(valLabel);
-      lv_label_set_text(valLabel, "");
+      valLabel = tsStyle.newValue(lvobj);
 
       init = true;
       refresh();
@@ -719,6 +731,7 @@ class SensorEditWindow : public Page {
 ModelTelemetryPage::ModelTelemetryPage() :
   PageTab(STR_MENUTELEMETRY, ICON_MODEL_TELEMETRY)
 {
+  tsStyle.init();
 }
 
 void ModelTelemetryPage::checkEvents()


### PR DESCRIPTION
The change to fix memory leaks in PR #3547 broke changing themes/colors - the icon colors did not get updated.

This PR fixes the problem by splitting the icon creation (memory allocation) from the icon loading (setting theme color).
