### PR TITLE
fix(color): 'Unlabeled' option does not appear in labels list.

### DIFF
--- a/radio/src/storage/modelslist.cpp
+++ b/radio/src/storage/modelslist.cpp
@@ -455,12 +455,12 @@ LabelsVector ModelMap::fromCSV(const char* str)
     c = strchr(c, ',');
   }
 
-  {
-    std::string lbl(prev_c);
+  std::string lbl(prev_c);
+  if (!lbl.empty()) {
     unEscapeCSV(lbl);
     lbls.push_back(lbl);
   }
-  
+
   return lbls;
 }
 


### PR DESCRIPTION
If there are models without labels the 'Unlabeled' option should appear in the labels list of the Manage Models page.

This was broken in PR #4288.
