### PR TITLE
refactor: notify module driver on config changes

### DIFF
--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -1260,9 +1260,6 @@ void menuModelSetup(event_t event)
                                   MODULE_SUBTYPE_R9M_LAST, EE_MODEL);
                   if (checkIncDec_Ret) {
                     g_model.moduleData[moduleIdx].pxx.power = 0;
-                    g_model.moduleData[moduleIdx].channelsStart = 0;
-                    g_model.moduleData[moduleIdx].channelsCount =
-                        defaultModuleChannels_M8(moduleIdx);
                   }
                 } else {
                   CHECK_INCDEC_MODELVAR(event,
@@ -1274,6 +1271,8 @@ void menuModelSetup(event_t event)
                   g_model.moduleData[moduleIdx].channelsStart = 0;
                   g_model.moduleData[moduleIdx].channelsCount =
                       defaultModuleChannels_M8(moduleIdx);
+
+                  pulsesModuleSettingsUpdate(moduleIdx);
                 }
             }
           }

--- a/radio/src/gui/212x64/model_setup.cpp
+++ b/radio/src/gui/212x64/model_setup.cpp
@@ -1142,52 +1142,73 @@ void menuModelSetup(event_t event)
           if (s_editMode > 0) {
             switch (menuHorizontalPosition) {
               case 0:
-                reusableBuffer.moduleSetup.newType = checkIncDec(event, reusableBuffer.moduleSetup.newType, MODULE_TYPE_NONE, MODULE_TYPE_MAX, 0, isExternalModuleAvailable);
+                reusableBuffer.moduleSetup.newType = checkIncDec(
+                    event, reusableBuffer.moduleSetup.newType, MODULE_TYPE_NONE,
+                    MODULE_TYPE_MAX, 0, isExternalModuleAvailable);
                 break;
 
               case 1:
                 if (isModuleDSM2(EXTERNAL_MODULE)) {
-                  CHECK_INCDEC_MODELVAR(event, g_model.moduleData[EXTERNAL_MODULE].subType, DSM2_PROTO_LP45, DSM2_PROTO_DSMX);
-                } 
+                  CHECK_INCDEC_MODELVAR(
+                      event, g_model.moduleData[EXTERNAL_MODULE].subType,
+                      DSM2_PROTO_LP45, DSM2_PROTO_DSMX);
+                }
 #if defined(PPM)
                 else if (isModulePPM(EXTERNAL_MODULE)) {
-                  CHECK_INCDEC_MODELVAR(event, g_model.moduleData[EXTERNAL_MODULE].subType, PPM_PROTO_TLM_NONE, PPM_PROTO_TLM_MLINK);
+                  CHECK_INCDEC_MODELVAR(
+                      event, g_model.moduleData[EXTERNAL_MODULE].subType,
+                      PPM_PROTO_TLM_NONE, PPM_PROTO_TLM_MLINK);
                 }
 #endif
 #if defined(MULTIMODULE)
                 else if (isModuleMultimodule(EXTERNAL_MODULE)) {
-                  int multiRfProto = g_model.moduleData[EXTERNAL_MODULE].multi.rfProtocol;
-                  CHECK_INCDEC_MODELVAR_CHECK(event, multiRfProto, MODULE_SUBTYPE_MULTI_FIRST, MODULE_SUBTYPE_MULTI_LAST, isMultiProtocolSelectable);
+                  int multiRfProto =
+                      g_model.moduleData[EXTERNAL_MODULE].multi.rfProtocol;
+                  CHECK_INCDEC_MODELVAR_CHECK(
+                      event, multiRfProto, MODULE_SUBTYPE_MULTI_FIRST,
+                      MODULE_SUBTYPE_MULTI_LAST, isMultiProtocolSelectable);
                   if (checkIncDec_Ret) {
-                    g_model.moduleData[EXTERNAL_MODULE].multi.rfProtocol = multiRfProto;
+                    g_model.moduleData[EXTERNAL_MODULE].multi.rfProtocol =
+                        multiRfProto;
                     g_model.moduleData[EXTERNAL_MODULE].subType = 0;
                     resetMultiProtocolsOptions(EXTERNAL_MODULE);
                   }
                 }
 #endif
                 else if (isModuleR9MNonAccess(EXTERNAL_MODULE)) {
-                  g_model.moduleData[EXTERNAL_MODULE].subType = checkIncDec(event, g_model.moduleData[EXTERNAL_MODULE].subType,
-                                                                            MODULE_SUBTYPE_R9M_FCC, MODULE_SUBTYPE_R9M_LAST, EE_MODEL);
+                  g_model.moduleData[EXTERNAL_MODULE].subType = checkIncDec(
+                      event, g_model.moduleData[EXTERNAL_MODULE].subType,
+                      MODULE_SUBTYPE_R9M_FCC, MODULE_SUBTYPE_R9M_LAST,
+                      EE_MODEL);
                 }
 #if defined(AFHDS3)
                 else if (isModuleAFHDS3(EXTERNAL_MODULE)) {
-                  CHECK_INCDEC_MODELVAR(event, g_model.moduleData[EXTERNAL_MODULE].subType, AFHDS_SUBTYPE_FIRST, AFHDS_SUBTYPE_LAST);
+                  CHECK_INCDEC_MODELVAR(
+                      event, g_model.moduleData[EXTERNAL_MODULE].subType,
+                      AFHDS_SUBTYPE_FIRST, AFHDS_SUBTYPE_LAST);
                 }
 #endif
                 else {
-                  g_model.moduleData[EXTERNAL_MODULE].subType = checkIncDec(event, g_model.moduleData[EXTERNAL_MODULE].subType,
-                                                                               MODULE_SUBTYPE_PXX1_ACCST_D16, MODULE_SUBTYPE_PXX1_LAST, EE_MODEL,
-                                                                               isRfProtocolAvailable);
+                  g_model.moduleData[EXTERNAL_MODULE].subType = checkIncDec(
+                      event, g_model.moduleData[EXTERNAL_MODULE].subType,
+                      MODULE_SUBTYPE_PXX1_ACCST_D16, MODULE_SUBTYPE_PXX1_LAST,
+                      EE_MODEL, isRfProtocolAvailable);
                 }
+
                 if (checkIncDec_Ret) {
                   g_model.moduleData[EXTERNAL_MODULE].channelsStart = 0;
-                  g_model.moduleData[EXTERNAL_MODULE].channelsCount = defaultModuleChannels_M8(EXTERNAL_MODULE);
+                  g_model.moduleData[EXTERNAL_MODULE].channelsCount =
+                      defaultModuleChannels_M8(EXTERNAL_MODULE);
+
+                  pulsesModuleSettingsUpdate(EXTERNAL_MODULE);
                 }
                 break;
 
 #if defined(MULTIMODULE)
               case 2:
-                CHECK_INCDEC_MODELVAR(event, g_model.moduleData[EXTERNAL_MODULE].subType, 0, getMaxMultiSubtype(EXTERNAL_MODULE));
+                CHECK_INCDEC_MODELVAR(
+                    event, g_model.moduleData[EXTERNAL_MODULE].subType, 0,
+                    getMaxMultiSubtype(EXTERNAL_MODULE));
                 if (checkIncDec_Ret) {
                   resetMultiProtocolsOptions(EXTERNAL_MODULE);
                 }
@@ -1198,18 +1219,22 @@ void menuModelSetup(event_t event)
 #if POPUP_LEVEL > 1
           else if (old_editMode > 0) {
             if (isModuleR9MNonAccess(EXTERNAL_MODULE)) {
-              if (g_model.moduleData[EXTERNAL_MODULE].subType > MODULE_SUBTYPE_R9M_EU) {
+              if (g_model.moduleData[EXTERNAL_MODULE].subType >
+                  MODULE_SUBTYPE_R9M_EU) {
                 POPUP_WARNING(STR_MODULE_PROTOCOL_FLEX_WARN_LINE1);
-                SET_WARNING_INFO(STR_MODULE_PROTOCOL_WARN_LINE2, sizeof(TR_MODULE_PROTOCOL_WARN_LINE2) - 1, 0);
+                SET_WARNING_INFO(STR_MODULE_PROTOCOL_WARN_LINE2,
+                                 sizeof(TR_MODULE_PROTOCOL_WARN_LINE2) - 1, 0);
               }
 #if POPUP_LEVEL >= 3
-              else if (g_model.moduleData[EXTERNAL_MODULE].subType == MODULE_SUBTYPE_R9M_EU) {
+              else if (g_model.moduleData[EXTERNAL_MODULE].subType ==
+                       MODULE_SUBTYPE_R9M_EU) {
                 POPUP_WARNING(STR_MODULE_PROTOCOL_EU_WARN_LINE1);
-                SET_WARNING_INFO(STR_MODULE_PROTOCOL_WARN_LINE2, sizeof(TR_MODULE_PROTOCOL_WARN_LINE2) - 1, 0);
-              }
-              else {
+                SET_WARNING_INFO(STR_MODULE_PROTOCOL_WARN_LINE2,
+                                 sizeof(TR_MODULE_PROTOCOL_WARN_LINE2) - 1, 0);
+              } else {
                 POPUP_WARNING(STR_MODULE_PROTOCOL_FCC_WARN_LINE1);
-                SET_WARNING_INFO(STR_MODULE_PROTOCOL_WARN_LINE2, sizeof(TR_MODULE_PROTOCOL_WARN_LINE2) - 1, 0);
+                SET_WARNING_INFO(STR_MODULE_PROTOCOL_WARN_LINE2,
+                                 sizeof(TR_MODULE_PROTOCOL_WARN_LINE2) - 1, 0);
               }
 #endif
             }

--- a/radio/src/gui/colorlcd/module_setup.cpp
+++ b/radio/src/gui/colorlcd/module_setup.cpp
@@ -714,11 +714,14 @@ static void update_module_window(lv_event_t* e)
   ModuleWindow* mw = (ModuleWindow*)lv_event_get_user_data(e);
   if (!mw) return;
 
-  if (isModuleISRM(mw->getModuleIdx())) {
+  auto module = mw->getModuleIdx();
+  if (isModuleISRM(module)) {
     mw->updateModule();
   } else {
     mw->updateSubType();
   }
+
+  pulsesModuleSettingsUpdate(module);
 }
 
 ModulePage::ModulePage(uint8_t moduleIdx) : Page(ICON_MODEL_SETUP)

--- a/radio/src/hal/module_driver.h
+++ b/radio/src/hal/module_driver.h
@@ -27,7 +27,6 @@ enum ChannelsProtocols {
   PROTOCOL_CHANNELS_UNINITIALIZED,
   PROTOCOL_CHANNELS_NONE,
   PROTOCOL_CHANNELS_PPM,
-  PROTOCOL_CHANNELS_PPM_MLINK,
   PROTOCOL_CHANNELS_PXX1,
   PROTOCOL_CHANNELS_DSM2_LP45,
   PROTOCOL_CHANNELS_DSM2_DSM2,
@@ -57,5 +56,5 @@ struct etx_proto_driver_t {
     void (*sendPulses)(void* ctx, uint8_t* buffer, int16_t* channels, uint8_t nChannels);
 
     // Process input data byte (telemetry)
-    void (*processData)(void* context, uint8_t data, uint8_t* buffer, uint8_t* len);
+    void (*processData)(void* ctx, uint8_t data, uint8_t* buffer, uint8_t* len);
 };

--- a/radio/src/hal/module_driver.h
+++ b/radio/src/hal/module_driver.h
@@ -57,4 +57,7 @@ struct etx_proto_driver_t {
 
     // Process input data byte (telemetry)
     void (*processData)(void* ctx, uint8_t data, uint8_t* buffer, uint8_t* len);
+
+    // Some module settings may have been modified
+    void (*onConfigChange)(void* ctx);
 };

--- a/radio/src/hal/module_driver.h
+++ b/radio/src/hal/module_driver.h
@@ -28,9 +28,7 @@ enum ChannelsProtocols {
   PROTOCOL_CHANNELS_NONE,
   PROTOCOL_CHANNELS_PPM,
   PROTOCOL_CHANNELS_PXX1,
-  PROTOCOL_CHANNELS_DSM2_LP45,
-  PROTOCOL_CHANNELS_DSM2_DSM2,
-  PROTOCOL_CHANNELS_DSM2_DSMX,
+  PROTOCOL_CHANNELS_DSM2,
   PROTOCOL_CHANNELS_CROSSFIRE,
   PROTOCOL_CHANNELS_MULTIMODULE,
   PROTOCOL_CHANNELS_SBUS,
@@ -60,4 +58,7 @@ struct etx_proto_driver_t {
 
     // Some module settings may have been modified
     void (*onConfigChange)(void* ctx);
+
+    // Module state mode has been modified
+    // void (*onModeChange)(void* ctx, uint8_t old_mode, uint8_t new_mode);
 };

--- a/radio/src/pulses/ppm.cpp
+++ b/radio/src/pulses/ppm.cpp
@@ -110,10 +110,12 @@ static etx_serial_init ppmMLinkSerialParams = {
 
 static bool ppmInitMLinkTelemetry(uint8_t module)
 {
-  if (modulePortInitSerial(module, ETX_MOD_PORT_UART, &ppmMLinkSerialParams) != nullptr) {
+  // Try S.PORT hardware USART (requires HW inverters)
+  if (modulePortInitSerial(module, ETX_MOD_PORT_SPORT, &ppmMLinkSerialParams) != nullptr) {
     return true;
   }
 
+  // fall-back to softserial
   if (modulePortInitSerial(module, ETX_MOD_PORT_SPORT_INV, &ppmMLinkSerialParams) != nullptr) {
     return true;
   }

--- a/radio/src/pulses/ppm.h
+++ b/radio/src/pulses/ppm.h
@@ -24,4 +24,3 @@
 #include "hal/module_driver.h"
 
 extern const etx_proto_driver_t PpmDriver;
-extern const etx_proto_driver_t PpmDriverMLink;

--- a/radio/src/pulses/pulses.cpp
+++ b/radio/src/pulses/pulses.cpp
@@ -297,25 +297,7 @@ uint8_t getRequiredProtocol(uint8_t module)
 
 #if defined(DSM2)
     case MODULE_TYPE_DSM2:
-      protocol = limit<uint8_t>(
-          PROTOCOL_CHANNELS_DSM2_LP45,
-          PROTOCOL_CHANNELS_DSM2_LP45 + g_model.moduleData[module].subType,
-          PROTOCOL_CHANNELS_DSM2_DSMX);
-      // The module is set to OFF during one second before BIND start
-      // TODO: move this to DSM2 driver...
-      {
-        static tmr10ms_t bindStartTime = 0;
-        if (moduleState[module].mode == MODULE_MODE_BIND) {
-          if (bindStartTime == 0) bindStartTime = get_tmr10ms();
-          if ((tmr10ms_t)(get_tmr10ms() - bindStartTime) < 100) {
-            protocol = PROTOCOL_CHANNELS_NONE;
-            break;
-          }
-        }
-        else {
-          bindStartTime = 0;
-        }
-      }
+      protocol = PROTOCOL_CHANNELS_DSM2;
       break;
 #endif
 
@@ -428,9 +410,7 @@ static void pulsesEnableModule(uint8_t module, uint8_t protocol)
 #endif
 
 #if defined(DSM2)
-    case PROTOCOL_CHANNELS_DSM2_LP45:
-    case PROTOCOL_CHANNELS_DSM2_DSM2:
-    case PROTOCOL_CHANNELS_DSM2_DSMX:
+    case PROTOCOL_CHANNELS_DSM2:
       _init_module(module, &DSM2Driver);
       break;
 #endif

--- a/radio/src/pulses/pulses.cpp
+++ b/radio/src/pulses/pulses.cpp
@@ -263,16 +263,7 @@ uint8_t getRequiredProtocol(uint8_t module)
 
   switch (getModuleType(module)) {
     case MODULE_TYPE_PPM:
-      switch (g_model.moduleData[module].subType) {
-        case PPM_PROTO_TLM_NONE: 
-          protocol = PROTOCOL_CHANNELS_PPM;
-          break;
-        case PPM_PROTO_TLM_MLINK:
-          protocol = PROTOCOL_CHANNELS_PPM_MLINK;
-          break;
-        default:
-          protocol = PROTOCOL_CHANNELS_PPM;
-      }
+      protocol = PROTOCOL_CHANNELS_PPM;
       break;
 
     case MODULE_TYPE_XJT_PXX1:
@@ -473,9 +464,6 @@ static void pulsesEnableModule(uint8_t module, uint8_t protocol)
   case PROTOCOL_CHANNELS_PPM:
       _init_module(module, &PpmDriver);
       break;
-  case PROTOCOL_CHANNELS_PPM_MLINK:
-      _init_module(module, &PpmDriverMLink);
-      break;  
 #endif
 
 #if defined(INTERNAL_MODULE_AFHDS2A) && defined(AFHDS2)

--- a/radio/src/pulses/pulses.h
+++ b/radio/src/pulses/pulses.h
@@ -66,7 +66,8 @@ PACK(struct ModuleState {
   uint8_t protocol;
   uint8_t mode:4;
   uint8_t forced_off:1;
-  uint8_t spare:3;
+  uint8_t settings_updated:1;
+  uint8_t spare:2;
   uint16_t counter;
 
 #if defined(PXX2)
@@ -173,6 +174,8 @@ void pulsesSetModuleDeInitCb(module_deinit_cb_t cb);
 
 void restartModule(uint8_t module);
 bool restartModuleAsync(uint8_t module, uint8_t cnt_delay);
+
+void pulsesModuleSettingsUpdate(uint8_t module);
 
 void setupPulsesPPMTrainer();
 

--- a/radio/src/telemetry/mlink.cpp
+++ b/radio/src/telemetry/mlink.cpp
@@ -181,7 +181,7 @@ void mlinkSetDefault(int index, uint16_t id, uint8_t subId, uint8_t instance)
   storageDirty(EE_MODEL);
 }
 
-void processExternalMLinkSerialData(void* ctx, uint8_t data, uint8_t* buffer, uint8_t* len) {
+void processExternalMLinkSerialData(uint8_t module, uint8_t data, uint8_t* buffer, uint8_t* len) {
   static bool destuff = false;                // byte requires adjustment
   static bool started = false;                // start of frame detected
 

--- a/radio/src/telemetry/mlink.h
+++ b/radio/src/telemetry/mlink.h
@@ -65,4 +65,4 @@ void processMLinkPacket(const uint8_t *packet, bool multi);
 // used by external MLink module driver
 #define PPM_MSB_BAUDRATE  115200
 
-void processExternalMLinkSerialData(void* ctx, uint8_t data, uint8_t* buffer, uint8_t* len);
+void processExternalMLinkSerialData(uint8_t module, uint8_t data, uint8_t* buffer, uint8_t* len);

--- a/radio/src/telemetry/spektrum.cpp
+++ b/radio/src/telemetry/spektrum.cpp
@@ -775,8 +775,7 @@ void processDSMBindPacket(uint8_t module, const uint8_t *packet)
     storageDirty(EE_MODEL);
 
     moduleState[module].mode = MODULE_MODE_NORMAL;
-    restartModuleAsync(module, 50); // ~200ms
-    
+    restartModuleAsync(module, 50); // ~500ms
   }
 #if defined(MULTIMODULE)
   else if (g_model.moduleData[module].type == MODULE_TYPE_MULTIMODULE &&

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -127,7 +127,7 @@ rxStatStruct *getRxStatLabels() {
       break;
 #endif
     case MODULE_TYPE_PPM:
-      if(moduleState[moduleToUse].protocol == PROTOCOL_CHANNELS_PPM_MLINK) {
+      if(g_model.moduleData[moduleToUse].subType == PPM_PROTO_TLM_MLINK) {
         rxStat.label = STR_RXSTAT_LABEL_RQLY;
         rxStat.unit  = STR_RXSTAT_UNIT_PERCENT;
       }


### PR DESCRIPTION
In order to remove certain limitations and thus further generalise the modules' life cycle, it is necessary to notify the module driver on certain config changes in order to let it decide what is required to apply these changes. 