### PR TITLE
fix: ADC EXT channel shifting on some ADC configuration

### DIFF
--- a/radio/src/targets/common/arm/stm32/stm32_adc.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_adc.cpp
@@ -299,6 +299,7 @@ static bool adc_init_dma_stream(ADC_TypeDef* adc, DMA_TypeDef* DMAx,
   // disable direct mode, half full FIFO
   LL_DMA_EnableFifoMode(DMAx, stream);
   LL_DMA_SetFIFOThreshold(DMAx, stream, LL_DMA_FIFOTHRESHOLD_1_2);
+  LL_DMA_SetMemoryBurstxfer(DMAx, stream, LL_DMA_MBURST_INC4);
 
   return true;
 }

--- a/radio/src/targets/common/arm/stm32/stm32_adc.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_adc.cpp
@@ -405,7 +405,7 @@ static void adc_start_dma_conversion(ADC_TypeDef* ADCx, DMA_TypeDef* DMAx, uint3
   SET_BIT(dma_stream->CR, DMA_SxCR_EN);
 
   // Trigger ADC start
-  SET_BIT(ADCx->CR2, ADC_CR2_SWSTART);
+  SET_BIT(ADCx->CR2, ADC_CR2_DMA | ADC_CR2_SWSTART);
 }
 
 static bool adc_disable_dma(DMA_TypeDef* DMAx, uint32_t stream)
@@ -580,6 +580,9 @@ void stm32_hal_adc_dma_isr(const stm32_adc_t* adc)
 {
   // Disable IRQ
   adc_dma_clear_flags(adc->DMAx, adc->DMA_Stream);
+
+  // Disable DMA
+  CLEAR_BIT(adc->ADCx->CR2, ADC_CR2_DMA);
 
   uint16_t* dma_buffer = _adc_dma_buffer + adc->offset;
   copy_adc_values(dma_buffer, adc, _adc_inputs);

--- a/radio/src/targets/pl18/hal.h
+++ b/radio/src/targets/pl18/hal.h
@@ -222,8 +222,6 @@
 #define ADC_CHANNEL_STICK_RV
 #define ADC_CHANNEL_STICK_RH
 
-// Each ADC cannot map more than 8 channels, otherwise it will cause problems
-
 #define ADC_CHANNEL_POT1                LL_ADC_CHANNEL_6    // ADC12_IN6   -> ADC1_IN6
 #define ADC_CHANNEL_POT2                LL_ADC_CHANNEL_14   // ADC12_IN14  -> ADC1_IN14
 #define ADC_CHANNEL_POT3                LL_ADC_CHANNEL_6    // ADC3_IN6    -> ADC3_IN6
@@ -249,11 +247,7 @@
 #define ADC_CHANNEL_SWH                 LL_ADC_CHANNEL_8    // ADC3_IN8    -> ADC3_IN8
 
 #define ADC_CHANNEL_BATT                LL_ADC_CHANNEL_15   // ADC12_IN15  -> ADC1_IN15
-
-#if !defined(RADIO_PL18EV)
-// Disabled for PL18EV because 2 ADC 16 channels are fully mapped already
 #define ADC_CHANNEL_RTC_BAT             LL_ADC_CHANNEL_VBAT // ADC1_IN18
-#endif
 
 #define ADC_MAIN                        ADC1
 #define ADC_EXT                         ADC3
@@ -286,6 +280,7 @@
     -1,-1,   /* sliders */    \
     0,0,0,0, /* ext1-4 */     \
     0,	     /* vbat */       \
+    0,       /* rtc_bat */    \
     -1,      /* SWB */        \
     -1,      /* SWD */        \
     0,       /* SWE */        \


### PR DESCRIPTION
When trying to support PL18EV, in which it requires 17 ADC channels, in certain configuration, the EXT ADC may sometimes have output shifted by 1 channel and the EXT ADC channel mappings will goes all wrong.

I finally find a relevant case and got a solution and cannot see the problem anymore after this fix.

The related post can be found here:

http://forum.chibios.org/viewtopic.php?t=4608
