### PR TITLE
fix(color): Crash in theme editor

### DIFF
--- a/radio/src/gui/colorlcd/themes/etx_lv_theme.cpp
+++ b/radio/src/gui/colorlcd/themes/etx_lv_theme.cpp
@@ -374,7 +374,7 @@ void usePreviewStyle()
 {
   if (!previewStyles) previewStyles = new EdgeTxStyles();
   styles = previewStyles;
-  styles->applyColors();
+  styles->init();
 }
 
 void useMainStyle() { styles = &mainStyles; }


### PR DESCRIPTION
Fix radio crash when editing a theme - missed in LVGL 8.3 upgrade.