### PR TITLE
fix(color): Reading of RGB theme colors in hex format

### DIFF
--- a/radio/src/gui/colorlcd/theme_manager.cpp
+++ b/radio/src/gui/colorlcd/theme_manager.cpp
@@ -43,7 +43,7 @@ static uint32_t r_color(const YamlNode* node, const char* val, uint8_t val_len)
 {
   if ((strncmp(val, RGBSTRING, strlen(RGBSTRING)) == 0) && (val[val_len - 1] == ')')) {
     int r, g, b;
-    int numTokens = sscanf(val, "RGB(%d,%d,%d)", &r, &g, &b);
+    int numTokens = sscanf(val, "RGB(%i,%i,%i)", &r, &g, &b);
 
     if (numTokens == 3)
       return RGB(r, g, b);


### PR DESCRIPTION
Handle reading of colors from theme file where the color is in RGB(0x??, 0x??, 0x??) format.

Should be applied to 2.9 as well.
