### PR TITLE
fix(cpn): prevent googletest installation

### DIFF
--- a/cmake/FetchGtest.cmake
+++ b/cmake/FetchGtest.cmake
@@ -8,6 +8,12 @@ FetchContent_Declare(
   GIT_TAG        f8d7d77c06936315286eb55f8de22cd23c188571 # v1.14.0
 )
 
+# For Windows: Prevent overriding the parent project's compiler/linker settings
+set(gtest_force_shared_crt ON CACHE BOOL "" FORCE)
+
+option(BUILD_GMOCK "Build GMock" OFF)
+option(INSTALL_GTEST "Install GTest" OFF)
+
 FetchContent_MakeAvailable(googletest)
 
 include_directories(


### PR DESCRIPTION
It seems that `googletest` generates `install`targets by default without a few tweaks.