### PR TITLE
fix: Auto adjust PPM frame length

### DIFF
--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -1489,6 +1489,8 @@ void menuModelSetup(event_t event)
               break;
             case 1:
               CHECK_INCDEC_MODELVAR(event, g_model.trainerData.channelsCount, -4, min<int8_t>(MAX_TRAINER_CHANNELS_M8, 32-8-g_model.trainerData.channelsStart));
+              if (checkIncDec_Ret)
+                setDefaultPpmFrameLengthTrainer();
               break;
           }
         }

--- a/radio/src/gui/212x64/model_setup.cpp
+++ b/radio/src/gui/212x64/model_setup.cpp
@@ -1376,6 +1376,8 @@ void menuModelSetup(event_t event)
               break;
             case 1:
               CHECK_INCDEC_MODELVAR(event, g_model.trainerData.channelsCount, -4, min<int8_t>(MAX_TRAINER_CHANNELS_M8, 32-8-g_model.trainerData.channelsStart));
+              if (checkIncDec_Ret)
+                setDefaultPpmFrameLengthTrainer();
               break;
           }
         }

--- a/radio/src/gui/colorlcd/channel_range.cpp
+++ b/radio/src/gui/colorlcd/channel_range.cpp
@@ -35,9 +35,11 @@ inline int16_t ppmFrameLen(int8_t chCount) {
 
 void cb_value_changed(lv_event_t* e) {
   ChannelRange* chRangeEditObject = (ChannelRange*)lv_event_get_user_data(e);
-  NumberEdit* ppmFrameLenEditObject = chRangeEditObject->getPpmFrameLenEditObject();
+  if(!chRangeEditObject)
+    return;
 
-  if(!ppmFrameLen)
+  NumberEdit* ppmFrameLenEditObject = chRangeEditObject->getPpmFrameLenEditObject();
+  if(!ppmFrameLenEditObject)
     return;
 
   ppmFrameLenEditObject->setValue(ppmFrameLen(chRangeEditObject->getChannelsCount()));
@@ -116,8 +118,7 @@ ModuleChannelRange::ModuleChannelRange(Window* parent, uint8_t moduleIdx) :
   build();
   update();
 
-  // add callbacks to be notified of changes in channels start or beginning
-  lv_obj_add_event_cb(chStart->getLvObj(), cb_value_changed, LV_EVENT_VALUE_CHANGED, (void *)this);
+  // add callback to be notified when channel count changes
   lv_obj_add_event_cb(chEnd->getLvObj(), cb_value_changed, LV_EVENT_VALUE_CHANGED, (void *)this);
 }
 
@@ -188,8 +189,7 @@ TrainerChannelRange::TrainerChannelRange(Window* parent) :
   build();
   update();
 
-  // add callbacks to be notified of changes in channels start or beginning
-  lv_obj_add_event_cb(chStart->getLvObj(), cb_value_changed, LV_EVENT_VALUE_CHANGED, (void *)this);
+  // add callback to be notified when channel count changes
   lv_obj_add_event_cb(chEnd->getLvObj(), cb_value_changed, LV_EVENT_VALUE_CHANGED, (void *)this);
 }
 

--- a/radio/src/gui/colorlcd/channel_range.h
+++ b/radio/src/gui/colorlcd/channel_range.h
@@ -36,16 +36,20 @@ class ChannelRange : public FormGroup
   void updateStart();
   void updateEnd();
 
+  virtual int8_t getChannelsCount() = 0;
+  void setPpmFrameLenEditObject(NumberEdit* ppmFrameLenEditObject);
+  NumberEdit* getPpmFrameLenEditObject();
+
  protected:
   NumberEdit* chStart;
   NumberEdit* chEnd;
+  NumberEdit* ppmFrameLenEditObject = nullptr;
 
   void build();
     
   virtual uint8_t getChannelsStart() = 0;
   virtual void setChannelsStart(uint8_t val) = 0;
 
-  virtual int8_t getChannelsCount() = 0;
   virtual void setChannelsCount(int8_t val) = 0;
 
   virtual uint8_t getChannelsUsed() = 0;
@@ -62,7 +66,6 @@ class ModuleChannelRange : public ChannelRange
   uint8_t getChannelsStart() override;
   void setChannelsStart(uint8_t val) override;
 
-  int8_t getChannelsCount() override;
   void setChannelsCount(int8_t val) override;
 
   uint8_t getChannelsUsed() override;
@@ -71,6 +74,8 @@ class ModuleChannelRange : public ChannelRange
 
  public:
   ModuleChannelRange(Window* parent, uint8_t moduleIdx);
+
+  int8_t getChannelsCount() override;
 };
 
 class TrainerChannelRange : public ChannelRange
@@ -78,7 +83,6 @@ class TrainerChannelRange : public ChannelRange
   uint8_t getChannelsStart() override;
   void setChannelsStart(uint8_t val) override;
 
-  int8_t getChannelsCount() override;
   void setChannelsCount(int8_t val) override;
 
   uint8_t getChannelsUsed() override;
@@ -87,4 +91,6 @@ class TrainerChannelRange : public ChannelRange
 
  public:
   TrainerChannelRange(Window* parent);
+
+  int8_t getChannelsCount() override;
 };

--- a/radio/src/gui/colorlcd/module_setup.cpp
+++ b/radio/src/gui/colorlcd/module_setup.cpp
@@ -242,7 +242,13 @@ void ModuleWindow::updateModule()
 
   // PPM modules
   if (isModulePPM(moduleIdx)) {
-    new PpmSettings(this, grid, moduleIdx);
+    // PPM frame
+    auto line = newLine(&grid);
+    new StaticText(line, rect_t{}, STR_PPMFRAME, 0, COLOR_THEME_PRIMARY1);
+    auto obj = new PpmFrameSettings<PpmModule>(line, &md->ppm);
+  
+    // copy pointer to frame len edit object to channel range
+    chRange->setPpmFrameLenEditObject(obj->getPpmFrameLenEditObject());
   }
 
   // Generic module parameters

--- a/radio/src/gui/colorlcd/ppm_settings.cpp
+++ b/radio/src/gui/colorlcd/ppm_settings.cpp
@@ -25,7 +25,7 @@
 #define SET_DIRTY() storageDirty(EE_MODEL)
 
 template <typename T>
-PpmFrameSettings<T>::PpmFrameSettings(Window* parent, const FlexGridLayout& g, T* ppm) :
+PpmFrameSettings<T>::PpmFrameSettings(Window* parent, T* ppm) :
     FormGroup(parent, rect_t{})
 {
   setFlexLayout(LV_FLEX_FLOW_ROW);
@@ -38,6 +38,9 @@ PpmFrameSettings<T>::PpmFrameSettings(Window* parent, const FlexGridLayout& g, T
       0, PREC1);
   edit->setStep(PPM_STEP_SIZE);
   edit->setSuffix(STR_MS);
+  
+  // memorize PPM frame length NumberEdit object
+  this->ppmFrameLenEditObject = edit;
 
   // PPM frame delay
   edit = new NumberEdit(this, rect_t{}, 100, 800,
@@ -50,17 +53,6 @@ PpmFrameSettings<T>::PpmFrameSettings(Window* parent, const FlexGridLayout& g, T
   new Choice(this, rect_t{}, STR_PPM_POL, 0, 1, GET_SET_DEFAULT(ppm->pulsePol));
 }
 
-// explicit instantiation
+// explicit instantiation to make linker happy
 template struct PpmFrameSettings<TrainerModuleData>;
-
-PpmSettings::PpmSettings(Window* parent, const FlexGridLayout& g, uint8_t moduleIdx) :
-    FormGroup(parent, rect_t{}), md(&g_model.moduleData[moduleIdx])
-{
-  FlexGridLayout grid(g);
-  setFlexLayout();
-
-  // PPM frame
-  auto line = newLine(&grid);
-  new StaticText(line, rect_t{}, STR_PPMFRAME, 0, COLOR_THEME_PRIMARY1);
-  new PpmFrameSettings<PpmModule>(line, grid, &md->ppm);
-}
+template struct PpmFrameSettings<PpmModule>;

--- a/radio/src/gui/colorlcd/ppm_settings.h
+++ b/radio/src/gui/colorlcd/ppm_settings.h
@@ -22,18 +22,17 @@
 #pragma once
 
 #include "form.h"
-
-struct ModuleData;
-
-class PpmSettings : public FormGroup
-{
-  ModuleData* md;
-
-public:
-  PpmSettings(Window* parent, const FlexGridLayout& g, uint8_t moduleIdx);
-};
+#include "numberedit.h"
 
 template <typename T>
 struct PpmFrameSettings : public FormGroup {
-  PpmFrameSettings(Window* parent, const FlexGridLayout& g, T* ppm);
+  private:
+    NumberEdit* ppmFrameLenEditObject = nullptr;
+
+  public:
+    PpmFrameSettings(Window* parent, T* ppm);
+    
+    NumberEdit* getPpmFrameLenEditObject() {
+      return ppmFrameLenEditObject;
+    };
 };

--- a/radio/src/gui/colorlcd/trainer_setup.cpp
+++ b/radio/src/gui/colorlcd/trainer_setup.cpp
@@ -134,7 +134,10 @@ void TrainerModuleWindow::update()
     // PPM frame
     line = newLine(&grid);
     new StaticText(line, rect_t{}, STR_PPMFRAME, 0, COLOR_THEME_PRIMARY1);
-    new PpmFrameSettings<TrainerModuleData>(line, grid, td);
+    auto obj = new PpmFrameSettings<TrainerModuleData>(line, td);
+  
+    // copy pointer to frame len edit object to channel range
+    chRange->setPpmFrameLenEditObject(obj->getPpmFrameLenEditObject());
   }
 }
 

--- a/radio/src/pulses/modules_helpers.h
+++ b/radio/src/pulses/modules_helpers.h
@@ -788,6 +788,12 @@ inline void setDefaultPpmFrameLength(uint8_t moduleIdx)
       4 * max<int>(0, g_model.moduleData[moduleIdx].channelsCount);
 }
 
+inline void setDefaultPpmFrameLengthTrainer()
+{
+  g_model.trainerData.frameLength =
+      4 * max<int>(0, g_model.trainerData.channelsCount);
+}
+
 inline void resetAccessAuthenticationCount()
 {
   // the module will reset on mode switch, we need to reset the authentication counter


### PR DESCRIPTION
Summary of changes:
- adjusts PPM frame length if channel count > 8
- channel count in [1;8] -> frame length = 22.5 ms
- channel count in [9,16] -> frame length = 22.5ms + (channel count - 8)  * 2ms
- example channel count 9 -> frame length = 24.5ms
- example channel count 16 -> frame length = 38.5ms
- auto adjusted value can be manually overriden

