### PR TITLE
fix(color): Set default value for various number edit fields

### DIFF
--- a/radio/src/gui/colorlcd/curveedit.cpp
+++ b/radio/src/gui/colorlcd/curveedit.cpp
@@ -352,6 +352,7 @@ void CurveEditWindow::buildBody(FormWindow * window)
                                  }
                              });
   edit->setSuffix(STR_PTS);
+  edit->setDefault(5);
 
   iLine = form->newLine(&iGrid);
   iLine->padAll(0);

--- a/radio/src/gui/colorlcd/gvar_numberedit.cpp
+++ b/radio/src/gui/colorlcd/gvar_numberedit.cpp
@@ -34,7 +34,7 @@ void GVarNumberEdit::value_changed(lv_event_t* e)
 GVarNumberEdit::GVarNumberEdit(Window* parent, const rect_t& rect, int32_t vmin,
                                int32_t vmax, std::function<int32_t()> getValue,
                                std::function<void(int32_t)> setValue,
-                               LcdFlags textFlags, int32_t voffset) :
+                               LcdFlags textFlags, int32_t voffset, int32_t vdefault) :
     Window(parent, rect),
     vmin(vmin),
     vmax(vmax),
@@ -70,6 +70,7 @@ GVarNumberEdit::GVarNumberEdit(Window* parent, const rect_t& rect, int32_t vmin,
       this, rect_t{}, vmin, vmax, [=]() { return getValue() + voffset; },
       nullptr, windowFlags, textFlags);
   num_field->setWidth(70);
+  num_field->setDefault(vdefault);
 
 #if defined(GVARS)
   // The GVAR button

--- a/radio/src/gui/colorlcd/gvar_numberedit.h
+++ b/radio/src/gui/colorlcd/gvar_numberedit.h
@@ -37,7 +37,7 @@ class GVarNumberEdit : public Window
   GVarNumberEdit(Window* parent, const rect_t& rect, int32_t vmin, int32_t vmax,
                  std::function<int32_t()> getValue,
                  std::function<void(int32_t)> setValue,
-                 LcdFlags textFlags = 0, int32_t voffset = 0);
+                 LcdFlags textFlags = 0, int32_t voffset = 0, int32_t vdefault = 0);
 
   void switchGVarMode();
   void setSuffix(std::string value);

--- a/radio/src/gui/colorlcd/output_edit.cpp
+++ b/radio/src/gui/colorlcd/output_edit.cpp
@@ -166,7 +166,7 @@ void OutputEditWindow::buildBody(FormWindow* form)
   line = form->newLine(&grid);
   minText = new StaticText(line, rect_t{}, TR_MIN, 0, COLOR_THEME_PRIMARY1);
   minEdit = new GVarNumberEdit(line, rect_t{}, -limit, 0, GET_SET_DEFAULT(output->min),
-                     PREC1, -LIMIT_STD_MAX);
+                     PREC1, -LIMIT_STD_MAX, -limit);
   minText->setBackgroundColor(COLOR_THEME_ACTIVE);
   minEdit->setFastStep(20);
   minEdit->setAccelFactor(16);
@@ -174,7 +174,7 @@ void OutputEditWindow::buildBody(FormWindow* form)
   // Max
   maxText = new StaticText(line, rect_t{}, TR_MAX, 0, COLOR_THEME_PRIMARY1);
   maxEdit = new GVarNumberEdit(line, rect_t{}, 0, +limit, GET_SET_DEFAULT(output->max),
-                     PREC1, +LIMIT_STD_MAX);
+                     PREC1, +LIMIT_STD_MAX, limit);
   maxText->setBackgroundColor(COLOR_THEME_ACTIVE);
   maxEdit->setFastStep(20);
   maxEdit->setAccelFactor(16);

--- a/radio/src/gui/colorlcd/widget_settings.cpp
+++ b/radio/src/gui/colorlcd/widget_settings.cpp
@@ -61,7 +61,7 @@ WidgetSettings::WidgetSettings(Window* parent, Widget* widget) :
 
     switch (option.type) {
       case ZoneOption::Integer:
-        new NumberEdit(
+        (new NumberEdit(
             line, rect_t{}, option.min.signedValue,
             option.max.signedValue,
             [=]() -> int {
@@ -70,7 +70,7 @@ WidgetSettings::WidgetSettings(Window* parent, Widget* widget) :
             [=](int32_t newValue) {
               widget->getOptionValue(optIdx)->signedValue = newValue;
               SET_DIRTY();
-            });
+            }))->setDefault(option.deflt.signedValue);
         break;
 
       case ZoneOption::Source:


### PR DESCRIPTION
Fixes #826 

Set default value for:
- Widget - 'VALUE' option
- Curve - number of points
- Output - Min and Max fields
