### PR TITLE
Include scale in getInput and insertInput

### DIFF
--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -591,6 +591,7 @@ Return input data for given input and line number
  * `name` (string) input line name
  * `inputName` (string) input input name
  * `source` (number) input source index
+ * `scale` (number)  input scaling (for telemetry)
  * `weight` (number) input weight
  * `offset` (number) input offset
  * `switch` (number) input switch index
@@ -600,7 +601,7 @@ Return input data for given input and line number
  * 'trimSource' (number) a positive number representing trim source
  * 'flightModes' (number) bit-mask of active flight modes
 
-@status current Introduced in 2.0.0, curveType/curveValue/carryTrim added in 2.3, inputName added 2.3.10, flighmode reworked in 2.3.11, broken carryTrim replaced by trimSource in 2.8.1
+@status current Introduced in 2.0.0, curveType/curveValue/carryTrim added in 2.3, inputName added 2.3.10, flighmode reworked in 2.3.11, broken carryTrim replaced by trimSource in 2.8.1, scale added in 2.10
 */
 static int luaModelGetInput(lua_State *L)
 {
@@ -640,7 +641,7 @@ Insert an Input at specified line
 
 @param value (table) input data, see model.getInput()
 
-@status current Introduced in 2.0.0, curveType/curveValue/carryTrim added in 2.3, inputName added 2.3.10, broken carryTrim replaced by trimSource in EdgeTX 2.8.1
+@status current Introduced in 2.0.0, curveType/curveValue/carryTrim added in 2.3, inputName added 2.3.10, broken carryTrim replaced by trimSource in EdgeTX 2.8.1, scale added in 2.10
 */
 static int luaModelInsertInput(lua_State *L)
 {

--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -614,6 +614,7 @@ static int luaModelGetInput(lua_State *L)
     lua_pushtablenstring(L, "name", expo->name);
     lua_pushtablenstring(L, "inputName", g_model.inputNames[chn]);
     lua_pushtableinteger(L, "source", expo->srcRaw);
+    lua_pushtableinteger(L, "scale", expo->scale);
     lua_pushtableinteger(L, "weight", expo->weight);
     lua_pushtableinteger(L, "offset", expo->offset);
     lua_pushtableinteger(L, "switch", expo->swtch);
@@ -672,6 +673,9 @@ static int luaModelInsertInput(lua_State *L)
       }
       else if (!strcmp(key, "source")) {
         expo->srcRaw = luaL_checkinteger(L, -1);
+      }
+      else if (!strcmp(key, "scale")) {
+        expo->scale = luaL_checkinteger(L, -1);
       }
       else if (!strcmp(key, "weight")) {
         expo->weight = luaL_checkinteger(L, -1);


### PR DESCRIPTION
When using telemetry as an input, the scale field is used to convert from a value with units (like volts or meters) to a percentage. I'd like to modify an input's scale via Lua script. However this field does not seem to be supported by the Lua API. This seems like an oversight, so I added it.

Summary of changes:
Modify model.getInput and model.insertInput API to add the "scale" field.