### PR TITLE
feat(lua): add support for CRSF 'direct command' packets

### DIFF
--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1194,15 +1194,31 @@ static int luaCrossfireTelemetryPush(lua_State * L)
     uint8_t command = luaL_checkunsigned(L, 1);
     luaL_checktype(L, 2, LUA_TTABLE);
     uint8_t length = luaL_len(L, 2);
+    
     outputTelemetryBuffer.pushByte(MODULE_ADDRESS);
-    outputTelemetryBuffer.pushByte(2 + length); // 1(COMMAND) + data length + 1(CRC)
+    
+    if (command == COMMAND_ID) { // length 
+      outputTelemetryBuffer.pushByte(3 + length); // 1(COMMAND) + length(data) + 1(CRC_BA) + 1(CRC_D5)
+    } else {
+      outputTelemetryBuffer.pushByte(2 + length); // 1(COMMAND) + length(data) + 1(CRC_D5)
+    }
+    
     outputTelemetryBuffer.pushByte(command); // COMMAND
-    for (int i=0; i<length; i++) {
-      lua_rawgeti(L, 2, i+1);
+
+    // payload    
+    for (int i = 0; i < length; i++) {
+      lua_rawgeti(L, 2, i + 1);
       outputTelemetryBuffer.pushByte(luaL_checkunsigned(L, -1));
     }
-    outputTelemetryBuffer.pushByte(crc8(outputTelemetryBuffer.data + 2, 1 + length));
-    outputTelemetryBuffer.setDestination(internal ? 0 : TELEMETRY_ENDPOINT_SPORT);
+    // CRC
+    if (command == COMMAND_ID) {
+      outputTelemetryBuffer.pushByte(crc8_BA(outputTelemetryBuffer.data + 2, 1 + length)); // 1 byte CRC8_BA (counted from COMMAND byte)
+      outputTelemetryBuffer.pushByte(crc8(outputTelemetryBuffer.data + 2, 2 + length)); // 1 byte CRC8_D5 (counted from COMMAND byte including CRC8_BA byte)
+    } else {
+      outputTelemetryBuffer.pushByte(crc8(outputTelemetryBuffer.data + 2, 1 + length)); // 1 byte CRC8_D5 (counted from COMMAND byte)
+    }
+    
+    outputTelemetryBuffer.setDestination(TELEMETRY_ENDPOINT_SPORT);
     lua_pushboolean(L, true);
   }
   else {

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1197,7 +1197,8 @@ static int luaCrossfireTelemetryPush(lua_State* L)
 
     outputTelemetryBuffer.pushByte(MODULE_ADDRESS);
 
-    if (command == COMMAND_ID) {  // length
+    // LENGTH
+    if (command == COMMAND_ID) {
       // 1(COMMAND) + length(data) + 1(CRC_BA) + 1(CRC_D5)
       outputTelemetryBuffer.pushByte(3 + length);
     } else {
@@ -1228,7 +1229,7 @@ static int luaCrossfireTelemetryPush(lua_State* L)
           crc8(outputTelemetryBuffer.data + 2, 1 + length));
     }
 
-    outputTelemetryBuffer.setDestination(TELEMETRY_ENDPOINT_SPORT);
+    outputTelemetryBuffer.setDestination(internal ? 0 : TELEMETRY_ENDPOINT_SPORT);
     lua_pushboolean(L, true);
   } else {
     lua_pushboolean(L, false);


### PR DESCRIPTION
Summary of changes:
Modified LUA crsfTelemetryPush() to support CRSF direct commands

Fixes #983 

Testing:
1. Legacy
Since this PR changes LUA function that is used in scripts to configure devices using CRSF protocol (ELRS)
- run ELRS LUA and check if everything works as intended
- run TBS Agent and check if everything works as intended

2. Direct commands
- Install TBS TX module (any) in radio - led on module button should light yellow
- Install enclosed LUA test script (move to /SCRIPTS/TOOLS/)
- Select "CRSF TX Module Start Bind" and press Enter - led on module button should blink green slowly
- Select "CRSF TX Module Stop Bind" and press Enter - led on module button should stop blinking and go back to solid yellow.

[CRSF_direct_cmd_test.lua.zip](https://github.com/EdgeTX/edgetx/files/14236887/CRSF_direct_cmd_test.lua.zip)