### PR TITLE
Decrease backlight minimum for X10E on 2.9

### DIFF
--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -522,7 +522,7 @@ void DMABitmapConvert(uint16_t * dest, const uint8_t * src, uint16_t w, uint16_t
 #define BACKLIGHT_FORCED_ON     BACKLIGHT_LEVEL_MAX + 1
 #if defined(PCBX12S)
 #define BACKLIGHT_LEVEL_MIN   5
-#elif defined(RADIO_FAMILY_T16)
+#elif defined(RADIO_FAMILY_T16) || defined(RADIO_X10E)
 #define BACKLIGHT_LEVEL_MIN   1
 #else
 #define BACKLIGHT_LEVEL_MIN   46


### PR DESCRIPTION
If it looks familiar, it is! Same as #4539 but for the 2.9 branch.

Zero tears will be shed if this isn't something worth merging into the 2.9 branch.

I did build & flash this to my X10SE briefly, but decided running the actual 2.9.2 release w/ the same changes was a "safer" bet, so time spent was minimal, but so was the LCD backlight brightness, and zero flickers were observed. (I have a freakishly high flicker fusion threshold fwiw.)