### PR TITLE
feat(color): Show custom image during shutdown if present

### DIFF
--- a/radio/src/gui/colorlcd/draw_functions.cpp
+++ b/radio/src/gui/colorlcd/draw_functions.cpp
@@ -129,6 +129,7 @@ const int8_t bmp_shutdown_yo[] = {
 void drawShutdownAnimation(uint32_t duration, uint32_t totalDuration,
                            const char* message)
 {
+  static BitmapBuffer* shutdownSplashImg = nullptr;
   if (totalDuration == 0) return;
 
   LcdFlags fgColor;
@@ -150,12 +151,22 @@ void drawShutdownAnimation(uint32_t duration, uint32_t totalDuration,
   int quarter = duration / (totalDuration / 5);
 
   if (shutdown) {
-    lcd->drawMask((LCD_W - shutdown->width()) / 2,
-                  (LCD_H - shutdown->height()) / 2, shutdown, fgColor);
+    if (!sdMounted()) sdInit();
+    shutdownSplashImg = BitmapBuffer::loadBitmap(
+        BITMAPS_PATH "/" SHUTDOWN_SPLASH_FILE, BMP_RGB565);
 
-    for (int i = 0; i <= 3 - quarter; i += 1) {
-      lcd->drawBitmapPattern(LCD_W / 2 + bmp_shutdown_xo[i], LCD_H / 2 + bmp_shutdown_yo[i],
-                             LBM_SHUTDOWN_CIRCLE, fgColor, i * SHUTDOWN_CIRCLE_RADIUS, SHUTDOWN_CIRCLE_RADIUS);
+    if (shutdownSplashImg) {
+      lcd->drawBitmap(0, 0, shutdownSplashImg);
+    } else {
+      lcd->drawMask((LCD_W - shutdown->width()) / 2,
+                    (LCD_H - shutdown->height()) / 2, shutdown, fgColor);
+
+      for (int i = 0; i <= 3 - quarter; i += 1) {
+        lcd->drawBitmapPattern(
+            LCD_W / 2 + bmp_shutdown_xo[i], LCD_H / 2 + bmp_shutdown_yo[i],
+            LBM_SHUTDOWN_CIRCLE, fgColor, i * SHUTDOWN_CIRCLE_RADIUS,
+            SHUTDOWN_CIRCLE_RADIUS);
+      }
     }
   } else {
     for (int i = 1; i <= 4; i++) {

--- a/radio/src/sdcard.h
+++ b/radio/src/sdcard.h
@@ -78,6 +78,7 @@ const char RADIO_SETTINGS_ERRORFILE_YAML_PATH[] = RADIO_PATH PATH_SEPARATOR "rad
 const char YAMLFILE_CHECKSUM_TAG_NAME[] = "checksum";
 #endif
 #define    SPLASH_FILE             "splash.png"
+#define    SHUTDOWN_SPLASH_FILE    "shutdown.png"
 #endif
 
 #define MODELS_EXT          ".bin"


### PR DESCRIPTION
With this PR, by including a custom `shutdown.png` on SD card `\IMAGES` subfolder, a custom shutdown image will be displayed while powering off the radio.

Example video below uses following `shutdown.png`:
![grafik](https://github.com/EdgeTX/edgetx/assets/21011587/bffb366e-1da5-4159-a53a-1df2a4d83eea)

Result (click on image below to start video): 
[![Final video of fixing issues in your code in VS Code](https://img.youtube.com/vi/kNuXOPtfEqs/0.jpg)](https://www.youtube.com/watch?v=kNuXOPtfEqs)
