### PR TITLE
fix(color): Refresh main view if pots or sliders changed.

### DIFF
--- a/radio/src/gui/colorlcd/hw_inputs.h
+++ b/radio/src/gui/colorlcd/hw_inputs.h
@@ -21,9 +21,9 @@
 
 #pragma once
 
-#include "form.h"
-#include "dialog.h"
 #include "button.h"
+#include "dialog.h"
+#include "form.h"
 
 struct HWSticks : public FormWindow {
   HWSticks(Window* parent);
@@ -31,15 +31,15 @@ struct HWSticks : public FormWindow {
 
 struct HWPots : public FormWindow {
   HWPots(Window* parent);
+  bool potsChanged;
 };
 
 struct HWSwitches : public FormWindow {
   HWSwitches(Window* parent);
 };
 
-template<class T>
-struct HWInputDialog : public Dialog
-{
+template <class T>
+struct HWInputDialog : public Dialog {
   HWInputDialog(const char* title = nullptr);
 };
 


### PR DESCRIPTION
Fix issue where main view does not update if a pot or slider state is changed in radio hardware.
The corresponding control is not added or removed from the main view when the state changes.
