### PR TITLE
fix 2.9: wrong RTC backup register address calculation

### DIFF
--- a/radio/src/rtc.h
+++ b/radio/src/rtc.h
@@ -56,8 +56,9 @@ gtime_t gmktime (struct gtm *tm);
 uint8_t rtcAdjust(uint16_t year, uint8_t mon, uint8_t day, uint8_t hour, uint8_t min, uint8_t sec);
 
 
-#define RTCBKP0R 0    // RTC backup register 0
-#define RTCBKP1R 1    // RTC backup register 1
+#define RTCBKBR_BASE  ((void *)(&(RTC->BKP0R))) // base address of RTC backup registers
+#define RTCBKP0R 0                              // RTC backup register 0
+#define RTCBKP1R 1                              // RTC backup register 1
 
 uint32_t getRTCBKPR(uint8_t RTCBKPRegister);
 void setRTCBKPR(uint8_t RTCBKPRegister, uint32_t value);

--- a/radio/src/targets/common/arm/stm32/rtc_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/rtc_driver.cpp
@@ -21,7 +21,6 @@
 
 #include "stm32_hal.h"
 #include "rtc.h"
-#include "debug.h"
 
 //
 // Color screen targets use the first 2 out of the 20 

--- a/radio/src/targets/common/arm/stm32/rtc_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/rtc_driver.cpp
@@ -21,6 +21,7 @@
 
 #include "stm32_hal.h"
 #include "rtc.h"
+#include "debug.h"
 
 //
 // Color screen targets use the first 2 out of the 20 
@@ -48,7 +49,7 @@ uint32_t getRTCBKPR(uint8_t RTCBKPRegister) {
     RTC->BKP19R = RTCCHKSUM();
   }
 
-  uint32_t value = ((uint32_t *)RTC)[RTCBKPRegister];
+  uint32_t value = ((uint32_t *)RTCBKBR_BASE)[RTCBKPRegister];   // RTC backup registers are 32bit registers
 
   if(!prim) 
     __enable_irq();
@@ -62,10 +63,10 @@ uint32_t getRTCBKPR(uint8_t RTCBKPRegister) {
 // 
 void setRTCBKPR(uint8_t RTCBKPRegister, uint32_t value) {
   uint32_t prim = __get_PRIMASK();
-  
+
   __disable_irq();
 
-  ((uint32_t *)RTC)[RTCBKPRegister] = value;
+  ((uint32_t *)RTCBKBR_BASE)[RTCBKPRegister] = value;   // RTC backup registers are 32bit registers
 
   RTC->BKP19R = RTCCHKSUM();
 


### PR DESCRIPTION
@philmoz @pfeerick I'm very sorry, I f'd this up. Was using RTC base address instead of intended RTC backup register base address to read and write RTC backup registers.

Summary of changes:
- use RTC backup registers base address

address calculation verified on TX16s instrumented firmware:
```
0.88s: address rtc struct (RTC is defined as &rtc) 0x40002800
0.88s: base address RTC backup registers (expect offset 0x50) 0x40002850
0.88s: size of a single RTC backup register (expect 4, 32bit) 4
0.88s: address RTC BKP0R (expect offset 0x50) 0x40002850
0.88s: address RTC BKP1R (expect offset 0x54) 0x40002854
```

