### PR TITLE
fix: USB device name, remove the hack

### DIFF
--- a/radio/src/targets/common/arm/stm32/usbd_storage_msd.cpp
+++ b/radio/src/targets/common/arm/stm32/usbd_storage_msd.cpp
@@ -65,13 +65,6 @@ enum MassstorageLuns {
   STORAGE_LUN_NBR
 };
 
-
-// TODO: remove hack
-//#define USB_NAME                     "RM TX16S"
-//#define USB_MANUFACTURER             'R', 'M', '_', 'T', 'X', ' ', ' ', ' '  /* 8 bytes */
-//#define USB_PRODUCT                  'R', 'M', ' ', 'T', 'X', '1', '6', 'S'  /* 8 Bytes */
-
-
 /** USB Mass storage Standard Inquiry Data. */
 const uint8_t STORAGE_Inquirydata_FS[] = {/* 36 */
   /* LUN 0 */

--- a/radio/src/targets/common/arm/stm32/usbd_storage_msd.cpp
+++ b/radio/src/targets/common/arm/stm32/usbd_storage_msd.cpp
@@ -33,6 +33,7 @@
 #include "hal.h"
 #include "debug.h"
 
+#include "usb_descriptor.h"
 #include "usbd_storage_msd.h"
 
 #include <string.h>
@@ -66,9 +67,9 @@ enum MassstorageLuns {
 
 
 // TODO: remove hack
-#define USB_NAME                     "RM TX16S"
-#define USB_MANUFACTURER             'R', 'M', '_', 'T', 'X', ' ', ' ', ' '  /* 8 bytes */
-#define USB_PRODUCT                  'R', 'M', ' ', 'T', 'X', '1', '6', 'S'  /* 8 Bytes */
+//#define USB_NAME                     "RM TX16S"
+//#define USB_MANUFACTURER             'R', 'M', '_', 'T', 'X', ' ', ' ', ' '  /* 8 bytes */
+//#define USB_PRODUCT                  'R', 'M', ' ', 'T', 'X', '1', '6', 'S'  /* 8 Bytes */
 
 
 /** USB Mass storage Standard Inquiry Data. */


### PR DESCRIPTION
Related to https://github.com/EdgeTX/edgetx/pull/4207
Forgot the hack, all radios appear as RM TX16S
