### PR TITLE
fix: external MPM flash

### DIFF
--- a/radio/src/io/multi_firmware_update.cpp
+++ b/radio/src/io/multi_firmware_update.cpp
@@ -96,7 +96,7 @@ bool MultiFirmwareUpdateDriver::init()
     params.polarity = ETX_Pol_Inverted;
     mod_st = modulePortInitSerial(EXTERNAL_MODULE, ETX_MOD_PORT_UART, &params);
     if (!mod_st) {
-      params.polarity = ETX_Pol_Normal;
+      params.polarity = ETX_Pol_Inverted;
       mod_st = modulePortInitSerial(EXTERNAL_MODULE, ETX_MOD_PORT_SOFT_INV, &params);
       if (!mod_st) return false;
     }
@@ -104,7 +104,7 @@ bool MultiFirmwareUpdateDriver::init()
     params.direction = ETX_Dir_RX;
     params.polarity = ETX_Pol_Inverted;
     if (!modulePortInitSerial(EXTERNAL_MODULE, ETX_MOD_PORT_SPORT, &params)) {
-      params.polarity = ETX_Pol_Normal;
+      params.polarity = ETX_Pol_Inverted;
       if (!modulePortInitSerial(EXTERNAL_MODULE, ETX_MOD_PORT_SPORT_INV, &params)) {
         modulePortDeInit(mod_st);
         return false;
@@ -161,11 +161,9 @@ void MultiFirmwareUpdateDriver::deinit()
 
 bool MultiFirmwareUpdateDriver::getRxByte(uint8_t & byte) const
 {
-  uint16_t time;
-
-  time = getTmr2MHz();
-  while ((uint16_t) (getTmr2MHz() - time) < 25000) {  // 12.5mS
-
+  uint32_t time = RTOS_GET_MS();
+  
+  while ((RTOS_GET_MS() - time) < 100) {              // 100ms
     if (getByte(byte)) {
 #if defined(DEBUG_EXT_MODULE_FLASH)
       TRACE("[RX] 0x%X", byte);

--- a/radio/src/targets/common/arm/stm32/stm32_pulse_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_pulse_driver.cpp
@@ -298,12 +298,18 @@ void stm32_pulse_start_dma_req(const stm32_pulse_timer_t* tim,
   // Enable TC IRQ
   LL_DMA_EnableIT_TC(tim->DMAx, tim->DMA_Stream);
 
-  // Reset counter
-  LL_TIM_SetCounter(tim->TIMx, 0x00);
-
-  // only on PWM (preloads the first period)
-  if (ocmode == LL_TIM_OCMODE_PWM1)
+  if (ocmode == LL_TIM_OCMODE_PWM1) {
+    // preloads first period for PWM)
+    LL_TIM_SetCounter(tim->TIMx, 0x00);
     LL_TIM_GenerateEvent_UPDATE(tim->TIMx);
+  } else {
+    // Reset counter close to overflow
+    if (IS_TIM_32B_COUNTER_INSTANCE(tim->TIMx)) {
+      LL_TIM_SetCounter(tim->TIMx, 0xFFFFFFFF);
+    } else {
+      LL_TIM_SetCounter(tim->TIMx, 0xFFFF);
+    }
+  }
 
   LL_TIM_EnableDMAReq_UPDATE(tim->TIMx);
   LL_DMA_EnableStream(tim->DMAx, tim->DMA_Stream);


### PR DESCRIPTION
Summary of changes:
- specific pulse timer inits for and pwm toggle mode
- set correct RX/TX polarity for MPM bootloader
- extended flash process timeout from 12.5ms to 100ms as robustness measure