### PR TITLE
fix(color): Fixes for switch and source select popup menus.

### DIFF
--- a/radio/src/gui/colorlcd/sourcechoice.cpp
+++ b/radio/src/gui/colorlcd/sourcechoice.cpp
@@ -40,20 +40,39 @@ class SourceChoiceMenuToolbar : public MenuToolbar
       if (modelCustomScriptsEnabled())
         addButton(STR_CHAR_LUA, MIXSRC_FIRST_LUA, MIXSRC_LAST_LUA);
 #endif
-      addButton(STR_CHAR_STICK, MIXSRC_FIRST_STICK, MIXSRC_LAST_STICK);
+#if defined(PCBHORUS)
+      auto lastSource = MIXSRC_LAST_SPACEMOUSE;
+#elif defined(IMU)
+      auto lastSource = MIXSRC_TILT_Y;
+#else
+      auto lastSource = MIXSRC_LAST_STICK;
+#endif
+      addButton(STR_CHAR_STICK, MIXSRC_FIRST_STICK, lastSource, [=](int16_t index) {
+        if (index >= MIXSRC_FIRST_POT && index <= MIXSRC_LAST_POT)
+          return false;
+#if MAX_AXIS > 0
+        if (index >= MIXSRC_FIRST_AXIS && index <= MIXSRC_LAST_AXIS)
+          return false;
+#endif
+        return index >= MIXSRC_FIRST_STICK && index <= lastSource;
+      });
       addButton(STR_CHAR_POT, MIXSRC_FIRST_POT, MIXSRC_LAST_POT);
-      addButton(STR_CHAR_FUNCTION, MIXSRC_MIN, MIXSRC_MAX);
+      addButton(STR_CHAR_FUNCTION, MIXSRC_MIN, MIXSRC_LAST_TIMER, [=](int16_t index) {
+        return (index >= MIXSRC_MIN && index <= MIXSRC_MAX) || (index >= MIXSRC_TX_VOLTAGE && index <= MIXSRC_LAST_TIMER);
+      });
 #if defined(HELI)
       if (modelHeliEnabled())
         addButton(STR_CHAR_CYC, MIXSRC_FIRST_HELI, MIXSRC_LAST_HELI);
 #endif
       addButton(STR_CHAR_TRIM, MIXSRC_FIRST_TRIM, MIXSRC_LAST_TRIM);
       addButton(STR_CHAR_SWITCH, MIXSRC_FIRST_SWITCH, MIXSRC_LAST_SWITCH);
+      if (modelLSEnabled())
+        addButton(STR_CHAR_SWITCH, MIXSRC_FIRST_LOGICAL_SWITCH, MIXSRC_LAST_LOGICAL_SWITCH);
       addButton(STR_CHAR_TRAINER, MIXSRC_FIRST_TRAINER, MIXSRC_LAST_TRAINER);
       addButton(STR_CHAR_CHANNEL, MIXSRC_FIRST_CH, MIXSRC_LAST_CH);
 #if defined(GVARS)
       if (modelGVEnabled())
-        addButton(STR_CHAR_SLIDER, MIXSRC_LAST_GVAR, MIXSRC_FIRST_GVAR);
+        addButton(STR_CHAR_SLIDER, MIXSRC_FIRST_GVAR, MIXSRC_LAST_GVAR);
 #endif
       if (modelTelemetryEnabled())
         addButton(STR_CHAR_TELEMETRY, MIXSRC_FIRST_TELEM, MIXSRC_LAST_TELEM);

--- a/radio/src/gui/colorlcd/switchchoice.cpp
+++ b/radio/src/gui/colorlcd/switchchoice.cpp
@@ -34,10 +34,19 @@ class SwitchChoiceMenuToolbar : public MenuToolbar
   SwitchChoiceMenuToolbar(SwitchChoice* choice, Menu* menu) :
       MenuToolbar(choice, menu)
   {
-    addButton(STR_CHAR_SWITCH, SWSRC_FIRST_SWITCH, SWSRC_LAST_SWITCH);
+    addButton(STR_CHAR_SWITCH, SWSRC_FIRST_SWITCH, SWSRC_LAST_MULTIPOS_SWITCH);
     addButton(STR_CHAR_TRIM, SWSRC_FIRST_TRIM, SWSRC_LAST_TRIM);
-    addButton(STR_CHAR_SWITCH, SWSRC_FIRST_LOGICAL_SWITCH,
-              SWSRC_LAST_LOGICAL_SWITCH);
+    addButton(STR_CHAR_SWITCH, SWSRC_FIRST_LOGICAL_SWITCH, SWSRC_LAST_LOGICAL_SWITCH);
+    addButton(STR_CHAR_TELEMETRY, SWSRC_FIRST_SENSOR, SWSRC_LAST_SENSOR);
+#if defined(DEBUG_LATENCY)
+    auto lastSource = SWSRC_LATENCY_TOGGLE;
+#else
+    auto lastSource = SWSRC_RADIO_ACTIVITY;
+#endif
+    addButton(STR_CHAR_FUNCTION, SWSRC_TELEMETRY_STREAMING, lastSource, [=](int16_t index) {
+      index = abs(index);
+      return index == 0 || (index >= SWSRC_TELEMETRY_STREAMING && index <= lastSource && !(index >= SWSRC_FIRST_SENSOR && index <= SWSRC_LAST_SENSOR));
+    });
   }
 };
 

--- a/radio/src/gui/colorlcd/themes/etx_lv_theme.cpp
+++ b/radio/src/gui/colorlcd/themes/etx_lv_theme.cpp
@@ -497,6 +497,7 @@ void table_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)
   lv_obj_add_style(obj, &styles.pad_small, LV_PART_ITEMS);
   lv_obj_add_style(obj, &styles.pressed, LV_PART_ITEMS | LV_STATE_PRESSED);
   lv_obj_add_style(obj, &styles.bg_color_focus, LV_PART_ITEMS | LV_STATE_EDITED);
+  lv_obj_set_style_pad_ver(obj, 7, LV_PART_ITEMS);
 }
 
 void etx_keyboard_constructor(const lv_obj_class_t * class_p, lv_obj_t * obj)

--- a/radio/src/targets/horus/libopenui_config.h
+++ b/radio/src/targets/horus/libopenui_config.h
@@ -32,9 +32,9 @@ constexpr uint32_t ALERT_MESSAGE_LEFT =            ALERT_TITLE_LEFT;
 
 constexpr coord_t INPUT_EDIT_CURVE_WIDTH = 132;
 constexpr coord_t INPUT_EDIT_CURVE_HEIGHT = INPUT_EDIT_CURVE_WIDTH;
-constexpr coord_t MENUS_LINE_HEIGHT = 30;
+constexpr coord_t MENUS_LINE_HEIGHT = 35;
 constexpr coord_t MENUS_WIDTH = 200;
-constexpr coord_t MENUS_MAX_HEIGHT = LCD_H * 0.9;
+constexpr coord_t MENUS_MAX_HEIGHT = (MENUS_LINE_HEIGHT * 7);
 
 constexpr rect_t MENUS_TOOLBAR_RECT =              { 100, 51, 30, 209 };
 

--- a/radio/src/targets/nv14/libopenui_config.h
+++ b/radio/src/targets/nv14/libopenui_config.h
@@ -32,9 +32,9 @@ constexpr uint32_t ALERT_MESSAGE_LEFT =            15;
 
 constexpr coord_t INPUT_EDIT_CURVE_WIDTH = 176;
 constexpr coord_t INPUT_EDIT_CURVE_HEIGHT = 132;
-constexpr coord_t MENUS_LINE_HEIGHT = 40;
+constexpr coord_t MENUS_LINE_HEIGHT = 35;
 constexpr coord_t MENUS_WIDTH = 200;
-constexpr coord_t MENUS_MAX_HEIGHT = 7 * MENUS_LINE_HEIGHT - 1;
+constexpr coord_t MENUS_MAX_HEIGHT = (MENUS_LINE_HEIGHT * 10);
 
 constexpr rect_t MENUS_TOOLBAR_RECT =              { 35, (LCD_H - MENUS_MAX_HEIGHT) / 2, 50, MENUS_MAX_HEIGHT };
 

--- a/radio/src/thirdparty/libopenui/src/choice.cpp
+++ b/radio/src/thirdparty/libopenui/src/choice.cpp
@@ -194,9 +194,10 @@ void Choice::fillMenu(Menu *menu, const FilterFct& filter)
 {
   menu->removeLines();
   auto value = _getValue();
-  
+
   int count = 0;
   int selectedIx = -1;
+  int selectedIx0 = -1;
   for (int i = vmin; i <= vmax; ++i) {
     if (filter && !filter(i)) continue;
     if (isValueAvailable && !isValueAvailable(i)) continue;
@@ -208,10 +209,19 @@ void Choice::fillMenu(Menu *menu, const FilterFct& filter)
       menu->addLineBuffered(std::to_string(i), [=]() { setValue(i); });
     }
     if (value == i) { selectedIx = count; }
+    if (i == 0) { selectedIx0 = count; }
     ++count;
   }
   menu->updateLines();
-  if (selectedIx >= 0) { menu->select(selectedIx); }
+  // Force update - in case selected row is first row
+  menu->select(-1);
+  if (selectedIx >= 0)
+    menu->select(selectedIx);
+  else if (selectedIx0 >= 0)
+    menu->select(selectedIx0);
+  else {
+    menu->select(0);
+  }
 }
 
 void Choice::openMenu()

--- a/radio/src/thirdparty/libopenui/src/menutoolbar.cpp
+++ b/radio/src/thirdparty/libopenui/src/menutoolbar.cpp
@@ -106,14 +106,16 @@ rect_t MenuToolbar::getButtonRect(size_t buttons)
 }
 
 bool MenuToolbar::filterMenu(MenuToolbarButton* btn, int16_t filtermin,
-                             int16_t filtermax)
+                             int16_t filtermax, const FilterFct& filterFunc)
 {
   btn->check(!btn->checked());
 
   Choice::FilterFct filter = nullptr;
   if (btn->checked()) {
     filter = [=](int16_t index) {
-      return index >= filtermin && index <= filtermax;
+      if (filterFunc)
+        return filterFunc(index);
+      return index == 0 || (abs(index) >= filtermin && abs(index) <= filtermax);
     };
   }
 
@@ -135,7 +137,7 @@ static int getFirstAvailable(int min, int max, IsValueAvailable isValueAvailable
 }
 
 void MenuToolbar::addButton(const char* picto, int16_t filtermin,
-                            int16_t filtermax)
+                            int16_t filtermax, const FilterFct& filterFunc)
 {
   int vmin = choice->vmin;
   int vmax = choice->vmax;
@@ -150,7 +152,7 @@ void MenuToolbar::addButton(const char* picto, int16_t filtermin,
   auto button = new MenuToolbarButton(this, r, picto);
 
   button->setPressHandler(
-      std::bind(&MenuToolbar::filterMenu, this, button, filtermin, filtermax));
+      std::bind(&MenuToolbar::filterMenu, this, button, filtermin, filtermax, filterFunc));
 
   lv_group_add_obj(group, button->getLvObj());
 }

--- a/radio/src/thirdparty/libopenui/src/menutoolbar.h
+++ b/radio/src/thirdparty/libopenui/src/menutoolbar.h
@@ -47,11 +47,12 @@ class MenuToolbar : public Window
  protected:
   Choice* choice;
   Menu* menu;
+  typedef std::function<bool(int16_t)> FilterFct;
 
   lv_group_t* group;
 
-  void addButton(const char* picto, int16_t filtermin, int16_t filtermax);
-  bool filterMenu(MenuToolbarButton* btn, int16_t filtermin, int16_t filtermax);
+  void addButton(const char* picto, int16_t filtermin, int16_t filtermax, const FilterFct& filterFunc = nullptr);
+  bool filterMenu(MenuToolbarButton* btn, int16_t filtermin, int16_t filtermax, const FilterFct& filterFunc = nullptr);
 
   rect_t getButtonRect(size_t buttons);
 


### PR DESCRIPTION
- Fix missing GV filter in source select
- Ensure all available options are also included in one of the filters
- Add misc filter to switch select (for TELE and ACT options)
- Show inverted and no-selection options when a filter is selected
- Make menu line height consistent.

![Screenshot 2023-09-17 at 2 53 37 pm](https://github.com/EdgeTX/edgetx/assets/9474356/faf72873-6668-4c1c-981f-c0636cce888e)

![Screenshot 2023-09-17 at 3 00 36 pm](https://github.com/EdgeTX/edgetx/assets/9474356/59dac08f-e6c7-483f-9512-c6ed2c8d7782)

![Screenshot 2023-09-17 at 2 53 29 pm](https://github.com/EdgeTX/edgetx/assets/9474356/a7aee241-4b10-4a62-9b8d-720aab831370)

