### PR TITLE
fix(color): 'Reset' SF does not show telemetry parameter when edited

### DIFF
--- a/radio/src/gui/colorlcd/special_functions.cpp
+++ b/radio/src/gui/colorlcd/special_functions.cpp
@@ -142,7 +142,7 @@ class SpecialFunctionEditPage : public Page
       }
 
       case FUNC_RESET:
-        if (CFN_PARAM(cfn) < FUNC_RESET_PARAM_FIRST_TELEM) {
+        if (CFN_PARAM(cfn) <= FUNC_RESET_PARAM_LAST) {
           new StaticText(line, rect_t{}, STR_RESET, 0, COLOR_THEME_PRIMARY1);
           auto choice = new Choice(
               line, rect_t{}, 0,


### PR DESCRIPTION
Fixes #4234

Fix validation check on parameter.
