### PR TITLE
fix(color): Bootloader tick mark position.

### DIFF
--- a/radio/src/targets/horus/bootloader/boot_menu.cpp
+++ b/radio/src/targets/horus/bootloader/boot_menu.cpp
@@ -149,7 +149,7 @@ void bootloaderDrawScreen(BootloaderState st, int opt, const char* str)
             lcd->drawText(168, 178, TR_BL_RADIO, RIGHT | BL_FOREGROUND);
             lcd->drawText(174, 178, tag.flavour, BL_FOREGROUND);
 
-            lcd->drawText(356, 156, LV_SYMBOL_OK, BL_GREEN);
+            lcd->drawText(78, 158, LV_SYMBOL_OK, BL_GREEN);
           }
         }
 

--- a/radio/src/targets/nv14/bootloader/boot_menu.cpp
+++ b/radio/src/targets/nv14/bootloader/boot_menu.cpp
@@ -181,7 +181,7 @@ void bootloaderDrawScreen(BootloaderState st, int opt, const char* str)
                         MESSAGE_TOP + DEFAULT_PADDING, tag.flavour,
                         BL_FOREGROUND);
 
-          lcd->drawText(LCD_W - DOUBLE_PADDING, MESSAGE_TOP - 10,
+          lcd->drawText(LCD_W / 4 + DEFAULT_PADDING - 90, MESSAGE_TOP,
                         LV_SYMBOL_OK, BL_GREEN);
         }
       }


### PR DESCRIPTION
Move the tick mark on the bootloader 'Write Firmware' screen to the left of the 'Version' string so it does not overlap the version text.

![IMG_1716](https://github.com/EdgeTX/edgetx/assets/9474356/94a2cab3-dda7-43ec-8ab3-94b9bb7e3d38)

![IMG_1719](https://github.com/EdgeTX/edgetx/assets/9474356/b9cd9474-c9a4-418b-b050-641ebd85c277)
