### PR TITLE
1khz update rate for F.Sim competitions

### DIFF
--- a/radio/src/gui/128x64/view_statistics.cpp
+++ b/radio/src/gui/128x64/view_statistics.cpp
@@ -21,6 +21,7 @@
 
 #include "opentx.h"
 #include "tasks.h"
+#include "mixer_scheduler.h"
 
 #include "hal/adc_driver.h"
 
@@ -204,6 +205,9 @@ void menuStatisticsDebug(event_t event)
   lcdDrawTextAlignedLeft(y, STR_TMIXMAXMS);
   lcdDrawNumber(MENU_DEBUG_COL1_OFS, y, DURATION_MS_PREC2(maxMixerDuration), PREC2|LEFT);
   lcdDrawText(lcdLastRightPos, y, STR_MS);
+  lcdDrawText(lcdLastRightPos, y, " (");
+  lcdDrawNumber(lcdLastRightPos, y, getMixerSchedulerPeriod() / 1000, LEFT);
+  lcdDrawText(lcdLastRightPos, y, "ms)");
   y += FH;
 
   lcdDrawTextAlignedLeft(y, STR_FREE_STACK);

--- a/radio/src/mixer_scheduler.h
+++ b/radio/src/mixer_scheduler.h
@@ -24,7 +24,7 @@
 #include <stdint.h>
 
 #define MIXER_SCHEDULER_DEFAULT_PERIOD_US  4000u // 4ms
-#define MIXER_SCHEDULER_JOYSTICK_PERIOD_US 1000u // 2ms
+#define MIXER_SCHEDULER_JOYSTICK_PERIOD_US 1000u // 1ms
 
 #define MIN_REFRESH_RATE       850 /* us */
 #define MAX_REFRESH_RATE     50000 /* us */

--- a/radio/src/mixer_scheduler.h
+++ b/radio/src/mixer_scheduler.h
@@ -24,7 +24,7 @@
 #include <stdint.h>
 
 #define MIXER_SCHEDULER_DEFAULT_PERIOD_US  4000u // 4ms
-#define MIXER_SCHEDULER_JOYSTICK_PERIOD_US 2000u // 2ms
+#define MIXER_SCHEDULER_JOYSTICK_PERIOD_US 1000u // 2ms
 
 #define MIN_REFRESH_RATE       850 /* us */
 #define MAX_REFRESH_RATE     50000 /* us */


### PR DESCRIPTION
This make the mixer run at 1000Hz when in Joystick mode (Needed for F.Sim competitors), also displays mixer run time in statistic/debug screen.

BOTH MODULE need to be off on model setup page to get that speed

Result of work with TDog on discord

![image](https://github.com/EdgeTX/edgetx/assets/5167938/8efd80b4-6a86-47e3-bac4-42a7229645c2)

(Windows may require special drivers to reach that speed)