### PR TITLE
fix: Create `THEMES` dir if missing when creating a new theme

### DIFF
--- a/radio/src/gui/colorlcd/theme_manager.cpp
+++ b/radio/src/gui/colorlcd/theme_manager.cpp
@@ -433,6 +433,12 @@ bool ThemePersistance::createNewTheme(std::string name, ThemeFile &theme)
   s = strAppend(s, "/", FF_MAX_LFN - (s - fullPath));
   s = strAppend(s, name.c_str(), FF_MAX_LFN - (s - fullPath));
 
+  if (!isFileAvailable(THEMES_PATH))
+  {
+    FRESULT result = f_mkdir(THEMES_PATH);
+    if (result != FR_OK) return false;
+  }
+
   FRESULT result = f_mkdir(fullPath);
   if (result != FR_OK) return false;
   s = strAppend(s, "/", FF_MAX_LFN - (s - fullPath));


### PR DESCRIPTION
Summary of changes:
- If the `THEMES` directory is missing, create it on creating (although at this point it is really when duplicating, but that is probably splitting hairs) a new theme. 
- Prior to this, it would fail silently with no theme created. 

