### PR TITLE
chore(color): Change STR_CAL to STR_CALIBRATION on trainer page

### DIFF
--- a/radio/src/gui/colorlcd/radio_trainer.cpp
+++ b/radio/src/gui/colorlcd/radio_trainer.cpp
@@ -119,6 +119,6 @@ void RadioTrainerPage::build(FormWindow * form)
 #if LCD_H > LCD_W
   lv_obj_set_grid_cell(btn->getLvObj(), LV_GRID_ALIGN_STRETCH, 1, 2, LV_GRID_ALIGN_CENTER, 0, 1);
 #else
-  lv_obj_set_grid_cell(btn->getLvObj(), LV_GRID_ALIGN_STRETCH, 4, 1, LV_GRID_ALIGN_CENTER, 0, 1);
+  lv_obj_set_grid_cell(btn->getLvObj(), LV_GRID_ALIGN_START, 3, 2, LV_GRID_ALIGN_CENTER, 0, 1);
 #endif
 }

--- a/radio/src/gui/colorlcd/radio_trainer.cpp
+++ b/radio/src/gui/colorlcd/radio_trainer.cpp
@@ -38,12 +38,10 @@ RadioTrainerPage::RadioTrainerPage():
 static const lv_coord_t col_dsc[] = {LV_GRID_FR(7), LV_GRID_FR(13), LV_GRID_FR(10), LV_GRID_FR(10), LV_GRID_FR(10),
                                      LV_GRID_TEMPLATE_LAST};
                                      
-#define MULT_COL_CNT    3
 #define NUM_EDIT_W 80
 #else
 static const lv_coord_t col_dsc[] = {LV_GRID_FR(7), LV_GRID_FR(15), LV_GRID_FR(9), LV_GRID_FR(9),
                                      LV_GRID_TEMPLATE_LAST};
-#define MULT_COL_CNT    2
 #define NUM_EDIT_W 65
 #endif
 
@@ -98,12 +96,13 @@ void RadioTrainerPage::build(FormWindow * form)
   // Trainer multiplier
   auto lbl = new StaticText(line, rect_t{}, STR_MULTIPLIER, 0, COLOR_THEME_PRIMARY1);
   lbl->padRight(4);
-  lv_obj_set_grid_cell(lbl->getLvObj(), LV_GRID_ALIGN_END, 0, MULT_COL_CNT, LV_GRID_ALIGN_CENTER, 0, 1);
+  lv_obj_set_grid_cell(lbl->getLvObj(), LV_GRID_ALIGN_END, 0, 2, LV_GRID_ALIGN_CENTER, 0, 1);
+
   auto multiplier = new NumberEdit(line, rect_t{0, 0, NUM_EDIT_W, 0}, -10, 40,
                                    GET_SET_DEFAULT(g_eeGeneral.PPM_Multiplier));
   multiplier->setDisplayHandler(
       [](int32_t value) { return formatNumberAsString(value + 10, PREC1); });
-  lv_obj_set_grid_cell(multiplier->getLvObj(), LV_GRID_ALIGN_START, MULT_COL_CNT, 1, LV_GRID_ALIGN_CENTER, 0, 1);
+  lv_obj_set_grid_cell(multiplier->getLvObj(), LV_GRID_ALIGN_START, 2, 1, LV_GRID_ALIGN_CENTER, 0, 1);
 
 #if LCD_H > LCD_W
   line = form->newLine(&grid);
@@ -111,11 +110,15 @@ void RadioTrainerPage::build(FormWindow * form)
 #endif
 
   // Trainer calibration
-  auto btn = new TextButton(line, rect_t{0, 0, 0, 30}, std::string(STR_CAL), [=]() -> uint8_t {
+  auto btn = new TextButton(line, rect_t{}, std::string(STR_CALIBRATION), [=]() -> uint8_t {
     memcpy(g_eeGeneral.trainer.calib, trainerInput,
            sizeof(g_eeGeneral.trainer.calib));
     SET_DIRTY();
     return 0;
   });
-  lv_obj_set_grid_cell(btn->getLvObj(), LV_GRID_ALIGN_STRETCH, MULT_COL_CNT+1, 1, LV_GRID_ALIGN_CENTER, 0, 1);
+#if LCD_H > LCD_W
+  lv_obj_set_grid_cell(btn->getLvObj(), LV_GRID_ALIGN_STRETCH, 1, 2, LV_GRID_ALIGN_CENTER, 0, 1);
+#else
+  lv_obj_set_grid_cell(btn->getLvObj(), LV_GRID_ALIGN_STRETCH, 4, 1, LV_GRID_ALIGN_CENTER, 0, 1);
+#endif
 }


### PR DESCRIPTION
Resolves #4121 (remainder of) by switching string used, and moving the button around. 

![snapshot_01](https://github.com/EdgeTX/edgetx/assets/5500713/802b6c47-0c53-4c6b-92e5-e6c7714e9ec8)
![snapshot_01](https://github.com/EdgeTX/edgetx/assets/5500713/96335f28-1748-469b-a12a-0a82c2b28406)

@philmoz I'm open to suggestions/improvements if this can easily be made to look  nicer... focus was really just on making sure button was fully visible. Feel free to edit the PR if you wish. 