### PR TITLE
fix(color): 2.9 - No startup/shutdown haptic if haptic mode set to quiet

### DIFF
--- a/radio/src/gui/colorlcd/draw_functions.cpp
+++ b/radio/src/gui/colorlcd/draw_functions.cpp
@@ -292,34 +292,33 @@ void drawTrimMode(BitmapBuffer * dc, coord_t x, coord_t y, uint8_t phase, uint8_
 
 void drawDate(BitmapBuffer * dc, coord_t x, coord_t y, TelemetryItem & telemetryItem, LcdFlags att)
 {
-  // TODO
+  bool doTwoLines = false;
+  coord_t ox = x;
+
   if (att & FONT(XL)) {
-    x -= 42;
     att &= ~FONT_MASK;
-    x = dc->drawNumber(x, y, telemetryItem.datetime.day, att|LEADING0|LEFT, 2);
-    x = dc->drawText(x - 1, y, "-", att);
-    x = dc->drawNumber(x - 1, y, telemetryItem.datetime.month, att|LEFT, 2);
-    x = dc->drawText(x - 1, y, "-", att);
-    x = dc->drawNumber(x - 1, y, telemetryItem.datetime.year-2000, att|LEFT);
-    y += FH;
-    /* TODO dc->drawNumber(x, y, telemetryItem.datetime.hour, att|LEADING0|LEFT, 2);
-    dc->drawText(lcdNextPos, y, ":", att);
-    dc->drawNumber(lcdNextPos, y, telemetryItem.datetime.min, att|LEADING0|LEFT, 2);
-    dc->drawText(lcdNextPos, y, ":", att);
-    dc->drawNumber(lcdNextPos, y, telemetryItem.datetime.sec, att|LEADING0|LEFT, 2); */
+    doTwoLines = true;
   }
-  else {
-    x = dc->drawNumber(x, y, telemetryItem.datetime.day, att|LEADING0|LEFT, 2);
-    x = dc->drawText(x - 1, y, "-", att);
-    x = dc->drawNumber(x, y, telemetryItem.datetime.month, att|LEFT, 2);
-    x = dc->drawText(x - 1, y, "-", att);
-    x = dc->drawNumber(x, y, telemetryItem.datetime.year-2000, att|LEFT);
-    x = dc->drawNumber(x + 11, y, telemetryItem.datetime.hour, att|LEADING0|LEFT, 2);
-    x = dc->drawText(x, y, ":", att);
-    x = dc->drawNumber(x, y, telemetryItem.datetime.min, att|LEADING0|LEFT, 2);
-    x = dc->drawText(x, y, ":", att);
-    dc->drawNumber(x, y, telemetryItem.datetime.sec, att|LEADING0|LEFT, 2);
+
+  LcdFlags fl = att|LEADING0|LEFT;
+
+  x = dc->drawNumber(x, y, telemetryItem.datetime.year, fl,4);
+  x = dc->drawText(x, y, "-", att);
+  x = dc->drawNumber(x, y, telemetryItem.datetime.month, fl, 2);
+  x = dc->drawText(x, y, "-", att);
+  x = dc->drawNumber(x, y, telemetryItem.datetime.day, fl, 2);
+  
+  if (doTwoLines) {
+    y += FH;  x = ox;
+  } else {
+    x += 11;
   }
+
+  x = dc->drawNumber(x, y, telemetryItem.datetime.hour, fl, 2);
+  x = dc->drawText(x, y, ":", att);
+  x = dc->drawNumber(x, y, telemetryItem.datetime.min, fl, 2);
+  x = dc->drawText(x, y, ":", att);
+  dc->drawNumber(x, y, telemetryItem.datetime.sec, fl, 2);
 }
 
 coord_t drawGPSCoord(BitmapBuffer * dc, coord_t x, coord_t y, int32_t value, const char * direction, LcdFlags flags, bool seconds=true)

--- a/radio/src/gui/colorlcd/model_telemetry.cpp
+++ b/radio/src/gui/colorlcd/model_telemetry.cpp
@@ -985,9 +985,9 @@ void ModelTelemetryPage::build(FormWindow * window)
 std::string getDate(TelemetryItem & telemetryItem)
 {
   return
-    formatNumberAsString(telemetryItem.datetime.day, LEADING0|LEFT, 2) + "-" +
-    formatNumberAsString(telemetryItem.datetime.month, LEFT, 2) + "-" +
-    formatNumberAsString(telemetryItem.datetime.year-2000, LEFT) + " " +
+    formatNumberAsString(telemetryItem.datetime.year, LEADING0|LEFT,4) + "-" +
+    formatNumberAsString(telemetryItem.datetime.month, LEADING0|LEFT, 2) + "-" +
+    formatNumberAsString(telemetryItem.datetime.day, LEADING0|LEFT, 2) + " " +
     formatNumberAsString(telemetryItem.datetime.hour, LEADING0|LEFT, 2) + ":" +
     formatNumberAsString(telemetryItem.datetime.min, LEADING0|LEFT, 2) + ":" +
     formatNumberAsString(telemetryItem.datetime.sec, LEADING0|LEFT, 2);

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1258,7 +1258,7 @@ void opentxClose(uint8_t shutdown)
     AUDIO_BYE();
     // TODO needed? telemetryEnd();
 #if defined(HAPTIC)
-    hapticOff();
+    if (g_eeGeneral.hapticMode != e_mode_quiet) hapticOff();
 #endif
   }
 
@@ -1479,7 +1479,9 @@ void runStartupAnimation()
     else if (!isPowerOn) {
       isPowerOn = true;
       pwrOn();
-      haptic.play(15, 3, PLAY_NOW);
+#if defined(HAPTIC)
+      if (g_eeGeneral.hapticMode != e_mode_quiet) haptic.play(15, 3, PLAY_NOW);
+#endif
     }
   }
 
@@ -1573,7 +1575,9 @@ void opentxInit()
   }
 #else // defined(PWR_BUTTON_PRESS)
   pwrOn();
-  haptic.play(15, 3, PLAY_NOW);
+#if defined(HAPTIC)
+  if (g_eeGeneral.hapticMode != e_mode_quiet) haptic.play(15, 3, PLAY_NOW);
+#endif
 #endif
 
   // Radios handle UNEXPECTED_SHUTDOWN() differently:
@@ -1917,8 +1921,10 @@ uint32_t pwrCheck()
 
 #endif // COLORLCD
         }
-
-        haptic.play(15, 3, PLAY_NOW);
+#if defined(HAPTIC)
+        if (g_eeGeneral.hapticMode != e_mode_quiet)
+          haptic.play(15, 3, PLAY_NOW);
+#endif
         pwr_check_state = PWR_CHECK_OFF;
         return e_power_off;
       }

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -909,8 +909,8 @@ void checkThrottleStick()
                              throttleNotIdle, STR_PRESS_ANY_KEY_TO_SKIP);
     dialog->setCloseCondition([]() { return !isThrottleWarningAlertNeeded(); });
     dialog->runForever();
-    LED_ERROR_END();
   }
+  LED_ERROR_END();
 }
 #else
 void checkThrottleStick()

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1555,13 +1555,21 @@ void opentxInit()
   lcdClear();
   lcdRefresh();
   lcdRefreshWait();
+#endif
 
-  bool radioSettingsValid = storageReadRadioSettings(false);
-  (void)radioSettingsValid;
+  // Load radio.yml so radio settings can be used
+  bool radioSettingsValid = false;
+#if defined(RTC_BACKUP_RAM)
+  // Skip loading if EM startup and radio has RTC backup data
+  if (!UNEXPECTED_SHUTDOWN())
+    radioSettingsValid = storageReadRadioSettings(false);
+#else
+  // No RTC backup - try and load even for EM startup
+  radioSettingsValid = storageReadRadioSettings(false);
+#endif
 
 #if defined(GUI) && !defined(COLORLCD)
   lcdSetContrast();
-#endif
 #endif
 
   BACKLIGHT_ENABLE(); // we start the backlight during the startup animation

--- a/radio/src/storage/sdcard_common.cpp
+++ b/radio/src/storage/sdcard_common.cpp
@@ -71,6 +71,9 @@ void storageFormat()
 
 void storageCheck(bool immediately)
 {
+  // Don't write anything to SD card if in EM
+  if (globalData.unexpectedShutdown) return;
+
   if (storageDirtyMsk & EE_GENERAL) {
     TRACE("eeprom write general");
     storageDirtyMsk &= ~EE_GENERAL;

--- a/radio/src/telemetry/telemetry_sensors.cpp
+++ b/radio/src/telemetry/telemetry_sensors.cpp
@@ -150,7 +150,9 @@ void TelemetryItem::setValue(const TelemetrySensor &sensor, int32_t val,
       }
 #endif
     }
-    newVal = 0;
+    value = hash((void *) &datetime, sizeof(datetime));
+    setFresh();
+    return;
   }
   else if (unit == UNIT_GPS_LATITUDE) {
 #if defined(INTERNAL_GPS)
@@ -177,6 +179,8 @@ void TelemetryItem::setValue(const TelemetrySensor &sensor, int32_t val,
       pilotLongitude = newVal;
     }
     gps.longitude = newVal;
+
+    value = hash((void *) &gps, sizeof(gps));
     setFresh();
     return;
   }
@@ -198,7 +202,9 @@ void TelemetryItem::setValue(const TelemetrySensor &sensor, int32_t val,
   }
   else if (unit == UNIT_DATETIME_SEC) {
     datetime.sec = newVal & 0xFFu;
-    newVal = 0;
+    value = hash((void *) &datetime, sizeof(datetime));
+    setFresh();
+    return;
   }
   else if (unit == UNIT_RPMS) {
     if (sensor.custom.ratio != 0) {


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Resolves #4018 for 2.9

Ports the following from #4027:
- Link startup and shutdown haptic triggers to state of hapticMode setting
- Include throttle LED fix
- Load settings on boot unless EM startup so haptic state can be loaded on boot