### PR TITLE
allow X10(/S) Express radio displays to actually dim, not just get slightly less blinding

### DIFF
--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -226,7 +226,7 @@ void lcdCopy(void * dest, void * src);
 #define BACKLIGHT_FORCED_ON     BACKLIGHT_LEVEL_MAX + 1
 #if defined(PCBX12S)
 #define BACKLIGHT_LEVEL_MIN   5
-#elif defined(RADIO_FAMILY_T16) || defined(PCBX10)
+#elif defined(RADIO_FAMILY_T16) || defined(RADIO_X10E)
 #define BACKLIGHT_LEVEL_MIN   1
 #else
 #define BACKLIGHT_LEVEL_MIN   46

--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -226,7 +226,7 @@ void lcdCopy(void * dest, void * src);
 #define BACKLIGHT_FORCED_ON     BACKLIGHT_LEVEL_MAX + 1
 #if defined(PCBX12S)
 #define BACKLIGHT_LEVEL_MIN   5
-#elif defined(RADIO_FAMILY_T16)
+#elif defined(RADIO_FAMILY_T16) || defined(PCBX10)
 #define BACKLIGHT_LEVEL_MIN   1
 #else
 #define BACKLIGHT_LEVEL_MIN   46


### PR DESCRIPTION
### Fixes
...an issue I nearly opened myself before opening the PR (but didn't!), and does not fix the open issues around backlights & X10 targets that I was able to find.

### Summary of changes
The diff truly does speak for itself in this case -- the brightness floor which was formerly 46 for X10 targets is now 1, hopefully w/ as few char changes as possible.

### Testing
I was able to test on my own X10S Express. I do not have X10 hardware onto which I could load my build. There may be a "very good reason" the minimum of 46 had been set for X10 targets, but I see zero ill side-effects.

### Jesus man, for a change so tiny, just stop typing already!
IMHO, bringing this into 2.9 _might_ be worth considering, but I may be the sole x10 owner whose retinas are made of delicate flower petals that were grown within earshot of sensitivity seminars in the bay area.

It feels good to no longer be backed into a corner of using ETHOS* in order to comfortably use one of my radios. Here's hoping it might help another delicate flower out, too.

*credit where it's due: their UX is decent and likely preferred by anyone whose radio expectations haven't been twisted all around by (o/e)tx use.
