### PR TITLE
Missing translated line for IT in recent commit

### DIFF
--- a/radio/src/translations/it.h
+++ b/radio/src/translations/it.h
@@ -839,6 +839,7 @@
 #define TR_DEBUG                        "Debug"
 #define TR_KEYS_BTN                     BUTTON(TR("SW", "Tasti"))
 #define TR_ANALOGS_BTN                  BUTTON("Analogici")
+#define TR_FS_BTN                       BUTTON(TR("Fun. Inter.", "Funzione interruttori"))
 #define TR_TOUCH_NOTFOUND               "Schermo touch non trovato"
 #define TR_TOUCH_EXIT                   "Tocca lo schermo per uscire"
 #define TR_SET                          BUTTON("Set")


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #

Missing line in recent commit, so for IT you can't compile it.
Please when posting commits that contemplate a new translation ping the translators, thank you!

Summary of changes:

Line 842
#define TR_FS_BTN                       BUTTON(TR("Fun. Inter.", "Funzione interruttori"))