### PR TITLE
fix(bw128): Show first 4 trims when radio has > 4 trims

### DIFF
--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -217,6 +217,13 @@ void displayTrims(uint8_t phase)
           lcdDrawSolidVerticalLine(xm + 2, ym - 1, 3);
           lcdDrawSolidVerticalLine(xm + 3, ym - 2, 5);
         }
+        if (g_model.displayTrims != DISPLAY_TRIMS_NEVER && dir != 0 && i < 4) {
+          if (g_model.displayTrims == DISPLAY_TRIMS_ALWAYS ||
+              (trimsDisplayTimer > 0 && (trimsDisplayMask & (1 << i)))) {
+            lcdDrawNumber(dir > 0 ? 12 : 40, xm - 2, -abs(dir),
+                          TINSIZE | VERTICAL);
+          }
+        }
       }
     }
     else {
@@ -259,6 +266,15 @@ void displayTrims(uint8_t phase)
           lcdDrawSolidHorizontalLine(xm, ym - 1, 1);
           lcdDrawSolidHorizontalLine(xm - 1, ym - 2, 3);
           lcdDrawSolidHorizontalLine(xm - 2, ym - 3, 5);
+        }
+        if (g_model.displayTrims != DISPLAY_TRIMS_NEVER && dir != 0 && i < 4) {
+          if (g_model.displayTrims == DISPLAY_TRIMS_ALWAYS ||
+              (trimsDisplayTimer > 0 && (trimsDisplayMask & (1 << i)))) {
+            lcdDrawNumber(
+                (xm < LCD_W / 2 ? (dir > 0 ? TRIM_LH_POS : TRIM_LH_NEG)
+                                 : (dir > 0 ? TRIM_RH_POS : TRIM_RH_NEG)),
+                ym - 2, -abs(dir), TINSIZE);
+          }
         }
       }
     }


### PR DESCRIPTION
On radio with more than 4 trims (MT12, T20,..), obey trim value display settings for the first 4 trims (the others are not displaying values no matter the settings)