### PR TITLE
fix: Ext module not powered when using SBUS or CPPM trainer

### DIFF
--- a/radio/src/targets/common/arm/stm32/trainer_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/trainer_driver.cpp
@@ -303,6 +303,8 @@ extern "C" void TRAINER_TIMER_IRQHandler()
 
 #if defined(TRAINER_MODULE_CPPM)
 
+#include "hal/module_port.h"
+
 static_assert(__IS_TRAINER_TIMER_IN_CHANNEL_SUPPORTED(TRAINER_MODULE_CPPM_TIMER_Channel),
               "Unsupported trainer timer input channel");
 
@@ -323,12 +325,14 @@ static const stm32_pulse_timer_t trainerModuleTimer = {
 
 void init_trainer_module_cppm()
 {
+  modulePortSetPower(EXTERNAL_MODULE,true);
   _init_trainer_capture(&trainerModuleTimer);
 }
 
 void stop_trainer_module_cppm()
 {
   _stop_trainer(&trainerModuleTimer);
+  modulePortSetPower(EXTERNAL_MODULE,false);
 }
 
 #if defined(TRAINER_MODULE_CPPM_TIMER_IRQHandler)
@@ -362,6 +366,7 @@ static etx_module_state_t* sbus_trainer_mod_st = nullptr;
 void init_trainer_module_sbus()
 {
   if (sbus_trainer_mod_st) return;
+  modulePortSetPower(EXTERNAL_MODULE,true);
 
   sbus_trainer_mod_st = modulePortInitSerial(EXTERNAL_MODULE, ETX_MOD_PORT_UART,
                                              &sbusTrainerParams, false);
@@ -371,6 +376,8 @@ void stop_trainer_module_sbus()
 {
   if (!sbus_trainer_mod_st) return;
   modulePortDeInit(sbus_trainer_mod_st);
+  modulePortSetPower(EXTERNAL_MODULE,false);
+  sbus_trainer_mod_st= nullptr;
 }
 
 int trainerModuleSbusGetByte(uint8_t* data)

--- a/radio/src/targets/common/arm/stm32/trainer_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/trainer_driver.cpp
@@ -377,7 +377,7 @@ void stop_trainer_module_sbus()
   if (!sbus_trainer_mod_st) return;
   modulePortDeInit(sbus_trainer_mod_st);
   modulePortSetPower(EXTERNAL_MODULE,false);
-  sbus_trainer_mod_st= nullptr;
+  sbus_trainer_mod_st = nullptr;
 }
 
 int trainerModuleSbusGetByte(uint8_t* data)


### PR DESCRIPTION

Fixes #3634 

Summary of changes:
Power on/off of the external module is now in the module init/deinit code. Since trainer/sbus and trainer/ccpm are no modules,  power on/off is not handled for that mode of operation. Therefore, moduleSetPower calls were added to the init/deinit subroutines for trainer/sbus and trainer/cppm. There is also a fix in stop_trainer_module_sbus() where sbus_trainer_mod_st has to be set to nullptr after deiniztialization of the sbus port.

Tested on QX7-ACCESS with edgetx 2.9.1 with mode trainer/sbus (with SBUS data source and power pin voltage check) and with mode trainer/sbus (power pin voltage check only, I do not have a ccpm data source).