### PR TITLE
fix(radio): Refresh Lua scripts if needed when SF/GF updated.

### DIFF
--- a/radio/src/gui/212x64/model_special_functions.cpp
+++ b/radio/src/gui/212x64/model_special_functions.cpp
@@ -443,6 +443,9 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
                        attr);
           if (active)
             CFN_ACTIVE(cfn) = checkIncDec(event, CFN_ACTIVE(cfn), 0, 1, eeFlags);
+            if (checkIncDec_Ret && (func == FUNC_PLAY_SCRIPT)) {
+              LUA_LOAD_MODEL_SCRIPTS();
+            }
           break;
       }
     }


### PR DESCRIPTION
PR #4621 fixed refresh of Lua scripts when a SF/GF is enabled/disabled on 128x64 B&W radios.

This PR extends that fix to 212x64 B&W and color radios.

For color radios it also fixes an issue where the radio.yml file would not get saved if a GF was pasted into the list.
