### PR TITLE
Show only defined entries in diaganas

### DIFF
--- a/radio/src/gui/colorlcd/radio_diaganas.cpp
+++ b/radio/src/gui/colorlcd/radio_diaganas.cpp
@@ -74,6 +74,7 @@ class AnaViewWindow: public FormWindow {
         + adcGetMaxInputs(ADC_INPUT_POT);
 
       for (uint8_t i = 0; i < max_inputs; i++) {
+        if (i > adcGetMaxInputs(ADC_INPUT_MAIN) && !IS_POT_AVAILABLE(i - adcGetMaxInputs(ADC_INPUT_MAIN))) continue;
 #if LCD_W > LCD_H
         if ((i & 1) == 0)
           line = newLine(grid);


### PR DESCRIPTION
This displays only configured POT/Sliders in colorlcd diaganas, so that unpopulated extra entries aren't displayed

While it started as a workaround for a curent issue handling EXT3/EXT4 in ADC refactor, it is also I guess a logical thing to do