### PR TITLE
feat(cpn): Clear clipboard on profile change

### DIFF
--- a/companion/src/mainwindow.cpp
+++ b/companion/src/mainwindow.cpp
@@ -1250,6 +1250,7 @@ void MainWindow::onCurrentProfileChanged()
 {
   Firmware::setCurrentVariant(Firmware::getFirmwareForId(g.currentProfile().fwType()));
   emit firmwareChanged();
+  QApplication::clipboard()->clear();
   updateMenus();
 }
 


### PR DESCRIPTION
Prevents pasting clipboard data from one profile to another possibly incompatible one which could result in corrupted models and settings