### PR TITLE
perf: Use FreeRTOS mutex instead of binary semaphore

### DIFF
--- a/radio/src/FreeRTOSConfig.h
+++ b/radio/src/FreeRTOSConfig.h
@@ -41,7 +41,7 @@ extern uint32_t SystemCoreClock;
 #define configUSE_16_BIT_TICKS          0
 #define configIDLE_SHOULD_YIELD         1
 // Use notifications
-#define configUSE_MUTEXES               0
+#define configUSE_MUTEXES               1
 #define configQUEUE_REGISTRY_SIZE       0
 #define configUSE_RECURSIVE_MUTEXES     0
 #define configUSE_MALLOC_FAILED_HOOK    0

--- a/radio/src/rtos.h
+++ b/radio/src/rtos.h
@@ -206,7 +206,7 @@ extern "C++" {
   
   static inline void _RTOS_CREATE_MUTEX(RTOS_MUTEX_HANDLE* h)
   {
-    h->rtos_handle = xSemaphoreCreateBinaryStatic(&h->mutex_struct);
+    h->rtos_handle = xSemaphoreCreateMutexStatic(&h->mutex_struct);
     xSemaphoreGive(h->rtos_handle);
   }
 


### PR DESCRIPTION
This PR switches from FreeRTOS binary semaphores to mutexes. The main advantage is that it gives us `Priority Inheritance` (see [here](https://www.freertos.org/Real-time-embedded-RTOS-mutexes.html)).

`Priority Inheritance` should reduce lock contention when a mutex is locked from a lower priority task but needed by a higher priority task. This is done by temporarily raising the priority of the lower priority task to allow it to complete the current operation and release the mutex, thus giving way to the higher priority task to carry on.

This happens in the following cases:
- FatFs I/O mutex (`ioMutex`) is used from `UI (low prio)`, `Timer (mid prio)` and `Audio (high prio)` tasks.
- Mixer mutex is used from `UI (low prio)` and `Mixer (very high prio)` tasks.
- Audio mutex is used from `UI (low prio)` and `Timer (mid prio)` tasks.

However, this change does not come for free. It add some FLASH and RAM usage:
- `BOXER`: +672 bytes FLASH / +48 bytes RAM.
- `X9D+ 2019`: +672 bytes FLASH / +40 bytes RAM.
 