### PR TITLE
chore: Cleanup obsolete ioMutex debug lines

### DIFF
--- a/radio/src/cli.cpp
+++ b/radio/src/cli.cpp
@@ -1400,17 +1400,9 @@ int cliDisplay(const char ** argv)
 
 int cliDebugVars(const char ** argv)
 {
-#if defined(PCBHORUS)
-  /* broken
-  extern uint32_t ioMutexReq, ioMutexRel;
-  extern uint32_t sdReadRetries;
-  cliSerialPrint("ioMutexReq=%d", ioMutexReq);
-  cliSerialPrint("ioMutexRel=%d", ioMutexRel);
-  cliSerialPrint("sdReadRetries=%d", sdReadRetries);*/
 #if defined(INTERNAL_MODULE_PXX2) && defined(ACCESS_DENIED) && !defined(SIMU)
   extern volatile int32_t authenticateFrames;
   cliSerialPrint("authenticateFrames=%d", authenticateFrames);
-#endif
 #elif defined(PCBTARANIS)
   //cliSerialPrint("telemetryErrors=%d", telemetryErrors);
 #endif


### PR DESCRIPTION
Mutex debug is not going to come back, but I (still ?) have a secret hope for the error counter to come back one day