### PR TITLE
feat: auto expand sensor list when discovering sensors

### DIFF
--- a/radio/src/gui/128x64/model_telemetry.cpp
+++ b/radio/src/gui/128x64/model_telemetry.cpp
@@ -205,6 +205,7 @@ void menuModelTelemetry(event_t event)
         if (attr && event==EVT_KEY_BREAK(KEY_ENTER)) {
           s_editMode = 0;
           allowNewSensors = !allowNewSensors;
+          telemExpandState.sensors = true;
         }
         break;
 

--- a/radio/src/gui/212x64/model_telemetry.cpp
+++ b/radio/src/gui/212x64/model_telemetry.cpp
@@ -199,6 +199,7 @@ void menuModelTelemetry(event_t event)
         if (attr && event==EVT_KEY_BREAK(KEY_ENTER)) {
           s_editMode = 0;
           allowNewSensors = !allowNewSensors;
+          telemExpandState.sensors = true;
         }
         break;
 


### PR DESCRIPTION
This is a small qualilty of life PR that automaticaly expand sensor list when discovering sensor (basicaly, you want to see sensors poping when you launch that function).
