### PR TITLE
fix(cpn): Translation of GPS Run/Stop in telemetry simulator

### DIFF
--- a/companion/src/simulation/telemetrysimu.cpp
+++ b/companion/src/simulation/telemetrysimu.cpp
@@ -1388,13 +1388,13 @@ void TelemetrySimulator::on_loadTelemetryvalues_clicked()
 
 void TelemetrySimulator::on_GPSpushButton_clicked()
 {
-  if (ui->GPSpushButton->text() == "Run") {
-    ui->GPSpushButton->setText("Stop");
+  if (ui->GPSpushButton->text() == tr("Run")) {
+    ui->GPSpushButton->setText(tr("Stop"));
     gpsTimer.start();
   }
   else
   {
-    ui->GPSpushButton->setText("Run");
+    ui->GPSpushButton->setText(tr("Run"));
     gpsTimer.stop();
   }
 }

--- a/companion/src/translations/companion_sv.ts
+++ b/companion/src/translations/companion_sv.ts
@@ -7417,7 +7417,7 @@ fält</translation>
     <message>
         <location filename="../mainwindow.cpp" line="659"/>
         <source>If you&apos;ve found this program useful, please support by &lt;a href=&apos;%1&apos;&gt;donating&lt;/a&gt;</source>
-        <translation>Om du tycker att programet är användbart kan du stödja utvecklingen genom en &lt;a href=&apos;%1&apos;&gt;gåva.&lt;/a&gt;</translation>
+        <translation>Om du tycker att programet är användbart kan du stödja utvecklingen med en &lt;a href=&apos;%1&apos;&gt;gåva.&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="817"/>
@@ -7558,7 +7558,7 @@ fält</translation>
     <message>
         <location filename="../mainwindow.cpp" line="1165"/>
         <source>%2</source>
-        <translation>%2</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="284"/>
@@ -14578,6 +14578,10 @@ hh:mm:ss</translation>
         <location filename="../simulation/telemetrysimu.ui" line="1418"/>
         <source>Run</source>
         <translation>Kör</translation>
+    </message>
+    <message>
+        <source>Stop</source>
+        <translation>Stoppa</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="1425"/>


### PR DESCRIPTION
Fixes #4429 

Summary of changes:
Added translation for Run and Stop for the GPS simulator. 
Also added a text string for "Stop" in the TelemetrySimulator section in SE Qt translation file. 

