### PR TITLE
fix(telemetry): Inconsistent/wrong GPS distance calculation

### DIFF
--- a/radio/src/telemetry/telemetry_sensors.cpp
+++ b/radio/src/telemetry/telemetry_sensors.cpp
@@ -161,12 +161,12 @@ void TelemetryItem::setValue(const TelemetrySensor &sensor, int32_t val,
 #if defined(INTERNAL_GPS)
     if (gpsData.fix  && gpsData.hdop < PILOTPOS_MIN_HDOP) {
       pilotLatitude = gpsData.latitude;
-      distFromEarthAxis = getDistFromEarthAxis(pilotLatitude);
+      gps.pilotDistFromEarthAxis = getDistFromEarthAxis(pilotLatitude);
     }
 #endif
     if (!pilotLatitude) {
       pilotLatitude = newVal;
-      distFromEarthAxis = getDistFromEarthAxis(newVal);
+      gps.pilotDistFromEarthAxis = getDistFromEarthAxis(newVal);
     }
     gps.latitude = newVal;
     setFresh();
@@ -380,7 +380,7 @@ void TelemetryItem::eval(const TelemetrySensor & sensor)
         uint32_t result = dist * dist;
 
         angle = abs(gpsItem.gps.longitude - gpsItem.pilotLongitude);
-        dist = uint64_t(gpsItem.distFromEarthAxis) * angle / 1000000;
+        dist = uint64_t(gpsItem.gps.pilotDistFromEarthAxis) * angle / 1000000;
         result += dist * dist;
 
         // Length on ground (ignoring curvature of the earth)

--- a/radio/src/telemetry/telemetry_sensors.h
+++ b/radio/src/telemetry/telemetry_sensors.h
@@ -32,10 +32,7 @@ constexpr uint8_t TELEMETRY_SENSOR_TEXT_LENGTH = 16;
 class TelemetryItem
 {
   public:
-    union {
-      int32_t  value;           // value, stored as uint32_t but interpreted accordingly to type
-      uint32_t distFromEarthAxis;
-    };
+    int32_t  value;           // value, stored as uint32_t but interpreted accordingly to type
 
     union {
       int32_t valueMin;         // min store
@@ -72,9 +69,9 @@ class TelemetryItem
       struct {
         int32_t latitude;
         int32_t longitude;
-        // pilot longitude is stored in min
-        // pilot latitude is stored in max
-        // distFromEarthAxis is stored in value
+        uint32_t pilotDistFromEarthAxis;  // pilot distance from earth axis
+                                          // pilot longitude is stored in min
+                                          // pilot latitude is stored in max
       } gps;
       char text[TELEMETRY_SENSOR_TEXT_LENGTH];
     };


### PR DESCRIPTION
fixes #4437

PR #4250 introduced a mechanism to allow a value widget to detect a change in GPS position. This was realized by storing a hash value in the `value `variable of class TelemetryItem. Unfortunately `value ` is defined in a union together with a placeholder for `distFromEarthAxis`.

```
class TelemetryItem
{
  public:
    union {
      int32_t  value;           // value, stored as uint32_t but interpreted accordingly to type
      uint32_t distFromEarthAxis;
    };
...
```

By writing the hash for the changed lat/lon to `value` the calculated `distFromEarthAxis` is overwritten. In case a calculated telemetry sensor "distance" is defined this leads to a wrong calculation of the distance between craft and home point. 

Changes: 
- separated and moved storage of `distFromEarthAxis `to class `TelemetryItem`'s gps struct to prevent overwriting `distFromEarthAxis`. This should not affect RAM usage due to the way the gps struct is embedded in a union for other types of data (`cells `struct is still larger).
- changed `distFromEarthAxis  `to `pilotDistFromEarthAxis `to align variable name with `pilotLatitude `and `pilotLongitude`

Tested using the procedure described in #4437