### PR TITLE
chore: Comment out the top two trace flooding calls

### DIFF
--- a/radio/src/targets/horus/diskio.cpp
+++ b/radio/src/targets/horus/diskio.cpp
@@ -220,7 +220,7 @@ DRESULT __disk_write(
     return(RES_NOTRDY);
 
   if ((DWORD)buff < 0x20000000 || ((DWORD)buff & 3)) {
-    TRACE("disk_write bad alignment (%p)", buff);
+    //TRACE("disk_write bad alignment (%p)", buff);
     while(count--) {
       memcpy(scratch, buff, BLOCK_SIZE);
 

--- a/radio/src/targets/horus/lcd_driver.cpp
+++ b/radio/src/targets/horus/lcd_driver.cpp
@@ -156,8 +156,8 @@ static void startLcdRefresh(lv_disp_drv_t *disp_drv, uint16_t *buffer,
       lv_area_t refr_area;
       lv_area_copy(&refr_area, &disp->inv_areas[i]);
 
-      TRACE("{%d,%d,%d,%d}", refr_area.x1,
-            refr_area.y1, refr_area.x2, refr_area.y2);
+      //TRACE("{%d,%d,%d,%d}", refr_area.x1,
+      //      refr_area.y1, refr_area.x2, refr_area.y2);
 
       _rotate_area_180(refr_area);
 

--- a/radio/src/targets/nv14/diskio.cpp
+++ b/radio/src/targets/nv14/diskio.cpp
@@ -222,7 +222,7 @@ DRESULT __disk_write(
     return(RES_NOTRDY);
 
   if ((DWORD)buff < 0x20000000 || ((DWORD)buff & 3)) {
-    TRACE("disk_write bad alignment (%p)", buff);
+    //TRACE("disk_write bad alignment (%p)", buff);
     while(count--) {
       memcpy(scratch, buff, BLOCK_SIZE);
 


### PR DESCRIPTION
Fixes: having do comment out those TRACE() calls every time you start debugging using traces

Summary of changes:
- commented out misleading TRACE() call for bad alignment if writing stack allocated buffers to SD card
- commented out trace flooding TRACE() call in lcd driver

If it was Xmas I'd wish for this to be in 2.9 too.
