### PR TITLE
chore(cpn): disable backup and restore for all radios

### DIFF
--- a/companion/src/mainwindow.cpp
+++ b/companion/src/mainwindow.cpp
@@ -690,14 +690,8 @@ void MainWindow::updateMenus()
   compareAct->setEnabled(activeChild);
   writeSettingsAct->setEnabled(activeChild);
   readSettingsAct->setEnabled(true);
-  if (IS_FAMILY_HORUS_OR_T16(getCurrentBoard())) {
-    writeBUToRadioAct->setEnabled(false);
-    readBUToFileAct->setEnabled(false);
-  }
-  else {
-    writeBUToRadioAct->setEnabled(true);
-    readBUToFileAct->setEnabled(true);
-  }
+  writeBUToRadioAct->setEnabled(false);
+  readBUToFileAct->setEnabled(false);
   editSplashAct->setDisabled(IS_FAMILY_HORUS_OR_T16(getCurrentBoard()));
 
   foreach (QAction * act, fileWindowActions) {


### PR DESCRIPTION
Summary of changes:
- disable backup and restore for all radios until time can be found to rework
- completely broken with the move to yaml for B&W radios
- does not impact read and write models and settings 
