### PR TITLE
chore: improve finding Homebrew's Qt5 on macOS

### DIFF
--- a/cmake/QtDefs.cmake
+++ b/cmake/QtDefs.cmake
@@ -1,8 +1,6 @@
-if(APPLE AND EXISTS /usr/local/opt/qt5)
-	# Homebrew installs Qt5 (up to at least 5.9.1) in
-	# /usr/local/qt5, ensure it can be found by CMake since
-	# it is not in the default /usr/local prefix.
-	list(APPEND CMAKE_PREFIX_PATH "/usr/local/opt/qt5")
+if(APPLE AND DEFINED ENV{HOMEBREW_PREFIX} AND EXISTS $ENV{HOMEBREW_PREFIX}/opt/qt@5)
+  # If Homebrew is used, HOMEBREW_PREFIX should be defined
+  list(APPEND CMAKE_PREFIX_PATH "$ENV{HOMEBREW_PREFIX}/opt/qt@5")
 endif()
 
 set(CMAKE_AUTOMOC ON)


### PR DESCRIPTION
This should allow finding Qt5 without explicitly passing `-DCMAKE_PREFIX_PATH=$QT_DIR` in the `cmake` command line.