### PR TITLE
fix(color): No startup/shutdown haptic if haptic mode set to quiet

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1258,7 +1258,7 @@ void opentxClose(uint8_t shutdown)
     AUDIO_BYE();
     // TODO needed? telemetryEnd();
 #if defined(HAPTIC)
-    hapticOff();
+    if (g_eeGeneral.hapticMode != e_mode_quiet) hapticOff();
 #endif
   }
 
@@ -1479,7 +1479,9 @@ void runStartupAnimation()
     else if (!isPowerOn) {
       isPowerOn = true;
       pwrOn();
-      haptic.play(15, 3, PLAY_NOW);
+#if defined(HAPTIC)
+      if (g_eeGeneral.hapticMode != e_mode_quiet) haptic.play(15, 3, PLAY_NOW);
+#endif
     }
   }
 
@@ -1573,7 +1575,9 @@ void opentxInit()
   }
 #else // defined(PWR_BUTTON_PRESS)
   pwrOn();
-  haptic.play(15, 3, PLAY_NOW);
+#if defined(HAPTIC)
+  if (g_eeGeneral.hapticMode != e_mode_quiet) haptic.play(15, 3, PLAY_NOW);
+#endif
 #endif
 
   // Radios handle UNEXPECTED_SHUTDOWN() differently:
@@ -1917,8 +1921,10 @@ uint32_t pwrCheck()
 
 #endif // COLORLCD
         }
-
-        haptic.play(15, 3, PLAY_NOW);
+#if defined(HAPTIC)
+        if (g_eeGeneral.hapticMode != e_mode_quiet)
+          haptic.play(15, 3, PLAY_NOW);
+#endif
         pwr_check_state = PWR_CHECK_OFF;
         return e_power_off;
       }

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -909,8 +909,8 @@ void checkThrottleStick()
                              throttleNotIdle, STR_PRESS_ANY_KEY_TO_SKIP);
     dialog->setCloseCondition([]() { return !isThrottleWarningAlertNeeded(); });
     dialog->runForever();
-    LED_ERROR_END();
   }
+  LED_ERROR_END();
 }
 #else
 void checkThrottleStick()

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1258,7 +1258,7 @@ void opentxClose(uint8_t shutdown)
     AUDIO_BYE();
     // TODO needed? telemetryEnd();
 #if defined(HAPTIC)
-    if (g_eeGeneral.hapticMode != e_mode_quiet) hapticOff();
+    hapticOff();
 #endif
   }
 

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1555,13 +1555,21 @@ void opentxInit()
   lcdClear();
   lcdRefresh();
   lcdRefreshWait();
+#endif
 
-  bool radioSettingsValid = storageReadRadioSettings(false);
-  (void)radioSettingsValid;
+  // Load radio.yml so radio settings can be used
+  bool radioSettingsValid = false;
+#if defined(RTC_BACKUP_RAM)
+  // Skip loading if EM startup and radio has RTC backup data
+  if (!UNEXPECTED_SHUTDOWN())
+    radioSettingsValid = storageReadRadioSettings(false);
+#else
+  // No RTC backup - try and load even for EM startup
+  radioSettingsValid = storageReadRadioSettings(false);
+#endif
 
 #if defined(GUI) && !defined(COLORLCD)
   lcdSetContrast();
-#endif
 #endif
 
   BACKLIGHT_ENABLE(); // we start the backlight during the startup animation


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Resolves #4018 for 2.9

Ports the following from #4027:
- Link startup and shutdown haptic triggers to state of hapticMode setting
- Include throttle LED fix
- Load settings on boot unless EM startup so haptic state can be loaded on boot