### PR TITLE
fix(color): Fix switch selection when physical switch moved in Flight Mode edit page.

### DIFF
--- a/radio/src/gui/colorlcd/model_flightmodes.cpp
+++ b/radio/src/gui/colorlcd/model_flightmodes.cpp
@@ -168,6 +168,7 @@ class FlightModeEdit : public Page
           tr_value[i]->setValue(lastTrim[i]);
         }
       }
+      Page::checkEvents();
     }
 
   protected:


### PR DESCRIPTION
Fixes #3873 

Needs to be applied to 2.9 as well as 2.10.
