### PR TITLE
fix(color): Put LCD buffers at start of SDRAM

### DIFF
--- a/radio/src/boards/generic_stm32/linker/stm32f429_sdram/extra_sections.ld
+++ b/radio/src/boards/generic_stm32/linker/stm32f429_sdram/extra_sections.ld
@@ -14,6 +14,8 @@ INCLUDE section_ccm.ld
   . = ALIGN(4);
   *(.sdram)
   *(.sdram*)
+  *(.sdram_fonts)
+  *(.sdram_fonts*)
   *(.sdram_rodata)
   *(.sdram_rodata*)
 

--- a/radio/src/definitions.h
+++ b/radio/src/definitions.h
@@ -68,6 +68,9 @@
 
 #if defined(SDRAM) && !defined(SIMU)
   #define __SDRAM   __attribute__((section(".sdram"), aligned(4)))
+#if defined(COLORLCD)
+  #define __SDRAMFONTS  __attribute__((section(".sdram_fonts"), aligned(4)))
+#endif
 #else
   #define __SDRAM   __DMA
 #endif

--- a/radio/src/definitions.h
+++ b/radio/src/definitions.h
@@ -69,10 +69,13 @@
 #if defined(SDRAM) && !defined(SIMU)
   #define __SDRAM   __attribute__((section(".sdram"), aligned(4)))
 #if defined(COLORLCD)
-  #define __SDRAMFONTS  __attribute__((section(".sdram_fonts"), aligned(4)))
+  #define __SDRAMFONTS __attribute__((section(".sdram_fonts"), aligned(4)))
 #endif
 #else
   #define __SDRAM   __DMA
+#if defined(COLORLCD)
+  #define __SDRAMFONTS __DMA
+#endif
 #endif
 
 #if __GNUC__

--- a/radio/src/fonts/lvgl/lv_font_arimo_he_13.c
+++ b/radio/src/fonts/lvgl/lv_font_arimo_he_13.c
@@ -570,7 +570,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 1524, .range_length = 62127, .glyph_id_start = 141, .list_length = 63, .type = 3, .unicode_list = 1632, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[11869] __SDRAM;
+static uint8_t etxUncompBuf[11869] __SDRAMFONTS;
 
 const etxLz4Font lv_font_arimo_he_13 = {
 .uncomp_size = 11541,

--- a/radio/src/fonts/lvgl/lv_font_arimo_he_24.c
+++ b/radio/src/fonts/lvgl/lv_font_arimo_he_24.c
@@ -639,7 +639,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 1524, .range_length = 1, .glyph_id_start = 137, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[15388] __SDRAM;
+static uint8_t etxUncompBuf[15388] __SDRAMFONTS;
 
 const etxLz4Font lv_font_arimo_he_24 = {
 .uncomp_size = 15092,

--- a/radio/src/fonts/lvgl/lv_font_arimo_he_9.c
+++ b/radio/src/fonts/lvgl/lv_font_arimo_he_9.c
@@ -370,7 +370,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 1524, .range_length = 62127, .glyph_id_start = 141, .list_length = 63, .type = 3, .unicode_list = 1632, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[7418] __SDRAM;
+static uint8_t etxUncompBuf[7418] __SDRAMFONTS;
 
 const etxLz4Font lv_font_arimo_he_9 = {
 .uncomp_size = 7090,

--- a/radio/src/fonts/lvgl/lv_font_arimo_he_bold_16.c
+++ b/radio/src/fonts/lvgl/lv_font_arimo_he_bold_16.c
@@ -698,7 +698,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 1524, .range_length = 62127, .glyph_id_start = 141, .list_length = 63, .type = 3, .unicode_list = 1632, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[16507] __SDRAM;
+static uint8_t etxUncompBuf[16507] __SDRAMFONTS;
 
 const etxLz4Font lv_font_arimo_he_bold_16 = {
 .uncomp_size = 16179,

--- a/radio/src/fonts/lvgl/lv_font_arimo_he_bold_32.c
+++ b/radio/src/fonts/lvgl/lv_font_arimo_he_bold_32.c
@@ -733,7 +733,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 1524, .range_length = 1, .glyph_id_start = 124, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[22065] __SDRAM;
+static uint8_t etxUncompBuf[22065] __SDRAMFONTS;
 
 const etxLz4Font lv_font_arimo_he_bold_32 = {
 .uncomp_size = 21801,

--- a/radio/src/fonts/lvgl/lv_font_arimo_he_bold_64.c
+++ b/radio/src/fonts/lvgl/lv_font_arimo_he_bold_64.c
@@ -1161,7 +1161,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 176, .range_length = 1, .glyph_id_start = 96, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[64593] __SDRAM;
+static uint8_t etxUncompBuf[64593] __SDRAMFONTS;
 
 const etxLz4Font lv_font_arimo_he_bold_64 = {
 .uncomp_size = 64393,

--- a/radio/src/fonts/lvgl/lv_font_arimo_ru_13.c
+++ b/radio/src/fonts/lvgl/lv_font_arimo_ru_13.c
@@ -682,7 +682,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 1105, .range_length = 62546, .glyph_id_start = 177, .list_length = 63, .type = 3, .unicode_list = 1920, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[17343] __SDRAM;
+static uint8_t etxUncompBuf[17343] __SDRAMFONTS;
 
 const etxLz4Font lv_font_arimo_ru_13 = {
 .uncomp_size = 16983,

--- a/radio/src/fonts/lvgl/lv_font_arimo_ru_24.c
+++ b/radio/src/fonts/lvgl/lv_font_arimo_ru_24.c
@@ -814,7 +814,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 1105, .range_length = 1, .glyph_id_start = 173, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[24426] __SDRAM;
+static uint8_t etxUncompBuf[24426] __SDRAMFONTS;
 
 const etxLz4Font lv_font_arimo_ru_24 = {
 .uncomp_size = 24098,

--- a/radio/src/fonts/lvgl/lv_font_arimo_ru_9.c
+++ b/radio/src/fonts/lvgl/lv_font_arimo_ru_9.c
@@ -466,7 +466,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 1105, .range_length = 62546, .glyph_id_start = 177, .list_length = 63, .type = 3, .unicode_list = 1920, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[12168] __SDRAM;
+static uint8_t etxUncompBuf[12168] __SDRAMFONTS;
 
 const etxLz4Font lv_font_arimo_ru_9 = {
 .uncomp_size = 11808,

--- a/radio/src/fonts/lvgl/lv_font_arimo_ru_bold_16.c
+++ b/radio/src/fonts/lvgl/lv_font_arimo_ru_bold_16.c
@@ -829,7 +829,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 1105, .range_length = 62546, .glyph_id_start = 177, .list_length = 63, .type = 3, .unicode_list = 1920, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[23022] __SDRAM;
+static uint8_t etxUncompBuf[23022] __SDRAMFONTS;
 
 const etxLz4Font lv_font_arimo_ru_bold_16 = {
 .uncomp_size = 22662,

--- a/radio/src/fonts/lvgl/lv_font_arimo_ru_bold_32.c
+++ b/radio/src/fonts/lvgl/lv_font_arimo_ru_bold_32.c
@@ -923,7 +923,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 1105, .range_length = 1, .glyph_id_start = 160, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[35136] __SDRAM;
+static uint8_t etxUncompBuf[35136] __SDRAMFONTS;
 
 const etxLz4Font lv_font_arimo_ru_bold_32 = {
 .uncomp_size = 34840,

--- a/radio/src/fonts/lvgl/lv_font_arimo_ru_bold_64.c
+++ b/radio/src/fonts/lvgl/lv_font_arimo_ru_bold_64.c
@@ -1161,7 +1161,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 176, .range_length = 1, .glyph_id_start = 96, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[64593] __SDRAM;
+static uint8_t etxUncompBuf[64593] __SDRAMFONTS;
 
 const etxLz4Font lv_font_arimo_ru_bold_64 = {
 .uncomp_size = 64393,

--- a/radio/src/fonts/lvgl/lv_font_noto_cn_13.c
+++ b/radio/src/fonts/lvgl/lv_font_noto_cn_13.c
@@ -3116,7 +3116,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 176, .range_length = 63475, .glyph_id_start = 113, .list_length = 627, .type = 3, .unicode_list = 5920, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[63921] __SDRAM;
+static uint8_t etxUncompBuf[63921] __SDRAMFONTS;
 
 const etxLz4Font lv_font_noto_cn_13 = {
 .uncomp_size = 63657,

--- a/radio/src/fonts/lvgl/lv_font_noto_cn_24.c
+++ b/radio/src/fonts/lvgl/lv_font_noto_cn_24.c
@@ -5980,7 +5980,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 176, .range_length = 40609, .glyph_id_start = 109, .list_length = 565, .type = 3, .unicode_list = 5392, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[165378] __SDRAM;
+static uint8_t etxUncompBuf[165378] __SDRAMFONTS;
 
 const etxLz4Font lv_font_noto_cn_24 = {
 .uncomp_size = 165146,

--- a/radio/src/fonts/lvgl/lv_font_noto_cn_9.c
+++ b/radio/src/fonts/lvgl/lv_font_noto_cn_9.c
@@ -1965,7 +1965,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 176, .range_length = 63475, .glyph_id_start = 113, .list_length = 627, .type = 3, .unicode_list = 5920, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[38517] __SDRAM;
+static uint8_t etxUncompBuf[38517] __SDRAMFONTS;
 
 const etxLz4Font lv_font_noto_cn_9 = {
 .uncomp_size = 38253,

--- a/radio/src/fonts/lvgl/lv_font_noto_cn_bold_16.c
+++ b/radio/src/fonts/lvgl/lv_font_noto_cn_bold_16.c
@@ -4215,7 +4215,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 176, .range_length = 63475, .glyph_id_start = 113, .list_length = 627, .type = 3, .unicode_list = 5920, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[92284] __SDRAM;
+static uint8_t etxUncompBuf[92284] __SDRAMFONTS;
 
 const etxLz4Font lv_font_noto_cn_bold_16 = {
 .uncomp_size = 92020,

--- a/radio/src/fonts/lvgl/lv_font_noto_cn_bold_32.c
+++ b/radio/src/fonts/lvgl/lv_font_noto_cn_bold_32.c
@@ -8520,7 +8520,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 176, .range_length = 40609, .glyph_id_start = 96, .list_length = 565, .type = 3, .unicode_list = 5288, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[291513] __SDRAM;
+static uint8_t etxUncompBuf[291513] __SDRAMFONTS;
 
 const etxLz4Font lv_font_noto_cn_bold_32 = {
 .uncomp_size = 291313,

--- a/radio/src/fonts/lvgl/lv_font_noto_cn_bold_64.c
+++ b/radio/src/fonts/lvgl/lv_font_noto_cn_bold_64.c
@@ -1273,7 +1273,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 176, .range_length = 1, .glyph_id_start = 96, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[70230] __SDRAM;
+static uint8_t etxUncompBuf[70230] __SDRAMFONTS;
 
 const etxLz4Font lv_font_noto_cn_bold_64 = {
 .uncomp_size = 70030,

--- a/radio/src/fonts/lvgl/lv_font_noto_jp_13.c
+++ b/radio/src/fonts/lvgl/lv_font_noto_jp_13.c
@@ -2303,7 +2303,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 12527, .range_length = 51124, .glyph_id_start = 231, .list_length = 342, .type = 3, .unicode_list = 4719, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[60102] __SDRAM;
+static uint8_t etxUncompBuf[60102] __SDRAMFONTS;
 
 const etxLz4Font lv_font_noto_jp_13 = {
 .uncomp_size = 59742,

--- a/radio/src/fonts/lvgl/lv_font_noto_jp_24.c
+++ b/radio/src/fonts/lvgl/lv_font_noto_jp_24.c
@@ -4112,7 +4112,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 12527, .range_length = 27114, .glyph_id_start = 225, .list_length = 282, .type = 3, .unicode_list = 4187, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[127521] __SDRAM;
+static uint8_t etxUncompBuf[127521] __SDRAMFONTS;
 
 const etxLz4Font lv_font_noto_jp_24 = {
 .uncomp_size = 127193,

--- a/radio/src/fonts/lvgl/lv_font_noto_jp_9.c
+++ b/radio/src/fonts/lvgl/lv_font_noto_jp_9.c
@@ -1484,7 +1484,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 12527, .range_length = 51124, .glyph_id_start = 231, .list_length = 342, .type = 3, .unicode_list = 4719, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[41981] __SDRAM;
+static uint8_t etxUncompBuf[41981] __SDRAMFONTS;
 
 const etxLz4Font lv_font_noto_jp_9 = {
 .uncomp_size = 41621,

--- a/radio/src/fonts/lvgl/lv_font_noto_jp_bold_16.c
+++ b/radio/src/fonts/lvgl/lv_font_noto_jp_bold_16.c
@@ -3038,7 +3038,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 12527, .range_length = 51124, .glyph_id_start = 231, .list_length = 342, .type = 3, .unicode_list = 4719, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[80432] __SDRAM;
+static uint8_t etxUncompBuf[80432] __SDRAMFONTS;
 
 const etxLz4Font lv_font_noto_jp_bold_16 = {
 .uncomp_size = 80072,

--- a/radio/src/fonts/lvgl/lv_font_noto_jp_bold_32.c
+++ b/radio/src/fonts/lvgl/lv_font_noto_jp_bold_32.c
@@ -5750,7 +5750,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 12527, .range_length = 27114, .glyph_id_start = 212, .list_length = 282, .type = 3, .unicode_list = 4083, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[213365] __SDRAM;
+static uint8_t etxUncompBuf[213365] __SDRAMFONTS;
 
 const etxLz4Font lv_font_noto_jp_bold_32 = {
 .uncomp_size = 213069,

--- a/radio/src/fonts/lvgl/lv_font_noto_jp_bold_64.c
+++ b/radio/src/fonts/lvgl/lv_font_noto_jp_bold_64.c
@@ -1273,7 +1273,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 176, .range_length = 1, .glyph_id_start = 96, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[70230] __SDRAM;
+static uint8_t etxUncompBuf[70230] __SDRAMFONTS;
 
 const etxLz4Font lv_font_noto_jp_bold_64 = {
 .uncomp_size = 70030,

--- a/radio/src/fonts/lvgl/lv_font_noto_tw_13.c
+++ b/radio/src/fonts/lvgl/lv_font_noto_tw_13.c
@@ -3332,7 +3332,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 176, .range_length = 63475, .glyph_id_start = 113, .list_length = 654, .type = 3, .unicode_list = 6136, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[66606] __SDRAM;
+static uint8_t etxUncompBuf[66606] __SDRAMFONTS;
 
 const etxLz4Font lv_font_noto_tw_13 = {
 .uncomp_size = 66342,

--- a/radio/src/fonts/lvgl/lv_font_noto_tw_24.c
+++ b/radio/src/fonts/lvgl/lv_font_noto_tw_24.c
@@ -6645,7 +6645,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 176, .range_length = 40609, .glyph_id_start = 109, .list_length = 592, .type = 3, .unicode_list = 5608, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[173882] __SDRAM;
+static uint8_t etxUncompBuf[173882] __SDRAMFONTS;
 
 const etxLz4Font lv_font_noto_tw_24 = {
 .uncomp_size = 173650,

--- a/radio/src/fonts/lvgl/lv_font_noto_tw_9.c
+++ b/radio/src/fonts/lvgl/lv_font_noto_tw_9.c
@@ -2066,7 +2066,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 176, .range_length = 63475, .glyph_id_start = 113, .list_length = 654, .type = 3, .unicode_list = 6136, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[40081] __SDRAM;
+static uint8_t etxUncompBuf[40081] __SDRAMFONTS;
 
 const etxLz4Font lv_font_noto_tw_9 = {
 .uncomp_size = 39817,

--- a/radio/src/fonts/lvgl/lv_font_noto_tw_bold_16.c
+++ b/radio/src/fonts/lvgl/lv_font_noto_tw_bold_16.c
@@ -4521,7 +4521,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 176, .range_length = 63475, .glyph_id_start = 113, .list_length = 654, .type = 3, .unicode_list = 6136, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[96104] __SDRAM;
+static uint8_t etxUncompBuf[96104] __SDRAMFONTS;
 
 const etxLz4Font lv_font_noto_tw_bold_16 = {
 .uncomp_size = 95840,

--- a/radio/src/fonts/lvgl/lv_font_noto_tw_bold_32.c
+++ b/radio/src/fonts/lvgl/lv_font_noto_tw_bold_32.c
@@ -9409,7 +9409,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 176, .range_length = 40609, .glyph_id_start = 96, .list_length = 592, .type = 3, .unicode_list = 5504, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[305974] __SDRAM;
+static uint8_t etxUncompBuf[305974] __SDRAMFONTS;
 
 const etxLz4Font lv_font_noto_tw_bold_32 = {
 .uncomp_size = 305774,

--- a/radio/src/fonts/lvgl/lv_font_noto_tw_bold_64.c
+++ b/radio/src/fonts/lvgl/lv_font_noto_tw_bold_64.c
@@ -1273,7 +1273,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 176, .range_length = 1, .glyph_id_start = 96, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[70230] __SDRAM;
+static uint8_t etxUncompBuf[70230] __SDRAMFONTS;
 
 const etxLz4Font lv_font_noto_tw_bold_64 = {
 .uncomp_size = 70030,

--- a/radio/src/fonts/lvgl/lv_font_roboto_13.c
+++ b/radio/src/fonts/lvgl/lv_font_roboto_13.c
@@ -816,7 +816,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 8226, .range_length = 55425, .glyph_id_start = 306, .list_length = 62, .type = 3, .unicode_list = 2944, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[21439] __SDRAM;
+static uint8_t etxUncompBuf[21439] __SDRAMFONTS;
 
 const etxLz4Font lv_font_roboto_13 = {
 .uncomp_size = 21111,

--- a/radio/src/fonts/lvgl/lv_font_roboto_24.c
+++ b/radio/src/fonts/lvgl/lv_font_roboto_24.c
@@ -1040,7 +1040,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 192, .range_length = 192, .glyph_id_start = 110, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[38742] __SDRAM;
+static uint8_t etxUncompBuf[38742] __SDRAMFONTS;
 
 const etxLz4Font lv_font_roboto_24 = {
 .uncomp_size = 38478,

--- a/radio/src/fonts/lvgl/lv_font_roboto_9.c
+++ b/radio/src/fonts/lvgl/lv_font_roboto_9.c
@@ -563,7 +563,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 8226, .range_length = 55425, .glyph_id_start = 306, .list_length = 62, .type = 3, .unicode_list = 2944, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[14011] __SDRAM;
+static uint8_t etxUncompBuf[14011] __SDRAMFONTS;
 
 const etxLz4Font lv_font_roboto_9 = {
 .uncomp_size = 13683,

--- a/radio/src/fonts/lvgl/lv_font_roboto_bold_16.c
+++ b/radio/src/fonts/lvgl/lv_font_roboto_bold_16.c
@@ -988,7 +988,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 8226, .range_length = 55425, .glyph_id_start = 306, .list_length = 62, .type = 3, .unicode_list = 2944, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[29836] __SDRAM;
+static uint8_t etxUncompBuf[29836] __SDRAMFONTS;
 
 const etxLz4Font lv_font_roboto_bold_16 = {
 .uncomp_size = 29508,

--- a/radio/src/fonts/lvgl/lv_font_roboto_bold_32.c
+++ b/radio/src/fonts/lvgl/lv_font_roboto_bold_32.c
@@ -1213,7 +1213,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 192, .range_length = 192, .glyph_id_start = 97, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[62096] __SDRAM;
+static uint8_t etxUncompBuf[62096] __SDRAMFONTS;
 
 const etxLz4Font lv_font_roboto_bold_32 = {
 .uncomp_size = 61864,

--- a/radio/src/fonts/lvgl/lv_font_roboto_bold_64.c
+++ b/radio/src/fonts/lvgl/lv_font_roboto_bold_64.c
@@ -1153,7 +1153,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 176, .range_length = 1, .glyph_id_start = 96, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-static uint8_t etxUncompBuf[63281] __SDRAM;
+static uint8_t etxUncompBuf[63281] __SDRAMFONTS;
 
 const etxLz4Font lv_font_roboto_bold_64 = {
 .uncomp_size = 63081,

--- a/radio/src/fonts/lvgl/lz4_font.cpp
+++ b/radio/src/fonts/lvgl/lz4_font.cpp
@@ -233,7 +233,7 @@ int main(int argc, char* argv[])
              sizeof(lv_font_fmt_txt_glyph_cache_t) +
              dsc->cmap_num * sizeof(lv_font_fmt_txt_cmap_t);
   if (dsc->kern_classes) size += sizeof(lv_font_fmt_txt_kern_classes_t);
-  fprintf(fp, "static uint8_t etxUncompBuf[%d] __SDRAM;\n\n", size);
+  fprintf(fp, "static uint8_t etxUncompBuf[%d] __SDRAMFONTS;\n\n", size);
 
   // Custom font structure
   fprintf(fp, "const etxLz4Font %s = {\n", argv[1]);


### PR DESCRIPTION
The font decompression buffers added in PR #4419 may cause alignment issues with the LCD buffers.

This PR forces the LCD buffers back to the start of SDRAM and moves the font buffers to after the LCD buffers.

