### PR TITLE
fix(radio): Don't update YAML files on SD card if radio in emergency mode

### DIFF
--- a/radio/src/storage/sdcard_common.cpp
+++ b/radio/src/storage/sdcard_common.cpp
@@ -75,6 +75,9 @@ void storageFormat()
 
 void storageCheck(bool immediately)
 {
+  // Don't write anything to SD card if in EM
+  if (globalData.unexpectedShutdown) return;
+
   if (storageDirtyMsk & EE_GENERAL) {
     TRACE("eeprom write general");
     storageDirtyMsk &= ~EE_GENERAL;


### PR DESCRIPTION
Fixes an issue where the radio may overwrite YAML files on the SD card after starting in emergency mode.
The data restored from the backup is only a partial copy of the last used radio and model data so this can result in settings being lost.
