### PR TITLE
fix: NV14 uses active-high for keys and trims

### DIFF
--- a/radio/src/targets/nv14/bootloader/boot_menu.cpp
+++ b/radio/src/targets/nv14/bootloader/boot_menu.cpp
@@ -70,6 +70,7 @@ void bootloaderInitScreen()
   lcdInitDisplayDriver();
   backlightInit();
   backlightEnable(100);
+  setTrimsAsButtons(true);
 }
 
 static void bootloaderDrawTitle(const char* text)

--- a/radio/src/targets/nv14/hal.h
+++ b/radio/src/targets/nv14/hal.h
@@ -105,6 +105,9 @@
 #define KEYS_GPIOH_PINS                 (GPIO_Pin_2 | GPIO_Pin_7)
 #define KEYS_GPIOJ_PINS                 (GPIO_Pin_0 | GPIO_Pin_12)
 
+#define KEYS_GPIO_ACTIVE_HIGH
+#define TRIMS_GPIO_ACTIVE_HIGH
+
 // ADC
 #define ADC_RCC_AHB1Periph              (RCC_AHB1Periph_DMA2)
 #define ADC_RCC_APB2Periph              0

--- a/radio/util/hw_defs/hal_keys.py
+++ b/radio/util/hw_defs/hal_keys.py
@@ -60,6 +60,7 @@ class Key:
     def __init__(self, gpio, pin):
         self.gpio = gpio
         self.pin = pin
+        self.active_low = True
 
 class Trim:
 
@@ -67,6 +68,7 @@ class Trim:
         self.name = name
         self.dec = dec
         self.inc = inc
+        self.active_low = True
 
 def get_trim_switch(hw_defs, tag):
 
@@ -74,7 +76,10 @@ def get_trim_switch(hw_defs, tag):
     pin  = f'TRIMS_GPIO_PIN_{tag}'
 
     if (gpio in hw_defs) and (pin in hw_defs):
-        return Key(hw_defs[gpio], hw_defs[pin])
+        key = Key(hw_defs[gpio], hw_defs[pin])
+        if 'TRIMS_GPIO_ACTIVE_HIGH' in hw_defs:
+            key.active_low = False
+        return key
 
     return None
 
@@ -108,6 +113,8 @@ def parse_keys(hw_defs):
             key.key = k['key']
             key.name = name
             key.label = k['label']
+            if 'KEYS_GPIO_ACTIVE_HIGH' in hw_defs:
+                key.active_low = False
             keys.append(key)
 
     return keys

--- a/radio/util/hw_defs/stm32_keys.jinja
+++ b/radio/util/hw_defs/stm32_keys.jinja
@@ -5,14 +5,16 @@
 
 static inline void _init_keys()
 {
+{% for key_gpio, pins in key_gpios | dictsort %}
+  stm32_gpio_enable_clock({{ key_gpio }});
+{% endfor %}
   LL_GPIO_InitTypeDef pinInit;
   LL_GPIO_StructInit(&pinInit);
   pinInit.Mode = LL_GPIO_MODE_INPUT;
-  pinInit.Pull = LL_GPIO_PULL_UP;
-{% for key_gpio, pins in key_gpios.items() | sort %}
-  stm32_gpio_enable_clock({{ key_gpio }});
-  pinInit.Pin = {{ pins | join('|') }};
-  LL_GPIO_Init({{ key_gpio }}, &pinInit);
+{% for key in keys %}
+  pinInit.Pin = {{ key.pin }};
+  pinInit.Pull = {{ 'LL_GPIO_PULL_UP' if key.active_low else 'LL_GPIO_PULL_DOWN' }};
+  LL_GPIO_Init({{ key.gpio }}, &pinInit);
 {% endfor %}
 }
 
@@ -20,7 +22,7 @@ static inline uint32_t _read_keys()
 {
   uint32_t keys = 0;
 {% for key in keys %}
-  if (!LL_GPIO_IsInputPinSet({{ key.gpio }}, {{ key.pin }}))
+  if ({{'!' if key.active_low }}LL_GPIO_IsInputPinSet({{ key.gpio }}, {{ key.pin }}))
     keys |= (1 << {{ key.key }});
 {% endfor %}
   return keys;
@@ -28,14 +30,19 @@ static inline uint32_t _read_keys()
 
 static inline void _init_trims()
 {
+{% for trim_gpio, pins in trim_gpios | dictsort %}
+  stm32_gpio_enable_clock({{ trim_gpio }});
+{% endfor %}
   LL_GPIO_InitTypeDef pinInit;
   LL_GPIO_StructInit(&pinInit);
   pinInit.Mode = LL_GPIO_MODE_INPUT;
-  pinInit.Pull = LL_GPIO_PULL_UP;
-{% for trim_gpio, pins in trim_gpios.items() | sort %}
-  stm32_gpio_enable_clock({{ trim_gpio }});
-  pinInit.Pin = {{ pins | join('|') }};
-  LL_GPIO_Init({{ trim_gpio }}, &pinInit);
+{% for trim in trims %}
+  pinInit.Pin = {{ trim.dec.pin }};
+  pinInit.Pull = {{ 'LL_GPIO_PULL_UP' if trim.dec.active_low else 'LL_GPIO_PULL_DOWN' }};
+  LL_GPIO_Init({{ trim.dec.gpio }}, &pinInit);
+  pinInit.Pin = {{ trim.inc.pin }};
+  pinInit.Pull = {{ 'LL_GPIO_PULL_UP' if trim.inc.active_low else 'LL_GPIO_PULL_DOWN' }};
+  LL_GPIO_Init({{ trim.inc.gpio }}, &pinInit);
 {% endfor %}
 }
 
@@ -43,9 +50,9 @@ static inline uint32_t _read_trims()
 {
   uint32_t trims = 0;
 {% for trim in trims %}
-  if (!LL_GPIO_IsInputPinSet({{ trim.dec.gpio }}, {{ trim.dec.pin }}))
+  if ({{'!' if trim.dec.active_low }}LL_GPIO_IsInputPinSet({{ trim.dec.gpio }}, {{ trim.dec.pin }}))
     trims |= (1 << {{ loop.index0 * 2 }});
-  if (!LL_GPIO_IsInputPinSet({{ trim.inc.gpio }}, {{ trim.inc.pin }}))
+  if ({{'!' if trim.inc.active_low }}LL_GPIO_IsInputPinSet({{ trim.inc.gpio }}, {{ trim.inc.pin }}))
     trims |= (1 << {{ loop.index0 * 2 + 1 }});
 {% endfor %}
   return trims;


### PR DESCRIPTION
Summary of changes:
- add `active_low` boolean attribute for trims and keys
- init pins separately to allow for different pull-up/-down settings based on `active_low`
- read pins according to `active_low`
- activate *"trims as buttons"* in bootloader