### PR TITLE
feat(cpn): warn if radio settings version not supported

### DIFF
--- a/companion/src/firmwares/edgetx/yaml_generalsettings.cpp
+++ b/companion/src/firmwares/edgetx/yaml_generalsettings.cpp
@@ -32,7 +32,7 @@
 
 #include <QMessageBox>
 
-SemanticVersion version;  // used for data conversions
+SemanticVersion radioSettingsVersion;
 
 const YamlLookupTable beeperModeLut = {
   {  GeneralSettings::BEEPER_QUIET, "mode_quiet" },
@@ -264,6 +264,7 @@ Node convert<GeneralSettings>::encode(const GeneralSettings& rhs)
     node["switchConfig"] = switchConfig;
   }
 
+  // combine pots and sliders into potsConfig
   Node potsConfig;
   potsConfig = YamlPotConfig(rhs.potName, rhs.potConfig);
   if (potsConfig && potsConfig.IsMap()) {
@@ -317,10 +318,12 @@ bool convert<GeneralSettings>::decode(const Node& node, GeneralSettings& rhs)
   //   qDebug() << QString::fromStdString(n.first.Scalar());
   // }
 
+  radioSettingsVersion = SemanticVersion();
+
   if (node["semver"]) {
     node["semver"] >> rhs.semver;
     if (SemanticVersion().isValid(rhs.semver)) {
-      version = SemanticVersion(QString(rhs.semver));
+      radioSettingsVersion = SemanticVersion(QString(rhs.semver));
     }
     else {
       qDebug() << "Invalid settings version:" << rhs.semver;
@@ -328,11 +331,11 @@ bool convert<GeneralSettings>::decode(const Node& node, GeneralSettings& rhs)
     }
   }
 
-  qDebug() << "Settings version:" << version.toString();
+  qDebug() << "Settings version:" << radioSettingsVersion.toString();
 
-  if (version > SemanticVersion(VERSION)) {
+  if (radioSettingsVersion > SemanticVersion(VERSION)) {
     QString prmpt = QCoreApplication::translate("YamlGeneralSettings", "Warning: Radio settings file version %1 is not supported by this version of Companion!\n\nModel and radio settings may be corrupted if you continue.\n\nI acknowledge and accept the consequences.");
-    if (QMessageBox::warning(NULL, CPN_STR_APP_NAME, prmpt.arg(version.toString()), (QMessageBox::Yes | QMessageBox::No), QMessageBox::No) != QMessageBox::Yes) {
+    if (QMessageBox::warning(NULL, CPN_STR_APP_NAME, prmpt.arg(radioSettingsVersion.toString()), (QMessageBox::Yes | QMessageBox::No), QMessageBox::No) != QMessageBox::Yes) {
       //  TODO: this triggers an error in the calling code so we need a graceful way to handle
       return false;
     }


### PR DESCRIPTION
Summary of changes:
- compare radio.yml semver to Companion version
- warn user that proceeding may result in corrupted radio and/or model settings

Related to but DOES NOT resolve
#3758

The purpose of this PR is to link to the commits that can be cherry picked into 2.8.5 and 2.9 RC and merged into main.
