### PR TITLE
fix(cpn): QT lupdate gremlins in translations

### DIFF
--- a/companion/src/generaledit/generalsetup.ui
+++ b/companion/src/generaledit/generalsetup.ui
@@ -2099,7 +2099,7 @@ Mode 4:
        </property>
        <property name="whatsThis">
         <string>Battery warning voltage.
-This is the threashhold where the battery warning sounds.
+This is the threshold where the battery warning sounds.
 
 Acceptable values are 3v..12v</string>
        </property>

--- a/companion/src/translations/companion_cs.ts
+++ b/companion/src/translations/companion_cs.ts
@@ -5709,7 +5709,7 @@ Mode 4:
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2101"/>
         <source>Battery warning voltage.
-This is the threashhold where the battery warning sounds.
+This is the threshold where the battery warning sounds.
 
 Acceptable values are 3v..12v</source>
         <translation type="unfinished">Hodnoto pro varování při nízkém stavu baterie rádia.

--- a/companion/src/translations/companion_cs.ts
+++ b/companion/src/translations/companion_cs.ts
@@ -5713,7 +5713,7 @@ This is the threashhold where the battery warning sounds.
 
 Acceptable values are 3v..12v</source>
         <translation type="unfinished">Hodnoto pro varování při nízkém stavu baterie rádia.
-Použitelné hodnoty jsou 5v..10v {3v?} {12v?}</translation>
+Použitelné hodnoty jsou 3v..12v</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2160"/>

--- a/companion/src/translations/companion_da.ts
+++ b/companion/src/translations/companion_da.ts
@@ -1210,7 +1210,7 @@ Mode 4:
         <location filename="../firmwares/boards.cpp" line="848"/>
         <location filename="../firmwares/boards.cpp" line="888"/>
         <source>6POS</source>
-        <translation>2 positioner {6P?}</translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="862"/>
@@ -4958,7 +4958,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../firmwares/gvardata.cpp" line="43"/>
         <source>0.0</source>
-        <translation>6P {0.0?}</translation>
+        <translation>0.0</translation>
     </message>
     <message>
         <location filename="../firmwares/gvardata.cpp" line="45"/>
@@ -5724,37 +5724,37 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2418"/>
         <source>2s</source>
-        <translation>9X {2s?}</translation>
+        <translation>2s</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2423"/>
         <source>3s</source>
-        <translation>9X {3s?}</translation>
+        <translation>3s</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2428"/>
         <source>4s</source>
-        <translation>9X {4s?}</translation>
+        <translation>4s</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2433"/>
         <source>6s</source>
-        <translation>9X {6s?}</translation>
+        <translation>6s</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2438"/>
         <source>8s</source>
-        <translation>9X {8s?}</translation>
+        <translation>8s</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2443"/>
         <source>10s</source>
-        <translation>9X {10s?}</translation>
+        <translation>10s</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2448"/>
         <source>15s</source>
-        <translation>9X {15s?}</translation>
+        <translation>15s</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1823"/>

--- a/companion/src/translations/companion_da.ts
+++ b/companion/src/translations/companion_da.ts
@@ -6158,7 +6158,7 @@ Tilstand 4:
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2101"/>
         <source>Battery warning voltage.
-This is the threashhold where the battery warning sounds.
+This is the threshold where the battery warning sounds.
 
 Acceptable values are 3v..12v</source>
         <translation>Advarsel for batteriets spæningsniveau.

--- a/companion/src/translations/companion_de.ts
+++ b/companion/src/translations/companion_de.ts
@@ -5683,7 +5683,7 @@ Mode 4:
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2101"/>
         <source>Battery warning voltage.
-This is the threashhold where the battery warning sounds.
+This is the threshold where the battery warning sounds.
 
 Acceptable values are 3v..12v</source>
         <translation type="unfinished">Akku Unterspannungswarnung.

--- a/companion/src/translations/companion_de.ts
+++ b/companion/src/translations/companion_de.ts
@@ -5689,7 +5689,7 @@ Acceptable values are 3v..12v</source>
         <translation type="unfinished">Akku Unterspannungswarnung.
 Legt die Schaltschwelle fest wann die Warnung für die Akku-Unterspannungmeldung kommt.
 
-Werte liegen zwischen 5-10V {3v?} {12v?}</translation>
+Werte liegen zwischen 3-12V</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2160"/>
@@ -5970,7 +5970,7 @@ Werte liegen zwischen 5-10V {3v?} {12v?}</translation>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1210"/>
         <source>9600 Baud</source>
-        <translation>115200 Baud {9600 ?}</translation>
+        <translation>9600 Baud</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1215"/>
@@ -11707,22 +11707,22 @@ r</translation>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="46"/>
         <source>Trim 7 Down</source>
-        <translation type="unfinished">Trimmer 6 runter {7 ?}</translation>
+        <translation type="unfinished">Trimmer 7 runter</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="46"/>
         <source>Trim 7 Up</source>
-        <translation type="unfinished">Trimmer 6 hoch {7 ?}</translation>
+        <translation type="unfinished">Trimmer 7 hoch</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="47"/>
         <source>Trim 8 Down</source>
-        <translation type="unfinished">Trimmer 6 runter {8 ?}</translation>
+        <translation type="unfinished">Trimmer 8 runter</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="47"/>
         <source>Trim 8 Up</source>
-        <translation type="unfinished">Trimmer 6 hoch {8 ?}</translation>
+        <translation type="unfinished">Trimmer 8 hoch</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="51"/>
@@ -15283,7 +15283,7 @@ Timestamp</source>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="46"/>
         <source>%1 %2</source>
-        <translation type="unfinished">%1s {1 %2?}</translation>
+        <translation type="unfinished">%1 %2</translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="46"/>

--- a/companion/src/translations/companion_en.ts
+++ b/companion/src/translations/companion_en.ts
@@ -5655,7 +5655,7 @@ Mode 4:
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2101"/>
         <source>Battery warning voltage.
-This is the threashhold where the battery warning sounds.
+This is the threshold where the battery warning sounds.
 
 Acceptable values are 3v..12v</source>
         <translation type="unfinished"></translation>

--- a/companion/src/translations/companion_es.ts
+++ b/companion/src/translations/companion_es.ts
@@ -5763,7 +5763,7 @@ Acceptable values are 3v..12v</source>
         <translation type="unfinished">Voltaje de aviso de la batería.
 Este es el umbral cuando la batería emite sonidos de aviso.
 
-Los valores aceptables son 5v..10v {3v?} {12v?}</translation>
+Los valores aceptables son 3v..12v</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2160"/>
@@ -11759,22 +11759,22 @@ s</source>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="46"/>
         <source>Trim 7 Down</source>
-        <translation type="unfinished">Trim 6 abajo {7 ?}</translation>
+        <translation type="unfinished">Trim 7 abajo</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="46"/>
         <source>Trim 7 Up</source>
-        <translation type="unfinished">Trim 6 arriba {7 ?}</translation>
+        <translation type="unfinished">Trim 7 arriba</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="47"/>
         <source>Trim 8 Down</source>
-        <translation type="unfinished">Trim 6 abajo {8 ?}</translation>
+        <translation type="unfinished">Trim 8 abajo</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="47"/>
         <source>Trim 8 Up</source>
-        <translation type="unfinished">Trim 6 arriba {8 ?}</translation>
+        <translation type="unfinished">Trim 8 arriba</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="51"/>

--- a/companion/src/translations/companion_es.ts
+++ b/companion/src/translations/companion_es.ts
@@ -5757,7 +5757,7 @@ Modo 4:
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2101"/>
         <source>Battery warning voltage.
-This is the threashhold where the battery warning sounds.
+This is the threshold where the battery warning sounds.
 
 Acceptable values are 3v..12v</source>
         <translation type="unfinished">Voltaje de aviso de la batería.

--- a/companion/src/translations/companion_fi.ts
+++ b/companion/src/translations/companion_fi.ts
@@ -5736,7 +5736,7 @@ Tila 4:
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2101"/>
         <source>Battery warning voltage.
-This is the threashhold where the battery warning sounds.
+This is the threshold where the battery warning sounds.
 
 Acceptable values are 3v..12v</source>
         <translation type="unfinished">Akun varoitus jännite.

--- a/companion/src/translations/companion_fi.ts
+++ b/companion/src/translations/companion_fi.ts
@@ -4530,7 +4530,7 @@ Käytät nyt:
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="387"/>
         <source>0.0</source>
-        <translation type="unfinished">6P {0.0?}</translation>
+        <translation type="unfinished">0.0</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="492"/>
@@ -4943,7 +4943,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../firmwares/gvardata.cpp" line="43"/>
         <source>0.0</source>
-        <translation type="unfinished">6P {0.0?}</translation>
+        <translation type="unfinished">0.0</translation>
     </message>
     <message>
         <location filename="../firmwares/gvardata.cpp" line="45"/>
@@ -5742,7 +5742,7 @@ Acceptable values are 3v..12v</source>
         <translation type="unfinished">Akun varoitus jännite.
 Tämä on jännitealue jolloin akun varoitus ääni annetaan.
 
-Hyväksytty arvo: 5v - 10v {3v?} {12v?}</translation>
+Hyväksytty arvo: 3v - 12v</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2160"/>
@@ -5773,7 +5773,7 @@ Hyväksytty arvo: 5v - 10v {3v?} {12v?}</translation>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2507"/>
         <source>0.0</source>
-        <translation type="unfinished">6P {0.0?}</translation>
+        <translation type="unfinished">0.0</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2512"/>
@@ -15300,7 +15300,7 @@ hh:mm:ss</source>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="46"/>
         <source>%1 %2</source>
-        <translation type="unfinished">%1s {1 %2?}</translation>
+        <translation type="unfinished">%1 %2</translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="46"/>

--- a/companion/src/translations/companion_fr.ts
+++ b/companion/src/translations/companion_fr.ts
@@ -11765,22 +11765,22 @@ E</translation>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="46"/>
         <source>Trim 7 Down</source>
-        <translation type="unfinished">Trim 6 Bas {7 ?}</translation>
+        <translation type="unfinished">Trim 7 Bas</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="46"/>
         <source>Trim 7 Up</source>
-        <translation type="unfinished">Trim 6 Haut {7 ?}</translation>
+        <translation type="unfinished">Trim 7 Haut</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="47"/>
         <source>Trim 8 Down</source>
-        <translation type="unfinished">Trim 6 Bas {8 ?}</translation>
+        <translation type="unfinished">Trim 8 Bas</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="47"/>
         <source>Trim 8 Up</source>
-        <translation type="unfinished">Trim 6 Haut {8 ?}</translation>
+        <translation type="unfinished">Trim 8 Haut</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="51"/>

--- a/companion/src/translations/companion_fr.ts
+++ b/companion/src/translations/companion_fr.ts
@@ -5745,7 +5745,7 @@ Mode 4:
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2101"/>
         <source>Battery warning voltage.
-This is the threashhold where the battery warning sounds.
+This is the threshold where the battery warning sounds.
 
 Acceptable values are 3v..12v</source>
         <translation>Tension d&apos;alerte de batterie.

--- a/companion/src/translations/companion_he.ts
+++ b/companion/src/translations/companion_he.ts
@@ -5624,7 +5624,7 @@ Mode 4:
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2101"/>
         <source>Battery warning voltage.
-This is the threashhold where the battery warning sounds.
+This is the threshold where the battery warning sounds.
 
 Acceptable values are 3v..12v</source>
         <translation type="unfinished"></translation>

--- a/companion/src/translations/companion_it.ts
+++ b/companion/src/translations/companion_it.ts
@@ -5660,7 +5660,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2101"/>
         <source>Battery warning voltage.
-This is the threashhold where the battery warning sounds.
+This is the threshold where the battery warning sounds.
 
 Acceptable values are 3v..12v</source>
         <translation type="unfinished">Valore di allarme per batteria scarica.

--- a/companion/src/translations/companion_it.ts
+++ b/companion/src/translations/companion_it.ts
@@ -4530,7 +4530,7 @@ state attualmente utilizzando:
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="387"/>
         <source>0.0</source>
-        <translation type="unfinished">9X {6P?} {0.0?}</translation>
+        <translation type="unfinished">0.0</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="492"/>
@@ -4943,7 +4943,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../firmwares/gvardata.cpp" line="43"/>
         <source>0.0</source>
-        <translation type="unfinished">9X {6P?} {0.0?}</translation>
+        <translation type="unfinished">0.0</translation>
     </message>
     <message>
         <location filename="../firmwares/gvardata.cpp" line="45"/>
@@ -5666,7 +5666,7 @@ Acceptable values are 3v..12v</source>
         <translation type="unfinished">Valore di allarme per batteria scarica.
 Al di sotto di questo valore verrà generato un seganle di allarme.
 
-Valori accettabili da 5v a 10v {3v?} {12v?}</translation>
+Valori accettabili da 3v a 12v</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2477"/>
@@ -5687,7 +5687,7 @@ Valori accettabili da 5v a 10v {3v?} {12v?}</translation>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2507"/>
         <source>0.0</source>
-        <translation type="unfinished">9X {6P?} {0.0?}</translation>
+        <translation type="unfinished">0.0</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2512"/>
@@ -14287,12 +14287,12 @@ Timestamp</source>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="3117"/>
         <source>1/5x</source>
-        <translation type="unfinished">9X {1/5x?}</translation>
+        <translation type="unfinished">1/5x</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="3133"/>
         <source>5x</source>
-        <translation type="unfinished">9X {5x?}</translation>
+        <translation type="unfinished">5x</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="3145"/>
@@ -15306,7 +15306,7 @@ hh:mm:ss</source>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="46"/>
         <source>%1 %2</source>
-        <translation type="unfinished">%1s {1 %2?}</translation>
+        <translation type="unfinished">%1 %2</translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="46"/>

--- a/companion/src/translations/companion_ja.ts
+++ b/companion/src/translations/companion_ja.ts
@@ -6024,7 +6024,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2101"/>
         <source>Battery warning voltage.
-This is the threashhold where the battery warning sounds.
+This is the threshold where the battery warning sounds.
 
 Acceptable values are 3v..12v</source>
         <translation>バッテリー警告電圧

--- a/companion/src/translations/companion_ja.ts
+++ b/companion/src/translations/companion_ja.ts
@@ -1100,7 +1100,7 @@ Mode 4:
         <location filename="../firmwares/boards.cpp" line="834"/>
         <location filename="../firmwares/boards.cpp" line="872"/>
         <source>6P</source>
-        <translation type="unfinished">30秒 {6P?}</translation>
+        <translation type="unfinished">6P</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="836"/>
@@ -2213,7 +2213,7 @@ Do you want to import settings from a file?</source>
         <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
         <location filename="../firmwares/customfunctiondata.cpp" line="404"/>
         <source>1x</source>
-        <translation type="unfinished">30秒 {1x?}</translation>
+        <translation type="unfinished">1x</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
@@ -6162,7 +6162,7 @@ Mode 4:
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="276"/>
         <source>1s</source>
-        <translation type="unfinished">30秒 {1s?}</translation>
+        <translation type="unfinished">1s</translation>
     </message>
 </context>
 <context>
@@ -11750,22 +11750,22 @@ X
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="46"/>
         <source>Trim 7 Down</source>
-        <translation type="unfinished">トリム6 下 {7 ?}</translation>
+        <translation type="unfinished">トリム7 下</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="46"/>
         <source>Trim 7 Up</source>
-        <translation type="unfinished">トリム6 上 {7 ?}</translation>
+        <translation type="unfinished">トリム7 上</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="47"/>
         <source>Trim 8 Down</source>
-        <translation type="unfinished">トリム6 下 {8 ?}</translation>
+        <translation type="unfinished">トリム8 下</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="47"/>
         <source>Trim 8 Up</source>
-        <translation type="unfinished">トリム6 上 {8 ?}</translation>
+        <translation type="unfinished">トリム8 上</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="51"/>
@@ -14248,7 +14248,7 @@ Too many errors, giving up.</source>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="2157"/>
         <source>25.9973,-97.1572</source>
-        <translation type="unfinished">30秒 {25.9973,-97.1572?}</translation>
+        <translation type="unfinished">25.9973,-97.1572</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="2308"/>

--- a/companion/src/translations/companion_nl.ts
+++ b/companion/src/translations/companion_nl.ts
@@ -5624,7 +5624,7 @@ Mode 4:
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2101"/>
         <source>Battery warning voltage.
-This is the threashhold where the battery warning sounds.
+This is the threshold where the battery warning sounds.
 
 Acceptable values are 3v..12v</source>
         <translation type="unfinished"></translation>

--- a/companion/src/translations/companion_pl.ts
+++ b/companion/src/translations/companion_pl.ts
@@ -6042,7 +6042,7 @@ Acceptable values are 3v..12v</source>
         <translation type="unfinished">Ostrzeżenie o napięciu zasilania.
 Ustala próg ostrzeżenia.
 
-Dopuszczalne wartości 5v-10v {3v?} {12v?}</translation>
+Dopuszczalne wartości 3v-12v</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2160"/>
@@ -6149,7 +6149,7 @@ Dopuszczalne wartości 5v-10v {3v?} {12v?}</translation>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="276"/>
         <source>1s</source>
-        <translation type="unfinished">5x {1s?}</translation>
+        <translation type="unfinished">1s</translation>
     </message>
 </context>
 <context>
@@ -15323,7 +15323,7 @@ hh:mm:ss</translation>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="46"/>
         <source>%1 %2</source>
-        <translation type="unfinished">%1s {1 %2?}</translation>
+        <translation type="unfinished">%1 %2</translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="46"/>

--- a/companion/src/translations/companion_pl.ts
+++ b/companion/src/translations/companion_pl.ts
@@ -6036,7 +6036,7 @@ Mode 4:
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2101"/>
         <source>Battery warning voltage.
-This is the threashhold where the battery warning sounds.
+This is the threshold where the battery warning sounds.
 
 Acceptable values are 3v..12v</source>
         <translation type="unfinished">Ostrzeżenie o napięciu zasilania.

--- a/companion/src/translations/companion_pt.ts
+++ b/companion/src/translations/companion_pt.ts
@@ -5624,7 +5624,7 @@ Mode 4:
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2101"/>
         <source>Battery warning voltage.
-This is the threashhold where the battery warning sounds.
+This is the threshold where the battery warning sounds.
 
 Acceptable values are 3v..12v</source>
         <translation type="unfinished"></translation>

--- a/companion/src/translations/companion_pt.ts
+++ b/companion/src/translations/companion_pt.ts
@@ -2294,7 +2294,7 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
         <source>%1s</source>
-        <translation type="unfinished">%1ss {1s?}</translation>
+        <translation type="unfinished">%1s</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="233"/>
@@ -7258,7 +7258,7 @@ The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are opt
     <message>
         <location filename="../mainwindow.cpp" line="1165"/>
         <source>%2</source>
-        <translation type="unfinished">%1s {2?}</translation>
+        <translation type="unfinished">%2</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="284"/>
@@ -15152,7 +15152,7 @@ Timestamp</source>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="46"/>
         <source>%1 %2</source>
-        <translation type="unfinished">%1s {1 %2?}</translation>
+        <translation type="unfinished">%1 %2</translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="46"/>

--- a/companion/src/translations/companion_ru.ts
+++ b/companion/src/translations/companion_ru.ts
@@ -5669,7 +5669,7 @@ Mode 4:
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2101"/>
         <source>Battery warning voltage.
-This is the threashhold where the battery warning sounds.
+This is the threshold where the battery warning sounds.
 
 Acceptable values are 3v..12v</source>
         <translation type="unfinished">Предупреждение о разряде аккумулятора.

--- a/companion/src/translations/companion_ru.ts
+++ b/companion/src/translations/companion_ru.ts
@@ -2236,7 +2236,7 @@ Do you want to import settings from a file?</source>
         <location filename="../firmwares/customfunctiondata.cpp" line="223"/>
         <location filename="../firmwares/customfunctiondata.cpp" line="404"/>
         <source>1x</source>
-        <translation type="unfinished">15 сек. {1x?}</translation>
+        <translation type="unfinished">1x</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
@@ -2776,22 +2776,22 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../wizarddialog.cpp" line="796"/>
         <source>90</source>
-        <translation type="unfinished">15 сек. {90?}</translation>
+        <translation type="unfinished">90</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="798"/>
         <source>120</source>
-        <translation type="unfinished">15 сек. {120?}</translation>
+        <translation type="unfinished">120</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="799"/>
         <source>120x</source>
-        <translation type="unfinished">15 сек. {120x?}</translation>
+        <translation type="unfinished">120x</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="800"/>
         <source>140</source>
-        <translation type="unfinished">15 сек. {140?}</translation>
+        <translation type="unfinished">140</translation>
     </message>
 </context>
 <context>
@@ -4527,7 +4527,7 @@ You are currently using:
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="387"/>
         <source>0.0</source>
-        <translation type="unfinished">15 сек. {0.0?}</translation>
+        <translation type="unfinished">0.0</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="492"/>
@@ -4896,7 +4896,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../firmwares/gvardata.cpp" line="43"/>
         <source>0.0</source>
-        <translation type="unfinished">15 сек. {0.0?}</translation>
+        <translation type="unfinished">0.0</translation>
     </message>
     <message>
         <location filename="../firmwares/gvardata.cpp" line="45"/>
@@ -5675,7 +5675,7 @@ Acceptable values are 3v..12v</source>
         <translation type="unfinished">Предупреждение о разряде аккумулятора.
 Значение при котором сработает сигнализация.
 
-Диапазон 5В..10В {3v?} {12v?}</translation>
+Диапазон 3В..12В</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2160"/>
@@ -5706,7 +5706,7 @@ Acceptable values are 3v..12v</source>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2507"/>
         <source>0.0</source>
-        <translation type="unfinished">15 сек. {0.0?}</translation>
+        <translation type="unfinished">0.0</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2512"/>
@@ -6104,7 +6104,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="276"/>
         <source>1s</source>
-        <translation type="unfinished">15 сек. {1s?}</translation>
+        <translation type="unfinished">1s</translation>
     </message>
 </context>
 <context>
@@ -6454,22 +6454,22 @@ Are you sure ?</source>
     <message>
         <location filename="../modeledit/heli.ui" line="29"/>
         <source>120</source>
-        <translation type="unfinished">15 сек. {120?}</translation>
+        <translation type="unfinished">120</translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="34"/>
         <source>120X</source>
-        <translation type="unfinished">15 сек. {120X?}</translation>
+        <translation type="unfinished">120X</translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="39"/>
         <source>140</source>
-        <translation type="unfinished">15 сек. {140?}</translation>
+        <translation type="unfinished">140</translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="44"/>
         <source>90</source>
-        <translation type="unfinished">15 сек. {90?}</translation>
+        <translation type="unfinished">90</translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="77"/>
@@ -9440,22 +9440,22 @@ This determines how mixer values are added.
     <message>
         <location filename="../modelprinter.cpp" line="254"/>
         <source>90</source>
-        <translation type="unfinished">15 сек. {90?}</translation>
+        <translation type="unfinished">90</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="256"/>
         <source>120</source>
-        <translation type="unfinished">15 сек. {120?}</translation>
+        <translation type="unfinished">120</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="258"/>
         <source>120X</source>
-        <translation type="unfinished">15 сек. {120X?}</translation>
+        <translation type="unfinished">120X</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="260"/>
         <source>140</source>
-        <translation type="unfinished">15 сек. {140?}</translation>
+        <translation type="unfinished">140</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="364"/>
@@ -14372,7 +14372,7 @@ hh:mm:ss</source>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="2157"/>
         <source>25.9973,-97.1572</source>
-        <translation type="unfinished">15 сек. {25.9973,-97.1572?}</translation>
+        <translation type="unfinished">25.9973,-97.1572</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="2308"/>
@@ -14433,12 +14433,12 @@ Timestamp</source>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="3117"/>
         <source>1/5x</source>
-        <translation type="unfinished">15 сек. {1/5x?}</translation>
+        <translation type="unfinished">1/5x</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="3133"/>
         <source>5x</source>
-        <translation type="unfinished">15 сек. {5x?}</translation>
+        <translation type="unfinished">5x</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="3145"/>
@@ -14622,7 +14622,7 @@ Timestamp</source>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="127"/>
         <source>5s</source>
-        <translation type="unfinished">15 сек. {5s?}</translation>
+        <translation type="unfinished">5 сек.</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="129"/>
@@ -14632,12 +14632,12 @@ Timestamp</source>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="131"/>
         <source>20s</source>
-        <translation type="unfinished">15 сек. {20s?}</translation>
+        <translation type="unfinished">20 сек.</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="133"/>
         <source>30s</source>
-        <translation type="unfinished">15 сек. {30s?}</translation>
+        <translation type="unfinished">30 сек.</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="144"/>

--- a/companion/src/translations/companion_sv.ts
+++ b/companion/src/translations/companion_sv.ts
@@ -6158,7 +6158,7 @@ Mode 4:
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2101"/>
         <source>Battery warning voltage.
-This is the threashhold where the battery warning sounds.
+This is the threshold where the battery warning sounds.
 
 Acceptable values are 3v..12v</source>
         <translation>Varning för batteriets spänningsnivå.

--- a/companion/src/translations/companion_zh_CN.ts
+++ b/companion/src/translations/companion_zh_CN.ts
@@ -2252,7 +2252,7 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
         <source>%1s</source>
-        <translation type="unfinished">1s</translation>
+        <translation type="unfinished">%1s</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="342"/>

--- a/companion/src/translations/companion_zh_CN.ts
+++ b/companion/src/translations/companion_zh_CN.ts
@@ -5789,7 +5789,7 @@ MODE4 模式4:
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2101"/>
         <source>Battery warning voltage.
-This is the threashhold where the battery warning sounds.
+This is the threshold where the battery warning sounds.
 
 Acceptable values are 3v..12v</source>
         <translation type="unfinished">遥控器电池警告电压 

--- a/companion/src/translations/companion_zh_CN.ts
+++ b/companion/src/translations/companion_zh_CN.ts
@@ -2252,7 +2252,7 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
         <source>%1s</source>
-        <translation type="unfinished">每%1s秒播放一次 {1s?}</translation>
+        <translation type="unfinished">1s</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
@@ -5795,7 +5795,7 @@ Acceptable values are 3v..12v</source>
         <translation type="unfinished">遥控器电池警告电压 
 当电压低于此数值时电量告警响起
 
-允许值是5V - 10V {3v?} {12v?}</translation>
+允许值是3V - 12V</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2160"/>
@@ -15414,7 +15414,7 @@ hh:mm:ss</source>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="46"/>
         <source>%1 %2</source>
-        <translation type="unfinished">每%1秒播放一次 {1 %2?}</translation>
+        <translation type="unfinished">%1 %2</translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="46"/>

--- a/companion/src/translations/companion_zh_TW.ts
+++ b/companion/src/translations/companion_zh_TW.ts
@@ -2252,7 +2252,7 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="226"/>
         <source>%1s</source>
-        <translation type="unfinished">每%1s秒播放一次 {1s?}</translation>
+        <translation type="unfinished">%1s</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="342"/>
@@ -5795,7 +5795,7 @@ Acceptable values are 3v..12v</source>
         <translation type="unfinished">遙控器電池警告電壓
 當電壓低於此數值時電量警告響起
 
-允許值是5V - 10V {3v?} {12v?}</translation>
+允許值是3V - 12V</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2160"/>
@@ -15414,7 +15414,7 @@ hh:mm:ss</source>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="46"/>
         <source>%1 %2</source>
-        <translation type="unfinished">每%1秒播放一次 {1 %2?}</translation>
+        <translation type="unfinished">%1 %2</translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="46"/>

--- a/companion/src/translations/companion_zh_TW.ts
+++ b/companion/src/translations/companion_zh_TW.ts
@@ -5789,7 +5789,7 @@ MODE4 模式4:
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2101"/>
         <source>Battery warning voltage.
-This is the threashhold where the battery warning sounds.
+This is the threshold where the battery warning sounds.
 
 Acceptable values are 3v..12v</source>
         <translation type="unfinished">遙控器電池警告電壓


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Relates to #4571 - appears lupdate matches what it can for some text and higlights discrepancies in what looked like a bad translation  - the clue being the translation entry is left marked unfinished ;)
