### PR TITLE
fix(bw): Progressive checklist `=` behaviour was reversed

### DIFF
--- a/radio/src/gui/common/stdlcd/view_text.cpp
+++ b/radio/src/gui/common/stdlcd/view_text.cpp
@@ -22,7 +22,7 @@
 #include "opentx.h"
 
 constexpr uint32_t TEXT_FILE_MAXSIZE = 2048;
-constexpr char NON_CHECKABLE_PREFIX = '=';
+constexpr char CHECKABLE_PREFIX = '=';
 int checklistPosition;
 
 static void sdReadTextFile(const char * filename, char lines[TEXT_VIEWER_LINES][LCD_COLS + 1], int & lines_count)
@@ -169,7 +169,12 @@ void menuTextView(event_t event)
 
   for (int i=0; i<LCD_LINES-1; i++) {
     if (g_model.checklistInteractive){
-      if (reusableBuffer.viewText.lines[i][0] == NON_CHECKABLE_PREFIX) {
+      if (reusableBuffer.viewText.lines[i][0] == CHECKABLE_PREFIX) {
+        if (i < reusableBuffer.viewText.linesCount && !reusableBuffer.viewText.pushMenu)
+          drawCheckBox(0, i*FH+FH+1, i < checklistPosition-(int)menuVerticalOffset, i == checklistPosition-(int)menuVerticalOffset);
+        lcdDrawText(8, i*FH+FH+1, reusableBuffer.viewText.lines[i], FIXEDWIDTH);
+      }
+      else {
         lcdDrawText(8, i*FH+FH+1, &reusableBuffer.viewText.lines[i][1], FIXEDWIDTH);
         if (i == checklistPosition-(int)menuVerticalOffset){
           ++checklistPosition;
@@ -179,11 +184,6 @@ void menuTextView(event_t event)
             i = 0;  // Reset rendering of the display after changing the offest
           }
         }
-      }
-      else {
-        if (i < reusableBuffer.viewText.linesCount && !reusableBuffer.viewText.pushMenu)
-          drawCheckBox(0, i*FH+FH+1, i < checklistPosition-(int)menuVerticalOffset, i == checklistPosition-(int)menuVerticalOffset);
-        lcdDrawText(8, i*FH+FH+1, reusableBuffer.viewText.lines[i], FIXEDWIDTH);
       }
     }
     else {

--- a/radio/src/gui/common/stdlcd/view_text.cpp
+++ b/radio/src/gui/common/stdlcd/view_text.cpp
@@ -175,7 +175,7 @@ void menuTextView(event_t event)
         lcdDrawText(8, i*FH+FH+1, reusableBuffer.viewText.lines[i], FIXEDWIDTH);
       }
       else {
-        lcdDrawText(8, i*FH+FH+1, &reusableBuffer.viewText.lines[i][1], FIXEDWIDTH);
+        lcdDrawText(8, i*FH+FH+1, &reusableBuffer.viewText.lines[i][0], FIXEDWIDTH);
         if (i == checklistPosition-(int)menuVerticalOffset){
           ++checklistPosition;
           if (checklistPosition-(int)menuVerticalOffset == LCD_LINES-1 && menuVerticalOffset+LCD_LINES-1 < reusableBuffer.viewText.linesCount) {

--- a/radio/src/gui/common/stdlcd/view_text.cpp
+++ b/radio/src/gui/common/stdlcd/view_text.cpp
@@ -172,7 +172,7 @@ void menuTextView(event_t event)
       if (reusableBuffer.viewText.lines[i][0] == CHECKABLE_PREFIX) {
         if (i < reusableBuffer.viewText.linesCount && !reusableBuffer.viewText.pushMenu)
           drawCheckBox(0, i*FH+FH+1, i < checklistPosition-(int)menuVerticalOffset, i == checklistPosition-(int)menuVerticalOffset);
-        lcdDrawText(8, i*FH+FH+1, reusableBuffer.viewText.lines[i], FIXEDWIDTH);
+        lcdDrawText(8, i*FH+FH+1, &reusableBuffer.viewText.lines[i][1], FIXEDWIDTH);
       }
       else {
         lcdDrawText(8, i*FH+FH+1, &reusableBuffer.viewText.lines[i][0], FIXEDWIDTH);

--- a/radio/src/gui/common/stdlcd/view_text.cpp
+++ b/radio/src/gui/common/stdlcd/view_text.cpp
@@ -99,8 +99,24 @@ void readModelNotes()
   LED_ERROR_BEGIN();
 
   strcpy(reusableBuffer.viewText.filename, MODELS_PATH "/");
-  char *buf = strcat_currentmodelname(&reusableBuffer.viewText.filename[sizeof(MODELS_PATH)], 0);
+  char *buf = strcat_currentmodelname(
+      &reusableBuffer.viewText.filename[sizeof(MODELS_PATH)], 0);
   strcpy(buf, TEXT_EXT);
+
+  if (!isFileAvailable(reusableBuffer.viewText.filename)) {
+    buf = strcat_currentmodelname(
+        &reusableBuffer.viewText.filename[sizeof(MODELS_PATH)], ' ');
+    strcpy(buf, TEXT_EXT);
+
+#if defined(STORAGE_MODELSLIST)
+    if (!isFileAvailable(reusableBuffer.viewText.filename)) {
+      buf = strAppendFilename(
+          &reusableBuffer.viewText.filenam[sizeof(MODELS_PATH)],
+          g_eeGeneral.currModelFilename, LEN_MODEL_FILENAME);
+      strcpy(buf, TEXT_EXT);
+    }
+#endif
+  }
 
   waitKeysReleased();
   event_t event = EVT_ENTRY;


### PR DESCRIPTION
using "=" as indicator for checkable entries on B&W radio to align the behavior with color LCD radios
