### PR TITLE
fix(b&w): Bootloader "USB Connected" alignment

### DIFF
--- a/radio/src/targets/taranis/bootloader/boot_menu.cpp
+++ b/radio/src/targets/taranis/bootloader/boot_menu.cpp
@@ -75,11 +75,11 @@ void bootloaderDrawScreen(BootloaderState st, int opt, const char *str)
     if (strncmp(vers, "opentx-", 7) == 0)
       vers += 7;
 #endif
-    lcdDrawText(LCD_W / 2, 7 * FH, vers, CENTERED);
+    lcdDrawCenteredText(7 * FH, vers);
     lcdInvertLine(7);
   }
   else if (st == ST_USB) {
-    lcdDrawTextAlignedLeft(4 * FH, TR_BL_USB_CONNECTED);
+    lcdDrawCenteredText(4 * FH, TR_BL_USB_CONNECTED);
   }
   else if (st == ST_DIR_CHECK) {
     if (opt == FR_NO_PATH) {
@@ -111,7 +111,7 @@ void bootloaderDrawScreen(BootloaderState st, int opt, const char *str)
     }
   }
   else if (st == ST_FLASHING) {
-    lcdDrawTextAlignedLeft(4 * FH, TR_BL_WRITING_FW);
+    lcdDrawCenteredText(4 * FH, TR_BL_WRITING_FW);
 
     lcdDrawRect(3, 6 * FH + 4, (LCD_W - 8), 7);
     lcdDrawSolidHorizontalLine(5, 6 * FH + 6, (LCD_W - 12) * opt / 100, FORCE);
@@ -119,7 +119,7 @@ void bootloaderDrawScreen(BootloaderState st, int opt, const char *str)
     lcdDrawSolidHorizontalLine(5, 6 * FH + 8, (LCD_W - 12) * opt / 100, FORCE);
   }
   else if (st == ST_FLASH_DONE) {
-    lcdDrawTextAlignedLeft(4 * FH, TR_BL_WRITING_COMPL);
+    lcdDrawCenteredText(4 * FH, TR_BL_WRITING_COMPL);
   }
 }
 

--- a/radio/src/targets/taranis/bootloader/boot_menu.cpp
+++ b/radio/src/targets/taranis/bootloader/boot_menu.cpp
@@ -69,10 +69,10 @@ void bootloaderDrawScreen(BootloaderState st, int opt, const char *str)
 
     lcdDrawText(LCD_W / 2, 5 * FH + FH / 2, TR_BL_OR_PLUGIN_USB_CABLE, CENTERED);
 
-    // Remove "opentx-" from string
     const char * vers = getFirmwareVersion();
 #if LCD_W < 212
-    if (strncmp(vers, "opentx-", 7) == 0)
+    // Remove "edgetx-" from string
+    if (strncmp(vers, "edgetx-", 7) == 0)
       vers += 7;
 #endif
     lcdDrawCenteredText(7 * FH, vers);
@@ -101,8 +101,8 @@ void bootloaderDrawScreen(BootloaderState st, int opt, const char *str)
       if (memoryType == MEM_FLASH) {
         const char * vers = getFirmwareVersion((const char *)Block_buffer);
 #if LCD_W < 212
-        // Remove "opentx-" from string
-        if (strncmp(vers, "opentx-", 7) == 0)
+        // Remove "edgetx-" from string
+        if (strncmp(vers, "edgetx-", 7) == 0)
           vers += 7;
 #endif
         bootloaderDrawMsg(INDENT_WIDTH, vers, 0, false);

--- a/radio/src/translations/cn.h
+++ b/radio/src/translations/cn.h
@@ -1053,7 +1053,11 @@
 #endif
 
 // Bootloader common - Ascii only
+#if defined(COLORLCD)
+#define TR_BL_USB_CONNECTED           "USB Connected"
+#else
 #define TR_BL_USB_CONNECTED           CENTER "\011USB Connected"
+#endif
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"

--- a/radio/src/translations/cn.h
+++ b/radio/src/translations/cn.h
@@ -1053,8 +1053,7 @@
 #endif
 
 // Bootloader common - Ascii only
-#define TR_BL_USB_CONNECT_BOOT        CENTER "\011USB Connected"
-#define TR_BL_USB_CONNECTED           "USB Connected"
+#define TR_BL_USB_CONNECTED           CENTER "\011USB Connected"
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"

--- a/radio/src/translations/cn.h
+++ b/radio/src/translations/cn.h
@@ -1053,11 +1053,7 @@
 #endif
 
 // Bootloader common - Ascii only
-#if defined(COLORLCD)
 #define TR_BL_USB_CONNECTED           "USB Connected"
-#else
-#define TR_BL_USB_CONNECTED           CENTER "\011USB Connected"
-#endif
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"
@@ -1068,6 +1064,8 @@
 #define TR_BL_EXIT                    "Exit"
 #define TR_BL_DIR_MISSING             " Directory is missing"
 #define TR_BL_DIR_EMPTY               " Directory is empty"
+#define TR_BL_WRITING_FW              "Writing..."
+#define TR_BL_WRITING_COMPL           "Writing complete"
 
 #if LCD_W >= 480
   #define TR_BL_INVALID_FIRMWARE       "Not a valid firmware file"
@@ -1086,23 +1084,17 @@
 #if defined(PCBTARANIS)
    // Bootloader Taranis specific - Ascii only
   #define TR_BL_RESTORE_EEPROM        "Restore EEPROM"
-  #define TR_BL_WRITING_FW            CENTER "\015Writing..."
-  #define TR_BL_WRITING_COMPL         CENTER "\007Writing complete"
   #if defined(RADIO_COMMANDO8)
     #define TR_BL_POWER_KEY           "Press the power button."
     #define TR_BL_FLASH_EXIT          "Exit the flashing mode."
   #endif
 #elif defined(PCBHORUS)
    // Bootloader Horus specific - Ascii only
-  #define TR_BL_WRITING_FW            "Writing Firmware ..."
-  #define TR_BL_WRITING_COMPL         "Writing Completed"
   #define TR_BL_SELECT_KEY            "[ENT] to select file"
   #define TR_BL_FLASH_KEY             "Hold [ENT] long to flash"
   #define TR_BL_EXIT_KEY              "[RTN] to exit"
 #elif defined(PCBNV14)
    // Bootloader NV14 specific - Ascii only
-  #define TR_BL_WRITING_FW            "Writing Firmware ..."
-  #define TR_BL_WRITING_COMPL         "Writing Completed"
   #define TR_BL_RF_USB_ACCESS         "RF USB access"
   #define TR_BL_CURRENT_FW            "Current Firmware:"
   #define TR_BL_SELECT_KEY            "[R TRIM] to select file"

--- a/radio/src/translations/cz.h
+++ b/radio/src/translations/cz.h
@@ -1057,11 +1057,7 @@
 #endif
 
 // Bootloader common (Poznamka: nutne pouziti textu bez diakritiky - omezeni velikosti pameti bootloader!)
-#if defined(COLORLCD)
 #define TR_BL_USB_CONNECTED           "USB pripojeno"
-#else
-#define TR_BL_USB_CONNECTED           CENTER "\011USB pripojeno"
-#endif
 #define TR_BL_USB_PLUGIN              "nebo pripojte USB kabel"
 #define TR_BL_USB_MASS_STORE          "pro pouziti uloziste"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "nebo pripojte USB kabel pro pouziti uloziste"
@@ -1072,6 +1068,8 @@
 #define TR_BL_EXIT                    "Ukoncit"
 #define TR_BL_DIR_MISSING             " Adresar chybi"
 #define TR_BL_DIR_EMPTY               " Adresar je prazdny"
+#define TR_BL_WRITING_FW              "Nahravani firmware ..."
+#define TR_BL_WRITING_COMPL           "Nahravani dokonceno"
 
 #if LCD_W >= 480
   #define TR_BL_INVALID_FIRMWARE       "Neplatny soubor s firmwarem"
@@ -1090,23 +1088,17 @@
 #if defined(PCBTARANIS)
    // Bootloader Taranis specific - Ascii only
   #define TR_BL_RESTORE_EEPROM        "Obnovit EEPROM"
-  #define TR_BL_WRITING_FW            CENTER "\015Nahravani..."
-  #define TR_BL_WRITING_COMPL         CENTER "\007Nahravani dokonceno"
   #if defined(RADIO_COMMANDO8)
     #define TR_BL_POWER_KEY           "Stisknete tlacitko napajeni."
     #define TR_BL_FLASH_EXIT          "Ukoncit rezim nahravani."
   #endif
 #elif defined(PCBHORUS)
    // Bootloader Horus specific - Ascii only
-  #define TR_BL_WRITING_FW            "Nahravani firmware ..."
-  #define TR_BL_WRITING_COMPL         "Nahravani dokonceno"
   #define TR_BL_SELECT_KEY            "[ENT] pro vybrani souboru"
   #define TR_BL_FLASH_KEY             "Drzet dlouze [ENT] pro nahrani"
   #define TR_BL_EXIT_KEY              "[RTN] pro ukonceni"
 #elif defined(PCBNV14)
    // Bootloader NV14 specific - Ascii only
-  #define TR_BL_WRITING_FW            "Nahravani firmware ..."
-  #define TR_BL_WRITING_COMPL         "Nahravani dokonceno"
   #define TR_BL_RF_USB_ACCESS         "RF USB pristup"
   #define TR_BL_CURRENT_FW            "Aktualni firmware:"
   #define TR_BL_SELECT_KEY            "[R TRIM] pro vybrani souboru"

--- a/radio/src/translations/cz.h
+++ b/radio/src/translations/cz.h
@@ -1057,8 +1057,7 @@
 #endif
 
 // Bootloader common (Poznamka: nutne pouziti textu bez diakritiky - omezeni velikosti pameti bootloader!)
-#define TR_BL_USB_CONNECT_BOOT        CENTER "\011USB pripojeno"
-#define TR_BL_USB_CONNECTED           "USB pripojeno"
+#define TR_BL_USB_CONNECTED           CENTER "\011USB pripojeno"
 #define TR_BL_USB_PLUGIN              "nebo pripojte USB kabel"
 #define TR_BL_USB_MASS_STORE          "pro pouziti uloziste"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "nebo pripojte USB kabel pro pouziti uloziste"

--- a/radio/src/translations/cz.h
+++ b/radio/src/translations/cz.h
@@ -1057,7 +1057,11 @@
 #endif
 
 // Bootloader common (Poznamka: nutne pouziti textu bez diakritiky - omezeni velikosti pameti bootloader!)
+#if defined(COLORLCD)
+#define TR_BL_USB_CONNECTED           "USB pripojeno"
+#else
 #define TR_BL_USB_CONNECTED           CENTER "\011USB pripojeno"
+#endif
 #define TR_BL_USB_PLUGIN              "nebo pripojte USB kabel"
 #define TR_BL_USB_MASS_STORE          "pro pouziti uloziste"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "nebo pripojte USB kabel pro pouziti uloziste"

--- a/radio/src/translations/da.h
+++ b/radio/src/translations/da.h
@@ -1058,7 +1058,11 @@
 #endif
 
 // Bootloader common - Ascii only
+#if defined(COLORLCD)
+#define TR_BL_USB_CONNECTED           "USB forbundet"
+#else
 #define TR_BL_USB_CONNECTED           CENTER "\011USB forbundet"
+#endif
 #define TR_BL_USB_PLUGIN              "eller brug USB kabel"
 #define TR_BL_USB_MASS_STORE          "for USB disk"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "eller brug USB kabel for USB disk"

--- a/radio/src/translations/da.h
+++ b/radio/src/translations/da.h
@@ -1058,8 +1058,7 @@
 #endif
 
 // Bootloader common - Ascii only
-#define TR_BL_USB_CONNECT_BOOT        CENTER "\011USB forbundet"
-#define TR_BL_USB_CONNECTED           "USB forbundet"
+#define TR_BL_USB_CONNECTED           CENTER "\011USB forbundet"
 #define TR_BL_USB_PLUGIN              "eller brug USB kabel"
 #define TR_BL_USB_MASS_STORE          "for USB disk"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "eller brug USB kabel for USB disk"

--- a/radio/src/translations/da.h
+++ b/radio/src/translations/da.h
@@ -1058,11 +1058,7 @@
 #endif
 
 // Bootloader common - Ascii only
-#if defined(COLORLCD)
 #define TR_BL_USB_CONNECTED           "USB forbundet"
-#else
-#define TR_BL_USB_CONNECTED           CENTER "\011USB forbundet"
-#endif
 #define TR_BL_USB_PLUGIN              "eller brug USB kabel"
 #define TR_BL_USB_MASS_STORE          "for USB disk"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "eller brug USB kabel for USB disk"
@@ -1073,6 +1069,8 @@
 #define TR_BL_EXIT                    "Forlad"
 #define TR_BL_DIR_MISSING             " Katalog mangler"
 #define TR_BL_DIR_EMPTY               " Katalog er tomt"
+#define TR_BL_WRITING_FW              "Installerer..."
+#define TR_BL_WRITING_COMPL           "Installation slut"
 
 #if LCD_W >= 480
   #define TR_BL_INVALID_FIRMWARE       "Ikke en installationsfil!"
@@ -1091,23 +1089,17 @@
 #if defined(PCBTARANIS)
    // Bootloader Taranis specific - Ascii only
   #define TR_BL_RESTORE_EEPROM        "Genskab EEPROM"
-  #define TR_BL_WRITING_FW            CENTER "\015Installerer..."
-  #define TR_BL_WRITING_COMPL         CENTER "\007Installation slut"
   #if defined(RADIO_COMMANDO8)
     #define TR_BL_POWER_KEY           "Tryk power knap."
     #define TR_BL_FLASH_EXIT          "Forlad installation tilstand."
   #endif
 #elif defined(PCBHORUS)
    // Bootloader Horus specific - Ascii only
-  #define TR_BL_WRITING_FW            "Installerer firmware ..."
-  #define TR_BL_WRITING_COMPL         "Installation slut"
   #define TR_BL_SELECT_KEY            "[ENT] for at bruge fil"
   #define TR_BL_FLASH_KEY             "[ENT] lang tid for at starte"
   #define TR_BL_EXIT_KEY              "[RTN] for at forlade"
 #elif defined(PCBNV14)
    // Bootloader NV14 specific - Ascii only
-  #define TR_BL_WRITING_FW            "Installerer firmware ..."
-  #define TR_BL_WRITING_COMPL         "Installation slut"
   #define TR_BL_RF_USB_ACCESS         "RF USB adgang"
   #define TR_BL_CURRENT_FW            "Firmware version:"
   #define TR_BL_SELECT_KEY            "[R TRIM] for at bruge fil"

--- a/radio/src/translations/de.h
+++ b/radio/src/translations/de.h
@@ -1041,11 +1041,7 @@
 #endif
 
 // Bootloader common - Ascii only
-#if defined(COLORLCD)
 #define TR_BL_USB_CONNECTED           "USB verbunden"
-#else
-#define TR_BL_USB_CONNECTED           CENTER "\011USB verbunden"
-#endif
 #define TR_BL_USB_PLUGIN              "Oder schließen Sie ein USB-Kabel"
 #define TR_BL_USB_MASS_STORE          "für den SD-Speicher an"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Oder schließen Sie ein USB-Kabel für den SD-Speicher an"
@@ -1056,6 +1052,8 @@
 #define TR_BL_EXIT                    "Beenden"
 #define TR_BL_DIR_MISSING             " Verzeichnis fehlt"
 #define TR_BL_DIR_EMPTY               " Verzeichnis leer"
+#define TR_BL_WRITING_FW              "Schreibe..."
+#define TR_BL_WRITING_COMPL           "Schreiben abgeschlossen"
 
 #if LCD_W >= 480
   #define TR_BL_INVALID_FIRMWARE       "Keine gültige Firmwaredatei"
@@ -1074,23 +1072,17 @@
 #if defined(PCBTARANIS)
    // Bootloader Taranis specific - Ascii only
   #define TR_BL_RESTORE_EEPROM        "EEPROM wiederherstellen"
-  #define TR_BL_WRITING_FW            CENTER "\015Schreibe..."
-  #define TR_BL_WRITING_COMPL         CENTER "\007Schreiben abgeschlossen"
   #if defined(RADIO_COMMANDO8)
     #define TR_BL_POWER_KEY           "Drücke den Power Knopf."
     #define TR_BL_FLASH_EXIT          "Verlasse den Flashmodus."
   #endif
 #elif defined(PCBHORUS)
    // Bootloader Horus specific - Ascii only
-  #define TR_BL_WRITING_FW            "Schreibe Firmware ..."
-  #define TR_BL_WRITING_COMPL         "Schreiben abgeschlossen"
   #define TR_BL_SELECT_KEY            "[ENT] um Datei auszuwählen"
   #define TR_BL_FLASH_KEY             "Halte [ENT] gedrückt, zum schreiben"
   #define TR_BL_EXIT_KEY              "[RTN] zum beenden"
 #elif defined(PCBNV14)
    // Bootloader NV14 specific - Ascii only
-  #define TR_BL_WRITING_FW            "Schreibe Firmware ..."
-  #define TR_BL_WRITING_COMPL         "Schreiben abgeschlossen"
   #define TR_BL_RF_USB_ACCESS         "RF USB Zugriff"
   #define TR_BL_CURRENT_FW            "Aktuelle Firmware:"
   #define TR_BL_SELECT_KEY            "[R TRIM] um Datei auszuwählen"

--- a/radio/src/translations/de.h
+++ b/radio/src/translations/de.h
@@ -1041,8 +1041,7 @@
 #endif
 
 // Bootloader common - Ascii only
-#define TR_BL_USB_CONNECT_BOOT        CENTER "\011USB verbunden"
-#define TR_BL_USB_CONNECTED           "USB verbunden"
+#define TR_BL_USB_CONNECTED        CENTER "\011USB verbunden"
 #define TR_BL_USB_PLUGIN              "Oder schließen Sie ein USB-Kabel"
 #define TR_BL_USB_MASS_STORE          "für den SD-Speicher an"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Oder schließen Sie ein USB-Kabel für den SD-Speicher an"

--- a/radio/src/translations/de.h
+++ b/radio/src/translations/de.h
@@ -1041,7 +1041,11 @@
 #endif
 
 // Bootloader common - Ascii only
-#define TR_BL_USB_CONNECTED        CENTER "\011USB verbunden"
+#if defined(COLORLCD)
+#define TR_BL_USB_CONNECTED           "USB verbunden"
+#else
+#define TR_BL_USB_CONNECTED           CENTER "\011USB verbunden"
+#endif
 #define TR_BL_USB_PLUGIN              "Oder schließen Sie ein USB-Kabel"
 #define TR_BL_USB_MASS_STORE          "für den SD-Speicher an"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Oder schließen Sie ein USB-Kabel für den SD-Speicher an"

--- a/radio/src/translations/en.h
+++ b/radio/src/translations/en.h
@@ -1050,8 +1050,7 @@
 #endif
 
 // Bootloader common - Ascii only
-#define TR_BL_USB_CONNECT_BOOT        CENTER "\011USB Connected"
-#define TR_BL_USB_CONNECTED           "USB Connected"
+#define TR_BL_USB_CONNECTED           CENTER "\011USB Connected"
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"

--- a/radio/src/translations/en.h
+++ b/radio/src/translations/en.h
@@ -1050,11 +1050,7 @@
 #endif
 
 // Bootloader common - Ascii only
-#if defined(COLORLCD)
 #define TR_BL_USB_CONNECTED           "USB Connected"
-#else
-#define TR_BL_USB_CONNECTED           CENTER "\011USB Connected"
-#endif
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"
@@ -1065,6 +1061,8 @@
 #define TR_BL_EXIT                    "Exit"
 #define TR_BL_DIR_MISSING             " Directory is missing"
 #define TR_BL_DIR_EMPTY               " Directory is empty"
+#define TR_BL_WRITING_FW              "Writing..."
+#define TR_BL_WRITING_COMPL           "Writing complete"
 
 #if LCD_W >= 480
   #define TR_BL_INVALID_FIRMWARE       "Not a valid firmware file"
@@ -1083,23 +1081,17 @@
 #if defined(PCBTARANIS)
    // Bootloader Taranis specific - Ascii only
   #define TR_BL_RESTORE_EEPROM        "Restore EEPROM"
-  #define TR_BL_WRITING_FW            CENTER "\015Writing..."
-  #define TR_BL_WRITING_COMPL         CENTER "\007Writing complete"
   #if defined(RADIO_COMMANDO8)
     #define TR_BL_POWER_KEY           "Press the power button."
     #define TR_BL_FLASH_EXIT          "Exit the flashing mode."
   #endif
 #elif defined(PCBHORUS)
    // Bootloader Horus specific - Ascii only
-  #define TR_BL_WRITING_FW            "Writing Firmware ..."
-  #define TR_BL_WRITING_COMPL         "Writing Completed"
   #define TR_BL_SELECT_KEY            "[ENT] to select file"
   #define TR_BL_FLASH_KEY             "Hold [ENT] long to flash"
   #define TR_BL_EXIT_KEY              "[RTN] to exit"
 #elif defined(PCBNV14)
    // Bootloader NV14 specific - Ascii only
-  #define TR_BL_WRITING_FW            "Writing Firmware ..."
-  #define TR_BL_WRITING_COMPL         "Writing Completed"
   #define TR_BL_RF_USB_ACCESS         "RF USB access"
   #define TR_BL_CURRENT_FW            "Current Firmware:"
   #define TR_BL_SELECT_KEY            "[R TRIM] to select file"

--- a/radio/src/translations/en.h
+++ b/radio/src/translations/en.h
@@ -1050,7 +1050,11 @@
 #endif
 
 // Bootloader common - Ascii only
+#if defined(COLORLCD)
+#define TR_BL_USB_CONNECTED           "USB Connected"
+#else
 #define TR_BL_USB_CONNECTED           CENTER "\011USB Connected"
+#endif
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"

--- a/radio/src/translations/es.h
+++ b/radio/src/translations/es.h
@@ -1058,8 +1058,7 @@
 #endif
 
 // Bootloader common - Ascii only
-#define TR_BL_USB_CONNECT_BOOT        CENTER "\011USB Connected"
-#define TR_BL_USB_CONNECTED           "USB Connected"
+#define TR_BL_USB_CONNECTED           CENTER "\011USB Connected"
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"

--- a/radio/src/translations/es.h
+++ b/radio/src/translations/es.h
@@ -1058,7 +1058,11 @@
 #endif
 
 // Bootloader common - Ascii only
+#if defined(COLORLCD)
+#define TR_BL_USB_CONNECTED           "USB Connected"
+#else
 #define TR_BL_USB_CONNECTED           CENTER "\011USB Connected"
+#endif
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"

--- a/radio/src/translations/es.h
+++ b/radio/src/translations/es.h
@@ -1058,11 +1058,7 @@
 #endif
 
 // Bootloader common - Ascii only
-#if defined(COLORLCD)
 #define TR_BL_USB_CONNECTED           "USB Connected"
-#else
-#define TR_BL_USB_CONNECTED           CENTER "\011USB Connected"
-#endif
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"
@@ -1073,6 +1069,8 @@
 #define TR_BL_EXIT                    "Exit"
 #define TR_BL_DIR_MISSING             " Directory is missing"
 #define TR_BL_DIR_EMPTY               " Directory is empty"
+#define TR_BL_WRITING_FW              "Writing..."
+#define TR_BL_WRITING_COMPL           "Writing complete"
 
 #if LCD_W >= 480
   #define TR_BL_INVALID_FIRMWARE       "Not a valid firmware file"
@@ -1091,23 +1089,17 @@
 #if defined(PCBTARANIS)
    // Bootloader Taranis specific - Ascii only
   #define TR_BL_RESTORE_EEPROM        "Restore EEPROM"
-  #define TR_BL_WRITING_FW            CENTER "\015Writing..."
-  #define TR_BL_WRITING_COMPL         CENTER "\007Writing complete"
   #if defined(RADIO_COMMANDO8)
     #define TR_BL_POWER_KEY           "Press the power button."
     #define TR_BL_FLASH_EXIT          "Exit the flashing mode."
   #endif
 #elif defined(PCBHORUS)
    // Bootloader Horus specific - Ascii only
-  #define TR_BL_WRITING_FW            "Writing Firmware ..."
-  #define TR_BL_WRITING_COMPL         "Writing Completed"
   #define TR_BL_SELECT_KEY            "[ENT] to select file"
   #define TR_BL_FLASH_KEY             "Hold [ENT] long to flash"
   #define TR_BL_EXIT_KEY              "[RTN] to exit"
 #elif defined(PCBNV14)
    // Bootloader NV14 specific - Ascii only
-  #define TR_BL_WRITING_FW            "Writing Firmware ..."
-  #define TR_BL_WRITING_COMPL         "Writing Completed"
   #define TR_BL_RF_USB_ACCESS         "RF USB access"
   #define TR_BL_CURRENT_FW            "Current Firmware:"
   #define TR_BL_SELECT_KEY            "[R TRIM] to select file"

--- a/radio/src/translations/fi.h
+++ b/radio/src/translations/fi.h
@@ -1068,7 +1068,11 @@
 #endif
 
 // Bootloader common - Ascii only
+#if defined(COLORLCD)
+#define TR_BL_USB_CONNECTED           "USB Connected"
+#else
 #define TR_BL_USB_CONNECTED           CENTER "\011USB Connected"
+#endif
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"

--- a/radio/src/translations/fi.h
+++ b/radio/src/translations/fi.h
@@ -1068,11 +1068,7 @@
 #endif
 
 // Bootloader common - Ascii only
-#if defined(COLORLCD)
 #define TR_BL_USB_CONNECTED           "USB Connected"
-#else
-#define TR_BL_USB_CONNECTED           CENTER "\011USB Connected"
-#endif
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"
@@ -1083,6 +1079,8 @@
 #define TR_BL_EXIT                    "Exit"
 #define TR_BL_DIR_MISSING             " Directory is missing"
 #define TR_BL_DIR_EMPTY               " Directory is empty"
+#define TR_BL_WRITING_FW              "Writing..."
+#define TR_BL_WRITING_COMPL           "Writing complete"
 
 #if LCD_W >= 480
   #define TR_BL_INVALID_FIRMWARE       "Not a valid firmware file"
@@ -1101,23 +1099,17 @@
 #if defined(PCBTARANIS)
    // Bootloader Taranis specific - Ascii only
   #define TR_BL_RESTORE_EEPROM        "Restore EEPROM"
-  #define TR_BL_WRITING_FW            CENTER "\015Writing..."
-  #define TR_BL_WRITING_COMPL         CENTER "\007Writing complete"
   #if defined(RADIO_COMMANDO8)
     #define TR_BL_POWER_KEY           "Press the power button."
     #define TR_BL_FLASH_EXIT          "Exit the flashing mode."
   #endif
 #elif defined(PCBHORUS)
    // Bootloader Horus specific - Ascii only
-  #define TR_BL_WRITING_FW            "Writing Firmware ..."
-  #define TR_BL_WRITING_COMPL         "Writing Completed"
   #define TR_BL_SELECT_KEY            "[ENT] to select file"
   #define TR_BL_FLASH_KEY             "Hold [ENT] long to flash"
   #define TR_BL_EXIT_KEY              "[RTN] to exit"
 #elif defined(PCBNV14)
    // Bootloader NV14 specific - Ascii only
-  #define TR_BL_WRITING_FW            "Writing Firmware ..."
-  #define TR_BL_WRITING_COMPL         "Writing Completed"
   #define TR_BL_RF_USB_ACCESS         "RF USB access"
   #define TR_BL_CURRENT_FW            "Current Firmware:"
   #define TR_BL_SELECT_KEY            "[R TRIM] to select file"

--- a/radio/src/translations/fi.h
+++ b/radio/src/translations/fi.h
@@ -1068,8 +1068,7 @@
 #endif
 
 // Bootloader common - Ascii only
-#define TR_BL_USB_CONNECT_BOOT        CENTER "\011USB Connected"
-#define TR_BL_USB_CONNECTED           "USB Connected"
+#define TR_BL_USB_CONNECTED           CENTER "\011USB Connected"
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"

--- a/radio/src/translations/fr.h
+++ b/radio/src/translations/fr.h
@@ -1072,7 +1072,11 @@
 #endif
 
 // Bootloader common - Ascii only
+#if defined(COLORLCD)
+#define TR_BL_USB_CONNECTED           "USB Connecte"
+#else
 #define TR_BL_USB_CONNECTED           CENTER "\011USB Connecte"
+#endif
 #define TR_BL_USB_PLUGIN              "ou branchez cable USB"
 #define TR_BL_USB_MASS_STORE          "pour stockage de masse"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "ou branchez cable USB pour stockage de masse"

--- a/radio/src/translations/fr.h
+++ b/radio/src/translations/fr.h
@@ -1072,8 +1072,7 @@
 #endif
 
 // Bootloader common - Ascii only
-#define TR_BL_USB_CONNECT_BOOT        CENTER "\011USB Connecte"
-#define TR_BL_USB_CONNECTED           "USB Connecte"
+#define TR_BL_USB_CONNECTED           CENTER "\011USB Connecte"
 #define TR_BL_USB_PLUGIN              "ou branchez cable USB"
 #define TR_BL_USB_MASS_STORE          "pour stockage de masse"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "ou branchez cable USB pour stockage de masse"

--- a/radio/src/translations/fr.h
+++ b/radio/src/translations/fr.h
@@ -1072,11 +1072,7 @@
 #endif
 
 // Bootloader common - Ascii only
-#if defined(COLORLCD)
 #define TR_BL_USB_CONNECTED           "USB Connecte"
-#else
-#define TR_BL_USB_CONNECTED           CENTER "\011USB Connecte"
-#endif
 #define TR_BL_USB_PLUGIN              "ou branchez cable USB"
 #define TR_BL_USB_MASS_STORE          "pour stockage de masse"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "ou branchez cable USB pour stockage de masse"
@@ -1087,6 +1083,8 @@
 #define TR_BL_EXIT                    "Quitter"
 #define TR_BL_DIR_MISSING             " Repertoire absent"
 #define TR_BL_DIR_EMPTY               " Repertoire vide"
+#define TR_BL_WRITING_FW              "Ecriture Firmware ..."
+#define TR_BL_WRITING_COMPL           "Ecriture terminée"
 
 #if LCD_W >= 480
   #define TR_BL_INVALID_FIRMWARE       "Fichier firmware non valide"
@@ -1105,23 +1103,17 @@
 #if defined(PCBTARANIS)
    // Bootloader Taranis specific - Ascii only
   #define TR_BL_RESTORE_EEPROM        "Restaurer EEPROM"
-  #define TR_BL_WRITING_FW            CENTER "\015Ecriture ..."
-  #define TR_BL_WRITING_COMPL         CENTER "\007Ecriture terminee"
   #if defined(RADIO_COMMANDO8)
     #define TR_BL_POWER_KEY           "Appuyez sur le bouton power."
     #define TR_BL_FLASH_EXIT          "Quitter mode flashage."
   #endif
 #elif defined(PCBHORUS)
    // Bootloader Horus specific - Ascii only
-  #define TR_BL_WRITING_FW            "Ecriture Firmware ..."
-  #define TR_BL_WRITING_COMPL         "Ecriture terminée"
   #define TR_BL_SELECT_KEY            "[ENT] pour select. fichier"
   #define TR_BL_FLASH_KEY             "Appui long [ENT] pour flasher"
   #define TR_BL_EXIT_KEY              "[RTN] pour quitter"
 #elif defined(PCBNV14)
    // Bootloader NV14 specific - Ascii only
-  #define TR_BL_WRITING_FW            "Ecriture Firmware ..."
-  #define TR_BL_WRITING_COMPL         "Ecriture terminée"
   #define TR_BL_RF_USB_ACCESS         "RF USB access"
   #define TR_BL_CURRENT_FW            "Firmware actuel:"
   #define TR_BL_SELECT_KEY            "[R TRIM] pour sélect. fichier"

--- a/radio/src/translations/he.h
+++ b/radio/src/translations/he.h
@@ -1053,8 +1053,7 @@
 #endif
 
 // Bootloader common - Ascii only
-#define TR_BL_USB_CONNECT_BOOT        CENTER "\011חיבור חוטי חובר"
-#define TR_BL_USB_CONNECTED           "חיבור חוטי חובר"
+#define TR_BL_USB_CONNECTED           CENTER "\011חיבור חוטי חובר"
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"

--- a/radio/src/translations/he.h
+++ b/radio/src/translations/he.h
@@ -1053,7 +1053,11 @@
 #endif
 
 // Bootloader common - Ascii only
+#if defined(COLORLCD)
+#define TR_BL_USB_CONNECTED           "חיבור חוטי חובר"
+#else
 #define TR_BL_USB_CONNECTED           CENTER "\011חיבור חוטי חובר"
+#endif
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"

--- a/radio/src/translations/he.h
+++ b/radio/src/translations/he.h
@@ -1053,11 +1053,7 @@
 #endif
 
 // Bootloader common - Ascii only
-#if defined(COLORLCD)
 #define TR_BL_USB_CONNECTED           "חיבור חוטי חובר"
-#else
-#define TR_BL_USB_CONNECTED           CENTER "\011חיבור חוטי חובר"
-#endif
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"
@@ -1068,6 +1064,8 @@
 #define TR_BL_EXIT                    "יציאה"
 #define TR_BL_DIR_MISSING             " ארכיון חסר"
 #define TR_BL_DIR_EMPTY               " ארכיון ריק"
+#define TR_BL_WRITING_FW              "... כותב תוכנה"
+#define TR_BL_WRITING_COMPL           "כתיבה הושלמה"
 
 #if LCD_W >= 480
   #define TR_BL_INVALID_FIRMWARE       "Not a valid firmware file"
@@ -1086,23 +1084,17 @@
 #if defined(PCBTARANIS)
    // Bootloader Taranis specific - Ascii only
   #define TR_BL_RESTORE_EEPROM        "Restore EEPROM"
-  #define TR_BL_WRITING_FW            CENTER "\015...ממתין"
-  #define TR_BL_WRITING_COMPL         CENTER "\007כתיבה הושלמה"
   #if defined(RADIO_COMMANDO8)
     #define TR_BL_POWER_KEY           "לחץ על כפתור ההפעלה"
     #define TR_BL_FLASH_EXIT          "Exit the flashing mode."
   #endif
 #elif defined(PCBHORUS)
    // Bootloader Horus specific - Ascii only
-  #define TR_BL_WRITING_FW            "... כותב תוכנה"
-  #define TR_BL_WRITING_COMPL         "כתיבה הושלמה"
   #define TR_BL_SELECT_KEY            "[ENT] לבחירת קובץ"
   #define TR_BL_FLASH_KEY             "Hold [ENT] long to flash"
   #define TR_BL_EXIT_KEY              "[RTN] ליציאה"
 #elif defined(PCBNV14)
    // Bootloader NV14 specific - Ascii only
-  #define TR_BL_WRITING_FW            "Writing Firmware ..."
-  #define TR_BL_WRITING_COMPL         "Writing Completed"
   #define TR_BL_RF_USB_ACCESS         "RF USB access"
   #define TR_BL_CURRENT_FW            "Current Firmware:"
   #define TR_BL_SELECT_KEY            "[R TRIM] to select file"

--- a/radio/src/translations/it.h
+++ b/radio/src/translations/it.h
@@ -1055,7 +1055,11 @@
 #endif
 
 // Bootloader common
+#if defined(COLORLCD)
+#define TR_BL_USB_CONNECTED           "USB Connessa"
+#else
 #define TR_BL_USB_CONNECTED           CENTER "\011USB Connessa"
+#endif
 #define TR_BL_USB_PLUGIN              "O connetti il cavo USB"
 #define TR_BL_USB_MASS_STORE          "per memoria di massa"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "O connetti il cavo USB per memoria di massa"

--- a/radio/src/translations/it.h
+++ b/radio/src/translations/it.h
@@ -1055,11 +1055,7 @@
 #endif
 
 // Bootloader common
-#if defined(COLORLCD)
 #define TR_BL_USB_CONNECTED           "USB Connessa"
-#else
-#define TR_BL_USB_CONNECTED           CENTER "\011USB Connessa"
-#endif
 #define TR_BL_USB_PLUGIN              "O connetti il cavo USB"
 #define TR_BL_USB_MASS_STORE          "per memoria di massa"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "O connetti il cavo USB per memoria di massa"
@@ -1070,6 +1066,8 @@
 #define TR_BL_EXIT                    "Esci"
 #define TR_BL_DIR_MISSING             " Cartella non trovata"
 #define TR_BL_DIR_EMPTY               " Cartella vuota"
+#define TR_BL_WRITING_FW              "Scrittura Firmware..."
+#define TR_BL_WRITING_COMPL           "Scrittura completata"
 
 #if LCD_W >= 480
   #define TR_BL_INVALID_FIRMWARE       "Firmware non valido"
@@ -1088,23 +1086,17 @@
 #if defined(PCBTARANIS)
    // Bootloader Taranis specific
   #define TR_BL_RESTORE_EEPROM        "Ripristino EEPROM"
-  #define TR_BL_WRITING_FW            CENTER "\015Scrittura..."
-  #define TR_BL_WRITING_COMPL         CENTER "\007Scrittura completata"
   #if defined(RADIO_COMMANDO8)
     #define TR_BL_POWER_KEY           "Premi il bottone d'accensione"
     #define TR_BL_FLASH_EXIT          "Esci dal modo scrittura."
   #endif
 #elif defined(PCBHORUS)
    // Bootloader Horus specific
-  #define TR_BL_WRITING_FW            "Scrittura Firmware..."
-  #define TR_BL_WRITING_COMPL         "Scrittura completata"
   #define TR_BL_SELECT_KEY            "[ENT] per scegliere il file"
   #define TR_BL_FLASH_KEY             "Tenere premuto [ENT] per scrivere"
   #define TR_BL_EXIT_KEY              "[RTN] per uscire"
 #elif defined(PCBNV14)
    // Bootloader NV14 specific
-  #define TR_BL_WRITING_FW            "Scrittura Firmware..."
-  #define TR_BL_WRITING_COMPL         "Scrittura completata"
   #define TR_BL_RF_USB_ACCESS         "RF Accesso USB"
   #define TR_BL_CURRENT_FW            "Firmware corrente:"
   #define TR_BL_SELECT_KEY            "[R TRIM] per scegliere il file"

--- a/radio/src/translations/it.h
+++ b/radio/src/translations/it.h
@@ -1055,8 +1055,7 @@
 #endif
 
 // Bootloader common
-#define TR_BL_USB_CONNECT_BOOT        CENTER "\011USB Connessa"
-#define TR_BL_USB_CONNECTED           "USB Connessa"
+#define TR_BL_USB_CONNECTED           CENTER "\011USB Connessa"
 #define TR_BL_USB_PLUGIN              "O connetti il cavo USB"
 #define TR_BL_USB_MASS_STORE          "per memoria di massa"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "O connetti il cavo USB per memoria di massa"

--- a/radio/src/translations/jp.h
+++ b/radio/src/translations/jp.h
@@ -1051,8 +1051,7 @@
 #endif
 
 // Bootloader common - Ascii only
-#define TR_BL_USB_CONNECT_BOOT        CENTER "\011USB Connected"
-#define TR_BL_USB_CONNECTED           "USB Connected"
+#define TR_BL_USB_CONNECTED           CENTER "\011USB Connected"
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"

--- a/radio/src/translations/jp.h
+++ b/radio/src/translations/jp.h
@@ -1051,11 +1051,7 @@
 #endif
 
 // Bootloader common - Ascii only
-#if defined(COLORLCD)
 #define TR_BL_USB_CONNECTED           "USB Connected"
-#else
-#define TR_BL_USB_CONNECTED           CENTER "\011USB Connected"
-#endif
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"
@@ -1066,6 +1062,8 @@
 #define TR_BL_EXIT                    "Exit"
 #define TR_BL_DIR_MISSING             " Directory is missing"
 #define TR_BL_DIR_EMPTY               " Directory is empty"
+#define TR_BL_WRITING_FW              "Writing Firmware ..."
+#define TR_BL_WRITING_COMPL           "Writing Complete"
 
 #if LCD_W >= 480
   #define TR_BL_INVALID_FIRMWARE       "Not a valid firmware file"
@@ -1084,23 +1082,17 @@
 #if defined(PCBTARANIS)
    // Bootloader Taranis specific - Ascii only
   #define TR_BL_RESTORE_EEPROM        "Restore EEPROM"
-  #define TR_BL_WRITING_FW            CENTER "\015Writing..."
-  #define TR_BL_WRITING_COMPL         CENTER "\007Writing complete"
   #if defined(RADIO_COMMANDO8)
     #define TR_BL_POWER_KEY           "Press the power button."
     #define TR_BL_FLASH_EXIT          "Exit the flashing mode."
   #endif
 #elif defined(PCBHORUS)
    // Bootloader Horus specific - Ascii only
-  #define TR_BL_WRITING_FW            "Writing Firmware ..."
-  #define TR_BL_WRITING_COMPL         "Writing Completed"
   #define TR_BL_SELECT_KEY            "[ENT] to select file"
   #define TR_BL_FLASH_KEY             "Hold [ENT] long to flash"
   #define TR_BL_EXIT_KEY              "[RTN] to exit"
 #elif defined(PCBNV14)
    // Bootloader NV14 specific - Ascii only
-  #define TR_BL_WRITING_FW            "Writing Firmware ..."
-  #define TR_BL_WRITING_COMPL         "Writing Completed"
   #define TR_BL_RF_USB_ACCESS         "RF USB access"
   #define TR_BL_CURRENT_FW            "Current Firmware:"
   #define TR_BL_SELECT_KEY            "[R TRIM] to select file"

--- a/radio/src/translations/jp.h
+++ b/radio/src/translations/jp.h
@@ -1051,7 +1051,11 @@
 #endif
 
 // Bootloader common - Ascii only
+#if defined(COLORLCD)
+#define TR_BL_USB_CONNECTED           "USB Connected"
+#else
 #define TR_BL_USB_CONNECTED           CENTER "\011USB Connected"
+#endif
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"

--- a/radio/src/translations/nl.h
+++ b/radio/src/translations/nl.h
@@ -1066,7 +1066,11 @@
 #endif
 
 // Bootloader common - Ascii only
+#if defined(COLORLCD)
+#define TR_BL_USB_CONNECTED           "USB Connected"
+#else
 #define TR_BL_USB_CONNECTED           CENTER "\011USB Connected"
+#endif
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"

--- a/radio/src/translations/nl.h
+++ b/radio/src/translations/nl.h
@@ -1066,11 +1066,7 @@
 #endif
 
 // Bootloader common - Ascii only
-#if defined(COLORLCD)
 #define TR_BL_USB_CONNECTED           "USB Connected"
-#else
-#define TR_BL_USB_CONNECTED           CENTER "\011USB Connected"
-#endif
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"
@@ -1081,6 +1077,8 @@
 #define TR_BL_EXIT                    "Exit"
 #define TR_BL_DIR_MISSING             " Directory is missing"
 #define TR_BL_DIR_EMPTY               " Directory is empty"
+#define TR_BL_WRITING_FW              "Writing Firmware ..."
+#define TR_BL_WRITING_COMPL           "Writing Complete"
 
 #if LCD_W >= 480
   #define TR_BL_INVALID_FIRMWARE       "Not a valid firmware file"
@@ -1099,23 +1097,17 @@
 #if defined(PCBTARANIS)
    // Bootloader Taranis specific - Ascii only
   #define TR_BL_RESTORE_EEPROM        "Restore EEPROM"
-  #define TR_BL_WRITING_FW            CENTER "\015Writing..."
-  #define TR_BL_WRITING_COMPL         CENTER "\007Writing complete"
   #if defined(RADIO_COMMANDO8)
     #define TR_BL_POWER_KEY           "Press the power button."
     #define TR_BL_FLASH_EXIT          "Exit the flashing mode."
   #endif
 #elif defined(PCBHORUS)
    // Bootloader Horus specific - Ascii only
-  #define TR_BL_WRITING_FW            "Writing Firmware ..."
-  #define TR_BL_WRITING_COMPL         "Writing Completed"
   #define TR_BL_SELECT_KEY            "[ENT] to select file"
   #define TR_BL_FLASH_KEY             "Hold [ENT] long to flash"
   #define TR_BL_EXIT_KEY              "[RTN] to exit"
 #elif defined(PCBNV14)
    // Bootloader NV14 specific - Ascii only
-  #define TR_BL_WRITING_FW            "Writing Firmware ..."
-  #define TR_BL_WRITING_COMPL         "Writing Completed"
   #define TR_BL_RF_USB_ACCESS         "RF USB access"
   #define TR_BL_CURRENT_FW            "Current Firmware:"
   #define TR_BL_SELECT_KEY            "[R TRIM] to select file"

--- a/radio/src/translations/nl.h
+++ b/radio/src/translations/nl.h
@@ -1066,8 +1066,7 @@
 #endif
 
 // Bootloader common - Ascii only
-#define TR_BL_USB_CONNECT_BOOT        CENTER "\011USB Connected"
-#define TR_BL_USB_CONNECTED           "USB Connected"
+#define TR_BL_USB_CONNECTED           CENTER "\011USB Connected"
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"

--- a/radio/src/translations/pl.h
+++ b/radio/src/translations/pl.h
@@ -1053,7 +1053,11 @@
 #endif
 
 // Bootloader common - Ascii only
+#if defined(COLORLCD)
+#define TR_BL_USB_CONNECTED           "USB polaczone"
+#else
 #define TR_BL_USB_CONNECTED           CENTER "\011USB polaczone"
+#endif
 #define TR_BL_USB_PLUGIN              "lub podlacz kabel USB"
 #define TR_BL_USB_MASS_STORE          "dla trybu danych"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "lub podlacz kabel USB dla trybu danych"

--- a/radio/src/translations/pl.h
+++ b/radio/src/translations/pl.h
@@ -1053,11 +1053,7 @@
 #endif
 
 // Bootloader common - Ascii only
-#if defined(COLORLCD)
 #define TR_BL_USB_CONNECTED           "USB polaczone"
-#else
-#define TR_BL_USB_CONNECTED           CENTER "\011USB polaczone"
-#endif
 #define TR_BL_USB_PLUGIN              "lub podlacz kabel USB"
 #define TR_BL_USB_MASS_STORE          "dla trybu danych"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "lub podlacz kabel USB dla trybu danych"
@@ -1068,6 +1064,8 @@
 #define TR_BL_EXIT                    "Wyjdz"
 #define TR_BL_DIR_MISSING             " Brak katalogu"
 #define TR_BL_DIR_EMPTY               " Katalog jest pusty"
+#define TR_BL_WRITING_FW              "Zapis firmware ..."
+#define TR_BL_WRITING_COMPL           "Zapis ukonczony"
 
 #if LCD_W >= 480
   #define TR_BL_INVALID_FIRMWARE       "Nieprawidlowy plik firmware"
@@ -1086,23 +1084,17 @@
 #if defined(PCBTARANIS)
    // Bootloader Taranis specific - Ascii only
   #define TR_BL_RESTORE_EEPROM        "Przywroc EEPROM"
-  #define TR_BL_WRITING_FW            CENTER "\015Zapis..."
-  #define TR_BL_WRITING_COMPL         CENTER "\007Zapis ukonczony"
   #if defined(RADIO_COMMANDO8)
     #define TR_BL_POWER_KEY           "Nacisnij przycisk Power"
     #define TR_BL_FLASH_EXIT          "Wyjdz z trybu flashowania"
   #endif
 #elif defined(PCBHORUS)
    // Bootloader Horus specific - Ascii only
-  #define TR_BL_WRITING_FW            "Zapis firmware ..."
-  #define TR_BL_WRITING_COMPL         "Zapis ukonczony"
   #define TR_BL_SELECT_KEY            "[ENT] aby wybrac plik"
   #define TR_BL_FLASH_KEY             "Przytrzymaj [ENT] aby flashowac"
   #define TR_BL_EXIT_KEY              "[RTN] aby wyjsc"
 #elif defined(PCBNV14)
    // Bootloader NV14 specific - Ascii only
-  #define TR_BL_WRITING_FW            "Zapis firmware ..."
-  #define TR_BL_WRITING_COMPL         "Zapis ukonczony"
   #define TR_BL_RF_USB_ACCESS         "Dostep RF USB"
   #define TR_BL_CURRENT_FW            "Obecny firmware:"
   #define TR_BL_SELECT_KEY            "[R TRIM] aby wybrac plik"

--- a/radio/src/translations/pl.h
+++ b/radio/src/translations/pl.h
@@ -1053,8 +1053,7 @@
 #endif
 
 // Bootloader common - Ascii only
-#define TR_BL_USB_CONNECT_BOOT        CENTER "\011USB polaczone"
-#define TR_BL_USB_CONNECTED           "USB polaczone"
+#define TR_BL_USB_CONNECTED           CENTER "\011USB polaczone"
 #define TR_BL_USB_PLUGIN              "lub podlacz kabel USB"
 #define TR_BL_USB_MASS_STORE          "dla trybu danych"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "lub podlacz kabel USB dla trybu danych"

--- a/radio/src/translations/pt.h
+++ b/radio/src/translations/pt.h
@@ -1061,11 +1061,7 @@
 #endif
 
 // Bootloader common - Ascii only
-#if defined(COLORLCD)
 #define TR_BL_USB_CONNECTED           "USB Connected"
-#else
-#define TR_BL_USB_CONNECTED           CENTER "\011USB Connected"
-#endif
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"
@@ -1076,6 +1072,8 @@
 #define TR_BL_EXIT                    "Exit"
 #define TR_BL_DIR_MISSING             " Directory is missing"
 #define TR_BL_DIR_EMPTY               " Directory is empty"
+#define TR_BL_WRITING_FW              "Writing Firmware ..."
+#define TR_BL_WRITING_COMPL           "Writing Complete"
 
 #if LCD_W >= 480
   #define TR_BL_INVALID_FIRMWARE       "Not a valid firmware file"
@@ -1094,23 +1092,17 @@
 #if defined(PCBTARANIS)
    // Bootloader Taranis specific - Ascii only
   #define TR_BL_RESTORE_EEPROM        "Restore EEPROM"
-  #define TR_BL_WRITING_FW            CENTER "\015Writing..."
-  #define TR_BL_WRITING_COMPL         CENTER "\007Writing complete"
   #if defined(RADIO_COMMANDO8)
     #define TR_BL_POWER_KEY           "Press the power button."
     #define TR_BL_FLASH_EXIT          "Exit the flashing mode."
   #endif
 #elif defined(PCBHORUS)
    // Bootloader Horus specific - Ascii only
-  #define TR_BL_WRITING_FW            "Writing Firmware ..."
-  #define TR_BL_WRITING_COMPL         "Writing Completed"
   #define TR_BL_SELECT_KEY            "[ENT] to select file"
   #define TR_BL_FLASH_KEY             "Hold [ENT] long to flash"
   #define TR_BL_EXIT_KEY              "[RTN] to exit"
 #elif defined(PCBNV14)
    // Bootloader NV14 specific - Ascii only
-  #define TR_BL_WRITING_FW            "Writing Firmware ..."
-  #define TR_BL_WRITING_COMPL         "Writing Completed"
   #define TR_BL_RF_USB_ACCESS         "RF USB access"
   #define TR_BL_CURRENT_FW            "Current Firmware:"
   #define TR_BL_SELECT_KEY            "[R TRIM] to select file"

--- a/radio/src/translations/pt.h
+++ b/radio/src/translations/pt.h
@@ -1061,7 +1061,11 @@
 #endif
 
 // Bootloader common - Ascii only
+#if defined(COLORLCD)
+#define TR_BL_USB_CONNECTED           "USB Connected"
+#else
 #define TR_BL_USB_CONNECTED           CENTER "\011USB Connected"
+#endif
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"

--- a/radio/src/translations/pt.h
+++ b/radio/src/translations/pt.h
@@ -1061,8 +1061,7 @@
 #endif
 
 // Bootloader common - Ascii only
-#define TR_BL_USB_CONNECT_BOOT        CENTER "\011USB Connected"
-#define TR_BL_USB_CONNECTED           "USB Connected"
+#define TR_BL_USB_CONNECTED           CENTER "\011USB Connected"
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"

--- a/radio/src/translations/se.h
+++ b/radio/src/translations/se.h
@@ -1089,8 +1089,7 @@
 #endif
 
 // Bootloader common
-#define TR_BL_USB_CONNECT_BOOT          CENTER "\011USB ansluten"
-#define TR_BL_USB_CONNECTED             "USB ansluten"
+#define TR_BL_USB_CONNECTED             CENTER "\011USB ansluten"
 #define TR_BL_USB_PLUGIN                "Eller anslut med en USB-kabel"
 #define TR_BL_USB_MASS_STORE            "foer masslagring"
 #define TR_BL_USB_PLUGIN_MASS_STORE     "Eller anslut med en USB-kabel foer masslagring"

--- a/radio/src/translations/se.h
+++ b/radio/src/translations/se.h
@@ -1089,7 +1089,11 @@
 #endif
 
 // Bootloader common
+#if defined(COLORLCD)
+#define TR_BL_USB_CONNECTED             "USB ansluten"
+#else
 #define TR_BL_USB_CONNECTED             CENTER "\011USB ansluten"
+#endif
 #define TR_BL_USB_PLUGIN                "Eller anslut med en USB-kabel"
 #define TR_BL_USB_MASS_STORE            "foer masslagring"
 #define TR_BL_USB_PLUGIN_MASS_STORE     "Eller anslut med en USB-kabel foer masslagring"

--- a/radio/src/translations/se.h
+++ b/radio/src/translations/se.h
@@ -1089,11 +1089,7 @@
 #endif
 
 // Bootloader common
-#if defined(COLORLCD)
 #define TR_BL_USB_CONNECTED             "USB ansluten"
-#else
-#define TR_BL_USB_CONNECTED             CENTER "\011USB ansluten"
-#endif
 #define TR_BL_USB_PLUGIN                "Eller anslut med en USB-kabel"
 #define TR_BL_USB_MASS_STORE            "foer masslagring"
 #define TR_BL_USB_PLUGIN_MASS_STORE     "Eller anslut med en USB-kabel foer masslagring"
@@ -1104,6 +1100,8 @@
 #define TR_BL_EXIT                      "Avsluta"
 #define TR_BL_DIR_MISSING               " Katalogen saknas"
 #define TR_BL_DIR_EMPTY                 " Katalogen aer tom"
+#define TR_BL_WRITING_FW                "Skriver firmware ..."
+#define TR_BL_WRITING_COMPL             "Skrivning klar"
 
 #if LCD_W >= 480
   #define TR_BL_INVALID_FIRMWARE        "Inte en giltig firmwarefil"
@@ -1122,23 +1120,17 @@
 #if defined(PCBTARANIS)
    // Bootloader Taranis specific
   #define TR_BL_RESTORE_EEPROM          "Aaterställ EEPROM"
-  #define TR_BL_WRITING_FW              CENTER "\015Skriver..."
-  #define TR_BL_WRITING_COMPL           CENTER "\007Skrivning klar"
   #if defined(RADIO_COMMANDO8)
     #define TR_BL_POWER_KEY             "Tryck paa startknappen."
     #define TR_BL_FLASH_EXIT            "Avsluta flashningsläget."
   #endif
 #elif defined(PCBHORUS)
    // Bootloader Horus specific
-  #define TR_BL_WRITING_FW              "Skriver firmware ..."
-  #define TR_BL_WRITING_COMPL           "Skrivning klar"
   #define TR_BL_SELECT_KEY              "[ENT] för att vaelja fil"
   #define TR_BL_FLASH_KEY               "Tryck [ENT] foer att flasha"
   #define TR_BL_EXIT_KEY                "[RTN] foer att avbryta"
 #elif defined(PCBNV14)
    // Bootloader NV14 specific
-  #define TR_BL_WRITING_FW              "Skriver firmware ..."
-  #define TR_BL_WRITING_COMPL           "Skrivning klar"
   #define TR_BL_RF_USB_ACCESS           "RF USB access"
   #define TR_BL_CURRENT_FW              "Nuvarande firmware:"
   #define TR_BL_SELECT_KEY              "[R TRIM] foer att vaelja fil"

--- a/radio/src/translations/tw.h
+++ b/radio/src/translations/tw.h
@@ -1051,11 +1051,7 @@
 #endif
 
 // Bootloader common
-#if defined(COLORLCD)
 #define TR_BL_USB_CONNECTED           "USB Connected"
-#else
-#define TR_BL_USB_CONNECTED           CENTER "\011USB Connected"
-#endif
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"
@@ -1066,6 +1062,8 @@
 #define TR_BL_EXIT                    "Exit"
 #define TR_BL_DIR_MISSING             " Directory is missing"
 #define TR_BL_DIR_EMPTY               " Directory is empty"
+#define TR_BL_WRITING_FW              "Writing Firmware ..."
+#define TR_BL_WRITING_COMPL           "Writing Completed"
 
 #if LCD_W >= 480
   #define TR_BL_INVALID_FIRMWARE       "Not a valid firmware file"
@@ -1084,23 +1082,17 @@
 #if defined(PCBTARANIS)
    // Bootloader Taranis specific
   #define TR_BL_RESTORE_EEPROM        "Restore EEPROM"
-  #define TR_BL_WRITING_FW            CENTER "\015Writing..."
-  #define TR_BL_WRITING_COMPL         CENTER "\007Writing complete"
   #if defined(RADIO_COMMANDO8)
     #define TR_BL_POWER_KEY           "Press the power button."
     #define TR_BL_FLASH_EXIT          "Exit the flashing mode."
   #endif
 #elif defined(PCBHORUS)
    // Bootloader Horus specific
-  #define TR_BL_WRITING_FW            "Writing Firmware ..."
-  #define TR_BL_WRITING_COMPL         "Writing Completed"
   #define TR_BL_SELECT_KEY            "[ENT] to select file"
   #define TR_BL_FLASH_KEY             "Hold [ENT] long to flash"
   #define TR_BL_EXIT_KEY              "[RTN] to exit"
 #elif defined(PCBNV14)
    // Bootloader NV14 specific
-  #define TR_BL_WRITING_FW            "Writing Firmware ..."
-  #define TR_BL_WRITING_COMPL         "Writing Completed"
   #define TR_BL_RF_USB_ACCESS         "RF USB access"
   #define TR_BL_CURRENT_FW            "Current Firmware:"
   #define TR_BL_SELECT_KEY            "[R TRIM] to select file"

--- a/radio/src/translations/tw.h
+++ b/radio/src/translations/tw.h
@@ -1051,7 +1051,11 @@
 #endif
 
 // Bootloader common
+#if defined(COLORLCD)
+#define TR_BL_USB_CONNECTED           "USB Connected"
+#else
 #define TR_BL_USB_CONNECTED           CENTER "\011USB Connected"
+#endif
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"

--- a/radio/src/translations/tw.h
+++ b/radio/src/translations/tw.h
@@ -1051,8 +1051,7 @@
 #endif
 
 // Bootloader common
-#define TR_BL_USB_CONNECT_BOOT        CENTER "\011USB Connected"
-#define TR_BL_USB_CONNECTED           "USB Connected"
+#define TR_BL_USB_CONNECTED           CENTER "\011USB Connected"
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
 #define TR_BL_USB_PLUGIN_MASS_STORE   "Or plug in a USB cable for mass storage"


### PR DESCRIPTION
Fix centering of "USB connected" on B&W bootloader

Introduced in 2.9 thorugh #2946