### PR TITLE
feat(radio): Show model level setting for 'Enabled Features' when altering radio level setting

### DIFF
--- a/radio/src/gui/128x64/radio_setup.cpp
+++ b/radio/src/gui/128x64/radio_setup.cpp
@@ -135,21 +135,11 @@ enum {
 uint8_t viewOptCheckBox(coord_t y, const char* title, uint8_t value, uint8_t attr, event_t event, uint8_t modelOption)
 {
   lcdDrawText(INDENT_WIDTH, y, title);
-  if (modelOption == OVERRIDE_GLOBAL) {
-    return !editCheckBox(!value, LCD_W-9, y, nullptr, attr, event ) ;
-  } else {
-    std::string s("M-");
-    s += STR_ADCFILTERVALUES[modelOption];
-    lcdDrawText(LCD_W, y, s.c_str(), RIGHT);
-    return value;
+  if (modelOption != OVERRIDE_GLOBAL) {
+    std::string s(STR_ADCFILTERVALUES[modelOption]);
+    lcdDrawText(LCD_W-3*FW, y, s.c_str());
   }
-}
-
-uint8_t viewOptTab(uint8_t modelOption)
-{
-  if (modelOption == OVERRIDE_GLOBAL)
-    return 0;
-  return READONLY_ROW;
+  return !editCheckBox(!value, LCD_W-4*FW-3, y, nullptr, attr, event ) ;
 }
 
 void menuRadioSetup(event_t event)
@@ -226,16 +216,16 @@ void menuRadioSetup(event_t event)
     CASE_TX_MODE(0)
     LABEL(ViewOptions),
      LABEL(RadioMenuTabs),
-      viewOptTab(g_model.radioGFDisabled),
-      viewOptTab(g_model.radioTrainerDisabled),
+      0,
+      0,
      LABEL(ModelMenuTabs),
-      CASE_HELI(viewOptTab(g_model.modelHeliDisabled))
-      CASE_FLIGHT_MODES(viewOptTab(g_model.modelFMDisabled))
-      viewOptTab(g_model.modelCurvesDisabled),
-      viewOptTab(g_model.modelLSDisabled),
-      viewOptTab(g_model.modelSFDisabled),
-      CASE_LUA_MODEL_SCRIPTS(viewOptTab(g_model.modelCustomScriptsDisabled))
-      viewOptTab(g_model.modelTelemetryDisabled),
+      CASE_HELI(0)
+      CASE_FLIGHT_MODES(0)
+      0,
+      0,
+      0,
+      CASE_LUA_MODEL_SCRIPTS(0)
+      0,
     1/*to force edit mode*/});
 
   if (event == EVT_ENTRY) {

--- a/radio/src/gui/128x64/radio_setup.cpp
+++ b/radio/src/gui/128x64/radio_setup.cpp
@@ -132,10 +132,24 @@ enum {
   ITEM_RADIO_SETUP_MAX
 };
 
-uint8_t viewOptCheckBox(coord_t y, const char* title, uint8_t value, uint8_t attr, event_t event)
+uint8_t viewOptCheckBox(coord_t y, const char* title, uint8_t value, uint8_t attr, event_t event, uint8_t modelOption)
 {
   lcdDrawText(INDENT_WIDTH, y, title);
-  return !editCheckBox(!value, LCD_W-9, y, nullptr, attr, event ) ;
+  if (modelOption == OVERRIDE_GLOBAL) {
+    return !editCheckBox(!value, LCD_W-9, y, nullptr, attr, event ) ;
+  } else {
+    std::string s("M-");
+    s += STR_ADCFILTERVALUES[modelOption];
+    lcdDrawText(LCD_W, y, s.c_str(), RIGHT);
+    return value;
+  }
+}
+
+uint8_t viewOptTab(uint8_t modelOption)
+{
+  if (modelOption == OVERRIDE_GLOBAL)
+    return 0;
+  return READONLY_ROW;
 }
 
 void menuRadioSetup(event_t event)
@@ -210,7 +224,18 @@ void menuRadioSetup(event_t event)
     0,
     CASE_TX_MODE(LABEL(TX_MODE))
     CASE_TX_MODE(0)
-    LABEL(ViewOptions), LABEL(RadioMenuTabs), 0, 0, LABEL(ModelMenuTabs), CASE_HELI(0) CASE_FLIGHT_MODES(0) 0, 0, 0, CASE_LUA_MODEL_SCRIPTS(0) 0,
+    LABEL(ViewOptions),
+     LABEL(RadioMenuTabs),
+      viewOptTab(g_model.radioGFDisabled),
+      viewOptTab(g_model.radioTrainerDisabled),
+     LABEL(ModelMenuTabs),
+      CASE_HELI(viewOptTab(g_model.modelHeliDisabled))
+      CASE_FLIGHT_MODES(viewOptTab(g_model.modelFMDisabled))
+      viewOptTab(g_model.modelCurvesDisabled),
+      viewOptTab(g_model.modelLSDisabled),
+      viewOptTab(g_model.modelSFDisabled),
+      CASE_LUA_MODEL_SCRIPTS(viewOptTab(g_model.modelCustomScriptsDisabled))
+      viewOptTab(g_model.modelTelemetryDisabled),
     1/*to force edit mode*/});
 
   if (event == EVT_ENTRY) {
@@ -770,40 +795,40 @@ void menuRadioSetup(event_t event)
         lcdDrawText(INDENT_WIDTH-2, y, TR_RADIO_MENU_TABS);
         break;
       case ITEM_VIEW_OPTIONS_GF:
-        g_eeGeneral.radioGFDisabled = viewOptCheckBox(y, STR_MENUSPECIALFUNCS, g_eeGeneral.radioGFDisabled, attr, event);
+        g_eeGeneral.radioGFDisabled = viewOptCheckBox(y, STR_MENUSPECIALFUNCS, g_eeGeneral.radioGFDisabled, attr, event, g_model.radioGFDisabled);
         break;
       case ITEM_VIEW_OPTIONS_TRAINER:
-        g_eeGeneral.radioTrainerDisabled = viewOptCheckBox(y, STR_MENUTRAINER, g_eeGeneral.radioTrainerDisabled, attr, event);
+        g_eeGeneral.radioTrainerDisabled = viewOptCheckBox(y, STR_MENUTRAINER, g_eeGeneral.radioTrainerDisabled, attr, event, g_model.radioTrainerDisabled);
         break;
       case ITEM_VIEW_OPTIONS_MODEL_TAB:
         lcdDrawText(INDENT_WIDTH-2, y, TR_MODEL_MENU_TABS);
         break;
 #if defined(HELI)
       case ITEM_VIEW_OPTIONS_HELI:
-        g_eeGeneral.modelHeliDisabled = viewOptCheckBox(y, STR_MENUHELISETUP, g_eeGeneral.modelHeliDisabled, attr, event);
+        g_eeGeneral.modelHeliDisabled = viewOptCheckBox(y, STR_MENUHELISETUP, g_eeGeneral.modelHeliDisabled, attr, event, g_model.modelHeliDisabled);
         break;
 #endif
 #if defined(FLIGHT_MODES)
       case ITEM_VIEW_OPTIONS_FM:
-        g_eeGeneral.modelFMDisabled = viewOptCheckBox(y, STR_MENUFLIGHTMODES, g_eeGeneral.modelFMDisabled, attr, event);
+        g_eeGeneral.modelFMDisabled = viewOptCheckBox(y, STR_MENUFLIGHTMODES, g_eeGeneral.modelFMDisabled, attr, event, g_model.modelFMDisabled);
         break;
 #endif
       case ITEM_VIEW_OPTIONS_CURVES:
-        g_eeGeneral.modelCurvesDisabled = viewOptCheckBox(y, STR_MENUCURVES, g_eeGeneral.modelCurvesDisabled, attr, event);
+        g_eeGeneral.modelCurvesDisabled = viewOptCheckBox(y, STR_MENUCURVES, g_eeGeneral.modelCurvesDisabled, attr, event, g_model.modelCurvesDisabled);
         break;
       case ITEM_VIEW_OPTIONS_LS:
-        g_eeGeneral.modelLSDisabled = viewOptCheckBox(y, STR_MENULOGICALSWITCHES, g_eeGeneral.modelLSDisabled, attr, event);
+        g_eeGeneral.modelLSDisabled = viewOptCheckBox(y, STR_MENULOGICALSWITCHES, g_eeGeneral.modelLSDisabled, attr, event, g_model.modelLSDisabled);
         break;
       case ITEM_VIEW_OPTIONS_SF:
-        g_eeGeneral.modelSFDisabled = viewOptCheckBox(y, STR_MENUCUSTOMFUNC, g_eeGeneral.modelSFDisabled, attr, event);
+        g_eeGeneral.modelSFDisabled = viewOptCheckBox(y, STR_MENUCUSTOMFUNC, g_eeGeneral.modelSFDisabled, attr, event, g_model.modelSFDisabled);
         break;
 #if defined(LUA_MODEL_SCRIPTS)
       case ITEM_VIEW_OPTIONS_CUSTOM_SCRIPTS:
-        g_eeGeneral.modelCustomScriptsDisabled = viewOptCheckBox(y, STR_MENUCUSTOMSCRIPTS, g_eeGeneral.modelCustomScriptsDisabled, attr, event);
+        g_eeGeneral.modelCustomScriptsDisabled = viewOptCheckBox(y, STR_MENUCUSTOMSCRIPTS, g_eeGeneral.modelCustomScriptsDisabled, attr, event, g_model.modelCustomScriptsDisabled);
         break;
 #endif
       case ITEM_VIEW_OPTIONS_TELEMETRY:
-        g_eeGeneral.modelTelemetryDisabled = viewOptCheckBox(y, STR_MENUTELEMETRY, g_eeGeneral.modelTelemetryDisabled, attr, event);
+        g_eeGeneral.modelTelemetryDisabled = viewOptCheckBox(y, STR_MENUTELEMETRY, g_eeGeneral.modelTelemetryDisabled, attr, event, g_model.modelTelemetryDisabled);
         break;
     }
   }

--- a/radio/src/gui/212x64/radio_setup.cpp
+++ b/radio/src/gui/212x64/radio_setup.cpp
@@ -119,10 +119,24 @@ enum MenuRadioSetupItems {
   ITEM_RADIO_SETUP_MAX
 };
 
-uint8_t viewOptCheckBox(coord_t y, const char* title, uint8_t value, uint8_t attr, event_t event)
+uint8_t viewOptCheckBox(coord_t y, const char* title, uint8_t value, uint8_t attr, event_t event, uint8_t modelOption)
 {
   lcdDrawText(INDENT_WIDTH*2, y, title);
-  return !editCheckBox(!value, RADIO_SETUP_2ND_COLUMN, y, nullptr, attr, event );
+  if (modelOption == OVERRIDE_GLOBAL) {
+    return !editCheckBox(!value, RADIO_SETUP_2ND_COLUMN, y, nullptr, attr, event );
+  } else {
+    std::string s("M-");
+    s += STR_ADCFILTERVALUES[modelOption];
+    lcdDrawText(RADIO_SETUP_2ND_COLUMN, y, s.c_str());
+    return value;
+  }
+}
+
+uint8_t viewOptTab(uint8_t modelOption)
+{
+  if (modelOption == OVERRIDE_GLOBAL)
+    return 0;
+  return READONLY_ROW;
 }
 
 void menuRadioSetup(event_t event)
@@ -205,7 +219,19 @@ void menuRadioSetup(event_t event)
     CASE_ROTARY_ENCODER(0)  // Invert rotary encoder
     LABEL(TX_MODE),
       0, // sticks mode
-    LABEL(ViewOptions), LABEL(RadioMenuTabs), 0, 0, LABEL(ModelMenuTabs), CASE_HELI(0) CASE_FLIGHT_MODES(0) CASE_GVARS(0) 0, 0, 0, CASE_LUA_MODEL_SCRIPTS(0) 0,
+    LABEL(ViewOptions),
+     LABEL(RadioMenuTabs),
+      viewOptTab(g_model.radioGFDisabled),
+      viewOptTab(g_model.radioTrainerDisabled),
+     LABEL(ModelMenuTabs),
+      CASE_HELI(viewOptTab(g_model.modelHeliDisabled))
+      CASE_FLIGHT_MODES(viewOptTab(g_model.modelFMDisabled))
+      viewOptTab(g_model.modelCurvesDisabled),
+      CASE_GVARS(viewOptTab(g_model.modelGVDisabled))
+      viewOptTab(g_model.modelLSDisabled),
+      viewOptTab(g_model.modelSFDisabled),
+      CASE_LUA_MODEL_SCRIPTS(viewOptTab(g_model.modelCustomScriptsDisabled))
+      viewOptTab(g_model.modelTelemetryDisabled),
       1 /*to force edit mode*/
   });
 
@@ -692,45 +718,45 @@ void menuRadioSetup(event_t event)
         lcdDrawText(INDENT_WIDTH, y, TR_RADIO_MENU_TABS);
         break;
       case ITEM_VIEW_OPTIONS_GF:
-        g_eeGeneral.radioGFDisabled = viewOptCheckBox(y, STR_MENUSPECIALFUNCS, g_eeGeneral.radioGFDisabled, attr, event);
+        g_eeGeneral.radioGFDisabled = viewOptCheckBox(y, STR_MENUSPECIALFUNCS, g_eeGeneral.radioGFDisabled, attr, event, g_model.radioGFDisabled);
         break;
       case ITEM_VIEW_OPTIONS_TRAINER:
-        g_eeGeneral.radioTrainerDisabled = viewOptCheckBox(y, STR_MENUTRAINER, g_eeGeneral.radioTrainerDisabled, attr, event);
+        g_eeGeneral.radioTrainerDisabled = viewOptCheckBox(y, STR_MENUTRAINER, g_eeGeneral.radioTrainerDisabled, attr, event, g_model.radioTrainerDisabled);
         break;
       case ITEM_VIEW_OPTIONS_MODEL_TAB:
         lcdDrawText(INDENT_WIDTH, y, TR_MODEL_MENU_TABS);
         break;
 #if defined(HELI)
       case ITEM_VIEW_OPTIONS_HELI:
-        g_eeGeneral.modelHeliDisabled = viewOptCheckBox(y, STR_MENUHELISETUP, g_eeGeneral.modelHeliDisabled, attr, event);
+        g_eeGeneral.modelHeliDisabled = viewOptCheckBox(y, STR_MENUHELISETUP, g_eeGeneral.modelHeliDisabled, attr, event, g_model.modelHeliDisabled);
         break;
 #endif
 #if defined(FLIGHT_MODES)
       case ITEM_VIEW_OPTIONS_FM:
-        g_eeGeneral.modelFMDisabled = viewOptCheckBox(y, STR_MENUFLIGHTMODES, g_eeGeneral.modelFMDisabled, attr, event);
+        g_eeGeneral.modelFMDisabled = viewOptCheckBox(y, STR_MENUFLIGHTMODES, g_eeGeneral.modelFMDisabled, attr, event, g_model.modelFMDisabled);
         break;
 #endif
       case ITEM_VIEW_OPTIONS_CURVES:
-        g_eeGeneral.modelCurvesDisabled = viewOptCheckBox(y, STR_MENUCURVES, g_eeGeneral.modelCurvesDisabled, attr, event);
+        g_eeGeneral.modelCurvesDisabled = viewOptCheckBox(y, STR_MENUCURVES, g_eeGeneral.modelCurvesDisabled, attr, event, g_model.modelCurvesDisabled);
         break;
 #if defined(GVARS)
       case ITEM_VIEW_OPTIONS_GV:
-        g_model.modelGVDisabled = viewOptCheckBox(y, STR_MENU_GLOBAL_VARS, g_model.modelGVDisabled, attr, event);
+        g_model.modelGVDisabled = viewOptCheckBox(y, STR_MENU_GLOBAL_VARS, g_model.modelGVDisabled, attr, event, g_model.modelGVDisabled);
         break;
 #endif
       case ITEM_VIEW_OPTIONS_LS:
-        g_eeGeneral.modelLSDisabled = viewOptCheckBox(y, STR_MENULOGICALSWITCHES, g_eeGeneral.modelLSDisabled, attr, event);
+        g_eeGeneral.modelLSDisabled = viewOptCheckBox(y, STR_MENULOGICALSWITCHES, g_eeGeneral.modelLSDisabled, attr, event, g_model.modelLSDisabled);
         break;
       case ITEM_VIEW_OPTIONS_SF:
-        g_eeGeneral.modelSFDisabled = viewOptCheckBox(y, STR_MENUCUSTOMFUNC, g_eeGeneral.modelSFDisabled, attr, event);
+        g_eeGeneral.modelSFDisabled = viewOptCheckBox(y, STR_MENUCUSTOMFUNC, g_eeGeneral.modelSFDisabled, attr, event, g_model.modelSFDisabled);
         break;
 #if defined(LUA_MODEL_SCRIPTS)
       case ITEM_VIEW_OPTIONS_CUSTOM_SCRIPTS:
-        g_eeGeneral.modelCustomScriptsDisabled = viewOptCheckBox(y, STR_MENUCUSTOMSCRIPTS, g_eeGeneral.modelCustomScriptsDisabled, attr, event);
+        g_eeGeneral.modelCustomScriptsDisabled = viewOptCheckBox(y, STR_MENUCUSTOMSCRIPTS, g_eeGeneral.modelCustomScriptsDisabled, attr, event, g_model.modelCustomScriptsDisabled);
         break;
 #endif
       case ITEM_VIEW_OPTIONS_TELEMETRY:
-        g_eeGeneral.modelTelemetryDisabled = viewOptCheckBox(y, STR_MENUTELEMETRY, g_eeGeneral.modelTelemetryDisabled, attr, event);
+        g_eeGeneral.modelTelemetryDisabled = viewOptCheckBox(y, STR_MENUTELEMETRY, g_eeGeneral.modelTelemetryDisabled, attr, event, g_model.modelTelemetryDisabled);
         break;
     }
   }

--- a/radio/src/gui/212x64/radio_setup.cpp
+++ b/radio/src/gui/212x64/radio_setup.cpp
@@ -125,7 +125,8 @@ uint8_t viewOptCheckBox(coord_t y, const char* title, uint8_t value, uint8_t att
   if (modelOption == OVERRIDE_GLOBAL) {
     return !editCheckBox(!value, RADIO_SETUP_2ND_COLUMN, y, nullptr, attr, event );
   } else {
-    std::string s("M-");
+    std::string s(STR_MODEL);
+    s += " - ";
     s += STR_ADCFILTERVALUES[modelOption];
     lcdDrawText(RADIO_SETUP_2ND_COLUMN, y, s.c_str());
     return value;

--- a/radio/src/gui/212x64/radio_setup.cpp
+++ b/radio/src/gui/212x64/radio_setup.cpp
@@ -122,22 +122,13 @@ enum MenuRadioSetupItems {
 uint8_t viewOptCheckBox(coord_t y, const char* title, uint8_t value, uint8_t attr, event_t event, uint8_t modelOption)
 {
   lcdDrawText(INDENT_WIDTH*2, y, title);
-  if (modelOption == OVERRIDE_GLOBAL) {
-    return !editCheckBox(!value, RADIO_SETUP_2ND_COLUMN, y, nullptr, attr, event );
-  } else {
+  if (modelOption != OVERRIDE_GLOBAL) {
     std::string s(STR_MODEL);
     s += " - ";
     s += STR_ADCFILTERVALUES[modelOption];
     lcdDrawText(RADIO_SETUP_2ND_COLUMN, y, s.c_str());
-    return value;
   }
-}
-
-uint8_t viewOptTab(uint8_t modelOption)
-{
-  if (modelOption == OVERRIDE_GLOBAL)
-    return 0;
-  return READONLY_ROW;
+  return !editCheckBox(!value, RADIO_SETUP_2ND_COLUMN-10, y, nullptr, attr, event );
 }
 
 void menuRadioSetup(event_t event)
@@ -222,17 +213,17 @@ void menuRadioSetup(event_t event)
       0, // sticks mode
     LABEL(ViewOptions),
      LABEL(RadioMenuTabs),
-      viewOptTab(g_model.radioGFDisabled),
-      viewOptTab(g_model.radioTrainerDisabled),
+      0,
+      0,
      LABEL(ModelMenuTabs),
-      CASE_HELI(viewOptTab(g_model.modelHeliDisabled))
-      CASE_FLIGHT_MODES(viewOptTab(g_model.modelFMDisabled))
-      viewOptTab(g_model.modelCurvesDisabled),
-      CASE_GVARS(viewOptTab(g_model.modelGVDisabled))
-      viewOptTab(g_model.modelLSDisabled),
-      viewOptTab(g_model.modelSFDisabled),
-      CASE_LUA_MODEL_SCRIPTS(viewOptTab(g_model.modelCustomScriptsDisabled))
-      viewOptTab(g_model.modelTelemetryDisabled),
+      CASE_HELI(0)
+      CASE_FLIGHT_MODES(0)
+      0,
+      CASE_GVARS(0)
+      0,
+      0,
+      CASE_LUA_MODEL_SCRIPTS(0)
+      0,
       1 /*to force edit mode*/
   });
 

--- a/radio/src/gui/colorlcd/radio_setup.cpp
+++ b/radio/src/gui/colorlcd/radio_setup.cpp
@@ -596,9 +596,24 @@ class GpsPage : public SubPage {
 
 class ViewOptionsPage : public SubPage
 {
-   public:
+   private:
     const lv_coord_t opt_col_two_dsc[3] = {LV_GRID_FR(7), LV_GRID_FR(3), LV_GRID_TEMPLATE_LAST};
 
+    void viewOption(FormWindow::Line *line, const char* name, std::function<uint8_t()> getValue, std::function<void(uint8_t)> setValue, uint8_t modelOption)
+    {
+      line->padLeft(10);
+      new StaticText(line, rect_t{}, name, 0, COLOR_THEME_PRIMARY1);
+      if (modelOption == OVERRIDE_GLOBAL) {
+        new ToggleSwitch(line, rect_t{}, getValue, setValue);
+      } else {
+        std::string s(STR_MODEL);
+        s += " - ";
+        s += STR_ADCFILTERVALUES[modelOption];
+        new StaticText(line, rect_t{}, s.c_str(), 0, COLOR_THEME_PRIMARY1);
+      }
+    }
+
+  public:
     ViewOptionsPage() : SubPage(ICON_RADIO_SETUP, STR_ENABLED_FEATURES, false)
     {
       FlexGridLayout grid(opt_col_two_dsc, row_dsc, 2);
@@ -611,70 +626,48 @@ class ViewOptionsPage : public SubPage
       new StaticText(line, rect_t{}, STR_RADIO_MENU_TABS, 0, COLOR_THEME_PRIMARY1);
 
       line = form->newLine(&grid);
-      line->padLeft(10);
-      new StaticText(line, rect_t{}, STR_THEME_EDITOR, 0, COLOR_THEME_PRIMARY1);
-      new ToggleSwitch(line, rect_t{}, GET_SET_INVERTED(g_eeGeneral.radioThemesDisabled));
+      viewOption(line, STR_THEME_EDITOR, GET_SET_INVERTED(g_eeGeneral.radioThemesDisabled), g_model.radioThemesDisabled);
 
       line = form->newLine(&grid);
-      line->padLeft(10);
-      new StaticText(line, rect_t{}, STR_MENUSPECIALFUNCS, 0, COLOR_THEME_PRIMARY1);
-      new ToggleSwitch(line, rect_t{}, GET_SET_INVERTED(g_eeGeneral.radioGFDisabled));
+      viewOption(line, STR_MENUSPECIALFUNCS, GET_SET_INVERTED(g_eeGeneral.radioGFDisabled), g_model.radioGFDisabled);
 
       line = form->newLine(&grid);
-      line->padLeft(10);
-      new StaticText(line, rect_t{}, STR_MENUTRAINER, 0, COLOR_THEME_PRIMARY1);
-      new ToggleSwitch(line, rect_t{}, GET_SET_INVERTED(g_eeGeneral.radioTrainerDisabled));
+      viewOption(line, STR_MENUTRAINER, GET_SET_INVERTED(g_eeGeneral.radioTrainerDisabled), g_model.radioTrainerDisabled);
 
       line = form->newLine(&grid);
       new StaticText(line, rect_t{}, STR_MODEL_MENU_TABS, 0, COLOR_THEME_PRIMARY1);
 
 #if defined(HELI)
       line = form->newLine(&grid);
-      line->padLeft(10);
-      new StaticText(line, rect_t{}, STR_MENUHELISETUP, 0, COLOR_THEME_PRIMARY1);
-      new ToggleSwitch(line, rect_t{}, GET_SET_INVERTED(g_eeGeneral.modelHeliDisabled));
+      viewOption(line, STR_MENUHELISETUP, GET_SET_INVERTED(g_eeGeneral.modelHeliDisabled), g_model.modelHeliDisabled);
 #endif
 
 #if defined(FLIGHT_MODES)
       line = form->newLine(&grid);
-      line->padLeft(10);
-      new StaticText(line, rect_t{}, STR_MENUFLIGHTMODES, 0, COLOR_THEME_PRIMARY1);
-      new ToggleSwitch(line, rect_t{}, GET_SET_INVERTED(g_eeGeneral.modelFMDisabled));
+      viewOption(line, STR_MENUFLIGHTMODES, GET_SET_INVERTED(g_eeGeneral.modelFMDisabled), g_model.modelFMDisabled);
 #endif
 
 #if defined(GVARS)
       line = form->newLine(&grid);
-      line->padLeft(10);
-      new StaticText(line, rect_t{}, STR_MENU_GLOBAL_VARS, 0, COLOR_THEME_PRIMARY1);
-      new ToggleSwitch(line, rect_t{}, GET_SET_INVERTED(g_eeGeneral.modelGVDisabled));
+      viewOption(line, STR_MENU_GLOBAL_VARS, GET_SET_INVERTED(g_eeGeneral.modelGVDisabled), g_model.modelGVDisabled);
 #endif
 
       line = form->newLine(&grid);
-      line->padLeft(10);
-      new StaticText(line, rect_t{}, STR_MENUCURVES, 0, COLOR_THEME_PRIMARY1);
-      new ToggleSwitch(line, rect_t{}, GET_SET_INVERTED(g_eeGeneral.modelCurvesDisabled));
+      viewOption(line, STR_MENUCURVES, GET_SET_INVERTED(g_eeGeneral.modelCurvesDisabled), g_model.modelCurvesDisabled);
 
       line = form->newLine(&grid);
-      line->padLeft(10);
-      new StaticText(line, rect_t{}, STR_MENULOGICALSWITCHES, 0, COLOR_THEME_PRIMARY1);
-      new ToggleSwitch(line, rect_t{}, GET_SET_INVERTED(g_eeGeneral.modelLSDisabled));
+      viewOption(line, STR_MENULOGICALSWITCHES, GET_SET_INVERTED(g_eeGeneral.modelLSDisabled), g_model.modelLSDisabled);
 
       line = form->newLine(&grid);
-      line->padLeft(10);
-      new StaticText(line, rect_t{}, STR_MENUCUSTOMFUNC, 0, COLOR_THEME_PRIMARY1);
-      new ToggleSwitch(line, rect_t{}, GET_SET_INVERTED(g_eeGeneral.modelSFDisabled));
+      viewOption(line, STR_MENUCUSTOMFUNC, GET_SET_INVERTED(g_eeGeneral.modelSFDisabled), g_model.modelSFDisabled);
 
 #if defined(LUA_MODEL_SCRIPTS)
       line = form->newLine(&grid);
-      line->padLeft(10);
-      new StaticText(line, rect_t{}, STR_MENUCUSTOMSCRIPTS, 0, COLOR_THEME_PRIMARY1);
-      new ToggleSwitch(line, rect_t{}, GET_SET_INVERTED(g_eeGeneral.modelCustomScriptsDisabled));
+      viewOption(line, STR_MENUCUSTOMSCRIPTS, GET_SET_INVERTED(g_eeGeneral.modelCustomScriptsDisabled), g_model.modelCustomScriptsDisabled);
 #endif
 
       line = form->newLine(&grid);
-      line->padLeft(10);
-      new StaticText(line, rect_t{}, STR_MENUTELEMETRY, 0, COLOR_THEME_PRIMARY1);
-      new ToggleSwitch(line, rect_t{}, GET_SET_INVERTED(g_eeGeneral.modelTelemetryDisabled));
+      viewOption(line, STR_MENUTELEMETRY, GET_SET_INVERTED(g_eeGeneral.modelTelemetryDisabled), g_model.modelTelemetryDisabled);
     }
 };
 

--- a/radio/src/gui/colorlcd/radio_setup.cpp
+++ b/radio/src/gui/colorlcd/radio_setup.cpp
@@ -597,26 +597,25 @@ class GpsPage : public SubPage {
 class ViewOptionsPage : public SubPage
 {
    private:
-    const lv_coord_t opt_col_two_dsc[3] = {LV_GRID_FR(7), LV_GRID_FR(3), LV_GRID_TEMPLATE_LAST};
+    const lv_coord_t opt_col_dsc[4] = {LV_GRID_FR(5), LV_GRID_FR(2), LV_GRID_FR(4), LV_GRID_TEMPLATE_LAST};
 
     void viewOption(FormWindow::Line *line, const char* name, std::function<uint8_t()> getValue, std::function<void(uint8_t)> setValue, uint8_t modelOption)
     {
       line->padLeft(10);
       new StaticText(line, rect_t{}, name, 0, COLOR_THEME_PRIMARY1);
-      if (modelOption == OVERRIDE_GLOBAL) {
-        new ToggleSwitch(line, rect_t{}, getValue, setValue);
-      } else {
+      new ToggleSwitch(line, rect_t{}, getValue, setValue);
+      if (modelOption != OVERRIDE_GLOBAL) {
         std::string s(STR_MODEL);
         s += " - ";
         s += STR_ADCFILTERVALUES[modelOption];
-        new StaticText(line, rect_t{}, s.c_str(), 0, COLOR_THEME_PRIMARY1);
+        new StaticText(line, rect_t{}, s.c_str(), 0, COLOR_THEME_SECONDARY1);
       }
     }
 
   public:
     ViewOptionsPage() : SubPage(ICON_RADIO_SETUP, STR_ENABLED_FEATURES, false)
     {
-      FlexGridLayout grid(opt_col_two_dsc, row_dsc, 2);
+      FlexGridLayout grid(opt_col_dsc, row_dsc, 2);
 
       auto form = new FormWindow(&body, rect_t{});
       form->setFlexLayout();

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1935,41 +1935,43 @@ uint32_t availableMemory()
 #endif
 }
 
+#define FEATURE_ENABLED(f) (g_model.f == OVERRIDE_GLOBAL && g_eeGeneral.f == 0) || (g_model.f == OVERRIDE_ON)
+
 // Radio menu tab state
 #if defined(COLORLCD)
 bool radioThemesEnabled() {
-  return (g_model.radioThemesDisabled == OVERRIDE_GLOBAL && g_eeGeneral.radioThemesDisabled == 0) || (g_model.radioThemesDisabled == 2);
+  return FEATURE_ENABLED(radioThemesDisabled);
 }
 #endif
 bool radioGFEnabled() {
-  return (g_model.radioGFDisabled == OVERRIDE_GLOBAL && g_eeGeneral.radioGFDisabled == 0) || (g_model.radioGFDisabled == 2);
+  return FEATURE_ENABLED(radioGFDisabled);
 }
 bool radioTrainerEnabled() {
-  return (g_model.radioTrainerDisabled == OVERRIDE_GLOBAL && g_eeGeneral.radioTrainerDisabled == 0) || (g_model.radioTrainerDisabled == 2);
+  return FEATURE_ENABLED(radioTrainerDisabled);
 }
 
 // Model menu tab state
 bool modelHeliEnabled() {
-  return (g_model.modelHeliDisabled == OVERRIDE_GLOBAL && g_eeGeneral.modelHeliDisabled == 0) || (g_model.modelHeliDisabled == 2);
+  return FEATURE_ENABLED(modelHeliDisabled);
 }
 bool modelFMEnabled() {
-  return (g_model.modelFMDisabled == OVERRIDE_GLOBAL && g_eeGeneral.modelFMDisabled == 0) || (g_model.modelFMDisabled == 2);
+  return FEATURE_ENABLED(modelFMDisabled);
 }
 bool modelCurvesEnabled() {
-  return (g_model.modelCurvesDisabled == OVERRIDE_GLOBAL && g_eeGeneral.modelCurvesDisabled == 0) || (g_model.modelCurvesDisabled == 2);
+  return FEATURE_ENABLED(modelCurvesDisabled);
 }
 bool modelGVEnabled() {
-  return (g_model.modelGVDisabled == OVERRIDE_GLOBAL && g_eeGeneral.modelGVDisabled == 0) || (g_model.modelGVDisabled == 2);
+  return FEATURE_ENABLED(modelGVDisabled);
 }
 bool modelLSEnabled() {
-  return (g_model.modelLSDisabled == OVERRIDE_GLOBAL && g_eeGeneral.modelLSDisabled == 0) || (g_model.modelLSDisabled == 2);
+  return FEATURE_ENABLED(modelLSDisabled);
 }
 bool modelSFEnabled() {
-  return (g_model.modelSFDisabled == OVERRIDE_GLOBAL && g_eeGeneral.modelSFDisabled == 0) || (g_model.modelSFDisabled == 2);
+  return FEATURE_ENABLED(modelSFDisabled);
 }
 bool modelCustomScriptsEnabled() {
-  return (g_model.modelCustomScriptsDisabled == OVERRIDE_GLOBAL && g_eeGeneral.modelCustomScriptsDisabled == 0) || (g_model.modelCustomScriptsDisabled == 2);
+  return FEATURE_ENABLED(modelCustomScriptsDisabled);
 }
 bool modelTelemetryEnabled() {
-  return (g_model.modelTelemetryDisabled == OVERRIDE_GLOBAL && g_eeGeneral.modelTelemetryDisabled == 0) || (g_model.modelTelemetryDisabled == 2);
+  return FEATURE_ENABLED(modelTelemetryDisabled);
 }


### PR DESCRIPTION
The model level setting for enabled features takes precedence over the radio level setting if the model setting is not 'Global'.

In this case the radio setting has no effect on the tab visibility which may lead to confusion.

This PR hides the enabled features toggle in radio settings if it is overridden in model settings and shows the model setting instead.

![Screenshot 2023-09-12 at 8 50 39 am](https://github.com/EdgeTX/edgetx/assets/9474356/65600ecf-6953-4ebe-b96a-28c7faec4592)
![Screenshot 2023-09-12 at 9 59 41 am](https://github.com/EdgeTX/edgetx/assets/9474356/fb7b89eb-b6b7-48be-8432-c93fdc925aae)
![Screenshot 2023-09-12 at 10 14 53 am](https://github.com/EdgeTX/edgetx/assets/9474356/52613165-124d-4ba4-9042-6c708b89a10f)
