### PR TITLE
fix(ws2812): Bit order of WS2812 data stream

### DIFF
--- a/radio/src/targets/common/arm/stm32/stm32_ws2812.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_ws2812.cpp
@@ -93,8 +93,8 @@ static uint8_t _led_seq_cnt;
 static void _fill_byte(uint8_t c, led_timer_value_t* dma_buffer)
 {
   for (int i = 0; i < 8; i++) {
-    dma_buffer[i] = c & 1 ? WS2812_ONE : WS2812_ZERO;
-    c >>= 1;
+    dma_buffer[i] = c & 0x80 ? WS2812_ONE : WS2812_ZERO;
+    c <<= 1;
   }
 }
 


### PR DESCRIPTION
Fixes #4399

(bit order of data sent to WS2812 was LSB first, which is wrong)

Summary of changes:

Sends MSB first, as per WS2812 datasheet