### PR TITLE
fix(radio): Fix size of fields on sensor edit page for portrait layout

### DIFF
--- a/radio/src/gui/colorlcd/model_telemetry.cpp
+++ b/radio/src/gui/colorlcd/model_telemetry.cpp
@@ -604,13 +604,21 @@ class SensorEditWindow : public Page {
 
       paramLines[P_ID] = form->newLine(&grid2);
       new StaticText(paramLines[P_ID], rect_t{}, STR_ID, 0, COLOR_THEME_PRIMARY1);
-      auto hex = new NumberEdit(paramLines[P_ID], rect_t{}, 0, 0xFFFF, GET_SET_DEFAULT(sensor->id));
-      hex->setDisplayHandler([](int32_t value) {
+      auto num = new NumberEdit(paramLines[P_ID], rect_t{}, 0, 0xFFFF, GET_SET_DEFAULT(sensor->id));
+#if LCD_H > LCD_W
+      // Portrait layout - need to limit width of edit box
+      num->setWidth((lv_pct(28)));
+#endif
+      num->setDisplayHandler([](int32_t value) {
         std::stringstream stream;
         stream << std::hex << value;
         return stream.str();
       });
-      new NumberEdit(paramLines[P_ID], rect_t{}, 0, 0xff, GET_SET_DEFAULT(sensor->instance));
+      num = new NumberEdit(paramLines[P_ID], rect_t{}, 0, 0xff, GET_SET_DEFAULT(sensor->instance));
+#if LCD_H > LCD_W
+      // Portrait layout - need to limit width of edit box
+      num->setWidth(lv_pct(28));
+#endif
 
       paramLines[P_UNIT] = form->newLine(&grid);
       new StaticText(paramLines[P_UNIT], rect_t{}, STR_UNIT, 0, COLOR_THEME_PRIMARY1);


### PR DESCRIPTION
Fixes #4095 

Summary of changes:
- Limit width of number edit boxes for 'id' and 'instance' fields to prevent overlap.