### PR TITLE
fix(tts): DE play value "TIME" wrong for 00:xx:xx hours

### DIFF
--- a/radio/src/translations/tts_de.cpp
+++ b/radio/src/translations/tts_de.cpp
@@ -196,36 +196,34 @@ I18N_PLAY_FUNCTION(de, playDuration, int seconds PLAY_DURATION_ATT)
   }
 
   if (hours > 0 || IS_PLAY_TIME()) {
-    if (hours > 1) {
-      PLAY_NUMBER(hours, 0, 0);
-      PUSH_NUMBER_PROMPT(DE_PROMPT_STUNDEN);
-    } else {
+    if (hours == 1) {
       PUSH_NUMBER_PROMPT(DE_PROMPT_EINE);
       PUSH_NUMBER_PROMPT(DE_PROMPT_STUNDE);
+    } else {
+      PLAY_NUMBER(hours, 0, 0);
+      PUSH_NUMBER_PROMPT(DE_PROMPT_STUNDEN);
     }
   }
 
   if (minutes > 0) {
-    if (hours)
-      PUSH_NUMBER_PROMPT(DE_PROMPT_UND);
-    if (minutes > 1) {
-      PLAY_NUMBER(minutes, 0, 0);
-      PUSH_NUMBER_PROMPT(DE_PROMPT_MINUTEN);
-    } else {
+    if (minutes == 1) {
       PUSH_NUMBER_PROMPT(DE_PROMPT_EINE);
       PUSH_NUMBER_PROMPT(DE_PROMPT_MINUTE);
+    } else {
+      PLAY_NUMBER(minutes, 0, 0);
+      PUSH_NUMBER_PROMPT(DE_PROMPT_MINUTEN);
     }
   }
 
   if (!IS_PLAY_LONG_TIMER() && seconds > 0) {
-    if (minutes)
+    if (minutes || IS_PLAY_TIME())
       PUSH_NUMBER_PROMPT(DE_PROMPT_UND);
-    if (seconds > 1) {
-      PLAY_NUMBER(seconds, 0, 0);
-      PUSH_NUMBER_PROMPT(DE_PROMPT_SEKUNDEN);
-    } else {
+    if (seconds == 1) {
       PUSH_NUMBER_PROMPT(DE_PROMPT_EINE);
       PUSH_NUMBER_PROMPT(DE_PROMPT_SEKUNDE);
+    } else {
+      PLAY_NUMBER(seconds, 0, 0);
+      PUSH_NUMBER_PROMPT(DE_PROMPT_SEKUNDEN);
     }
   }
 }

--- a/radio/src/translations/tts_de.cpp
+++ b/radio/src/translations/tts_de.cpp
@@ -196,35 +196,18 @@ I18N_PLAY_FUNCTION(de, playDuration, int seconds PLAY_DURATION_ATT)
   }
 
   if (hours > 0 || IS_PLAY_TIME()) {
-    if (hours == 1) {
-      PUSH_NUMBER_PROMPT(DE_PROMPT_EINE);
-      PUSH_NUMBER_PROMPT(DE_PROMPT_STUNDE);
-    } else {
-      PLAY_NUMBER(hours, 0, 0);
-      PUSH_NUMBER_PROMPT(DE_PROMPT_STUNDEN);
-    }
+    PLAY_NUMBER(hours, UNIT_HOURS, 0);
   }
 
   if (minutes > 0) {
-    if (minutes == 1) {
-      PUSH_NUMBER_PROMPT(DE_PROMPT_EINE);
-      PUSH_NUMBER_PROMPT(DE_PROMPT_MINUTE);
-    } else {
-      PLAY_NUMBER(minutes, 0, 0);
-      PUSH_NUMBER_PROMPT(DE_PROMPT_MINUTEN);
-    }
+    PLAY_NUMBER(minutes, UNIT_MINUTES, 0);
   }
 
   if (!IS_PLAY_LONG_TIMER() && seconds > 0) {
-    if (minutes || IS_PLAY_TIME())
+    if (minutes)
       PUSH_NUMBER_PROMPT(DE_PROMPT_UND);
-    if (seconds == 1) {
-      PUSH_NUMBER_PROMPT(DE_PROMPT_EINE);
-      PUSH_NUMBER_PROMPT(DE_PROMPT_SEKUNDE);
-    } else {
-      PLAY_NUMBER(seconds, 0, 0);
-      PUSH_NUMBER_PROMPT(DE_PROMPT_SEKUNDEN);
-    }
+      
+    PLAY_NUMBER(seconds, UNIT_SECONDS, 0);
   }
 }
 


### PR DESCRIPTION
Fixes #4235 

Summary of changes:
- fixed use of  singular and plural in TIME tts
- removed "and" between hours and minutes (as is implemented for language EN) to make for shorter and more concise "TIME" speech messages
