### PR TITLE
feat(cpn): External module form factor set in Radio Profile to allow aligning with firmware compile option

### DIFF
--- a/companion/src/apppreferencesdialog.cpp
+++ b/companion/src/apppreferencesdialog.cpp
@@ -153,6 +153,7 @@ void AppPreferencesDialog::accept()
   }
 
   profile.defaultInternalModule(ui->defaultInternalModuleCB->currentData().toInt());
+  profile.externalModuleSize(ui->externalModuleSizeCB->currentData().toInt());
   profile.channelOrder(ui->channelorderCB->currentIndex());
   profile.defaultMode(ui->stickmodeCB->currentIndex());
   profile.renameFwFiles(ui->renameFirmware->isChecked());
@@ -300,6 +301,8 @@ void AppPreferencesDialog::initSettings()
   //  Profile Tab Inits
   ui->defaultInternalModuleCB->setModel(ModuleData::internalModuleItemModel());
   ui->defaultInternalModuleCB->setCurrentIndex(ui->defaultInternalModuleCB->findData(profile.defaultInternalModule()));
+  ui->externalModuleSizeCB->setModel(Boards::externalModuleSizeItemModel());
+  ui->externalModuleSizeCB->setCurrentIndex(ui->externalModuleSizeCB->findData(profile.externalModuleSize()));
   ui->channelorderCB->setCurrentIndex(profile.channelOrder());
   ui->stickmodeCB->setCurrentIndex(profile.defaultMode());
   ui->renameFirmware->setChecked(profile.renameFwFiles());
@@ -682,6 +685,10 @@ void AppPreferencesDialog::onBaseFirmwareChanged()
   profile.defaultInternalModule(Boards::getDefaultInternalModules(newfw->getBoard()));
   ui->defaultInternalModuleCB->setModel(ModuleData::internalModuleItemModel(newfw->getBoard()));
   ui->defaultInternalModuleCB->setCurrentIndex(ui->defaultInternalModuleCB->findData(profile.defaultInternalModule()));
+
+  profile.externalModuleSize(Boards::getDefaultExternalModuleSize(newfw->getBoard()));
+  ui->externalModuleSizeCB->setModel(Boards::externalModuleSizeItemModel());
+  ui->externalModuleSizeCB->setCurrentIndex(ui->externalModuleSizeCB->findData(profile.externalModuleSize()));
 }
 
 Firmware *AppPreferencesDialog::getBaseFirmware() const

--- a/companion/src/apppreferencesdialog.ui
+++ b/companion/src/apppreferencesdialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>865</width>
-    <height>673</height>
+    <height>692</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -52,33 +52,26 @@
        <string>Radio Profile</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0,0,0,0">
-       <item row="14" column="0">
-        <widget class="QLabel" name="label_14">
+       <item row="5" column="0">
+        <widget class="QLabel" name="label_6">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
          <property name="text">
-          <string>Default Stick Mode</string>
+          <string>Options</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
          </property>
         </widget>
        </item>
-       <item row="10" column="2">
-        <widget class="QLineEdit" name="profilebackupPath">
-         <property name="toolTip">
-          <string>If set it will override the application general setting</string>
-         </property>
-         <property name="readOnly">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="0">
-        <widget class="QLabel" name="label_2">
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_7">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
@@ -90,85 +83,40 @@
           </font>
          </property>
          <property name="text">
-          <string>Profile Name</string>
-         </property>
-        </widget>
-       </item>
-       <item row="19" column="2">
-        <spacer name="verticalSpacer_3">
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>5</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="9" column="0">
-        <widget class="QLabel" name="sdPathLabel">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>SD Structure path</string>
+          <string>Radio Type</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
          </property>
         </widget>
        </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="langLabel">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
+       <item row="9" column="2">
+        <widget class="QLineEdit" name="sdPath">
+         <property name="enabled">
+          <bool>true</bool>
          </property>
          <property name="text">
-          <string>Language</string>
+          <string/>
          </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         <property name="readOnly">
+          <bool>false</bool>
          </property>
         </widget>
        </item>
-       <item row="0" column="2">
-        <widget class="QLineEdit" name="profileNameLE"/>
-       </item>
-       <item row="12" column="0">
-        <widget class="QLabel" name="label_4">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>General Settings</string>
-         </property>
-        </widget>
-       </item>
-       <item row="17" column="2">
-        <widget class="QCheckBox" name="burnFirmware">
+       <item row="6" column="0" colspan="5">
+        <widget class="Line" name="splashSeparator">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="text">
-          <string>Prompt to write firmware to radio after update</string>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
          </property>
         </widget>
        </item>
-       <item row="15" column="2">
+       <item row="16" column="2">
         <widget class="QComboBox" name="channelorderCB">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -304,6 +252,36 @@
          </item>
         </widget>
        </item>
+       <item row="13" column="0">
+        <widget class="QLabel" name="label_21">
+         <property name="text">
+          <string>Default Int. Module</string>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="3" colspan="2">
+        <widget class="QPushButton" name="sdPathButton">
+         <property name="text">
+          <string>Select Folder</string>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="0">
+        <widget class="QLabel" name="sdPathLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>SD Structure path</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
        <item row="12" column="2">
         <widget class="QLabel" name="lblGeneralSettings">
          <property name="enabled">
@@ -320,223 +298,14 @@
          </property>
         </widget>
        </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="label_6">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
+       <item row="19" column="2">
+        <widget class="QCheckBox" name="chkPromptSDSync">
          <property name="text">
-          <string>Options</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+          <string>Prompt to run SD Sync after update</string>
          </property>
         </widget>
        </item>
-       <item row="8" column="0" colspan="5">
-        <widget class="QLabel" name="label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Other Settings</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0" colspan="5">
-        <widget class="Line" name="splashSeparator">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="11" column="2">
-        <widget class="QCheckBox" name="pbackupEnable">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>if set, will override general backup enable</string>
-         </property>
-         <property name="text">
-          <string>Enable automatic backup before writing firmware</string>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="0">
-        <widget class="QLabel" name="profilebackupPathLabel">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>The profile specific folder,  if set, will override general Backup folder</string>
-         </property>
-         <property name="text">
-          <string>Backup folder</string>
-         </property>
-        </widget>
-       </item>
-       <item row="10" column="3" colspan="2">
-        <widget class="QPushButton" name="ProfilebackupPathButton">
-         <property name="toolTip">
-          <string>The profile specific folder,  if set, will override general Backup folder</string>
-         </property>
-         <property name="text">
-          <string>Select Folder</string>
-         </property>
-        </widget>
-       </item>
-       <item row="14" column="2">
-        <widget class="QComboBox" name="stickmodeCB">
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="whatsThis">
-          <string>Mode selection:
-
-Mode 1:
-  Left stick:  Elevator, Rudder
-  Right stick:  Throttle, Aileron
-
-Mode 2:
-  Left stick:  Throttle, Rudder
-  Right stick:  Elevator, Aileron
-
-Mode 3:
-  Left stick:  Elevator, Aileron
-  Right stick:  Throttle, Rudder
-
-Mode 4:
-  Left stick:  Throttle, Aileron
-  Right stick:  Elevator, Rudder
-
-</string>
-         </property>
-         <property name="currentIndex">
-          <number>1</number>
-         </property>
-         <item>
-          <property name="text">
-           <string>Mode 1 (RUD ELE THR AIL)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Mode 2 (RUD THR ELE AIL)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Mode 3 (AIL ELE THR RUD)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Mode 4 (AIL THR ELE RUD)</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="13" column="0">
-        <widget class="QLabel" name="label_21">
-         <property name="text">
-          <string>Default Int. Module</string>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label_7">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="font">
-          <font>
-           <weight>75</weight>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Radio Type</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="9" column="3" colspan="2">
-        <widget class="QPushButton" name="sdPathButton">
-         <property name="text">
-          <string>Select Folder</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="2">
-        <widget class="QComboBox" name="langCombo">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-        </widget>
-       </item>
-       <item row="16" column="2">
-        <widget class="QCheckBox" name="renameFirmware">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Append version number to firmware file name</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0" colspan="5">
-        <widget class="Line" name="line_8">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="15" column="0">
+       <item row="16" column="0">
         <widget class="QLabel" name="label_13">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -549,6 +318,19 @@ Mode 4:
          </property>
          <property name="alignment">
           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="13" column="2">
+        <widget class="QComboBox" name="defaultInternalModuleCB"/>
+       </item>
+       <item row="4" column="2">
+        <widget class="QComboBox" name="langCombo">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
         </widget>
        </item>
@@ -666,28 +448,95 @@ Mode 4:
          </layout>
         </widget>
        </item>
-       <item row="9" column="2">
-        <widget class="QLineEdit" name="sdPath">
-         <property name="enabled">
-          <bool>true</bool>
+       <item row="10" column="3" colspan="2">
+        <widget class="QPushButton" name="ProfilebackupPathButton">
+         <property name="toolTip">
+          <string>The profile specific folder,  if set, will override general Backup folder</string>
          </property>
          <property name="text">
-          <string/>
-         </property>
-         <property name="readOnly">
-          <bool>false</bool>
+          <string>Select Folder</string>
          </property>
         </widget>
        </item>
-       <item row="2" column="2">
-        <widget class="QComboBox" name="boardCB">
-         <property name="enabled">
-          <bool>true</bool>
+       <item row="12" column="0">
+        <widget class="QLabel" name="label_4">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>General Settings</string>
          </property>
         </widget>
        </item>
-       <item row="13" column="2">
-        <widget class="QComboBox" name="defaultInternalModuleCB"/>
+       <item row="20" column="2">
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>5</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="15" column="2">
+        <widget class="QComboBox" name="stickmodeCB">
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="whatsThis">
+          <string>Mode selection:
+
+Mode 1:
+  Left stick:  Elevator, Rudder
+  Right stick:  Throttle, Aileron
+
+Mode 2:
+  Left stick:  Throttle, Rudder
+  Right stick:  Elevator, Aileron
+
+Mode 3:
+  Left stick:  Elevator, Aileron
+  Right stick:  Throttle, Rudder
+
+Mode 4:
+  Left stick:  Throttle, Aileron
+  Right stick:  Elevator, Rudder
+
+</string>
+         </property>
+         <property name="currentIndex">
+          <number>1</number>
+         </property>
+         <item>
+          <property name="text">
+           <string>Mode 1 (RUD ELE THR AIL)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Mode 2 (RUD THR ELE AIL)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Mode 3 (AIL ELE THR RUD)</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Mode 4 (AIL THR ELE RUD)</string>
+          </property>
+         </item>
+        </widget>
        </item>
        <item row="5" column="2">
         <widget class="QWidget" name="optionsWidget" native="true">
@@ -719,12 +568,173 @@ Mode 4:
          </layout>
         </widget>
        </item>
-       <item row="18" column="2">
-        <widget class="QCheckBox" name="chkPromptSDSync">
+       <item row="15" column="0">
+        <widget class="QLabel" name="label_14">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
-          <string>Prompt to run SD Sync after update</string>
+          <string>Default Stick Mode</string>
          </property>
         </widget>
+       </item>
+       <item row="11" column="2">
+        <widget class="QCheckBox" name="pbackupEnable">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>if set, will override general backup enable</string>
+         </property>
+         <property name="text">
+          <string>Enable automatic backup before writing firmware</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="langLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Language</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0" colspan="5">
+        <widget class="Line" name="line_8">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0" colspan="5">
+        <widget class="QLabel" name="label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Other Settings</string>
+         </property>
+        </widget>
+       </item>
+       <item row="18" column="2">
+        <widget class="QCheckBox" name="burnFirmware">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Prompt to write firmware to radio after update</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Profile Name</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="QComboBox" name="boardCB">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <widget class="QLineEdit" name="profileNameLE"/>
+       </item>
+       <item row="17" column="2">
+        <widget class="QCheckBox" name="renameFirmware">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Append version number to firmware file name</string>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="2">
+        <widget class="QLineEdit" name="profilebackupPath">
+         <property name="toolTip">
+          <string>If set it will override the application general setting</string>
+         </property>
+         <property name="readOnly">
+          <bool>false</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="0">
+        <widget class="QLabel" name="profilebackupPathLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>The profile specific folder,  if set, will override general Backup folder</string>
+         </property>
+         <property name="text">
+          <string>Backup folder</string>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="0">
+        <widget class="QLabel" name="label_18">
+         <property name="text">
+          <string>External Module</string>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="2">
+        <widget class="QComboBox" name="externalModuleSizeCB"/>
        </item>
       </layout>
      </widget>

--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -764,6 +764,9 @@ QString Boards::getBoardName(Board::Type board)
       return "BETAFPV LR3PRO";
     case BOARD_IFLIGHT_COMMANDO8:
       return "iFlight Commando 8";
+    // not supported yet
+    //case BOARD_FLYSKY_EL18:
+    //  return "FlySky EL18";
     default:
       return CPN_STR_UNKNOWN_ITEM;
   }
@@ -988,4 +991,59 @@ int Boards::getDefaultInternalModules(Board::Type board)
   default:
     return (int)MODULE_TYPE_NONE;
   }
+}
+
+// static
+int Boards::getDefaultExternalModuleSize(Board::Type board)
+{
+  if (!getCapability(board, HasExternalModuleSupport))
+    return EXTMODSIZE_NONE;
+
+  if (getCapability(board, HasColorLcd)) {
+    if (IS_FLYSKY_EL18(board))
+      return EXTMODSIZE_BOTH;
+    else
+      return EXTMODSIZE_STD;
+  }
+
+  if (IS_TARANIS_X9LITE(board)    ||
+      IS_TARANIS_X9DP_2019(board) ||
+      IS_RADIOMASTER_ZORRO(board) ||
+      IS_JUMPER_TLITE(board)      ||
+      IS_JUMPER_TPRO(board)       ||
+      IS_BETAFPV_LR3PRO(board))
+    return EXTMODSIZE_SMALL;
+
+  return EXTMODSIZE_STD;
+}
+
+//  static
+QString Boards::externalModuleSizeToString(int value)
+{
+  switch(value) {
+    case EXTMODSIZE_NONE:
+      return tr("None");
+    case EXTMODSIZE_STD:
+      return tr("Standard");
+    case EXTMODSIZE_SMALL:
+      return tr("Small");
+    case EXTMODSIZE_BOTH:
+      return tr("Both");
+    default:
+      return CPN_STR_UNKNOWN_ITEM;
+  }
+}
+
+//  static
+AbstractStaticItemModel * Boards::externalModuleSizeItemModel()
+{
+  AbstractStaticItemModel * mdl = new AbstractStaticItemModel();
+  mdl->setName(AIM_BOARDS_MODULE_SIZE);
+
+  for (int i = 0; i < EXTMODSIZE_COUNT; i++) {
+    mdl->appendToItemList(externalModuleSizeToString(i), i);
+  }
+
+  mdl->loadItemList();
+  return mdl;
 }

--- a/companion/src/firmwares/boards.h
+++ b/companion/src/firmwares/boards.h
@@ -31,6 +31,7 @@ class AbstractStaticItemModel;
 constexpr char AIM_BOARDS_POT_TYPE[]        {"boards.pottype"};
 constexpr char AIM_BOARDS_SLIDER_TYPE[]     {"boards.slidertype"};
 constexpr char AIM_BOARDS_SWITCH_TYPE[]     {"boards.switchtype"};
+constexpr char AIM_BOARDS_MODULE_SIZE[]     {"boards.extmodulesize"};
 
 // TODO create a Board class with all these functions
 
@@ -70,6 +71,7 @@ namespace Board {
     BOARD_JUMPER_TPRO,
     BOARD_BETAFPV_LR3PRO,
     BOARD_IFLIGHT_COMMANDO8,
+    BOARD_FLYSKY_EL18,
     BOARD_TYPE_COUNT,
     BOARD_TYPE_MAX = BOARD_TYPE_COUNT - 1
   };
@@ -182,6 +184,14 @@ namespace Board {
     SwitchTypeContext3Pos = SwitchTypeFlag2Pos | SwitchTypeFlag3Pos
   };
 
+  enum ExternalModuleSizes {
+    EXTMODSIZE_NONE,
+    EXTMODSIZE_STD,
+    EXTMODSIZE_SMALL,
+    EXTMODSIZE_BOTH,
+    EXTMODSIZE_COUNT
+  };
+
 }
 
 class Boards
@@ -228,6 +238,9 @@ class Boards
     static StringTagMappingTable getTrimSourcesLookupTable(Board::Type board);
     static QList<int> getSupportedInternalModules(Board::Type board);
     static int getDefaultInternalModules(Board::Type board);
+    static int getDefaultExternalModuleSize(Board::Type board);
+    static QString externalModuleSizeToString(int value);
+    static AbstractStaticItemModel * externalModuleSizeItemModel();
 
   protected:
 
@@ -335,6 +348,11 @@ inline bool IS_FAMILY_T12(Board::Type board)
 inline bool IS_FLYSKY_NV14(Board::Type board)
 {
   return (board == Board::BOARD_FLYSKY_NV14);
+}
+
+inline bool IS_FLYSKY_EL18(Board::Type board)
+{
+  return (board == Board::BOARD_FLYSKY_EL18);
 }
 
 inline bool IS_TARANIS_XLITE(Board::Type board)

--- a/companion/src/firmwares/moduledata.cpp
+++ b/companion/src/firmwares/moduledata.cpp
@@ -25,6 +25,7 @@
 #include "radiodataconversionstate.h"
 #include "compounditemmodels.h"
 #include "generalsettings.h"
+#include "appdata.h"
 
 #include <QPair>
 #include <QVector>
@@ -259,7 +260,7 @@ QString ModuleData::subTypeToString(int type) const
     case PULSES_MULTIMODULE:
       return Multiprotocols::subTypeToString((int)multi.rfProtocol, (unsigned)type);
     case PULSES_PPM:
-      return CHECK_IN_ARRAY(ppmSubTypeStrings, type); 
+      return CHECK_IN_ARRAY(ppmSubTypeStrings, type);
     case PULSES_PXX_R9M:
       return CHECK_IN_ARRAY(strings, type);
     case PULSES_AFHDS3:
@@ -528,44 +529,59 @@ bool ModuleData::isProtocolAvailable(int moduleidx, unsigned int protocol, Gener
   if (moduleidx == 0)
     return (int)generalSettings.internalModule == getTypeFromProtocol(protocol);
 
-  QString id = fw->getId();
-
   if (IS_HORUS_OR_TARANIS(board)) {
     switch (moduleidx) {
-      case 1:
-        switch (protocol) {
-          case PULSES_OFF:
-          case PULSES_PPM:
-            return true;
-          case PULSES_PXX_XJT_X16:
-          case PULSES_PXX_XJT_D8:
-          case PULSES_PXX_XJT_LR12:
-            return !(IS_TARANIS_XLITES(board) || IS_TARANIS_X9LITE(board));
-          case PULSES_PXX_R9M:
-          case PULSES_LP45:
-          case PULSES_DSM2:
-          case PULSES_DSMX:
-          case PULSES_SBUS:
-          case PULSES_MULTIMODULE:
-          case PULSES_CROSSFIRE:
-          case PULSES_AFHDS3:
-          case PULSES_GHOST:
-          case PULSES_LEMON_DSMP:
-            return true;
-          case PULSES_ACCESS_R9M:
-            return (IS_ACCESS_RADIO(board, id) ||
-                   generalSettings.serialPort[GeneralSettings::SP_AUX1] == GeneralSettings::AUX_SERIAL_EXT_MODULE);
-          case PULSES_PXX_R9M_LITE:
-          case PULSES_ACCESS_R9M_LITE:
-          case PULSES_ACCESS_R9M_LITE_PRO:
-          case PULSES_XJT_LITE_X16:
-          case PULSES_XJT_LITE_D8:
-          case PULSES_XJT_LITE_LR12:
-            return (IS_TARANIS_XLITE(board) || IS_TARANIS_X9LITE(board) || IS_RADIOMASTER_ZORRO(board));
+      case 1: {
+        const int moduleSize = g.currentProfile().externalModuleSize();
+        const int moduleType = getTypeFromProtocol(protocol);
+
+        switch(moduleSize) {
+          case Board::EXTMODSIZE_NONE:
+            return false;
+          case Board::EXTMODSIZE_BOTH:
+            switch (moduleType) {
+              case MODULE_TYPE_XJT_PXX1:
+              case MODULE_TYPE_ISRM_PXX2:
+              case MODULE_TYPE_R9M_PXX1:
+              case MODULE_TYPE_R9M_PXX2:
+              case MODULE_TYPE_DSM2:
+              case MODULE_TYPE_FLYSKY:
+              case MODULE_TYPE_LEMON_DSMP:
+              case MODULE_TYPE_R9M_LITE_PXX1:
+              case MODULE_TYPE_R9M_LITE_PXX2:
+              case MODULE_TYPE_R9M_LITE_PRO_PXX2:
+              case MODULE_TYPE_XJT_LITE_PXX2:
+                return true;
+              default:
+                return false;
+            }
+          case Board::EXTMODSIZE_STD:
+            switch (moduleType) {
+              case MODULE_TYPE_XJT_PXX1:
+              case MODULE_TYPE_ISRM_PXX2:
+              case MODULE_TYPE_R9M_PXX1:
+              case MODULE_TYPE_R9M_PXX2:
+              case MODULE_TYPE_DSM2:
+              case MODULE_TYPE_FLYSKY:
+              case MODULE_TYPE_LEMON_DSMP:
+                return true;
+              default:
+                return false;
+            }
+          case Board::EXTMODSIZE_SMALL:
+            switch (moduleType) {
+              case MODULE_TYPE_R9M_LITE_PXX1:
+              case MODULE_TYPE_R9M_LITE_PXX2:
+              case MODULE_TYPE_R9M_LITE_PRO_PXX2:
+              case MODULE_TYPE_XJT_LITE_PXX2:
+                return true;
+              default:
+                return false;
+            }
           default:
             return false;
         }
-
+      }
       case -1:
         switch (protocol) {
           case PULSES_PPM:

--- a/companion/src/mainwindow.cpp
+++ b/companion/src/mainwindow.cpp
@@ -1272,6 +1272,7 @@ int MainWindow::newProfile(bool loadProfile)
   g.profile[i].name("New Radio");
   g.profile[i].fwType(newfw->getId());
   g.profile[i].defaultInternalModule(Boards::getDefaultInternalModules(newfw->getBoard()));
+  g.profile[i].externalModuleSize(Boards::getDefaultExternalModuleSize(newfw->getBoard()));
 
   if (loadProfile) {
     if (loadProfileId(i))

--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -264,11 +264,16 @@ ModulePanel::ModulePanel(QWidget * parent, ModelData & model, ModuleData & modul
   if (panelFilteredItemModels) {
     if (moduleIdx >= 0) {
       int id = panelFilteredItemModels->registerItemModel(new FilteredItemModel(ModuleData::protocolItemModel(generalSettings), moduleIdx + 1/*flag cannot be 0*/), QString("Module Protocol %1").arg(moduleIdx));
+      panelFilteredItemModels->getItemModel(id)->setSortCaseSensitivity(Qt::CaseInsensitive);
+      panelFilteredItemModels->getItemModel(id)->sort(0);
       ui->protocol->setModel(panelFilteredItemModels->getItemModel(id));
 
       if (ui->protocol->findData(module.protocol) < 0) {
-        QString msg = tr("Warning: The internal module protocol <b>%1</b> is incompatible with the hardware internal module <b>%2</b> and has been set to <b>OFF</b>!");
-        msg = msg.arg(module.protocolToString(module.protocol)).arg(ModuleData::typeToString(generalSettings.internalModule));
+        const QString moduleIdxDesc = moduleIdx == 0 ? tr("internal") : tr("external");
+        const QString compareDesc = moduleIdx == 0 ? tr("hardware") : tr("profile");
+        const QString intModuleDesc = moduleIdx == 0 ? ModuleData::typeToString(generalSettings.internalModule) : "";
+        QString msg = tr("Warning: The %1 module protocol <b>%2</b> is incompatible with the <b>%3 %1 module %4</b> and has been set to <b>OFF</b>!");
+        msg = msg.arg(moduleIdxDesc).arg(module.protocolToString(module.protocol)).arg(compareDesc).arg(intModuleDesc);
 
         QMessageBox *msgBox = new QMessageBox(this);
         msgBox->setIcon( QMessageBox::Warning );

--- a/companion/src/storage/appdata.h
+++ b/companion/src/storage/appdata.h
@@ -486,6 +486,7 @@ class Profile: public CompStoreObj
     PROPERTYSTR(pBackupDir)
 
     PROPERTY (int, defaultInternalModule, 0)
+    PROPERTY (int, externalModuleSize, 1) // added 2.9 - Board::EXTMODSIZE_STD used for existing profiles (Nightly users)
     PROPERTY4(int, channelOrder, "default_channel_order",  0)
     PROPERTY4(int, defaultMode,  "default_mode",           1)
     PROPERTY (int, volumeGain,   10)

--- a/companion/src/storage/appdata.h
+++ b/companion/src/storage/appdata.h
@@ -486,7 +486,7 @@ class Profile: public CompStoreObj
     PROPERTYSTR(pBackupDir)
 
     PROPERTY (int, defaultInternalModule, 0)
-    PROPERTY (int, externalModuleSize, 1) // added 2.9 - Board::EXTMODSIZE_STD used for existing profiles (Nightly users)
+    PROPERTY (int, externalModuleSize, 1) // added 2.9 - Board::EXTMODSIZE_STD used for existing profiles
     PROPERTY4(int, channelOrder, "default_channel_order",  0)
     PROPERTY4(int, defaultMode,  "default_mode",           1)
     PROPERTY (int, volumeGain,   10)


### PR DESCRIPTION
Summary of changes:
- provide support for #3624
- add setting External Module to Radio Profiles
- the setting default value is based on the radio type (None, Standard, Small, Both)
'None' can be a hardware limitation or it is never used so force protocol to OFF
'Both' if factory or custom mods to hardware. All protocols will be available.
- existing profiles will have the value of 'Standard' set on first use (see RELEASE NOTE below). It is not practical to code the default for each profile as app settings are loaded prior to firmware/board objects
- available external module protocols are based on the new setting (complete change to logic so high importance for regression testing)
- new warning message when opening a model for editing if external module protocol is not supported by profile setting

**RELEASE NOTE: Existing radio profiles will need to be changed if the default External Module value of 'Standard' is not correct for the radio**

![profilesettings](https://github.com/EdgeTX/edgetx/assets/15316949/9c27c7f0-71e7-4b72-bb56-c48056e52aa8)

![warningmsg](https://github.com/EdgeTX/edgetx/assets/15316949/c86ab813-b674-4d87-9d9b-fd5caa65f804)
