### PR TITLE
fix: Correctly reflect state of AUX1 when DEBUG build

### DIFF
--- a/radio/src/serial.cpp
+++ b/radio/src/serial.cpp
@@ -449,12 +449,21 @@ void serialInit(uint8_t port_nr, int mode)
 
 void initSerialPorts()
 {
+#if defined(DEBUG)  
+  // AUX1 and serialPortStates was already initialized early in DEBUG config
+  for (uint8_t port_nr = 0; port_nr < MAX_AUX_SERIAL; port_nr++) {
+    if(port_nr != AUX1) {
+      auto mode = getSerialPortMode(port_nr);
+      serialInit(port_nr, mode);
+    }
+  }
+#else
   memset(serialPortStates, 0, sizeof(serialPortStates));
-
   for (uint8_t port_nr = 0; port_nr < MAX_AUX_SERIAL; port_nr++) {
     auto mode = getSerialPortMode(port_nr);
     serialInit(port_nr, mode);
   }
+#endif
 }
 
 int serialGetMode(uint8_t port_nr)

--- a/radio/src/serial.cpp
+++ b/radio/src/serial.cpp
@@ -90,7 +90,7 @@ extern "C" void dbgSerialPrintf(const char * format, ...)
 
   const char *t = tmp;
   while (*t) {
-    SEGGER_RTT_Write(0, (const void *)t++, 1);
+    SEGGER_RTT_Write(0, (const void*)t++, 1);
   }
 }
 #else
@@ -449,10 +449,10 @@ void serialInit(uint8_t port_nr, int mode)
 
 void initSerialPorts()
 {
-#if defined(DEBUG)  
+#if defined(DEBUG)
   // AUX1 and serialPortStates was already initialized early in DEBUG config
   for (uint8_t port_nr = 0; port_nr < MAX_AUX_SERIAL; port_nr++) {
-    if(port_nr != AUX1) {
+    if (port_nr != AUX1) {
       auto mode = getSerialPortMode(port_nr);
       serialInit(port_nr, mode);
     }

--- a/radio/src/serial.cpp
+++ b/radio/src/serial.cpp
@@ -452,7 +452,7 @@ void initSerialPorts()
 #if defined(DEBUG)
   // AUX1 and serialPortStates was already initialized early in DEBUG config
   for (uint8_t port_nr = 0; port_nr < MAX_AUX_SERIAL; port_nr++) {
-    if (port_nr != AUX1) {
+    if (port_nr != SP_AUX1) {
       auto mode = getSerialPortMode(port_nr);
       serialInit(port_nr, mode);
     }

--- a/radio/src/serial.cpp
+++ b/radio/src/serial.cpp
@@ -458,7 +458,6 @@ void initSerialPorts()
     }
   }
 #else
-  memset(serialPortStates, 0, sizeof(serialPortStates));
   for (uint8_t port_nr = 0; port_nr < MAX_AUX_SERIAL; port_nr++) {
     auto mode = getSerialPortMode(port_nr);
     serialInit(port_nr, mode);

--- a/radio/src/storage/storage_common.cpp
+++ b/radio/src/storage/storage_common.cpp
@@ -106,11 +106,11 @@ void postRadioSettingsLoad()
   }
 #endif
 #if !defined(DEBUG)
-    // clean up leftovers from a previous DEBUG config
-    for (uint8_t port_nr = 0; port_nr < MAX_AUX_SERIAL; port_nr++) {
-      if(serialGetMode(port_nr) == UART_MODE_DEBUG)
-        serialSetMode(port_nr, UART_MODE_NONE);
-    }
+  // clean up leftovers from a previous DEBUG config
+  for (uint8_t port_nr = 0; port_nr < MAX_AUX_SERIAL; port_nr++) {
+    if (serialGetMode(port_nr) == UART_MODE_DEBUG)
+      serialSetMode(port_nr, UART_MODE_NONE);
+  }
 #endif
 }
 

--- a/radio/src/storage/storage_common.cpp
+++ b/radio/src/storage/storage_common.cpp
@@ -105,6 +105,13 @@ void postRadioSettingsLoad()
     g_eeGeneral.stickDeadZone = DEFAULT_STICK_DEADZONE;
   }
 #endif
+#if !defined(DEBUG)
+    // clean up leftovers from a previous DEBUG config
+    for (uint8_t port_nr = 0; port_nr < MAX_AUX_SERIAL; port_nr++) {
+      if(serialGetMode(port_nr) == UART_MODE_DEBUG)
+        serialSetMode(port_nr, UART_MODE_NONE);
+    }
+#endif
 }
 
 static bool sortMixerLines()

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -146,7 +146,7 @@ void boardInit()
   __enable_irq();
 
 #if defined(DEBUG)
-  memset(serialPortStates, 0, sizeof(serialPortStates));  // early init of serialPortStates
+  // memset(serialPortStates, 0, sizeof(serialPortStates));  // early init of serialPortStates
   serialSetMode(SP_AUX1, UART_MODE_DEBUG);                // indicate AUX1 is used
   serialInit(SP_AUX1, UART_MODE_DEBUG);                   // early AUX1 init
 #endif

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -144,6 +144,12 @@ void boardInit()
   delaysInit();
 
   __enable_irq();
+  
+#if defined(DEBUG)
+  memset(serialPortStates, 0, sizeof(serialPortStates));  // early init of serialPortStates
+  serialSetMode(SP_AUX1, UART_MODE_DEBUG);                // indicate AUX1 is used
+  serialInit(SP_AUX1, UART_MODE_DEBUG);                   // early AUX1 init 
+#endif
 
   TRACE("\nHorus board started :)");
   TRACE("RCC->CSR = %08x", RCC->CSR);

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -146,7 +146,6 @@ void boardInit()
   __enable_irq();
 
 #if defined(DEBUG)
-  // memset(serialPortStates, 0, sizeof(serialPortStates));  // early init of serialPortStates
   serialSetMode(SP_AUX1, UART_MODE_DEBUG);                // indicate AUX1 is used
   serialInit(SP_AUX1, UART_MODE_DEBUG);                   // early AUX1 init
 #endif

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -145,10 +145,6 @@ void boardInit()
 
   __enable_irq();
 
-#if defined(DEBUG)
-  serialInit(SP_AUX1, UART_MODE_DEBUG);
-#endif
-
   TRACE("\nHorus board started :)");
   TRACE("RCC->CSR = %08x", RCC->CSR);
 

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -144,7 +144,7 @@ void boardInit()
   delaysInit();
 
   __enable_irq();
-  
+
 #if defined(DEBUG)
   memset(serialPortStates, 0, sizeof(serialPortStates));  // early init of serialPortStates
   serialSetMode(SP_AUX1, UART_MODE_DEBUG);                // indicate AUX1 is used

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -148,7 +148,7 @@ void boardInit()
 #if defined(DEBUG)
   memset(serialPortStates, 0, sizeof(serialPortStates));  // early init of serialPortStates
   serialSetMode(SP_AUX1, UART_MODE_DEBUG);                // indicate AUX1 is used
-  serialInit(SP_AUX1, UART_MODE_DEBUG);                   // early AUX1 init 
+  serialInit(SP_AUX1, UART_MODE_DEBUG);                   // early AUX1 init
 #endif
 
   TRACE("\nHorus board started :)");

--- a/radio/src/targets/nv14/board.cpp
+++ b/radio/src/targets/nv14/board.cpp
@@ -209,7 +209,7 @@ void boardInit()
 #if defined(DEBUG)
   memset(serialPortStates, 0, sizeof(serialPortStates));  // early init of serialPortStates
   serialSetMode(SP_AUX1, UART_MODE_DEBUG);                // indicate AUX1 is used
-  serialInit(SP_AUX1, UART_MODE_DEBUG);                   // early AUX1 init 
+  serialInit(SP_AUX1, UART_MODE_DEBUG);                   // early AUX1 init
 #endif
 
   TRACE("\n%s board started :)",

--- a/radio/src/targets/nv14/board.cpp
+++ b/radio/src/targets/nv14/board.cpp
@@ -206,6 +206,12 @@ void boardInit()
   // detect NV14 vs EL18
   hardwareOptions.pcbrev = boardGetPcbRev();
 
+#if defined(DEBUG)
+  memset(serialPortStates, 0, sizeof(serialPortStates));  // early init of serialPortStates
+  serialSetMode(SP_AUX1, UART_MODE_DEBUG);                // indicate AUX1 is used
+  serialInit(SP_AUX1, UART_MODE_DEBUG);                   // early AUX1 init 
+#endif
+
   TRACE("\n%s board started :)",
         hardwareOptions.pcbrev == PCBREV_NV14 ?
         "NV14" : "EL18");

--- a/radio/src/targets/nv14/board.cpp
+++ b/radio/src/targets/nv14/board.cpp
@@ -207,7 +207,7 @@ void boardInit()
   hardwareOptions.pcbrev = boardGetPcbRev();
 
 #if defined(DEBUG)
-  memset(serialPortStates, 0, sizeof(serialPortStates));  // early init of serialPortStates
+  // memset(serialPortStates, 0, sizeof(serialPortStates));  // early init of serialPortStates
   serialSetMode(SP_AUX1, UART_MODE_DEBUG);                // indicate AUX1 is used
   serialInit(SP_AUX1, UART_MODE_DEBUG);                   // early AUX1 init
 #endif

--- a/radio/src/targets/nv14/board.cpp
+++ b/radio/src/targets/nv14/board.cpp
@@ -206,10 +206,6 @@ void boardInit()
   // detect NV14 vs EL18
   hardwareOptions.pcbrev = boardGetPcbRev();
 
-#if defined(DEBUG)
-  serialInit(SP_AUX1, UART_MODE_DEBUG);
-#endif
-
   TRACE("\n%s board started :)",
         hardwareOptions.pcbrev == PCBREV_NV14 ?
         "NV14" : "EL18");

--- a/radio/src/targets/nv14/board.cpp
+++ b/radio/src/targets/nv14/board.cpp
@@ -207,7 +207,6 @@ void boardInit()
   hardwareOptions.pcbrev = boardGetPcbRev();
 
 #if defined(DEBUG)
-  // memset(serialPortStates, 0, sizeof(serialPortStates));  // early init of serialPortStates
   serialSetMode(SP_AUX1, UART_MODE_DEBUG);                // indicate AUX1 is used
   serialInit(SP_AUX1, UART_MODE_DEBUG);                   // early AUX1 init
 #endif

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -227,7 +227,7 @@ void boardInit()
 #if defined(DEBUG)
   memset(serialPortStates, 0, sizeof(serialPortStates));  // early init of serialPortStates
   serialSetMode(SP_AUX1, UART_MODE_DEBUG);                // indicate AUX1 is used
-  serialInit(SP_AUX1, UART_MODE_DEBUG);                   // early AUX1 init 
+  serialInit(SP_AUX1, UART_MODE_DEBUG);                   // early AUX1 init
 #endif
 
 #if defined(HAPTIC)

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -225,7 +225,7 @@ void boardInit()
   usbInit();
 
 #if defined(DEBUG)
-  memset(serialPortStates, 0, sizeof(serialPortStates));  // early init of serialPortStates
+  // memset(serialPortStates, 0, sizeof(serialPortStates));  // early init of serialPortStates
   serialSetMode(SP_AUX1, UART_MODE_DEBUG);                // indicate AUX1 is used
   serialInit(SP_AUX1, UART_MODE_DEBUG);                   // early AUX1 init
 #endif

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -225,7 +225,6 @@ void boardInit()
   usbInit();
 
 #if defined(DEBUG)
-  // memset(serialPortStates, 0, sizeof(serialPortStates));  // early init of serialPortStates
   serialSetMode(SP_AUX1, UART_MODE_DEBUG);                // indicate AUX1 is used
   serialInit(SP_AUX1, UART_MODE_DEBUG);                   // early AUX1 init
 #endif

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -224,6 +224,12 @@ void boardInit()
   timersInit();
   usbInit();
 
+#if defined(DEBUG)
+  memset(serialPortStates, 0, sizeof(serialPortStates));  // early init of serialPortStates
+  serialSetMode(SP_AUX1, UART_MODE_DEBUG);                // indicate AUX1 is used
+  serialInit(SP_AUX1, UART_MODE_DEBUG);                   // early AUX1 init 
+#endif
+
 #if defined(HAPTIC)
   hapticInit();
 #endif

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -224,10 +224,6 @@ void boardInit()
   timersInit();
   usbInit();
 
-#if defined(DEBUG)
-  serialInit(SP_AUX1, UART_MODE_DEBUG);
-#endif
-
 #if defined(HAPTIC)
   hapticInit();
 #endif


### PR DESCRIPTION
fixes #3813

Summary of changes:
- removed forced default serial initialization of AUX1 for debug builds
