### PR TITLE
fix(color): Trim display inconsistent with B&W

### DIFF
--- a/radio/src/gui/colorlcd/layouts/trims.cpp
+++ b/radio/src/gui/colorlcd/layouts/trims.cpp
@@ -110,10 +110,10 @@ void MainViewHorizontalTrim::drawMarkerLines(BitmapBuffer * dc, coord_t x, coord
 {
   // Small lines on the square
   if (value >= 0) {
-    dc->drawSolidVerticalLine(x + 4, 3, 9, COLOR_THEME_PRIMARY2);
+    dc->drawSolidVerticalLine(x + 10, 3, 9, COLOR_THEME_PRIMARY2);
   }
   if (value <= 0) {
-    dc->drawSolidVerticalLine(x + 10, 3, 9, COLOR_THEME_PRIMARY2);
+    dc->drawSolidVerticalLine(x + 4, 3, 9, COLOR_THEME_PRIMARY2);
   }
 }
 


### PR DESCRIPTION
The marker bars on the color radio horizontal trim display work backwards compared to the B&W bars and the color vertical bar.

PR changes the color horizontal bar to match.

B&W:
![screenshot_x7_23-12-09_18-26-06](https://github.com/EdgeTX/edgetx/assets/9474356/c6747a05-3f46-4ded-a4a6-4d26e97a733f)

Color:
![screenshot_tx16s_23-12-09_18-36-19](https://github.com/EdgeTX/edgetx/assets/9474356/7f58754b-56f2-490f-9d45-ef30ef67e25e)
