### PR TITLE
fix: keys diag displaying wrongly navigation keys

### DIFF
--- a/radio/src/gui/128x64/radio_diagkeys.cpp
+++ b/radio/src/gui/128x64/radio_diagkeys.cpp
@@ -93,12 +93,12 @@ void menuRadioDiagKeys(event_t event)
       if (i >= 7) { // max 7 lines on display
         y = MENU_HEADER_HEIGHT + 1 + FH * 6;
         lcdDrawText(8, y, keysGetLabel(k), 0);
-        displayKeyState(lcdNextPos + 10, y, i);
+        displayKeyState(lcdNextPos + 10, y, k);
       }
       else {
         y = MENU_HEADER_HEIGHT + 1 + FH * i;
         lcdDrawText(0, y, keysGetLabel(k), 0);
-        displayKeyState(5 * FW + 2, y, i);
+        displayKeyState(5 * FW + 2, y, k);
       }
     }
 

--- a/radio/src/gui/212x64/radio_diagkeys.cpp
+++ b/radio/src/gui/212x64/radio_diagkeys.cpp
@@ -66,7 +66,7 @@ void menuRadioDiagKeys(event_t event)
     auto k = get_ith_key(i);
     coord_t y = MENU_HEADER_HEIGHT + 1 + FH * i;
     lcdDrawText(0, y, keysGetLabel(k), 0);
-    displayKeyState(5 * FW + 2, y, i);
+    displayKeyState(5 * FW + 2, y, k);
   }
 
   for (uint8_t i = 0, cnt = 0; i < switchGetMaxSwitches(); i++) {


### PR DESCRIPTION
Fix BW screen displaying the wrong keys entry in keys debug screen