### PR TITLE
Allow compile without multimodule support

### DIFF
--- a/radio/src/gui/gui_common.h
+++ b/radio/src/gui/gui_common.h
@@ -172,6 +172,7 @@ inline uint8_t MODULE_CHANNELS_ROWS(int moduleIdx)
   if (!IS_MODULE_ENABLED(moduleIdx)) {
     return HIDDEN_ROW;
   }
+#if defined(MULTIMODULE)
   else if (isModuleMultimodule(moduleIdx)) {
     if (IS_RX_MULTI(moduleIdx))
       return HIDDEN_ROW;
@@ -179,7 +180,9 @@ inline uint8_t MODULE_CHANNELS_ROWS(int moduleIdx)
       return 1;
     else
       return 0;
-  } else if (isModuleDSM2(moduleIdx) || isModuleCrossfire(moduleIdx) ||
+  }
+#endif
+  else if (isModuleDSM2(moduleIdx) || isModuleCrossfire(moduleIdx) ||
              isModuleGhost(moduleIdx) || isModuleSBUS(moduleIdx) ||
              isModuleDSMP(moduleIdx)) {
     // fixed number of channels

--- a/radio/src/targets/common/arm/CMakeLists.txt
+++ b/radio/src/targets/common/arm/CMakeLists.txt
@@ -181,6 +181,7 @@ endif()
 
 if(PPM)
   add_definitions(-DPPM)
+  set(SRC ${SRC} telemetry/mlink.cpp)
 endif()
 
 if(DSM2)
@@ -224,6 +225,7 @@ if(MULTIMODULE)
   add_definitions(-DMULTIMODULE)
   set(SRC ${SRC} pulses/multi.cpp telemetry/hitec.cpp telemetry/hott.cpp telemetry/mlink.cpp telemetry/multi.cpp io/multi_firmware_update.cpp)
 endif()
+
 if(MULTIMODULE OR AFHDS3)
   set(SRC ${SRC} telemetry/flysky_ibus.cpp)
 endif()

--- a/radio/src/telemetry/frsky_defs.h
+++ b/radio/src/telemetry/frsky_defs.h
@@ -186,12 +186,10 @@
 #define SP2UART_A_ID              0xFD00
 #define SP2UART_B_ID              0xFD01
 
-#if defined(MULTIMODULE)
 // Virtual IDs, value can be changed to anything only used for display
 #define RX_LQI_ID                 0xFFFC
 #define TX_LQI_ID                 0xFFFD
 #define TX_RSSI_ID                0xFFFE
-#endif
 
 // Default sensor data IDs (Physical IDs + CRC)
 #define DATA_ID_VARIO             0x00 // 0

--- a/radio/src/telemetry/spektrum.cpp
+++ b/radio/src/telemetry/spektrum.cpp
@@ -562,7 +562,7 @@ void processSpektrumPacket(const uint8_t *packet)
     return; // Not a sensor
   }
 
-#if defined(LUA)
+#if defined(LUA) && defined(MULTIMODULE)
     // Generic way for LUA Script to request ANY Specktrum Telemety Raw Data
     // this can be used for TextGen or any other telemetry message
 
@@ -775,7 +775,9 @@ void processDSMBindPacket(uint8_t module, const uint8_t *packet)
     moduleState[module].mode = MODULE_MODE_NORMAL;
     restartModuleAsync(module, 50); // ~200ms
     
-  } else if (g_model.moduleData[module].type == MODULE_TYPE_MULTIMODULE &&
+  }
+#if defined(MULTIMODULE)
+  else if (g_model.moduleData[module].type == MODULE_TYPE_MULTIMODULE &&
              g_model.moduleData[module].multi.rfProtocol ==
              MODULE_SUBTYPE_MULTI_DSM2 &&
              g_model.moduleData[module].subType == MM_RF_DSM2_SUBTYPE_AUTO) {
@@ -817,7 +819,7 @@ void processDSMBindPacket(uint8_t module, const uint8_t *packet)
 
     storageDirty(EE_MODEL);
   }
-
+#endif
   debugval = packet[7] << 24 | packet[6] << 16 | packet[5] << 8 | packet[4];
 
   /* log the bind packet as telemetry for quick debugging */

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -50,6 +50,9 @@
   #include "hitec.h"
   #include "hott.h"
   #include "multi.h"
+#endif
+
+#if  defined(MULTIMODULE) || defined(PPM)
   #include "mlink.h"
 #endif
 
@@ -110,6 +113,7 @@ rxStatStruct *getRxStatLabels() {
   uint8_t moduleType = g_model.moduleData[moduleToUse].type;
 
   switch(moduleType) {
+#if defined(MULTIMODULE)
     case MODULE_TYPE_MULTIMODULE: {
         uint8_t multiProtocol = g_model.moduleData[moduleToUse].multi.rfProtocol;
 
@@ -121,7 +125,7 @@ rxStatStruct *getRxStatLabels() {
         }
       }
       break;
-    
+#endif
     case MODULE_TYPE_PPM:
       if(moduleState[moduleToUse].protocol == PROTOCOL_CHANNELS_PPM_MLINK) {
         rxStat.label = STR_RXSTAT_LABEL_RQLY;

--- a/radio/src/telemetry/telemetry_sensors.cpp
+++ b/radio/src/telemetry/telemetry_sensors.cpp
@@ -45,6 +45,9 @@
   #include "hitec.h"
   #include "hott.h"
   #include "multi.h"
+#endif
+
+#if  defined(MULTIMODULE) || defined(PPM)
   #include "mlink.h"
 #endif
 
@@ -566,7 +569,7 @@ int setTelemetryValue(TelemetryProtocol protocol, uint16_t id, uint8_t subId,
         break;
 #endif
 
-#if defined(MULTIMODULE) or defined(PPM)
+#if defined(MULTIMODULE) || defined(PPM)
       case PROTOCOL_TELEMETRY_MLINK:
         mlinkSetDefault(index, id, subId, instance);
         break;


### PR DESCRIPTION
Since we are getting real low on flash on some radio, it may be needed to exclude multi for special purposes (make room for DEBUG for exemple).

This fixes current compilation issues when MULTIMODULE is not define. 

No end user impact