### PR TITLE
Fix BT power level

### DIFF
--- a/radio/src/bluetooth.cpp
+++ b/radio/src/bluetooth.cpp
@@ -470,7 +470,7 @@ void Bluetooth::wakeup()
     } else if (state == BLUETOOTH_STATE_NAME_SENT && (line != nullptr) &&
                (!strncmp(line, "OK+", 3) || !strncmp(line, "Central:", 8) ||
                 !strncmp(line, "Peripheral:", 11))) {
-      writeString("AT+TXPW0");
+      writeString("AT+TXPW2");
       state = BLUETOOTH_STATE_POWER_SENT;
     } else if (state == BLUETOOTH_STATE_POWER_SENT &&
                (line != nullptr) &&


### PR DESCRIPTION
Summary of changes:
For years I had trouble with bluetooth range and reliability on my modded TX16S with X10S module until I now finally discovered that EdgeTX sets the BT transmission power to -23dBm by default. This did not allow any connection with more than 2-3m range and even then it is unreliable with the slightest interference. I changed the power level to the CC2540/CC2541 default power level 2 (0dBm) and now I have perfect range and a reliable connection that goes through 2 rooms of my apartment. 

1mW power should not interfere with any RC link but might need testing. Maybe add a option to configure the power in the GUI. 