### PR TITLE
fix(color) - Fix window sizes where the ComboChannelBar is displayed.

### DIFF
--- a/radio/src/gui/colorlcd/mixer_edit.cpp
+++ b/radio/src/gui/colorlcd/mixer_edit.cpp
@@ -79,7 +79,7 @@ void MixEditWindow::buildHeader(Window *window)
   new MixerEditStatusBar(
       window,
       {window->getRect().w - MIX_STATUS_BAR_WIDTH - MIX_RIGHT_MARGIN, 0,
-       MIX_STATUS_BAR_WIDTH, MENU_HEADER_HEIGHT + 3},
+       MIX_STATUS_BAR_WIDTH, MENU_HEADER_HEIGHT},
       channel);
 }
 

--- a/radio/src/gui/colorlcd/model_usbjoystick.cpp
+++ b/radio/src/gui/colorlcd/model_usbjoystick.cpp
@@ -285,7 +285,7 @@ class USBChannelEditWindow : public Page
       statusBar = new USBChannelEditStatusBar(
           window,
           {window->getRect().w - USBCH_EDIT_STATUS_BAR_WIDTH - USBCH_EDIT_RIGHT_MARGIN,
-           0, USBCH_EDIT_STATUS_BAR_WIDTH, MENU_HEADER_HEIGHT + 3},
+           0, USBCH_EDIT_STATUS_BAR_WIDTH, MENU_HEADER_HEIGHT},
           channel);
     }
 

--- a/radio/src/gui/colorlcd/output_edit.cpp
+++ b/radio/src/gui/colorlcd/output_edit.cpp
@@ -125,7 +125,7 @@ void OutputEditWindow::buildHeader(Window *window)
       window,
       {window->getRect().w - OUTPUT_EDIT_STATUS_BAR_WIDTH -
            OUTPUT_EDIT_RIGHT_MARGIN,
-       0, OUTPUT_EDIT_STATUS_BAR_WIDTH, MENU_HEADER_HEIGHT + 3},
+       0, OUTPUT_EDIT_STATUS_BAR_WIDTH, MENU_HEADER_HEIGHT},
       channel);
 }
 

--- a/radio/src/gui/colorlcd/view_channels.cpp
+++ b/radio/src/gui/colorlcd/view_channels.cpp
@@ -79,7 +79,7 @@ void ChannelsViewPage::build(FormWindow * window)
     coord_t xPos = (chan % 8) >= 4 ? width + (hmargin * 2) : hmargin;
     coord_t yPos = (chan % 4) * ((window->height() - CHANNEL_VIEW_FOOTER_HEIGHT - 4) / 4);
 #endif
-    new ComboChannelBar(window, {xPos, yPos, width, 3 * BAR_HEIGHT + 1}, chan);
+    new ComboChannelBar(window, {xPos, yPos, width, 3 * BAR_HEIGHT + 3}, chan);
   }
 
   // Footer


### PR DESCRIPTION
Fixes two issues where the channel bar is being used:
- The header height on the mixes, outputs and USB joystick edit pages is incorrect, allowing the header to be scrolled up and down by a few pixels.
- The height for each row in the channel monitor window is too small truncating the channel bar (and again allowing scrolling).

