### PR TITLE
chore: Fix build when GVARS=NO

### DIFF
--- a/radio/src/gui/colorlcd/gvar_numberedit.cpp
+++ b/radio/src/gui/colorlcd/gvar_numberedit.cpp
@@ -92,6 +92,7 @@ GVarNumberEdit::GVarNumberEdit(Window* parent, const rect_t& rect, int32_t vmin,
 
 void GVarNumberEdit::switchGVarMode()
 {
+#if defined(GVARS)
   if (modelGVEnabled()) {
     int32_t value = getValue();
     setValue(
@@ -106,6 +107,7 @@ void GVarNumberEdit::switchGVarMode()
     // update field type based on value
     update();
   }
+#endif
 }
 
 void GVarNumberEdit::setSuffix(std::string value)


### PR DESCRIPTION
Fixes #3768 

Add missing '#if defined(GVARS)' check.