### PR TITLE
feat(128): Swap modelname for timer1 if defined

### DIFF
--- a/radio/src/gui/128x64/lcd.cpp
+++ b/radio/src/gui/128x64/lcd.cpp
@@ -627,13 +627,14 @@ void lcdDrawFilledRect(coord_t x, coord_t y, coord_t w, coord_t h, uint8_t pat, 
 
 void drawTelemetryTopBar()
 {
-  drawModelName(0, 0, g_model.header.name, g_eeGeneral.currModel, 0);
+  if (g_model.timers[0].mode) {
+    uint8_t att = (timersStates[0].val<0 ? BLINK : 0);
+    drawTimer(0, 0, timersStates[0].val, att, att);
+  } else {
+    drawModelName(0, 0, g_model.header.name, g_eeGeneral.currModel, 0);
+  }
   uint8_t att = (IS_TXBATT_WARNING() ? BLINK : 0);
   putsVBat(10*FW-1,0,att);
-  if (g_model.timers[0].mode) {
-    att = (timersStates[0].val<0 ? BLINK : 0);
-    drawTimer(13*FW+2, 0, timersStates[0].val, att, att);
-  }
 #if defined(RTCLOCK)
   drawRtcTime(17*FW+3, 0, LEFT|TIMEBLINK);
 #endif


### PR DESCRIPTION
Resolves #3836

Swaps the model name for timer1 if it is defined. I was tempted to make it so if no RTC, the timer is drawn where the time would be, but that will then create a "if this handset, looks like this, if that handset, looks like that" documentation/tutorial issue. 

Timer 1 defined
![snapshot_03](https://github.com/EdgeTX/edgetx/assets/5500713/84415c2a-3130-416a-aec1-3789a6b34fa1)

No timer 1 (i.e. like before, minus timer)
![snapshot_04](https://github.com/EdgeTX/edgetx/assets/5500713/7dd193c8-0934-42bb-860d-15f857e9b8d7)

