### PR TITLE
feat: set better internal crossfire module default baudrate

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -293,7 +293,7 @@ void generalDefault()
 #if defined(DEFAULT_INTERNAL_MODULE)
     g_eeGeneral.internalModule = DEFAULT_INTERNAL_MODULE;
     if (g_eeGeneral.internalModule == MODULE_TYPE_CROSSFIRE)
-      g_eeGeneral.internalModuleBaudrate = CROSSFIRE_MAX_INTERNAL_BAUDRATE;
+      g_eeGeneral.internalModuleBaudrate = min(1, (int)CROSSFIRE_MAX_INTERNAL_BAUDRATE);  // 921k if possible
 #endif
 
   adcCalibDefaults();

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -57,6 +57,10 @@
   #include "gui/colorlcd/LvglWrapper.h"
 #endif
 
+#if defined(CROSSFIRE)
+#include "telemetry/crossfire.h"
+#endif
+
 #if !defined(SIMU)
 #include <malloc.h>
 #endif
@@ -288,6 +292,8 @@ void generalDefault()
 
 #if defined(DEFAULT_INTERNAL_MODULE)
     g_eeGeneral.internalModule = DEFAULT_INTERNAL_MODULE;
+    if (g_eeGeneral.internalModule == MODULE_TYPE_CROSSFIRE)
+      g_eeGeneral.internalModuleBaudrate = CROSSFIRE_MAX_INTERNAL_BAUDRATE;
 #endif
 
   adcCalibDefaults();


### PR DESCRIPTION
Set internal default CRSF module to max working baudrate on specific hardware instead of current default of 400k