### PR TITLE
feat: better microsecond timer

### DIFF
--- a/radio/src/globals.h
+++ b/radio/src/globals.h
@@ -49,7 +49,7 @@ extern safetych_t safetyCh[MAX_OUTPUT_CHANNELS];
 extern uint8_t trimsCheckTimer;
 extern uint8_t trimsDisplayTimer;
 extern uint8_t trimsDisplayMask;
-extern uint16_t maxMixerDuration;
+extern uint32_t maxMixerDuration;
 
 extern uint8_t requiredSpeakerVolume;
 extern uint8_t requiredBacklightBright;

--- a/radio/src/haptic.cpp
+++ b/radio/src/haptic.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "opentx.h"
+#include "haptic.h"
 
 hapticQueue::hapticQueue()
 {
@@ -107,3 +108,11 @@ void hapticQueue::event(uint8_t e)
 }
 
 hapticQueue haptic;
+
+// from timers_driver.cpp
+void per5ms()
+{
+  DEBUG_TIMER_START(debugTimerHaptic);
+  HAPTIC_HEARTBEAT();
+  DEBUG_TIMER_STOP(debugTimerHaptic);
+}

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -63,7 +63,7 @@ Clipboard clipboard;
 
 GlobalData globalData;
 
-uint16_t maxMixerDuration; // step = 0.01ms
+uint32_t maxMixerDuration; // microseconds
 uint8_t heartbeat;
 
 #if defined(OVERRIDE_CHANNEL_FUNCTION)
@@ -138,6 +138,9 @@ void checkValidMCU(void)
 
 void per10ms()
 {
+  DEBUG_TIMER_START(debugTimerPer10ms);
+  DEBUG_TIMER_SAMPLE(debugTimerPer10msPeriod);
+
   g_tmr10ms++;
 
 #if defined(GUI)
@@ -203,6 +206,8 @@ void per10ms()
   outputTelemetryBuffer.per10ms();
 
   heartbeat |= HEART_TIMER_10MS;
+
+  DEBUG_TIMER_STOP(debugTimerPer10ms);
 }
 
 FlightModeData *flightModeAddress(uint8_t idx)

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -445,7 +445,6 @@ void doMixerPeriodicUpdates();
 void checkTrims();
 extern uint8_t currentBacklightBright;
 void perMain();
-void per10ms();
 
 getvalue_t getValue(mixsrc_t i, bool* valid = nullptr);
 

--- a/radio/src/sbus.cpp
+++ b/radio/src/sbus.cpp
@@ -23,7 +23,7 @@
 #include "sbus.h"
 #include "timers_driver.h"
 
-#define SBUS_FRAME_GAP_DELAY   1000 // 500uS
+#define SBUS_FRAME_GAP_DELAY_US 500
 
 #define SBUS_START_BYTE        0x0F
 #define SBUS_END_BYTE          0x00
@@ -99,7 +99,7 @@ void processSbusInput()
 
   // TODO: place this outside of the function
   static uint8_t SbusIndex = 0;
-  static uint16_t SbusTimer;
+  static uint32_t SbusTimer;
   static uint8_t SbusFrame[SBUS_FRAME_SIZE];
 
   uint32_t active = 0;
@@ -117,13 +117,13 @@ void processSbusInput()
 
   // Data has been received
   if (active) {
-    SbusTimer = getTmr2MHz();
+    SbusTimer = timersGetUsTick();
     return;
   }
 
   // Check if end-of-frame is detected
   if (SbusIndex) {
-    if ((uint16_t)(getTmr2MHz() - SbusTimer) > SBUS_FRAME_GAP_DELAY) {
+    if ((uint32_t)(timersGetUsTick() - SbusTimer) > SBUS_FRAME_GAP_DELAY_US) {
       processSbusFrame(SbusFrame, trainerInput, SbusIndex);
       SbusIndex = 0;
     }

--- a/radio/src/targets/common/arm/stm32/bootloader/CMakeLists.txt
+++ b/radio/src/targets/common/arm/stm32/bootloader/CMakeLists.txt
@@ -30,6 +30,7 @@ set(BOOTLOADER_SRC
   ../usbd_usr.cpp
   ../usbd_storage_msd.cpp
   ../delays_driver.cpp
+  ../timers_driver.cpp
   ../usbd_desc.c
   ../usb_bsp.c
   ../usb_driver.cpp
@@ -38,6 +39,7 @@ set(BOOTLOADER_SRC
   ../stm32_serial_driver.cpp
   ../stm32_usart_driver.cpp
   ../stm32_gpio_driver.cpp
+  ../stm32_timer.cpp
   ../stm32_dma.cpp
   init.c
   boot.cpp

--- a/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
+++ b/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
@@ -34,6 +34,7 @@
 // #include "keys.h"
 #include "debug.h"
 
+#include "timers_driver.h"
 #include "watchdog_driver.h"
 
 #include "hal/rotary_encoder.h"
@@ -97,7 +98,7 @@ uint32_t unlocked = 0;
 
 volatile uint32_t timer10MsCount;
 
-void interrupt10ms()
+void per10ms()
 {
   timer10MsCount++;
   tenms |= 1u; // 10 mS has passed
@@ -122,48 +123,6 @@ extern "C" uint32_t HAL_GetTick(void)
     return timer10MsCount * 10;
 }
 
-#if !defined(SIMU)
-static volatile uint32_t _us_overflow_cnt;
-
-void initTimers()
-{
-  timer10MsCount = 0;
-  INTERRUPT_xMS_TIMER->ARR = 9999;  // 10mS in uS
-  INTERRUPT_xMS_TIMER->PSC = (PERI1_FREQUENCY * TIMER_MULT_APB1) / 1000000 - 1; // 1uS
-  INTERRUPT_xMS_TIMER->CR1 = TIM_CR1_CEN;
-  INTERRUPT_xMS_TIMER->DIER = TIM_DIER_UIE;
-  NVIC_EnableIRQ(INTERRUPT_xMS_IRQn);
-
-  _us_overflow_cnt = 0;
-  TIMER_2MHz_TIMER->ARR = 65535;
-  TIMER_2MHz_TIMER->PSC = (PERI1_FREQUENCY * TIMER_MULT_APB1) / 2000000 - 1; // 0.5 uS, 2 MHz
-  TIMER_2MHz_TIMER->CR1 = TIM_CR1_CEN;
-  TIMER_2MHz_TIMER->DIER = TIM_DIER_UIE;
-  NVIC_EnableIRQ(TIMER_2MHz_IRQn);
-
-  while(timer10MsCount < 10);
-}
-
-uint32_t timersGetUsTick()
-{
-  uint32_t us;
-  us = TIMER_2MHz_TIMER->CNT >> 1;
-  us += _us_overflow_cnt << 15;
-  return us;
-}
-
-extern "C" void INTERRUPT_xMS_IRQHandler()
-{
-  INTERRUPT_xMS_TIMER->SR &= ~TIM_SR_UIF;
-  interrupt10ms();
-}
-
-extern "C" void TIMER_2MHz_IRQHandler()
-{
-  TIMER_2MHz_TIMER->SR &= ~TIM_SR_UIF;
-  _us_overflow_cnt += 1;
-}
-#endif
 
 uint32_t isValidBufferStart(const uint8_t * buffer)
 {
@@ -254,9 +213,7 @@ void bootloaderInitApp()
                          ENABLE);
 
   RCC_APB1PeriphClockCmd(ROTARY_ENCODER_RCC_APB1Periph | LCD_RCC_APB1Periph |
-                             BACKLIGHT_RCC_APB1Periph |
-                             INTERRUPT_xMS_RCC_APB1Periph |
-                             TIMER_2MHz_RCC_APB1Periph,
+                             BACKLIGHT_RCC_APB1Periph,
                          ENABLE);
 
   RCC_APB2PeriphClockCmd(
@@ -322,7 +279,7 @@ void bootloaderInitApp()
   eepromInit();
 #endif
 
-  initTimers();
+  timersInit();
 
   // SD card detect pin
   sdInit();

--- a/radio/src/targets/common/arm/stm32/heartbeat_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/heartbeat_driver.cpp
@@ -36,7 +36,6 @@ volatile HeartbeatCapture heartbeatCapture;
 
 static void trigger_intmodule_heartbeat()
 {
-  heartbeatCapture.timestamp = getTmr2MHz();
 #if defined(DEBUG_LATENCY)
   heartbeatCapture.count++;
 #endif

--- a/radio/src/targets/common/arm/stm32/mixer_scheduler_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/mixer_scheduler_driver.cpp
@@ -21,6 +21,7 @@
 
 #include "mixer_scheduler.h"
 #include "stm32_hal_ll.h"
+#include "stm32_timer.h"
 
 #include "FreeRTOSConfig.h"
 #include "hal.h"
@@ -28,6 +29,8 @@
 // Start scheduler with default period
 void mixerSchedulerStart()
 {
+  stm32_timer_enable_clock(MIXER_SCHEDULER_TIMER);
+
   MIXER_SCHEDULER_TIMER->CR1 &= ~TIM_CR1_CEN;
   MIXER_SCHEDULER_TIMER->PSC   = MIXER_SCHEDULER_TIMER_FREQ / 1000000 - 1; // 1uS (1Mhz)
   MIXER_SCHEDULER_TIMER->CCER  = 0;

--- a/radio/src/targets/common/arm/stm32/stm32_timer.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_timer.cpp
@@ -35,6 +35,10 @@ void stm32_timer_enable_clock(TIM_TypeDef *TIMx)
     LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_TIM5);
   } else if (TIMx == TIM8) {
     LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_TIM8);
+  } else if (TIMx == TIM12) {
+    LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_TIM12);
+  } else if (TIMx == TIM14) {
+    LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_TIM14);
   }  
 }
 
@@ -52,5 +56,9 @@ void stm32_timer_disable_clock(TIM_TypeDef *TIMx)
     LL_APB1_GRP1_DisableClock(LL_APB1_GRP1_PERIPH_TIM5);
   } else if (TIMx == TIM8) {
     LL_APB2_GRP1_DisableClock(LL_APB2_GRP1_PERIPH_TIM8);
+  } else if (TIMx == TIM12) {
+    LL_APB1_GRP1_DisableClock(LL_APB1_GRP1_PERIPH_TIM12);
+  } else if (TIMx == TIM14) {
+    LL_APB1_GRP1_DisableClock(LL_APB1_GRP1_PERIPH_TIM14);
   }  
 }

--- a/radio/src/targets/common/arm/stm32/timers_driver.h
+++ b/radio/src/targets/common/arm/stm32/timers_driver.h
@@ -21,33 +21,18 @@
 
 #pragma once
 
-#if defined(SIMU)
-
-uint16_t getTmr2MHz();
-#define watchdogSuspend(timeout)
-
-#else // SIMU
-
-#include "hal.h"
-
-void init2MhzTimer();
-void init1msTimer();
-void stop1msTimer();
-
-#define getTmr2MHz() TIMER_2MHz_TIMER->CNT
-
-void watchdogSuspend(uint32_t timeout);
-
-#endif
-
 #include "opentx_types.h"
 
 extern "C" volatile tmr10ms_t g_tmr10ms;
+static inline tmr10ms_t get_tmr10ms() { return g_tmr10ms; }
 
-static inline tmr10ms_t get_tmr10ms()
-{
-  return g_tmr10ms;
-}
+void watchdogSuspend(uint32_t timeout);
+
+void timersInit();
 
 uint32_t timersGetMsTick();
 uint32_t timersGetUsTick();
+
+// declared "weak", to be implemented by application
+void per5ms();
+void per10ms();

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -106,12 +106,9 @@ void boardInit()
                          ENABLE);
 
   RCC_APB1PeriphClockCmd(ROTARY_ENCODER_RCC_APB1Periph |
-                         INTERRUPT_xMS_RCC_APB1Periph |
-                         TIMER_2MHz_RCC_APB1Periph |
                          AUDIO_RCC_APB1Periph |
                          TELEMETRY_RCC_APB1Periph |
                          AUDIO_RCC_APB1Periph |
-                         MIXER_SCHEDULER_TIMER_RCC_APB1Periph |
                          BACKLIGHT_RCC_APB1Periph,
                          ENABLE);
 
@@ -172,8 +169,7 @@ void boardInit()
   if (!adcInit(&_adc_driver))
     TRACE("adcInit failed");
 
-  init2MhzTimer();
-  init1msTimer();
+  timersInit();
 
   usbInit();
   hapticInit();

--- a/radio/src/targets/horus/hal.h
+++ b/radio/src/targets/horus/hal.h
@@ -987,21 +987,12 @@
 #define TRAINER_MODULE_CPPM_TIMER_IRQHandler TIM4_IRQHandler
 #define TRAINER_MODULE_CPPM_GPIO_AF          LL_GPIO_AF_2
 
-
-// Xms Interrupt
-#define INTERRUPT_xMS_RCC_APB1Periph    RCC_APB1Periph_TIM14
-#define INTERRUPT_xMS_TIMER             TIM14
-#define INTERRUPT_xMS_IRQn              TIM8_TRG_COM_TIM14_IRQn
-#define INTERRUPT_xMS_IRQHandler        TIM8_TRG_COM_TIM14_IRQHandler
-
-// 2MHz Timer
-#define TIMER_2MHz_RCC_APB1Periph       RCC_APB1Periph_TIM7
-#define TIMER_2MHz_TIMER                TIM7
-#define TIMER_2MHz_IRQn                 TIM7_IRQn
-#define TIMER_2MHz_IRQHandler           TIM7_IRQHandler
+// Millisecond timer
+#define MS_TIMER                        TIM14
+#define MS_TIMER_IRQn                   TIM8_TRG_COM_TIM14_IRQn
+#define MS_TIMER_IRQHandler             TIM8_TRG_COM_TIM14_IRQHandler
 
 // Mixer scheduler timer
-#define MIXER_SCHEDULER_TIMER_RCC_APB1Periph RCC_APB1Periph_TIM13
 #define MIXER_SCHEDULER_TIMER                TIM13
 #define MIXER_SCHEDULER_TIMER_FREQ           (PERI1_FREQUENCY * TIMER_MULT_APB1)
 #define MIXER_SCHEDULER_TIMER_IRQn           TIM8_UP_TIM13_IRQn

--- a/radio/src/targets/nv14/board.cpp
+++ b/radio/src/targets/nv14/board.cpp
@@ -126,14 +126,9 @@ void delay_self(int count)
                               )
 #define RCC_AHB3PeriphMinimum (SDRAM_RCC_AHB3Periph)
 
-#define RCC_APB1PeriphMinimum (INTERRUPT_xMS_RCC_APB1Periph |\
-                               TIMER_2MHz_RCC_APB1Periph |\
-                               BACKLIGHT_RCC_APB1Periph \
-                              )
+#define RCC_APB1PeriphMinimum (BACKLIGHT_RCC_APB1Periph)
 
-#define RCC_APB1PeriphOther   (TELEMETRY_RCC_APB1Periph |\
-                               MIXER_SCHEDULER_TIMER_RCC_APB1Periph \
-                              )
+#define RCC_APB1PeriphOther   (TELEMETRY_RCC_APB1Periph)
 #define RCC_APB2PeriphMinimum (LCD_RCC_APB2Periph)
 
 #define RCC_APB2PeriphOther   (HAPTIC_RCC_APB2Periph |\
@@ -228,8 +223,7 @@ void boardInit()
   init_trainer();
   battery_charge_init();
   flysky_gimbal_init();
-  init2MhzTimer();
-  init1msTimer();
+  timersInit();
   TouchInit();
   usbInit();
 

--- a/radio/src/targets/nv14/hal.h
+++ b/radio/src/targets/nv14/hal.h
@@ -541,20 +541,12 @@
 #define BT_CMD_MODE_GPIO                GPIOH
 #define BT_CMD_MODE_GPIO_PIN            GPIO_Pin_6 // PH.6
 
-// Xms Interrupt
-#define INTERRUPT_xMS_RCC_APB1Periph    RCC_APB1Periph_TIM14
-#define INTERRUPT_xMS_TIMER             TIM14
-#define INTERRUPT_xMS_IRQn              TIM8_TRG_COM_TIM14_IRQn
-#define INTERRUPT_xMS_IRQHandler        TIM8_TRG_COM_TIM14_IRQHandler
-
-// 2MHz Timer
-#define TIMER_2MHz_RCC_APB1Periph       RCC_APB1Periph_TIM7
-#define TIMER_2MHz_TIMER                TIM7
-#define TIMER_2MHz_IRQn                 TIM7_IRQn
-#define TIMER_2MHz_IRQHandler           TIM7_IRQHandler
+// Millisecond timer
+#define MS_TIMER                        TIM14
+#define MS_TIMER_IRQn                   TIM8_TRG_COM_TIM14_IRQn
+#define MS_TIMER_IRQHandler             TIM8_TRG_COM_TIM14_IRQHandler
 
 // Mixer scheduler timer
-#define MIXER_SCHEDULER_TIMER_RCC_APB1Periph RCC_APB1Periph_TIM12
 #define MIXER_SCHEDULER_TIMER                TIM12
 #define MIXER_SCHEDULER_TIMER_FREQ           (PERI1_FREQUENCY * TIMER_MULT_APB1)
 #define MIXER_SCHEDULER_TIMER_IRQn           TIM8_BRK_TIM12_IRQn

--- a/radio/src/targets/simu/CMakeLists.txt
+++ b/radio/src/targets/simu/CMakeLists.txt
@@ -18,6 +18,7 @@ set(SIMU_DRIVERS
   backlight_driver.cpp
   gyro_driver.cpp
   bt_driver.cpp
+  timers_driver.cpp
   )
 
 set(HW_DESC_JSON ${FLAVOUR}.json)

--- a/radio/src/targets/simu/timers_driver.cpp
+++ b/radio/src/targets/simu/timers_driver.cpp
@@ -19,16 +19,8 @@
  * GNU General Public License for more details.
  */
 
-#pragma once
+#include "timers_driver.h"
 
-struct HeartbeatCapture {
-  uint8_t valid;
-#if defined(DEBUG_LATENCY)
-  uint32_t count;
-#endif
-};
+void watchdogSuspend(unsigned int) {}
+uint32_t timersGetUsTick() { return 0; }
 
-extern volatile HeartbeatCapture heartbeatCapture;
-
-void init_intmodule_heartbeat();
-void stop_intmodule_heartbeat();

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -107,10 +107,7 @@ void boardInit()
                          AUDIO_RCC_APB1Periph |
                          BACKLIGHT_RCC_APB1Periph |
                          HAPTIC_RCC_APB1Periph |
-                         INTERRUPT_xMS_RCC_APB1Periph |
-                         TIMER_2MHz_RCC_APB1Periph |
                          TELEMETRY_RCC_APB1Periph |
-                         MIXER_SCHEDULER_TIMER_RCC_APB1Periph |
                          BT_RCC_APB1Periph,
                          ENABLE);
 
@@ -224,8 +221,7 @@ void boardInit()
 
   lcdInit(); // delaysInit() must be called before
   audioInit();
-  init2MhzTimer();
-  init1msTimer();
+  timersInit();
   usbInit();
 
 #if defined(DEBUG)

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -2800,20 +2800,12 @@
   #define BT_RCC_APB2Periph             0
 #endif
 
-// Xms Interrupt
-#define INTERRUPT_xMS_RCC_APB1Periph    RCC_APB1Periph_TIM14
-#define INTERRUPT_xMS_TIMER             TIM14
-#define INTERRUPT_xMS_IRQn              TIM8_TRG_COM_TIM14_IRQn
-#define INTERRUPT_xMS_IRQHandler        TIM8_TRG_COM_TIM14_IRQHandler
-
-// 2MHz Timer
-#define TIMER_2MHz_RCC_APB1Periph       RCC_APB1Periph_TIM7
-#define TIMER_2MHz_TIMER                TIM7
-#define TIMER_2MHz_IRQn                 TIM7_IRQn
-#define TIMER_2MHz_IRQHandler           TIM7_IRQHandler
+// Millisecond timer
+#define MS_TIMER                        TIM14
+#define MS_TIMER_IRQn                   TIM8_TRG_COM_TIM14_IRQn
+#define MS_TIMER_IRQHandler             TIM8_TRG_COM_TIM14_IRQHandler
 
 // Mixer scheduler timer
-#define MIXER_SCHEDULER_TIMER_RCC_APB1Periph RCC_APB1Periph_TIM12
 #define MIXER_SCHEDULER_TIMER                TIM12
 #define MIXER_SCHEDULER_TIMER_FREQ           (PERI1_FREQUENCY * TIMER_MULT_APB1)
 #define MIXER_SCHEDULER_TIMER_IRQn           TIM8_BRK_TIM12_IRQn

--- a/radio/src/tasks/mixer_task.cpp
+++ b/radio/src/tasks/mixer_task.cpp
@@ -187,7 +187,7 @@ TASK_FUNCTION(mixerTask)
 
     if (_mixer_running) {
 
-      uint16_t t0 = getTmr2MHz();
+      uint32_t t0 = timersGetUsTick();
 
       DEBUG_TIMER_START(debugTimerMixer);
       mixerTaskLock();
@@ -213,7 +213,7 @@ TASK_FUNCTION(mixerTask)
       // so let's do it here.
       WDG_RESET();
 
-      t0 = getTmr2MHz() - t0;
+      t0 = timersGetUsTick() - t0;
       if (t0 > maxMixerDuration)
         maxMixerDuration = t0;
     }


### PR DESCRIPTION
The microseconds timer introduced in #3957 is prone to some errors. This PR corrects these errors and uses a single timer instead of 2, thus removing the 2MHz timer.