### PR TITLE
fix(x12s): init periph clocks in ads79xx driver

### DIFF
--- a/radio/src/targets/common/arm/stm32/CMakeLists.txt
+++ b/radio/src/targets/common/arm/stm32/CMakeLists.txt
@@ -43,6 +43,7 @@ set(FIRMWARE_TARGET_SRC ${FIRMWARE_TARGET_SRC}
   ../common/arm/stm32/module_timer_driver.cpp
   ../common/arm/stm32/stm32_switch_driver.cpp
   ../common/arm/stm32/stm32_adc.cpp
+  ../common/arm/stm32/stm32_spi.cpp
   ../common/arm/stm32/stm32_timer.cpp
   ../common/arm/stm32/stm32_dma.cpp
   ../common/arm/stm32/stm32_gpio_driver.cpp

--- a/radio/src/targets/common/arm/stm32/ads79xx.cpp
+++ b/radio/src/targets/common/arm/stm32/ads79xx.cpp
@@ -20,6 +20,8 @@
  */
 
 #include "ads79xx.h"
+#include "stm32_spi.h"
+#include "stm32_gpio_driver.h"
 #include "delays_driver.h"
 
 #include "stm32_hal_ll.h"
@@ -39,6 +41,7 @@ static uint16_t ads79xx_rw(SPI_TypeDef* SPIx, uint16_t value)
 
 void ads79xx_init(const stm32_spi_adc_t* adc)
 {
+  stm32_gpio_enable_clock(adc->GPIOx);
   LL_GPIO_InitTypeDef pinInit;
   LL_GPIO_StructInit(&pinInit);
 
@@ -53,6 +56,7 @@ void ads79xx_init(const stm32_spi_adc_t* adc)
   LL_GPIO_Init(adc->GPIOx, &pinInit);
 
   auto SPIx = adc->SPIx;
+  stm32_spi_enable_clock(SPIx);
   LL_SPI_DeInit(SPIx);
 
   LL_SPI_InitTypeDef spiInit;

--- a/radio/src/targets/common/arm/stm32/stm32_spi.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_spi.cpp
@@ -19,8 +19,37 @@
  * GNU General Public License for more details.
  */
 
-#pragma once
+#include "stm32_spi.h"
 
-#include "hal/adc_driver.h"
+void stm32_spi_enable_clock(SPI_TypeDef *SPIx)
+{
+  if (SPIx == SPI1) {
+    LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_SPI1);
+  }
+#if defined(SPI2)
+  else if (SPIx == SPI2) {
+    LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_SPI2);
+  }
+#endif
+#if defined(SPI3)
+  else if (SPIx == SPI3) {
+    LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_SPI3);
+  }
+#endif
+#if defined(SPI4)
+  else if (SPIx == SPI4) {
+    LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_SPI4);
+  }
+#endif
+#if defined(SPI5)
+  else if (SPIx == SPI5) {
+    LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_SPI5);
+  }
+#endif
+#if defined(SPI6)
+  else if (SPIx == SPI6) {
+    LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_SPI6);
+  }
+#endif
+}
 
-extern const etx_hal_adc_driver_t x12s_adc_driver;

--- a/radio/src/targets/common/arm/stm32/stm32_spi.h
+++ b/radio/src/targets/common/arm/stm32/stm32_spi.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) EdgeTx
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include "stm32_hal_ll.h"
+
+void stm32_spi_enable_clock(SPI_TypeDef *SPIx);


### PR DESCRIPTION
#3790 removed `ADC_RCC`, so that peripheral clocks for ADC driver must now be initialised properly within the driver.

Summary of changes:
- initialise GPIO peripheral clock
- initialise SPI peripheral clock
