### PR TITLE
fix(color): Change behaviour of TELE button on widget setup page to work like RTN button.

### DIFF
--- a/radio/src/gui/colorlcd/widgets_setup.cpp
+++ b/radio/src/gui/colorlcd/widgets_setup.cpp
@@ -138,7 +138,8 @@ void SetupWidgetsPage::deleteLater(bool detach, bool trash)
 void SetupWidgetsPage::onEvent(event_t event)
 {
 #if defined(HARDWARE_KEYS)
-  if (event == EVT_KEY_FIRST(KEY_PAGEUP) || event == EVT_KEY_FIRST(KEY_PAGEDN)) {
+  if (event == EVT_KEY_FIRST(KEY_PAGEUP) || event == EVT_KEY_FIRST(KEY_PAGEDN) ||
+      event == EVT_KEY_FIRST(KEY_SYS) || event == EVT_KEY_FIRST(KEY_MODEL)) {
     killEvents(event);
   } else if (event == EVT_KEY_FIRST(KEY_TELE)) {
     onCancel();

--- a/radio/src/gui/colorlcd/widgets_setup.cpp
+++ b/radio/src/gui/colorlcd/widgets_setup.cpp
@@ -137,9 +137,15 @@ void SetupWidgetsPage::deleteLater(bool detach, bool trash)
 
 void SetupWidgetsPage::onEvent(event_t event)
 {
+#if defined(HARDWARE_KEYS)
   if (event == EVT_KEY_FIRST(KEY_PAGEUP) || event == EVT_KEY_FIRST(KEY_PAGEDN)) {
     killEvents(event);
+  } else if (event == EVT_KEY_FIRST(KEY_TELE)) {
+    onCancel();
   } else {
     FormWindow::onEvent(event);
   }
+#else
+  FormWindow::onEvent(event);
+#endif
 }


### PR DESCRIPTION
Prevents recursive loading of widget setup page.

Fixes #3842 
