### PR TITLE
chore: Remove TLite F4 from Buddy

### DIFF
--- a/fw.json
+++ b/fw.json
@@ -22,7 +22,6 @@
         ["Jumper T16", "t16-"],
         ["Jumper T18", "t18-"],
         ["Jumper T-Lite", "tlite-"],
-        ["Jumper T-Lite (F4 MCU)", "tlitef4-"],
         ["Jumper T-Pro", "tpro-"],
         ["Jumper T-Pro V2", "tprov2-"],
         ["Jumper T20", "t20-"],


### PR DESCRIPTION
Per https://github.com/EdgeTX/edgetx/issues/4002#issuecomment-1704986318 removing the option for T-Lite F4 since it will only confuse. 