### PR TITLE
fix: strengthen lcd buffer protection

### DIFF
--- a/radio/src/gui/128x64/lcd.cpp
+++ b/radio/src/gui/128x64/lcd.cpp
@@ -953,7 +953,7 @@ void lcdMaskPoint(uint8_t * p, uint8_t mask, LcdFlags att)
 void lcdDrawPoint(coord_t x, coord_t y, LcdFlags att)
 {
   uint8_t * p = &displayBuf[ y / 8 * LCD_W + x ];
-  if (p < DISPLAY_END) {
+  if (IS_IN_DISPLAY(p)) {
     lcdMaskPoint(p, bfBit<uint8_t>(y % 8), att);
   }
 }

--- a/radio/src/gui/128x64/lcd.h
+++ b/radio/src/gui/128x64/lcd.h
@@ -91,6 +91,7 @@ extern coord_t lcdLastLeftPos;
 extern coord_t lcdNextPos;
 
 #define DISPLAY_END                    (displayBuf + DISPLAY_BUFFER_SIZE)
+#define IS_IN_DISPLAY(p)               ((p) >= displayBuf && (p) < DISPLAY_END)
 #define ASSERT_IN_DISPLAY(p)           assert((p) >= displayBuf && (p) < DISPLAY_END)
 
 

--- a/radio/src/gui/common/stdlcd/model_curves.cpp
+++ b/radio/src/gui/common/stdlcd/model_curves.cpp
@@ -156,6 +156,8 @@ void drawFunction(FnFuncP fn, uint8_t offset)
 
   for (int xv = -CURVE_SIDE_WIDTH; xv <= CURVE_SIDE_WIDTH; xv++) {
     coord_t yv = -(fn((xv * RESX) / CURVE_SIDE_WIDTH) * (CURVE_SIDE_WIDTH*2+1) / (RESX*2));
+    if (yv < -CURVE_SIDE_WIDTH) yv = -CURVE_SIDE_WIDTH;
+    if (yv > CURVE_SIDE_WIDTH) yv = CURVE_SIDE_WIDTH;
     if ((xv > -CURVE_SIDE_WIDTH) && (abs((int8_t)yv-prev_yv) > 1)) {
       int len = 0;
       if (yv > prev_yv) {


### PR DESCRIPTION
Improve LCD buffer protection by checking negative x/y values

This fixes #4544

NB: 
- this should be applied to 2.9.x too