### PR TITLE
fix: prevent enabling USART IRQ if not supported

### DIFF
--- a/radio/src/targets/common/arm/stm32/stm32_usart_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_usart_driver.cpp
@@ -289,7 +289,9 @@ void stm32_usart_init(const stm32_usart_t* usart, const etx_serial_init* params)
 
   if (params->direction & ETX_Dir_RX) {
     // IRQ based RX
-    LL_USART_EnableIT_RXNE(usart->USARTx);
+    if ((int32_t)(usart->IRQn) >= 0) {
+      LL_USART_EnableIT_RXNE(usart->USARTx);
+    }
 
     // half-duplex: start in input mode
     if (usart->set_input)


### PR DESCRIPTION
Fixes #4073

In the issue at hand, the USART IRQ is enabled whereby the hardware definition does not provide a valid `IRQn` for this USART:
```c++
static const stm32_usart_t sbus_trainer_USART = {
  .USARTx = TRAINER_MODULE_SBUS_USART,
  .GPIOx = TRAINER_MODULE_SBUS_GPIO,
  .GPIO_Pin = TRAINER_MODULE_SBUS_GPIO_PIN,
  .IRQn = (IRQn_Type)-1,
  .IRQ_Prio = 0,
  .txDMA = nullptr,
  .txDMA_Stream = 0,
  .txDMA_Channel = 0,
  .rxDMA = TRAINER_MODULE_SBUS_DMA,
  .rxDMA_Stream = TRAINER_MODULE_SBUS_DMA_STREAM_LL,
  .rxDMA_Channel = TRAINER_MODULE_SBUS_DMA_CHANNEL,
};
```

This result in all sort of potential issues messing up with random places in RAM.