### PR TITLE
fix(color): Clipped progress bar when flashing bootloader/module firmware

### DIFF
--- a/radio/src/gui/colorlcd/radio_sdmanager.cpp
+++ b/radio/src/gui/colorlcd/radio_sdmanager.cpp
@@ -117,7 +117,7 @@ class FlashDialog: public FullScreenDialog
     explicit FlashDialog(const T & device):
       FullScreenDialog(WARNING_TYPE_INFO, STR_FLASH_DEVICE),
       device(device),
-      progress(this, {LCD_W / 2 - 50, LCD_H / 2, 100, 15})
+      progress(this, {LCD_W / 2 - 50, LCD_H / 2, 100, 32})
     {
     }
 


### PR DESCRIPTION
Progress bar was not tall enough so it got clipped.