### PR TITLE
fix: race condition on mixer task handle

### DIFF
--- a/radio/src/tasks/mixer_task.cpp
+++ b/radio/src/tasks/mixer_task.cpp
@@ -60,9 +60,11 @@ void mixerTaskUnlock()
 
 void mixerTaskInit()
 {
+  mixerSchedulerInit();
   RTOS_CREATE_MUTEX(mixerMutex);
   RTOS_CREATE_TASK(mixerTaskId, mixerTask, "mixer", mixerStack,
                    MIXER_STACK_SIZE, MIXER_TASK_PRIO);
+  mixerSchedulerStart();
 }
 
 bool mixerTaskStarted()
@@ -146,9 +148,6 @@ TASK_FUNCTION(mixerTask)
 #if defined(IMU)
   gyroInit();
 #endif
-
-  mixerSchedulerInit();
-  mixerSchedulerStart();
 
   while (!_mixer_exit) {
 


### PR DESCRIPTION
PR #3451 moved the start of the mixer task to a point in time where the task scheduler is already started (UI task). Before that change, the mixer task would be created *before* and effectively started *after* the task scheduler started.

This introduces a race condition on `mixerTaskId.rtos_handle`, as the mixer scheduler might trigger before `xTaskCreateStatic` returns and the task handle is assigned.

This PR fixes the issue by delaying the start of the mixer scheduler until `xTaskCreateStatic` returned and the task handler has been properly assigned.