### PR TITLE
fix(b&w): Top left '!' warning always flashing on B&W simulators

### DIFF
--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -59,7 +59,7 @@
 #define CLOCK_X       53
 #define CLOCK_Y       57
 
-#if defined(ASTERISK) || !defined(USE_WATCHDOG) || defined(LOG_TELEMETRY) || \
+#if defined(ASTERISK) || (!defined(USE_WATCHDOG) && !defined(SIMU)) || defined(LOG_TELEMETRY) || \
     defined(LOG_BLUETOOTH) || defined(DEBUG_LATENCY)
 
 static bool isAsteriskDisplayed() {

--- a/radio/src/gui/212x64/view_main.cpp
+++ b/radio/src/gui/212x64/view_main.cpp
@@ -76,7 +76,7 @@ const unsigned char icons[]  = {
 #define ICON_REBOOT   91, 11
 #define ICON_ALTITUDE 102, 9
 
-#if defined(ASTERISK) || !defined(USE_WATCHDOG) || defined(LOG_TELEMETRY) || \
+#if defined(ASTERISK) || (!defined(USE_WATCHDOG) && !defined(SIMU)) || defined(LOG_TELEMETRY) || \
     defined(LOG_BLUETOOTH) || defined(DEBUG_LATENCY)
 
 static bool isAsteriskDisplayed() {


### PR DESCRIPTION
Caused by changes in PR #3846 
