### PR TITLE
fix: EM when LUA script is running and radio is turned off

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1259,14 +1259,14 @@ void opentxClose(uint8_t shutdown)
     pulsesStop();
     AUDIO_BYE();
     // TODO needed? telemetryEnd();
-#if defined(LUA)
-    luaClose(&lsScripts);
-#endif
-
 #if defined(HAPTIC)
     hapticOff();
 #endif
   }
+
+#if defined(LUA)
+  luaClose(&lsScripts);
+#endif
 
 #if defined(SDCARD)
   logsClose();

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1259,6 +1259,10 @@ void opentxClose(uint8_t shutdown)
     pulsesStop();
     AUDIO_BYE();
     // TODO needed? telemetryEnd();
+#if defined(LUA)
+    luaClose(&lsScripts);
+#endif
+
 #if defined(HAPTIC)
     hapticOff();
 #endif
@@ -1301,11 +1305,6 @@ void opentxClose(uint8_t shutdown)
   luaClose(&lsWidgets);
   lsWidgets = 0;
 #endif
-#endif
-#if defined(LUA)
-  // the script context needs to be closed *after*
-  // the widgets, as it has been the first to be opened
-  luaClose(&lsScripts);
 #endif
 
 #if defined(SDCARD)


### PR DESCRIPTION
This revert a minor change part of #2994, which cause very bad EM when trying to power off the radio and a LUA script is running (a wizard for example).

At the time of writing, I have not been able to gather why the change was made in #2994, so it may introduce another issue I'm not aware off, but it does fix the EM issue (tested on TX16S and Zorro).

This fixes #3919

While 2.9 is timing wise the most critical, 2.10 needs it too