### PR TITLE
chore(ci): Bump action versions due to Node.js 16 EoL

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -128,7 +128,7 @@ jobs:
           echo "Running firmware build"
           ./tools/build-gh.sh
 
-      - name: Package firmware ${{ matrix.target }}
+      - name: Upload ${{ matrix.target }}
         uses: actions/upload-artifact@v4
         with:
           name: firmare-${{ matrix.target }}
@@ -139,8 +139,8 @@ jobs:
           retention-days: 15
           if-no-files-found: error
 
-  merge:
-    name: Merge builds into one artifact
+  package:
+    name: Package firmwares
     needs: build
     runs-on: ubuntu-latest
     steps:
@@ -148,7 +148,7 @@ jobs:
         # https://stackoverflow.com/questions/58033366/how-to-get-current-branch-within-github-actions
         run: echo "artifact_name=edgetx-firmware-${GITHUB_REF##*/}" >> $GITHUB_ENV
 
-      - name: Merge Artifacts
+      - name: Merge firmware artifact packages
         uses: actions/upload-artifact/merge@v4
         with:
           name: "${{ env.artifact_name }}"

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -73,7 +73,7 @@ jobs:
         - ${{ github.workspace }}:/src
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
           # fetch-depth: 0 # https://github.com/actions/checkout#Fetch-all-history-for-all-tags-and-branches
@@ -117,7 +117,7 @@ jobs:
         - ${{ github.workspace }}:/src
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -133,7 +133,7 @@ jobs:
         run: echo "artifact_name=edgetx-firmware-${GITHUB_REF##*/}" >> $GITHUB_ENV
 
       - name: Package firmware ${{ matrix.target }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ env.artifact_name }}"
           path: |

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -152,8 +152,6 @@ jobs:
         with:
           name: "${{ env.artifact_name }}"
           pattern: firmare-*
-          path: |
-            fw.json
-            LICENSE
-            *.bin
           delete-merged: true
+          retention-days: 15
+          if-no-files-found: error

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -140,8 +140,9 @@ jobs:
           if-no-files-found: error
 
   merge:
-    runs-on: ubuntu-latest
+    name: Merge builds into one artifact
     needs: build
+    runs-on: ubuntu-latest
     steps:
       - name: Compose release filename
         # https://stackoverflow.com/questions/58033366/how-to-get-current-branch-within-github-actions

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -99,8 +99,7 @@ jobs:
           - t16;t18
           - t8;zorro;pocket;mt12;commando8
           - tlite;tpro;tprov2;lr3pro
-          - t20
-          - t14
+          - t20;t14
           - tx12;tx12mk2;boxer
           - tx16s
           - x10;x10-access

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -128,17 +128,32 @@ jobs:
           echo "Running firmware build"
           ./tools/build-gh.sh
 
-      - name: Compose release filename
-        # https://stackoverflow.com/questions/58033366/how-to-get-current-branch-within-github-actions
-        run: echo "artifact_name=edgetx-firmware-${GITHUB_REF##*/}" >> $GITHUB_ENV
-
       - name: Package firmware ${{ matrix.target }}
         uses: actions/upload-artifact@v4
         with:
-          name: "${{ env.artifact_name }}"
+          name: firmare-${{ matrix.target }}
           path: |
             fw.json
             LICENSE
             *.bin
           retention-days: 15
           if-no-files-found: error
+
+  merge:
+    runs-on: ubuntu-latest
+    needs: build
+    steps:
+      - name: Compose release filename
+        # https://stackoverflow.com/questions/58033366/how-to-get-current-branch-within-github-actions
+        run: echo "artifact_name=edgetx-firmware-${GITHUB_REF##*/}" >> $GITHUB_ENV
+
+      - name: Merge Artifacts
+        uses: actions/upload-artifact/merge@v4
+        with:
+          name: "${{ env.artifact_name }}"
+          pattern: firmare-*
+          path: |
+            fw.json
+            LICENSE
+            *.bin
+          delete-merged: true

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -155,4 +155,3 @@ jobs:
           pattern: firmare-*
           delete-merged: true
           retention-days: 15
-          if-no-files-found: error

--- a/.github/workflows/linux_cpn.yml
+++ b/.github/workflows/linux_cpn.yml
@@ -35,7 +35,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -51,7 +51,7 @@ jobs:
         run: echo "artifact_name=edgetx-cpn-linux-${GITHUB_REF##*/}" >> $GITHUB_ENV
 
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ env.artifact_name }}"
           path:  ${{github.workspace}}/output

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -46,7 +46,7 @@ jobs:
           submodules: recursive
 
       - name: Setup Python 3.9
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.9'
 

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -41,7 +41,7 @@ jobs:
           xcode-version: '11.7'
 
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -98,7 +98,7 @@ jobs:
         run: echo "artifact_name=edgetx-cpn-osx-${GITHUB_REF##*/}" >> $GITHUB_ENV
 
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ env.artifact_name }}"
           path:  ${{github.workspace}}/output

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Package firmware ${{ matrix.target }}
         uses: actions/upload-artifact@v4
         with:
-          name: edgetx-firmware-nightly
+          name: edgetx-firmware-nightly-${{ matrix.target }}
           path: |
             fw.json
             LICENSE
@@ -65,10 +65,10 @@ jobs:
     needs: build
     steps:
       - name: Download artifacts
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
-          name: edgetx-firmware-nightly
-          path: edgetx-firmware-nightly
+          pattern: edgetx-firmware-nightly-*
+          merge-multiple: true
 
       - name: Compose release filename
         run: echo "release_filename=edgetx-firmware-nightly-${GITHUB_SHA::8}.zip" >> $GITHUB_ENV

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,7 +38,7 @@ jobs:
         - ${{ github.workspace }}:/src
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -49,7 +49,7 @@ jobs:
         run: ./tools/build-gh.sh
 
       - name: Package firmware ${{ matrix.target }}
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: edgetx-firmware-nightly
           path: |

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,8 +18,7 @@ jobs:
           - nv14;el18
           - pl18;pl18ev
           - t12
-          - t16
-          - t18
+          - t16;t18
           - t8;zorro;pocket;mt12;commando8
           - tlite;tpro;tprov2;lr3pro
           - t20;t14
@@ -32,6 +31,7 @@ jobs:
           - x9e;x9e-hall
           - x9lite;x9lites
           - xlite;xlites
+          - mt12
     container:
       image: ghcr.io/edgetx/edgetx-dev:latest
       volumes:

--- a/.github/workflows/win_cpn-32.yml
+++ b/.github/workflows/win_cpn-32.yml
@@ -70,7 +70,7 @@ jobs:
           arch: ${{ env.MINGW_VERSION }}
 
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -86,7 +86,7 @@ jobs:
         run: echo "artifact_name=edgetx-cpn-win32-${GITHUB_REF##*/}" >> $GITHUB_ENV
 
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ env.artifact_name }}"
           path:  ${{github.workspace}}/output

--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -78,7 +78,7 @@ jobs:
           arch: ${{ env.MINGW_VERSION }}
 
       - name: Check out the repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           submodules: recursive
 
@@ -95,7 +95,7 @@ jobs:
         run: echo "artifact_name=edgetx-cpn-win64-${GITHUB_REF##*/}" >> $GITHUB_ENV
 
       - name: Archive production artifacts
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: "${{ env.artifact_name }}"
           path:  ${{github.workspace}}/output


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Summary of changes:
- Bump checkout and upload-artifact to Node.js 20 based actions. While this was announced Sept last year, looks like Github only just flipped the notifications toggle in the last day or so for warnings in the actions logs. 
- upload-artifact@v4 does has some major breaking changes, ~~but it does not appear we use any of the changed functionality.~~ whereby artifacts are immutable, so we can't just keep uploading to the same artifact in each matrix run. 

https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/
