### PR TITLE
fix(radio): Special/Global functions showing wrong function name

### DIFF
--- a/radio/src/translations/cn.h
+++ b/radio/src/translations/cn.h
@@ -75,11 +75,10 @@
 
 #define TR_CSWTIMER                  "定时"
 #define TR_CSWSTICKY                 "粘滞"
-#define TR_CSWRANGE                  "范围"
 #define TR_CSWSTAY                   "边沿"
 
 #define TR_CSWEQUAL                    "a=x"
-#define TR_VCSWFUNC                    "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x",TR_CSWRANGE,"|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
+#define TR_VCSWFUNC                    "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x","|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
 
 
 #define TR_SF_TRAINER                  "教练"

--- a/radio/src/translations/cz.h
+++ b/radio/src/translations/cz.h
@@ -82,17 +82,15 @@
 #if LCD_W >= 212
   #define TR_CSWTIMER                  "Stopky"
   #define TR_CSWSTICKY                 "Sticky"
-  #define TR_CSWRANGE                  "Dosah"
   #define TR_CSWSTAY                   "Edge"
 #else
   #define TR_CSWTIMER                  "Tim"
   #define TR_CSWSTICKY                 "Stky"
-  #define TR_CSWRANGE                  "Rnge"
   #define TR_CSWSTAY                   "Edge"
 #endif
 
 #define TR_CSWEQUAL                    "a=x"
-#define TR_VCSWFUNC                    "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x",TR_CSWRANGE,"|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
+#define TR_VCSWFUNC                    "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x","|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
 
 #define TR_TEXT_SIZE                   "Standard","Nejmenší","Malé","Střední","Dvojité"
 

--- a/radio/src/translations/da.h
+++ b/radio/src/translations/da.h
@@ -82,17 +82,15 @@
 #if LCD_W >= 212
   #define TR_CSWTIMER                  "Tid"
   #define TR_CSWSTICKY                 "Sej"
-  #define TR_CSWRANGE                  "Afstand"
   #define TR_CSWSTAY                   "Edge"
 #else
   #define TR_CSWTIMER                  "Tid"
   #define TR_CSWSTICKY                 "Sej"
-  #define TR_CSWRANGE                  "Afst"
   #define TR_CSWSTAY                   "Edge"
 #endif
 
 #define TR_CSWEQUAL                    "a=x"
-#define TR_VCSWFUNC                    "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x",TR_CSWRANGE,"|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
+#define TR_VCSWFUNC                    "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x","|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
 
 #define TR_SF_TRAINER                  "Træner"
 #define TR_SF_INST_TRIM                "Inst. Trim"

--- a/radio/src/translations/de.h
+++ b/radio/src/translations/de.h
@@ -79,17 +79,15 @@
 #if LCD_W >= 212
   #define TR_CSWTIMER                  "Takt"  // TIM = Takt = Taktgenerator
   #define TR_CSWSTICKY                 "SRFF"  // Sticky = RS-Flip-Flop
-  #define TR_CSWRANGE                  "Range" // Range = Bereichsabfrage von bis
   #define TR_CSWSTAY                   "Puls"  // Edge = einstellbarer Impuls
 #else
   #define TR_CSWTIMER                  "Takt"  // TIM = Takt = Taktgenerator
   #define TR_CSWSTICKY                 "SRFF"  // Sticky = RS-Flip-Flop
-    #define TR_CSWRANGE                "Rnge"  // Range= Bereichsabfrage von bis
-    #define TR_CSWSTAY                 "Puls"  // Edge = einstellbarer Impuls
+  #define TR_CSWSTAY                   "Puls"  // Edge = einstellbarer Impuls
 #endif
 
 #define TR_CSWEQUAL                    "a=x"
-#define TR_VCSWFUNC            			"---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x",TR_CSWRANGE,"|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
+#define TR_VCSWFUNC            			"---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x","|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
 
 #define TR_SF_TRAINER                  "Lehrer"
 #define TR_SF_INST_TRIM                "Inst. Trim"

--- a/radio/src/translations/en.h
+++ b/radio/src/translations/en.h
@@ -75,17 +75,15 @@
 #if LCD_W >= 212
   #define TR_CSWTIMER                  "Timer"
   #define TR_CSWSTICKY                 "Stcky"
-  #define TR_CSWRANGE                  "Range"
   #define TR_CSWSTAY                   "Edge"
 #else
   #define TR_CSWTIMER                  "Tim"
   #define TR_CSWSTICKY                 "Stky"
-  #define TR_CSWRANGE                  "Rnge"
   #define TR_CSWSTAY                   "Edge"
 #endif
 
 #define TR_CSWEQUAL                    "a=x"
-#define TR_VCSWFUNC                    "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x",TR_CSWRANGE,"|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
+#define TR_VCSWFUNC                    "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x","|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
 
 #define TR_SF_TRAINER                  "Trainer"
 #define TR_SF_INST_TRIM                "Inst. Trim"

--- a/radio/src/translations/es.h
+++ b/radio/src/translations/es.h
@@ -76,18 +76,16 @@
 #if LCD_W >= 212
   #define TR_CSWTIMER          "Timer"
   #define TR_CSWSTICKY         "Pega"
-  #define TR_CSWRANGE          "Rango"
   #define TR_CSWSTAY           "Borde"
 #else
   #define TR_CSWTIMER          "Tim"
   #define TR_CSWSTICKY         "Pega"
-  #define TR_CSWRANGE          "Rngo"
   #define TR_CSWSTAY           "Bord"
 #endif
 
 #define TR_CSWEQUAL      "a=x"
 
-#define TR_VCSWFUNC      "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x",TR_CSWRANGE,"|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
+#define TR_VCSWFUNC      "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x","|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
 
 #define TR_SF_TRAINER                  "Entrenador"
 #define TR_SF_INST_TRIM                "Inst. Trim"

--- a/radio/src/translations/fi.h
+++ b/radio/src/translations/fi.h
@@ -79,18 +79,16 @@
 #if defined(PCBTARANIS)
   #define TR_CSWTIMER                  "Timer"
   #define TR_CSWSTICKY                 "Stcky"
-  #define TR_CSWRANGE                  "Range"
   #define TR_CSWSTAY                   "Edge"
 #else
   #define TR_CSWTIMER                  "Tim"
   #define TR_CSWSTICKY                 "Glue"
-    #define TR_CSWRANGE                "Rnge"
-    #define TR_CSWSTAY                 "Edge"
+  #define TR_CSWSTAY                   "Edge"
 #endif
 
 #define TR_CSWEQUAL                    "a=x"
 
-#define TR_VCSWFUNC                    "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x",TR_CSWRANGE,"|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
+#define TR_VCSWFUNC                    "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x","|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
 
 #define TR_TEXT_SIZE                   "Standard","Tiny","Small","Mid","Double"
 

--- a/radio/src/translations/fr.h
+++ b/radio/src/translations/fr.h
@@ -79,17 +79,15 @@
 #if LCD_W >= 212
   #define TR_CSWTIMER                  "Chrono"
   #define TR_CSWSTICKY                 "Bistb"
-  #define TR_CSWRANGE                  "Plage"
   #define TR_CSWSTAY                   "Edge"
 #else
   #define TR_CSWTIMER                  "Chrono"
   #define TR_CSWSTICKY                 "Bist"
-  #define TR_CSWRANGE                  "Plage"
   #define TR_CSWSTAY                   "Edge"
 #endif
 
 #define TR_CSWEQUAL                    "a=x"
-#define TR_VCSWFUNC                    "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x",TR_CSWRANGE,"|a|>x","|a|<x","ET","OU","OUX",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
+#define TR_VCSWFUNC                    "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x","|a|>x","|a|<x","ET","OU","OUX",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
 
 #define TR_TEXT_SIZE                   "Standard","Mini","Petit","Moyen","Double"
 

--- a/radio/src/translations/he.h
+++ b/radio/src/translations/he.h
@@ -78,17 +78,15 @@
 #if LCD_W >= 212
   #define TR_CSWTIMER                  "שעון"
   #define TR_CSWSTICKY                 "Stcky"
-  #define TR_CSWRANGE                  "טווח"
   #define TR_CSWSTAY                   "Edge"
 #else
   #define TR_CSWTIMER                  "שעון"
   #define TR_CSWSTICKY                 "Stky"
-  #define TR_CSWRANGE                  "Rnge"
   #define TR_CSWSTAY                   "Edge"
 #endif
 
 #define TR_CSWEQUAL                    "a=x"
-#define TR_VCSWFUNC                    "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x",TR_CSWRANGE,"|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
+#define TR_VCSWFUNC                    "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x","|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
 
 #define TR_SF_TRAINER                  "Trainer"
 #define TR_SF_INST_TRIM                "Inst. Trim"

--- a/radio/src/translations/it.h
+++ b/radio/src/translations/it.h
@@ -80,17 +80,15 @@
 #if LCD_W >= 212
   #define TR_CSWTIMER                  "Timer"
   #define TR_CSWSTICKY                  "Stcky"
-  #define TR_CSWRANGE                   "Campo"
   #define TR_CSWSTAY                    "Edge"
 #else
   #define TR_CSWTIMER                   "Tim"
   #define TR_CSWSTICKY                  "Glue"
-  #define TR_CSWRANGE                   "Rnge"
   #define TR_CSWSTAY                    "Edge"
 #endif
 
 #define TR_CSWEQUAL                 "a=x"
-#define TR_VCSWFUNC                 "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x",TR_CSWRANGE,"|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
+#define TR_VCSWFUNC                 "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x","|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
 
 #define TR_SF_TRAINER                  "Maestro"
 #define TR_SF_INST_TRIM                "Inst. Trim"

--- a/radio/src/translations/jp.h
+++ b/radio/src/translations/jp.h
@@ -75,17 +75,15 @@
 #if LCD_W >= 212
   #define TR_CSWTIMER                  "Timer"
   #define TR_CSWSTICKY                 "Stcky"
-  #define TR_CSWRANGE                  "Range"
   #define TR_CSWSTAY                   "Edge"
 #else
   #define TR_CSWTIMER                  "Tim"
   #define TR_CSWSTICKY                 "Stky"
-  #define TR_CSWRANGE                  "Rnge"
   #define TR_CSWSTAY                   "Edge"
 #endif
 
 #define TR_CSWEQUAL                    "a=x"
-#define TR_VCSWFUNC                    "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x",TR_CSWRANGE,"|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA,"≥x","|",STR_CHAR_DELTA,"|≥x",TR_CSWTIMER,TR_CSWSTICKY
+#define TR_VCSWFUNC                    "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x","|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA,"≥x","|",STR_CHAR_DELTA,"|≥x",TR_CSWTIMER,TR_CSWSTICKY
 
 #define TR_SF_TRAINER                  "トレーナー"
 #define TR_SF_INST_TRIM                "Inst.トリム"

--- a/radio/src/translations/nl.h
+++ b/radio/src/translations/nl.h
@@ -77,17 +77,15 @@
 #if LCD_W >= 212
   #define TR_CSWTIMER          "Timer"
   #define TR_CSWSTICKY         "Stcky"
-  #define TR_CSWRANGE          "Range"
   #define TR_CSWSTAY           "Edge"
 #else
   #define TR_CSWTIMER          "Tim"
   #define TR_CSWSTICKY         "Glue"
-  #define TR_CSWRANGE          "Rnge"
   #define TR_CSWSTAY           "Edge"
 #endif
 
 #define TR_CSWEQUAL            "a=x"
-#define TR_VCSWFUNC            "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x",TR_CSWRANGE,"|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
+#define TR_VCSWFUNC            "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x","|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
 
 #define TR_SF_TRAINER          "Trainer"
 #define TR_SF_INST_TRIM        "Inst. Trim"

--- a/radio/src/translations/pl.h
+++ b/radio/src/translations/pl.h
@@ -76,17 +76,15 @@
 #if LCD_W >= 212
   #define TR_CSWTIMER          "Timer"
   #define TR_CSWSTICKY         "Stały"
-  #define TR_CSWRANGE          "Zasię"
   #define TR_CSWSTAY           "Brzeg"
 #else
   #define TR_CSWTIMER          "Tim"
   #define TR_CSWSTICKY         "Stały"
-  #define TR_CSWRANGE          "Zasię"
   #define TR_CSWSTAY           "Brzeg"
 #endif
 
 #define TR_CSWEQUAL  "a=x"
-#define TR_VCSWFUNC  "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x",TR_CSWRANGE,"|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
+#define TR_VCSWFUNC  "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x","|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
 
 #define TR_SF_TRAINER         "Trener"
 #define TR_SF_INST_TRIM       "Inst-Trim"

--- a/radio/src/translations/pt.h
+++ b/radio/src/translations/pt.h
@@ -78,17 +78,15 @@
 #if LCD_W >= 212
   #define TR_CSWTIMER                  "Timer"
   #define TR_CSWSTICKY                 "Stcky"
-  #define TR_CSWRANGE                  "Range"
   #define TR_CSWSTAY                   "Edge"
 #else
   #define TR_CSWTIMER                  "Tim"
   #define TR_CSWSTICKY                 "Stky"
-  #define TR_CSWRANGE                  "Rnge"
   #define TR_CSWSTAY                   "Edge"
 #endif
 
 #define TR_CSWEQUAL                    "a=x"
-#define TR_VCSWFUNC                    "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x",TR_CSWRANGE,"|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
+#define TR_VCSWFUNC                    "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x","|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
 
 #define TR_SF_TRAINER                  "Trainer"
 #define TR_SF_INST_TRIM                "Trim Inst."

--- a/radio/src/translations/ru.h
+++ b/radio/src/translations/ru.h
@@ -77,17 +77,15 @@
 #if LCD_W >= 212
   #define TR_CSWTIMER                  "Таймер"
   #define TR_CSWSTICKY                 "Липучка"
-  #define TR_CSWRANGE                  "Диапазон"
   #define TR_CSWSTAY                   "Край"
 #else
   #define TR_CSWTIMER                  "Таймер"
   #define TR_CSWSTICKY                 "Липучка"
-  #define TR_CSWRANGE                  "Диапазон"
   #define TR_CSWSTAY                   "Кррай"
 #endif
 
 #define TR_CSWEQUAL                    "a=x"
-#define TR_VCSWFUNC                    "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x",TR_CSWRANGE,"|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
+#define TR_VCSWFUNC                    "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x","|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
 
 #define TR_SF_TRAINER                  "Таймер"
 #define TR_SF_INST_TRIM                "Мгнов трим"

--- a/radio/src/translations/se.h
+++ b/radio/src/translations/se.h
@@ -84,17 +84,15 @@
 #if LCD_W >= 212
   #define TR_CSWTIMER                   "Timer"
   #define TR_CSWSTICKY                  "Seg"
-  #define TR_CSWRANGE                   "Vidd"
   #define TR_CSWSTAY                    "Kant"
 #else
   #define TR_CSWTIMER                   "Tim"
   #define TR_CSWSTICKY                  "Seg"
-  #define TR_CSWRANGE                   "Vidd"
   #define TR_CSWSTAY                    "Kant"
 #endif
 
 #define TR_CSWEQUAL                     "a=x"
-#define TR_VCSWFUNC                     "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x",TR_CSWRANGE,"|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
+#define TR_VCSWFUNC                     "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x","|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
 
 #define TR_TEXT_SIZE                    "Std","XS","S","M","L"
 

--- a/radio/src/translations/tw.h
+++ b/radio/src/translations/tw.h
@@ -76,17 +76,15 @@
 #if LCD_W >= 212
   #define TR_CSWTIMER                  "定時"
   #define TR_CSWSTICKY                 "粘滯"
-  #define TR_CSWRANGE                  "範圍"
   #define TR_CSWSTAY                   "邊沿"
 #else
   #define TR_CSWTIMER                  "定時"
   #define TR_CSWSTICKY                 "粘滯"
-  #define TR_CSWRANGE                  "範圍"
   #define TR_CSWSTAY                   "邊沿"
 #endif
 
 #define TR_CSWEQUAL                    "a=x"
-#define TR_VCSWFUNC                    "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x",TR_CSWRANGE,"|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
+#define TR_VCSWFUNC                    "---",TR_CSWEQUAL,"a" STR_CHAR_TILDE "x","a>x","a<x","|a|>x","|a|<x","AND","OR","XOR",TR_CSWSTAY,"a=b","a>b","a<b",STR_CHAR_DELTA "≥x","|" STR_CHAR_DELTA "|≥x",TR_CSWTIMER,TR_CSWSTICKY
 
 #define TR_SF_TRAINER                  "教練"
 #define TR_SF_INST_TRIM                "搖桿值存儲到微調"


### PR DESCRIPTION
Remove 'Range' value from strings so offsets are correct (missed in PR #4267).