### PR TITLE
chore(radio): Don't save joystick configuration data to the EM backup storage

### DIFF
--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -760,10 +760,10 @@ PACK(struct ModelData {
     }
   }
 
-  uint8_t usbJoystickExtMode:1;
-  uint8_t usbJoystickIfMode:3 ENUM(USBJoystickIfMode);
-  uint8_t usbJoystickCircularCut:4;
-  USBJoystickChData usbJoystickCh[USBJ_MAX_JOYSTICK_CHANNELS];
+  NOBACKUP(uint8_t usbJoystickExtMode:1);
+  NOBACKUP(uint8_t usbJoystickIfMode:3 ENUM(USBJoystickIfMode));
+  NOBACKUP(uint8_t usbJoystickCircularCut:4);
+  NOBACKUP(USBJoystickChData usbJoystickCh[USBJ_MAX_JOYSTICK_CHANNELS]);
   
   // Radio level tabs control (model settings)
 #if defined(COLORLCD)


### PR DESCRIPTION
Since the USB joystick doesn't get re-enabled on EM start there is no point having the joystick configuration in the backup data.