### PR TITLE
fix: invert TPro V2 default roller handling to match previous version

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -345,10 +345,6 @@ void generalDefault()
   g_eeGeneral.pwrOffSpeed = 2;
 #endif
 
-#if defined(RADIO_TPROV2)
-  g_eeGeneral.rotEncMode = ROTARY_ENCODER_MODE_INVERT_BOTH;
-#endif
-
 #if defined(MANUFACTURER_RADIOMASTER)
   g_eeGeneral.audioMuteEnable = 1;
 #endif


### PR DESCRIPTION
As per @rotorman suggestion