### PR TITLE
Reduce ADC noise

### DIFF
--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -123,6 +123,10 @@ void boardInit()
   }
 #endif
 
+#if defined(RADIO_TX16S)
+  FLASH_PrefetchBufferCmd(DISABLE);
+#endif
+
   pwrInit();
   boardInitModulePorts();
 

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -138,6 +138,7 @@ void boardInit()
     FLASH_OB_Launch();
     FLASH_OB_Lock();
   }
+  FLASH_PrefetchBufferCmd(DISABLE);
 #endif
 
   // Sets 'hardwareOption.pcbrev' as well


### PR DESCRIPTION
This is an experimental provision. Another engineer told me: After he consulted a lot of relevant information, including ST official information, he obtained a description of FLASH_PrefetchBufferCmd. Try turning it off with FLASH_PrefetchBufferCmd(DISABLE), and by observation, it does reduce the magnitude of the joystick noise.
The indirect influence factors of FLASH_PrefetchBufferCmd on ADC noise are as follows:

```
When FLASH_PrefetchBufferCmd is enabled, the noise of the ADC increases, which may suggest some indirect effects.

Here are some possibilities:

1. System Noise: Enabling the prefetch instruction buffer may increase the system's power consumption, which may introduce more power supply noise, thereby affecting the performance of the ADC.

2. Interrupt Delay: The prefetch instruction buffer could potentially cause a delay in the CPU when handling ADC interrupts, which may affect the timing of ADC reads and possibly lead to increased noise.

3. Impact of System Clock: The prefetch instruction buffer could potentially have an effect on the system clock. If the ADC sampling time is correlated with these clock signals, it could possibly lead to increased noise.

4. Impact on System Power Consumption: Enabling the prefetch instruction buffer may increase the system's power consumption, introduce more power supply noise, or affect the CPU's handling time for ADC interrupts. This could indirectly affect the noise level of the ADC, leading to an increase in the LSB value.
``` 