### PR TITLE
fix(bw): Channel Monitor view not working correctly on startup

### DIFF
--- a/radio/src/gui/212x64/view_channels.cpp
+++ b/radio/src/gui/212x64/view_channels.cpp
@@ -21,10 +21,18 @@
 
 #include "opentx.h"
 
+struct ViewChannelsState {
+    bool longNames;
+    bool secondPage;
+    bool mixersView;
+};
+
+static ViewChannelsState viewChannels = { false, false, false };
+
 void menuChannelsView(event_t event)
 {
   uint8_t ch = 0;
-  uint8_t wbar = (reusableBuffer.viewChannels.longNames ? 54 : 64);
+  uint8_t wbar = (viewChannels.longNames ? 54 : 64);
   int16_t limits = 512 * 2;
 
   if (g_eeGeneral.ppmunit == PPM_PERCENT_PREC1) {
@@ -32,10 +40,6 @@ void menuChannelsView(event_t event)
   }
 
   switch(event) {
-    case EVT_ENTRY:
-      memclear(&reusableBuffer.viewChannels, sizeof(reusableBuffer.viewChannels));
-      break;
-
     case EVT_KEY_BREAK(KEY_EXIT):
       popMenu();
       break;
@@ -44,23 +48,23 @@ void menuChannelsView(event_t event)
     case EVT_ROTARY_RIGHT:
     case EVT_KEY_FIRST(KEY_PLUS):
     case EVT_KEY_FIRST(KEY_MINUS):
-      reusableBuffer.viewChannels.secondPage = !reusableBuffer.viewChannels.secondPage;
+      viewChannels.secondPage = !viewChannels.secondPage;
       break;
 
     case EVT_KEY_FIRST(KEY_ENTER):
-      reusableBuffer.viewChannels.mixersView = !reusableBuffer.viewChannels.mixersView;
+      viewChannels.mixersView = !viewChannels.mixersView;
       break;
   }
 
-  if (reusableBuffer.viewChannels.secondPage)
+  if (viewChannels.secondPage)
     ch = 16;
 
-  if (reusableBuffer.viewChannels.mixersView)
+  if (viewChannels.mixersView)
     limits *= 2;  // this could be handled nicer, but slower, by checking actual range for this mixer
   else if (g_model.extendedLimits)
     limits *= LIMIT_EXT_PERCENT / 100;
 
-  lcdDrawText(LCD_W / 2, 0, reusableBuffer.viewChannels.mixersView ? STR_MIXERS_MONITOR : STR_CHANNELS_MONITOR, CENTERED);
+  lcdDrawText(LCD_W / 2, 0, viewChannels.mixersView ? STR_MIXERS_MONITOR : STR_CHANNELS_MONITOR, CENTERED);
   lcdInvertLine(0);
 
   // Column separator
@@ -73,13 +77,13 @@ void menuChannelsView(event_t event)
     // Channels
     for (uint8_t line=0; line < 8; line++) {
       const uint8_t y = 9 + line * 7;
-      const int32_t val = reusableBuffer.viewChannels.mixersView ? ex_chans[ch] : channelOutputs[ch];
+      const int32_t val = viewChannels.mixersView ? ex_chans[ch] : channelOutputs[ch];
       const uint8_t lenLabel = ZLEN(g_model.limitData[ch].name);
 
       // Channel name if present, number if not
       if (lenLabel > 0) {
         if (lenLabel > 4)
-          reusableBuffer.viewChannels.longNames = true;
+          viewChannels.longNames = true;
         lcdDrawSizedText(x+1-ofs, y, g_model.limitData[ch].name, sizeof(g_model.limitData[ch].name), ZCHAR | SMLSIZE);
       }
       else {

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -806,12 +806,6 @@ union ReusableBuffer
 #endif
 
   struct {
-    bool longNames;
-    bool secondPage;
-    bool mixersView;
-  } viewChannels;
-
-  struct {
     uint8_t maxNameLen;
   } modelFailsafe;
 

--- a/radio/src/tasks.cpp
+++ b/radio/src/tasks.cpp
@@ -52,6 +52,11 @@ TASK_FUNCTION(menusTask)
 
   mixerTaskInit();
 
+#if !defined(COLORLCD)
+  // Ensure correct init on B&W if starting on 'Channels Monitor' page.
+  pushEvent(EVT_ENTRY);
+#endif
+
 #if defined(PWR_BUTTON_PRESS)
   while (true) {
     uint32_t pwr_check = pwrCheck();

--- a/radio/src/tasks.cpp
+++ b/radio/src/tasks.cpp
@@ -52,11 +52,6 @@ TASK_FUNCTION(menusTask)
 
   mixerTaskInit();
 
-#if !defined(COLORLCD)
-  // Ensure correct init on B&W if starting on 'Channels Monitor' page.
-  pushEvent(EVT_ENTRY);
-#endif
-
 #if defined(PWR_BUTTON_PRESS)
   while (true) {
     uint32_t pwr_check = pwrCheck();


### PR DESCRIPTION
Fixes #4467 

If the 'Channels Monitor' is the start view (or is selected after startup), the view opens on the 'Mixers Monitor' instead and the ENTER key cannot be used to change view. 

User must enter a setup menu and return to the main view for the channel monitor to work correctly.

On startup - the view is not initialised correctly.
