### PR TITLE
feat(color): Don't show popup when adding a widget to an empty slot.

### DIFF
--- a/radio/src/gui/colorlcd/widgets_setup.cpp
+++ b/radio/src/gui/colorlcd/widgets_setup.cpp
@@ -59,6 +59,7 @@ void SetupWidgetsPageSlot::addNewWidget(WidgetsContainer* container,
                                         uint8_t slotIndex)
 {
   Menu* menu = new Menu(parent);
+  menu->setTitle(STR_SELECT_WIDGET);
   for (auto factory : getRegisteredWidgets()) {
     menu->addLine(factory->getDisplayName(), [=]() {
       container->createWidget(slotIndex, factory);

--- a/radio/src/gui/colorlcd/widgets_setup.cpp
+++ b/radio/src/gui/colorlcd/widgets_setup.cpp
@@ -20,16 +20,15 @@
  */
 
 #include "widgets_setup.h"
-#include "menu_screen.h"
-#include "view_main.h"
-#include "widget_settings.h"
-#include "widget.h"
-
-#include "layer.h"
-#include "menu.h"
 
 #include "gui.h"
+#include "layer.h"
+#include "menu.h"
+#include "menu_screen.h"
 #include "translations.h"
+#include "view_main.h"
+#include "widget.h"
+#include "widget_settings.h"
 
 SetupWidgetsPageSlot::SetupWidgetsPageSlot(FormWindow* parent,
                                            const rect_t& rect,
@@ -37,41 +36,47 @@ SetupWidgetsPageSlot::SetupWidgetsPageSlot(FormWindow* parent,
                                            uint8_t slotIndex) :
     Button(parent, rect)
 {
-  setPressHandler([parent, container, slotIndex]() -> uint8_t {
-    Menu* menu = new Menu(parent);
-    menu->addLine(STR_SELECT_WIDGET, [=]() {
-      Menu* menu = new Menu(parent);
-      for (auto factory : getRegisteredWidgets()) {
-        menu->addLine(factory->getDisplayName(), [=]() {
-          container->createWidget(slotIndex, factory);
-          auto widget = container->getWidget(slotIndex);
-          if (widget->getOptions() && widget->getOptions()->name)
-            new WidgetSettings(parent, widget);
-        });
-      }
-    });
-
+  setPressHandler([=]() -> uint8_t {
     if (container->getWidget(slotIndex)) {
+      Menu* menu = new Menu(parent);
+      menu->addLine(STR_SELECT_WIDGET,
+                    [=]() { addNewWidget(container, slotIndex); });
       auto widget = container->getWidget(slotIndex);
       if (widget->getOptions() && widget->getOptions()->name)
         menu->addLine(STR_WIDGET_SETTINGS,
                       [=]() { new WidgetSettings(parent, widget); });
       menu->addLine(STR_REMOVE_WIDGET,
                     [=]() { container->removeWidget(slotIndex); });
+    } else {
+      addNewWidget(container, slotIndex);
     }
 
     return 0;
   });
 }
 
+void SetupWidgetsPageSlot::addNewWidget(WidgetsContainer* container,
+                                        uint8_t slotIndex)
+{
+  Menu* menu = new Menu(parent);
+  for (auto factory : getRegisteredWidgets()) {
+    menu->addLine(factory->getDisplayName(), [=]() {
+      container->createWidget(slotIndex, factory);
+      auto widget = container->getWidget(slotIndex);
+      if (widget->getOptions() && widget->getOptions()->name)
+        new WidgetSettings(parent, widget);
+    });
+  }
+}
+
 void SetupWidgetsPageSlot::paint(BitmapBuffer* dc)
 {
-  dc->drawRect(0, 0, width(), height(), 2, hasFocus() ? STASHED : SOLID, COLOR_THEME_FOCUS);
+  dc->drawRect(0, 0, width(), height(), 2, hasFocus() ? STASHED : SOLID,
+               COLOR_THEME_FOCUS);
 }
 
 SetupWidgetsPage::SetupWidgetsPage(uint8_t customScreenIdx) :
-    FormWindow(ViewMain::instance(), rect_t{}),
-    customScreenIdx(customScreenIdx)
+    FormWindow(ViewMain::instance(), rect_t{}), customScreenIdx(customScreenIdx)
 {
   Layer::push(this);
 
@@ -98,20 +103,16 @@ SetupWidgetsPage::SetupWidgetsPage(uint8_t customScreenIdx) :
         this->deleteLater();
         return 1;
       },
-      NO_FOCUS,
-      0, window_create);
+      NO_FOCUS, 0, window_create);
 #endif
 }
 
 void SetupWidgetsPage::onClicked()
 {
-  // block event forwarding (window is transparent)  
+  // block event forwarding (window is transparent)
 }
 
-void SetupWidgetsPage::onCancel()
-{
-  deleteLater();  
-}
+void SetupWidgetsPage::onCancel() { deleteLater(); }
 
 void SetupWidgetsPage::deleteLater(bool detach, bool trash)
 {
@@ -133,8 +134,9 @@ void SetupWidgetsPage::deleteLater(bool detach, bool trash)
 void SetupWidgetsPage::onEvent(event_t event)
 {
 #if defined(HARDWARE_KEYS)
-  if (event == EVT_KEY_FIRST(KEY_PAGEUP) || event == EVT_KEY_FIRST(KEY_PAGEDN) ||
-      event == EVT_KEY_FIRST(KEY_SYS) || event == EVT_KEY_FIRST(KEY_MODEL)) {
+  if (event == EVT_KEY_FIRST(KEY_PAGEUP) ||
+      event == EVT_KEY_FIRST(KEY_PAGEDN) || event == EVT_KEY_FIRST(KEY_SYS) ||
+      event == EVT_KEY_FIRST(KEY_MODEL)) {
     killEvents(event);
   } else if (event == EVT_KEY_FIRST(KEY_TELE)) {
     onCancel();

--- a/radio/src/gui/colorlcd/widgets_setup.h
+++ b/radio/src/gui/colorlcd/widgets_setup.h
@@ -21,8 +21,8 @@
 
 #pragma once
 
-#include "form.h"
 #include "button.h"
+#include "form.h"
 
 class ScreenMenu;
 class WidgetsContainer;
@@ -46,7 +46,7 @@ class SetupWidgetsPage : public FormWindow
  protected:
   uint8_t customScreenIdx;
   unsigned savedView = 0;
-  void onEvent(event_t event)  override;
+  void onEvent(event_t event) override;
 };
 
 class SetupWidgetsPageSlot : public Button
@@ -56,4 +56,7 @@ class SetupWidgetsPageSlot : public Button
                        WidgetsContainer* container, uint8_t slotIndex);
 
   void paint(BitmapBuffer* dc) override;
+
+ protected:
+  void addNewWidget(WidgetsContainer* container, uint8_t slotIndex);
 };


### PR DESCRIPTION
When editing the widget layout, clicking on an empty widget slot shows a popup with a single 'Select widget' option. Clicking this opens the popup to select which widget to add.

This PR bypasses the 'Select widget' popup and goes straight to the list of widgets to choose from.
