### PR TITLE
fix(cpn): Custom screens yaml being truncated

### DIFF
--- a/companion/src/firmwares/customisation_data.cpp
+++ b/companion/src/firmwares/customisation_data.cpp
@@ -132,9 +132,16 @@ bool RadioLayout::CustomScreenData::isEmpty() const
   return strlen(layoutId) == 0;
 }
 
+void RadioLayout::CustomScreens::clear()
+{
+  for (int i = 0; i < MAX_CUSTOM_SCREENS; i++) {
+    customScreenData[i] = CustomScreenData();
+  }
+}
+
 void RadioLayout::init(const char* layoutId, CustomScreens& customScreens)
 {
-  memset(&customScreens, 0, sizeof(CustomScreens));
+  customScreens.clear();
 
   for (int i = 0; i < MAX_CUSTOM_SCREENS; i++) {
     if (i == 0)

--- a/companion/src/firmwares/customisation_data.h
+++ b/companion/src/firmwares/customisation_data.h
@@ -35,9 +35,9 @@ constexpr int MAX_THEME_OPTIONS       {5};
 constexpr int LEN_ZONE_OPTION_STRING  {8};
 constexpr int MAX_LAYOUT_ZONES        {10};
 constexpr int MAX_LAYOUT_OPTIONS      {10};
-constexpr int WIDGET_NAME_LEN         {10};
+constexpr int WIDGET_NAME_LEN         {12};
 constexpr int MAX_WIDGET_OPTIONS      {5};
-constexpr int MAX_TOPBAR_ZONES        {4};
+constexpr int MAX_TOPBAR_ZONES        {6};  //  max 4 used for portrait
 constexpr int MAX_TOPBAR_OPTIONS      {1};
 constexpr int LAYOUT_ID_LEN           {12};
 
@@ -79,8 +79,6 @@ enum ZoneOptionAlign
   ALIGN_LEFT,
   ALIGN_CENTER,
   ALIGN_RIGHT,
-
-  // this one MUST be last
   ALIGN_COUNT
 };
 

--- a/companion/src/firmwares/customisation_data.h
+++ b/companion/src/firmwares/customisation_data.h
@@ -158,6 +158,8 @@ class RadioLayout
 
     struct CustomScreens {
       CustomScreenData customScreenData[MAX_CUSTOM_SCREENS];
+
+      void clear();
     };
 
     static void init(const char * layoutId, CustomScreens & customScreens);

--- a/companion/src/firmwares/opentx/opentxeeprom.cpp
+++ b/companion/src/firmwares/opentx/opentxeeprom.cpp
@@ -2940,7 +2940,7 @@ void OpenTxModelData::afterImport()
     if (version < 220) {  //  re-initialise as no conversion possible
       const char * layoutId = "Layout2P1";  // currently all using same default though might change for NV14
       RadioLayout::init(layoutId, modelData.customScreens);
-      memset(&modelData.topBarData, 0, sizeof(TopBarPersistentData));
+      modelData.topBarData = TopBarPersistentData();
     }
   }
 


### PR DESCRIPTION
Fixes #4528

Summary of changes:
- increase widget name length from 10 to 12 characters
- increase number of top bar zones from 4 to 6
- silence compiler warnings