### PR TITLE
fix: reset proto scan software timer to MULTI_PROTOLIST_START_TIMEOUT - 2.8 port

### DIFF
--- a/radio/src/io/multi_protolist.cpp
+++ b/radio/src/io/multi_protolist.cpp
@@ -247,6 +247,12 @@ bool MultiRfProtocols::triggerScan()
       scanTimer->timer = xTimerCreateStatic(
           "MPM", MULTI_PROTOLIST_START_TIMEOUT / RTOS_MS_PER_TICK, pdTRUE,
           (void*)moduleIdx, MultiRfProtocols::timerCb, &scanTimer->timerBuffer);
+    } else {
+      if (xTimerChangePeriod(scanTimer->timer,
+          MULTI_PROTOLIST_START_TIMEOUT / RTOS_MS_PER_TICK,
+          0) != pdPASS) {
+          /* The timer period could not be reset. */
+      }
     }
 
     if (scanTimer->timer) {


### PR DESCRIPTION
2.8 port of #3763