### PR TITLE
feat: Default audio mute on for RM radios

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -349,6 +349,10 @@ void generalDefault()
   g_eeGeneral.rotEncMode = ROTARY_ENCODER_MODE_INVERT_BOTH;
 #endif
 
+#if defined(MANUFACTURER_RADIOMASTER)
+  g_eeGeneral.audioMuteEnable = 1;
+#endif
+
   g_eeGeneral.chkSum = 0xFFFF;
 }
 


### PR DESCRIPTION
Radiomaster as asked to default their radio with mute on (they are doing it on production lines, but if you wipe your sd, it default cxurrently to disabled)