### PR TITLE
feat(color): Use case insensitive sorting for list of widget names.

### DIFF
--- a/radio/src/gui/colorlcd/widget.cpp
+++ b/radio/src/gui/colorlcd/widget.cpp
@@ -209,7 +209,7 @@ void registerWidget(const WidgetFactory * factory)
   }
   TRACE("register widget %s %s", name, factory->getDisplayName());
   for (auto it = getRegisteredWidgets().cbegin(); it != getRegisteredWidgets().cend(); ++it) {
-    if (strcmp((*it)->getDisplayName(), factory->getDisplayName()) > 0) {
+    if (strcasecmp((*it)->getDisplayName(), factory->getDisplayName()) > 0) {
       getRegisteredWidgets().insert(it, factory);
       return;
     }


### PR DESCRIPTION
When selecting a widget the popup list has the names sorted in case sensitive order.
This puts widgets whose name starts with a lower case letter (e.g. showall0.9) at the end.

This PR changes the sorting to case insensitive.
