### PR TITLE
fix(radio): Don't allow negative values for V2 on LS functions '|x|>y', '|x|<y' and '|dx|>=y'

### DIFF
--- a/radio/src/gui/128x64/model_logical_switches.cpp
+++ b/radio/src/gui/128x64/model_logical_switches.cpp
@@ -159,9 +159,7 @@ void menuModelLogicalSwitchOne(event_t event)
           if (v1_val >= MIXSRC_FIRST_TELEM) {
             drawSourceCustomValue(CSWONE_2ND_COLUMN, y, v1_val, convertLswTelemValue(cs), attr|LEFT);
             v2_max = maxTelemValue(v1_val - MIXSRC_FIRST_TELEM + 1);
-            if (cs->func == LS_FUNC_DIFFEGREATER)
-              v2_min = -v2_max;
-            else if (cs->func == LS_FUNC_ADIFFEGREATER)
+            if ((cs->func == LS_FUNC_APOS) || (cs->func == LS_FUNC_ANEG) || (cs->func == LS_FUNC_ADIFFEGREATER))
               v2_min = 0;
             else
               v2_min = -v2_max;
@@ -175,6 +173,8 @@ void menuModelLogicalSwitchOne(event_t event)
           {
             LcdFlags lf = attr | LEFT;
             getMixSrcRange(v1_val, v2_min, v2_max, &lf);
+            if ((cs->func == LS_FUNC_APOS) || (cs->func == LS_FUNC_ANEG) || (cs->func == LS_FUNC_ADIFFEGREATER))
+              v2_min = 0;
             drawSourceCustomValue(CSWONE_2ND_COLUMN, y, v1_val, (v1_val <= MIXSRC_LAST_CH ? calc100toRESX(cs->v2) : cs->v2), lf);
           }
         }

--- a/radio/src/gui/212x64/model_logical_switches.cpp
+++ b/radio/src/gui/212x64/model_logical_switches.cpp
@@ -173,6 +173,8 @@ void menuModelLogicalSwitches(event_t event)
       }
       LcdFlags lf = attr2 | LEFT;
       getMixSrcRange(v1_val, v2_min, v2_max, &lf);
+      if ((cs->func == LS_FUNC_APOS) || (cs->func == LS_FUNC_ANEG) || (cs->func == LS_FUNC_ADIFFEGREATER))
+        v2_min = 0;
       drawSourceCustomValue(CSW_3RD_COLUMN, y, v1_val, (v1_val <= MIXSRC_LAST_CH ? calc100toRESX(cs->v2) : cs->v2), lf);
     }
 

--- a/radio/src/gui/colorlcd/model_logical_switches.cpp
+++ b/radio/src/gui/colorlcd/model_logical_switches.cpp
@@ -81,6 +81,13 @@ class LogicalSwitchEditPage : public Page
                                getFont(FONT(BOLD)), LV_STATE_USER_1);
   }
 
+  void getV2Range(LogicalSwitchData* cs, int16_t& v2_min, int16_t& v2_max)
+  {
+    getMixSrcRange(cs->v1, v2_min, v2_max);
+    if ((cs->func == LS_FUNC_APOS) || (cs->func == LS_FUNC_ANEG) || (cs->func == LS_FUNC_ADIFFEGREATER))
+      v2_min = 0;
+  }
+
   void updateLogicalSwitchOneWindow()
   {
     SwitchChoice* choice;
@@ -124,7 +131,7 @@ class LogicalSwitchEditPage : public Page
                            cs->v1 = newValue;
                            if (v2Edit != nullptr) {
                              int16_t v2_min = 0, v2_max = 0;
-                             getMixSrcRange(cs->v1, v2_min, v2_max);
+                             getV2Range(cs, v2_min, v2_max);
                              v2Edit->setMin(v2_min);
                              v2Edit->setMax(v2_max);
                              v2Edit->setValue(cs->v2);
@@ -189,7 +196,7 @@ class LogicalSwitchEditPage : public Page
         break;
       default:
         int16_t v2_min = 0, v2_max = 0;
-        getMixSrcRange(cs->v1, v2_min, v2_max);
+        getV2Range(cs, v2_min, v2_max);
         v2Edit = new NumberEdit(line, rect_t{}, v2_min, v2_max,
                                 GET_SET_DEFAULT(cs->v2));
         lv_obj_set_width(v2Edit->getLvObj(), LV_SIZE_CONTENT);


### PR DESCRIPTION
Fixes #4238

Limit V2 range to positive values, where function compares to |V1|.

