### PR TITLE
fix(color): Incorrect scroll position on quick menu if model has notes

### DIFF
--- a/radio/src/gui/colorlcd/view_main_menu.cpp
+++ b/radio/src/gui/colorlcd/view_main_menu.cpp
@@ -46,8 +46,14 @@ ViewMainMenu::ViewMainMenu(Window* parent, std::function<void()> closeHandler) :
   // Save focus
   Layer::push(this);
 
+  coord_t width = VM_W;
+#if LCD_W > LCD_H
+  if (modelHasNotes())
+    width += FAB_BUTTON_SIZE;
+#endif
+
   auto box =
-      new Window(this, {(LCD_W - VM_W) / 2, (LCD_H - VM_H) / 2, VM_W, VM_H}, 0,
+      new Window(this, {(LCD_W - width) / 2, (LCD_H - VM_H) / 2, width, VM_H}, 0,
                  0, etx_modal_dialog_create);
   box->padAll(8);
 
@@ -120,8 +126,6 @@ ViewMainMenu::ViewMainMenu(Window* parent, std::function<void()> closeHandler) :
                         new AboutUs();
                         return 0;
                       });
-
-  lv_obj_center(carousel->getLvObj());
 }
 
 void ViewMainMenu::deleteLater(bool detach, bool trash)


### PR DESCRIPTION
Fixes #4334 

Fix default scroll for quick menu.
Resize quick menu window if model has notes.

No model notes:
![screenshot_tx16s_23-11-18_21-02-36](https://github.com/EdgeTX/edgetx/assets/9474356/2f24573d-ea09-4630-a0ca-ce6832a4ea54)

Has model notes:
![screenshot_tx16s_23-11-18_21-02-46](https://github.com/EdgeTX/edgetx/assets/9474356/cde942c7-9e08-4f50-9ce9-e842ece6489d)

Portrait layout has 9 slots so no resizing necessary.
