### PR TITLE
feat(cpn): Only show active channels in source lists

### DIFF
--- a/companion/src/firmwares/rawsource.cpp
+++ b/companion/src/firmwares/rawsource.cpp
@@ -351,6 +351,9 @@ bool RawSource::isAvailable(const ModelData * const model, const GeneralSettings
         return false;
       }
     }
+
+    if (type == SOURCE_TYPE_CH && !model->hasMixes(index))
+      return false;
   }
 
   if (gs) {

--- a/companion/src/modeledit/mixes.cpp
+++ b/companion/src/modeledit/mixes.cpp
@@ -187,6 +187,7 @@ void MixesPanel::gm_openMix(int index)
   if(dlg->exec()) {
     model->mixData[index] = mixd;
     emit modified();
+    updateItemModels();
     update();
   }
   else {
@@ -194,6 +195,7 @@ void MixesPanel::gm_openMix(int index)
       gm_deleteMix(index);
     }
     mixInserted = false;
+    updateItemModels();
     update();
   }
   delete dlg;
@@ -275,6 +277,7 @@ void MixesPanel::mixersDelete(bool prompt)
 
   mixersDeleteList(list);
   emit modified();
+  updateItemModels();
   update();
 }
 
@@ -331,6 +334,7 @@ void MixesPanel::pasteMixerMimeData(const QMimeData * mimeData, int destIdx)
     }
 
     emit modified();
+    updateItemModels();
     update();
   }
 }
@@ -519,6 +523,7 @@ void MixesPanel::moveMixUp()
     highlightList << gm_moveMix(idx, false);
   }
   emit modified();
+  updateItemModels();
   update();
   setSelectedByMixList(highlightList);
 }
@@ -531,6 +536,7 @@ void MixesPanel::moveMixDown()
     highlightList << gm_moveMix(idx, true);
   }
   emit modified();
+  updateItemModels();
   update();
   setSelectedByMixList(highlightList);
 }
@@ -540,6 +546,7 @@ void MixesPanel::clearMixes()
   if (QMessageBox::question(this, tr("Clear Mixes?"), tr("Really clear all the mixes?"), QMessageBox::Yes | QMessageBox::No) == QMessageBox::Yes) {
     model->clearMixes();
     emit modified();
+    updateItemModels();
     update();
   }
 }
@@ -567,3 +574,10 @@ void MixesPanel::onItemModelUpdateComplete()
     lock = false;
   }
 }
+
+void MixesPanel::updateItemModels()
+{
+  lock = true;
+  sharedItemModels->update(AbstractItemModel::IMUE_Channels);
+}
+

--- a/companion/src/modeledit/mixes.h
+++ b/companion/src/modeledit/mixes.h
@@ -82,6 +82,7 @@ class MixesPanel : public ModelPanel
     void AddMixerLine(int dest);
     QString getMixerText(int dest, bool newChannel);
     void connectItemModelEvents(const int id);
+    void updateItemModels();
 };
 
 #endif // _MIXES_H_


### PR DESCRIPTION
Fixes #3958

Summary of changes:
- add active test to channels in source lists
- update shared dynamic data models when changes to mixes

Note: active test not applied to Override Channel functions as these bypass the mixes