### PR TITLE
fix(lua): serialRead is not limited to CLI

### DIFF
--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -2321,7 +2321,6 @@ Reads characters from the serial port. The string is allowed to contain any char
 */
 static int luaSerialRead(lua_State * L)
 {
-#if defined(LUA) && !defined(CLI)
   int num = luaL_optunsigned(L, 1, 0);
 
   uint8_t str[LUA_FIFO_SIZE];
@@ -2350,9 +2349,6 @@ static int luaSerialRead(lua_State * L)
     }
   }
   lua_pushlstring(L, (const char*)str, p - str);
-#else
-  lua_pushlstring(L, "", 0);
-#endif
 
   return 1;
 }


### PR DESCRIPTION
Fixes #4605

<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Summary of changes:
- lua serialRead is not limited to CLI, so shouldn't be disabled when CLI not present (i.e. it is no different to serialWrite). 


It would be interesting to know the justification for this... perhaps it was some attempt at preventing CLI "noise" being read by `serialRead()` - maybe there was a shared buffer at that time?