### PR TITLE
fix: inaccurate Batt measurement on T20

### DIFF
--- a/radio/src/targets/taranis/board.h
+++ b/radio/src/targets/taranis/board.h
@@ -473,7 +473,7 @@ void setTopBatteryValue(uint32_t volts);
 
 #if defined(RADIO_ZORRO) || defined(RADIO_TX12MK2) || defined(RADIO_BOXER) || defined(RADIO_POCKET)
   #define VOLTAGE_DROP 45
-#elif defined(RADIO_TPROV2)
+#elif defined(RADIO_TPROV2) || defined(RADIO_T20)
   #define VOLTAGE_DROP 60
 #else
   #define VOLTAGE_DROP 20


### PR DESCRIPTION
This fix offset on batt measurement, fixing thereby the number of led on during charging