### PR TITLE
fix(color): Refreshing of GPS and DATE_TIME telemetry when using Value Widget

### DIFF
--- a/radio/src/gui/colorlcd/draw_functions.cpp
+++ b/radio/src/gui/colorlcd/draw_functions.cpp
@@ -294,34 +294,31 @@ void drawTrimMode(BitmapBuffer * dc, coord_t x, coord_t y, uint8_t phase, uint8_
 
 void drawDate(BitmapBuffer * dc, coord_t x, coord_t y, TelemetryItem & telemetryItem, LcdFlags att)
 {
-  // TODO
+  bool doTwoLines = false;
+  coord_t ox = x;
+
   if (att & FONT(XL)) {
-    x -= 42;
     att &= ~FONT_MASK;
-    x = dc->drawNumber(x, y, telemetryItem.datetime.day, att|LEADING0|LEFT, 2);
-    x = dc->drawText(x - 1, y, "-", att);
-    x = dc->drawNumber(x - 1, y, telemetryItem.datetime.month, att|LEFT, 2);
-    x = dc->drawText(x - 1, y, "-", att);
-    x = dc->drawNumber(x - 1, y, telemetryItem.datetime.year-2000, att|LEFT);
-    y += FH;
-    /* TODO dc->drawNumber(x, y, telemetryItem.datetime.hour, att|LEADING0|LEFT, 2);
-    dc->drawText(lcdNextPos, y, ":", att);
-    dc->drawNumber(lcdNextPos, y, telemetryItem.datetime.min, att|LEADING0|LEFT, 2);
-    dc->drawText(lcdNextPos, y, ":", att);
-    dc->drawNumber(lcdNextPos, y, telemetryItem.datetime.sec, att|LEADING0|LEFT, 2); */
+    doTwoLines = true;
   }
-  else {
-    x = dc->drawNumber(x, y, telemetryItem.datetime.day, att|LEADING0|LEFT, 2);
-    x = dc->drawText(x - 1, y, "-", att);
-    x = dc->drawNumber(x, y, telemetryItem.datetime.month, att|LEFT, 2);
-    x = dc->drawText(x - 1, y, "-", att);
-    x = dc->drawNumber(x, y, telemetryItem.datetime.year-2000, att|LEFT);
-    x = dc->drawNumber(x + 11, y, telemetryItem.datetime.hour, att|LEADING0|LEFT, 2);
-    x = dc->drawText(x, y, ":", att);
-    x = dc->drawNumber(x, y, telemetryItem.datetime.min, att|LEADING0|LEFT, 2);
-    x = dc->drawText(x, y, ":", att);
-    dc->drawNumber(x, y, telemetryItem.datetime.sec, att|LEADING0|LEFT, 2);
+
+  x = dc->drawNumber(x, y, telemetryItem.datetime.day, att|LEADING0|LEFT, 2);
+  x = dc->drawText(x - 1, y, "-", att);
+  x = dc->drawNumber(x, y, telemetryItem.datetime.month, att|LEFT, 2);
+  x = dc->drawText(x - 1, y, "-", att);
+  x = dc->drawNumber(x, y, telemetryItem.datetime.year-2000, att|LEFT);
+
+  if (doTwoLines) {
+    y += FH;  x = ox;
+  } else {
+    x += 11;
   }
+
+  x = dc->drawNumber(x, y, telemetryItem.datetime.hour, att|LEADING0|LEFT, 2);
+  x = dc->drawText(x, y, ":", att);
+  x = dc->drawNumber(x, y, telemetryItem.datetime.min, att|LEADING0|LEFT, 2);
+  x = dc->drawText(x, y, ":", att);
+  dc->drawNumber(x, y, telemetryItem.datetime.sec, att|LEADING0|LEFT, 2);
 }
 
 coord_t drawGPSCoord(BitmapBuffer * dc, coord_t x, coord_t y, int32_t value, const char * direction, LcdFlags flags, bool seconds=true)

--- a/radio/src/gui/colorlcd/draw_functions.cpp
+++ b/radio/src/gui/colorlcd/draw_functions.cpp
@@ -302,23 +302,25 @@ void drawDate(BitmapBuffer * dc, coord_t x, coord_t y, TelemetryItem & telemetry
     doTwoLines = true;
   }
 
-  x = dc->drawNumber(x, y, telemetryItem.datetime.day, att|LEADING0|LEFT, 2);
-  x = dc->drawText(x - 1, y, "-", att);
-  x = dc->drawNumber(x, y, telemetryItem.datetime.month, att|LEFT, 2);
-  x = dc->drawText(x - 1, y, "-", att);
-  x = dc->drawNumber(x, y, telemetryItem.datetime.year-2000, att|LEFT);
+  LcdFlags fl = att|LEADING0|LEFT;
 
+  x = dc->drawNumber(x, y, telemetryItem.datetime.year-2000, fl,2);
+  x = dc->drawText(x, y, "-", att);
+  x = dc->drawNumber(x, y, telemetryItem.datetime.month, fl, 2);
+  x = dc->drawText(x, y, "-", att);
+  x = dc->drawNumber(x, y, telemetryItem.datetime.day, fl, 2);
+  
   if (doTwoLines) {
     y += FH;  x = ox;
   } else {
     x += 11;
   }
 
-  x = dc->drawNumber(x, y, telemetryItem.datetime.hour, att|LEADING0|LEFT, 2);
+  x = dc->drawNumber(x, y, telemetryItem.datetime.hour, fl, 2);
   x = dc->drawText(x, y, ":", att);
-  x = dc->drawNumber(x, y, telemetryItem.datetime.min, att|LEADING0|LEFT, 2);
+  x = dc->drawNumber(x, y, telemetryItem.datetime.min, fl, 2);
   x = dc->drawText(x, y, ":", att);
-  dc->drawNumber(x, y, telemetryItem.datetime.sec, att|LEADING0|LEFT, 2);
+  dc->drawNumber(x, y, telemetryItem.datetime.sec, fl, 2);
 }
 
 coord_t drawGPSCoord(BitmapBuffer * dc, coord_t x, coord_t y, int32_t value, const char * direction, LcdFlags flags, bool seconds=true)

--- a/radio/src/gui/colorlcd/draw_functions.cpp
+++ b/radio/src/gui/colorlcd/draw_functions.cpp
@@ -304,7 +304,7 @@ void drawDate(BitmapBuffer * dc, coord_t x, coord_t y, TelemetryItem & telemetry
 
   LcdFlags fl = att|LEADING0|LEFT;
 
-  x = dc->drawNumber(x, y, telemetryItem.datetime.year-2000, fl,2);
+  x = dc->drawNumber(x, y, telemetryItem.datetime.year, fl,4);
   x = dc->drawText(x, y, "-", att);
   x = dc->drawNumber(x, y, telemetryItem.datetime.month, fl, 2);
   x = dc->drawText(x, y, "-", att);

--- a/radio/src/gui/colorlcd/model_telemetry.cpp
+++ b/radio/src/gui/colorlcd/model_telemetry.cpp
@@ -998,7 +998,7 @@ void ModelTelemetryPage::build(FormWindow * window)
 std::string getDate(TelemetryItem & telemetryItem)
 {
   return
-    formatNumberAsString(telemetryItem.datetime.year-2000, LEADING0|LEFT,2) + "-" +
+    formatNumberAsString(telemetryItem.datetime.year, LEADING0|LEFT,4) + "-" +
     formatNumberAsString(telemetryItem.datetime.month, LEADING0|LEFT, 2) + "-" +
     formatNumberAsString(telemetryItem.datetime.day, LEADING0|LEFT, 2) + " " +
     formatNumberAsString(telemetryItem.datetime.hour, LEADING0|LEFT, 2) + ":" +

--- a/radio/src/gui/colorlcd/model_telemetry.cpp
+++ b/radio/src/gui/colorlcd/model_telemetry.cpp
@@ -998,9 +998,9 @@ void ModelTelemetryPage::build(FormWindow * window)
 std::string getDate(TelemetryItem & telemetryItem)
 {
   return
-    formatNumberAsString(telemetryItem.datetime.day, LEADING0|LEFT, 2) + "-" +
-    formatNumberAsString(telemetryItem.datetime.month, LEFT, 2) + "-" +
-    formatNumberAsString(telemetryItem.datetime.year-2000, LEFT) + " " +
+    formatNumberAsString(telemetryItem.datetime.year-2000, LEADING0|LEFT,2) + "-" +
+    formatNumberAsString(telemetryItem.datetime.month, LEADING0|LEFT, 2) + "-" +
+    formatNumberAsString(telemetryItem.datetime.day, LEADING0|LEFT, 2) + " " +
     formatNumberAsString(telemetryItem.datetime.hour, LEADING0|LEFT, 2) + ":" +
     formatNumberAsString(telemetryItem.datetime.min, LEADING0|LEFT, 2) + ":" +
     formatNumberAsString(telemetryItem.datetime.sec, LEADING0|LEFT, 2);

--- a/radio/src/telemetry/spektrum.cpp
+++ b/radio/src/telemetry/spektrum.cpp
@@ -1016,47 +1016,51 @@ static bool real0x16 = false;
 static bool real0x17 = false;
 static bool real0x34 = false;
 
+// *********** GPS LOC (BCD) ******************************
+// Example 0x16:          0  1    2  3  4  5    6  7  8  9    10 11   12   13
+//                16 00 | 97 00 | 54 71 12 28 | 40 80 09 82 | 85 14 | 13 | B9
+//                Alt: 009.7, LAT: 28o 12'7154, LON: -82 09 8040 Course: 148.5, HDOP 1.3 Flags= B9
+static char test16data[] = {0x16, 0x00, 0x97, 0x00, 0x54, 0x71, 0x12, 0x28,
+                            0x40, 0x80, 0x09, 0x82, 0x85, 0x14, 0x13, 0xB9};
+
+// *********** GPS STAT (BCD) *****************************
+// Example 0x17:          0  1    2  3  4  5    6    7
+//                17 00 | 25 00 | 00 28 18 21 | 06 | 00    
+//                Spd:002.5k, TimeUTC:21:18:28.00, Sats: 06, AltH=00
+static char test17data[] = {0x17, 0x00, 0x25, 0x00, 0x00,
+                            0x28, 0x18, 0x21, 0x06, 0x00};
+
+// *********** Dual Flight pack monitor (Little-Endian)***************
+// Example 0x34:          0  1    2  3    4  5    6  7    8  9    10 11 
+//                34 00 | 2F 00 | 30 09 | 85 01 | 2B 00 | 07 0A | 81 01 
+//                B1: 004.7A, 2352mAh, 38.9C   B2: 004.3A, 2567mAh, 38.5C  
+static char test34data[] = {0x34, 0x00, 0x2F, 0x00, 0x30, 0x09, 0x85, 0x01, 
+                                        0x2B, 0x00, 0x07, 0x0A, 0x81, 0x01 };
+
 static uint8_t replaceForTestingPackage(const uint8_t *packet)
 {
   uint8_t i2cAddress = packet[2] & 0x7f;
 
   // If we received a real package for the ones that we can Fake it, disable replacement
-  if (i2cAddress != I2C_GPS_LOC) real0x16 = true;
-  else if (i2cAddress != I2C_GPS_STAT) real0x17 = true;
-  else if (i2cAddress != I2C_FP_BATT) real0x34 = true;
+  if (i2cAddress == I2C_GPS_LOC) real0x16 = true;
+  else if (i2cAddress == I2C_GPS_STAT) real0x17 = true;
+  else if (i2cAddress == I2C_FP_BATT) real0x34 = true;
   
   // Only Substiture AS3X/SAFE I2C_FLITECTRL packages, since they are constantly brodcast
   if (i2cAddress != I2C_FLITECTRL) {  
     return i2cAddress;
   }
 
-  // *********** GPS LOC (BCD) ******************************
-  // Example 0x16:          0  1    2  3  4  5    6  7  8  9    10 11   12   13
-  //                16 00 | 97 00 | 54 71 12 28 | 40 80 09 82 | 85 14 | 13 | B9
-  //                Alt: 009.7, LAT: 28o 12'7154, LON: -82 09 8040 Course: 148.5, HDOP 1.3 Flags= B9
-  const char test16data[] = {0x16, 0x00, 0x97, 0x00, 0x54, 0x71, 0x12, 0x28,
-                             0x40, 0x80, 0x09, 0x82, 0x85, 0x14, 0x13, 0xB9};
-
-  // *********** GPS STAT (BCD) *****************************
-  // Example 0x17:          0  1    2  3  4  5    6    7
-  //                17 00 | 25 00 | 00 28 18 21 | 06 | 00    
-  //                Spd:002.5k, TimeUTC:21:18:28.00, Sats: 06, AltH=00
-  const char test17data[] = {0x17, 0x00, 0x25, 0x00, 0x00,
-                             0x28, 0x18, 0x21, 0x06, 0x00};
-
-  // *********** Dual Flight pack monitor (Little-Endian)***************
-  // Example 0x34:          0  1    2  3    4  5    6  7    8  9    10 11 
-  //                34 00 | 2F 00 | 30 09 | 85 01 | 2B 00 | 07 0A | 81 01 
-  //                B1: 004.7A, 2352mAh, 38.9C   B2: 004.3A, 2567mAh, 38.5C  
-  const char test34data[] = {0x34, 0x00, 0x2F, 0x00, 0x30, 0x09, 0x85, 0x01, 
-                                         0x2B, 0x00, 0x07, 0x0A, 0x81, 0x01 };
-
   switch (testStep) {
     case 0:
         // return original packet
         break;
     case 1: // return GSP LOG
-        if (!real0x16) memcpy((char *)packet + 2, test16data, 16);
+        if (!real0x16) {
+          test16data[4]=test16data[4]+1;
+          test16data[8]=test16data[8]+1;
+          memcpy((char *)packet + 2, test16data, 16);
+        }
         break;
     case 2: // Return GPS STAT
         if (!real0x17) memcpy((char *)packet + 2, test17data, 10);

--- a/radio/src/telemetry/telemetry_sensors.cpp
+++ b/radio/src/telemetry/telemetry_sensors.cpp
@@ -153,7 +153,9 @@ void TelemetryItem::setValue(const TelemetrySensor &sensor, int32_t val,
       }
 #endif
     }
-    newVal = 0;
+    value = hash((void *) &datetime, sizeof(datetime));
+    setFresh();
+    return;
   }
   else if (unit == UNIT_GPS_LATITUDE) {
 #if defined(INTERNAL_GPS)
@@ -180,6 +182,8 @@ void TelemetryItem::setValue(const TelemetrySensor &sensor, int32_t val,
       pilotLongitude = newVal;
     }
     gps.longitude = newVal;
+
+    value = hash((void *) &gps, sizeof(gps));
     setFresh();
     return;
   }
@@ -201,7 +205,9 @@ void TelemetryItem::setValue(const TelemetrySensor &sensor, int32_t val,
   }
   else if (unit == UNIT_DATETIME_SEC) {
     datetime.sec = newVal & 0xFFu;
-    newVal = 0;
+    value = hash((void *) &datetime, sizeof(datetime));
+    setFresh();
+    return;
   }
   else if (unit == UNIT_RPMS) {
     if (sensor.custom.ratio != 0) {


### PR DESCRIPTION
Fixes #4170 

Summary of changes:
With data-types who are not plain 32bit numbers, like GPS, Text, DATE_TIME,  we have to populate the telemetry "value" with something that changes so that the "value" widget detects the change.  The trick is to populate the "value" with a hash of the GPS or DATE_TIME complex value. The actual value for GPS and DateTime are stored in different variables. 

The "value" widget was not displaying correctly DATE_TIME, fixed it (don't know why was moving the x coordinate -42 pixels!).
Change dateTime format to ISO 8601 date for color radios (YYYY-MM-DD HH:MM:SS).

NOTE: B&W was already this format (with 4 digits for year), and sensor log writing too... good for consistency.

NOT COMPILED FOR PRODUCTION: Updated Spektrun GPS testing code to change the values for GPS coordinates and Date without having the physical sensor (used previously captured data). 

NOTE:  Same PR worked for 2.9.1 as well as Main.

