### PR TITLE
fix: SD Logs interval shown as default value when entering SF edit window

### DIFF
--- a/radio/src/gui/colorlcd/special_functions.cpp
+++ b/radio/src/gui/colorlcd/special_functions.cpp
@@ -232,7 +232,8 @@ class SpecialFunctionEditPage : public Page
         break;
 
       case FUNC_LOGS: {
-        CFN_PARAM(cfn) = SD_LOGS_PERIOD_DEFAULT;          // set default value
+        if(CFN_PARAM(cfn) == 0)                           // use stored value if SF exists
+          CFN_PARAM(cfn) = SD_LOGS_PERIOD_DEFAULT;        // otherwise initialize with default value
 
         auto edit = addNumberEdit(line, STR_INTERVAL, cfn, SD_LOGS_PERIOD_MIN, SD_LOGS_PERIOD_MAX);
         edit->setDefault(SD_LOGS_PERIOD_DEFAULT);         // set default period for DEF button


### PR DESCRIPTION
fixes #3751

changes:
- use stored value if SF exists otherwise initialize with default value