### PR TITLE
(re)enable mute for TX16S based on RM feedback

### DIFF
--- a/radio/src/targets/horus/hal.h
+++ b/radio/src/targets/horus/hal.h
@@ -694,14 +694,14 @@
 #endif
 
 #if defined(RADIO_FAMILY_T16)
+#if defined(RADIO_TX16S)
+  #define AUDIO_UNMUTE_DELAY            150  // ms
+#else
   #define AUDIO_UNMUTE_DELAY            120  // ms
+#endif
   #define AUDIO_MUTE_DELAY              500  // ms
 #endif
 
-#if defined(RADIO_TX16S)
-// Only slight noise with 868MHz > 1W, if complaints later remove and set AUDIO_UNMUTE_DELAY to 150
-  #undef AUDIO_MUTE_GPIO_PIN
-#endif
 
 // Touch
 #if defined(HARDWARE_TOUCH)


### PR DESCRIPTION
Based on feedback received from Radiomaster customers, they would prefer to re-enable mute for TX16S.

I'll do later a user configurable version, but for 2.10

Would be nice if this one could be part of 2.9