### PR TITLE
fix(color): Fix the popup menu entries when selecting the value for the Trainer special function.

### DIFF
--- a/radio/src/gui/colorlcd/special_functions.cpp
+++ b/radio/src/gui/colorlcd/special_functions.cpp
@@ -136,7 +136,7 @@ class SpecialFunctionEditPage : public Page
           else if (value == MAX_STICKS + 1)
             return std::string(STR_CHANS);
 
-          return std::string(getMainControlLabel(value));
+          return std::string(getMainControlLabel(value - 1));
         });
         break;
       }


### PR DESCRIPTION
Fixes #4089 

Fix incorrect offset when populating the menu.
