### PR TITLE
fix(cpn): Edit radio settings application crash

### DIFF
--- a/companion/src/firmwares/customfunctiondata.cpp
+++ b/companion/src/firmwares/customfunctiondata.cpp
@@ -251,7 +251,8 @@ bool CustomFunctionData::isFuncAvailable(const int index, const ModelData * mode
         ((index == FuncPlayBoth) && !fw->getCapability(HasBeeper)) ||
         ((index == FuncLogs) && !fw->getCapability(HasSDLogs)) ||
         ((index >= FuncSetTimer1 && index <= FuncSetTimerLast) &&
-         (index > FuncSetTimer1 + fw->getCapability(Timers) || model->timers[index - FuncSetTimer1].isModeOff())) ||
+         (index > FuncSetTimer1 + fw->getCapability(Timers) ||
+         (model ? model->timers[index - FuncSetTimer1].isModeOff() : false))) ||
         ((index == FuncScreenshot) && !IS_HORUS_OR_TARANIS(fw->getBoard())) ||
         ((index >= FuncRangeCheckInternalModule && index <= FuncBindExternalModule) && !fw->getCapability(DangerousFunctions)) ||
         ((index >= FuncAdjustGV1 && index <= FuncAdjustGVLast) && !fw->getCapability(Gvars)) ||
@@ -313,7 +314,7 @@ bool CustomFunctionData::isResetParamAvailable(const int index, const ModelData 
   Firmware * firmware = getCurrentFirmware();
 
   if (index < CPN_MAX_TIMERS) {
-    if (index < firmware->getCapability(Timers) && !model->timers[index].isModeOff())
+    if (index < firmware->getCapability(Timers) && (model ? !model->timers[index].isModeOff() : true))
       return true;
     else
       return false;

--- a/companion/src/firmwares/rawsource.cpp
+++ b/companion/src/firmwares/rawsource.cpp
@@ -326,15 +326,14 @@ bool RawSource::isAvailable(const ModelData * const model, const GeneralSettings
     if (!model || index >= b.getCapability(Board::FunctionSwitches))
       return false;
 
-  if (type == SOURCE_TYPE_SPECIAL) {
-    if (index >= SOURCE_TYPE_SPECIAL_FIRST_RESERVED && index <= SOURCE_TYPE_SPECIAL_LAST_RESERVED)
+  if (type == SOURCE_TYPE_SPECIAL && index >= SOURCE_TYPE_SPECIAL_FIRST_RESERVED && index <= SOURCE_TYPE_SPECIAL_LAST_RESERVED)
       return false;
-    else if (index >= SOURCE_TYPE_SPECIAL_FIRST_TIMER && index <= SOURCE_TYPE_SPECIAL_LAST_TIMER &&
-             model->timers[index - SOURCE_TYPE_SPECIAL_FIRST_TIMER].isModeOff())
-      return false;
-  }
 
   if (model) {
+    if (type == SOURCE_TYPE_SPECIAL && index >= SOURCE_TYPE_SPECIAL_FIRST_TIMER && index <= SOURCE_TYPE_SPECIAL_LAST_TIMER &&
+        model->timers[index - SOURCE_TYPE_SPECIAL_FIRST_TIMER].isModeOff())
+      return false;
+
     if (type == SOURCE_TYPE_FUNCTIONSWITCH && !model->isFunctionSwitchSourceAllowed(index))
       return false;
 


### PR DESCRIPTION
Fixes #3977

Bug in global functions when building lists containing timer related entries introduced by #3956

Summary of changes:
- test for existence of a model pointer in function parameters before calling model functions
