### PR TITLE
Add RX OTA flash for frsky X10s & X12s.

### DIFF
--- a/radio/src/gui/colorlcd/radio_sdmanager.h
+++ b/radio/src/gui/colorlcd/radio_sdmanager.h
@@ -39,6 +39,9 @@ class RadioSdManagerPage : public PageTab
   void fileAction(const char* path, const char* name, const char* fullpath);
   
   void BootloaderUpdate(const char* fn);
+#if defined(BLUETOOTH)
+  void BluetoothFirmwareUpdate(const char* fn);
+#endif
   void FrSkyFirmwareUpdate(const char* fn, ModuleIndex module);
   void MultiFirmwareUpdate(const char* fn, ModuleIndex module,
                            MultiModuleType type);


### PR DESCRIPTION
Fixes #2147 

Summary of changes:
The OTA flash code are basically copied from stdlcd, rewrite UI part based on the new implementation for color screens.

The UI part cost me some time. My finding is to close dialogs & menus programmatically, they needs to be deleteLater() in stack order, from latest widget to older widget. If the order is wrong the UI will crash immediately. After fix the order of deleteLater(), the UI works fine.

I run several tests in my X10s, click no and yes, flash by OTA several times. Seems working well in my device. It should also work in X12s, but I don't have a device to test.
![X10s-OTA-flash](https://github.com/EdgeTX/edgetx/assets/16578367/b8cc08bc-6978-4e55-bfc1-39e81ff8e15e)
