### PR TITLE
fix(color) - Only reset Lua if changing PLAY SCRIPT special function

### DIFF
--- a/radio/src/gui/colorlcd/special_functions.cpp
+++ b/radio/src/gui/colorlcd/special_functions.cpp
@@ -192,7 +192,8 @@ class SpecialFunctionEditPage : public Page
             [=](std::string newValue) {
               strncpy(cfn->play.name, newValue.c_str(), sizeof(cfn->play.name));
               SET_DIRTY();
-              LUA_LOAD_MODEL_SCRIPTS();
+              if (func == FUNC_PLAY_SCRIPT)
+                LUA_LOAD_MODEL_SCRIPTS();
             },
             true);  // strip extension
         break;


### PR DESCRIPTION
Don't reset Lua for PLAY TRACK, or BACKGND MUSIC functions.

Fixes #3692 
