### PR TITLE
fix: PXX1 external module timings

### DIFF
--- a/radio/src/boards/generic_stm32/module_ports.cpp
+++ b/radio/src/boards/generic_stm32/module_ports.cpp
@@ -520,6 +520,10 @@ const etx_module_t _sport_module = {
 
 #endif // SPORT_UPDATE_PWR_GPIO
 
+#if !defined(RADIO_X10E)
+uint32_t __pxx1_get_inverter_comp() { return 1; }
+#endif
+
 void boardInitModulePorts()
 {
   _sport_direction_init();

--- a/radio/src/targets/common/arm/stm32/stm32_softserial_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_softserial_driver.cpp
@@ -310,6 +310,7 @@ static void _conv_byte_8n1(stm32_softserial_tx_state* st, uint8_t b)
 //
 #define PXX1_FREQ      1000000 /* 1 MHz */
 #define PXX1_PWM_ON    8  /* 8us */
+#define PXX1_SLOW_INVERTER_COMPENSATION   1  /* 1us, only on rise (polarity == false) */
 #define PXX1_BIT_ZERO  16 /* 0 = 16us */
 #define PXX1_BIT_ONE   24 /* 1 = 24us */
 
@@ -360,7 +361,7 @@ static void* stm32_softserial_tx_init(void* hw_def, const etx_serial_init* param
     freq = PXX1_FREQ;
     polarity = false;
     ocmode = LL_TIM_OCMODE_FORCED_INACTIVE;
-    cmp_val = PXX1_PWM_ON;
+    cmp_val = PXX1_PWM_ON + PXX1_SLOW_INVERTER_COMPENSATION;
     break;
 
   default:
@@ -483,7 +484,7 @@ static void stm32_softserial_tx_send_buffer(void* ctx, const uint8_t* data, uint
   // dirty hack...
   if (st->conv_byte == _conv_byte_pxx1) {
     ocmode = LL_TIM_OCMODE_PWM1;
-    cmp_val = PXX1_PWM_ON;
+    cmp_val = PXX1_PWM_ON + PXX1_SLOW_INVERTER_COMPENSATION;
   }
 
   stm32_pulse_start_dma_req(timer, pulses, length, ocmode, cmp_val);

--- a/radio/src/targets/common/arm/stm32/stm32_softserial_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_softserial_driver.cpp
@@ -310,7 +310,11 @@ static void _conv_byte_8n1(stm32_softserial_tx_state* st, uint8_t b)
 //
 #define PXX1_FREQ      1000000 /* 1 MHz */
 #define PXX1_PWM_ON    8  /* 8us */
-#define PXX1_SLOW_INVERTER_COMPENSATION   1  /* 1us, only on rise (polarity == false) */
+#if defined(RADIO_X10E)
+  #define PXX1_SLOW_INVERTER_COMPENSATION   0  /* x10Express does have fast inverters that do not require compensation */
+#else
+  #define PXX1_SLOW_INVERTER_COMPENSATION   1  /* 1us, only on rise (polarity == false) */
+#endif
 #define PXX1_BIT_ZERO  16 /* 0 = 16us */
 #define PXX1_BIT_ONE   24 /* 1 = 24us */
 

--- a/radio/src/targets/common/arm/stm32/stm32_softserial_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_softserial_driver.cpp
@@ -310,13 +310,10 @@ static void _conv_byte_8n1(stm32_softserial_tx_state* st, uint8_t b)
 //
 #define PXX1_FREQ      1000000 /* 1 MHz */
 #define PXX1_PWM_ON    8  /* 8us */
-#if defined(RADIO_X10E)
-  #define PXX1_SLOW_INVERTER_COMPENSATION   0  /* x10Express does have fast inverters that do not require compensation */
-#else
-  #define PXX1_SLOW_INVERTER_COMPENSATION   1  /* 1us, only on rise (polarity == false) */
-#endif
 #define PXX1_BIT_ZERO  16 /* 0 = 16us */
 #define PXX1_BIT_ONE   24 /* 1 = 24us */
+
+__attribute__ ((weak)) uint32_t __pxx1_get_inverter_comp() { return 0; }
 
 static void _conv_byte_pxx1(stm32_softserial_tx_state* st, uint8_t b)
 {
@@ -365,7 +362,7 @@ static void* stm32_softserial_tx_init(void* hw_def, const etx_serial_init* param
     freq = PXX1_FREQ;
     polarity = false;
     ocmode = LL_TIM_OCMODE_FORCED_INACTIVE;
-    cmp_val = PXX1_PWM_ON + PXX1_SLOW_INVERTER_COMPENSATION;
+    cmp_val = PXX1_PWM_ON + __pxx1_get_inverter_comp();
     break;
 
   default:
@@ -488,7 +485,7 @@ static void stm32_softserial_tx_send_buffer(void* ctx, const uint8_t* data, uint
   // dirty hack...
   if (st->conv_byte == _conv_byte_pxx1) {
     ocmode = LL_TIM_OCMODE_PWM1;
-    cmp_val = PXX1_PWM_ON + PXX1_SLOW_INVERTER_COMPENSATION;
+    cmp_val = PXX1_PWM_ON + __pxx1_get_inverter_comp();
   }
 
   stm32_pulse_start_dma_req(timer, pulses, length, ocmode, cmp_val);

--- a/radio/src/targets/common/arm/stm32/stm32_softserial_driver.h
+++ b/radio/src/targets/common/arm/stm32/stm32_softserial_driver.h
@@ -105,3 +105,7 @@ struct stm32_softserial_tx_port {
 #define REF_STM32_SOFTSERIAL_PORT(p) ((void*)& p ## _STM32Softserial)
 
 extern const etx_serial_driver_t STM32SoftSerialTxDriver;
+
+// This is defined as a weak symbol to allow stretching the prelude part
+// of PXX1 pulses to an acceptable length
+uint32_t __pxx1_get_inverter_comp();


### PR DESCRIPTION
Over the course of the previous months, a series of changes have been made to clean pulse generation. Part of it has broken external R9M (and likely XJT).

Bottom line is the software is trying to generate a 8µS/8µs pulse (and the MCU does it correctly), but after the inverters, you have basicaly 7µS/9µS, and the module does fail.

![image](https://github.com/EdgeTX/edgetx/assets/5167938/4d089548-ab12-4316-8710-a53d500e07a0)

![image](https://github.com/EdgeTX/edgetx/assets/5167938/d770acfe-0005-4b97-a469-be0b427d1e8b)

![image](https://github.com/EdgeTX/edgetx/assets/5167938/faea9d6f-c4b5-4b22-bf75-74b40426d4a0)

(red is MCU output pin, white is inverter out)

This introduces a compensation for the slow inverters. This has been successfully tested on TX16S and X7S. X10 Express does have (because of ACCESS support) fast inverters, so the compensation is not needed.

It needs to be noted that this also affect internal module PXX1 used by X7 and X9(D/D+/E), but they also have an inverter inside