### PR TITLE
fix: reset proto scan software timer to MULTI_PROTOLIST_START_TIMEOUT

### DIFF
--- a/radio/src/io/multi_protolist.cpp
+++ b/radio/src/io/multi_protolist.cpp
@@ -233,6 +233,12 @@ bool MultiRfProtocols::triggerScan()
       scanTimer->timer = xTimerCreateStatic(
           "MPM", MULTI_PROTOLIST_START_TIMEOUT / RTOS_MS_PER_TICK, pdTRUE,
           (void*)moduleIdx, MultiRfProtocols::timerCb, &scanTimer->timerBuffer);
+    } else {
+      if (xTimerChangePeriod(scanTimer->timer,
+          MULTI_PROTOLIST_START_TIMEOUT / RTOS_MS_PER_TICK,
+          0) != pdPASS) {
+          /* The timer period could not be reset. */
+      }
     }
 
     if (scanTimer->timer) {


### PR DESCRIPTION
... if timer already exists (from previous scan)

fixes #3084

changes:
Protocol scans use software timers to fetch the MPM protocol list at 100ms rate but with an initial rate of MULTI_PROTOLIST_START_TIMEOUT (3000ms) for the first poll to allow the MPM to finish its startup sequence after power on. Switching models back and forth power cycles the MPM. As the software timer already exists it is not instantiated again but reused. but with the rate it was left, i.e. 100ms, not the required 3000ms to allow the MPM to settle. Resetting the timer rate to MULTI_PROTOLIST_START_TIMEOUT solves the problem.

Note: the current implementation will under certain circumstances (e.g. model change back and forth) poll the MPM at 100ms with every poll failing and rebuilding the fallback list because the MPM missed the initial handshake. This goes on for the entire radio power life cycle. This is why I'd strongly advise to cherry pick the fix also into 2.8.5 and 2.9.