### PR TITLE
fix: external module power for SBUS trainer

### DIFF
--- a/radio/src/targets/common/arm/stm32/trainer_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/trainer_driver.cpp
@@ -417,12 +417,14 @@ static void* _sbus_trainer_ctx = nullptr;
 
 void init_trainer_module_sbus()
 {
+  modulePortSetPower(EXTERNAL_MODULE, true);
   _sbus_trainer_ctx = STM32SerialDriver.init(REF_STM32_SERIAL_PORT(SbusTrainer),
                                              &sbusTrainerParams);
 }
 
 void stop_trainer_module_sbus()
 {
+  modulePortSetPower(EXTERNAL_MODULE, false);
   STM32SerialDriver.deinit(_sbus_trainer_ctx);
   _sbus_trainer_ctx = nullptr;
 }


### PR DESCRIPTION
Please note that this PR is explicitely targeted at `2.9`, as the `main` should be fixed with the more generic PR (see #4266)

Fixes #4324
