### PR TITLE
Solve the messy display after Boxer shutdown

### DIFF
--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -307,7 +307,7 @@ void boardOff()
   }
 #endif
 
-#if defined(RADIO_ZORRO) || defined(RADIO_TX12MK2)
+#if defined(RADIO_ZORRO) || defined(RADIO_TX12MK2) || defined(RADIO_BOXER)
   lcdInit(); 
 #endif
 

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -307,7 +307,7 @@ void boardOff()
   }
 #endif
 
-#if defined(RADIO_ZORRO) || defined(RADIO_TX12MK2) || defined(RADIO_BOXER)
+#if defined(MANUFACTURER_RADIOMASTER) && defined(STM32F407xx)
   lcdInit(); 
 #endif
 


### PR DESCRIPTION
Solve the redundant cluttered display on the screen after Boxer is shut down.
