### PR TITLE
fix(bw): 212x64 trainer page text overlap

### DIFF
--- a/radio/src/gui/common/stdlcd/radio_trainer.cpp
+++ b/radio/src/gui/common/stdlcd/radio_trainer.cpp
@@ -23,12 +23,15 @@
 #include "hal/adc_driver.h"
 #include "input_mapping.h"
 
+#define COL_TWO     5
 #if LCD_W >= 212
   #define TRAINER_CALIB_COLUMN_WIDTH (6 * FW)
-  #define WIDESPACE 5
+  #define COL_THREE 16
+  #define COL_FOUR  17
 #else
   #define TRAINER_CALIB_COLUMN_WIDTH (4 * FW + 2)
-  #define WIDESPACE 0
+  #define COL_THREE 12
+  #define COL_FOUR  13
 #endif
 
 void menuRadioTrainer(event_t event)
@@ -46,9 +49,9 @@ void menuRadioTrainer(event_t event)
   LcdFlags attr;
   LcdFlags blink = ((s_editMode>0) ? BLINK|INVERS : INVERS);
 
-  lcdDrawText(5*FW, MENU_HEADER_HEIGHT+1, STR_MODE);
-  lcdDrawText((12+WIDESPACE)*FW, MENU_HEADER_HEIGHT+1, "%", RIGHT);
-  lcdDrawText((13+WIDESPACE)*FW, MENU_HEADER_HEIGHT+1, STR_SOURCE);
+  lcdDrawText(COL_TWO*FW, MENU_HEADER_HEIGHT+1, STR_MODE);
+  lcdDrawText(COL_THREE*FW, MENU_HEADER_HEIGHT+1, "%", RIGHT);
+  lcdDrawText(COL_FOUR*FW, MENU_HEADER_HEIGHT+1, STR_SOURCE);
 
   y = MENU_HEADER_HEIGHT + 1 + FH;
 
@@ -66,17 +69,17 @@ void menuRadioTrainer(event_t event)
 
       switch (j) {
         case 0:
-          lcdDrawTextAtIndex(5*FW, y, STR_TRNMODE, td->mode, attr);
+          lcdDrawTextAtIndex(COL_TWO*FW, y, STR_TRNMODE, td->mode, attr);
           if (attr&BLINK) CHECK_INCDEC_GENVAR(event, td->mode, 0, 2);
           break;
 
         case 1:
-          lcdDrawNumber((12+WIDESPACE)*FW, y, td->studWeight, attr|RIGHT);
+          lcdDrawNumber(COL_THREE*FW, y, td->studWeight, attr|RIGHT);
           if (attr&BLINK) CHECK_INCDEC_GENVAR(event, td->studWeight, -125, 125);
           break;
 
         case 2:
-          lcdDrawTextAtIndex((13+WIDESPACE)*FW, y, STR_TRNCHN, td->srcChn, attr);
+          lcdDrawTextAtIndex(COL_FOUR*FW, y, STR_TRNCHN, td->srcChn, attr);
           if (attr&BLINK) CHECK_INCDEC_GENVAR(event, td->srcChn, 0, 3);
           break;
       }

--- a/radio/src/gui/common/stdlcd/radio_trainer.cpp
+++ b/radio/src/gui/common/stdlcd/radio_trainer.cpp
@@ -25,8 +25,10 @@
 
 #if LCD_W >= 212
   #define TRAINER_CALIB_COLUMN_WIDTH (6 * FW)
+  #define WIDESPACE 5
 #else
   #define TRAINER_CALIB_COLUMN_WIDTH (4 * FW + 2)
+  #define WIDESPACE 0
 #endif
 
 void menuRadioTrainer(event_t event)
@@ -45,8 +47,8 @@ void menuRadioTrainer(event_t event)
   LcdFlags blink = ((s_editMode>0) ? BLINK|INVERS : INVERS);
 
   lcdDrawText(5*FW, MENU_HEADER_HEIGHT+1, STR_MODE);
-  lcdDrawText(11*FW, MENU_HEADER_HEIGHT+1, "%", RIGHT);
-  lcdDrawText(12*FW, MENU_HEADER_HEIGHT+1, STR_SOURCE);
+  lcdDrawText((12+WIDESPACE)*FW, MENU_HEADER_HEIGHT+1, "%", RIGHT);
+  lcdDrawText((13+WIDESPACE)*FW, MENU_HEADER_HEIGHT+1, STR_SOURCE);
 
   y = MENU_HEADER_HEIGHT + 1 + FH;
 
@@ -69,12 +71,12 @@ void menuRadioTrainer(event_t event)
           break;
 
         case 1:
-          lcdDrawNumber(11*FW, y, td->studWeight, attr|RIGHT);
+          lcdDrawNumber((12+WIDESPACE)*FW, y, td->studWeight, attr|RIGHT);
           if (attr&BLINK) CHECK_INCDEC_GENVAR(event, td->studWeight, -125, 125);
           break;
 
         case 2:
-          lcdDrawTextAtIndex(12*FW, y, STR_TRNCHN, td->srcChn, attr);
+          lcdDrawTextAtIndex((13+WIDESPACE)*FW, y, STR_TRNCHN, td->srcChn, attr);
           if (attr&BLINK) CHECK_INCDEC_GENVAR(event, td->srcChn, 0, 3);
           break;
       }

--- a/radio/src/gui/common/stdlcd/radio_trainer.cpp
+++ b/radio/src/gui/common/stdlcd/radio_trainer.cpp
@@ -23,15 +23,15 @@
 #include "hal/adc_driver.h"
 #include "input_mapping.h"
 
-#define COL_TWO     5
+#define COL_TWO (5 * FW)
 #if LCD_W >= 212
-  #define TRAINER_CALIB_COLUMN_WIDTH (6 * FW)
-  #define COL_THREE 16
-  #define COL_FOUR  17
+#define COL_THREE (16 * FW)
+#define COL_FOUR (17 * FW)
+#define TRAINER_CALIB_COLUMN_WIDTH (6 * FW)
 #else
-  #define TRAINER_CALIB_COLUMN_WIDTH (4 * FW + 2)
-  #define COL_THREE 12
-  #define COL_FOUR  13
+#define COL_THREE (12 * FW)
+#define COL_FOUR (13 * FW)
+#define TRAINER_CALIB_COLUMN_WIDTH (4 * FW + 2)
 #endif
 
 void menuRadioTrainer(event_t event)
@@ -49,9 +49,9 @@ void menuRadioTrainer(event_t event)
   LcdFlags attr;
   LcdFlags blink = ((s_editMode>0) ? BLINK|INVERS : INVERS);
 
-  lcdDrawText(COL_TWO*FW, MENU_HEADER_HEIGHT+1, STR_MODE);
-  lcdDrawText(COL_THREE*FW, MENU_HEADER_HEIGHT+1, "%", RIGHT);
-  lcdDrawText(COL_FOUR*FW, MENU_HEADER_HEIGHT+1, STR_SOURCE);
+  lcdDrawText(COL_TWO, MENU_HEADER_HEIGHT + 1, STR_MODE);
+  lcdDrawText(COL_THREE, MENU_HEADER_HEIGHT + 1, "%", RIGHT);
+  lcdDrawText(COL_FOUR, MENU_HEADER_HEIGHT + 1, STR_SOURCE);
 
   y = MENU_HEADER_HEIGHT + 1 + FH;
 
@@ -69,18 +69,19 @@ void menuRadioTrainer(event_t event)
 
       switch (j) {
         case 0:
-          lcdDrawTextAtIndex(COL_TWO*FW, y, STR_TRNMODE, td->mode, attr);
-          if (attr&BLINK) CHECK_INCDEC_GENVAR(event, td->mode, 0, 2);
+          lcdDrawTextAtIndex(COL_TWO, y, STR_TRNMODE, td->mode, attr);
+          if (attr & BLINK) CHECK_INCDEC_GENVAR(event, td->mode, 0, 2);
           break;
 
         case 1:
-          lcdDrawNumber(COL_THREE*FW, y, td->studWeight, attr|RIGHT);
-          if (attr&BLINK) CHECK_INCDEC_GENVAR(event, td->studWeight, -125, 125);
+          lcdDrawNumber(COL_THREE, y, td->studWeight, attr | RIGHT);
+          if (attr & BLINK)
+            CHECK_INCDEC_GENVAR(event, td->studWeight, -125, 125);
           break;
 
         case 2:
-          lcdDrawTextAtIndex(COL_FOUR*FW, y, STR_TRNCHN, td->srcChn, attr);
-          if (attr&BLINK) CHECK_INCDEC_GENVAR(event, td->srcChn, 0, 3);
+          lcdDrawTextAtIndex(COL_FOUR, y, STR_TRNCHN, td->srcChn, attr);
+          if (attr & BLINK) CHECK_INCDEC_GENVAR(event, td->srcChn, 0, 3);
           break;
       }
     }


### PR DESCRIPTION
It seems #3354 didn't take 212 screens into account.

Adds some padding on widescreen (212x64) B&W

Before:
![Screenshot 2023-11-02 104810](https://github.com/EdgeTX/edgetx/assets/5500713/c8ca81ed-4864-4f31-aa58-2cedaa0d7b75)

After:
![Screenshot 2023-11-02 104734](https://github.com/EdgeTX/edgetx/assets/5500713/a3ce1110-5701-47cb-86e8-4ad7f6946ffd)

Before:
![Screenshot 2023-11-02 105832](https://github.com/EdgeTX/edgetx/assets/5500713/0719856c-5153-4c77-99cd-1fe3d0cc3297)

After:
![Screenshot 2023-11-02 105630](https://github.com/EdgeTX/edgetx/assets/5500713/289a1262-6644-4249-aa95-94e13313a121)


@3djc Complaints? Concerns? Small furry animals? 😆 