### PR TITLE
fix: prevent enabling USART IRQ if not supported

### DIFF
--- a/radio/src/targets/common/arm/stm32/stm32_usart_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_usart_driver.cpp
@@ -286,7 +286,9 @@ void stm32_usart_init(const stm32_usart_t* usart, const etx_serial_init* params)
 
   if (params->direction & ETX_Dir_RX) {
     // IRQ based RX
-    LL_USART_EnableIT_RXNE(usart->USARTx);
+    if ((int32_t)(usart->IRQn) >= 0) {
+      LL_USART_EnableIT_RXNE(usart->USARTx);
+    }
 
     // half-duplex: start in input mode
     if (usart->set_input)


### PR DESCRIPTION
Fixes #4073