### PR TITLE
fix(color):  EditNumber class not implementing zeroText logic

### DIFF
--- a/radio/src/thirdparty/libopenui/src/numberedit.h
+++ b/radio/src/thirdparty/libopenui/src/numberedit.h
@@ -118,6 +118,8 @@ class NumberEdit: public FormField
         std::string str;
         if (displayFunction != nullptr) {
           str = displayFunction(currentValue);
+        } else if (!zeroText.empty() && currentValue==0) {
+          str = zeroText;
         } else {
           str = formatNumberAsString(currentValue, textFlags, 0, prefix.c_str(),
                                      suffix.c_str());
@@ -176,6 +178,8 @@ class NumberEdit: public FormField
         std::string str;
         if (displayFunction != nullptr) {
           str = displayFunction(currentValue);
+        } else if (!zeroText.empty() && currentValue==0) {
+          str = zeroText;
         } else {
           str = formatNumberAsString(currentValue, textFlags, 0, prefix.c_str(),
                                      suffix.c_str());


### PR DESCRIPTION
For Color Radios,   small display inconsistency/bug.

Class EditNumber has the option to replace a zero value for any other text.   But was not working.
Looking at the code, there is no logic to handle the ZeroText.

**NOTE: this fix is only for the main (2.10) branch.
On branch 2.9, this code is in basenumberedit (BaseNumberEdit class).   Let me know if you want a PR specific for 2,9**

Example Screen: Telemetry Sensor Edit, the Ratio should show "-" when 0, and is not.  B&W radios works properly.

![image](https://github.com/EdgeTX/edgetx/assets/32604366/aac0bd3f-84e4-4dcb-8b59-9e6e726ce305)
![image](https://github.com/EdgeTX/edgetx/assets/32604366/83eae968-2e1c-4772-8294-9a09375c039f)
![image](https://github.com/EdgeTX/edgetx/assets/32604366/5204c183-384d-4441-a9a2-35f059436ec2)


Example: Mixer Edit, Warning should show "Off" when zero.
![image](https://github.com/EdgeTX/edgetx/assets/32604366/9bc03b8c-2124-42bb-b298-7a73ec6f0287)
![image](https://github.com/EdgeTX/edgetx/assets/32604366/bc28b48d-10bf-49e1-846c-014c74d685d2)



Summary of changes:

Libopenui:   numberedit  (NumberEdit class):   Added code to show the zeroText string if the value is 0.


According to the the reference, is only used in 4 pages:
![image](https://github.com/EdgeTX/edgetx/assets/32604366/a51e1c3f-8528-45b3-a629-4a1a2b4f4698)




