### PR TITLE
fix(bw): Uncleared reusable buffer in sdmanager

### DIFF
--- a/radio/src/gui/common/stdlcd/radio_sdmanager.cpp
+++ b/radio/src/gui/common/stdlcd/radio_sdmanager.cpp
@@ -273,9 +273,21 @@ void onUpdateReceiverSelection(const char * result)
 
 void menuRadioSdManager(event_t _event)
 {
-#if LCD_DEPTH > 1
+#if defined(NAVIGATION_X9D)
   int lastPos = menuVerticalPosition;
 #endif
+
+  if (_event == EVT_ENTRY) {
+    f_chdir(ROOT_PATH);
+#if defined(NAVIGATION_X9D)
+    lastPos = -1;
+#endif
+  }
+
+  if (_event == EVT_ENTRY || _event == EVT_ENTRY_UP) {
+    memclear(&reusableBuffer.sdManager, sizeof(reusableBuffer.sdManager));
+    REFRESH_FILES();
+  }
 
 #if defined(PXX2)
   if (EVT_KEY_MASK(_event) == KEY_EXIT && moduleState[reusableBuffer.sdManager.otaUpdateInformation.module].mode == MODULE_MODE_BIND) {
@@ -291,19 +303,8 @@ void menuRadioSdManager(event_t _event)
   SIMPLE_MENU(STR_SD_CARD, menuTabGeneral, MENU_RADIO_SD_MANAGER, HEADER_LINE + reusableBuffer.sdManager.count);
 
   switch (_event) {
-    case EVT_ENTRY:
-      f_chdir(ROOT_PATH);
-#if LCD_DEPTH > 1
-      lastPos = -1;
-#endif
-      // no break
 
-    case EVT_ENTRY_UP:
-      memclear(&reusableBuffer.sdManager, sizeof(reusableBuffer.sdManager));
-      REFRESH_FILES();
-      break;
-
-#if defined(PCBX9) || defined(RADIO_X7) || defined(RADIO_X7ACCESS) // TODO NO_MENU_KEY
+#if defined(KEYS_GPIO_REG_MENU)
     case EVT_KEY_LONG(KEY_MENU):
       if (SD_CARD_PRESENT() && !READ_ONLY() && s_editMode == 0) {
         killEvents(_event);
@@ -338,7 +339,7 @@ void menuRadioSdManager(event_t _event)
       break;
 
     case EVT_KEY_LONG(KEY_ENTER):
-#if (HEADER_LINE > 0) && !defined(PCBX9) && !defined(RADIO_X7) && !defined(RADIO_X7ACCESS) // TODO NO_HEADER_LINE
+#if (HEADER_LINE > 0)
       if (menuVerticalPosition < HEADER_LINE) {
         killEvents(_event);
         POPUP_MENU_ADD_ITEM(STR_SD_INFO);


### PR DESCRIPTION
Some bugs can stay hidden for years .....

Did a bit of housekeeping while I was at it

This fixes #4417 