### PR TITLE
feat(color): Shortcut keys for text keyboard.

### DIFF
--- a/radio/src/gui/colorlcd/LvglWrapper.cpp
+++ b/radio/src/gui/colorlcd/LvglWrapper.cpp
@@ -147,6 +147,8 @@ static void keyboardDriverRead(lv_indev_drv_t *drv, lv_indev_data_t *data)
     bool is_lvgl_evt = evt_to_indev_data(evt, data);
     if (!is_lvgl_evt) {
       auto w = (Window*)lv_obj_get_user_data(obj);
+      // If no window, check for keyboard window
+      if (!w) w = Keyboard::keyboardWindow();
       dispatch_kb_event(w, evt);
       return;
     }

--- a/radio/src/thirdparty/libopenui/src/keyboard_base.h
+++ b/radio/src/thirdparty/libopenui/src/keyboard_base.h
@@ -31,6 +31,8 @@ class Keyboard : public Window
   void clearField();
   static void hide();
 
+  static Keyboard* keyboardWindow() { return activeKeyboard; }
+
  protected:
   static Keyboard *activeKeyboard;
 

--- a/radio/src/thirdparty/libopenui/src/keyboard_number.cpp
+++ b/radio/src/thirdparty/libopenui/src/keyboard_number.cpp
@@ -70,62 +70,114 @@ void NumberKeyboard::onEvent(event_t event)
 {
   NumberEdit* edit = (NumberEdit*)field;
 
+#if (defined(KEYS_GPIO_REG_PAGEUP) || defined(USE_HATS_AS_KEYS)) && !defined(PCBX12S)
+  // Radios with both PGUP and PGDN buttons except X12S
   switch (event) {
     case EVT_KEY_BREAK(KEY_SYS):
+      // "<<"
       edit->onEvent(EVT_VIRTUAL_KEY_BACKWARD);
-      break;
+    break;
 
     case EVT_KEY_LONG(KEY_SYS):
       killEvents(event);
+      // "MIN"
       edit->onEvent(EVT_VIRTUAL_KEY_MIN);
       break;
 
     case EVT_KEY_BREAK(KEY_MODEL):
+      // ">>"
       edit->onEvent(EVT_VIRTUAL_KEY_FORWARD);
       break;
 
     case EVT_KEY_LONG(KEY_MODEL):
       killEvents(event);
+      // "MAX"
       edit->onEvent(EVT_VIRTUAL_KEY_MAX);
       break;
 
     case EVT_KEY_BREAK(KEY_PAGEDN):
+      // "+"
       edit->onEvent(EVT_VIRTUAL_KEY_PLUS);
       break;
 
-// TODO: these need to go away!
-//  -> board code should map the keys as required
-#if defined(KEYS_GPIO_REG_PAGEUP) || defined(USE_HATS_AS_KEYS)
     case EVT_KEY_BREAK(KEY_PAGEUP):
-#else
-    case EVT_KEY_LONG(KEY_PAGEDN):
-      killEvents(event);
-#endif
+      // "-"
       edit->onEvent(EVT_VIRTUAL_KEY_MINUS);
       break;
 
-#if defined(KEYS_GPIO_REG_PAGEUP) || defined(USE_HATS_AS_KEYS)
-    case EVT_KEY_LONG(KEY_PAGEDN):
-      killEvents(event);
-      break;
-
-    case EVT_KEY_LONG(KEY_PAGEUP):
-      killEvents(event);
-      break;
-#endif
-
-    case EVT_KEY_BREAK(KEY_TELE):
+    case EVT_KEY_BREAK(KEY_TELE): 
+      // "+/-"
       edit->onEvent(EVT_VIRTUAL_KEY_SIGN);
-      break;
+    break;
 
     case EVT_KEY_LONG(KEY_TELE):
       killEvents(event);
+      // "DEF"
       edit->onEvent(EVT_VIRTUAL_KEY_DEFAULT);
       break;
 
     default:
       break;
   }
+
+#else
+  // Radios witb only a single PGUP/DN button or X12S
+  switch (event) {
+    case EVT_KEY_BREAK(KEY_SYS):
+      // "-"
+      edit->onEvent(EVT_VIRTUAL_KEY_MINUS);
+      break;
+
+    case EVT_KEY_LONG(KEY_SYS):
+      killEvents(event);
+      // "MIN"
+      edit->onEvent(EVT_VIRTUAL_KEY_MIN);
+      break;
+
+    case EVT_KEY_BREAK(KEY_MODEL):
+      // ">>"
+      edit->onEvent(EVT_VIRTUAL_KEY_FORWARD);
+    break;
+
+    case EVT_KEY_LONG(KEY_MODEL):
+      killEvents(event);
+      // "+/-"
+      edit->onEvent(EVT_VIRTUAL_KEY_SIGN);
+      break;
+
+#if defined(PCBX12S)
+    case EVT_KEY_BREAK(KEY_PAGEUP):
+#endif
+    case EVT_KEY_BREAK(KEY_PAGEDN):
+      // "<<"
+      edit->onEvent(EVT_VIRTUAL_KEY_BACKWARD);
+    break;
+
+#if defined(PCBX12S)
+    case EVT_KEY_LONG(KEY_PAGEUP):
+#endif
+    case EVT_KEY_LONG(KEY_PAGEDN):
+      killEvents(event);
+      // "DEF"
+      edit->onEvent(EVT_VIRTUAL_KEY_DEFAULT);
+      break;
+
+    case EVT_KEY_BREAK(KEY_TELE):
+      // "+"
+      edit->onEvent(EVT_VIRTUAL_KEY_PLUS);
+    break;
+
+    case EVT_KEY_LONG(KEY_TELE):
+      killEvents(event);
+      // "MAX"
+      edit->onEvent(EVT_VIRTUAL_KEY_MAX);
+    break;
+
+    default:
+      break;
+  }
+
+#endif
 }
 #endif
 

--- a/radio/src/thirdparty/libopenui/src/keyboard_number.h
+++ b/radio/src/thirdparty/libopenui/src/keyboard_number.h
@@ -35,5 +35,9 @@ class NumberKeyboard : public Keyboard
   static void show(NumberEdit* field);
 
  protected:
+#if defined(HARDWARE_KEYS)
+  void onEvent(event_t event) override;
+#endif
+
   static NumberKeyboard* _instance;
 };

--- a/radio/src/thirdparty/libopenui/src/keyboard_text.cpp
+++ b/radio/src/thirdparty/libopenui/src/keyboard_text.cpp
@@ -59,8 +59,8 @@ void TextKeyboard::onEvent(event_t event)
     case EVT_KEY_BREAK(KEY_PAGEUP):
 #else
     case EVT_KEY_LONG(KEY_PAGEDN):
-#endif
       killEvents(event);
+#endif
       lv_textarea_cursor_left(kb->ta);
       break;
 

--- a/radio/src/thirdparty/libopenui/src/keyboard_text.cpp
+++ b/radio/src/thirdparty/libopenui/src/keyboard_text.cpp
@@ -43,15 +43,10 @@ void TextKeyboard::onEvent(event_t event)
       lv_keyboard_set_mode(keyboard, mode);
     } break;
 
-    case EVT_KEY_BREAK(KEY_MODEL):
-      // Backspace
-      lv_textarea_del_char(kb->ta);
-      break;
-
     case EVT_KEY_LONG(KEY_MODEL):
       killEvents(event);
-      // Delete
-      lv_textarea_del_char_forward(kb->ta);
+      // Backspace
+      lv_textarea_del_char(kb->ta);
       break;
 
     case EVT_KEY_BREAK(KEY_PAGEDN):
@@ -89,6 +84,12 @@ void TextKeyboard::onEvent(event_t event)
         lv_textarea_cursor_left(kb->ta);
       }
     } break;
+
+    case EVT_KEY_LONG(KEY_TELE):
+      killEvents(event);
+      // Delete
+      lv_textarea_del_char_forward(kb->ta);
+      break;
 
     default:
       break;

--- a/radio/src/thirdparty/libopenui/src/keyboard_text.cpp
+++ b/radio/src/thirdparty/libopenui/src/keyboard_text.cpp
@@ -17,25 +17,81 @@
  */
 
 #include "keyboard_text.h"
-#include "textedit.h"
+
 #include "font.h"
+#include "textedit.h"
 
 constexpr coord_t KEYBOARD_HEIGHT = LCD_H * 2 / 5;
-TextKeyboard * TextKeyboard::_instance = nullptr;
+TextKeyboard* TextKeyboard::_instance = nullptr;
 
-TextKeyboard::TextKeyboard() :
-  Keyboard(KEYBOARD_HEIGHT)
-{
-}
+TextKeyboard::TextKeyboard() : Keyboard(KEYBOARD_HEIGHT) {}
 
-TextKeyboard::~TextKeyboard()
-{
-  _instance = nullptr;
-}
+TextKeyboard::~TextKeyboard() { _instance = nullptr; }
 
 #if defined(HARDWARE_KEYS)
 void TextKeyboard::onEvent(event_t event)
 {
+  lv_keyboard_t* kb = (lv_keyboard_t*)keyboard;
+
+  switch (event) {
+    case EVT_KEY_BREAK(KEY_SYS): {
+      lv_keyboard_mode_t mode = lv_keyboard_get_mode(keyboard);
+      mode = (mode + 1) & 3;
+      lv_keyboard_set_mode(keyboard, mode);
+    } break;
+
+    case EVT_KEY_BREAK(KEY_MODEL):
+      lv_textarea_del_char(kb->ta);
+      break;
+
+    case EVT_KEY_LONG(KEY_MODEL):
+      killEvents(event);
+      lv_textarea_del_char_forward(kb->ta);
+      break;
+
+    case EVT_KEY_BREAK(KEY_PAGEDN):
+      lv_textarea_cursor_right(kb->ta);
+      break;
+
+// TODO: these need to go away!
+//  -> board code should map the keys as required
+#if defined(KEYS_GPIO_REG_PAGEUP) || defined(USE_HATS_AS_KEYS)
+    case EVT_KEY_BREAK(KEY_PAGEUP):
+#else
+    case EVT_KEY_LONG(KEY_PAGEDN):
+#endif
+      killEvents(event);
+      lv_textarea_cursor_left(kb->ta);
+      break;
+
+#if defined(KEYS_GPIO_REG_PAGEUP) || defined(USE_HATS_AS_KEYS)
+    case EVT_KEY_LONG(KEY_PAGEDN): {
+      killEvents(event);
+      int l = strlen(lv_textarea_get_text(kb->ta));
+      while (lv_textarea_get_cursor_pos(kb->ta) < l)
+        lv_textarea_cursor_right(kb->ta);
+    } break;
+
+    case EVT_KEY_LONG(KEY_PAGEUP):
+      killEvents(event);
+      while (lv_textarea_get_cursor_pos(kb->ta) > 0)
+        lv_textarea_cursor_left(kb->ta);
+      break;
+#endif
+
+    case EVT_KEY_BREAK(KEY_TELE): {
+      char c = lv_textarea_get_text(kb->ta)[lv_textarea_get_cursor_pos(kb->ta)];
+      if (((c >= 'A') && (c <= 'Z')) || ((c >= 'a') && (c <= 'z'))) {
+        c ^= 0x20;
+        lv_textarea_del_char_forward(kb->ta);
+        lv_textarea_add_char(kb->ta, c);
+        lv_textarea_cursor_left(kb->ta);
+      }
+    } break;
+
+    default:
+      break;
+  }
 }
 #endif
 

--- a/radio/src/thirdparty/libopenui/src/keyboard_text.cpp
+++ b/radio/src/thirdparty/libopenui/src/keyboard_text.cpp
@@ -33,40 +33,40 @@ void TextKeyboard::onEvent(event_t event)
 {
   lv_keyboard_t* kb = (lv_keyboard_t*)keyboard;
 
+#if (defined(KEYS_GPIO_REG_PAGEUP) || defined(USE_HATS_AS_KEYS)) && !defined(PCBX12S)
+  // Radios with both PGUP and PGDN buttons except X12S
   switch (event) {
     case EVT_KEY_BREAK(KEY_SYS): {
+      // Change keyboard mode
       lv_keyboard_mode_t mode = lv_keyboard_get_mode(keyboard);
       mode = (mode + 1) & 3;
       lv_keyboard_set_mode(keyboard, mode);
     } break;
 
     case EVT_KEY_BREAK(KEY_MODEL):
+      // Backspace
       lv_textarea_del_char(kb->ta);
       break;
 
     case EVT_KEY_LONG(KEY_MODEL):
       killEvents(event);
+      // Delete
       lv_textarea_del_char_forward(kb->ta);
       break;
 
     case EVT_KEY_BREAK(KEY_PAGEDN):
+      // Cursor right
       lv_textarea_cursor_right(kb->ta);
       break;
 
-// TODO: these need to go away!
-//  -> board code should map the keys as required
-#if defined(KEYS_GPIO_REG_PAGEUP) || defined(USE_HATS_AS_KEYS)
     case EVT_KEY_BREAK(KEY_PAGEUP):
-#else
-    case EVT_KEY_LONG(KEY_PAGEDN):
-      killEvents(event);
-#endif
+      // Cursor left
       lv_textarea_cursor_left(kb->ta);
       break;
 
-#if defined(KEYS_GPIO_REG_PAGEUP) || defined(USE_HATS_AS_KEYS)
     case EVT_KEY_LONG(KEY_PAGEDN): {
       killEvents(event);
+      // Cursor to end
       int l = strlen(lv_textarea_get_text(kb->ta));
       while (lv_textarea_get_cursor_pos(kb->ta) < l)
         lv_textarea_cursor_right(kb->ta);
@@ -74,12 +74,13 @@ void TextKeyboard::onEvent(event_t event)
 
     case EVT_KEY_LONG(KEY_PAGEUP):
       killEvents(event);
+      // Cursor to start
       while (lv_textarea_get_cursor_pos(kb->ta) > 0)
         lv_textarea_cursor_left(kb->ta);
       break;
-#endif
 
     case EVT_KEY_BREAK(KEY_TELE): {
+      // Toggle case
       char c = lv_textarea_get_text(kb->ta)[lv_textarea_get_cursor_pos(kb->ta)];
       if (((c >= 'A') && (c <= 'Z')) || ((c >= 'a') && (c <= 'z'))) {
         c ^= 0x20;
@@ -92,6 +93,73 @@ void TextKeyboard::onEvent(event_t event)
     default:
       break;
   }
+
+#else
+  // Radios witb only a single PGUP/DN button or X12S
+  switch (event) {
+    case EVT_KEY_BREAK(KEY_SYS):
+      // Cursor left
+      lv_textarea_cursor_left(kb->ta);
+      break;
+
+    case EVT_KEY_LONG(KEY_SYS):
+      killEvents(event);
+      // Cursor to start
+      while (lv_textarea_get_cursor_pos(kb->ta) > 0)
+        lv_textarea_cursor_left(kb->ta);
+      break;
+
+    case EVT_KEY_BREAK(KEY_MODEL): {
+      // Change keyboard mode
+      lv_keyboard_mode_t mode = lv_keyboard_get_mode(keyboard);
+      mode = (mode + 1) & 3;
+      lv_keyboard_set_mode(keyboard, mode);
+    } break;
+
+    case EVT_KEY_LONG(KEY_MODEL):
+      killEvents(event);
+      // Backspace
+      lv_textarea_del_char(kb->ta);
+      break;
+
+#if defined(PCBX12S)
+    case EVT_KEY_BREAK(KEY_PAGEUP):
+#endif
+    case EVT_KEY_BREAK(KEY_PAGEDN): {
+      // Toggle case
+      char c = lv_textarea_get_text(kb->ta)[lv_textarea_get_cursor_pos(kb->ta)];
+      if (((c >= 'A') && (c <= 'Z')) || ((c >= 'a') && (c <= 'z'))) {
+        c ^= 0x20;
+        lv_textarea_del_char_forward(kb->ta);
+        lv_textarea_add_char(kb->ta, c);
+        lv_textarea_cursor_left(kb->ta);
+      }
+    } break;
+
+    case EVT_KEY_LONG(KEY_PAGEDN):
+      killEvents(event);
+      // Delete
+      lv_textarea_del_char_forward(kb->ta);
+      break;
+
+    case EVT_KEY_BREAK(KEY_TELE): {
+      // Cursor right
+      lv_textarea_cursor_right(kb->ta);
+    } break;
+
+    case EVT_KEY_LONG(KEY_TELE): {
+      killEvents(event);
+      // Cursor to end
+      int l = strlen(lv_textarea_get_text(kb->ta));
+      while (lv_textarea_get_cursor_pos(kb->ta) < l)
+        lv_textarea_cursor_right(kb->ta);
+    } break;
+
+    default:
+      break;
+  }
+
+#endif
 }
 #endif
 


### PR DESCRIPTION
Fixes #2425
Resolves #265

Adds shortcuts to the text keyboard using the hardware keys.

Short press:
- PG>/PGDN - move cursor right
- PG</PGUP - move cursor left
- SYS - cycle through keyboard layouts (alpha uppercase, alpha lowercase, numbers & symbols, numeric)
- TELE - change case of selected character (upper to lower or lower to upper)
- MDL - delete character to the left of the cursor (backspace)

Long press:
- PG>/PGDN - move cursor to the end of the input
- PG</PGUP - move cursor to the start of the input
- MDL - delete currently selected character

Long press SYS and TELE are available if there are other shortcuts that might be useful.
