### PR TITLE
fix: PCBREV detect not working

### DIFF
--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -2150,15 +2150,15 @@
 #define TELEMETRY_TIMER_IRQHandler      TIM1_TRG_COM_TIM11_IRQHandler
 
 // PCBREV
-// #if defined(RADIO_X7)
-  // #define PCBREV_RCC_AHB1Periph         RCC_AHB1Periph_GPIOA
-  // #define PCBREV_GPIO                   GPIOA
-  // #define PCBREV_GPIO_PIN               GPIO_Pin_14  // PA.14
-  // #define PCBREV_GPIO_PULL_DOWN
-  // #define PCBREV_VALUE()                GPIO_ReadInputDataBit(PCBREV_GPIO, PCBREV_GPIO_PIN)
-// #else
+#if defined(RADIO_X7)
+  #define PCBREV_RCC_AHB1Periph         RCC_AHB1Periph_GPIOA
+  #define PCBREV_GPIO                   GPIOA
+  #define PCBREV_GPIO_PIN               GPIO_Pin_14  // PA.14
+  #define PCBREV_GPIO_PULL_DOWN
+  #define PCBREV_VALUE()                GPIO_ReadInputDataBit(PCBREV_GPIO, PCBREV_GPIO_PIN)
+#else
   #define PCBREV_RCC_AHB1Periph         0
-// #endif
+#endif
 
 
 // USB Charger


### PR DESCRIPTION
PCBREV detection for X7 was disabled as part of early 2.10 work. It leads to SPORT port not been  available on X7

Once enable, option is back, tested flashing a receiver ok