### PR TITLE
fix: Filter out model specific sources

### DIFF
--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -265,7 +265,13 @@ bool isSourceAvailable(int source)
 
 bool isSourceAvailableInGlobalFunctions(int source)
 {
-  if (source >= MIXSRC_FIRST_TELEM && source <= MIXSRC_LAST_TELEM) {
+  if ((source >= MIXSRC_FIRST_INPUT && source <= MIXSRC_LAST_INPUT) ||
+      (source >= MIXSRC_FIRST_HELI && source <= MIXSRC_LAST_HELI) ||
+      (source >= MIXSRC_FIRST_TRAINER && source <= MIXSRC_LAST_TRAINER) ||
+      (source >= MIXSRC_FIRST_LOGICAL_SWITCH && source <= MIXSRC_LAST_LOGICAL_SWITCH) ||
+      (source >= MIXSRC_FIRST_GVAR && source <= MIXSRC_LAST_GVAR) ||
+      (source >= MIXSRC_FIRST_TIMER && source <= MIXSRC_LAST_TIMER) ||
+      (source >= MIXSRC_FIRST_TELEM && source <= MIXSRC_LAST_TELEM)) {
     return false;
   }
   return isSourceAvailable(source);


### PR DESCRIPTION
Following on from a discussion in #4104 about making it so that only sources that are not model specific are listed as valid sources, this PR aims to extend 

`isSourceAvailableInGlobalFunctions()`

and lock down the available sources even more. 

radio/src/gui/colorlcd/special_functions.cpp needs some work done do it also, so that functions such as 

https://github.com/EdgeTX/edgetx/blob/172dfdebd8f1aab92e4fc67273bdf26b00a4e534/radio/src/gui/colorlcd/special_functions.cpp#L164

https://github.com/EdgeTX/edgetx/blob/172dfdebd8f1aab92e4fc67273bdf26b00a4e534/radio/src/gui/colorlcd/special_functions.cpp#L168

also filter their lists when in global context... i.e. similar to how B&W does for PLAY_VALUE (probably another function that needs it's setAvailableHandler massaged 

https://github.com/EdgeTX/edgetx/blob/172dfdebd8f1aab92e4fc67273bdf26b00a4e534/radio/src/gui/128x64/model_special_functions.cpp#L343