### PR TITLE
fix(color): Clear edit mode when page closes

### DIFF
--- a/radio/src/thirdparty/libopenui/src/form.cpp
+++ b/radio/src/thirdparty/libopenui/src/form.cpp
@@ -72,6 +72,13 @@ void FormField::onCancel()
   }
 }
 
+void FormField::deleteLater(bool detach, bool trash)
+{
+  if (isEditMode())
+    setEditMode(false);
+  Window::deleteLater(detach, trash);
+}
+
 FormWindow::Line::Line(Window* parent, lv_obj_t* obj, FlexGridLayout* layout) :
     Window(parent, obj), layout(layout)
 {

--- a/radio/src/thirdparty/libopenui/src/form.h
+++ b/radio/src/thirdparty/libopenui/src/form.h
@@ -45,7 +45,8 @@ class FormField : public Window
 
     void onClicked() override;
     void onCancel() override;
-  
+    void deleteLater(bool detach = true, bool trash = true) override;
+
   protected:
     bool editMode = false;
     bool enabled = true;


### PR DESCRIPTION
Fixes an obscure issue with input fields and page navigation.

Steps to reproduce issue:
- Navigate to Radio Settings, Hardware tab
- Use rotary encoder to select Battery calibration field
- Press Enter key to activate edit mode
- Press Page>, then Page<

The Battery meter range field is now selected in partial edit mode; but the rotary encoder does not change the value and the RTN key exits the page instead of exiting edit mode.