### PR TITLE
fix(color): Wrong input could be used for updating curve preview

### DIFF
--- a/radio/src/gui/colorlcd/curveedit.cpp
+++ b/radio/src/gui/colorlcd/curveedit.cpp
@@ -230,6 +230,7 @@ CurveEditWindow::CurveEditWindow(uint8_t index):
   Page(ICON_MODEL_CURVES),
   index(index)
 {
+  CurveEdit::SetCurrentSource(0);
   buildBody(&body);
   buildHeader(&header);
 }

--- a/radio/src/gui/colorlcd/curveedit.cpp
+++ b/radio/src/gui/colorlcd/curveedit.cpp
@@ -230,7 +230,6 @@ CurveEditWindow::CurveEditWindow(uint8_t index):
   Page(ICON_MODEL_CURVES),
   index(index)
 {
-  CurveEdit::SetCurrentSource(0);
   buildBody(&body);
   buildHeader(&header);
 }

--- a/radio/src/gui/colorlcd/input_edit.cpp
+++ b/radio/src/gui/colorlcd/input_edit.cpp
@@ -159,3 +159,11 @@ void InputEditWindow::buildBody(FormWindow* form)
   });
   lv_obj_set_width(btn->getLvObj(), lv_pct(100));
 }
+
+void InputEditWindow::deleteLater(bool detach, bool trash)
+{
+  if (!deleted()) {
+    CurveEdit::SetCurrentSource(0);
+    Page::deleteLater(detach, trash);
+  }
+}

--- a/radio/src/gui/colorlcd/input_edit.h
+++ b/radio/src/gui/colorlcd/input_edit.h
@@ -38,4 +38,6 @@ class InputEditWindow : public Page
   Curve* preview;
 
   void buildBody(FormWindow *window);
+
+  void deleteLater(bool detach = true, bool trash = true) override;
 };

--- a/radio/src/gui/colorlcd/mixer_edit.cpp
+++ b/radio/src/gui/colorlcd/mixer_edit.cpp
@@ -113,6 +113,7 @@ void MixEditWindow::buildBody(FormWindow* form)
   new StaticText(line, rect_t{}, STR_SOURCE, 0, COLOR_THEME_PRIMARY1);
   new SourceChoice(line, rect_t{}, 0, MIXSRC_LAST,
                    GET_SET_DEFAULT(mix->srcRaw));
+  CurveEdit::SetCurrentSource(mix->srcRaw);
 
   // Weight
   line = form->newLine(&grid);
@@ -144,4 +145,12 @@ void MixEditWindow::buildBody(FormWindow* form)
     return 0;
   });
   lv_obj_set_width(btn->getLvObj(), lv_pct(100));
+}
+
+void MixEditWindow::deleteLater(bool detach, bool trash)
+{
+  if (!deleted()) {
+    CurveEdit::SetCurrentSource(0);
+    Page::deleteLater(detach, trash);
+  }
 }

--- a/radio/src/gui/colorlcd/mixer_edit.cpp
+++ b/radio/src/gui/colorlcd/mixer_edit.cpp
@@ -113,7 +113,6 @@ void MixEditWindow::buildBody(FormWindow* form)
   new StaticText(line, rect_t{}, STR_SOURCE, 0, COLOR_THEME_PRIMARY1);
   new SourceChoice(line, rect_t{}, 0, MIXSRC_LAST,
                    GET_SET_DEFAULT(mix->srcRaw));
-  CurveEdit::SetCurrentSource(mix->srcRaw);
 
   // Weight
   line = form->newLine(&grid);

--- a/radio/src/gui/colorlcd/mixer_edit.h
+++ b/radio/src/gui/colorlcd/mixer_edit.h
@@ -38,4 +38,6 @@ class MixEditWindow : public Page
 
   void buildHeader(Window *window);
   void buildBody(FormWindow *window);
+
+  void deleteLater(bool detach = true, bool trash = true) override;
 };


### PR DESCRIPTION
When editing a curve, moving any of the sticks will then attach that axis to the curve preview position and update the position as the stick is moved.

However if an input is edited first the curve preview becomes locked to the input source, and then in the curve edit page only this input source will move the preview position.

Also removes redundant (related) code in the mix editor.
