### PR TITLE
fix(color): Pre-flight check page does not always update.

### DIFF
--- a/radio/src/gui/colorlcd/preflight_checks.cpp
+++ b/radio/src/gui/colorlcd/preflight_checks.cpp
@@ -280,8 +280,7 @@ void SwitchWarnMatrix::onPress(uint8_t btn_id)
       bfSet(g_model.switchWarningState, newstate, 3 * sw, 3);
   SET_DIRTY();
 
-  // TODO: save state in object
-  setTextAndState(sw);
+  setTextAndState(btn_id);
 }
 
 bool SwitchWarnMatrix::isActive(uint8_t btn_id)


### PR DESCRIPTION
The switch section in the pre-flight check page would not update if one of the switches (except the last) was disabled or set as a toggle switch.
