### PR TITLE
fix(lua): re-implement luaSetSerialBaudrate

### DIFF
--- a/radio/src/gui/colorlcd/view_statistics.cpp
+++ b/radio/src/gui/colorlcd/view_statistics.cpp
@@ -356,7 +356,7 @@ void DebugViewPage::build(FormWindow* window)
 #endif
 
 #if defined(INTERNAL_GPS)
-  if (hasSerialMode(UART_MODE_GPS) != -1) {
+  if (serialGetModePort(UART_MODE_GPS) >= 0) {
     line = form->newLine(&grid);
     line->padAll(2);
 

--- a/radio/src/gui/colorlcd/widgets/radio_info.cpp
+++ b/radio/src/gui/colorlcd/widgets/radio_info.cpp
@@ -253,7 +253,7 @@ class InternalGPSWidget: public TopBarWidget
 
     void refresh(BitmapBuffer * dc) override
     {
-      if (hasSerialMode(UART_MODE_GPS) != -1) {
+      if (serialGetModePort(UART_MODE_GPS) >= 0) {
         if (gpsData.fix) {
           char s[10];
           sprintf(s, "%d", gpsData.numSat);

--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -202,7 +202,7 @@ bool isSourceAvailable(int source)
   if (source >= MIXSRC_FIRST_SPACEMOUSE && source <= MIXSRC_LAST_SPACEMOUSE)
     return false;
 #elif defined(PCBHORUS) && defined(SPACEMOUSE)
-  if ((hasSerialMode(UART_MODE_SPACEMOUSE) == -1) &&
+  if ((serialGetModePort(UART_MODE_SPACEMOUSE) < 0) &&
       (source >= MIXSRC_FIRST_SPACEMOUSE && source <= MIXSRC_LAST_SPACEMOUSE))
     return false;
 #endif
@@ -424,14 +424,6 @@ bool isSwitchAvailable(int swtch, SwitchContext context)
   return true;
 }
 
-int hasSerialMode(int mode)
-{
-  for (int p = 0; p < MAX_SERIAL_PORTS; p++) {
-    if (serialGetMode(p) == mode) return p;
-  }
-  return -1;
-}
-
 bool isSerialModeAvailable(uint8_t port_nr, int mode)
 {
 #if defined(USB_SERIAL)
@@ -492,7 +484,7 @@ bool isSerialModeAvailable(uint8_t port_nr, int mode)
     return false;
 #endif
 
-  auto p = hasSerialMode(mode);
+  auto p = serialGetModePort(mode);
   if (p >= 0 && p != port_nr) return false;
   return true;
 }
@@ -1014,7 +1006,7 @@ bool isTrainerModeAvailable(int mode)
 
   if (mode == TRAINER_MODE_MASTER_SERIAL) {
 #if defined(SBUS_TRAINER)
-    return hasSerialMode(UART_MODE_SBUS_TRAINER) >= 0;
+    return serialGetModePort(UART_MODE_SBUS_TRAINER) >= 0;
 #else
     return false;
 #endif

--- a/radio/src/gui/gui_common.h
+++ b/radio/src/gui/gui_common.h
@@ -83,7 +83,6 @@ bool isSourceAvailableInResetSpecialFunction(int index);
 bool isSourceAvailableInGlobalResetSpecialFunction(int index);
 bool isSwitchAvailable(int swtch, SwitchContext context);
 bool isSerialModeAvailable(uint8_t port_nr, int mode);
-int  hasSerialMode(int mode);
 bool isSwitchAvailableInLogicalSwitches(int swtch);
 bool isSwitchAvailableInCustomFunctions(int swtch);
 bool isSwitchAvailableInMixes(int swtch);

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -2258,24 +2258,13 @@ Set baudrate for serial port(s) affected to LUA
 */
 static int luaSetSerialBaudrate(lua_State * L)
 {
-// #if defined(AUX_SERIAL) || defined(AUX2_SERIAL)
-//   unsigned int baudrate = luaL_checkunsigned(L, 1);
-// #endif
+  int port_nr = serialGetModePort(UART_MODE_LUA);
+  if (port_nr < 0) return 0;
 
-// TODO: add some callbacks for serial settings
-// #if defined(AUX_SERIAL)
-//   if (auxSerialMode == UART_MODE_LUA) {
-//     auxSerialStop();
-//     auxSerialSetup(baudrate, false);
-//   }
-// #endif
-// #if defined(AUX2_SERIAL)
-//   if (aux2SerialMode == UART_MODE_LUA) {
-//     aux2SerialStop();
-//     aux2SerialSetup(baudrate, false);
-//   }
-// #endif
-  return 1;
+  uint32_t baudrate = luaL_checkunsigned(L, 1);
+  serialSetBaudrate(port_nr, baudrate);
+
+  return 0;
 }
 
 /*luadoc

--- a/radio/src/serial.cpp
+++ b/radio/src/serial.cpp
@@ -379,6 +379,38 @@ void serialSetPower(uint8_t port_nr, bool enabled)
 }
 #endif
 
+uint32_t serialGetBaudrate(uint8_t port_nr)
+{
+  auto state = getSerialPortState(port_nr);
+  if (!state || !state->port || !state->usart_ctx)
+    return 0;
+
+  auto port = state->port;
+  if (!port->uart || !port->uart->getBaudrate) return 0;
+
+  return port->uart->getBaudrate(state->usart_ctx);
+}
+
+void serialSetBaudrate(uint8_t port_nr, uint32_t baudrate)
+{
+  auto state = getSerialPortState(port_nr);
+  if (!state || !state->port || !state->usart_ctx)
+    return;
+
+  auto port = state->port;
+  if (!port->uart || !port->uart->setBaudrate) return;
+
+  port->uart->setBaudrate(state->usart_ctx, baudrate);
+}
+
+int serialGetModePort(int mode)
+{
+  for (int p = 0; p < MAX_SERIAL_PORTS; p++) {
+    if (serialGetMode(p) == mode) return p;
+  }
+  return -1;  
+}
+
 void serialInit(uint8_t port_nr, int mode)
 {
   auto state = getSerialPortState(port_nr);

--- a/radio/src/serial.h
+++ b/radio/src/serial.h
@@ -30,10 +30,17 @@
 #define SERIAL_CONF_POWER_BIT        7    /* MSBit of the configuration byte */
 
 const etx_serial_port_t* serialGetPort(uint8_t port_nr);
+
 int  serialGetMode(uint8_t port_nr);
 void serialSetMode(uint8_t port_nr, int mode);
+
 bool serialGetPower(uint8_t port_nr);
 void serialSetPower(uint8_t port_nr, bool enabled);
+
+uint32_t serialGetBaudrate(uint8_t port_nr);
+void serialSetBaudrate(uint8_t port_nr, uint32_t baudrate);
+
+int serialGetModePort(int mode);
 
 void initSerialPorts();
 void serialInit(uint8_t port_nr, int mode);


### PR DESCRIPTION
Fixes #4466

Summary of changes:
- added `serialGetBaudrate`, `serialSetBaudrate` and `serialGetModePort`,
- re-implement `luaSetSerialBaudrate`.
