### PR TITLE
fix(yaml): properly escape double quotes

### DIFF
--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -49,7 +49,7 @@ constexpr char AIM_MODELDATA_FUNCSWITCHSTART[]  {"modeldata.funcswitchstart"};
 constexpr int LABEL_LENGTH=16;
 
 #define CHAR_FOR_NAMES " ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_-."
-#define CHAR_FOR_NAMES_REGEX "[ A-Za-z0-9_.-,]*"
+#define CHAR_FOR_NAMES_REGEX "[ A-Za-z0-9_.-,\"]*"
 
 class RSSIAlarmData {
   public:

--- a/radio/src/storage/yaml/yaml_parser.cpp
+++ b/radio/src/storage/yaml/yaml_parser.cpp
@@ -285,10 +285,6 @@ YamlParser::parse(const char* buffer, unsigned int size)
                 state = ps_CRLF;
                 continue;
             }
-            if (*c == '\"') {
-                state = ps_ValQuo;
-                break;
-            }
             if (*c == '\\') {
                 state = ps_ValEsc;
                 break;

--- a/radio/src/storage/yaml/yaml_tree_walker.cpp
+++ b/radio/src/storage/yaml/yaml_tree_walker.cpp
@@ -119,7 +119,7 @@ static bool yaml_output_string(const char* str, uint32_t max_len,
         return false;
     
     while(max_len > 0 && *str) {
-        if (*str >= 0x20 && *str <= 0x7E) {
+        if (*str >= 0x20 && *str <= 0x7E && *str != '\"') {
             if (!wf(opaque, str++, 1)) return false;
             max_len--;
         }

--- a/radio/src/storage/yaml/yaml_tree_walker.cpp
+++ b/radio/src/storage/yaml/yaml_tree_walker.cpp
@@ -117,9 +117,9 @@ static bool yaml_output_string(const char* str, uint32_t max_len,
 {
     if (!wf(opaque, "\"", 1))
         return false;
-    
+
     while(max_len > 0 && *str) {
-        if (*str >= 0x20 && *str <= 0x7E && *str != '\"') {
+        if (*str >= 0x20 && *str <= 0x7E && *str != '"') {
             if (!wf(opaque, str++, 1)) return false;
             max_len--;
         }

--- a/radio/src/tests/model.cpp
+++ b/radio/src/tests/model.cpp
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "gtests.h"
+
+#include "storage/yaml/yaml_tree_walker.h"
+#include "storage/yaml/yaml_parser.h"
+#include "storage/yaml/yaml_datastructs.h"
+#include "storage/yaml/yaml_bits.h"
+
+static const char* _model_config[] =
+  {
+    // As written by radio firmware - always enclosed in double quotes
+    "header: \n"
+    "   name: \"Test Name\"\n",         // no embedded double quote
+
+    "header: \n"
+    "   name: \"Test \\x22 Name\"\n",   // embedded and encoded double quote
+
+    // As written by Companion - only enclosed in double quotes when necessary
+    "header: \n"
+    "   name: Test Name\n",             // no embedded double quote
+
+    "header: \n"
+    "   name: Test \" Name\n",          // embedded double quote in string
+
+    "header: \n"
+    "   name: \"\\\"Test Name\"\n",     // embedded double quote at start of string
+  };
+
+static void loadModelYamlStr(const char* str)
+{
+  YamlTreeWalker tree;
+  tree.reset(get_modeldata_nodes(), (uint8_t*)&g_model);
+
+  YamlParser yp;
+  yp.init(YamlTreeWalker::get_parser_calls(), &tree);
+
+  size_t len = strlen(str);
+  yp.parse(str, len);
+}
+
+static char* modelName()
+{
+  static char name[LEN_MODEL_NAME + 1];
+  strncpy(name, g_model.header.name, LEN_MODEL_NAME);
+  name[LEN_MODEL_NAME] = 0;
+  return name;
+}
+
+TEST(Model, testModelNameParse)
+{
+  loadModelYamlStr(_model_config[0]);
+  EXPECT_STREQ(modelName(), "Test Name");
+  loadModelYamlStr(_model_config[1]);
+  EXPECT_STREQ(modelName(), "Test \" Name");
+  loadModelYamlStr(_model_config[2]);
+  EXPECT_STREQ(modelName(), "Test Name");
+  loadModelYamlStr(_model_config[3]);
+  EXPECT_STREQ(modelName(), "Test \" Name");
+  loadModelYamlStr(_model_config[4]);
+  EXPECT_STREQ(modelName(), "\"Test Name");
+}

--- a/radio/src/tests/model.cpp
+++ b/radio/src/tests/model.cpp
@@ -30,20 +30,20 @@ static const char* _model_config[] =
   {
     // As written by radio firmware - always enclosed in double quotes
     "header: \n"
-    "   name: \"Test Name\"\n",         // no embedded double quote
+    "   name: \"Tst Name\"\n",         // no embedded double quote
 
     "header: \n"
-    "   name: \"Test \\x22 Name\"\n",   // embedded and encoded double quote
+    "   name: \"Tst \\x22 Name\"\n",   // embedded and encoded double quote
 
     // As written by Companion - only enclosed in double quotes when necessary
     "header: \n"
-    "   name: Test Name\n",             // no embedded double quote
+    "   name: Tst Name\n",             // no embedded double quote
 
     "header: \n"
-    "   name: Test \" Name\n",          // embedded double quote in string
+    "   name: Tst \" Name\n",          // embedded double quote in string
 
     "header: \n"
-    "   name: \"\\\"Test Name\"\n",     // embedded double quote at start of string
+    "   name: \"\\\"Tst Name\"\n",     // embedded double quote at start of string
   };
 
 static void loadModelYamlStr(const char* str)
@@ -69,13 +69,13 @@ static char* modelName()
 TEST(Model, testModelNameParse)
 {
   loadModelYamlStr(_model_config[0]);
-  EXPECT_STREQ(modelName(), "Test Name");
+  EXPECT_STREQ(modelName(), "Tst Name");
   loadModelYamlStr(_model_config[1]);
-  EXPECT_STREQ(modelName(), "Test \" Name");
+  EXPECT_STREQ(modelName(), "Tst \" Name");
   loadModelYamlStr(_model_config[2]);
-  EXPECT_STREQ(modelName(), "Test Name");
+  EXPECT_STREQ(modelName(), "Tst Name");
   loadModelYamlStr(_model_config[3]);
-  EXPECT_STREQ(modelName(), "Test \" Name");
+  EXPECT_STREQ(modelName(), "Tst \" Name");
   loadModelYamlStr(_model_config[4]);
-  EXPECT_STREQ(modelName(), "\"Test Name");
+  EXPECT_STREQ(modelName(), "\"Tst Name");
 }


### PR DESCRIPTION
Summary of changes:
- YAML output: escape double quotes `"` inside string elements
