### PR TITLE
fix(telemetry): Correct A1..A2 voltage sensors value for Frsky_D/OMP

### DIFF
--- a/radio/src/telemetry/frsky_d.cpp
+++ b/radio/src/telemetry/frsky_d.cpp
@@ -71,8 +71,8 @@ void frskyDProcessPacket(uint8_t module, const uint8_t *packet, uint8_t len)
     // A1/A2/RSSI values
     case LINKPKT:
     {
-      setTelemetryValue(proto, D_A1_ID, 0, 0, packet[1], UNIT_VOLTS, 0);
-      setTelemetryValue(proto, D_A2_ID, 0, 0, packet[2], UNIT_VOLTS, 0);
+      setTelemetryValue(proto, D_A1_ID, 0, 0, packet[1], UNIT_VOLTS, 1);
+      setTelemetryValue(proto, D_A2_ID, 0, 0, packet[2], UNIT_VOLTS, 1);
       setTelemetryValue(proto, D_RSSI_ID, 0, 0, packet[3], UNIT_RAW, 0);
       
       if (len >= 7) {


### PR DESCRIPTION
Fixes #4572
Tested on 2.9 branch (currently 2.9.3) as well as Main.

Summary of changes:
Make consistent the prec parameter with the Sensor definition below.

![image](https://github.com/EdgeTX/edgetx/assets/32604366/6955ee3d-6f4c-44f1-88f5-902ba8ed591c)
![image](https://github.com/EdgeTX/edgetx/assets/32604366/8e7a5f08-17a7-4aa7-8d42-dfc2388880c4)

The code as it is, was creating a x10 after removing the code who was affecting other protocols when using "ratio" on PREC2 sensors (#4083).  Conversion from Prec0->Prec1 means 10x.
The sensor is really a Prec1 in the definition a few lines below (2nd screenshot)

FIX:
![image](https://github.com/EdgeTX/edgetx/assets/32604366/8ea8a4ba-b509-41d6-9ca6-3faad9668c58)
