### PR TITLE
fix(color): `TELE` navigation issue when editing top bar widgets

### DIFF
--- a/radio/src/gui/colorlcd/screen_user_interface.cpp
+++ b/radio/src/gui/colorlcd/screen_user_interface.cpp
@@ -136,9 +136,8 @@ void ScreenUserInterfacePage::build(FormWindow* window)
   auto line = window->newLine(&grid);
   new StaticText(line, rect_t{}, STR_TOP_BAR, 0, COLOR_THEME_PRIMARY1);
 
-  auto menu = this->menu;
   auto setupTopbarWidgets = new TextButton(line, rect_t{}, STR_SETUP_WIDGETS);
-  setupTopbarWidgets->setPressHandler([menu]() -> uint8_t {
+  setupTopbarWidgets->setPressHandler([=]() -> uint8_t {
       menu->deleteLater();
       new SetupTopBarWidgetsPage();
       return 0;

--- a/radio/src/gui/colorlcd/topbar.cpp
+++ b/radio/src/gui/colorlcd/topbar.cpp
@@ -87,3 +87,19 @@ void SetupTopBarWidgetsPage::deleteLater(bool detach, bool trash)
 
   storageDirty(EE_MODEL);
 }
+
+void SetupTopBarWidgetsPage::onEvent(event_t event)
+{
+#if defined(HARDWARE_KEYS)
+  if (event == EVT_KEY_FIRST(KEY_PAGEUP) || event == EVT_KEY_FIRST(KEY_PAGEDN) ||
+      event == EVT_KEY_FIRST(KEY_SYS) || event == EVT_KEY_FIRST(KEY_MODEL)) {
+    killEvents(event);
+  } else if (event == EVT_KEY_FIRST(KEY_TELE)) {
+    onCancel();
+  } else {
+    FormWindow::onEvent(event);
+  }
+#else
+  FormWindow::onEvent(event);
+#endif
+}

--- a/radio/src/gui/colorlcd/topbar.h
+++ b/radio/src/gui/colorlcd/topbar.h
@@ -48,5 +48,6 @@ class SetupTopBarWidgetsPage : public FormWindow
 
   void onClicked() override;
   void onCancel() override;
+  void onEvent(event_t event)  override;
   void deleteLater(bool detach = true, bool trash = true) override;
 };


### PR DESCRIPTION
Pressing the TELE button while editing top bar widgets opens a new copy of the screen setup page instead of returning to the previous one.

It then takes two presses of the RTN button to close back to the main view.
