### PR TITLE
chore: improve 128x64 calibration strings

### DIFF
--- a/radio/src/translations/en.h
+++ b/radio/src/translations/en.h
@@ -415,8 +415,13 @@
   #define TR_MOVESTICKSPOTS            "MOVE AXIS/POTS"
 #else
   #define TR_MENUTOSTART               CENTER "\010" TR_ENTER " TO START"
-  #define TR_SETMIDPOINT               TR(CENTER "\004SET AXIS MIDPOINT", CENTER "\004CENTER AXIS/SLIDERS")
-  #define TR_MOVESTICKSPOTS            CENTER "\006MOVE AXIS/POTS"
+#if defined(SURFACE_RADIO)
+  #define TR_SETMIDPOINT               CENTER "\006SET POTS MIDPOINT"
+  #define TR_MOVESTICKSPOTS            CENTER "\002MOVE ST/TH/POTS/AXIS"
+#else
+  #define TR_SETMIDPOINT               TR(CENTER "\006SET AXIS MIDPOINT", CENTER "\004CENTER AXIS/SLIDERS")
+  #define TR_MOVESTICKSPOTS            CENTER "\007MOVE AXIS/POTS"
+#endif
   #define TR_MENUWHENDONE              CENTER "\006" TR_ENTER " WHEN DONE"
 #endif
 #define TR_TXnRX                       "Tx:\0Rx:"


### PR DESCRIPTION
Minor changes to better guide users during calib

Surface radio
![image](https://github.com/EdgeTX/edgetx/assets/5167938/e14e3460-5e80-44c1-a840-f850cb56b6b3)
![image](https://github.com/EdgeTX/edgetx/assets/5167938/1bdd4579-645a-4d96-807f-287c2e8fc18f)

'air' radio
![image](https://github.com/EdgeTX/edgetx/assets/5167938/e156d291-7e22-4303-a9af-bed9e0871d9d)
![image](https://github.com/EdgeTX/edgetx/assets/5167938/fe619de0-045a-4eef-aebd-211c38d58f0f)


