### PR TITLE
fix: revert Zorro default contrast

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1450,6 +1450,10 @@ void opentxInit()
 
   bool radioSettingsValid = storageReadRadioSettings(false);
   (void)radioSettingsValid;
+
+#if defined(GUI) && !defined(COLORLCD)
+  lcdSetContrast();
+#endif
 #endif
 
   BACKLIGHT_ENABLE(); // we start the backlight during the startup animation
@@ -1588,7 +1592,7 @@ void opentxInit()
   }
 #endif
 
-#if defined(GUI) && !defined(COLORLCD)
+#if defined(GUI) && !defined(COLORLCD) && !defined(STARTUP_ANIMATION)
   lcdSetContrast();
 #endif
 

--- a/radio/src/targets/taranis/board.h
+++ b/radio/src/targets/taranis/board.h
@@ -410,7 +410,7 @@ void ledBlue();
 
 #if defined(OLED_SCREEN)
   #define LCD_CONTRAST_DEFAULT          255 // full brightness
-#elif defined(RADIO_TX12) || defined(RADIO_TX12MK2) || defined(RADIO_ZORRO) || defined(RADIO_BOXER)
+#elif defined(RADIO_TX12) || defined(RADIO_TX12MK2) || defined(RADIO_BOXER)
   #define LCD_CONTRAST_DEFAULT          20
 #elif defined(RADIO_TPRO) || defined(RADIO_FAMILY_JUMPER_T12) || defined(RADIO_TPRO) || defined(RADIO_COMMANDO8)
   #define LCD_CONTRAST_DEFAULT          25


### PR DESCRIPTION
Revert a change introduced in https://github.com/EdgeTX/edgetx/pull/3575

With settings introduced in 3575, author custom splash with a lot of black pixels looks better, but default EdgeTX and many other look worse. Suggesting reverting to initial value

This fixes #3830

Recommend applying to 2.9