### PR TITLE
fix(color): Long press and filtering in new Switch Choice popup.

### DIFF
--- a/radio/src/gui/colorlcd/switchchoice.cpp
+++ b/radio/src/gui/colorlcd/switchchoice.cpp
@@ -76,13 +76,13 @@ class SwitchChoiceMenuToolbar : public MenuToolbar
 
     invertBtn->setPressHandler([=]() {
       lv_obj_clear_state(invertBtn->getLvObj(), LV_STATE_FOCUSED);
-      longPress();
+      invertChoice();
       return choice->inverted;
     });
 #endif
   }
 
-  void longPress()
+  void invertChoice()
   {
     SwitchChoice* switchChoice = (SwitchChoice*)choice;
     switchChoice->inverted = !switchChoice->inverted;
@@ -92,6 +92,14 @@ class SwitchChoiceMenuToolbar : public MenuToolbar
 #if defined(HARDWARE_TOUCH)
     invertBtn->check(switchChoice->inverted);
 #endif
+  }
+
+  void longPress()
+  {
+    lv_indev_t* indev = lv_indev_get_act();
+    if (indev->driver->type == LV_INDEV_TYPE_KEYPAD) {
+      invertChoice();
+    }
   }
 
  protected:
@@ -153,7 +161,6 @@ SwitchChoice::SwitchChoice(Window* parent, const rect_t& rect, int vmin,
           val = swtch;
         }
         if (val && (!isValueAvailable || isValueAvailable(val))) {
-          // if (filtered) fillMenu(menu);
           tb->resetFilter();
           menu->select(getIndexFromValue(val));
         }

--- a/radio/src/gui/colorlcd/switchchoice.h
+++ b/radio/src/gui/colorlcd/switchchoice.h
@@ -39,11 +39,12 @@ class SwitchChoice : public Choice
  protected:
   friend SwitchChoiceMenuToolbar;
 
-  bool inverted = false;
   bool inMenu = false;
 
   void setValue(int value) override;
   int getIntValue() const override;
+
+  void invertChoice();
 
 #if defined(DEBUG_WINDOWS)
   std::string getName() const override { return "SwitchChoice"; }

--- a/radio/src/thirdparty/libopenui/src/choice.cpp
+++ b/radio/src/thirdparty/libopenui/src/choice.cpp
@@ -201,7 +201,7 @@ void Choice::fillMenu(Menu* menu, const FilterFct& filter)
   selectedIx0 = -1;
   for (int i = vmin; i <= vmax; ++i) {
     if (filter && !filter(i)) continue;
-    if (isValueAvailable && !isValueAvailable(i)) continue;
+    if (isValueAvailable && !isValueAvailable(inverted ? -i : i)) continue;
     if (textHandler) {
       menu->addLineBuffered(textHandler(i), [=]() { setValue(i); });
     } else if (unsigned(i - vmin) < values.size()) {

--- a/radio/src/thirdparty/libopenui/src/choice.h
+++ b/radio/src/thirdparty/libopenui/src/choice.h
@@ -181,6 +181,8 @@ class Choice : public ChoiceBase
  protected:
   friend class MenuToolbar;
 
+  bool inverted = false;
+
   std::string getLabelText() override;
   std::vector<std::string> values;
   int vmin = 0;


### PR DESCRIPTION
The new Switch Choice popup has some teething issues addressed in this PR:
- The 'Invert' button can be inadvertently activated while scrolling the list on the touch screen (phantom long press trigger).
- The 'ON' and 'ONE' options were not being filtered out when the list was inverted (showed as '0').
