### PR TITLE
feat(radio): modify Sensor Edit screens to show Ratio + Percentage

### DIFF
--- a/radio/src/gui/128x64/model_telemetry_sensor.cpp
+++ b/radio/src/gui/128x64/model_telemetry_sensor.cpp
@@ -42,7 +42,7 @@ enum SensorFields {
 };
 
 constexpr coord_t SENSOR_2ND_COLUMN  = 12 * FW;
-constexpr coord_t SENSOR_3RD_COLUMN = 18 * FW;
+constexpr coord_t SENSOR_3RD_COLUMN = 17 * FW - 2;
 
 void menuModelSensor(event_t event)
 {
@@ -220,10 +220,13 @@ void menuModelSensor(event_t event)
           else {
             lcdDrawTextAlignedLeft(y, STR_RATIO);
             if (attr) CHECK_INCDEC_MODELVAR(event, sensor->custom.ratio, 0, 30000);
-            if (sensor->custom.ratio == 0)
+            if (sensor->custom.ratio == 0) {
               lcdDrawChar(SENSOR_2ND_COLUMN, y, '-', attr);
-            else
+            } else {  // Ratio + Ratio Percent
               lcdDrawNumber(SENSOR_2ND_COLUMN, y, sensor->custom.ratio, LEFT|attr|PREC1);
+              lcdDrawNumber(SENSOR_3RD_COLUMN, y, (sensor->custom.ratio * 1000) / 255, LEFT|PREC1);
+              lcdDrawChar(SENSOR_3RD_COLUMN+(FWNUM*4)+3, y, '%', 0);
+            }
             break;
           }
         }

--- a/radio/src/gui/128x64/model_telemetry_sensor.cpp
+++ b/radio/src/gui/128x64/model_telemetry_sensor.cpp
@@ -224,40 +224,40 @@ void menuModelSensor(event_t event)
               lcdDrawChar(SENSOR_2ND_COLUMN, y, '-', attr);
             } else {  // Ratio + Ratio Percent
               uint32_t ratio = (sensor->custom.ratio * 1000) / 255;
-              int ratio_len = countDigits(sensor->custom.ratio);
-              int ratio_perc_len = countDigits(ratio);
+              int ratioLen = countDigits(sensor->custom.ratio);
+              int ratioPercLen = countDigits(ratio);
 
               int suffixOffset = 0;
-              int ratio_column_adjust = 0;
-              int ratio_perc_column_adjust = 0;
+              int ratioColAdj = 0;
+              int ratioPercColAdj = 0;
 
-              if (ratio_len <= 3) {
-                ratio_column_adjust = 0;
-              } else if (ratio_len <= 4) {
-                ratio_column_adjust = (FWNUM * 1);
-              } else if (ratio_len >= 5) {
-                ratio_column_adjust = (FWNUM * 2);
+              if (ratioLen <= 3) {
+                ratioColAdj = 0;
+              } else if (ratioLen <= 4) {
+                ratioColAdj = (FWNUM * 1);
+              } else if (ratioLen >= 5) {
+                ratioColAdj = (FWNUM * 2);
               }
 
-              if (ratio_perc_len < 2) {
-                ratio_perc_column_adjust = 0;
-                suffixOffset = (FWNUM * (ratio_perc_len + 1)) + 2;
-              } else if (ratio_perc_len <= 4 ) {
-                ratio_perc_column_adjust = 0;
-                suffixOffset = (FWNUM * ratio_perc_len) + 2;
-              } else if (ratio_perc_len <= 5) {
-                ratio_column_adjust += (FWNUM * 1); // move first column to maintain separation
-                ratio_perc_column_adjust = (FWNUM * 1);
-                suffixOffset = (FWNUM * (ratio_perc_len - 1)) + 2;
-              } else if (ratio_perc_len >= 6) {
-                ratio_column_adjust += (FWNUM * 2); // move first column to maintain separation
-                ratio_perc_column_adjust = (FWNUM * 2);
-                suffixOffset = (FWNUM * (ratio_perc_len - 2)) + 2;
+              if (ratioPercLen < 2) {
+                ratioPercColAdj = 0;
+                suffixOffset = (FWNUM * (ratioPercLen + 1)) + 2;
+              } else if (ratioPercLen <= 4 ) {
+                ratioPercColAdj = 0;
+                suffixOffset = (FWNUM * ratioPercLen) + 2;
+              } else if (ratioPercLen <= 5) {
+                ratioColAdj += (FWNUM * 1); // move first column to maintain separation
+                ratioPercColAdj = (FWNUM * 1);
+                suffixOffset = (FWNUM * (ratioPercLen - 1)) + 2;
+              } else if (ratioPercLen >= 6) {
+                ratioColAdj += (FWNUM * 2); // move first column to maintain separation
+                ratioPercColAdj = (FWNUM * 2);
+                suffixOffset = (FWNUM * (ratioPercLen - 2)) + 2;
               }
 
-              lcdDrawNumber(SENSOR_2ND_COLUMN - ratio_column_adjust, y,
+              lcdDrawNumber(SENSOR_2ND_COLUMN - ratioColAdj, y,
                             sensor->custom.ratio, LEFT | attr | PREC1);
-              lcdDrawNumber(SENSOR_3RD_COLUMN - ratio_perc_column_adjust, y,
+              lcdDrawNumber(SENSOR_3RD_COLUMN - ratioPercColAdj, y,
                             ratio, LEFT | PREC1);
               lcdDrawChar(SENSOR_3RD_COLUMN + suffixOffset, y, '%', 0);
             }

--- a/radio/src/gui/128x64/model_telemetry_sensor.cpp
+++ b/radio/src/gui/128x64/model_telemetry_sensor.cpp
@@ -224,20 +224,41 @@ void menuModelSensor(event_t event)
               lcdDrawChar(SENSOR_2ND_COLUMN, y, '-', attr);
             } else {  // Ratio + Ratio Percent
               uint32_t ratio = (sensor->custom.ratio * 1000) / 255;
-              int ratio_len = countDigits(ratio);
-              int suffixOffset;
-              lcdDrawNumber(SENSOR_2ND_COLUMN, y, sensor->custom.ratio,
-                            LEFT | attr | PREC1);
-              if (ratio_len < 5) {
-                lcdDrawNumber(SENSOR_3RD_COLUMN, y, ratio, LEFT | PREC1);
-                suffixOffset = (FWNUM * ratio_len + 3);
-              } else if (ratio_len < 7) {
-                lcdDrawNumber(SENSOR_3RD_COLUMN, y, ratio / 10, LEFT);
-                suffixOffset = (FWNUM * (ratio_len - 1));
-              } else {
-                lcdDrawNumber(SENSOR_3RD_COLUMN, y, ratio / 100, LEFT);
-                suffixOffset = (FWNUM * (ratio_len - 3));
+              int ratio_len = countDigits(sensor->custom.ratio);
+              int ratio_perc_len = countDigits(ratio);
+
+              int suffixOffset = 0;
+              int ratio_column_adjust = 0;
+              int ratio_perc_column_adjust = 0;
+
+              if (ratio_len <= 3) {
+                ratio_column_adjust = 0;
+              } else if (ratio_len <= 4) {
+                ratio_column_adjust = (FWNUM * 1);
+              } else if (ratio_len >= 5) {
+                ratio_column_adjust = (FWNUM * 2);
               }
+
+              if (ratio_perc_len < 2) {
+                ratio_perc_column_adjust = 0;
+                suffixOffset = (FWNUM * (ratio_perc_len + 1)) + 2;
+              } else if (ratio_perc_len <= 4 ) {
+                ratio_perc_column_adjust = 0;
+                suffixOffset = (FWNUM * ratio_perc_len) + 2;
+              } else if (ratio_perc_len <= 5) {
+                ratio_column_adjust += (FWNUM * 1); // move first column to maintain separation
+                ratio_perc_column_adjust = (FWNUM * 1);
+                suffixOffset = (FWNUM * (ratio_perc_len - 1)) + 2;
+              } else if (ratio_perc_len >= 6) {
+                ratio_column_adjust += (FWNUM * 2); // move first column to maintain separation
+                ratio_perc_column_adjust = (FWNUM * 2);
+                suffixOffset = (FWNUM * (ratio_perc_len - 2)) + 2;
+              }
+
+              lcdDrawNumber(SENSOR_2ND_COLUMN - ratio_column_adjust, y,
+                            sensor->custom.ratio, LEFT | attr | PREC1);
+              lcdDrawNumber(SENSOR_3RD_COLUMN - ratio_perc_column_adjust, y,
+                            ratio, LEFT | PREC1);
               lcdDrawChar(SENSOR_3RD_COLUMN + suffixOffset, y, '%', 0);
             }
             break;

--- a/radio/src/gui/128x64/model_telemetry_sensor.cpp
+++ b/radio/src/gui/128x64/model_telemetry_sensor.cpp
@@ -41,7 +41,7 @@ enum SensorFields {
   SENSOR_FIELD_MAX
 };
 
-constexpr coord_t SENSOR_2ND_COLUMN  = 12 * FW;
+constexpr coord_t SENSOR_2ND_COLUMN = 12 * FW;
 constexpr coord_t SENSOR_3RD_COLUMN = 17 * FW - 2;
 
 void menuModelSensor(event_t event)
@@ -223,9 +223,22 @@ void menuModelSensor(event_t event)
             if (sensor->custom.ratio == 0) {
               lcdDrawChar(SENSOR_2ND_COLUMN, y, '-', attr);
             } else {  // Ratio + Ratio Percent
-              lcdDrawNumber(SENSOR_2ND_COLUMN, y, sensor->custom.ratio, LEFT|attr|PREC1);
-              lcdDrawNumber(SENSOR_3RD_COLUMN, y, (sensor->custom.ratio * 1000) / 255, LEFT|PREC1);
-              lcdDrawChar(SENSOR_3RD_COLUMN+(FWNUM*4)+3, y, '%', 0);
+              uint32_t ratio = (sensor->custom.ratio * 1000) / 255;
+              int ratio_len = countDigits(ratio);
+              int suffixOffset;
+              lcdDrawNumber(SENSOR_2ND_COLUMN, y, sensor->custom.ratio,
+                            LEFT | attr | PREC1);
+              if (ratio_len < 5) {
+                lcdDrawNumber(SENSOR_3RD_COLUMN, y, ratio, LEFT | PREC1);
+                suffixOffset = (FWNUM * ratio_len + 3);
+              } else if (ratio_len < 7) {
+                lcdDrawNumber(SENSOR_3RD_COLUMN, y, ratio / 10, LEFT);
+                suffixOffset = (FWNUM * (ratio_len - 1));
+              } else {
+                lcdDrawNumber(SENSOR_3RD_COLUMN, y, ratio / 100, LEFT);
+                suffixOffset = (FWNUM * (ratio_len - 3));
+              }
+              lcdDrawChar(SENSOR_3RD_COLUMN + suffixOffset, y, '%', 0);
             }
             break;
           }

--- a/radio/src/gui/212x64/model_telemetry_sensor.cpp
+++ b/radio/src/gui/212x64/model_telemetry_sensor.cpp
@@ -42,7 +42,7 @@ enum SensorFields {
 };
 
 #define SENSOR_2ND_COLUMN      (12*FW)
-#define SENSOR_3RD_COLUMN      (17*FW-2)
+#define SENSOR_3RD_COLUMN      (18*FW)
 
 #define SENSOR_UNIT_ROWS       ((sensor->type == TELEM_TYPE_CALCULATED && (sensor->formula == TELEM_FORMULA_DIST)) || sensor->isConfigurable() ? (uint8_t)0 : HIDDEN_ROW)
 #define SENSOR_PREC_ROWS       (sensor->isPrecConfigurable() ? (uint8_t)0 : HIDDEN_ROW)
@@ -238,8 +238,10 @@ void menuModelSensor(event_t event)
               lcdDrawChar(SENSOR_2ND_COLUMN, y, '-', attr);
             } else {  // Ratio + Ratio Percent
               lcdDrawNumber(SENSOR_2ND_COLUMN, y, sensor->custom.ratio, LEFT|attr|PREC1);
-              lcdDrawNumber(SENSOR_3RD_COLUMN, y, (sensor->custom.ratio * 1000) / 255, LEFT|PREC1);
-              lcdDrawChar(SENSOR_3RD_COLUMN+(FWNUM*4)+3, y, '%', 0);
+              uint32_t ratio = (sensor->custom.ratio * 1000) / 255;
+              int ratio_len = countDigits(ratio);
+              lcdDrawNumber(SENSOR_3RD_COLUMN, y, ratio, LEFT|PREC1);
+              lcdDrawChar(SENSOR_3RD_COLUMN+(FWNUM*ratio_len)+3, y, '%', 0);
             }
             break;
           }

--- a/radio/src/gui/212x64/model_telemetry_sensor.cpp
+++ b/radio/src/gui/212x64/model_telemetry_sensor.cpp
@@ -42,7 +42,7 @@ enum SensorFields {
 };
 
 #define SENSOR_2ND_COLUMN      (12*FW)
-#define SENSOR_3RD_COLUMN      (18*FW)
+#define SENSOR_3RD_COLUMN      (17*FW-2)
 
 #define SENSOR_UNIT_ROWS       ((sensor->type == TELEM_TYPE_CALCULATED && (sensor->formula == TELEM_FORMULA_DIST)) || sensor->isConfigurable() ? (uint8_t)0 : HIDDEN_ROW)
 #define SENSOR_PREC_ROWS       (sensor->isPrecConfigurable() ? (uint8_t)0 : HIDDEN_ROW)
@@ -234,10 +234,13 @@ void menuModelSensor(event_t event)
           else {
             lcdDrawTextAlignedLeft(y, STR_RATIO);
             if (attr) sensor->custom.ratio = checkIncDec(event, sensor->custom.ratio, 0, 30000, EE_MODEL|NO_INCDEC_MARKS|INCDEC_REP10);
-            if (sensor->custom.ratio == 0)
+            if (sensor->custom.ratio == 0) {
               lcdDrawChar(SENSOR_2ND_COLUMN, y, '-', attr);
-            else
+            } else {  // Ratio + Ratio Percent
               lcdDrawNumber(SENSOR_2ND_COLUMN, y, sensor->custom.ratio, LEFT|attr|PREC1);
+              lcdDrawNumber(SENSOR_3RD_COLUMN, y, (sensor->custom.ratio * 1000) / 255, LEFT|PREC1);
+              lcdDrawChar(SENSOR_3RD_COLUMN+(FWNUM*4)+3, y, '%', 0);
+            }
             break;
           }
         }

--- a/radio/src/gui/colorlcd/model_telemetry.cpp
+++ b/radio/src/gui/colorlcd/model_telemetry.cpp
@@ -390,6 +390,51 @@ class SensorSourceChoice : public SourceChoice
   }
 };
 
+class SensorRatioEdit : Window
+{
+  public:
+    SensorRatioEdit(Window* parent, const rect_t &rect, int vmin, int vmax,
+              std::function<int()> _getValue,
+              std::function<void(int)> _setValue) :
+      Window(parent, rect),
+      m_getValue(std::move(_getValue)),
+      m_setValue(std::move(_setValue))
+    {
+      setFlexLayout(LV_FLEX_FLOW_ROW, 75);
+      lv_obj_set_flex_align(lvobj, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_SPACE_AROUND);
+
+      editRatio = new NumberEdit(this, rect_t{}, vmin, vmax, 
+                      m_getValue,
+                      [=](int32_t newValue) {
+                        m_setValue(newValue);
+                        setPercent();
+                      }, PREC1);
+      editRatio->setZeroText("-");
+      //editRatio->setFastStep(20);
+
+      percentText = new StaticText(this, rect_t{}, "");
+      setPercent();
+    }
+
+  protected:
+    int32_t ratioPercent;
+    NumberEdit* editRatio;
+    StaticText* percentText;
+    std::function<int()> m_getValue;
+    std::function<void(int)> m_setValue;
+
+  private:
+    void setPercent() {
+      int32_t value = m_getValue(); 
+      if (value == 0) { 
+        percentText->setText("");
+      } else {
+        std::string str = formatNumberAsString((value*1000)/255, PREC1, 0, "", "%");
+        percentText->setText(str);
+      }
+    }
+};
+
 class SensorEditWindow : public Page
 {
  public:
@@ -697,9 +742,7 @@ class SensorEditWindow : public Page
 
     paramLines[P_RATIO] = window->newLine(grid);
     new StaticText(paramLines[P_RATIO], rect_t{}, STR_RATIO);
-    auto edit = new NumberEdit(paramLines[P_RATIO], rect_t{}, 0, 30000,
-                               GET_SET_DEFAULT(sensor->custom.ratio), PREC1);
-    edit->setZeroText("-");
+    new SensorRatioEdit(paramLines[P_RATIO], rect_t{}, 0, 30000, GET_SET_DEFAULT(sensor->custom.ratio));
 
     paramLines[P_CELLINDEX] = window->newLine(grid);
     new StaticText(paramLines[P_CELLINDEX], rect_t{}, STR_CELLINDEX);

--- a/radio/src/gui/colorlcd/model_telemetry.cpp
+++ b/radio/src/gui/colorlcd/model_telemetry.cpp
@@ -392,47 +392,50 @@ class SensorSourceChoice : public SourceChoice
 
 class SensorRatioEdit : Window
 {
-  public:
-    SensorRatioEdit(Window* parent, const rect_t &rect, int vmin, int vmax,
-              std::function<int()> _getValue,
-              std::function<void(int)> _setValue) :
+ public:
+  SensorRatioEdit(Window* parent, const rect_t& rect, int vmin, int vmax,
+                  std::function<int()> _getValue,
+                  std::function<void(int)> _setValue) :
       Window(parent, rect),
       m_getValue(std::move(_getValue)),
       m_setValue(std::move(_setValue))
-    {
-      setFlexLayout(LV_FLEX_FLOW_ROW, 75);
-      lv_obj_set_flex_align(lvobj, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_SPACE_AROUND);
+  {
+    setFlexLayout(LV_FLEX_FLOW_ROW, 75);
+    lv_obj_set_flex_align(lvobj, LV_FLEX_ALIGN_START, LV_FLEX_ALIGN_CENTER,
+                          LV_FLEX_ALIGN_SPACE_AROUND);
 
-      editRatio = new NumberEdit(this, rect_t{}, vmin, vmax, 
-                      m_getValue,
-                      [=](int32_t newValue) {
-                        m_setValue(newValue);
-                        setPercent();
-                      }, PREC1);
-      editRatio->setZeroText("-");
-      //editRatio->setFastStep(20);
+    editRatio = new NumberEdit(
+        this, rect_t{}, vmin, vmax, m_getValue,
+        [=](int32_t newValue) {
+          m_setValue(newValue);
+          setPercent();
+        },
+        PREC1);
+    editRatio->setZeroText("-");
 
-      percentText = new StaticText(this, rect_t{}, "");
-      setPercent();
+    percentText = new StaticText(this, rect_t{}, "");
+    setPercent();
+  }
+
+ protected:
+  int32_t ratioPercent;
+  NumberEdit* editRatio;
+  StaticText* percentText;
+  std::function<int()> m_getValue;
+  std::function<void(int)> m_setValue;
+
+ private:
+  void setPercent()
+  {
+    int32_t value = m_getValue();
+    if (value == 0) {
+      percentText->setText("");
+    } else {
+      std::string str =
+          formatNumberAsString((value * 1000) / 255, PREC1, 0, "", "%");
+      percentText->setText(str);
     }
-
-  protected:
-    int32_t ratioPercent;
-    NumberEdit* editRatio;
-    StaticText* percentText;
-    std::function<int()> m_getValue;
-    std::function<void(int)> m_setValue;
-
-  private:
-    void setPercent() {
-      int32_t value = m_getValue(); 
-      if (value == 0) { 
-        percentText->setText("");
-      } else {
-        std::string str = formatNumberAsString((value*1000)/255, PREC1, 0, "", "%");
-        percentText->setText(str);
-      }
-    }
+  }
 };
 
 class SensorEditWindow : public Page
@@ -742,7 +745,8 @@ class SensorEditWindow : public Page
 
     paramLines[P_RATIO] = window->newLine(grid);
     new StaticText(paramLines[P_RATIO], rect_t{}, STR_RATIO);
-    new SensorRatioEdit(paramLines[P_RATIO], rect_t{}, 0, 30000, GET_SET_DEFAULT(sensor->custom.ratio));
+    new SensorRatioEdit(paramLines[P_RATIO], rect_t{}, 0, 30000,
+                        GET_SET_DEFAULT(sensor->custom.ratio));
 
     paramLines[P_CELLINDEX] = window->newLine(grid);
     new StaticText(paramLines[P_CELLINDEX], rect_t{}, STR_CELLINDEX);

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -1183,6 +1183,24 @@ char *strAppendDate(char *str, bool time)
 #if !defined(BOOT)
 #endif
 
+/** 
+ * @brief Count the number of digits in a string.
+ * Works with negative numbers, and zero is considered to have 1 digit.
+ * @param number Integer whose digits are to be counted.
+ * @return The number of digits in the integer.
+ */
+int countDigits(int number)
+{
+  number = std::abs(number);  // Handle negative numbers if any
+  if (number == 0) return 1;  // Special case for 0
+  int count = 0;
+  while (number > 0) {
+    number /= 10;
+    count++;
+  }
+  return count;
+}
+
 // Manage timezones
 // For backward compatibility timezone is stored as two separate values:
 //   timezone = hour value

--- a/radio/src/strhelpers.h
+++ b/radio/src/strhelpers.h
@@ -174,6 +174,8 @@ std::string getGPSSensorValue(TelemetryItem &telemetryItem, LcdFlags flags);
 std::string getTelemDate(TelemetryItem &telemetryItem);
 std::string getTelemTime(TelemetryItem &telemetryItem);
 
+int countDigits(int number);
+
 // Timezone handling
 extern int8_t minTimezone();
 extern int8_t maxTimezone();


### PR DESCRIPTION
Fixes #4648
**Works in main as well as 2.9 branch.**
Changes are isolated in the display portion of the UI

Summary of changes:
Change the Telemetry Sensor Edit to show the equivalent percentage.
Works on color and B&W radios.

![image](https://github.com/EdgeTX/edgetx/assets/32604366/3a618845-ea7d-4626-9356-c1932b222349)
![image](https://github.com/EdgeTX/edgetx/assets/32604366/e40866c2-4fa7-4555-9e08-edb68b30b869)

![image](https://github.com/EdgeTX/edgetx/assets/32604366/d90ab15e-72db-41d7-9920-513ee2e850e6)
![image](https://github.com/EdgeTX/edgetx/assets/32604366/e2a7c40f-09d3-4151-874d-82858ea023b2)


