### PR TITLE
fix(cpn): switches default types

### DIFF
--- a/companion/src/firmwares/boardjson.cpp
+++ b/companion/src/firmwares/boardjson.cpp
@@ -411,6 +411,7 @@ Board::SwitchInfo BoardJson::getSwitchInfo(const SwitchesTable * switches, int i
     info.type = defn.type;
     info.tag = defn.tag;
     info.name = defn.name;
+    info.dflt = defn.dflt;
     info.inverted = defn.inverted;
   }
 
@@ -920,8 +921,8 @@ bool BoardJson::loadFile(Board::Type board, QString hwdefn, InputsTable * inputs
 
         switches->insert(switches->end(), sw);
 
-//        qDebug() << "name:" << sw.name.c_str() << "type:" << sw.stype.c_str() << ">" << Boards::switchTypeToString(sw.type) <<
-//                    "flags:" << sw.flags << "default:" << sw.sdflt.c_str() << ">" << Boards::switchTypeToString(sw.dflt) <<
+//        qDebug() << "tag:" << sw.tag.c_str() << "name:" << sw.name.c_str() << "type:" << sw.type << ">" << Boards::switchTypeToString(sw.type) <<
+//                    "flags:" << sw.flags << "default:" << sw.dflt << ">" << Boards::switchTypeToString(sw.dflt) <<
 //                    "inverted:" << sw.inverted << "display:" << QString("%1").arg(sw.display.x) << "," << QString("%1").arg(sw.display.y);
       }
     }

--- a/companion/src/firmwares/boards.h
+++ b/companion/src/firmwares/boards.h
@@ -275,12 +275,14 @@ namespace Board {
       type(SWITCH_NOT_AVAILABLE),
       tag(""),
       name(""),
+      dflt(SWITCH_NOT_AVAILABLE),
       inverted(false)
     {}
 
     SwitchType type;
     std::string tag;
     std::string name;
+    SwitchType dflt;
     bool inverted;
   };
 }

--- a/companion/src/firmwares/edgetx/yaml_switchconfig.cpp
+++ b/companion/src/firmwares/edgetx/yaml_switchconfig.cpp
@@ -361,7 +361,18 @@ bool convert<YamlSwitchConfig>::decode(const Node& node, YamlSwitchConfig& rhs)
 {
   if (!node.IsMap()) return false;
 
-  const int maxcnt = Boards::getCapability(getCurrentBoard(), Board::Switches);
+  Board::Type board = getCurrentBoard();
+
+  const int maxcnt = Boards::getCapability(board, Board::Switches);
+
+  // load defaults in case values not in yaml file
+  for (int i = 0; i < maxcnt; i++) {
+    Board::SwitchInfo info =  Boards::getSwitchInfo(i, board);
+    rhs.config[i].tag = info.tag;
+    memset(rhs.config[i].name, 0, sizeof(rhs.config[i].name));
+    rhs.config[i].type = info.dflt;
+    rhs.config[i].inverted = info.inverted;
+  }
 
   for (const auto& kv : node) {
     std::string tag;

--- a/companion/src/firmwares/generalsettings.cpp
+++ b/companion/src/firmwares/generalsettings.cpp
@@ -385,7 +385,7 @@ void GeneralSettings::setDefaultControlTypes(Board::Type board)
 
   for (int i = 0; i < Boards::getCapability(board, Board::Switches); i++) {
     Board::SwitchInfo info =  Boards::getSwitchInfo(i, board);
-    switchConfig[i].type = info.type;
+    switchConfig[i].type = info.dflt;
     switchConfig[i].inverted = info.inverted;
     switchConfig[i].inputIdx = SWITCH_INPUTINDEX_NONE;
   }


### PR DESCRIPTION
Fixes #4640

Summary of changes:
- load switch default for new settings file and not max positions
- load defaults before reading yaml file to handle cases where yaml file does not include the switch settings