### PR TITLE
UI: remove rssiSource and use default value 

### DIFF
--- a/companion/src/datamodels/compounditemmodels.cpp
+++ b/companion/src/datamodels/compounditemmodels.cpp
@@ -46,8 +46,6 @@ QString AbstractItemModel::idToString(const int value)
       return "CustomFuncResetParam";
     case IMID_TeleSource:
       return "TeleSource";
-    case IMID_RssiSource:
-      return "RssiSource";
     case IMID_CurveRefType:
       return "CurveRefType";
     case IMID_CurveRefFunc:
@@ -512,49 +510,6 @@ void TelemetrySourceItemModel::update(const int event)
 }
 
 //
-// RssiSourceItemModel
-//
-
-RssiSourceItemModel::RssiSourceItemModel(const GeneralSettings * const generalSettings, const ModelData * const modelData,
-                                                   Firmware * firmware, const Boards * const board, const Board::Type boardType) :
-    AbstractDynamicItemModel(generalSettings, modelData, firmware, board, boardType)
-{
-  setId(IMID_RssiSource);
-
-  if (!modelData)
-    return;
-
-  setUpdateMask(IMUE_TeleSensors | IMUE_Modules);
-
-  for (int i = 0; i <= firmware->getCapability(Sensors); ++i) {
-    QStandardItem * modelItem = new QStandardItem();
-    modelItem->setData(i, IMDR_Id);
-    modelItem->setData(i < 0 ? IMDG_Negative : i > 0 ? IMDG_Positive : IMDG_None, IMDR_Flags);
-    setDynamicItemData(modelItem, i);
-    appendRow(modelItem);
-  }
-}
-
-void RssiSourceItemModel::setDynamicItemData(QStandardItem * item, const int value) const
-{
-  item->setText(SensorData::rssiSensorToString(modelData, value));
-  item->setData(SensorData::isRssiSensorAvailable(modelData, value), IMDR_Available);
-}
-
-void RssiSourceItemModel::update(const int event)
-{
-  if (doUpdate(event)) {
-    emit aboutToBeUpdated();
-
-    for (int i = 0; i < rowCount(); ++i) {
-      setDynamicItemData(item(i), item(i)->data(IMDR_Id).toInt());
-    }
-
-    emit updateComplete();
-  }
-}
-
-//
 // CurveRefTypeItemModel
 //
 
@@ -658,9 +613,6 @@ void CompoundItemModelFactory::addItemModel(const int id)
       break;
     case AbstractItemModel::IMID_TeleSource:
       registerItemModel(new TelemetrySourceItemModel(generalSettings, modelData, firmware, board, boardType));
-      break;
-    case AbstractItemModel::IMID_RssiSource:
-      registerItemModel(new RssiSourceItemModel(generalSettings, modelData, firmware, board, boardType));
       break;
     case AbstractItemModel::IMID_CurveRefType:
       registerItemModel(new CurveRefTypeItemModel(generalSettings, modelData, firmware, board, boardType));

--- a/companion/src/datamodels/compounditemmodels.h
+++ b/companion/src/datamodels/compounditemmodels.h
@@ -43,7 +43,6 @@ class AbstractItemModel: public QStandardItemModel
       IMID_CustomFuncAction,
       IMID_CustomFuncResetParam,
       IMID_TeleSource,
-      IMID_RssiSource,
       IMID_CurveRefType,
       IMID_CurveRefFunc,
       IMID_ReservedCount,
@@ -299,21 +298,6 @@ class TelemetrySourceItemModel: public AbstractDynamicItemModel
     explicit TelemetrySourceItemModel(const GeneralSettings * const generalSettings, const ModelData * const modelData,
                                       Firmware * firmware, const Boards * const board, const Board::Type boardType);
     virtual ~TelemetrySourceItemModel() {};
-
-  public slots:
-    virtual void update(const int event = IMUE_SystemRefresh) override;
-
-  protected:
-    virtual void setDynamicItemData(QStandardItem * item, const int value) const;
-};
-
-class RssiSourceItemModel: public AbstractDynamicItemModel
-{
-    Q_OBJECT
-  public:
-    explicit RssiSourceItemModel(const GeneralSettings * const generalSettings, const ModelData * const modelData,
-                                      Firmware * firmware, const Boards * const board, const Board::Type boardType);
-    virtual ~RssiSourceItemModel() {};
 
   public slots:
     virtual void update(const int event = IMUE_SystemRefresh) override;

--- a/companion/src/firmwares/edgetx/yaml_modeldata.cpp
+++ b/companion/src/firmwares/edgetx/yaml_modeldata.cpp
@@ -1155,7 +1155,6 @@ bool convert<ModelData>::decode(const Node& node, ModelData& rhs)
     YamlTelemSource rssiSource;
     node["rssiSource"] >> rssiSource;
     rhs.rssiSource = 0; //fix #2552 write rssiSource as none
-    //rhs.rssiSource = rssiSource.src;
   }
 
   if (node["voltsSource"]) {

--- a/companion/src/firmwares/edgetx/yaml_modeldata.cpp
+++ b/companion/src/firmwares/edgetx/yaml_modeldata.cpp
@@ -1154,7 +1154,8 @@ bool convert<ModelData>::decode(const Node& node, ModelData& rhs)
   if (node["rssiSource"]) {
     YamlTelemSource rssiSource;
     node["rssiSource"] >> rssiSource;
-    rhs.rssiSource = rssiSource.src;
+    rhs.rssiSource = 0; //fix #2552 write rssiSource as none
+    //rhs.rssiSource = rssiSource.src;
   }
 
   if (node["voltsSource"]) {

--- a/companion/src/modeledit/modeledit.cpp
+++ b/companion/src/modeledit/modeledit.cpp
@@ -66,7 +66,6 @@ ModelEdit::ModelEdit(QWidget * parent, RadioData & radioData, int modelId, Firmw
   sharedItemModels->addItemModel(AbstractItemModel::IMID_CustomFuncAction);
   sharedItemModels->addItemModel(AbstractItemModel::IMID_CustomFuncResetParam);
   sharedItemModels->addItemModel(AbstractItemModel::IMID_TeleSource);
-  sharedItemModels->addItemModel(AbstractItemModel::IMID_RssiSource);
   sharedItemModels->addItemModel(AbstractItemModel::IMID_CurveRefType);
   sharedItemModels->addItemModel(AbstractItemModel::IMID_CurveRefFunc);
 

--- a/companion/src/modeledit/telemetry.cpp
+++ b/companion/src/modeledit/telemetry.cpp
@@ -524,11 +524,16 @@ void TelemetryPanel::setup()
   ui->rssiAlarmCriticalSB->setRange(0, 127);
   ui->rssiAlarmCriticalSB->setValue(model->rssiAlarms.critical);
 
+  // fix #2552: remove rssiSource selection
+  /*
   ui->rssiSourceLabel->show();
   ui->rssiSourceLabel->setText(tr("Source"));
   ui->rssiSourceCB->setModel(panelFilteredItemModels->getItemModel(FIM_RSSISOURCE));
   ui->rssiSourceCB->setField(model->rssiSource, this);
   ui->rssiSourceCB->show();
+  */
+  ui->rssiSourceLabel->hide();
+  ui->rssiSourceCB->hide();
 
   ui->rssiAlarmWarningCB->hide();
   ui->rssiAlarmCriticalCB->hide();

--- a/companion/src/modeledit/telemetry.cpp
+++ b/companion/src/modeledit/telemetry.cpp
@@ -32,7 +32,6 @@ constexpr char FIM_SENSORFORMULA[]   {"Sensor.Formula"};
 constexpr char FIM_SENSORCELLINDEX[] {"Sensor.CellIndex"};
 constexpr char FIM_SENSORUNIT[]      {"Sensor.Unit"};
 constexpr char FIM_SENSORPRECISION[] {"Sensor.Precision"};
-constexpr char FIM_RSSISOURCE[]      {"Rssi Source"};
 
 TelemetrySensorPanel::TelemetrySensorPanel(QWidget *parent, SensorData & sensor, int sensorIndex, int sensorCapability, ModelData & model,
                                            GeneralSettings & generalSettings, Firmware * firmware, const bool & parentLock,
@@ -406,11 +405,6 @@ TelemetryPanel::TelemetryPanel(QWidget *parent, ModelData & model, GeneralSettin
                                                   FIM_TELEPOSSRC);
   connectItemModelEvents(id);
 
-
-  id = panelFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_RssiSource)),
-                                                  FIM_RSSISOURCE);
-  connectItemModelEvents(id);
-
   id = panelItemModels->registerItemModel(SensorData::typeItemModel());
   panelFilteredItemModels->registerItemModel(new FilteredItemModel(panelItemModels->getItemModel(id)), FIM_SENSORTYPE);
 
@@ -489,7 +483,6 @@ void TelemetryPanel::update()
       ui->telemetryProtocol->setCurrentIndex(0);
     }
 
-    ui->rssiSourceCB->updateValue();
     ui->voltsSource->updateValue();
     ui->altitudeSource->updateValue();
     ui->varioSource->updateValue();
@@ -523,17 +516,6 @@ void TelemetryPanel::setup()
   ui->rssiAlarmWarningSB->setValue(model->rssiAlarms.warning);
   ui->rssiAlarmCriticalSB->setRange(0, 127);
   ui->rssiAlarmCriticalSB->setValue(model->rssiAlarms.critical);
-
-  // fix #2552: remove rssiSource selection
-  /*
-  ui->rssiSourceLabel->show();
-  ui->rssiSourceLabel->setText(tr("Source"));
-  ui->rssiSourceCB->setModel(panelFilteredItemModels->getItemModel(FIM_RSSISOURCE));
-  ui->rssiSourceCB->setField(model->rssiSource, this);
-  ui->rssiSourceCB->show();
-  */
-  ui->rssiSourceLabel->hide();
-  ui->rssiSourceCB->hide();
 
   ui->rssiAlarmWarningCB->hide();
   ui->rssiAlarmCriticalCB->hide();

--- a/companion/src/modeledit/telemetry.ui
+++ b/companion/src/modeledit/telemetry.ui
@@ -264,16 +264,6 @@
         </item>
        </widget>
       </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="rssiSourceLabel">
-        <property name="text">
-         <string>Source</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1" colspan="2">
-       <widget class="AutoComboBox" name="rssiSourceCB"/>
-      </item>
      </layout>
     </widget>
    </item>

--- a/radio/src/gui/128x64/model_telemetry.cpp
+++ b/radio/src/gui/128x64/model_telemetry.cpp
@@ -24,7 +24,6 @@
 enum MenuModelTelemetryFrskyItems {
   ITEM_TELEMETRY_PROTOCOL_TYPE,
   ITEM_TELEMETRY_RSSI_LABEL,
-  //ITEM_TELEMETRY_RSSI_SOURCE,         // fix #2552: remove rssiSource selection
   ITEM_TELEMETRY_RSSI_ALARM1,
   ITEM_TELEMETRY_RSSI_ALARM2,
   ITEM_TELEMETRY_DISABLE_ALARMS,
@@ -230,26 +229,6 @@ void menuModelTelemetry(event_t event)
       case ITEM_TELEMETRY_RSSI_LABEL:
         lcdDrawTextAlignedLeft(y, getRxStatLabels()->label);
         break;
-
-      // fix #2552: remove rssiSource selection
-      /*
-      case ITEM_TELEMETRY_RSSI_SOURCE: {
-        lcdDrawTextAlignedLeft(y, INDENT TR_SOURCE);
-        if (g_model.rssiSource) {
-          drawSource(TELEM_COL2, y, MIXSRC_FIRST_TELEM + 3 * (g_model.rssiSource - 1), attr);
-          TelemetrySensor * sensor = &g_model.telemetrySensors[g_model.rssiSource - 1];
-          lcdDrawText(lcdNextPos, y, " ", attr);
-          drawReceiverName(lcdNextPos, y, sensor->frskyInstance.rxIndex >> 2, sensor->frskyInstance.rxIndex & 0x03, attr);
-        }
-        else {
-          lcdDrawText(TELEM_COL2, y, STR_DEFAULT, attr);
-        }
-        if (attr) {
-          g_model.rssiSource = checkIncDec(event, g_model.rssiSource, 0, MAX_TELEMETRY_SENSORS, EE_MODEL | NO_INCDEC_MARKS, isRssiSensorAvailable);
-        }
-        break;
-      }
-      */
 
       case ITEM_TELEMETRY_RSSI_ALARM1:
       case ITEM_TELEMETRY_RSSI_ALARM2:

--- a/radio/src/gui/128x64/model_telemetry.cpp
+++ b/radio/src/gui/128x64/model_telemetry.cpp
@@ -24,7 +24,7 @@
 enum MenuModelTelemetryFrskyItems {
   ITEM_TELEMETRY_PROTOCOL_TYPE,
   ITEM_TELEMETRY_RSSI_LABEL,
-  ITEM_TELEMETRY_RSSI_SOURCE,
+  //ITEM_TELEMETRY_RSSI_SOURCE,         // fix #2552: remove rssiSource selection
   ITEM_TELEMETRY_RSSI_ALARM1,
   ITEM_TELEMETRY_RSSI_ALARM2,
   ITEM_TELEMETRY_DISABLE_ALARMS,
@@ -231,6 +231,8 @@ void menuModelTelemetry(event_t event)
         lcdDrawTextAlignedLeft(y, getRxStatLabels()->label);
         break;
 
+      // fix #2552: remove rssiSource selection
+      /*
       case ITEM_TELEMETRY_RSSI_SOURCE: {
         lcdDrawTextAlignedLeft(y, INDENT TR_SOURCE);
         if (g_model.rssiSource) {
@@ -247,6 +249,7 @@ void menuModelTelemetry(event_t event)
         }
         break;
       }
+      */
 
       case ITEM_TELEMETRY_RSSI_ALARM1:
       case ITEM_TELEMETRY_RSSI_ALARM2:

--- a/radio/src/gui/212x64/model_telemetry.cpp
+++ b/radio/src/gui/212x64/model_telemetry.cpp
@@ -24,7 +24,7 @@
 enum MenuModelTelemetryFrskyItems {
   ITEM_TELEMETRY_PROTOCOL_TYPE,
   ITEM_TELEMETRY_RSSI_LABEL,
-  ITEM_TELEMETRY_RSSI_SOURCE,
+  //ITEM_TELEMETRY_RSSI_SOURCE,         // fix #2552: remove rssiSource selection
   ITEM_TELEMETRY_RSSI_ALARM1,
   ITEM_TELEMETRY_RSSI_ALARM2,
   ITEM_TELEMETRY_DISABLE_ALARMS,
@@ -223,6 +223,8 @@ void menuModelTelemetry(event_t event)
         lcdDrawTextAlignedLeft(y, getRxStatLabels()->label);
         break;
 
+      // fix #2552: remove rssiSource selection
+      /*
       case ITEM_TELEMETRY_RSSI_SOURCE: {
         lcdDrawTextAlignedLeft(y, INDENT TR_SOURCE);
         if (g_model.rssiSource) {
@@ -239,6 +241,7 @@ void menuModelTelemetry(event_t event)
         }
         break;
       }
+      */
 
       case ITEM_TELEMETRY_RSSI_ALARM1:
       case ITEM_TELEMETRY_RSSI_ALARM2:

--- a/radio/src/gui/212x64/model_telemetry.cpp
+++ b/radio/src/gui/212x64/model_telemetry.cpp
@@ -24,7 +24,6 @@
 enum MenuModelTelemetryFrskyItems {
   ITEM_TELEMETRY_PROTOCOL_TYPE,
   ITEM_TELEMETRY_RSSI_LABEL,
-  //ITEM_TELEMETRY_RSSI_SOURCE,         // fix #2552: remove rssiSource selection
   ITEM_TELEMETRY_RSSI_ALARM1,
   ITEM_TELEMETRY_RSSI_ALARM2,
   ITEM_TELEMETRY_DISABLE_ALARMS,
@@ -222,26 +221,6 @@ void menuModelTelemetry(event_t event)
       case ITEM_TELEMETRY_RSSI_LABEL:
         lcdDrawTextAlignedLeft(y, getRxStatLabels()->label);
         break;
-
-      // fix #2552: remove rssiSource selection
-      /*
-      case ITEM_TELEMETRY_RSSI_SOURCE: {
-        lcdDrawTextAlignedLeft(y, INDENT TR_SOURCE);
-        if (g_model.rssiSource) {
-          drawSource(TELEM_COL2, y, MIXSRC_FIRST_TELEM + 3 * (g_model.rssiSource - 1), attr);
-          TelemetrySensor * sensor = &g_model.telemetrySensors[g_model.rssiSource - 1];
-          lcdDrawText(lcdNextPos, y, " ", attr);
-          drawReceiverName(lcdNextPos, y, sensor->frskyInstance.rxIndex >> 2, sensor->frskyInstance.rxIndex & 0x03, attr);
-        }
-        else {
-          lcdDrawText(TELEM_COL2, y, STR_DEFAULT, attr);
-        }
-        if (attr) {
-          g_model.rssiSource = checkIncDec(event, g_model.rssiSource, 0, MAX_TELEMETRY_SENSORS, EE_MODEL | NO_INCDEC_MARKS, isRssiSensorAvailable);
-        }
-        break;
-      }
-      */
 
       case ITEM_TELEMETRY_RSSI_ALARM1:
       case ITEM_TELEMETRY_RSSI_ALARM2:

--- a/radio/src/storage/storage_common.cpp
+++ b/radio/src/storage/storage_common.cpp
@@ -147,6 +147,13 @@ void postModelLoad(bool alarms)
     storageDirty(EE_MODEL);
   }
 
+// fix #2552: reset rssiSource to default none (= 0)
+if(g_model.rssiSource) {
+  g_model.rssiSource = 0;
+
+  storageDirty(EE_MODEL);  
+}
+
 #if defined(PXX2)
   if (is_memclear(g_model.modelRegistrationID, PXX2_LEN_REGISTRATION_ID)) {
     memcpy(g_model.modelRegistrationID, g_eeGeneral.ownerRegistrationID, PXX2_LEN_REGISTRATION_ID);

--- a/radio/src/telemetry/frsky_sport.cpp
+++ b/radio/src/telemetry/frsky_sport.cpp
@@ -277,15 +277,8 @@ void sportProcessTelemetryPacketWithoutCrc(uint8_t module, uint8_t origin, const
         // in this case we don't want to update telemetryData.rssi
         return;
       }
-      if (g_model.rssiSource) {
-        TelemetrySensor * sensor = &g_model.telemetrySensors[g_model.rssiSource - 1];
-        if (sensor->isSameInstance(PROTOCOL_TELEMETRY_FRSKY_SPORT, instance)) {
-          telemetryData.rssi.set(data);
-        }
-      }
-      else {
-        telemetryData.rssi.set(data);
-      }
+      
+      telemetryData.rssi.set(data);
     }
     else if (dataId == VALID_FRAME_RATE_ID) {
       data = 100 - SPORT_DATA_U8(packet);


### PR DESCRIPTION
Fixes #2552 

For justification please refer to discussion in #2552 

Summary of changes:
- force rssi source to default yaml value ("rssiSource: none") at model load if not already set to default
- remove rssi source selection from Companion and b&w UI (color LCD never implemented this option)