### PR TITLE
fix(cpn): Default calibration values for 6POS switch.

### DIFF
--- a/companion/src/firmwares/generalsettings.cpp
+++ b/companion/src/firmwares/generalsettings.cpp
@@ -87,12 +87,6 @@ void GeneralSettings::clear()
 
 void GeneralSettings::init()
 {
-  for (int i = 0; i < CPN_MAX_ANALOGS; ++i) {
-    calibMid[i]     = 0x200;
-    calibSpanNeg[i] = 0x180;
-    calibSpanPos[i] = 0x180;
-  }
-
   Firmware * firmware = Firmware::getCurrentVariant();
   Board::Type board = firmware->getBoard();
 
@@ -124,6 +118,18 @@ void GeneralSettings::init()
   }
 
   setDefaultControlTypes(board);
+
+  for (int i = 0; i < CPN_MAX_ANALOGS; ++i) {
+    if ((i >= CPN_MAX_STICKS) && (i < CPN_MAX_STICKS + CPN_MAX_POTS) && (potConfig[i-CPN_MAX_STICKS] == Board::POT_MULTIPOS_SWITCH)) {
+      calibMid[i]     = 773;;
+      calibSpanNeg[i] = 5388;
+      calibSpanPos[i] = 9758;
+    } else {
+      calibMid[i]     = 0x200;
+      calibSpanNeg[i] = 0x180;
+      calibSpanPos[i] = 0x180;
+    }
+  }
 
   backlightMode = 3; // keys and sticks
   backlightDelay = 2; // 2 * 5 = 10 secs
@@ -687,6 +693,21 @@ AbstractStaticItemModel * GeneralSettings::uartSampleModeItemModel()
 QString GeneralSettings::hatsModeToString() const
 {
   return hatsModeToString(hatsMode);
+}
+
+bool GeneralSettings::fix6POSCalibration()
+{
+  bool changed = false;
+  // Fix default 6POS calibration
+  for (int i = CPN_MAX_STICKS; i < CPN_MAX_STICKS+CPN_MAX_POTS; i += 1) {
+    if ((potConfig[i-CPN_MAX_STICKS] == Board::POT_MULTIPOS_SWITCH) && (calibMid[i] == 0x200) && (calibSpanNeg[i] == 0x180) && (calibSpanPos[i] == 0x180)) {
+      calibMid[i] = 773;;
+      calibSpanNeg[i] = 5388;
+      calibSpanPos[i] = 9758;
+      changed = true;
+    }
+  }
+  return changed;
 }
 
 //  static

--- a/companion/src/firmwares/generalsettings.h
+++ b/companion/src/firmwares/generalsettings.h
@@ -195,6 +195,7 @@ class GeneralSettings {
     int getDefaultStick(unsigned int channel) const;
     RawSource getDefaultSource(unsigned int channel) const;
     int getDefaultChannel(unsigned int stick) const;
+    bool fix6POSCalibration();
 
     char semver[8 + 1];
     unsigned int version;

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1277,6 +1277,9 @@ bool MdiChild::loadFile(const QString & filename, bool resetCurrentFile)
     setCurrentFile(filename);
   }
 
+  if (radioData.generalSettings.fix6POSCalibration())
+    setModified();
+
   //  set after successful import
   if (getStorageType(filename) == STORAGE_TYPE_YML)
     setModified();
@@ -1663,6 +1666,9 @@ void MdiChild::openModelTemplate(int row)
   if (!warning.isEmpty()) {
     QMessageBox::warning(this, CPN_STR_TTL_WARNING, warning);
   }
+
+  if (radioData.generalSettings.fix6POSCalibration())
+    setModified();
 
   radioData.models[row] = data.models[0];
 


### PR DESCRIPTION
When creating a new configuration in Companion the default calibration values do not work for the 6POS switches.

This PR sets better default values (taken from my TX16S) and fixes the values when loading a .etx file if they are set to the old default.

Fixes #4269