### PR TITLE
fix(radio): Lua insertMix function not working

### DIFF
--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -890,7 +890,7 @@ static int luaModelInsertMix(lua_State *L)
 
   if (chn<MAX_OUTPUT_CHANNELS && getMixCount()<MAX_MIXERS && idx<=count) {
     idx += first;
-    insertMix(idx, chn + 1);
+    insertMix(idx, chn);
     MixData *mix = mixAddress(idx);
     luaL_checktype(L, -1, LUA_TTABLE);
     for (lua_pushnil(L); lua_next(L, -2); lua_pop(L, 1)) {

--- a/radio/src/mixes.cpp
+++ b/radio/src/mixes.cpp
@@ -40,7 +40,7 @@ void insertMix(uint8_t idx, uint8_t channel)
   mix->destCh = channel;
   mix->srcRaw = channel + 1;
   if (!isSourceAvailable(mix->srcRaw)) {
-    if (s_currCh > adcGetMaxInputs(ADC_INPUT_MAIN)) {
+    if (channel >= adcGetMaxInputs(ADC_INPUT_MAIN)) {
       mix->srcRaw = MIXSRC_FIRST_STICK + channel;
     } else {
       mix->srcRaw = MIXSRC_FIRST_STICK + inputMappingChannelOrder(channel);


### PR DESCRIPTION
Fixes #4128 

Needs to be applied to 2.9 as well as main. Broken in PR #4008/#3999
