### PR TITLE
fix(mt12): RGB LEDS not available as SF function.

### DIFF
--- a/radio/src/dataconstants.h
+++ b/radio/src/dataconstants.h
@@ -605,7 +605,7 @@ enum Functions {
 #if defined(DEBUG)
   FUNC_MAX SKIP
 #else
-  FUNC_MAX SKIP = FUNC_TEST - 1
+  FUNC_MAX SKIP = FUNC_TEST
 #endif
 };
 


### PR DESCRIPTION
Fix incorrect value for FUNC_MAX.

Fixes #4380 
