### PR TITLE
fix: halt T14 power up when USB connected

### DIFF
--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -155,7 +155,16 @@ void boardInit()
       //    // Let it charge ...
       getADC();  // Warning: the value read does not include VBAT calibration
       delay_ms(20);
-#if defined(STATUS_LEDS)
+#if defined(FUNCTION_SWITCHES)
+      // Support for FS Led to indicate battery charge level
+      if (getBatteryVoltage() >= 660) fsLedOn(0);
+      if (getBatteryVoltage() >= 700) fsLedOn(1);
+      if (getBatteryVoltage() >= 740) fsLedOn(2);
+      if (getBatteryVoltage() >= 780) fsLedOn(3);
+      if (getBatteryVoltage() >= 820) fsLedOn(4);
+      if (getBatteryVoltage() >= 842) fsLedOn(5);
+#elif defined(STATUS_LEDS)
+      // Use Status LED to indicate battery charge level instead
       if (getBatteryVoltage() <= 660) {
         for (auto i = 0; i < 2; i++) {
           ledRed();
@@ -185,35 +194,8 @@ void boardInit()
   }
 #endif
 
-// Support for FS Led to indicate battery charge level
-#if defined(FUNCTION_SWITCHES)
-  // This is needed to prevent radio from starting when usb is plugged to charge
-  usbInit();
-  // prime debounce state...
-  usbPlugged();
 
-  if (usbPlugged()) {
-    delaysInit();
-    adcInit(&_adc_driver);
-    getADC();
-    pwrOn();  // required to get bat adc reads
-    INTERNAL_MODULE_OFF();
-    EXTERNAL_MODULE_OFF();
 
-    while (usbPlugged()) {
-      // Let it charge ...
-      getADC();  // Warning: the value read does not include VBAT calibration
-      delay_ms(20);
-      if (getBatteryVoltage() >= 660) fsLedOn(0);
-      if (getBatteryVoltage() >= 700) fsLedOn(1);
-      if (getBatteryVoltage() >= 740) fsLedOn(2);
-      if (getBatteryVoltage() >= 780) fsLedOn(3);
-      if (getBatteryVoltage() >= 820) fsLedOn(4);
-      if (getBatteryVoltage() >= 842) fsLedOn(5);
-    }
-    pwrOff();
-  }
-#endif
 
   keysInit();
   switchInit();

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -155,7 +155,31 @@ void boardInit()
 
     while (usbPlugged()) {
       //    // Let it charge ...
+      getADC();  // Warning: the value read does not include VBAT calibration
       delay_ms(20);
+      if (getBatteryVoltage() <= 660) {
+        for (auto i = 0; i < 2; i++) {
+          ledRed();
+          delay_ms(200);
+          ledOff();
+          delay_ms(300);
+        }
+      } else if (getBatteryVoltage() <= 842) {
+        for (auto i = 0; i < 2; i++) {
+          ledBlue();
+          delay_ms(200);
+          ledOff();
+          delay_ms(300);
+        }
+      } else {
+        for (auto i = 0; i < 2; i++) {
+          ledGreen();
+          delay_ms(200);
+          ledOff();
+          delay_ms(300);
+        }
+      }
+      delay_ms(1000);
     }
     pwrOff();
   }

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -136,7 +136,6 @@ void boardInit()
 #endif
 #endif
 
-
 // If the radio was powered on by USB, halt
 // the boot process and charge the battery
 #if defined(PWR_BUTTON_PRESS)
@@ -184,7 +183,6 @@ void boardInit()
     pwrOff();
   }
 #endif
-
 
 // Support for FS Led to indicate battery charge level
 #if defined(FUNCTION_SWITCHES)

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -137,7 +137,7 @@ void boardInit()
 #endif
 
 // If the radio was powered on by USB, halt the boot process, let battery charge
-#if defined(PWR_BUTTON_PRESS) && !defined(FUNCTION_SWITCHES)
+#if defined(PWR_BUTTON_PRESS)
   // This is needed to prevent radio from starting when usb is plugged to charge
   usbInit();
   // prime debounce state...

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -137,7 +137,7 @@ void boardInit()
 #endif
 
 // If the radio was powered on by USB, halt the boot process, let battery charge
-#if defined(PWR_BUTTON_PRESS)
+#if defined(PWR_BUTTON_PRESS) && !defined(FUNCTION_SWITCHES)
   // This is needed to prevent radio from starting when usb is plugged to charge
   usbInit();
   // prime debounce state...

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -137,7 +137,10 @@ void boardInit()
 #endif
 
 // If the radio was powered on by dual use USB, halt the boot process, let battery charge
-#if defined(PWR_BUTTON_PRESS) && !defined(USB_CHARGER)
+// TODO: needs refactoring if any other manufacturer implements either of the following:
+// - function switches and the radio supports charging
+// - single USB for data + charge which powers on radio
+#if defined(MANUFACTURER_JUMPER)
   // This is needed to prevent radio from starting when usb is plugged to charge
   usbInit();
   // prime debounce state...

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -136,8 +136,8 @@ void boardInit()
 #endif
 #endif
 
-// If the radio was powered on by USB, halt the boot process, let battery charge
-#if defined(PWR_BUTTON_PRESS)
+// If the radio was powered on by dual use USB, halt the boot process, let battery charge
+#if defined(PWR_BUTTON_PRESS) && !defined(USB_CHARGER)
   // This is needed to prevent radio from starting when usb is plugged to charge
   usbInit();
   // prime debounce state...
@@ -165,28 +165,9 @@ void boardInit()
       if (getBatteryVoltage() >= 842) fsLedOn(5);
 #elif defined(STATUS_LEDS)
       // Use Status LED to indicate battery charge level instead
-      if (getBatteryVoltage() <= 660) {
-        for (auto i = 0; i < 2; i++) {
-          ledRed();
-          delay_ms(200);
-          ledOff();
-          delay_ms(300);
-        }
-      } else if (getBatteryVoltage() <= 842) {
-        for (auto i = 0; i < 2; i++) {
-          ledBlue();
-          delay_ms(200);
-          ledOff();
-          delay_ms(300);
-        }
-      } else {
-        for (auto i = 0; i < 2; i++) {
-          ledGreen();
-          delay_ms(200);
-          ledOff();
-          delay_ms(300);
-        }
-      }
+      if (getBatteryVoltage() <= 660) ledRed();         // low discharge
+      else if (getBatteryVoltage() <= 842) ledBlue();   // charging
+      else ledGreen();                                  // charging done
       delay_ms(1000);
 #endif
     }

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -136,8 +136,7 @@ void boardInit()
 #endif
 #endif
 
-// If the radio was powered on by USB, halt
-// the boot process and charge the battery
+// If the radio was powered on by USB, halt the boot process, let battery charge
 #if defined(PWR_BUTTON_PRESS)
   // This is needed to prevent radio from starting when usb is plugged to charge
   usbInit();

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -194,9 +194,6 @@ void boardInit()
   }
 #endif
 
-
-
-
   keysInit();
   switchInit();
 

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -155,6 +155,7 @@ void boardInit()
       //    // Let it charge ...
       getADC();  // Warning: the value read does not include VBAT calibration
       delay_ms(20);
+#if defined(STATUS_LEDS)
       if (getBatteryVoltage() <= 660) {
         for (auto i = 0; i < 2; i++) {
           ledRed();
@@ -178,6 +179,7 @@ void boardInit()
         }
       }
       delay_ms(1000);
+#endif
     }
     pwrOff();
   }

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -136,34 +136,60 @@ void boardInit()
 #endif
 #endif
 
+
+// If the radio was powered on by USB, halt
+// the boot process and charge the battery
+#if defined(PWR_BUTTON_PRESS)
+  // This is needed to prevent radio from starting when usb is plugged to charge
+  usbInit();
+  // prime debounce state...
+  usbPlugged();
+
+  if (usbPlugged()) {
+    delaysInit();
+    adcInit(&_adc_driver);
+    getADC();
+    pwrOn();  // required to get bat adc reads
+    INTERNAL_MODULE_OFF();
+    EXTERNAL_MODULE_OFF();
+
+    while (usbPlugged()) {
+      //    // Let it charge ...
+      delay_ms(20);
+    }
+    pwrOff();
+  }
+#endif
+
+
 // Support for FS Led to indicate battery charge level
 #if defined(FUNCTION_SWITCHES)
   // This is needed to prevent radio from starting when usb is plugged to charge
   usbInit();
   // prime debounce state...
-   usbPlugged();
+  usbPlugged();
 
-   if (usbPlugged()) {
-     delaysInit();
-     adcInit(&_adc_driver);
-     getADC();
+  if (usbPlugged()) {
+    delaysInit();
+    adcInit(&_adc_driver);
+    getADC();
     pwrOn();  // required to get bat adc reads
-     INTERNAL_MODULE_OFF();
-     EXTERNAL_MODULE_OFF();
+    INTERNAL_MODULE_OFF();
+    EXTERNAL_MODULE_OFF();
 
-     while (usbPlugged()) {
-       // Let it charge ...
+    while (usbPlugged()) {
+      // Let it charge ...
       getADC();  // Warning: the value read does not include VBAT calibration
-       delay_ms(20);
+      delay_ms(20);
       if (getBatteryVoltage() >= 660) fsLedOn(0);
       if (getBatteryVoltage() >= 700) fsLedOn(1);
       if (getBatteryVoltage() >= 740) fsLedOn(2);
       if (getBatteryVoltage() >= 780) fsLedOn(3);
       if (getBatteryVoltage() >= 820) fsLedOn(4);
       if (getBatteryVoltage() >= 842) fsLedOn(5);
-     }
-     pwrOff();
-   }
+    }
+    pwrOff();
+  }
 #endif
 
   keysInit();

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -147,26 +147,20 @@ void boardInit()
      delaysInit();
      adcInit(&_adc_driver);
      getADC();
-     pwrOn(); // required to get bat adc reads
+    pwrOn();  // required to get bat adc reads
      INTERNAL_MODULE_OFF();
      EXTERNAL_MODULE_OFF();
 
      while (usbPlugged()) {
        // Let it charge ...
-       getADC(); // Warning: the value read does not include VBAT calibration
+      getADC();  // Warning: the value read does not include VBAT calibration
        delay_ms(20);
-       if (getBatteryVoltage() >= 660)
-         fsLedOn(0);
-       if (getBatteryVoltage() >= 700)
-         fsLedOn(1);
-       if (getBatteryVoltage() >= 740)
-         fsLedOn(2);
-       if (getBatteryVoltage() >= 780)
-         fsLedOn(3);
-       if (getBatteryVoltage() >= 820)
-         fsLedOn(4);
-       if (getBatteryVoltage() >= 842)
-         fsLedOn(5);
+      if (getBatteryVoltage() >= 660) fsLedOn(0);
+      if (getBatteryVoltage() >= 700) fsLedOn(1);
+      if (getBatteryVoltage() >= 740) fsLedOn(2);
+      if (getBatteryVoltage() >= 780) fsLedOn(3);
+      if (getBatteryVoltage() >= 820) fsLedOn(4);
+      if (getBatteryVoltage() >= 842) fsLedOn(5);
      }
      pwrOff();
    }


### PR DESCRIPTION
Issue being resolved:
- as I've commented previously and was just reminded of in a review, T14 will power itself on if the USB is connected to charge, and re-power itself (in EM) if powered off with the USB connected. 
- this will catch power-on via USB for any radio with soft power button, and effectivel hang it until disconnected, and then power off
- while we're here doin' nothin', flash those leds as a crude "state of charge" indicator. I had initially gone for a simple "on/off" blink, but then though someone would thing the handset was just resetting itself, hence the more elaborate and more heartbeat-like timing. 

It's just a PoC, and I'm not particuarly attached to the blinky light code - and if it stays the voltage values probably need tweaking. 

@3djc What do you think? 

edit: Now that I look at it more, maybe it could be juggled around it is present if the radio has if defined(PWR_BUTTON_PRESS), and then either run the FUNCTION_SWITCH specific, STATUS_LED specific or no status led/no FS code (i.e. just halt)? 