### PR TITLE
fix(color): Model YAML file not updated after changing trim setting in flight mode.

### DIFF
--- a/radio/src/gui/colorlcd/model_flightmodes.cpp
+++ b/radio/src/gui/colorlcd/model_flightmodes.cpp
@@ -140,6 +140,7 @@ class FlightModeEdit : public Page
                                 [=](int val) {
                                   tr->mode = val;
                                   showControls(t, tr->mode);
+                                  SET_DIRTY();
                                 });
         tr_mode[t]->setTextHandler([=](uint8_t mode) { return getFMTrimStr(mode, true); });
         tr_mode[t]->setAvailableHandler([=](int mode) {


### PR DESCRIPTION
Changing a trim setting in flight modes does not mark the model as dirty so the YAML file does not get updated.

Should be added to 2.9 if another 2.9.x release is planned.

Note: for 2.10, this fix is also in PR #4465 so this can be ignored if 4465 is merged first.
