### PR TITLE
fix(color): Special/Global functions from 2.9 not imported correctly in 2.10.

### DIFF
--- a/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
@@ -1600,6 +1600,10 @@ static void r_customFn(void* user, uint8_t* data, uint32_t bitoffs,
     break;
   }
 
+  // Set 'enabled' to handle old format YAML files
+  // Will be updated if enabled flag is actually present
+  CFN_ACTIVE(cfn) = 1;
+
   if (eat_comma) {
     val += l_sep;
     val_len -= l_sep;
@@ -1618,8 +1622,6 @@ static void r_customFn(void* user, uint8_t* data, uint32_t bitoffs,
     if (l_sep == val_len) {
       // only one more value - assume it is repeat
       read_enable_flag = false;
-      // Set 'enabled'
-      CFN_ACTIVE(cfn) = 1;
     }
   }
 

--- a/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
@@ -1615,7 +1615,7 @@ static void r_customFn(void* user, uint8_t* data, uint32_t bitoffs,
   if (HAS_REPEAT_PARAM(func)) {
     // Check for 2 values to be parsed
     uint8_t l_sep = find_sep(val, val_len);
-    if (!l_sep) {
+    if (l_sep == val_len) {
       // only one more value - assume it is repeat
       read_enable_flag = false;
       // Set 'enabled'


### PR DESCRIPTION
Fixes #4495

Fix for reading 2.9 model files in 2.10 - correctly handle 2.9 special/global function syntax.