### PR TITLE
chore: Remove unused LCD_DUAL_BUFFER

### DIFF
--- a/radio/src/gui/212x64/lcd.cpp
+++ b/radio/src/gui/212x64/lcd.cpp
@@ -39,13 +39,7 @@
   #include "switches.h"
 #endif
 
-#if (defined(PCBX9E) || defined(PCBX9DP)) && defined(LCD_DUAL_BUFFER)
-  pixel_t displayBuf1[DISPLAY_BUFFER_SIZE] __DMA;
-  pixel_t displayBuf2[DISPLAY_BUFFER_SIZE] __DMA;
-  pixel_t * displayBuf = displayBuf1;
-#else
-  pixel_t displayBuf[DISPLAY_BUFFER_SIZE] __DMA;
-#endif
+pixel_t displayBuf[DISPLAY_BUFFER_SIZE] __DMA;
 
 inline bool lcdIsPointOutside(coord_t x, coord_t y)
 {

--- a/radio/src/gui/212x64/lcd.h
+++ b/radio/src/gui/212x64/lcd.h
@@ -88,14 +88,7 @@
 
 #define DISPLAY_BUFFER_SIZE            (LCD_W*LCD_H*4/8)
 
-#if (defined(PCBX9E) || defined(PCBX9DP)) && defined(LCD_DUAL_BUFFER)
-  extern pixel_t displayBuf1[DISPLAY_BUFFER_SIZE];
-  extern pixel_t displayBuf2[DISPLAY_BUFFER_SIZE];
-  extern pixel_t * displayBuf;
-#else
-  extern pixel_t displayBuf[DISPLAY_BUFFER_SIZE];
-#endif
-
+extern pixel_t displayBuf[DISPLAY_BUFFER_SIZE];
 extern coord_t lcdLastRightPos;
 extern coord_t lcdLastLeftPos;
 extern coord_t lcdNextPos;

--- a/radio/src/targets/taranis/CMakeLists.txt
+++ b/radio/src/targets/taranis/CMakeLists.txt
@@ -1,5 +1,4 @@
 option(SHUTDOWN_CONFIRMATION "Shutdown confirmation" OFF)
-option(LCD_DUAL_BUFFER "Dual LCD Buffer" OFF)
 option(PXX1 "PXX1 protocol support" ON)
 option(PXX2 "PXX2 protocol support" OFF)
 option(AFHDS3 "AFHDS3 TX Module" OFF)
@@ -613,9 +612,5 @@ set(FIRMWARE_SRC
   targets/common/arm/stm32/sdcard_spi.cpp
   targets/common/arm/stm32/diskio_spi.cpp
   )
-
-if(LCD_DUAL_BUFFER)
-  add_definitions(-DLCD_DUAL_BUFFER)
-endif()
 
 set(RADIO_DEPENDENCIES ${RADIO_DEPENDENCIES} ${BITMAPS_TARGET})

--- a/radio/src/targets/taranis/board.h
+++ b/radio/src/targets/taranis/board.h
@@ -421,8 +421,8 @@ void lcdInit();
 void lcdInitFinish();
 void lcdOff();
 
-// TODO lcdRefreshWait() stub in simpgmspace and remove LCD_DUAL_BUFFER
-#if defined(LCD_DMA) && !defined(LCD_DUAL_BUFFER) && !defined(SIMU)
+// TODO lcdRefreshWait() stub in simpgmspace
+#if defined(LCD_DMA) && !defined(SIMU)
 void lcdRefreshWait();
 #else
 #define lcdRefreshWait()

--- a/radio/src/targets/taranis/lcd_driver_spi.cpp
+++ b/radio/src/targets/taranis/lcd_driver_spi.cpp
@@ -204,12 +204,10 @@ void lcdWriteAddress(uint8_t x, uint8_t y)
 
 volatile bool lcd_busy;
 
-#if !defined(LCD_DUAL_BUFFER)
 void lcdRefreshWait()
 {
   WAIT_FOR_DMA_END();
 }
-#endif
 
 void lcdRefresh(bool wait)
 {
@@ -256,12 +254,6 @@ void lcdRefresh(bool wait)
 
   LCD_DMA_Stream->CR &= ~DMA_SxCR_EN; // Disable DMA
   LCD_DMA->HIFCR = LCD_DMA_FLAGS; // Write ones to clear bits
-
-#if defined(LCD_DUAL_BUFFER)
-  // Switch LCD buffer
-  LCD_DMA_Stream->M0AR = (uint32_t)displayBuf;
-  displayBuf = (displayBuf == displayBuf1) ? displayBuf2 : displayBuf1;
-#endif
 
   LCD_DMA_Stream->CR |= DMA_SxCR_EN | DMA_SxCR_TCIE; // Enable DMA & TC interrupts
   LCD_SPI->CR2 |= SPI_CR2_TXDMAEN;


### PR DESCRIPTION
Removes unused build time option LCD_DUAL_BUFFER, that was historically implemented for B/W 212x64 pixel X9E and X9D+, but by default disabled.