### PR TITLE
fix(radio): Trainer SF properties not read correctly from YAML file.

### DIFF
--- a/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
@@ -1458,7 +1458,7 @@ static void r_customFn(void* user, uint8_t* data, uint32_t bitoffs,
                && val[4] == 's') {
       CFN_CH_INDEX(cfn) = MAX_STICKS + 1;
     } else {
-      auto stick = analogLookupCanonicalIdx(ADC_INPUT_MAIN, val, val_len);
+      auto stick = analogLookupCanonicalIdx(ADC_INPUT_MAIN, val, l_sep);
       if (stick >= 0) {
         CFN_CH_INDEX(cfn) = stick + 1;
       }


### PR DESCRIPTION
Fixes #4575

Incorrect string length passed to function that converts source name to index.
