### PR TITLE
fix: unsuported %zu in arm compiler

### DIFF
--- a/radio/src/gui/colorlcd/input_mix_group.cpp
+++ b/radio/src/gui/colorlcd/input_mix_group.cpp
@@ -57,7 +57,7 @@ InputMixGroup::InputMixGroup(Window* parent, mixsrc_t idx) :
   if (idx >= MIXSRC_FIRST_CH && idx <= MIXSRC_LAST_CH
       && g_model.limitData[idx - MIXSRC_FIRST_CH].name[0] != '\0') {
     chText = lv_label_create(lvobj);
-    lv_label_set_text_fmt(chText, TR_CH "%zu", (size_t)(idx - MIXSRC_FIRST_CH + 1));
+    lv_label_set_text_fmt(chText, TR_CH "%" PRIu32, UINT32_C(idx - MIXSRC_FIRST_CH + 1));
     lv_obj_set_style_text_font(chText, getFont(FONT(XS)), 0);
 #if LCD_H > LCD_W
     lv_obj_set_style_pad_bottom(chText, -2, 0);

--- a/radio/src/gui/common/stdlcd/radio_version.cpp
+++ b/radio/src/gui/common/stdlcd/radio_version.cpp
@@ -162,8 +162,8 @@ void menuRadioModulesVersion(event_t event)
 #if defined(CROSSFIRE)
       if (isModuleCrossfire(module)) {
         char statusText[64] = "";
-        sprintf(statusText, "%d Hz %zu Err",
-                1000000 / getMixerSchedulerPeriod(), (size_t)0/*telemetryErrors*/);
+        sprintf(statusText, "%d Hz %" PRIu32" Err",
+                1000000 / getMixerSchedulerPeriod(), UINT32_C(0)/*telemetryErrors*/);
         lcdDrawText(COLUMN2_X, y, statusText);
         y += FH;
         continue;

--- a/radio/src/gui/common/stdlcd/radio_version.cpp
+++ b/radio/src/gui/common/stdlcd/radio_version.cpp
@@ -162,8 +162,8 @@ void menuRadioModulesVersion(event_t event)
 #if defined(CROSSFIRE)
       if (isModuleCrossfire(module)) {
         char statusText[64] = "";
-        sprintf(statusText, "%d Hz %" PRIu32" Err",
-                1000000 / getMixerSchedulerPeriod(), UINT32_C(0)/*telemetryErrors*/);
+        sprintf(statusText, "%d Hz"/* %" PRIu32" Err"*/,
+                1000000 / getMixerSchedulerPeriod()/*, UINT32_C(telemetryErrors)*/);
         lcdDrawText(COLUMN2_X, y, statusText);
         y += FH;
         continue;


### PR DESCRIPTION
Fix an issue reported by Radiomaster and introduced in #2748

This allow proper compilation with current arm compiler and also prevent the casting warning when compiled on 64bit platfrom.

Also the display of "0 Err" has been removed as it is quite misleading, but code is left in place in a hope that telemetryErrors is going to come back... one day :D

![image](https://github.com/EdgeTX/edgetx/assets/5167938/83d81f77-0fa8-4066-8e87-dcd9efbc08de)
