### PR TITLE
fix: compile error if X9D and USE_RTC_CLOCK=OFF

### DIFF
--- a/radio/src/gui/212x64/radio_setup.cpp
+++ b/radio/src/gui/212x64/radio_setup.cpp
@@ -230,6 +230,7 @@ void menuRadioSetup(event_t event)
     uint8_t attr = (sub == k ? blink : 0);
 
     switch (k) {
+#if defined(RTCLOCK)
       case ITEM_RADIO_SETUP_DATE:
         lcdDrawTextAlignedLeft(y, STR_DATE);
         lcdDrawChar(RADIO_SETUP_DATE_COLUMN, y, '-'); lcdDrawChar(RADIO_SETUP_DATE_COLUMN+3*FW-2, y, '-');
@@ -287,6 +288,7 @@ void menuRadioSetup(event_t event)
           g_rtcTime = gmktime(&t); // update local timestamp and get wday calculated
         }
         break;
+#endif
 
      case ITEM_RADIO_SETUP_BATTERY_CALIB:
         lcdDrawTextAlignedLeft(y, STR_BATT_CALIB);


### PR DESCRIPTION
fix issue #4039, compile error if X9D and USE_RTC_CLOCK=OFF

Summary of changes:

Added ifdefs to missing enums
