### PR TITLE
fix: Properly scale PREC2 sensor values using "ratio"

### DIFF
--- a/radio/src/gui/colorlcd/model_telemetry.cpp
+++ b/radio/src/gui/colorlcd/model_telemetry.cpp
@@ -671,7 +671,8 @@ class SensorEditWindow : public Page {
 
       paramLines[P_RATIO] = form->newLine(&grid);
       new StaticText(paramLines[P_RATIO], rect_t{}, STR_RATIO, 0, COLOR_THEME_PRIMARY1);
-      auto edit = new NumberEdit(paramLines[P_RATIO], rect_t{}, 0, 30000, GET_SET_DEFAULT(sensor->custom.ratio));
+      auto edit = new NumberEdit(paramLines[P_RATIO], rect_t{}, 0, 30000, GET_SET_DEFAULT(sensor->custom.ratio),
+                                  0, PREC1);
       edit->setZeroText("-");
 
       paramLines[P_CELLINDEX] = form->newLine(&grid);

--- a/radio/src/telemetry/telemetry_sensors.cpp
+++ b/radio/src/telemetry/telemetry_sensors.cpp
@@ -707,6 +707,7 @@ int32_t convertTelemetryValue(int32_t value, uint8_t unit, uint8_t prec, uint8_t
 int32_t TelemetrySensor::getValue(int32_t value, uint8_t unit, uint8_t prec) const
 {
   if (type == TELEM_TYPE_CUSTOM && custom.ratio) {
+    /*  farzu:  Not needed, scaling work properly for the 3 types of prec without it  
     if (this->prec == 2) {
       value *= 10;
       prec = 2;
@@ -714,7 +715,9 @@ int32_t TelemetrySensor::getValue(int32_t value, uint8_t unit, uint8_t prec) con
     else {
       prec = 1;
     }
-    value = (custom.ratio * value + 122) / 255;
+    */
+    
+    value = (custom.ratio * value + 122) / 255;  //  122/255 (0.48) is to aproximate up (ceiling) 
   }
 
   value = convertTelemetryValue(value, unit, prec, this->unit, this->prec);


### PR DESCRIPTION
Fixes #4021

History:
During the transition from 2.8.5 to 2.9.0, there was several fixes to DSM sensor values.   The values itself are correct, but it exposes a poblem when using "ratio" to adjust the value of a sensor.

The "ECUR" (ESC Current) sensor change from been in "mAh" (prec=1) to "A" (prec=2).  The change of prec exposed the scaling problem with ratio, The value in 2.8.5 got 10x bigger in 2.9.0 when using ratio.

Summary of changes:
* Simply commenting out code that doing the x10 when prec==2.
* The other problem was when prec==0, it was converting it to prec=1, effectively doing a / 10.

![image](https://github.com/EdgeTX/edgetx/assets/32604366/bb3d9f1f-6b05-4475-a06f-bc36af02b828)




How ratio works is that the value is multiplied by  ratio/255.   So using a ratio of 255 means no change.. value of less than 255 scale down the number, and values greater than 255 makes the value bigger.    This is not documented in the manual.. this was by looking how the code works.

**[pfeerick: added for clarity] As a possible future enhancement...** I think we should consider making it a percentage.  so a value of 100% means same value, > 100% scales up, and < 100% scales it down.  This will be more understandable to more people.  There is probably a historical reason for the 255, but can't find an explanation.

Testing:
Used 3 different sensors with prec=0 (integer), prec=1 (one decimal point), and prec=2 (2 decimal points).  Starts by using ratio 255.. should give the same value. lowering the number makes the sensor value smaller, and increasing it makes the value bigger.
















