### PR TITLE
fix(cpn): only timers with active modes should be included in lists

### DIFF
--- a/companion/src/datamodels/compounditemmodels.cpp
+++ b/companion/src/datamodels/compounditemmodels.cpp
@@ -413,7 +413,7 @@ CustomFuncActionItemModel::CustomFuncActionItemModel(const GeneralSettings * con
 void CustomFuncActionItemModel::setDynamicItemData(QStandardItem * item, const int value) const
 {
   item->setText(CustomFunctionData::funcToString((AssignFunc)value, modelData));
-  item->setData(CustomFunctionData::isFuncAvailable(value), IMDR_Available);
+  item->setData(CustomFunctionData::isFuncAvailable(value, modelData), IMDR_Available);
 }
 
 void CustomFuncActionItemModel::update(const int event)

--- a/companion/src/firmwares/customfunctiondata.cpp
+++ b/companion/src/firmwares/customfunctiondata.cpp
@@ -312,7 +312,7 @@ bool CustomFunctionData::isResetParamAvailable(const int index, const ModelData 
   Firmware * firmware = getCurrentFirmware();
 
   if (index < CPN_MAX_TIMERS) {
-    if (index < firmware->getCapability(Timers))
+    if (index < firmware->getCapability(Timers) && !model->timers[index].isModeOff())
       return true;
     else
       return false;

--- a/companion/src/firmwares/customfunctiondata.cpp
+++ b/companion/src/firmwares/customfunctiondata.cpp
@@ -240,7 +240,7 @@ QString CustomFunctionData::enabledToString() const
 }
 
 //  static
-bool CustomFunctionData::isFuncAvailable(const int index)
+bool CustomFunctionData::isFuncAvailable(const int index, const ModelData * model)
 {
   Firmware * fw = getCurrentFirmware();
 
@@ -250,7 +250,8 @@ bool CustomFunctionData::isFuncAvailable(const int index)
         ((index == FuncPlayHaptic) && !fw->getCapability(Haptic)) ||
         ((index == FuncPlayBoth) && !fw->getCapability(HasBeeper)) ||
         ((index == FuncLogs) && !fw->getCapability(HasSDLogs)) ||
-        ((index >= FuncSetTimer1 && index <= FuncSetTimerLast) && index > FuncSetTimer1 + fw->getCapability(Timers)) ||
+        ((index >= FuncSetTimer1 && index <= FuncSetTimerLast) &&
+         (index > FuncSetTimer1 + fw->getCapability(Timers) || model->timers[index - FuncSetTimer1].isModeOff())) ||
         ((index == FuncScreenshot) && !IS_HORUS_OR_TARANIS(fw->getBoard())) ||
         ((index >= FuncRangeCheckInternalModule && index <= FuncBindExternalModule) && !fw->getCapability(DangerousFunctions)) ||
         ((index >= FuncAdjustGV1 && index <= FuncAdjustGVLast) && !fw->getCapability(Gvars)) ||

--- a/companion/src/firmwares/customfunctiondata.h
+++ b/companion/src/firmwares/customfunctiondata.h
@@ -122,7 +122,7 @@ class CustomFunctionData {
 
     static QString nameToString(const int index, const bool globalContext = false);
     static QString funcToString(const AssignFunc func, const ModelData * model = nullptr);
-    static bool isFuncAvailable(const int index);
+    static bool isFuncAvailable(const int index, const ModelData * model = nullptr);
     static int funcContext(const int index);
     static QString resetToString(const int value, const ModelData * model = nullptr);
     static int resetParamCount();

--- a/companion/src/firmwares/edgetx/yaml_rawsource.cpp
+++ b/companion/src/firmwares/edgetx/yaml_rawsource.cpp
@@ -278,7 +278,23 @@ RawSource YamlRawSourceDecode(const std::string& src_str)
       rhs.index = cyc_idx;
     }
 
-    int sp_idx = getCurrentFirmware()->getRawSourceSpecialTypesIndex(src_str.c_str());
+    std::string special_str;
+    node >> special_str;
+
+    // 2.10 conversion of TIMERx to Tmrx
+    if (special_str.size() == 6) {
+      if (special_str.substr(0, 6) == "TIMER1") {
+        special_str = "Tmr1";
+      }
+      else if (special_str.substr(0, 6) == "TIMER2") {
+        special_str = "Tmr2";
+      }
+      else if (special_str.substr(0, 6) == "TIMER3") {
+        special_str = "Tmr3";
+      }
+    }
+
+    int sp_idx = getCurrentFirmware()->getRawSourceSpecialTypesIndex(special_str.c_str());
     if (sp_idx >= 0) {
       rhs.type = SOURCE_TYPE_SPECIAL;
       rhs.index = sp_idx;

--- a/companion/src/firmwares/rawsource.cpp
+++ b/companion/src/firmwares/rawsource.cpp
@@ -463,9 +463,9 @@ tbl.insert(tbl.end(), {
                           {std::to_string(SOURCE_TYPE_SPECIAL_RESERVED2),  "RESERVED2"},
                           {std::to_string(SOURCE_TYPE_SPECIAL_RESERVED3),  "RESERVED3"},
                           {std::to_string(SOURCE_TYPE_SPECIAL_RESERVED4),  "RESERVED4"},
-                          {std::to_string(SOURCE_TYPE_SPECIAL_TIMER1),     "TIMER1"},
-                          {std::to_string(SOURCE_TYPE_SPECIAL_TIMER2),     "TIMER2"},
-                          {std::to_string(SOURCE_TYPE_SPECIAL_TIMER3),     "TIMER3"},
+                          {std::to_string(SOURCE_TYPE_SPECIAL_TIMER1),     "Tmr1"},
+                          {std::to_string(SOURCE_TYPE_SPECIAL_TIMER2),     "Tmr2"},
+                          {std::to_string(SOURCE_TYPE_SPECIAL_TIMER3),     "Tmr3"},
                           });
 
   return tbl;

--- a/companion/src/firmwares/rawsource.cpp
+++ b/companion/src/firmwares/rawsource.cpp
@@ -323,8 +323,13 @@ bool RawSource::isAvailable(const ModelData * const model, const GeneralSettings
     if (!model || index >= b.getCapability(Board::FunctionSwitches))
       return false;
 
-  if (type == SOURCE_TYPE_SPECIAL && index >= SOURCE_TYPE_SPECIAL_FIRST_RESERVED && index <= SOURCE_TYPE_SPECIAL_LAST_RESERVED)
-    return false;
+  if (type == SOURCE_TYPE_SPECIAL) {
+    if (index >= SOURCE_TYPE_SPECIAL_FIRST_RESERVED && index <= SOURCE_TYPE_SPECIAL_LAST_RESERVED)
+      return false;
+    else if (index >= SOURCE_TYPE_SPECIAL_FIRST_TIMER && index <= SOURCE_TYPE_SPECIAL_LAST_TIMER &&
+             model->timers[index - SOURCE_TYPE_SPECIAL_FIRST_TIMER].isModeOff())
+      return false;
+  }
 
   if (model) {
     if (type == SOURCE_TYPE_FUNCTIONSWITCH && !model->isFunctionSwitchSourceAllowed(index))

--- a/companion/src/firmwares/timerdata.cpp
+++ b/companion/src/firmwares/timerdata.cpp
@@ -43,9 +43,9 @@ bool TimerData::isEmpty() const
           persistent == 0 /*&& pvalue == 0*/);
 }
 
-bool TimerData::isModeOff()
+bool TimerData::isModeOff() const
 {
-  return swtch == RawSwitch(SWITCH_TYPE_TIMER_MODE, 0);
+  return mode == TIMERMODE_OFF;
 }
 
 QString TimerData::nameToString(int index) const

--- a/companion/src/firmwares/timerdata.h
+++ b/companion/src/firmwares/timerdata.h
@@ -100,7 +100,7 @@ class TimerData {
    void convert(RadioDataConversionState& cstate);
    void clear();
    bool isEmpty() const;
-   bool isModeOff();
+   bool isModeOff() const;
    QString nameToString(int index) const;
    QString countdownBeepToString() const;
    QString countdownStartToString() const;

--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -195,6 +195,7 @@ void TimerPanel::onModeChanged(int index)
 {
   timer.modeChanged();
   update();
+  emit modeChanged();
 }
 
 /******************************************************************************/
@@ -1483,7 +1484,8 @@ SetupPanel::SetupPanel(QWidget * parent, ModelData & model, GeneralSettings & ge
       timers[i] = new TimerPanel(this, model, model.timers[i], generalSettings, firmware, prevFocus, panelFilteredModels, panelItemModels);
       ui->gridLayout->addWidget(timers[i], 1+i, 1);
       connect(timers[i], &TimerPanel::modified, this, &SetupPanel::modified);
-      connect(timers[i], &TimerPanel::nameChanged, this, &SetupPanel::onTimerNameChanged);
+      connect(timers[i], &TimerPanel::nameChanged, this, &SetupPanel::onTimerChanged);
+      connect(timers[i], &TimerPanel::modeChanged, this, &SetupPanel::onTimerChanged);
       connect(this, &SetupPanel::updated, timers[i], &TimerPanel::update);
       prevFocus = timers[i]->getLastFocus();
       //  TODO more reliable method required
@@ -2145,7 +2147,7 @@ void SetupPanel::swapTimerData(int idx1, int idx2)
   }
 }
 
-void SetupPanel::onTimerNameChanged()
+void SetupPanel::onTimerChanged()
 {
   updateItemModels();
 }

--- a/companion/src/modeledit/setup.h
+++ b/companion/src/modeledit/setup.h
@@ -57,6 +57,7 @@ class TimerPanel : public ModelPanel
 
   signals:
     void nameChanged();
+    void modeChanged();
 
   private:
     TimerData & timer;
@@ -209,7 +210,7 @@ class SetupPanel : public ModelPanel
     void cmTimerPaste();
     void cmTimerMoveDown();
     void cmTimerMoveUp();
-    void onTimerNameChanged();
+    void onTimerChanged();
     void onItemModelAboutToBeUpdated();
     void onItemModelUpdateComplete();
     void onModuleUpdateItemModels();


### PR DESCRIPTION
Fixes #3952

Summary of changes:
- add mode filter to source lists
- trigger update to source lists and cross references when mode changed in model edit
- fix mode off test
- add mode filter to Set functions and Reset function parameter
- support new yaml format for timers

MERGE NOTE: partner for #3949