### PR TITLE
fix: increase init repeat max time for slow(est) cards

### DIFF
--- a/radio/src/targets/common/arm/stm32/sdcard_spi.cpp
+++ b/radio/src/targets/common/arm/stm32/sdcard_spi.cpp
@@ -42,7 +42,7 @@
 // #endif
 
 #define US_PER_MS                   (1000UL)
-#define INIT_CMD_RETRY_US           (500 * US_PER_MS)
+#define INIT_CMD_RETRY_US           (750 * US_PER_MS)
 #define INIT_CMD0_RETRY_US          (100UL)
 #define R1_POLLING_RETRY_US         (100 * US_PER_MS)
 #define SD_DATA_TOKEN_RETRY_US      (100 * US_PER_MS)


### PR DESCRIPTION
Sometime, the fix looks trivial, yet the journey to get there hasn't been ....

This fixes #4439 

@raphaelcoeffic co-authored this change