### PR TITLE
fix(bw): Cannot change the 'enabled' state for global functions

### DIFF
--- a/radio/src/gui/128x64/menu_radio.cpp
+++ b/radio/src/gui/128x64/menu_radio.cpp
@@ -30,7 +30,7 @@ void menuRadioSpecialFunctions(event_t event)
   }
 #endif
 
-  MENU(STR_MENUSPECIALFUNCS, menuTabGeneral, MENU_RADIO_SPECIAL_FUNCTIONS, HEADER_LINE+MAX_SPECIAL_FUNCTIONS, { HEADER_LINE_COLUMNS NAVIGATION_LINE_BY_LINE|4/*repeated*/ });
+  MENU(STR_MENUSPECIALFUNCS, menuTabGeneral, MENU_RADIO_SPECIAL_FUNCTIONS, HEADER_LINE+MAX_SPECIAL_FUNCTIONS, { HEADER_LINE_COLUMNS NAVIGATION_LINE_BY_LINE|5/*repeated*/ });
 
   menuSpecialFunctions(event, g_eeGeneral.customFn, &globalFunctionsContext);
 

--- a/radio/src/gui/212x64/menu_radio.cpp
+++ b/radio/src/gui/212x64/menu_radio.cpp
@@ -35,6 +35,6 @@ const MenuHandler menuTabGeneral[MENU_RADIO_PAGES_COUNT] = {
 
 void menuRadioSpecialFunctions(event_t event)
 {
-  MENU(STR_MENUSPECIALFUNCS, menuTabGeneral, MENU_RADIO_SPECIAL_FUNCTIONS, MAX_SPECIAL_FUNCTIONS, { NAVIGATION_LINE_BY_LINE|4/*repeated*/ });
+  MENU(STR_MENUSPECIALFUNCS, menuTabGeneral, MENU_RADIO_SPECIAL_FUNCTIONS, MAX_SPECIAL_FUNCTIONS, { NAVIGATION_LINE_BY_LINE|5/*repeated*/ });
   return menuSpecialFunctions(event, g_eeGeneral.customFn, &globalFunctionsContext);
 }


### PR DESCRIPTION
In the radio Global Functions edit, the cursor cannot be scrolled across to the 'enable' checkbox.

Missed in the PR that added the enable checkbox to all SF/GF functions.
