### PR TITLE
Companion simulator pots and sliders adc refactor fixes

### DIFF
--- a/companion/src/firmwares/edgetx/yaml_modeldata.cpp
+++ b/companion/src/firmwares/edgetx/yaml_modeldata.cpp
@@ -148,7 +148,7 @@ struct YamlThrTrace {
   }
 };
 
-//  EdgeTX 2.9.0 ADC refactor changed order of pots and sliders that affected interpretation of model warnings
+//  EdgeTX 2.10.0 ADC refactor changed order of pots and sliders that affected interpretation of model warnings
 //  This conversion needs to be revisited when Companion is refactored to use ADC radio defns
 //  Make ADC orders backwards compatible
 
@@ -158,7 +158,7 @@ int adcPotsBeforeSliders()
 {
   auto board = getCurrentBoard();
 
-  if (version >= SemanticVersion("2.9.0")) {
+  if (version >= SemanticVersion("2.10.0")) {
     if (IS_TARANIS_X9(board) || IS_FAMILY_HORUS(board) || IS_FAMILY_T16(board) || IS_RADIOMASTER_BOXER(board))
       return 3;
     else if (IS_TARANIS_X9LITE(board))

--- a/companion/src/helpers.cpp
+++ b/companion/src/helpers.cpp
@@ -814,9 +814,11 @@ SemanticVersion& SemanticVersion::operator=(const SemanticVersion& rhs)
 
 bool SemanticVersion::isValid(const QString vers)
 {
-  QString v(vers);
+  QString v(vers.trimmed());
 
-  v = v.trimmed();
+  if (v.isEmpty())
+    return false;
+
   if (v.toLower().startsWith("v"))
     v = v.mid(1);
 

--- a/radio/src/targets/simu/opentxsimulator.cpp
+++ b/radio/src/targets/simu/opentxsimulator.cpp
@@ -236,15 +236,22 @@ void OpenTxSimulator::setTrainerInput(unsigned int inputNumber, int16_t value)
 
 void OpenTxSimulator::setInputValue(int type, uint8_t index, int16_t value)
 {
-  //qDebug() << type << index << value << this->thread();
+  qDebug() << type << index << value << this->thread();
   switch (type) {
     case INPUT_SRC_ANALOG :
     case INPUT_SRC_STICK :
       setAnalogValue(index, value);
       break;
     case INPUT_SRC_KNOB :
-    case INPUT_SRC_SLIDER :
       setAnalogValue(index + adcGetInputOffset(ADC_INPUT_POT), value);
+      break;
+    case INPUT_SRC_SLIDER :
+      // TODO redo this when Companion refactored to use radio json adc files
+      //setAnalogValue(index + adcGetInputOffset(ADC_INPUT_POT), value);
+      static const int slideroffset = adcGetInputIdx("SL1", 3);
+      //qDebug() << "SL1:" << slideroffset;
+      if (slideroffset >= 0)
+        setAnalogValue(index + slideroffset, value);
       break;
     case INPUT_SRC_TXVIN :
       if (adcGetMaxInputs(ADC_INPUT_VBAT) > 0) {

--- a/radio/src/targets/simu/opentxsimulator.cpp
+++ b/radio/src/targets/simu/opentxsimulator.cpp
@@ -239,7 +239,7 @@ void OpenTxSimulator::setTrainerInput(unsigned int inputNumber, int16_t value)
 
 void OpenTxSimulator::setInputValue(int type, uint8_t index, int16_t value)
 {
-  qDebug() << type << index << value << this->thread();
+  //qDebug() << type << index << value << this->thread();
   switch (type) {
     case INPUT_SRC_ANALOG :
     case INPUT_SRC_STICK :

--- a/radio/src/targets/simu/opentxsimulator.cpp
+++ b/radio/src/targets/simu/opentxsimulator.cpp
@@ -50,6 +50,9 @@ QVector<QIODevice *> OpenTxSimulator::tracebackDevices;
 
 uint16_t simu_get_analog(uint8_t idx)
 {
+  // 6POS simu mechanism use a different scale, so needs specific offset
+  if (IS_POT_MULTIPOS(idx - adcGetInputOffset(ADC_INPUT_POT)))
+      return (g_anas[idx] * 2);
   return (g_anas[idx] * 2) + 2048;
 }
 

--- a/radio/src/targets/simu/opentxsimulator.cpp
+++ b/radio/src/targets/simu/opentxsimulator.cpp
@@ -51,8 +51,18 @@ QVector<QIODevice *> OpenTxSimulator::tracebackDevices;
 uint16_t simu_get_analog(uint8_t idx)
 {
   // 6POS simu mechanism use a different scale, so needs specific offset
-  if (IS_POT_MULTIPOS(idx - adcGetInputOffset(ADC_INPUT_POT)))
-      return (g_anas[idx] * 2);
+  if (IS_POT_MULTIPOS(idx - adcGetInputOffset(ADC_INPUT_POT))) {
+    // Use radio calibration data to determine conversion factor
+    StepsCalibData * calib = (StepsCalibData *) &g_eeGeneral.calib[idx];
+    int range6POS = 2048; // Default if calibration is not valid
+    if (calib->count != 0) {
+      // calculate 6POS switch range from calibration data
+      int c1 = calib->steps[calib->count - 1] * 32; // last calibration value
+      int c2 = calib->steps[calib->count - 2] * 32; // 2nd last calibration value
+      range6POS = c1 + (c1 - c2) / 2;
+    }
+    return (g_anas[idx] * range6POS / 2048);
+  }
   return (g_anas[idx] * 2) + 2048;
 }
 

--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -479,7 +479,7 @@ uint32_t readTrims()
 {
   uint32_t result = 0;
 
-  for (int i = 0; i < MAX_TRIMS; i++) {
+  for (int i = 0; i < MAX_TRIMS * 2; i++) {
     if (trimsStates[i]) {
       // TRACE("trim pressed %d", i);
       result |= 1 << i;


### PR DESCRIPTION
Fixes #3724

Summary of changes:
- incorporate 3djc PR #3727
- calculate sliders offset in adc
- fix trims credit to @philmoz 
- 6POS calculation using calibration data if exists credit to @philmoz
- fix yaml to convert between pre and post adc refactor

TODO:
- [x] Sliders
- [x] Trims
- [x] 6POS
- [x] Center beep
- [x] Warnings