### PR TITLE
Grace period before setting sensor auto offset

### DIFF
--- a/radio/src/gui/128x64/model_telemetry_sensor.cpp
+++ b/radio/src/gui/128x64/model_telemetry_sensor.cpp
@@ -281,6 +281,10 @@ void menuModelSensor(event_t event)
 
       case SENSOR_FIELD_AUTOOFFSET:
         sensor->autoOffset = editCheckBox(sensor->autoOffset, SENSOR_2ND_COLUMN, y, STR_AUTOOFFSET, attr, event);
+        if(checkIncDec_Ret) {
+          if(sensor->autoOffset == 0)
+            telemetryItems[s_currIdx].std.offsetAutoStored = false;
+        };
         break;
 
       case SENSOR_FIELD_ONLYPOSITIVE:

--- a/radio/src/gui/212x64/model_telemetry_sensor.cpp
+++ b/radio/src/gui/212x64/model_telemetry_sensor.cpp
@@ -295,6 +295,10 @@ void menuModelSensor(event_t event)
 
       case SENSOR_FIELD_AUTOOFFSET:
         sensor->autoOffset = editCheckBox(sensor->autoOffset, SENSOR_2ND_COLUMN, y, STR_AUTOOFFSET, attr, event);
+        if(checkIncDec_Ret) {
+          if(sensor->autoOffset == 0)
+            telemetryItems[s_currIdx].std.offsetAutoStored = false;
+        };
         break;
 
       case SENSOR_FIELD_ONLYPOSITIVE:

--- a/radio/src/gui/colorlcd/model_telemetry.cpp
+++ b/radio/src/gui/colorlcd/model_telemetry.cpp
@@ -695,7 +695,13 @@ class SensorEditWindow : public Page {
 
       paramLines[P_AUTOOFFSET] = form->newLine(&grid);
       new StaticText(paramLines[P_AUTOOFFSET], rect_t{}, STR_AUTOOFFSET, 0, COLOR_THEME_PRIMARY1);
-      new ToggleSwitch(paramLines[P_AUTOOFFSET], rect_t{}, GET_SET_DEFAULT(sensor->autoOffset));
+      new ToggleSwitch(paramLines[P_AUTOOFFSET], rect_t{}, GET_DEFAULT(sensor->autoOffset),
+                       [=](uint8_t newValue) {
+                        sensor->autoOffset = newValue;
+                        if(sensor->autoOffset == 0)
+                          telemetryItems[index].std.offsetAutoStored = false;
+                        SET_DIRTY();
+                      });
 
       paramLines[P_ONLYPOS] = form->newLine(&grid);
       new StaticText(paramLines[P_ONLYPOS], rect_t{}, STR_ONLYPOSITIVE, 0, COLOR_THEME_PRIMARY1);

--- a/radio/src/telemetry/telemetry_sensors.cpp
+++ b/radio/src/telemetry/telemetry_sensors.cpp
@@ -213,8 +213,9 @@ void TelemetryItem::setValue(const TelemetrySensor &sensor, int32_t val,
   else {
     newVal = sensor.getValue(newVal, unit, prec);
     if (sensor.autoOffset) {
-      if (!isAvailable()) {
+      if (!std.offsetAutoStored && TELEMETRY_STREAMING()) {
         std.offsetAuto = -newVal;
+        std.offsetAutoStored = true;
       }
       newVal += std.offsetAuto;
     }

--- a/radio/src/telemetry/telemetry_sensors.h
+++ b/radio/src/telemetry/telemetry_sensors.h
@@ -52,6 +52,7 @@ class TelemetryItem
     union {
       struct {
         int32_t  offsetAuto;
+        bool     offsetAutoStored;
         int32_t  filterValues[TELEMETRY_AVERAGE_COUNT];
       } std;
       struct {


### PR DESCRIPTION
Harmonized setting sensor auto offset with TELEMETRY_STREAMING() which returns true after one second of stable telemetry data. Auto offset will be written for the specific sensor if it is enabled and telemetry streaming is stable and 
- was not yet stored in this power cycle or
- auto offset is disabled and enabled (later) again in this power cycle or
- Reset Telemetry is requested