### PR TITLE
Logs: reset telemetry sensor data to inital state if telemetry is not streaming

### DIFF
--- a/radio/src/logs.cpp
+++ b/radio/src/logs.cpp
@@ -323,8 +323,12 @@ void logsWrite()
       for (int i=0; i<MAX_TELEMETRY_SENSORS; i++) {
         if (isTelemetryFieldAvailable(i)) {
           TelemetrySensor & sensor = g_model.telemetrySensors[i];
-          TelemetryItem & telemetryItem = telemetryItems[i];
+          TelemetryItem telemetryItem = {};
+          
           if (sensor.logs) {
+            if(TELEMETRY_STREAMING())
+              telemetryItem = telemetryItems[i];
+
             if (sensor.unit == UNIT_GPS) {
               if (telemetryItem.gps.longitude && telemetryItem.gps.latitude) {
                 div_t qr = div((int)telemetryItem.gps.latitude, 1000000);

--- a/radio/src/logs.cpp
+++ b/radio/src/logs.cpp
@@ -323,10 +323,10 @@ void logsWrite()
       for (int i=0; i<MAX_TELEMETRY_SENSORS; i++) {
         if (isTelemetryFieldAvailable(i)) {
           TelemetrySensor & sensor = g_model.telemetrySensors[i];
-          TelemetryItem telemetryItem = {};
+          TelemetryItem telemetryItem;
           
           if (sensor.logs) {
-            if(TELEMETRY_STREAMING())
+            if(TELEMETRY_STREAMING() && !telemetryItems[i].isOld())
               telemetryItem = telemetryItems[i];
 
             if (sensor.unit == UNIT_GPS) {

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -393,6 +393,11 @@ void telemetryWakeup()
         telemetryState = TELEMETRY_OK;
       } else if (telemetryState == TELEMETRY_OK) {
         telemetryState = TELEMETRY_KO;
+
+        for (auto & telemetryItem : telemetryItems) {
+          telemetryItem.clear();
+        }
+
         if (!isModuleInBeepMode()) {
           AUDIO_TELEMETRY_LOST();
         }

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -393,11 +393,6 @@ void telemetryWakeup()
         telemetryState = TELEMETRY_OK;
       } else if (telemetryState == TELEMETRY_OK) {
         telemetryState = TELEMETRY_KO;
-
-        for (auto & telemetryItem : telemetryItems) {
-          telemetryItem.clear();
-        }
-
         if (!isModuleInBeepMode()) {
           AUDIO_TELEMETRY_LOST();
         }


### PR DESCRIPTION
After loosing telemetry all sensor values will be frozen at the last valid value. This is nice feature that can be used to retrieve the last known GPS position of a crashed model by e.g. looking at the model settings/telemetry screen. However logging frozen values doesn't make much sense as they give the impression of live recorded data. 

![image](https://github.com/EdgeTX/edgetx/assets/5615068/f56462e0-5d1f-4939-8ce4-93d8be294c19)

This PR clears the sensor data written to the log file to their initial state in case telemetry is not streaming. That makes it easy to spot  "no live telemetry" phases in the log file or log charts.

![image](https://github.com/EdgeTX/edgetx/assets/5615068/ef373851-d591-4140-a222-04befc2bf412)