### PR TITLE
feat(color): Run widget 'background' function while in setup pages.

### DIFF
--- a/radio/src/gui/colorlcd/model_outputs.cpp
+++ b/radio/src/gui/colorlcd/model_outputs.cpp
@@ -232,7 +232,7 @@ class OutputLineButton : public ListLineButton
 
   void checkEvents() override
   {
-    Window::checkEvents();
+    ListLineButton::checkEvents();
     if (!init) return;
 
     int newValue = channelOutputs[index];

--- a/radio/src/gui/colorlcd/page.cpp
+++ b/radio/src/gui/colorlcd/page.cpp
@@ -24,6 +24,7 @@
 #include "keyboard_base.h"
 #include "opentx.h"
 #include "theme.h"
+#include "view_main.h"
 
 PageHeader::PageHeader(Page * parent, uint8_t icon):
   FormWindow(parent, { 0, 0, LCD_W, MENU_HEADER_HEIGHT }, OPAQUE),
@@ -94,3 +95,9 @@ void Page::onCancel()
 }
 
 void Page::onClicked() { Keyboard::hide(false); }
+
+void Page::checkEvents()
+{
+  ViewMain::instance()->runBackground();
+  NavWindow::checkEvents();
+}

--- a/radio/src/gui/colorlcd/page.h
+++ b/radio/src/gui/colorlcd/page.h
@@ -63,6 +63,7 @@ class Page : public NavWindow
   PageHeader header;
   FormWindow body;
 
+  void checkEvents() override;
   bool bubbleEvents() override { return false; }
 };
 

--- a/radio/src/gui/colorlcd/radio_theme.cpp
+++ b/radio/src/gui/colorlcd/radio_theme.cpp
@@ -401,7 +401,7 @@ class ThemeEditPage : public Page
         started = true;
         _themeName->setText(_theme.getName());
       }
-      Window::checkEvents();
+      Page::checkEvents();
     }
 
     void editColorPage()

--- a/radio/src/gui/colorlcd/tabsgroup.cpp
+++ b/radio/src/gui/colorlcd/tabsgroup.cpp
@@ -255,6 +255,7 @@ void TabsGroup::checkEvents()
   if (currentTab) {
     currentTab->checkEvents();
   }
+  ViewMain::instance()->runBackground();
 
   static uint32_t lastRefresh = 0;
   uint32_t now = RTOS_GET_MS();

--- a/radio/src/gui/colorlcd/trainer_bluetooth.cpp
+++ b/radio/src/gui/colorlcd/trainer_bluetooth.cpp
@@ -116,6 +116,7 @@ void BluetoothTrainerWindow::checkEvents()
     refresh();
   lastbtstate = bluetooth.state;
   devcount = reusableBuffer.moduleSetup.bt.devicesCount;
+  Window::checkEvents();
 }
 
 void BluetoothTrainerWindow::refresh()

--- a/radio/src/gui/colorlcd/view_main.cpp
+++ b/radio/src/gui/colorlcd/view_main.cpp
@@ -379,3 +379,12 @@ void ViewMain::long_pressed(lv_event_t* e)
     lv_indev_wait_release(lv_indev_get_act());
   }
 }
+
+void ViewMain::runBackground()
+{
+  topbar->runBackground();
+  for (int i = 0; i < MAX_CUSTOM_SCREENS; i += 1) {
+    if (customScreens[i])
+      customScreens[i]->runBackground();
+  }
+}

--- a/radio/src/gui/colorlcd/view_main.h
+++ b/radio/src/gui/colorlcd/view_main.h
@@ -78,6 +78,8 @@ class ViewMain : public NavWindow
   void onClicked() override;
   void onCancel() override;
 
+  void runBackground();
+
  protected:
   static ViewMain* _instance;
 

--- a/radio/src/gui/colorlcd/widgets/widgets_container_impl.h
+++ b/radio/src/gui/colorlcd/widgets/widgets_container_impl.h
@@ -145,6 +145,15 @@ class WidgetsContainerImpl : public WidgetsContainer
   void adjustLayout() override {}
   void updateFromTheme() override {};
 
+  void runBackground() override
+  {
+    for (int i = 0; i < N; i++) {
+      if (widgets[i]) {
+        widgets[i]->background();
+      }
+    }
+  }
+
  protected:
   PersistentData* persistentData;
   Widget* widgets[N] = {};

--- a/radio/src/gui/colorlcd/widgets_container.h
+++ b/radio/src/gui/colorlcd/widgets_container.h
@@ -89,6 +89,7 @@ class WidgetsContainer: public Window
     virtual void adjustLayout() = 0;
     virtual void updateZones() = 0;
     virtual void updateFromTheme() = 0;
+    virtual void runBackground() = 0;
 
     virtual bool isLayout() { return false; }
     bool isWidgetsContainer() override { return true; }


### PR DESCRIPTION
Fixes #4279 

All setup pages inherit from the Page or TabsGroup (via PageTab) classes. These block the main view so no main view updates are processed while in the setup pages.

This PR adds a function to call just the 'background' function for all active widgets when using the setup pages. It does not call any of the UI objects 'checkEvents' functions so the only overhead is the processing time each widget 'background' call takes. So long as the widgets are well behaved, and there is not an excessive number of them it should not significantly affect performance.

However it needs extensive testing on a variety of radios especially with complex widget setups (which I don't use).
