### PR TITLE
radio.yml / model.yml tag hatsMode for featured radios only

### DIFF
--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -680,8 +680,12 @@ PACK(struct ModelData {
   uint8_t   disableTelemetryWarning:1;
   uint8_t   showInstanceIds:1;
   uint8_t   checklistInteractive:1;
+#if defined(USE_HATS_AS_KEYS)
   NOBACKUP(uint8_t hatsMode:2 ENUM(HatsMode));
   uint8_t   spare3:2 SKIP;  // padding to 8-bit aligment
+#else
+  uint8_t   spare3:4 SKIP;  // padding to 8-bit aligment
+#endif
   int8_t    customThrottleWarningPosition;
   BeepANACenter beepANACenter;
   MixData   mixData[MAX_MIXERS] NO_IDX;
@@ -843,8 +847,12 @@ PACK(struct RadioData {
   // Real attributes
   NOBACKUP(uint8_t manuallyEdited:1);
   int8_t timezoneMinutes:3;    // -3 to +3 ==> (-45 to 45 minutes in 15 minute increments)
-  NOBACKUP(uint8_t hatsMode:2 ENUM(HatsMode));
   NOBACKUP(uint8_t ppmunit:2);  // PPMUnit enum
+#if defined(USE_HATS_AS_KEYS)
+  NOBACKUP(uint8_t hatsMode:2 ENUM(HatsMode));
+#else
+  NOBACKUP(uint8_t hatsModeSpare:2 SKIP);
+#endif
   CUST_ATTR(semver,nullptr,w_semver);
   CUST_ATTR(board,nullptr,w_board);
   CalibData calib[MAX_CALIB_ANALOG_INPUTS] NO_IDX;

--- a/radio/src/model_init.cpp
+++ b/radio/src/model_init.cpp
@@ -134,7 +134,9 @@ void applyDefaultTemplate()
   }
 #endif
 
+#if defined(USE_HATS_AS_KEYS)
   g_model.hatsMode = HATSMODE_GLOBAL;
+#endif
 }
 
 void setModelDefaults(uint8_t id)

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -366,7 +366,9 @@ void generalDefault()
   // disable Custom Script
   g_eeGeneral.modelCustomScriptsDisabled = true;
 
- g_eeGeneral.hatsMode = HATSMODE_SWITCHABLE;
+#if defined(USE_HATS_AS_KEYS)
+  g_eeGeneral.hatsMode = HATSMODE_SWITCHABLE;
+#endif
 
   g_eeGeneral.chkSum = 0xFFFF;
 }

--- a/radio/src/storage/yaml/yaml_datastructs_128x64.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_128x64.cpp
@@ -4,13 +4,6 @@
 // Enums first
 //
 
-const struct YamlIdStr enum_HatsMode[] = {
-  {  HATSMODE_TRIMS_ONLY, "TRIMS_ONLY"  },
-  {  HATSMODE_KEYS_ONLY, "KEYS_ONLY"  },
-  {  HATSMODE_SWITCHABLE, "SWITCHABLE"  },
-  {  HATSMODE_GLOBAL, "GLOBAL"  },
-  {  0, NULL  }
-};
 const struct YamlIdStr enum_BacklightMode[] = {
   {  e_backlight_mode_off, "backlight_mode_off"  },
   {  e_backlight_mode_keys, "backlight_mode_keys"  },
@@ -279,8 +272,8 @@ static const struct YamlNode struct_CustomFunctionData[] = {
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
-  YAML_ENUM("hatsMode", 2, enum_HatsMode),
   YAML_UNSIGNED( "ppmunit", 2 ),
+  YAML_PADDING( 2 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 12, struct_CalibData, NULL),
@@ -804,8 +797,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
   YAML_UNSIGNED( "showInstanceIds", 1 ),
   YAML_UNSIGNED( "checklistInteractive", 1 ),
-  YAML_ENUM("hatsMode", 2, enum_HatsMode),
-  YAML_PADDING( 2 ),
+  YAML_PADDING( 4 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
@@ -290,8 +290,8 @@ static const struct YamlNode struct_CustomFunctionData[] = {
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
-  YAML_ENUM("hatsMode", 2, enum_HatsMode),
   YAML_UNSIGNED( "ppmunit", 2 ),
+  YAML_ENUM("hatsMode", 2, enum_HatsMode),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 20, struct_CalibData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_pl18.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_pl18.cpp
@@ -294,8 +294,8 @@ static const struct YamlNode struct_CustomFunctionData[] = {
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
-  YAML_ENUM("hatsMode", 2, enum_HatsMode),
   YAML_UNSIGNED( "ppmunit", 2 ),
+  YAML_ENUM("hatsMode", 2, enum_HatsMode),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 20, struct_CalibData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_t20.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t20.cpp
@@ -4,13 +4,6 @@
 // Enums first
 //
 
-const struct YamlIdStr enum_HatsMode[] = {
-  {  HATSMODE_TRIMS_ONLY, "TRIMS_ONLY"  },
-  {  HATSMODE_KEYS_ONLY, "KEYS_ONLY"  },
-  {  HATSMODE_SWITCHABLE, "SWITCHABLE"  },
-  {  HATSMODE_GLOBAL, "GLOBAL"  },
-  {  0, NULL  }
-};
 const struct YamlIdStr enum_BacklightMode[] = {
   {  e_backlight_mode_off, "backlight_mode_off"  },
   {  e_backlight_mode_keys, "backlight_mode_keys"  },
@@ -283,8 +276,8 @@ static const struct YamlNode struct_CustomFunctionData[] = {
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
-  YAML_ENUM("hatsMode", 2, enum_HatsMode),
   YAML_UNSIGNED( "ppmunit", 2 ),
+  YAML_PADDING( 2 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 12, struct_CalibData, NULL),
@@ -806,8 +799,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
   YAML_UNSIGNED( "showInstanceIds", 1 ),
   YAML_UNSIGNED( "checklistInteractive", 1 ),
-  YAML_ENUM("hatsMode", 2, enum_HatsMode),
-  YAML_PADDING( 2 ),
+  YAML_PADDING( 4 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_tpro.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tpro.cpp
@@ -4,13 +4,6 @@
 // Enums first
 //
 
-const struct YamlIdStr enum_HatsMode[] = {
-  {  HATSMODE_TRIMS_ONLY, "TRIMS_ONLY"  },
-  {  HATSMODE_KEYS_ONLY, "KEYS_ONLY"  },
-  {  HATSMODE_SWITCHABLE, "SWITCHABLE"  },
-  {  HATSMODE_GLOBAL, "GLOBAL"  },
-  {  0, NULL  }
-};
 const struct YamlIdStr enum_BacklightMode[] = {
   {  e_backlight_mode_off, "backlight_mode_off"  },
   {  e_backlight_mode_keys, "backlight_mode_keys"  },
@@ -279,8 +272,8 @@ static const struct YamlNode struct_CustomFunctionData[] = {
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
-  YAML_ENUM("hatsMode", 2, enum_HatsMode),
   YAML_UNSIGNED( "ppmunit", 2 ),
+  YAML_PADDING( 2 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 12, struct_CalibData, NULL),
@@ -802,8 +795,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
   YAML_UNSIGNED( "showInstanceIds", 1 ),
   YAML_UNSIGNED( "checklistInteractive", 1 ),
-  YAML_ENUM("hatsMode", 2, enum_HatsMode),
-  YAML_PADDING( 2 ),
+  YAML_PADDING( 4 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_x10.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x10.cpp
@@ -4,13 +4,6 @@
 // Enums first
 //
 
-const struct YamlIdStr enum_HatsMode[] = {
-  {  HATSMODE_TRIMS_ONLY, "TRIMS_ONLY"  },
-  {  HATSMODE_KEYS_ONLY, "KEYS_ONLY"  },
-  {  HATSMODE_SWITCHABLE, "SWITCHABLE"  },
-  {  HATSMODE_GLOBAL, "GLOBAL"  },
-  {  0, NULL  }
-};
 const struct YamlIdStr enum_BacklightMode[] = {
   {  e_backlight_mode_off, "backlight_mode_off"  },
   {  e_backlight_mode_keys, "backlight_mode_keys"  },
@@ -298,8 +291,8 @@ static const struct YamlNode struct_CustomFunctionData[] = {
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
-  YAML_ENUM("hatsMode", 2, enum_HatsMode),
   YAML_UNSIGNED( "ppmunit", 2 ),
+  YAML_PADDING( 2 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 20, struct_CalibData, NULL),
@@ -835,8 +828,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
   YAML_UNSIGNED( "showInstanceIds", 1 ),
   YAML_UNSIGNED( "checklistInteractive", 1 ),
-  YAML_ENUM("hatsMode", 2, enum_HatsMode),
-  YAML_PADDING( 2 ),
+  YAML_PADDING( 4 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
@@ -4,13 +4,6 @@
 // Enums first
 //
 
-const struct YamlIdStr enum_HatsMode[] = {
-  {  HATSMODE_TRIMS_ONLY, "TRIMS_ONLY"  },
-  {  HATSMODE_KEYS_ONLY, "KEYS_ONLY"  },
-  {  HATSMODE_SWITCHABLE, "SWITCHABLE"  },
-  {  HATSMODE_GLOBAL, "GLOBAL"  },
-  {  0, NULL  }
-};
 const struct YamlIdStr enum_BacklightMode[] = {
   {  e_backlight_mode_off, "backlight_mode_off"  },
   {  e_backlight_mode_keys, "backlight_mode_keys"  },
@@ -298,8 +291,8 @@ static const struct YamlNode struct_CustomFunctionData[] = {
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
-  YAML_ENUM("hatsMode", 2, enum_HatsMode),
   YAML_UNSIGNED( "ppmunit", 2 ),
+  YAML_PADDING( 2 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 20, struct_CalibData, NULL),
@@ -835,8 +828,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
   YAML_UNSIGNED( "showInstanceIds", 1 ),
   YAML_UNSIGNED( "checklistInteractive", 1 ),
-  YAML_ENUM("hatsMode", 2, enum_HatsMode),
-  YAML_PADDING( 2 ),
+  YAML_PADDING( 4 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
@@ -4,13 +4,6 @@
 // Enums first
 //
 
-const struct YamlIdStr enum_HatsMode[] = {
-  {  HATSMODE_TRIMS_ONLY, "TRIMS_ONLY"  },
-  {  HATSMODE_KEYS_ONLY, "KEYS_ONLY"  },
-  {  HATSMODE_SWITCHABLE, "SWITCHABLE"  },
-  {  HATSMODE_GLOBAL, "GLOBAL"  },
-  {  0, NULL  }
-};
 const struct YamlIdStr enum_BacklightMode[] = {
   {  e_backlight_mode_off, "backlight_mode_off"  },
   {  e_backlight_mode_keys, "backlight_mode_keys"  },
@@ -279,8 +272,8 @@ static const struct YamlNode struct_CustomFunctionData[] = {
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
-  YAML_ENUM("hatsMode", 2, enum_HatsMode),
   YAML_UNSIGNED( "ppmunit", 2 ),
+  YAML_PADDING( 2 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 12, struct_CalibData, NULL),
@@ -804,8 +797,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
   YAML_UNSIGNED( "showInstanceIds", 1 ),
   YAML_UNSIGNED( "checklistInteractive", 1 ),
-  YAML_ENUM("hatsMode", 2, enum_HatsMode),
-  YAML_PADDING( 2 ),
+  YAML_PADDING( 4 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
@@ -4,13 +4,6 @@
 // Enums first
 //
 
-const struct YamlIdStr enum_HatsMode[] = {
-  {  HATSMODE_TRIMS_ONLY, "TRIMS_ONLY"  },
-  {  HATSMODE_KEYS_ONLY, "KEYS_ONLY"  },
-  {  HATSMODE_SWITCHABLE, "SWITCHABLE"  },
-  {  HATSMODE_GLOBAL, "GLOBAL"  },
-  {  0, NULL  }
-};
 const struct YamlIdStr enum_BacklightMode[] = {
   {  e_backlight_mode_off, "backlight_mode_off"  },
   {  e_backlight_mode_keys, "backlight_mode_keys"  },
@@ -279,8 +272,8 @@ static const struct YamlNode struct_CustomFunctionData[] = {
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
-  YAML_ENUM("hatsMode", 2, enum_HatsMode),
   YAML_UNSIGNED( "ppmunit", 2 ),
+  YAML_PADDING( 2 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 12, struct_CalibData, NULL),
@@ -805,8 +798,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
   YAML_UNSIGNED( "showInstanceIds", 1 ),
   YAML_UNSIGNED( "checklistInteractive", 1 ),
-  YAML_ENUM("hatsMode", 2, enum_HatsMode),
-  YAML_PADDING( 2 ),
+  YAML_PADDING( 4 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_x9lite.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9lite.cpp
@@ -4,13 +4,6 @@
 // Enums first
 //
 
-const struct YamlIdStr enum_HatsMode[] = {
-  {  HATSMODE_TRIMS_ONLY, "TRIMS_ONLY"  },
-  {  HATSMODE_KEYS_ONLY, "KEYS_ONLY"  },
-  {  HATSMODE_SWITCHABLE, "SWITCHABLE"  },
-  {  HATSMODE_GLOBAL, "GLOBAL"  },
-  {  0, NULL  }
-};
 const struct YamlIdStr enum_BacklightMode[] = {
   {  e_backlight_mode_off, "backlight_mode_off"  },
   {  e_backlight_mode_keys, "backlight_mode_keys"  },
@@ -279,8 +272,8 @@ static const struct YamlNode struct_CustomFunctionData[] = {
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
-  YAML_ENUM("hatsMode", 2, enum_HatsMode),
   YAML_UNSIGNED( "ppmunit", 2 ),
+  YAML_PADDING( 2 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 12, struct_CalibData, NULL),
@@ -802,8 +795,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
   YAML_UNSIGNED( "showInstanceIds", 1 ),
   YAML_UNSIGNED( "checklistInteractive", 1 ),
-  YAML_ENUM("hatsMode", 2, enum_HatsMode),
-  YAML_PADDING( 2 ),
+  YAML_PADDING( 4 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
@@ -4,13 +4,6 @@
 // Enums first
 //
 
-const struct YamlIdStr enum_HatsMode[] = {
-  {  HATSMODE_TRIMS_ONLY, "TRIMS_ONLY"  },
-  {  HATSMODE_KEYS_ONLY, "KEYS_ONLY"  },
-  {  HATSMODE_SWITCHABLE, "SWITCHABLE"  },
-  {  HATSMODE_GLOBAL, "GLOBAL"  },
-  {  0, NULL  }
-};
 const struct YamlIdStr enum_BacklightMode[] = {
   {  e_backlight_mode_off, "backlight_mode_off"  },
   {  e_backlight_mode_keys, "backlight_mode_keys"  },
@@ -281,8 +274,8 @@ static const struct YamlNode struct_CustomFunctionData[] = {
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
-  YAML_ENUM("hatsMode", 2, enum_HatsMode),
   YAML_UNSIGNED( "ppmunit", 2 ),
+  YAML_PADDING( 2 ),
   YAML_CUSTOM("semver",nullptr,w_semver),
   YAML_CUSTOM("board",nullptr,w_board),
   YAML_ARRAY("calib", 48, 12, struct_CalibData, NULL),
@@ -807,8 +800,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "disableTelemetryWarning", 1 ),
   YAML_UNSIGNED( "showInstanceIds", 1 ),
   YAML_UNSIGNED( "checklistInteractive", 1 ),
-  YAML_ENUM("hatsMode", 2, enum_HatsMode),
-  YAML_PADDING( 2 ),
+  YAML_PADDING( 4 ),
   YAML_SIGNED( "customThrottleWarningPosition", 8 ),
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),


### PR DESCRIPTION
see discussion https://discord.com/channels/839849772864503828/839895574244229152/1194216145587286016

Summary of changes:
- yaml tag hatsMode only used for radios that have USE_HATS_AS_KEYS defined (currently NV14, EL18, PL18)