### PR TITLE
fix: Throttle idle trim for surface radio

### DIFF
--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -601,7 +601,7 @@ int getStickTrimValue(int stick, int stickValue)
     if (g_model.throttleReversed) trim = -trim;
     if (g_model.thrTrim) {
 #if defined(SURFACE_RADIO)
-      // Throttle trim should affect only forward stick (0 to 1024)
+      // Throttle Idle trim (g_model.thrTrim) should affect only forward stick (0 to 1024)
       // Return no trim for reverse side when throttle trim is enabled
       if (stickValue < 0) return 0;
 #endif

--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -598,7 +598,7 @@ int getStickTrimValue(int stick, int stickValue)
   int trim = trims[stick];
   uint8_t thrTrimSw = g_model.getThrottleStickTrimSource() - MIXSRC_FIRST_TRIM;
   if (stick == thrTrimSw) {
-#if defined(SURFACE_RADIO
+#if defined(SURFACE_RADIO)
     // divide throtle trim by two since since the full extend
     // of forward/reverse chan is only 1024 instead of 2048
     trim >>= 1;

--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -584,6 +584,12 @@ void evalInputs(uint8_t mode)
   }
 }
 
+#if defined(SURFACE_RADIO)
+  constexpr int IDLE_TRIM_SCALE = 1;
+#else
+  constexpr int IDLE_TRIM_SCALE = 2;
+#endif
+
 int getStickTrimValue(int stick, int stickValue)
 {
   if (stick < 0)
@@ -594,9 +600,14 @@ int getStickTrimValue(int stick, int stickValue)
   if (stick == thrTrimSw) {
     if (g_model.throttleReversed) trim = -trim;
     if (g_model.thrTrim) {
-      trim = (g_model.extendedTrims) ? 2 * TRIM_EXTENDED_MAX + trim
-                                     : 2 * TRIM_MAX + trim;
-      trim = trim * (1024 - stickValue) / (2 * RESX);
+#if defined(SURFACE_RADIO)
+      // Throttle trim should affect only forward stick (0 to 1024)
+      // Return no trim for reverse side when throttle trim is enabled
+      if (stickValue < 0) return 0;
+#endif
+      trim = (g_model.extendedTrims) ? IDLE_TRIM_SCALE * TRIM_EXTENDED_MAX + trim
+                                     : IDLE_TRIM_SCALE * TRIM_MAX + trim;
+      trim = trim * (1024 - stickValue) / (IDLE_TRIM_SCALE * RESX);
     }
   }
   return trim;

--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -602,7 +602,7 @@ int getStickTrimValue(int stick, int stickValue)
     if (g_model.thrTrim) {
 #if defined(SURFACE_RADIO)
       // Throttle Idle trim (g_model.thrTrim) should affect only forward stick (0 to 1024)
-      // Return no trim for reverse side when throttle trim is enabled
+      // Return no trim for reverse side when throttle idle trim is enabled
       if (stickValue < 0) return 0;
 #endif
       trim = (g_model.extendedTrims) ? IDLE_TRIM_SCALE * TRIM_EXTENDED_MAX + trim

--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -598,6 +598,11 @@ int getStickTrimValue(int stick, int stickValue)
   int trim = trims[stick];
   uint8_t thrTrimSw = g_model.getThrottleStickTrimSource() - MIXSRC_FIRST_TRIM;
   if (stick == thrTrimSw) {
+#if defined(SURFACE_RADIO
+    // divide throtle trim by two since since the full extend
+    // of forward/reverse chan is only 1024 instead of 2048
+    trim >>= 1;
+#endif
     if (g_model.throttleReversed) trim = -trim;
     if (g_model.thrTrim) {
 #if defined(SURFACE_RADIO)


### PR DESCRIPTION
Defines the following behavior for surface radio when **T-Trim-Idle is enabled**

Throttle trim only applies to forward section:
- all the reverse range should see no trim effect
- full effect should be a 0 throttle

Fixes #4504
