### PR TITLE
fix(color): Value widget not refreshing when telem lost

### DIFF
--- a/radio/src/gui/colorlcd/widgets/value.cpp
+++ b/radio/src/gui/colorlcd/widgets/value.cpp
@@ -192,10 +192,20 @@ class ValueWidget: public Widget
     {
       Widget::checkEvents();
 
-      auto newValue = getValue(persistentData->options[0].value.unsignedValue);
+      mixsrc_t field = persistentData->options[0].value.unsignedValue;
+
+      // if value changed
+      auto newValue = getValue(field);
       if (lastValue != newValue) {
         lastValue = newValue;
         invalidate();
+      }
+
+      // if telemetry value, and telemetry offline or old data
+      if (field >= MIXSRC_FIRST_TELEM) {
+        TelemetryItem& telemetryItem =
+            telemetryItems[(field - MIXSRC_FIRST_TELEM) / 3];
+        if (!telemetryItem.isAvailable() || telemetryItem.isOld()) invalidate();
       }
     }
 


### PR DESCRIPTION
Fixes value widget not triggering a refresh to change theme color when showing a telemetry sensor value and telemetry is lost. When the widget is in the top bar, it refreshed every 100ms (which is changing in pending PR IIRC), but not as a main view widget. 

Reported by a user on discord : https://discord.com/channels/761870396085108757/854744834698379274/1164226084762570862