### PR TITLE
feat: Use trim as a 3 pos toggle switch source

### DIFF
--- a/companion/src/firmwares/edgetx/yaml_modeldata.cpp
+++ b/companion/src/firmwares/edgetx/yaml_modeldata.cpp
@@ -514,6 +514,8 @@ struct convert<YamlTrim> {
     node["value"] = rhs.value;
     if (rhs.mode < 0) {
       node["mode"] = (1 << 5) - 1;
+    } else if (rhs.mode == TRIM_MODE_3POS) {
+      node["mode"] = TRIM_MODE_3POS;
     } else {
       node["mode"] = 2 * rhs.ref + rhs.mode;
     }
@@ -527,6 +529,8 @@ struct convert<YamlTrim> {
     node["mode"] >> trimMode;
     if (trimMode == (1 << 5) - 1) {
       rhs.mode = -1;
+    } else if (trimMode == TRIM_MODE_3POS) {
+      rhs.mode = TRIM_MODE_3POS;
     } else {
       rhs.mode = trimMode % 2;
       rhs.ref = trimMode / 2;

--- a/companion/src/helpers.h
+++ b/companion/src/helpers.h
@@ -51,6 +51,7 @@ extern const QColor colors[CPN_MAX_CURVES];
 #define TRIM_OFFSET 2
 
 #define TRIM_MODE_NONE  0x1F  // 0b11111
+#define TRIM_MODE_3POS  (2 * CPN_MAX_FLIGHT_MODES)
 
 bool displayT16ImportWarning();
 

--- a/companion/src/modeledit/flightmodes.cpp
+++ b/companion/src/modeledit/flightmodes.cpp
@@ -110,6 +110,7 @@ FlightModePanel::FlightModePanel(QWidget * parent, ModelData & model, int phaseI
     cb->setProperty("index", i);
     if (IS_HORUS_OR_TARANIS(board)) {
       cb->addItem(tr("Trim disabled"), -1);
+      cb->addItem(tr("3POS toggle switch"), TRIM_MODE_3POS);
     }
     for (int m = 0; m < fmCount; m++) {
       if (m == phaseIdx) {
@@ -435,10 +436,14 @@ void FlightModePanel::trimUpdate(unsigned int trim)
     trimsUse[trim]->setCurrentIndex(0);
     trimsValue[trim]->setEnabled(false);
     trimsSlider[trim]->setEnabled(false);
+  } else if (phase.trimMode[chn] == TRIM_MODE_3POS) {
+    trimsUse[trim]->setCurrentIndex(1);
+    trimsValue[trim]->setEnabled(false);
+    trimsSlider[trim]->setEnabled(false);
   }
   else {
     if (IS_HORUS_OR_TARANIS(board))
-      trimsUse[trim]->setCurrentIndex(1 + 2 * phase.trimRef[chn] + phase.trimMode[chn] - (phase.trimRef[chn] > phaseIdx ? 1 : 0));
+      trimsUse[trim]->setCurrentIndex(2 + 2 * phase.trimRef[chn] + phase.trimMode[chn] - (phase.trimRef[chn] > phaseIdx ? 1 : 0));
     else
       trimsUse[trim]->setCurrentIndex(phase.trimRef[chn]);
     if (phaseIdx == 0 || phase.trimRef[chn] == phaseIdx || (IS_HORUS_OR_TARANIS(board) && phase.trimMode[chn] != 0)) {
@@ -613,6 +618,10 @@ void FlightModePanel::phaseTrimUse_currentIndexChanged(int index)
     int data = comboBox->itemData(index).toInt();
     if (data < 0) {
       phase.trimMode[chn] = -1;
+      phase.trimRef[chn] = 0;
+      phase.trim[chn] = 0;
+    } else if (data == TRIM_MODE_3POS) {
+      phase.trimMode[chn] = TRIM_MODE_3POS;
       phase.trimRef[chn] = 0;
       phase.trim[chn] = 0;
     }

--- a/companion/src/modelprinter.cpp
+++ b/companion/src/modelprinter.cpp
@@ -287,6 +287,8 @@ QString ModelPrinter::printTrim(int flightModeIndex, int stickIndex)
 
   if (fm.trimMode[stickIndex] == -1) {
     return tr("OFF");
+  } else if (fm.trimMode[stickIndex] == CPN_MAX_FLIGHT_MODES * 2) {
+    return tr("3POS");
   }
   else {
     if (fm.trimRef[stickIndex] == flightModeIndex) {

--- a/radio/src/gui/128x64/model_flightmodes.cpp
+++ b/radio/src/gui/128x64/model_flightmodes.cpp
@@ -59,7 +59,9 @@ enum MenuModelFlightModeItems {
 
 bool isTrimModeAvailable(int mode)
 {
-  return (mode < 0 || (mode%2) == 0 || (mode/2) != s_currIdx);
+  if (mode < 0 || mode == TRIM_MODE_3POS) return true;
+  if (s_currIdx == 0) return mode == 0;
+  return (mode%2) == 0 || (mode/2) != s_currIdx;
 }
 
 void menuModelFlightModeOne(event_t event)
@@ -127,7 +129,7 @@ void menuModelFlightModeOne(event_t event)
             drawTrimMode(MIXES_2ND_COLUMN + (t*2*FW), y, s_currIdx, t, menuHorizontalPosition == t ? attr : 0);
             if (s_editMode > 0 && attr && menuHorizontalPosition == t) {
               trim_t & v = fm->trim[t];
-              v.mode = checkIncDec(event, v.mode==TRIM_MODE_NONE ? -1 : v.mode, -1, k==0 ? 0 : 2*MAX_FLIGHT_MODES-1, EE_MODEL, isTrimModeAvailable);
+              v.mode = checkIncDec(event, v.mode==TRIM_MODE_NONE ? -1 : v.mode, -1, 2*MAX_FLIGHT_MODES, EE_MODEL, isTrimModeAvailable);
             }
           }
         }
@@ -143,7 +145,7 @@ void menuModelFlightModeOne(event_t event)
             if (s_editMode > 0 && attr && menuHorizontalPosition == t - 4) {
               trim_t& v = fm->trim[t];
               v.mode = checkIncDec(event, v.mode == TRIM_MODE_NONE ? -1 : v.mode,
-                                   -1, k == 0 ? 0 : 2 * MAX_FLIGHT_MODES - 1,
+                                   -1, 2 * MAX_FLIGHT_MODES,
                                    EE_MODEL, isTrimModeAvailable);
             }
           }

--- a/radio/src/gui/212x64/model_flightmodes.cpp
+++ b/radio/src/gui/212x64/model_flightmodes.cpp
@@ -46,7 +46,9 @@ enum FlightModesItems {
 
 bool isTrimModeAvailable(int mode)
 {
-  return (mode < 0 || (mode%2) == 0 || (mode/2) != menuVerticalPosition);
+  if (mode < 0 || mode == TRIM_MODE_3POS) return true;
+  if (menuVerticalPosition == 0) return mode == 0;
+  return (mode%2) == 0 || (mode/2) != menuVerticalPosition;
 }
 
 void menuModelFlightModesAll(event_t event)
@@ -123,7 +125,7 @@ void menuModelFlightModesAll(event_t event)
           drawTrimMode((4+LEN_FLIGHT_MODE_NAME)*FW+j*(5*FW/2), y, k, t, attr);
           if (active) {
             trim_t & v = p->trim[t];
-            v.mode = checkIncDec(event, v.mode==TRIM_MODE_NONE ? -1 : v.mode, -1, k==0 ? 0 : 2*MAX_FLIGHT_MODES-1, EE_MODEL, isTrimModeAvailable);
+            v.mode = checkIncDec(event, v.mode==TRIM_MODE_NONE ? -1 : v.mode, -1, 2*MAX_FLIGHT_MODES, EE_MODEL, isTrimModeAvailable);
           }
           break;
         }

--- a/radio/src/gui/colorlcd/draw_functions.cpp
+++ b/radio/src/gui/colorlcd/draw_functions.cpp
@@ -283,8 +283,9 @@ void drawTrimMode(BitmapBuffer * dc, coord_t x, coord_t y, uint8_t phase, uint8_
 
   if (mode == TRIM_MODE_NONE) {
     dc->drawText(x, y, "--", att);
-  }
-  else {
+  } else if (mode == TRIM_MODE_3POS) {
+    dc->drawText(x, y, "3P", att);
+  } else {
     char s[2];
     s[0] = (mode % 2 == 0) ? ':' : '+';
     s[1] = '0'+p;

--- a/radio/src/gui/common/stdlcd/draw_functions.cpp
+++ b/radio/src/gui/common/stdlcd/draw_functions.cpp
@@ -77,8 +77,9 @@ void drawTrimMode(coord_t x, coord_t y, uint8_t flightMode, uint8_t idx, LcdFlag
 
   if (mode == TRIM_MODE_NONE) {
     lcdDrawText(x, y, "--", att);
-  }
-  else {
+  } else if (mode == TRIM_MODE_3POS) {
+    lcdDrawText(x, y, "3P", att);
+  } else {
     if (mode % 2 == 0)
       lcdDrawChar(x, y, ':', att|FIXEDWIDTH);
     else

--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -387,8 +387,8 @@ getvalue_t getValue(mixsrc_t i, bool* valid)
     if (getRawTrimValue(mixerCurrentFlightMode, i).mode == TRIM_MODE_3POS) {
       // Trim set as 3POS toggle switch in FM
       uint8_t tidx = i * 2;
-      if (trimDown(tidx)) return -1024;
-      else if (trimDown(tidx + 1)) return 1024;
+      if (trimDown(tidx)) return -RESX;
+      else if (trimDown(tidx + 1)) return RESX;
       return 0;
     }
     auto trim_value = getTrimValue(mixerCurrentFlightMode, i);

--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -384,8 +384,8 @@ getvalue_t getValue(mixsrc_t i, bool* valid)
 
   else if (i <= MIXSRC_LAST_TRIM) {
     i -= MIXSRC_FIRST_TRIM;
-    if (getRawTrimValue(mixerCurrentFlightMode, i).mode == TRIM_MODE_NONE) {
-      // Trim disabled in FM - treat as 3POS toggle switch
+    if (getRawTrimValue(mixerCurrentFlightMode, i).mode == TRIM_MODE_3POS) {
+      // Trim set as 3POS toggle switch in FM
       uint8_t tidx = i * 2;
       if (trimDown(tidx)) return -1024;
       else if (trimDown(tidx + 1)) return 1024;

--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -384,6 +384,13 @@ getvalue_t getValue(mixsrc_t i, bool* valid)
 
   else if (i <= MIXSRC_LAST_TRIM) {
     i -= MIXSRC_FIRST_TRIM;
+    if (getRawTrimValue(mixerCurrentFlightMode, i).mode == TRIM_MODE_NONE) {
+      // Trim disabled in FM - treat as 3POS toggle switch
+      uint8_t tidx = i * 2;
+      if (trimDown(tidx)) return -1024;
+      else if (trimDown(tidx + 1)) return 1024;
+      return 0;
+    }
     auto trim_value = getTrimValue(mixerCurrentFlightMode, i);
     return calc1000toRESX((int16_t)8 * trim_value);
   }

--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -386,7 +386,7 @@ getvalue_t getValue(mixsrc_t i, bool* valid)
     i -= MIXSRC_FIRST_TRIM;
     if (getRawTrimValue(mixerCurrentFlightMode, i).mode == TRIM_MODE_3POS) {
       // Trim set as 3POS toggle switch in FM
-      uint8_t tidx = i * 2;
+      uint8_t tidx = inputMappingConvertMode(i) * 2;
       if (trimDown(tidx)) return -RESX;
       else if (trimDown(tidx + 1)) return RESX;
       return 0;

--- a/radio/src/myeeprom.h
+++ b/radio/src/myeeprom.h
@@ -272,6 +272,7 @@ enum SwashType {
 
 #define TRIMS_ARRAY_SIZE  8
 #define TRIM_MODE_NONE  0x1F  // 0b11111
+#define TRIM_MODE_3POS  (2 * MAX_FLIGHT_MODES)
 
 #define IS_MANUAL_RESET_TIMER(idx)     (g_model.timers[idx].persistent == 2)
 

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -471,7 +471,7 @@ int getTrimValue(uint8_t phase, uint8_t idx)
   int result = 0;
   for (uint8_t i=0; i<MAX_FLIGHT_MODES; i++) {
     trim_t v = getRawTrimValue(phase, idx);
-    if (v.mode == TRIM_MODE_NONE) {
+    if (v.mode == TRIM_MODE_NONE || v.mode == TRIM_MODE_3POS) {
       return result;
     }
     else {
@@ -494,7 +494,7 @@ bool setTrimValue(uint8_t phase, uint8_t idx, int trim)
 {
   for (uint8_t i=0; i<MAX_FLIGHT_MODES; i++) {
     trim_t & v = flightModeAddress(phase)->trim[idx];
-    if (v.mode == TRIM_MODE_NONE)
+    if (v.mode == TRIM_MODE_NONE || v.mode == TRIM_MODE_3POS)
       return false;
     unsigned int p = v.mode >> 1;
     if (p == phase || phase == 0) {


### PR DESCRIPTION
Fixes #4453 

If trim is disabled in flight mode, treat it as a 3 position toggle switch in 'getValue' function.

