### PR TITLE
fix(cpn): Model index missing in model list for B&W radios

### DIFF
--- a/companion/src/modelslist.cpp
+++ b/companion/src/modelslist.cpp
@@ -621,7 +621,7 @@ void ModelsListModel::refresh()
     }
     else {
       current = rootItem->appendChild(i);
-      current->setData(currentColumn++, QString().arg(i + 1, 2, 10, QChar('0')));
+      current->setData(currentColumn++, QString("%1").arg(i + 1, 2, 10, QChar('0')));
     }
 
     if (!model.isEmpty() && current) {


### PR DESCRIPTION
Fixes #4305

Fix format string so index value is correctly displayed.

