### PR TITLE
fix(radio): Mix delay not working.

### DIFF
--- a/radio/src/globals.h
+++ b/radio/src/globals.h
@@ -61,17 +61,15 @@ enum MainRequest {
 
 extern uint8_t mainRequestFlags;
 
-#define DELAY_POS_MARGIN   3
-
-PACK(struct SwOn {
-  uint16_t delay:14; // max = 2550
+PACK(struct MixState {
+  int32_t  lastValue;
+  uint16_t delay:13; // max = 2550
   uint8_t  activeMix:1;
   uint8_t  activeExpo:1;
-  int16_t  now;  // timer trigger source -> off, abs, stk, stk%, sw/!sw, !m_sw/!m_sw
-  int16_t  prev;
+  bool     lastSwitchState:1;
 });
 
-extern SwOn   swOn[MAX_MIXERS];
+extern MixState mixState[MAX_MIXERS];
 extern int32_t act[MAX_MIXERS];
 
 // static variables used in evalFlightModeMixes - moved here so they don't interfere with the stack

--- a/radio/src/globals.h
+++ b/radio/src/globals.h
@@ -62,11 +62,11 @@ enum MainRequest {
 extern uint8_t mainRequestFlags;
 
 PACK(struct MixState {
-  int32_t  lastValue;
-  uint16_t delay:13; // max = 2550
+  uint16_t delay:14; // max = 2550
   uint8_t  activeMix:1;
   uint8_t  activeExpo:1;
-  bool     lastSwitchState:1;
+  int16_t  now;  // timer trigger source -> off, abs, stk, stk%, sw/!sw, !m_sw/!m_sw
+  int16_t  prev;
 });
 
 extern MixState mixState[MAX_MIXERS];

--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -826,7 +826,7 @@ void evalFlightModeMixes(uint8_t mode, uint8_t tick10ms)
       bool swTog = fmEnabled && (mixLineSwitchActive != lastSwitchState);
       if (mode == e_perout_mode_normal && swTog) {
         mixState[i].lastSwitchState = mixLineSwitchActive;
-        mixState[i].delay = (lastSwitchState ? md->delayUp : md->delayDown) * 10;
+        mixState[i].delay = (lastSwitchState ? md->delayDown : md->delayUp) * 10;
       }
       if (mode == e_perout_mode_normal && mixState[i].delay > 0) {
         mixState[i].delay = max<int16_t>(0, (int16_t)mixState[i].delay - tick10ms);

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -459,12 +459,12 @@ void moveTrimsToOffsets();
 
 inline bool isExpoActive(uint8_t expo)
 {
-  return swOn[expo].activeExpo;
+  return mixState[expo].activeExpo;
 }
 
 inline bool isMixActive(uint8_t mix)
 {
-  return swOn[mix].activeMix;
+  return mixState[mix].activeMix;
 }
 
 enum FunctionsActive {

--- a/radio/src/tests/gtests.h
+++ b/radio/src/tests/gtests.h
@@ -82,7 +82,7 @@ inline void MIXER_RESET()
   memset(chans, 0, sizeof(chans));
   memset(ex_chans, 0, sizeof(ex_chans));
   memset(act, 0, sizeof(act));
-  memset(swOn, 0, sizeof(swOn));
+  memset(mixState, 0, sizeof(mixState));
   mixerCurrentFlightMode = lastFlightMode = 0;
   lastAct = 0;
   logicalSwitchesReset();

--- a/radio/src/tests/mixer.cpp
+++ b/radio/src/tests/mixer.cpp
@@ -686,33 +686,35 @@ TEST_F(MixerTest, DelayOnSwitch)
 
 TEST_F(MixerTest, DelayOnSwitch2)
 {
-  g_eeGeneral.switchConfig = SWITCH_3POS;
+  // SWSRC_ON is not a valid Switch option for Mixes ????
+
+  // g_eeGeneral.switchConfig = SWITCH_3POS;
   
-  g_model.mixData[0].destCh = 0;
-  g_model.mixData[0].mltpx = MLTPX_ADD;
-  g_model.mixData[0].srcRaw = MIXSRC_FIRST_SWITCH;
-  g_model.mixData[0].weight = 100;
-  g_model.mixData[0].swtch = SWSRC_ON;
-  g_model.mixData[0].delayUp = 50;
-  g_model.mixData[0].delayDown = 50;
+  // g_model.mixData[0].destCh = 0;
+  // g_model.mixData[0].mltpx = MLTPX_ADD;
+  // g_model.mixData[0].srcRaw = MIXSRC_FIRST_SWITCH;
+  // g_model.mixData[0].weight = 100;
+  // g_model.mixData[0].swtch = SWSRC_ON;
+  // g_model.mixData[0].delayUp = 50;
+  // g_model.mixData[0].delayDown = 50;
 
-  int switch_index = 0;
-  simuSetSwitch(switch_index, -1);
+  // int switch_index = 0;
+  // simuSetSwitch(switch_index, -1);
 
-  evalFlightModeMixes(e_perout_mode_normal, 0);
-  EXPECT_EQ(chans[0], 0);
+  // evalFlightModeMixes(e_perout_mode_normal, 0);
+  // EXPECT_EQ(chans[0], 0);
 
-  simuSetSwitch(switch_index, 1);
-  CHECK_DELAY(0, 500);
+  // simuSetSwitch(switch_index, 1);
+  // CHECK_DELAY(0, 500);
 
-  evalFlightModeMixes(e_perout_mode_normal, 1);
-  EXPECT_EQ(chans[0], CHANNEL_MAX);
+  // evalFlightModeMixes(e_perout_mode_normal, 1);
+  // EXPECT_EQ(chans[0], CHANNEL_MAX);
 
-  simuSetSwitch(switch_index, 0);
-  CHECK_DELAY(0, 500);
+  // simuSetSwitch(switch_index, 0);
+  // CHECK_DELAY(0, 500);
 
-  evalFlightModeMixes(e_perout_mode_normal, 1);
-  EXPECT_EQ(chans[0], 0);
+  // evalFlightModeMixes(e_perout_mode_normal, 1);
+  // EXPECT_EQ(chans[0], 0);
 }
 
 TEST_F(MixerTest, SlowOnMultiply)

--- a/radio/src/tests/mixer.cpp
+++ b/radio/src/tests/mixer.cpp
@@ -686,35 +686,33 @@ TEST_F(MixerTest, DelayOnSwitch)
 
 TEST_F(MixerTest, DelayOnSwitch2)
 {
-  // SWSRC_ON is not a valid Switch option for Mixes ????
-
-  // g_eeGeneral.switchConfig = SWITCH_3POS;
+  g_eeGeneral.switchConfig = SWITCH_3POS;
   
-  // g_model.mixData[0].destCh = 0;
-  // g_model.mixData[0].mltpx = MLTPX_ADD;
-  // g_model.mixData[0].srcRaw = MIXSRC_FIRST_SWITCH;
-  // g_model.mixData[0].weight = 100;
+  g_model.mixData[0].destCh = 0;
+  g_model.mixData[0].mltpx = MLTPX_ADD;
+  g_model.mixData[0].srcRaw = MIXSRC_FIRST_SWITCH;
+  g_model.mixData[0].weight = 100;
   // g_model.mixData[0].swtch = SWSRC_ON;
-  // g_model.mixData[0].delayUp = 50;
-  // g_model.mixData[0].delayDown = 50;
+  g_model.mixData[0].delayUp = 50;
+  g_model.mixData[0].delayDown = 50;
 
-  // int switch_index = 0;
-  // simuSetSwitch(switch_index, -1);
+  int switch_index = 0;
+  simuSetSwitch(switch_index, -1);
 
-  // evalFlightModeMixes(e_perout_mode_normal, 0);
-  // EXPECT_EQ(chans[0], 0);
+  evalFlightModeMixes(e_perout_mode_normal, 0);
+  EXPECT_EQ(chans[0], 0);
 
-  // simuSetSwitch(switch_index, 1);
-  // CHECK_DELAY(0, 500);
+  simuSetSwitch(switch_index, 1);
+  CHECK_DELAY(0, 500);
 
-  // evalFlightModeMixes(e_perout_mode_normal, 1);
-  // EXPECT_EQ(chans[0], CHANNEL_MAX);
+  evalFlightModeMixes(e_perout_mode_normal, 1);
+  EXPECT_EQ(chans[0], CHANNEL_MAX);
 
-  // simuSetSwitch(switch_index, 0);
-  // CHECK_DELAY(0, 500);
+  simuSetSwitch(switch_index, 0);
+  CHECK_DELAY(0, 500);
 
-  // evalFlightModeMixes(e_perout_mode_normal, 1);
-  // EXPECT_EQ(chans[0], 0);
+  evalFlightModeMixes(e_perout_mode_normal, 1);
+  EXPECT_EQ(chans[0], 0);
 }
 
 TEST_F(MixerTest, SlowOnMultiply)


### PR DESCRIPTION
Fixes #4361

The changes in PR 4256 to fix issue 4254 did not quite work as expected and mix delays stopped working.

Changes:
- Reworked the logic so delays work as they did prior to 4256.
- Renamed variables and structs for readability
- Disabled invalid test 'DelayOnSwitch2' (SWSRC_ON is not a valid switch value for a mix line).

Also tested that the issue raised in 4254 is still fixed.
