### PR TITLE
fix(vs1053b): Remove EarSpeaker Spatial Processing

### DIFF
--- a/radio/src/targets/common/arm/stm32/vs1053b.cpp
+++ b/radio/src/targets/common/arm/stm32/vs1053b.cpp
@@ -250,7 +250,7 @@ uint8_t audioSoftReset(void)
   audioSpiReadWriteByte(0x00); // start the transfer
 
   uint8_t retry = 0;
-  uint16_t mode = SM_SDINEW | SM_EARSPEAKER_LO;
+  uint16_t mode = SM_SDINEW;
   while (audioSpiReadReg(SPI_MODE) != mode && retry < 100) {
     retry++;
     audioSpiWriteCmd(SPI_MODE, mode | SM_RESET);


### PR DESCRIPTION
See section *9.3 EarSpeaker Spatial Processing* of the VS1053b datasheet.

Fixes #4325