### PR TITLE
fix: GitPod container image now needs their workspace image as base

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -68,7 +68,7 @@ jobs:
           - xlite
           - xlites
     container:
-      image: ghcr.io/edgetx/edgetx-dev:pr-20
+      image: ghcr.io/edgetx/edgetx-dev:2.9.1
       volumes:
         - ${{ github.workspace }}:/src
     steps:
@@ -109,7 +109,7 @@ jobs:
           - x9lite;x9lites
           - xlite;xlites
     container:
-      image: ghcr.io/edgetx/edgetx-dev:pr-20
+      image: ghcr.io/edgetx/edgetx-dev:2.9.1
       volumes:
         - ${{ github.workspace }}:/src
     steps:

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -68,7 +68,7 @@ jobs:
           - xlite
           - xlites
     container:
-      image: ghcr.io/edgetx/edgetx-dev:2.9.0
+      image: ghcr.io/edgetx/edgetx-dev:pr-20
       volumes:
         - ${{ github.workspace }}:/src
     steps:
@@ -109,7 +109,7 @@ jobs:
           - x9lite;x9lites
           - xlite;xlites
     container:
-      image: ghcr.io/edgetx/edgetx-dev:2.9.0
+      image: ghcr.io/edgetx/edgetx-dev:pr-20
       volumes:
         - ${{ github.workspace }}:/src
     steps:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,4 +1,4 @@
-image: ghcr.io/edgetx/gitpod-workspace:pr-20
+image: ghcr.io/edgetx/gitpod-workspace:2.9.1
 
 tasks:
   - name: Prep build folder

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,8 +1,4 @@
-image: ghcr.io/edgetx/edgetx-dev:2.9.0
-
-vscode:
-  extensions:
-    - ms-vscode.cpptools
+image: ghcr.io/edgetx/gitpod-workspace:pr-20
 
 tasks:
   - name: Prep build folder

--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -184,7 +184,7 @@ if(RTC_BACKUP_RAM)
     )
 
   # Add custom target for debugging
-  add_custom_target(datacopy DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/datacopy.cpp)
+  add_custom_target(datacopy DEPENDS ${CMAKE_CURRENT_BINARY_DIR}/datacopy.inc)
 endif()
 
 option(LUA_MIXER "Enable LUA mixer/model scripts support" OFF)


### PR DESCRIPTION
This PR changes the Gitpod container image used as we need to use their base image.

See EdgeTX/build-edgetx#20

**Please note:** this PR is for testing only. It needs some edits before being merged. EdgeTX/build-edgetx#20 should be merged first.