### PR TITLE
fix(color): Backlight randomly turns back on when no user input.

### DIFF
--- a/radio/src/inactivity_timer.cpp
+++ b/radio/src/inactivity_timer.cpp
@@ -56,8 +56,12 @@ bool inactivityCheckInputs()
 {
   uint8_t sum = 0;
 
-  for (uint8_t i = 0; i < adcGetMaxInputs(ADC_INPUT_ALL); i++)
-    sum += anaIn(i) >> INAC_STICKS_SHIFT;
+  auto max_inputs = adcGetMaxInputs(ADC_INPUT_MAIN)
+    + adcGetMaxInputs(ADC_INPUT_FLEX);
+
+  for (uint8_t i = 0; i < max_inputs; i++) {
+    sum += getAnalogValue(i) >> INAC_STICKS_SHIFT;
+  }
 
   for (uint8_t i = 0; i < getSwitchCount(); i++)
     sum += getValue(MIXSRC_FIRST_SWITCH + i) >> INAC_SWITCHES_SHIFT;


### PR DESCRIPTION
On my TX16S and EL18 the backlight would not always turn off after inactivity and would randomly turn back on even if no input.

Fixed the code checking for activity on switches and analog inputs to not check the VBAT and RTC_BAT values.
