### PR TITLE
chore(cpn): python-lz4 for win32 no longer in mingw repo

### DIFF
--- a/.github/workflows/win-cpn-32.yml
+++ b/.github/workflows/win-cpn-32.yml
@@ -59,7 +59,7 @@ jobs:
                                 mingw-w64-i686-dfu-util \
                                 mingw-w64-i686-openssl
           python -m pip install clang jinja2
-          pip install --no-binary --no-cache-dir lz4
+          python -m pip install --no-binary :all: --no-cache-dir lz4
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v3

--- a/.github/workflows/win-cpn-32.yml
+++ b/.github/workflows/win-cpn-32.yml
@@ -57,9 +57,9 @@ jobs:
                                 mingw-w64-i686-clang \
                                 mingw-w64-i686-nsis \
                                 mingw-w64-i686-dfu-util \
-                                mingw-w64-i686-openssl 
+                                mingw-w64-i686-openssl
           python -m pip install clang jinja2
-          python -m pip install lz4 --no-binary --no-cache-dir
+          pip install --no-binary --no-cache-dir lz4
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v3

--- a/.github/workflows/win-cpn-32.yml
+++ b/.github/workflows/win-cpn-32.yml
@@ -59,7 +59,8 @@ jobs:
                                 mingw-w64-i686-dfu-util \
                                 mingw-w64-i686-openssl
           python -m pip install clang jinja2
-          python -m pip install --no-binary :all: --no-cache-dir lz4
+          SETUPTOOLS_USE_DISTUTILS=stdlib pip install lz4
+          python -m pip install lz4
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v3

--- a/.github/workflows/win-cpn-32.yml
+++ b/.github/workflows/win-cpn-32.yml
@@ -58,9 +58,8 @@ jobs:
                                 mingw-w64-i686-nsis \
                                 mingw-w64-i686-dfu-util \
                                 mingw-w64-i686-openssl
-          python -m pip install clang jinja2
           SETUPTOOLS_USE_DISTUTILS=stdlib pip install lz4
-          python -m pip install lz4
+          python -m pip install clang jinja2 lz4
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v3

--- a/.github/workflows/win-cpn-32.yml
+++ b/.github/workflows/win-cpn-32.yml
@@ -59,7 +59,7 @@ jobs:
                                 mingw-w64-i686-dfu-util \
                                 mingw-w64-i686-openssl
           python -m pip install clang jinja2
-          python -m pip install --no-binary --no-cache-dir lz4
+          python -m pip install --no-binary lz4
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v3

--- a/.github/workflows/win-cpn-32.yml
+++ b/.github/workflows/win-cpn-32.yml
@@ -44,7 +44,6 @@ jobs:
           pacman -S --noconfirm mingw-w64-i686-cmake \
                                 mingw-w64-i686-python-pip \
                                 mingw-w64-i686-python-pillow \
-                                mingw-w64-i686-python-lz4 \
                                 mingw-w64-i686-libjpeg-turbo \
                                 mingw-w64-i686-zlib \
                                 mingw-w64-i686-libtiff \
@@ -59,7 +58,7 @@ jobs:
                                 mingw-w64-i686-nsis \
                                 mingw-w64-i686-dfu-util \
                                 mingw-w64-i686-openssl
-          python -m pip install clang jinja2
+          python -m pip install clang jinja2 lz4
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v3

--- a/.github/workflows/win-cpn-32.yml
+++ b/.github/workflows/win-cpn-32.yml
@@ -57,9 +57,9 @@ jobs:
                                 mingw-w64-i686-clang \
                                 mingw-w64-i686-nsis \
                                 mingw-w64-i686-dfu-util \
-                                mingw-w64-i686-openssl
+                                mingw-w64-i686-openssl 
           python -m pip install clang jinja2
-          python -m pip install --no-binary lz4
+          python -m pip install lz4 --no-binary --no-cache-dir
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v3

--- a/.github/workflows/win-cpn-32.yml
+++ b/.github/workflows/win-cpn-32.yml
@@ -58,7 +58,8 @@ jobs:
                                 mingw-w64-i686-nsis \
                                 mingw-w64-i686-dfu-util \
                                 mingw-w64-i686-openssl
-          python -m pip install clang jinja2 lz4
+          python -m pip install clang jinja2
+          python -m pip install --no-binary --no-cache-dir lz4
 
       - name: Install Qt
         uses: jurplel/install-qt-action@v3


### PR DESCRIPTION
Was dropped in
https://github.com/msys2/MINGW-packages/commit/b379ec0637a836f3da5cd13a67788c4ddcbfdfad

Then the documentation for python-lz4 was listing an invalid install command, and even when the right command was used, it seems like MSYS2 has a patched version of `distutils` that wasn't been used 😖 What fun!


Fixes win32 companion build failure. If build is successful, will probably be needed in 2.9 branch also
