### PR TITLE
chore(color): Cleanup layout refresh logic.

### DIFF
--- a/radio/src/gui/colorlcd/layouts/layout_factory_impl.cpp
+++ b/radio/src/gui/colorlcd/layouts/layout_factory_impl.cpp
@@ -53,21 +53,6 @@ void Layout::paint(BitmapBuffer * dc)
 }
 #endif
 
-void Layout::checkEvents()
-{
-  LayoutBase::checkEvents();
-  adjustLayout();
-
-//   uint32_t now = RTOS_GET_MS();
-//   if (now - lastRefresh >= LAYOUT_REFRESH) {
-//     lastRefresh = now;
-//     invalidate();
-// #if defined(DEBUG_WINDOWS)
-//     TRACE_WINDOWS("# %s refresh: %s", factory->getId(), getWindowDebugString().c_str());
-// #endif
-//   }
-}
-
 void Layout::setTrimsVisible(bool visible)
 {
   decoration->setTrimsVisible(visible);

--- a/radio/src/gui/colorlcd/layouts/layout_factory_impl.h
+++ b/radio/src/gui/colorlcd/layouts/layout_factory_impl.h
@@ -79,8 +79,6 @@ class Layout: public LayoutBase
     {
       return factory;
     }
-
-    void checkEvents() override;
   
     bool hasTopbar() const {
       return getOptionValue(LAYOUT_OPTION_TOPBAR)->boolValue;

--- a/radio/src/gui/colorlcd/layouts/topbar_impl.cpp
+++ b/radio/src/gui/colorlcd/layouts/topbar_impl.cpp
@@ -88,7 +88,7 @@ void TopBar::checkEvents()
   uint32_t now = RTOS_GET_MS();
   if (now - lastRefresh >= TOPBAR_REFRESH) {
     lastRefresh = now;
-    invalidate();
+    TopBarBase::checkEvents();
   }
 }
 

--- a/radio/src/gui/colorlcd/widgets/widgets_container_impl.h
+++ b/radio/src/gui/colorlcd/widgets/widgets_container_impl.h
@@ -115,6 +115,7 @@ class WidgetsContainerImpl : public WidgetsContainer
   inline void setOptionValue(unsigned int index, const ZoneOptionValue& value)
   {
     persistentData->options[index].value = value;
+    adjustLayout();
   }
 
   unsigned int getZonesCount() const override = 0;


### PR DESCRIPTION
Summary of changes:
- Remove top bar forced refresh of widgets, let widgets decide if refresh is needed (while retaining 100ms refresh interval)
- Adjust main view layout when options are changed instead of checking options repeatedly in the checkEvents function
- Adjust date time widget to only refresh when value changes

