### PR TITLE
Simulator: do not allow launching if no radio profiles found

### DIFF
--- a/companion/src/constants.h
+++ b/companion/src/constants.h
@@ -51,6 +51,7 @@
 #define CPN_MAX_SPACEMOUSE             6
 
 #define CPN_STR_APP_NAME               QCoreApplication::translate("Companion", "EdgeTX Companion")
+#define CPN_STR_SIMU_NAME              QCoreApplication::translate("Companion", "EdgeTX Simulator")
 #define CPN_STR_TTL_INFO               QCoreApplication::translate("Companion", "Information")        // shared Title Case words, eg. for a window title or section heading
 #define CPN_STR_TTL_WARNING            QCoreApplication::translate("Companion", "Warning")
 #define CPN_STR_TTL_ERROR              QCoreApplication::translate("Companion", "Error")

--- a/companion/src/simulation/simulatorstartupdialog.cpp
+++ b/companion/src/simulation/simulatorstartupdialog.cpp
@@ -47,6 +47,7 @@ SimulatorStartupDialog::SimulatorStartupDialog(SimulatorOptions * options, int *
 {
   ui->setupUi(this);
   this->setWindowIcon(QIcon(":/icon.png"));
+  this->setWindowTitle(QString("%1 - %2").arg(CPN_STR_SIMU_NAME).arg(tr("Startup Options")));
 
   QMapIterator<int, QString> pi(g.getActiveProfiles());
   while (pi.hasNext()) {
@@ -103,7 +104,7 @@ SimulatorStartupDialog::SimulatorStartupDialog(SimulatorOptions * options, int *
   if (ui->radioProfile->count() < 1) {
     // give Startup dialog time to display so this error message can overlay it
     QTimer::singleShot(250, [=] {
-      QMessageBox::critical(this, CPN_STR_APP_NAME, tr("No radio profiles have been found. Use Companion to create."));
+      QMessageBox::critical(this, CPN_STR_SIMU_NAME, tr("No radio profiles have been found. Use %1 to create.").arg(CPN_STR_APP_NAME));
       ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
     });
   }

--- a/companion/src/simulation/simulatorstartupdialog.cpp
+++ b/companion/src/simulation/simulatorstartupdialog.cpp
@@ -29,6 +29,9 @@
 #include <QFileDialog>
 #include <QStandardItemModel>
 #include <QSortFilterProxyModel>
+#include <QMessageBox>
+#include <QPushButton>
+#include <QTimer>
 
 using namespace Simulator;
 
@@ -96,6 +99,14 @@ SimulatorStartupDialog::SimulatorStartupDialog(SimulatorOptions * options, int *
   QObject::connect(ui->btnSelectDataFile, &QToolButton::clicked, this, &SimulatorStartupDialog::onDataFileSelect);
   QObject::connect(ui->btnSelectDataFolder, &QToolButton::clicked, this, &SimulatorStartupDialog::onDataFolderSelect);
   QObject::connect(ui->btnSelectSdPath, &QToolButton::clicked, this, &SimulatorStartupDialog::onSdPathSelect);
+
+  if (ui->radioProfile->count() < 1) {
+    // give Startup dialog time to display so this error message can overlay it
+    QTimer::singleShot(250, [=] {
+      QMessageBox::critical(this, CPN_STR_APP_NAME, tr("No radio profiles have been found. Use Companion to create."));
+      ui->buttonBox->button(QDialogButtonBox::Ok)->setEnabled(false);
+    });
+  }
 
 }
 

--- a/companion/src/simulation/simulatorstartupdialog.ui
+++ b/companion/src/simulation/simulatorstartupdialog.ui
@@ -35,7 +35,7 @@
       </sizepolicy>
      </property>
      <property name="title">
-      <string>Simulator Startup Options:</string>
+      <string>Simulator Startup Options</string>
      </property>
      <layout class="QFormLayout" name="layout_options">
       <property name="sizeConstraint">


### PR DESCRIPTION
Fixes #3709

![Screenshot from 2023-06-23 10-30-53](https://github.com/EdgeTX/edgetx/assets/15316949/475f2f05-458e-47db-a291-1f3c832ce791)

After closing the message box the OK button is disabled to prevent attempting to launch the simulator.
![Screenshot from 2023-06-23 10-31-17](https://github.com/EdgeTX/edgetx/assets/15316949/e7aeb3b3-7dae-4b76-ac90-5a12a5175a62)
