### PR TITLE
fix: yaml generator for clang 15 and up

### DIFF
--- a/radio/util/generate_yaml.py
+++ b/radio/util/generate_yaml.py
@@ -147,7 +147,7 @@ class FieldAST(AST_Element):
             if self.type == 'char':
                 self.type = 'string'
         else:
-            self.type = map_type(t.spelling)
+            self.type = map_type(t.get_canonical().spelling)
 
 
 class StructAST(AST_Element):

--- a/radio/util/generate_yaml.py
+++ b/radio/util/generate_yaml.py
@@ -160,7 +160,7 @@ class StructAST(AST_Element):
         if len(alt_name) > 0:
             name = alt_name
 
-        if name == '':
+        if name == '' or (isinstance(cursor,Cursor) and cursor.is_anonymous()):
             name = self.name_prefix() + 'anonymous_' + get_next_anon()
         else:
             name = self.name_prefix() + name


### PR DESCRIPTION
This fixes an issue causing `generate_yaml.py` to bypass the `libclang` found automatically by the Python `clang` package.