### PR TITLE
fix(color): Progress bar position/size on firmware flasher dialog

### DIFF
--- a/radio/src/gui/colorlcd/radio_sdmanager.cpp
+++ b/radio/src/gui/colorlcd/radio_sdmanager.cpp
@@ -117,7 +117,7 @@ class FlashDialog: public FullScreenDialog
     explicit FlashDialog(const T & device):
       FullScreenDialog(WARNING_TYPE_INFO, STR_FLASH_DEVICE),
       device(device),
-      progress(this, {LCD_W / 2 - 50, LCD_H / 2, 100, 32})
+      progress(this, {LCD_W / 2 - 50, LCD_H / 2 + 27, 100, 32})
     {
     }
 

--- a/radio/src/gui/colorlcd/radio_sdmanager.cpp
+++ b/radio/src/gui/colorlcd/radio_sdmanager.cpp
@@ -117,7 +117,7 @@ class FlashDialog: public FullScreenDialog
     explicit FlashDialog(const T & device):
       FullScreenDialog(WARNING_TYPE_INFO, STR_FLASH_DEVICE),
       device(device),
-      progress(this, {LCD_W / 2 - 50, LCD_H / 2 + 27, 100, 32})
+      progress(this, {LCD_W / 2 - 100, LCD_H / 2 + 27, 200, 32})
     {
     }
 


### PR DESCRIPTION
PR #4331 adjusted the positions of the text on the full screen dialog to better fit the switch warning text.

This affected the 'Flash Bootloader' dialog where the progress bar now overlaps the text.

This PR moves the progress bar to not cover the text.
