### PR TITLE
Support changing module type from LUA model.setModule()

### DIFF
--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -226,7 +226,13 @@ static int luaModelSetModule(lua_State *L)
     for (lua_pushnil(L); lua_next(L, -2); lua_pop(L, 1)) {
       luaL_checktype(L, -2, LUA_TSTRING); // key is string
       const char * key = luaL_checkstring(L, -2);
-      if (!strcmp(key, "subType")) {
+      if (!strcmp(key, "Type")) {
+        uint8_t newtype = luaL_checkinteger(L, -1);
+        if (newtype != module.type) {
+          setModuleType(idx, newtype);
+        }
+      }
+      else if (!strcmp(key, "subType")) {
         module.subType = luaL_checkinteger(L, -1);
       }
       else if (!strcmp(key, "modelId")) {


### PR DESCRIPTION
Currently LUA model.setModule() cannot change module type. I want to change that to enable scripts that switch between internal and external module.
User scenario 1 is using same EdgeTX model with multiple craft on multiple receiver types; currently you either need to clone the model (making modifications cumbersome, since you need to keep them in sync), or manually switch modules in the menu.
User scenario 2:  this can be used to enable 'check antenna' warning for radios with removable internal module antennas - they can burn out the transmitter if the antenna isn't connected, so the user would be able to have LUA remind them to put on the antenna after the radio boots, and only enable the module (via model.setModule) once the user acknowledges the antenna is on by flipping a switch.