### PR TITLE
fix(radio): "DCL - The Game" not detecting USB joystick

### DIFF
--- a/radio/src/targets/common/arm/stm32/usbd_desc.c
+++ b/radio/src/targets/common/arm/stm32/usbd_desc.c
@@ -67,7 +67,7 @@
 #define USBD_VID_PID_CODES                  0x1209    // https://pid.codes
 
 #define USBD_LANGID_STRING                  0x409
-#define USBD_MANUFACTURER_STRING            "EdgeTX"
+#define USBD_MANUFACTURER_STRING            "OpenTX"
 #define USBD_SERIALNUMBER_FS_STRING         "00000000001B"
 
 #if defined(BOOT)


### PR DESCRIPTION
stop gap change to fix #4580 by reverting the USB manufacturer string to the pre-2.9.0 state ("OpenTX" instead of "EdgeTX")