### PR TITLE
fix(color): Fix inputs and mixes scroll order

### DIFF
--- a/radio/src/gui/colorlcd/model_inputs.cpp
+++ b/radio/src/gui/colorlcd/model_inputs.cpp
@@ -454,6 +454,12 @@ void ModelInputsPage::build(FormWindow *window)
   form = new FormWindow(window, rect_t{});
   form->setFlexLayout(LV_FLEX_FLOW_COLUMN, 3);
 
+  auto btn = new TextButton(window, rect_t{}, LV_SYMBOL_PLUS, [=]() {
+    newInput();
+    return 0;
+  });
+  lv_obj_set_width(btn->getLvObj(), lv_pct(100));
+
   groups.clear();
   lines.clear();
 
@@ -480,12 +486,5 @@ void ModelInputsPage::build(FormWindow *window)
       break;
     }
   }
-
-  auto btn = new TextButton(window, rect_t{}, LV_SYMBOL_PLUS, [=]() {
-    newInput();
-    return 0;
-  });
-  auto btn_obj = btn->getLvObj();
-  lv_obj_set_width(btn_obj, lv_pct(100));
 }
 

--- a/radio/src/gui/colorlcd/model_inputs.cpp
+++ b/radio/src/gui/colorlcd/model_inputs.cpp
@@ -458,11 +458,14 @@ void ModelInputsPage::build(FormWindow *window)
     newInput();
     return 0;
   });
-  lv_obj_set_width(btn->getLvObj(), lv_pct(100));
+  auto btn_obj = btn->getLvObj();
+  lv_obj_set_width(btn_obj, lv_pct(100));
+  lv_group_focus_obj(btn_obj);
 
   groups.clear();
   lines.clear();
 
+  bool focusSet = false;
   uint8_t index = 0;
   ExpoData* line = g_model.expoData;
   for (uint8_t input = 0; input < MAX_INPUTS; input++) {
@@ -475,7 +478,11 @@ void ModelInputsPage::build(FormWindow *window)
       groups.emplace_back(group);
       while (index < MAX_EXPOS && line->chn == input && EXPO_VALID(line)) {
         // one button per input line
-        createLineButton(group, index);
+        auto btn = createLineButton(group, index);
+        if (!focusSet) {
+          focusSet = true;
+          lv_group_focus_obj(btn->getLvObj());
+        }
         ++index;
         ++line;
       }

--- a/radio/src/gui/colorlcd/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model_mixes.cpp
@@ -547,6 +547,7 @@ void ModelMixesPage::build(FormWindow * window)
   groups.clear();
   lines.clear();
 
+  bool focusSet = false;
   uint8_t index = 0;
   MixData* line = g_model.mixData;
   for (uint8_t ch = 0; ch < MAX_OUTPUT_CHANNELS; ch++) {
@@ -561,7 +562,11 @@ void ModelMixesPage::build(FormWindow * window)
       groups.emplace_back(group);
       while (index < MAX_MIXERS && (line->destCh == ch) && !skip_mix) {
         // one button per input line
-        createLineButton(group, index);
+        auto btn = createLineButton(group, index);
+        if (!focusSet) {
+          focusSet = true;
+          lv_group_focus_obj(btn->getLvObj());
+        }
         ++index;
         ++line;
         skip_mix = (ch == 0 && is_memclear(line, sizeof(MixData)));

--- a/radio/src/gui/colorlcd/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model_mixes.cpp
@@ -523,6 +523,27 @@ void ModelMixesPage::build(FormWindow * window)
   form = new FormWindow(window, rect_t{});
   form->setFlexLayout(LV_FLEX_FLOW_COLUMN, 3);
 
+  auto box = new FormWindow(window, rect_t{});
+  box->setFlexLayout(LV_FLEX_FLOW_ROW, lv_dpx(8));
+  box->padLeft(lv_dpx(8));
+
+  auto box_obj = box->getLvObj();
+  lv_obj_set_width(box_obj, lv_pct(100));
+  lv_obj_set_style_flex_cross_place(box_obj, LV_FLEX_ALIGN_CENTER, 0);
+
+  new StaticText(box, rect_t{}, STR_SHOW_MIXER_MONITORS, 0, COLOR_THEME_PRIMARY1);
+  new CheckBox(
+      box, rect_t{}, [=]() { return showMonitors; },
+      [=](uint8_t val) { enableMonitors(val); });
+
+  auto btn = new TextButton(window, rect_t{}, LV_SYMBOL_PLUS, [=]() {
+    newMix();
+    return 0;
+  });
+  auto btn_obj = btn->getLvObj();
+  lv_obj_set_width(btn_obj, lv_pct(100));
+  lv_group_focus_obj(btn_obj);
+
   groups.clear();
   lines.clear();
 
@@ -547,26 +568,6 @@ void ModelMixesPage::build(FormWindow * window)
       }
     }
   }
-
-  auto box = new FormGroup(window, rect_t{});
-  box->setFlexLayout(LV_FLEX_FLOW_ROW, lv_dpx(8));
-  box->padLeft(lv_dpx(8));
-
-  auto box_obj = box->getLvObj();
-  lv_obj_set_width(box_obj, lv_pct(100));
-  lv_obj_set_style_flex_cross_place(box_obj, LV_FLEX_ALIGN_CENTER, 0);
-
-  new StaticText(box, rect_t{}, STR_SHOW_MIXER_MONITORS, 0, COLOR_THEME_PRIMARY1);
-  new CheckBox(
-      box, rect_t{}, [=]() { return showMonitors; },
-      [=](uint8_t val) { enableMonitors(val); });
-
-  auto btn = new TextButton(window, rect_t{}, LV_SYMBOL_PLUS, [=]() {
-    newMix();
-    return 0;
-  });
-  auto btn_obj = btn->getLvObj();
-  lv_obj_set_width(btn_obj, lv_pct(100));
 }
 
 void ModelMixesPage::enableMonitors(bool enabled)


### PR DESCRIPTION
Fixes #3774 

Change layout build code to match 2.8 so that scroll order works correctly when new inputs/mixes added.
Add logic to set focus to first input/mix line if present as per 2.9 changes.
