### PR TITLE
refactor(mixer): improve delays

### DIFF
--- a/radio/src/tests/mixer.cpp
+++ b/radio/src/tests/mixer.cpp
@@ -662,9 +662,40 @@ TEST_F(MixerTest, DelayOnSwitch)
   g_model.mixData[0].srcRaw = MIXSRC_MAX;
   g_model.mixData[0].weight = 100;
   g_model.mixData[0].swtch = SWSRC_FIRST_SWITCH + 2;
-  int switch_index = 0;
   g_model.mixData[0].delayUp = 50;
   g_model.mixData[0].delayDown = 50;
+
+  int switch_index = 0;
+  simuSetSwitch(switch_index, -1);
+
+  evalFlightModeMixes(e_perout_mode_normal, 0);
+  EXPECT_EQ(chans[0], 0);
+
+  simuSetSwitch(switch_index, 1);
+  CHECK_DELAY(0, 500);
+
+  evalFlightModeMixes(e_perout_mode_normal, 1);
+  EXPECT_EQ(chans[0], CHANNEL_MAX);
+
+  simuSetSwitch(switch_index, 0);
+  CHECK_DELAY(0, 500);
+
+  evalFlightModeMixes(e_perout_mode_normal, 1);
+  EXPECT_EQ(chans[0], 0);
+}
+
+TEST_F(MixerTest, DelayOnSwitch2)
+{
+  g_model.mixData[0].destCh = 0;
+  g_model.mixData[0].mltpx = MLTPX_ADD;
+  g_model.mixData[0].srcRaw = MIXSRC_FIRST_SWITCH;
+  g_model.mixData[0].weight = 100;
+  g_model.mixData[0].swtch = SWSRC_ON;
+  g_model.mixData[0].delayUp = 50;
+  g_model.mixData[0].delayDown = 50;
+
+  int switch_index = 0;
+  simuSetSwitch(switch_index, -1);
 
   evalFlightModeMixes(e_perout_mode_normal, 0);
   EXPECT_EQ(chans[0], 0);

--- a/radio/src/tests/mixer.cpp
+++ b/radio/src/tests/mixer.cpp
@@ -686,6 +686,8 @@ TEST_F(MixerTest, DelayOnSwitch)
 
 TEST_F(MixerTest, DelayOnSwitch2)
 {
+  g_eeGeneral.switchConfig = SWITCH_3POS;
+  
   g_model.mixData[0].destCh = 0;
   g_model.mixData[0].mltpx = MLTPX_ADD;
   g_model.mixData[0].srcRaw = MIXSRC_FIRST_SWITCH;


### PR DESCRIPTION
This PR removes the distinction between following with respect to how delays are handled:
- a conditional mixer line (using a set of flight modes and/or conditional switch),
- a non-conditional one.

Fixes #4254