### PR TITLE
fix(color): Popup for setting Trim in Input edit does not show any values.

### DIFF
--- a/radio/src/gui/colorlcd/input_edit_adv.cpp
+++ b/radio/src/gui/colorlcd/input_edit_adv.cpp
@@ -60,7 +60,7 @@ InputEditAdvanced::InputEditAdvanced(uint8_t input_n, uint8_t index) :
   line = form->newLine(&grid);
   new StaticText(line, rect_t{}, STR_TRIM, 0, COLOR_THEME_PRIMARY1);
   const auto trimLast = TRIM_OFF + keysGetMaxTrims() - 1;
-  auto c = new Choice(line, rect_t{}, -TRIM_OFF, -trimLast,
+  auto c = new Choice(line, rect_t{}, -TRIM_OFF, trimLast,
                       GET_VALUE(-input->trimSource),
                       SET_VALUE(input->trimSource, -newValue));
 


### PR DESCRIPTION
Broken in PR #4520 
