### PR TITLE
fix(telemetry): DSM/LemonRX sensor cleanup for Altimeter and Flight Pack Monitors

### DIFF
--- a/radio/src/telemetry/spektrum.cpp
+++ b/radio/src/telemetry/spektrum.cpp
@@ -749,7 +749,7 @@ void processSpektrumPacket(const uint8_t *packet)
     else if (i2cAddress == I2C_PBOX) {
       // hide mAh Consumption already reported in Fligh Pack message 
       // No Bat Voltage, hide Voltage and Consumption
-      if (flightPackTelemetry && (sensor->startByte == 4 ||  sensor->startByte == 6)) {
+      if (flightPackTelemetry && (sensor->startByte == 4 ||  sensor->startByte == 6)) 
           continue;
       else if ((sensor->startByte == 0 || sensor->startByte == 4) && // Bat1 Voltage
           spektrumGetValue(packet + 4, 0, uint16) == 0) continue;

--- a/radio/src/telemetry/spektrum.cpp
+++ b/radio/src/telemetry/spektrum.cpp
@@ -743,25 +743,34 @@ void processSpektrumPacket(const uint8_t *packet)
     else if (i2cAddress == I2C_FP_BATT) {
       flightPackTelemetry = true;
       // Lemon-RX G2: No Bat2: Current (-1.0 A)
-      if (sensor->startByte == 6 && ((int16_t) value) == -10) continue;  
+      if (sensor->startByte == 6 && ((int16_t) value) == -10) {
+        continue;
+      }  
     } // I2C_FP_BATT
 
     else if (i2cAddress == I2C_PBOX) {
-      // hide mAh Consumption already reported in Fligh Pack message 
-      // No Bat Voltage, hide Voltage and Consumption
-      if (flightPackTelemetry && (sensor->startByte == 4 ||  sensor->startByte == 6)) 
+      if (flightPackTelemetry && (sensor->startByte == 4 ||  sensor->startByte == 6)) {
+          // hide mAh Consumption already reported in Fligh Pack message 
           continue;
-      else if ((sensor->startByte == 0 || sensor->startByte == 4) && // Bat1 Voltage
-          spektrumGetValue(packet + 4, 0, uint16) == 0) continue;
-      else if ((sensor->startByte == 2 || sensor->startByte == 6) && // Bat2 Voltage
-          spektrumGetValue(packet + 4, 2, uint16) == 0) continue;
+      }
+      else if ((sensor->startByte == 0 || sensor->startByte == 4) && 
+          spektrumGetValue(packet + 4, 0, uint16) == 0) {
+          // No Bat1 Voltage, hide Voltage and Consumption
+          continue;
+      }
+      else if ((sensor->startByte == 2 || sensor->startByte == 6) && 
+          spektrumGetValue(packet + 4, 2, uint16) == 0) {
+          // No Bat2 Voltage, hide Voltage and Consumption
+          continue;
+      }
     } // I2C_PBOX
 
     else if (i2cAddress == I2C_VARIO) {
       varioTelemetry = true;
     }
     else if (i2cAddress == I2C_ALTITUDE && varioTelemetry) {
-      continue; // Altitude already reported in vario
+      // Altitude already reported in vario
+      continue; 
     }
 
     setTelemetryValue(PROTOCOL_TELEMETRY_SPEKTRUM, pseudoId, 0, instance, value, sensor->unit, sensor->precision);

--- a/radio/src/telemetry/spektrum.cpp
+++ b/radio/src/telemetry/spektrum.cpp
@@ -355,8 +355,8 @@ const SpektrumSensor spektrumSensors[] = {
 
 // Alt Low and High needs to be combined (in 2 diff packets)
 static uint8_t gpsAltHigh = 0;
-static bool    varioTelemetry = false;
-static bool    flightPackTelemetry = false;
+static bool varioTelemetry = false;
+static bool flightPackTelemetry = false;
 
 // Helper function declared later
 static void processAS3XPacket(const uint8_t *packet);
@@ -545,7 +545,7 @@ void processSpektrumPacket(const uint8_t *packet)
 
   uint8_t instance = packet[3];
 
-  if (telemetryState==TELEMETRY_INIT) { // Telemetry Reset?
+  if (telemetryState == TELEMETRY_INIT) {  // Telemetry Reset?
     gpsAltHigh = 0;
     varioTelemetry = false;
     flightPackTelemetry = false;
@@ -681,7 +681,7 @@ void processSpektrumPacket(const uint8_t *packet)
     else if (i2cAddress == I2C_QOS) {
       if (sensor->startByte == 0) {  // FdeA
         // Check if this looks like a LemonRX Transceiver, they use QoS Frame loss A as RSSI indicator(0-100)
-        // farzu: new G2s has different signature, but i think using the Cyrf chip strenght is
+        // farzu: new G2s has different signature, but i think using the Cyrf chip strength is
         //        more consistent across brands
         if (spektrumGetValue(packet + 4, 2, uint16) == 0x8000 &&
             spektrumGetValue(packet + 4, 4, uint16) == 0x8000 &&
@@ -936,9 +936,10 @@ void processSpektrumTelemetryData(uint8_t module, uint8_t data,
 
 const SpektrumSensor *getSpektrumSensor(uint16_t pseudoId)
 {
-  uint8_t startByte = (uint8_t) (pseudoId & 0xff);
-  uint8_t i2cadd = (uint8_t) (pseudoId >> 8);
-  for (const SpektrumSensor * sensor = spektrumSensors; sensor->i2caddress; sensor++) {
+  uint8_t startByte = (uint8_t)(pseudoId & 0xff);
+  uint8_t i2cadd = (uint8_t)(pseudoId >> 8);
+  for (const SpektrumSensor *sensor = spektrumSensors; sensor->i2caddress;
+       sensor++) {
     if (i2cadd == sensor->i2caddress && startByte == sensor->startByte) {
       return sensor;
     }
@@ -962,39 +963,32 @@ void spektrumSetDefault(int index, uint16_t id, uint8_t subId, uint8_t instance)
     if (unit == UNIT_RPMS) {
       telemetrySensor.custom.ratio = 1;
       telemetrySensor.custom.offset = 1;
-    }
-    else if (unit == UNIT_FAHRENHEIT) {
+    } else if (unit == UNIT_FAHRENHEIT) {
       if (!IS_IMPERIAL_ENABLE()) {
         telemetrySensor.unit = UNIT_CELSIUS;
       }
-    }
-    else if (unit == UNIT_CELSIUS) {
+    } else if (unit == UNIT_CELSIUS) {
       if (IS_IMPERIAL_ENABLE()) {
         telemetrySensor.unit = UNIT_FAHRENHEIT;
       }
-    }
-    else if (unit == UNIT_METERS) {
+    } else if (unit == UNIT_METERS) {
       if (IS_IMPERIAL_ENABLE()) {
         telemetrySensor.unit = UNIT_FEET;
       }
-    }
-    else if (unit == UNIT_KMH) {
+    } else if (unit == UNIT_KMH) {
       if (IS_IMPERIAL_ENABLE()) {
         telemetrySensor.unit = UNIT_KTS;
       }
-    }
-    else if (unit == UNIT_METERS_PER_SECOND) {
+    } else if (unit == UNIT_METERS_PER_SECOND) {
       if (IS_IMPERIAL_ENABLE()) {
         telemetrySensor.unit = UNIT_FEET_PER_SECOND;
       }
-    }
-    else if (unit == UNIT_KTS) {
+    } else if (unit == UNIT_KTS) {
       if (!IS_IMPERIAL_ENABLE()) {
         telemetrySensor.unit = UNIT_KMH;
       }
     }
-  }
-  else {
+  } else {
     telemetrySensor.init(id);
   }
 

--- a/radio/src/telemetry/spektrum.cpp
+++ b/radio/src/telemetry/spektrum.cpp
@@ -967,11 +967,30 @@ void spektrumSetDefault(int index, uint16_t id, uint8_t subId, uint8_t instance)
       if (!IS_IMPERIAL_ENABLE()) {
         telemetrySensor.unit = UNIT_CELSIUS;
       }
-
+    }
+    else if (unit == UNIT_CELSIUS) {
+      if (IS_IMPERIAL_ENABLE()) {
+        telemetrySensor.unit = UNIT_FAHRENHEIT;
+      }
     }
     else if (unit == UNIT_METERS) {
       if (IS_IMPERIAL_ENABLE()) {
         telemetrySensor.unit = UNIT_FEET;
+      }
+    }
+    else if (unit == UNIT_KMH) {
+      if (IS_IMPERIAL_ENABLE()) {
+        telemetrySensor.unit = UNIT_KTS;
+      }
+    }
+    else if (unit == UNIT_METERS_PER_SECOND) {
+      if (IS_IMPERIAL_ENABLE()) {
+        telemetrySensor.unit = UNIT_FEET_PER_SECOND;
+      }
+    }
+    else if (unit == UNIT_KTS) {
+      if (!IS_IMPERIAL_ENABLE()) {
+        telemetrySensor.unit = UNIT_KMH;
       }
     }
   }


### PR DESCRIPTION
Fixes #4598

## Summary of changes:
1. Hide "Flss" and "Hold" Sensors with populated with NO-DATA  (0x7FFF or 0xFFFF)
2. On PowerBox Telemetry (Voltage + Consumption), Only report data if the Sensor is connected (Volts > 0)
3. Handle Duplicate "Alt" sensor when RX reports separate messages for Altimeter (only)  and Vario  (Alt + VSpeed)
4. Handle Duplicate "RB1C" (Bat1 Consumption) if reported by Flight Pack Monitor Sensor and PowerBox in the same RX (Lemon)
5. Hide Bat2 data if Bat2 is not connected (PowerBox and FlightPack).  Most hardware only monitors 1 bat

**Note**:  On this scenario sometimes the duplicate sensors can show again:
1. Have Telemetry "Discover New" active, when we do "Reset Telemetry" on the main screen.
2. Have Telemetry "Discover New" active while binding. 

This is because we process the Altitude message before we know that we have a Vario message (Altitude + V Speed).  The duplicate sensor turns RED after a few seconds, and has to be deleted by the user.


## Testing:
Spektrum:   AR637T (altimeter) + Flight Pack Consumption sensor + Voltage Sensor
Lemon-RX G2 LM0087 (Altimeter) + Battery Sensors
Spectrum AR410 (only RX voltage)

### Regression Testing no external sensors
OrangeRX , AR636 , Blade 230s, AR631

NOTE: Screenshots taken before fixing the VSpeed units to respect radio configuration (English/Metric)

### LEMON RX: (no more duplicates)
![image](https://github.com/EdgeTX/edgetx/assets/32604366/73c583dd-9a3f-4e03-95c7-f2976bf8a63d)
![image](https://github.com/EdgeTX/edgetx/assets/32604366/041bdafc-2174-43bd-9e50-2916f02a18fe)
![image](https://github.com/EdgeTX/edgetx/assets/32604366/1e5ce636-edea-4083-992c-1cea689caf8e)

### Spektrum AR637T:  (Gyro/As3X/SAFE sensors removed for clarity)
Note: Does not report RB1V (PowerBox message), only Flight Pack Consumption (RB1A,RB1C). A3 is flight pack voltage
![image](https://github.com/EdgeTX/edgetx/assets/32604366/6e5377fa-b3ce-4568-8bcd-ea4e15debc0b)
![image](https://github.com/EdgeTX/edgetx/assets/32604366/016abdf1-9eab-4cb7-ad85-9676d711d23c)















