### PR TITLE
fix(color): Scale SF backlight value to user selected min/max backlight values

### DIFF
--- a/radio/src/functions.cpp
+++ b/radio/src/functions.cpp
@@ -394,12 +394,8 @@ void evalFunctions(const CustomFunctionData * functions, CustomFunctionsContext 
 
             getvalue_t raw = getValue(CFN_PARAM(cfn));
 #if defined(COLORLCD)
-            if (raw == -1024)
-              requiredBacklightBright = 100;
-            else
-              requiredBacklightBright =
-                  (1024 - raw) * (BACKLIGHT_LEVEL_MAX - BACKLIGHT_LEVEL_MIN) /
-                  2048;
+            requiredBacklightBright = BACKLIGHT_LEVEL_MAX - (g_eeGeneral.blOffBright + 
+                ((1024 + raw) * ((BACKLIGHT_LEVEL_MAX - g_eeGeneral.backlightBright) - g_eeGeneral.blOffBright) / 2048));
 #elif defined(OLED_SCREEN)
             requiredBacklightBright = (raw + 1024) * 254 / 2048;
 #else

--- a/radio/src/gui/colorlcd/radio_setup.cpp
+++ b/radio/src/gui/colorlcd/radio_setup.cpp
@@ -475,15 +475,17 @@ class BacklightPage : public SubPage {
 
       // Backlight ON bright
       new StaticText(backlightOnBright, rect_t{}, STR_BLONBRIGHTNESS, 0, COLOR_THEME_PRIMARY1);
-      new Slider(backlightOnBright, lv_pct(50), BACKLIGHT_LEVEL_MIN, BACKLIGHT_LEVEL_MAX,
+      backlightOnSlider = new Slider(backlightOnBright, lv_pct(50), BACKLIGHT_LEVEL_MIN, BACKLIGHT_LEVEL_MAX,
                  [=]() -> int32_t {
                    return BACKLIGHT_LEVEL_MAX - g_eeGeneral.backlightBright;
                  },
                  [=](int32_t newValue) {
-                   if(newValue >= g_eeGeneral.blOffBright || g_eeGeneral.backlightMode == e_backlight_mode_on)
+                   if(newValue >= g_eeGeneral.blOffBright || g_eeGeneral.backlightMode == e_backlight_mode_on) {
                      g_eeGeneral.backlightBright = BACKLIGHT_LEVEL_MAX - newValue;
-                   else
+                   } else {
                      g_eeGeneral.backlightBright = BACKLIGHT_LEVEL_MAX - g_eeGeneral.blOffBright;
+                     backlightOnSlider->update();
+                   }
                    SET_DIRTY();
                  });
 
@@ -491,13 +493,15 @@ class BacklightPage : public SubPage {
 
       // Backlight OFF bright
       new StaticText(backlightOffBright, rect_t{}, STR_BLOFFBRIGHTNESS, 0, COLOR_THEME_PRIMARY1);
-      new Slider(backlightOffBright, lv_pct(50), BACKLIGHT_LEVEL_MIN, BACKLIGHT_LEVEL_MAX, GET_DEFAULT(g_eeGeneral.blOffBright),
+      backlightOffSlider = new Slider(backlightOffBright, lv_pct(50), BACKLIGHT_LEVEL_MIN, BACKLIGHT_LEVEL_MAX, GET_DEFAULT(g_eeGeneral.blOffBright),
                  [=](int32_t newValue) {
                    int32_t onBright = BACKLIGHT_LEVEL_MAX - g_eeGeneral.backlightBright;
-                   if(newValue <= onBright || g_eeGeneral.backlightMode == e_backlight_mode_off)
+                   if(newValue <= onBright || g_eeGeneral.backlightMode == e_backlight_mode_off) {
                      g_eeGeneral.blOffBright = newValue;
-                   else
+                   } else {
                      g_eeGeneral.blOffBright = onBright;
+                     backlightOffSlider->update();
+                   }
                    SET_DIRTY();
                  });
 
@@ -522,6 +526,8 @@ class BacklightPage : public SubPage {
     Window* backlightTimeout = nullptr;
     Window* backlightOnBright = nullptr;
     Window* backlightOffBright = nullptr;
+    Slider* backlightOffSlider = nullptr;
+    Slider* backlightOnSlider = nullptr;
 
     void updateBacklightControls()
     {

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -538,11 +538,6 @@ void checkBacklight()
       }
       if (backlightOn) {
         currentBacklightBright = requiredBacklightBright;
-#if defined(COLORLCD)
-        // force backlight on for color lcd radios
-        if (currentBacklightBright > BACKLIGHT_LEVEL_MAX - BACKLIGHT_LEVEL_MIN)
-          currentBacklightBright = BACKLIGHT_LEVEL_MAX - BACKLIGHT_LEVEL_MIN;
-#endif
         BACKLIGHT_ENABLE();
       } else {
         BACKLIGHT_DISABLE();

--- a/radio/src/thirdparty/libopenui/src/slider.cpp
+++ b/radio/src/thirdparty/libopenui/src/slider.cpp
@@ -56,8 +56,15 @@ Slider::Slider(Window* parent, coord_t width, int32_t vmin, int32_t vmax,
 
 void Slider::update()
 {
-  if (_getValue != nullptr)
+  if (_getValue != nullptr) {
+    // Fix for lv_slider_set_value not working when using the rotary encoder to
+    // update value
+    auto bar = (lv_bar_t*)slider;
+    bar->cur_value_anim.anim_state = -1;
+    bar->cur_value_anim.anim_end = _getValue();
+
     lv_slider_set_value(slider, _getValue(), LV_ANIM_OFF);
+  }
 }
 
 void Slider::paint(BitmapBuffer* dc)

--- a/radio/src/thirdparty/libopenui/src/slider.cpp
+++ b/radio/src/thirdparty/libopenui/src/slider.cpp
@@ -51,6 +51,11 @@ Slider::Slider(Window* parent, coord_t width, int32_t vmin, int32_t vmax,
   lv_obj_add_event_cb(slider, slider_changed_cb, LV_EVENT_VALUE_CHANGED, this);
   lv_slider_set_range(slider, vmin, vmax);
 
+  update();
+}
+
+void Slider::update()
+{
   if (_getValue != nullptr)
     lv_slider_set_value(slider, _getValue(), LV_ANIM_OFF);
 }

--- a/radio/src/thirdparty/libopenui/src/slider.h
+++ b/radio/src/thirdparty/libopenui/src/slider.h
@@ -37,6 +37,8 @@ class Slider : public Window
 
   void paint(BitmapBuffer *) override;
 
+  void update();
+
  protected:
   int vmin;
   int vmax;


### PR DESCRIPTION
Fixes #4057 

Restrict the backlight value selected via the special function to lie between the user selected values for 'ON brightness' and 'OFF brightness' values.

When using a pot/slider to control the backlight the min value on the slider will be set to the 'OFF brightness' value, the max value will be 'ON brightness'. Values in between are scaled accordingly.

Tested on TX16S and EL18.

Note: If 'OFF brightness' is set to the lowest value in the settings UI then the inactivity timer will turn the LCD off. This is not true of the pot/sider value - the lowest value does not turn the LCD off.