### PR TITLE
fix(color): Expand analog diagnostic page to full height

### DIFF
--- a/radio/src/gui/colorlcd/radio_diaganas.cpp
+++ b/radio/src/gui/colorlcd/radio_diaganas.cpp
@@ -186,6 +186,8 @@ class AnaCalibratedViewWindow: public AnaViewWindow {
       lv_obj_set_grid_cell(lbl2->getLvObj(), LV_GRID_ALIGN_STRETCH, TSI2CEventsCol, 5, LV_GRID_ALIGN_CENTER, 0, 1);
 #endif
 #endif // defined(HARDWARE_TOUCH)
+
+      setHeight(parent->height());
     }
 
 #if defined(HARDWARE_TOUCH)


### PR DESCRIPTION
On portrait layout LCD screen the analog diagnostic page is clipped to the content height so the touch screen cursor gets clipped halfway down.
This PR resizes the page to full height so the crosshair is not clipped.