### PR TITLE
fix(radio) - Fix rounding errors in ADC value calculation for 6POS switch.

### DIFF
--- a/radio/src/hal/adc_driver.cpp
+++ b/radio/src/hal/adc_driver.cpp
@@ -346,7 +346,7 @@ void getADC()
     }
 #endif
 
-    #define ANAFILT_MAX    (2 * RESX * JITTER_ALPHA * ANALOG_MULTIPLIER - 1)
+    #define ANAFILT_MAX    (2 * RESX * JITTER_ALPHA * ANALOG_MULTIPLIER)
     StepsCalibData * calib = (StepsCalibData *) &g_eeGeneral.calib[x];
     if (IS_POT_MULTIPOS(x) && IS_MULTIPOS_CALIBRATED(calib)) {
       // TODO: consider adding another low pass filter to eliminate multipos switching glitches
@@ -354,7 +354,7 @@ void getADC()
       s_anaFilt[x] = ANAFILT_MAX;
       for (uint32_t i=0; i<calib->count; i++) {
         if (vShifted < calib->steps[i]) {
-          s_anaFilt[x] = (i * ANAFILT_MAX) / calib->count;
+          s_anaFilt[x] = (i * (ANAFILT_MAX + JITTER_ALPHA * ANALOG_MULTIPLIER)) / calib->count;
           break;
         }
       }


### PR DESCRIPTION
Fixes #3711 

Tested in simulator and on TX16S Mk2.
