### PR TITLE
chore(cpn): 2.9 Give SDL2 version of XCode it wants

### DIFF
--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -90,8 +90,18 @@ jobs:
           ./configure &&
           make install
 
+      - name: Select XCode version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '13.2.1'
+
       - name: Install SDL2
         run:  brew install SDL2
+
+      - name: Select XCode version
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: '11.7'
 
       - name: Build
         working-directory: ${{github.workspace}}

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -3,11 +3,7 @@ name: MacOSX Companion
 on:
   push:
     branches:
-      - '2.6'
-      - '2.7'
-      - '2.8'
       - '2.9'
-      - 'main'
     tags:
       - v*
     paths:
@@ -17,10 +13,7 @@ on:
 
   pull_request:
     branches:
-      - '2.6'
-      - '2.7'
-      - '2.8'
-      - 'main'
+      - '2.9'
     paths:
       - '.github/workflows/macosx_cpn.yml'
       - 'companion/**'


### PR DESCRIPTION
Summary of changes:
 - Hopefully allow MacOS cpn to build on 2.9 branch by applying same XCode version switcheroo 
