### PR TITLE
fix(color): Formatting of text on controls warning dialog

### DIFF
--- a/radio/src/gui/colorlcd/fullscreen_dialog.cpp
+++ b/radio/src/gui/colorlcd/fullscreen_dialog.cpp
@@ -28,6 +28,26 @@
 
 #include "watchdog_driver.h"
 
+#if LCD_W > LCD_H
+constexpr uint32_t ALERT_FRAME_TOP =               50;
+constexpr uint32_t ALERT_FRAME_HEIGHT =            (LCD_H - 120);
+constexpr uint32_t ALERT_BITMAP_TOP =              ALERT_FRAME_TOP + 25;
+constexpr uint32_t ALERT_BITMAP_LEFT =             20;
+constexpr uint32_t ALERT_TITLE_TOP =               ALERT_FRAME_TOP + 5;
+constexpr uint32_t ALERT_TITLE_LEFT =              146;
+constexpr uint32_t ALERT_MESSAGE_TOP =             ALERT_TITLE_TOP + 85;
+constexpr uint32_t ALERT_MESSAGE_LEFT =            ALERT_TITLE_LEFT;
+#else
+constexpr uint32_t ALERT_FRAME_TOP =               70;
+constexpr uint32_t ALERT_FRAME_HEIGHT =            (LCD_H - 2 * ALERT_FRAME_TOP);
+constexpr uint32_t ALERT_BITMAP_TOP =              ALERT_FRAME_TOP + 15;
+constexpr uint32_t ALERT_BITMAP_LEFT =             15;
+constexpr uint32_t ALERT_TITLE_TOP =               ALERT_FRAME_TOP + 10;
+constexpr uint32_t ALERT_TITLE_LEFT =              140;
+constexpr uint32_t ALERT_MESSAGE_TOP =             ALERT_TITLE_TOP + 130;
+constexpr uint32_t ALERT_MESSAGE_LEFT =            15;
+#endif
+
 static Window* _get_parent()
 {
   Window* p = Layer::back();

--- a/radio/src/gui/colorlcd/switch_warn_dialog.cpp
+++ b/radio/src/gui/colorlcd/switch_warn_dialog.cpp
@@ -80,6 +80,7 @@ void SwitchWarnDialog::paint(BitmapBuffer * dc)
       if (!IS_POT_SLIDER_AVAILABLE(i)) { continue; }
       if ( (g_model.potsWarnEnabled & (1 << i))) {
         if (abs(g_model.potsWarnPosition[i] - GET_LOWRES_POT_POSITION(i)) > 1) {
+          warn_txt += STR_CHAR_POT;
           warn_txt += getPotLabel(i);
           warn_txt += " ";
         }

--- a/radio/src/gui/colorlcd/switch_warn_dialog.cpp
+++ b/radio/src/gui/colorlcd/switch_warn_dialog.cpp
@@ -32,7 +32,7 @@ SwitchWarnDialog::SwitchWarnDialog() :
 
 void SwitchWarnDialog::delayedInit()
 {
-  lv_label_set_long_mode(messageLabel->getLvObj(), LV_LABEL_LONG_DOT);
+  lv_label_set_long_mode(messageLabel->getLvObj(), LV_LABEL_LONG_WRAP);
   AUDIO_ERROR_MESSAGE(AU_SWITCH_ALERT);
 }
 
@@ -68,6 +68,7 @@ void SwitchWarnDialog::paint(BitmapBuffer * dc)
         if ((switches_states & mask) != (states & mask)) {
           swarnstate_t state = (states >> (i*3)) & 0x07;
           warn_txt += getSwitchPositionName(SWSRC_FIRST_SWITCH + i * 3 + state - 1);
+          warn_txt += " ";
         }
       }
     }
@@ -80,6 +81,7 @@ void SwitchWarnDialog::paint(BitmapBuffer * dc)
       if ( (g_model.potsWarnEnabled & (1 << i))) {
         if (abs(g_model.potsWarnPosition[i] - GET_LOWRES_POT_POSITION(i)) > 1) {
           warn_txt += getPotLabel(i);
+          warn_txt += " ";
         }
       }
     }
@@ -96,7 +98,7 @@ ThrottleWarnDialog::ThrottleWarnDialog(const char* msg) :
 
 void ThrottleWarnDialog::delayedInit()
 {
-  lv_label_set_long_mode(messageLabel->getLvObj(), LV_LABEL_LONG_DOT);
+  lv_label_set_long_mode(messageLabel->getLvObj(), LV_LABEL_LONG_WRAP);
   AUDIO_ERROR_MESSAGE(AU_THROTTLE_ALERT);
 }
 

--- a/radio/src/targets/horus/libopenui_config.h
+++ b/radio/src/targets/horus/libopenui_config.h
@@ -21,15 +21,6 @@
 
 #pragma once
 
-constexpr uint32_t ALERT_FRAME_TOP =               70;
-constexpr uint32_t ALERT_FRAME_HEIGHT =            (LCD_H - 2 * ALERT_FRAME_TOP);
-constexpr uint32_t ALERT_BITMAP_TOP =              ALERT_FRAME_TOP + 15;
-constexpr uint32_t ALERT_BITMAP_LEFT =             40;
-constexpr uint32_t ALERT_TITLE_TOP =               ALERT_FRAME_TOP + 10;
-constexpr uint32_t ALERT_TITLE_LEFT =              186;
-constexpr uint32_t ALERT_MESSAGE_TOP =             ALERT_TITLE_TOP + 90;
-constexpr uint32_t ALERT_MESSAGE_LEFT =            ALERT_TITLE_LEFT;
-
 constexpr coord_t INPUT_EDIT_CURVE_WIDTH = 132;
 constexpr coord_t INPUT_EDIT_CURVE_HEIGHT = INPUT_EDIT_CURVE_WIDTH;
 constexpr coord_t MENUS_MAX_HEIGHT = (MENUS_LINE_HEIGHT * 7) + 8;

--- a/radio/src/targets/nv14/libopenui_config.h
+++ b/radio/src/targets/nv14/libopenui_config.h
@@ -21,15 +21,6 @@
 
 #pragma once
 
-constexpr uint32_t ALERT_FRAME_TOP =               70;
-constexpr uint32_t ALERT_FRAME_HEIGHT =            (LCD_H - 2 * ALERT_FRAME_TOP);
-constexpr uint32_t ALERT_BITMAP_TOP =              ALERT_FRAME_TOP + 15;
-constexpr uint32_t ALERT_BITMAP_LEFT =             15;
-constexpr uint32_t ALERT_TITLE_TOP =               ALERT_FRAME_TOP + 10;
-constexpr uint32_t ALERT_TITLE_LEFT =              140;
-constexpr uint32_t ALERT_MESSAGE_TOP =             ALERT_TITLE_TOP + 130;
-constexpr uint32_t ALERT_MESSAGE_LEFT =            15;
-
 constexpr coord_t INPUT_EDIT_CURVE_WIDTH = 176;
 constexpr coord_t INPUT_EDIT_CURVE_HEIGHT = 132;
 constexpr coord_t MENUS_MAX_HEIGHT = (MENUS_LINE_HEIGHT * 10);


### PR DESCRIPTION
Fix spacing and formatting of text on switch warning page.
