### PR TITLE
fix(x9d+): Default pots and sliders config

### DIFF
--- a/radio/util/hw_defs/pot_config.py
+++ b/radio/util/hw_defs/pot_config.py
@@ -101,13 +101,13 @@ POT_CONFIG = {
         "SL1": {"default": "SLIDER"},
         "SL2": {"default": "SLIDER"}
     },
-    "x9dp": {
+    "x9d+": {
         "P1": {"default": "POT_CENTER"},
         "P2": {"default": "POT_CENTER"},
         "SL1": {"default": "SLIDER"},
         "SL2": {"default": "SLIDER"}
     },
-    "x9dp2019": {
+    "x9d+2019": {
         "P1": {"default": "POT_CENTER"},
         "P2": {"default": "POT_CENTER"},
         "SL1": {"default": "SLIDER"},


### PR DESCRIPTION
Fixes generation of hw defn json files for x9d+ and x9d+ 2019
