### PR TITLE
fix: restore master serial option

### DIFF
--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -1008,11 +1008,7 @@ bool isTrainerModeAvailable(int mode)
 #endif
 
   if (mode == TRAINER_MODE_MASTER_SERIAL) {
-#if defined(SBUS_TRAINER)
     return serialGetModePort(UART_MODE_SBUS_TRAINER) >= 0;
-#else
-    return false;
-#endif
   }
 
   if ((mode == TRAINER_MODE_MASTER_BLUETOOTH ||


### PR DESCRIPTION
Restore serial master trainer on bw radio that was likely removed by mistake.

successfully tested on mt12 (both the menu and the subs trainer itself)
