### PR TITLE
chore(color): Remove unused code from 'About EdgeTX' popup.

### DIFF
--- a/radio/src/gui/colorlcd/view_about.cpp
+++ b/radio/src/gui/colorlcd/view_about.cpp
@@ -63,5 +63,3 @@ AboutUs::AboutUs() :
   lv_obj_set_pos(qr, (content->width() - 150) / 2, TOP_PADDING + (NUM_LINES * PAGE_LINE_HEIGHT) - 5);
   lv_qrcode_update(qr, edgetx_url.c_str(), edgetx_url.length());
 }
-
-AboutUs::~AboutUs() { delete qrcode; }

--- a/radio/src/gui/colorlcd/view_about.h
+++ b/radio/src/gui/colorlcd/view_about.h
@@ -23,9 +23,6 @@
 
 class AboutUs : public MessageDialog
 {
-  BitmapBuffer* qrcode = nullptr;
-
  public:
   AboutUs();
-  ~AboutUs();
 };


### PR DESCRIPTION
Missed when converting the QR code to LVGL.