### PR TITLE
fix(cpn): selection of sound packs in update process

### DIFF
--- a/companion/src/updates/chooserdialog.cpp
+++ b/companion/src/updates/chooserdialog.cpp
@@ -22,7 +22,7 @@
 #include "chooserdialog.h"
 #include "ui_chooserdialog.h"
 
-ChooserDialog::ChooserDialog(QWidget * parent, QString title, QStandardItemModel * itemModel) :
+ChooserDialog::ChooserDialog(QWidget * parent, QString title, QStandardItemModel * itemModel, QAbstractItemView::SelectionMode mode) :
   QDialog(parent),
   ui(new Ui::ChooserDialog)
 {
@@ -32,6 +32,7 @@ ChooserDialog::ChooserDialog(QWidget * parent, QString title, QStandardItemModel
 
   ui->listView->setModel(itemModel);
   ui->listView->setEditTriggers(QAbstractItemView::NoEditTriggers);
+  ui->listView->setSelectionMode(mode);
 
   connect(ui->buttonBox, &QDialogButtonBox::accepted, [=]() {
     QDialog::accept();

--- a/companion/src/updates/chooserdialog.h
+++ b/companion/src/updates/chooserdialog.h
@@ -25,6 +25,7 @@
 #include <QString>
 #include <QStandardItemModel>
 #include <QItemSelectionModel>
+#include <QAbstractItemView>
 
 namespace Ui {
   class ChooserDialog;
@@ -35,7 +36,8 @@ class ChooserDialog : public QDialog
     Q_OBJECT
 
   public:
-    ChooserDialog(QWidget * parent, QString title, QStandardItemModel * itemModel);
+    ChooserDialog(QWidget * parent, QString title, QStandardItemModel * itemModel,
+                  QAbstractItemView::SelectionMode selMode = QAbstractItemView::SingleSelection);
     virtual ~ChooserDialog();
 
     QItemSelectionModel* selectedItems();

--- a/companion/src/updates/chooserdialog.ui
+++ b/companion/src/updates/chooserdialog.ui
@@ -17,7 +17,7 @@
    <item>
     <widget class="QListView" name="listView">
      <property name="selectionMode">
-      <enum>QAbstractItemView::MultiSelection</enum>
+      <enum>QAbstractItemView::SingleSelection</enum>
      </property>
     </widget>
    </item>

--- a/companion/src/updates/updateinterface.cpp
+++ b/companion/src/updates/updateinterface.cpp
@@ -741,7 +741,7 @@ bool UpdateInterface::retrieveRepoJsonFile(const QString & filename, QJsonDocume
   return m_repo->getJson(filename, json);
 }
 
-bool UpdateInterface::setFilteredAssets(const UpdateParameters::AssetParams & ap)
+bool UpdateInterface::filterAssets(const UpdateParameters::AssetParams & ap)
 {
   QString pattern(m_params->buildFilterPattern(ap.filterType, ap.filter));
   m_repo->assets()->setFilterPattern(pattern);
@@ -756,6 +756,14 @@ bool UpdateInterface::setFilteredAssets(const UpdateParameters::AssetParams & ap
                         .arg(m_repo->assets()->count() + 1).arg(ap.maxExpected).arg(m_repo->releases()->name().arg(pattern)), QtCriticalMsg);
     return false;
   }
+
+  return true;
+}
+
+bool UpdateInterface::setFilteredAssets(const UpdateParameters::AssetParams & ap)
+{
+  if (!filterAssets(ap))
+    return false;
 
   for (int i = 0; i < m_repo->assets()->count(); i++) {
     m_repo->assets()->getSetId(i);

--- a/companion/src/updates/updateinterface.cpp
+++ b/companion/src/updates/updateinterface.cpp
@@ -472,6 +472,25 @@ bool UpdateInterface::decompress()
   return true;
 }
 
+bool UpdateInterface::filterAssets(const UpdateParameters::AssetParams & ap)
+{
+  QString pattern(m_params->buildFilterPattern(ap.filterType, ap.filter));
+  m_repo->assets()->setFilterPattern(pattern);
+  m_status->reportProgress(tr("Asset filter applied: %1 - %2 found").arg(pattern).arg(m_repo->assets()->count()), QtDebugMsg);
+
+  if (m_repo->assets()->count() < 1) {
+    m_status->reportProgress(tr("No assets found in release '%1' using filter '%2'").arg(m_repo->releases()->name()).arg(pattern), QtCriticalMsg);
+    return false;
+  }
+  else if (ap.maxExpected > 0 && m_repo->assets()->count() > ap.maxExpected) {
+    m_status->reportProgress(tr("%1 assets found when %2 expected in release '%3' using filter '%4'")
+                        .arg(m_repo->assets()->count() + 1).arg(ap.maxExpected).arg(m_repo->releases()->name().arg(pattern)), QtCriticalMsg);
+    return false;
+  }
+
+  return true;
+}
+
 bool UpdateInterface::flagAssets()
 {
   m_status->progressMessage(tr("Flagging assets"));
@@ -739,25 +758,6 @@ bool UpdateInterface::retrieveAssetsJsonFile(const QString & assetName, QJsonDoc
 bool UpdateInterface::retrieveRepoJsonFile(const QString & filename, QJsonDocument * json)
 {
   return m_repo->getJson(filename, json);
-}
-
-bool UpdateInterface::filterAssets(const UpdateParameters::AssetParams & ap)
-{
-  QString pattern(m_params->buildFilterPattern(ap.filterType, ap.filter));
-  m_repo->assets()->setFilterPattern(pattern);
-  m_status->reportProgress(tr("Asset filter applied: %1 - %2 found").arg(pattern).arg(m_repo->assets()->count()), QtDebugMsg);
-
-  if (m_repo->assets()->count() < 1) {
-    m_status->reportProgress(tr("No assets found in release '%1' using filter '%2'").arg(m_repo->releases()->name()).arg(pattern), QtCriticalMsg);
-    return false;
-  }
-  else if (ap.maxExpected > 0 && m_repo->assets()->count() > ap.maxExpected) {
-    m_status->reportProgress(tr("%1 assets found when %2 expected in release '%3' using filter '%4'")
-                        .arg(m_repo->assets()->count() + 1).arg(ap.maxExpected).arg(m_repo->releases()->name().arg(pattern)), QtCriticalMsg);
-    return false;
-  }
-
-  return true;
 }
 
 bool UpdateInterface::setFilteredAssets(const UpdateParameters::AssetParams & ap)

--- a/companion/src/updates/updateinterface.h
+++ b/companion/src/updates/updateinterface.h
@@ -113,6 +113,7 @@ class UpdateInterface : public QWidget
     bool decompressFlaggedAssets();
     const QString downloadDir() const;
     bool downloadFlaggedAssets();
+    bool filterAssets(const UpdateParameters::AssetParams & ap);
     void init(QString repo, QString nightly = "", int resultsPerPage = -1);
     const bool isSettingsIndexValid() const;
     UpdateNetwork* const network() const;

--- a/companion/src/updates/updatesounds.cpp
+++ b/companion/src/updates/updatesounds.cpp
@@ -29,7 +29,7 @@
 UpdateSounds::UpdateSounds(QWidget * parent) :
   UpdateInterface(parent, CID_Sounds, tr("Sounds"))
 {
-  init(QString(GH_API_REPOS_EDGETX).append("/edgetx-sdcard-sounds"));
+  init(QString(GH_API_REPOS_EDGETX).append("/edgetx-sdcard-sounds"), "", "50");
   langPacks = new QStandardItemModel();
 }
 

--- a/companion/src/updates/updatesounds.cpp
+++ b/companion/src/updates/updatesounds.cpp
@@ -51,7 +51,7 @@ void UpdateSounds::assetSettingsInit()
   cad.processes(UPDFLG_Common_Asset);
   cad.flags(cad.processes() | UPDFLG_CopyStructure);
   cad.filterType(UpdateParameters::UFT_Startswith);
-  cad.filter("edgetx-sdcard-sounds-%LANGUAGE%-");
+  cad.filter("edgetx-sdcard-sounds-%LANGUAGE%");
 
   qDebug() << "Asset settings initialised";
 }

--- a/companion/src/updates/updatesounds.cpp
+++ b/companion/src/updates/updatesounds.cpp
@@ -25,11 +25,12 @@
 #include <QMessageBox>
 #include <QStandardItem>
 #include <QItemSelectionModel>
+#include <QAbstractItemView>
 
 UpdateSounds::UpdateSounds(QWidget * parent) :
   UpdateInterface(parent, CID_Sounds, tr("Sounds"))
 {
-  init(QString(GH_API_REPOS_EDGETX).append("/edgetx-sdcard-sounds"), "", "50");
+  init(QString(GH_API_REPOS_EDGETX).append("/edgetx-sdcard-sounds"), "", 50);
   langPacks = new QStandardItemModel();
 }
 
@@ -59,69 +60,18 @@ bool UpdateSounds::flagAssets()
 {
   status()->progressMessage(tr("Processing available sounds"));
 
-  QJsonDocument *json = new QJsonDocument();
-
-  const QString jsonFile("sounds.json");
-
-  if (!retrieveAssetsJsonFile(jsonFile, json)) {
-    status()->reportProgress(tr("Unable to retrieve asset '%1' from release '%2'").arg(jsonFile).arg(repo()->releases()->name()), QtDebugMsg);
-    //  assume older release where file not an asset
-    if (!retrieveRepoJsonFile(jsonFile, json)) {
-      status()->reportProgress(tr("Unable to retrieve file '%1' from repo '%2'").arg(jsonFile).arg(repo()->path()), QtCriticalMsg);
-      delete json;
-      return false;
-    }
-  }
-
-  /*
-    {
-        "language": "en-GB",
-        "name": "British English Female",
-        "description": "British English Female Voice (en-GB-Libby)",
-        "directory": "en_gb-libby"
-    },
-  */
-
-  //  always refresh to allow for language change in radio profile
+  // always refresh to allow for language change in radio profile
   langPacks->clear();
 
-  if (json->isArray()) {
-    const QJsonArray &arr = json->array();
-
-    foreach (const QJsonValue &v, arr) {
-      if (v.isObject()) {
-        const QJsonObject obj = v.toObject();
-        QString langVariant;
-        QString lang;
-
-        if (!obj.value("language").isUndefined()) {
-          langVariant = obj.value("language").toString();
-          lang = langVariant.split("-").at(0);
-        }
-
-        if (lang == params()->language) {
-          QStandardItem * item = new QStandardItem();
-
-          if (!obj.value("language").isUndefined())
-            item->setData(obj.value("language").toString(), IMDR_Language);
-          if (!obj.value("name").isUndefined())
-            item->setData(obj.value("name").toString(), IMDR_Name);
-          if (!obj.value("description").isUndefined())
-            item->setData(obj.value("description").toString(), Qt::DisplayRole);
-          if (!obj.value("directory").isUndefined())
-            item->setData(obj.value("directory").toString(), IMDR_Directory);
-
-          langPacks->appendRow(item);
-        }
-      }
-    }
-  }
-
-  delete json;
-
-  if (langPacks->rowCount() < 1) {
-    status()->reportProgress(tr("Language '%1' not listed in '%2'").arg(params()->language).arg(jsonFile), QtCriticalMsg);
+  UpdateParameters::AssetParams ap = params()->assets[0];
+  if (!filterAssets(ap))
     return false;
+
+  for (int i = 0; i < repo()->assets()->count(); i++) {
+    repo()->assets()->getSetId(i);
+    QStandardItem * item = new QStandardItem();
+    item->setText(repo()->assets()->name());
+    langPacks->appendRow(item);
   }
 
   if (langPacks->rowCount() > 1) {
@@ -139,26 +89,25 @@ bool UpdateSounds::flagAssets()
 
     QModelIndexList selIndexes = selItems->selectedIndexes();
 
-    for (int i = 0; i < selIndexes.size(); i++) {
-      if (!flagLanguageAsset(langPacks->data(selIndexes.at(i), IMDR_Directory).toString()))
-        return false;
-    }
+    if (!flagLanguageAsset(langPacks->data(selIndexes.at(0)).toString()))
+      return false;
 
     dlg->deleteLater();
   }
   else if (langPacks->rowCount() == 1) {
-    if (!flagLanguageAsset(langPacks->data(langPacks->index(0, 0), IMDR_Directory).toString()))
+    if (!flagLanguageAsset(langPacks->data(langPacks->index(0, 0)).toString()))
       return false;
   }
 
   return true;
 }
 
-bool UpdateSounds::flagLanguageAsset(QString lang)
+bool UpdateSounds::flagLanguageAsset(QString asset)
 {
   status()->progressMessage(tr("Flagging assets"));
 
-  params()->language = lang;
   UpdateParameters::AssetParams ap = params()->assets[0];
+  ap.filter = asset;
+  ap.filterType = UpdateParameters::UFT_Exact;
   return setFilteredAssets(ap);
 }

--- a/companion/src/updates/updatesounds.h
+++ b/companion/src/updates/updatesounds.h
@@ -39,13 +39,6 @@ class UpdateSounds : public UpdateInterface
     virtual void assetSettingsInit() override;
 
   private:
-    enum ItemModelDataRoles {
-      IMDR_Language = Qt::UserRole,
-      IMDR_Name,
-      IMDR_Directory,
-    };
-    Q_ENUM(ItemModelDataRoles)
-
     QStandardItemModel *langPacks;
 
     bool flagLanguageAsset(QString lang);

--- a/companion/src/updates/updatestatus.cpp
+++ b/companion/src/updates/updatestatus.cpp
@@ -36,11 +36,8 @@ void UpdateStatus::reportProgress(QString text, QtMsgType type)
   if (m_logLevel == QtDebugMsg ||
      (m_logLevel == QtInfoMsg && type > QtDebugMsg) ||
      (type < QtInfoMsg && type >= m_logLevel)) {
-    if (m_progress) {
+    if (m_progress)
       m_progress->addMessage(text, type);
-      if (m_logLevel == QtDebugMsg)
-        qDebug() << text;
-    }
     else
       qDebug() << text;
   }


### PR DESCRIPTION
Fixes #3841

Summary of changes:
- refactor asset filtering to not use sounds.json file but instead filter the release assets
- only 1 pack can be downloaded per run as all language variants share the same destination directory
- supporting functions
- housekeeping

![Screenshot from 2023-07-24 09-32-06](https://github.com/EdgeTX/edgetx/assets/15316949/0ed0d4f8-0d01-41c3-9284-8426a7b40c6b)

Due to a change to the asset filter a release note is required as only 1 zip file will be found for each language with the old filter:
Steps:
1. Launch Companion
2. Select Settings
3. Select Update Settings tab
4. Click Sounds component Options button
5. Edit the Filter pattern by DELETING the trailing hypen
6. Click OK to save the change
7. Click OK to exit the Settings

![Screenshot from 2023-07-24 09-37-45](https://github.com/EdgeTX/edgetx/assets/15316949/1b375e71-6234-448a-99f8-1fd05eee63a6)
