### PR TITLE
feat(color): widget app mode

### DIFF
--- a/radio/src/gui/colorlcd/layouts/layout_factory_impl.h
+++ b/radio/src/gui/colorlcd/layouts/layout_factory_impl.h
@@ -109,6 +109,8 @@ class Layout: public LayoutBase
 
     bool isLayout() override { return true; }
 
+    bool isAppMode() { return decorationSettings == DECORATION_NONE && zoneCount == 1; }
+  
   protected:
     const LayoutFactory * factory  = nullptr;
     std::unique_ptr<ViewMainDecoration> decoration;

--- a/radio/src/gui/colorlcd/layouts/topbar_impl.cpp
+++ b/radio/src/gui/colorlcd/layouts/topbar_impl.cpp
@@ -22,15 +22,30 @@
 #include "topbar_impl.h"
 #include "opentx.h"
 #include "theme.h"
+#include "view_main.h"
 
 constexpr uint32_t TOPBAR_REFRESH = 1000 / 10; // 10 Hz
+
+class TopBarEdgeTx : public HeaderIcon
+{
+ public:
+  TopBarEdgeTx(Window* parent) : HeaderIcon(parent, ICON_EDGETX)
+  {
+    lv_obj_add_flag(lvobj, LV_OBJ_FLAG_CLICKABLE);
+  }
+
+  void onClicked() override
+  {
+    ViewMain::instance()->openMenu();
+  }
+};
 
 TopBar::TopBar(Window * parent) :
   TopBarBase(parent, {0, 0, LCD_W, MENU_HEADER_HEIGHT}, &g_model.topbarData)
 {
   etx_solid_bg(lvobj, COLOR_THEME_SECONDARY1_INDEX);
 
-  headerIcon = new HeaderIcon(this, ICON_EDGETX);
+  headerIcon = new TopBarEdgeTx(parent);
 }
 
 unsigned int TopBar::getZonesCount() const
@@ -80,6 +95,16 @@ coord_t TopBar::getVisibleHeight(float visible) const // 0.0 -> 1.0
 
   float h = (float)MENU_HEADER_HEIGHT * visible;
   return (coord_t)h;
+}
+
+void TopBar::showEdgeTxButton()
+{
+  headerIcon->show();
+}
+
+void TopBar::hideEdgeTxButton()
+{
+  headerIcon->hide();
 }
 
 void TopBar::checkEvents()

--- a/radio/src/gui/colorlcd/layouts/topbar_impl.h
+++ b/radio/src/gui/colorlcd/layouts/topbar_impl.h
@@ -51,6 +51,8 @@ class TopBar: public TopBarBase
 
     void setVisible(float visible);
     coord_t getVisibleHeight(float visible) const; // 0.0 -> 1.0
+    void showEdgeTxButton();
+    void hideEdgeTxButton();
   
     void checkEvents() override;
 

--- a/radio/src/gui/colorlcd/theme.cpp
+++ b/radio/src/gui/colorlcd/theme.cpp
@@ -107,10 +107,10 @@ void HeaderDateTime::setColor(uint32_t color)
   lv_obj_set_style_text_color(time, makeLvColor(color), LV_PART_MAIN);
 }
 
-HeaderIcon::HeaderIcon(Window* parent, EdgeTxIcon icon)
+HeaderIcon::HeaderIcon(Window* parent, EdgeTxIcon icon) :
+  StaticIcon(parent, 0, 0, ICON_TOPLEFT_BG, COLOR_THEME_FOCUS)
 {
-  auto bg = new StaticIcon(parent, 0, 0, ICON_TOPLEFT_BG, COLOR_THEME_FOCUS);
-  (new StaticIcon(parent, 0, 0, icon, COLOR_THEME_PRIMARY2))->center(bg->width(), bg->height());
+  (new StaticIcon(this, 0, 0, icon, COLOR_THEME_PRIMARY2))->center(width(), height());
 }
 
 UsbSDConnected::UsbSDConnected() :

--- a/radio/src/gui/colorlcd/theme.h
+++ b/radio/src/gui/colorlcd/theme.h
@@ -23,6 +23,7 @@
 
 #include "opentx.h"
 #include "bitmaps.h"
+#include "static.h"
 
 class BitmapBuffer;
 
@@ -59,7 +60,7 @@ class HeaderDateTime
   int8_t lastMinute = -1;
 };
 
-class HeaderIcon
+class HeaderIcon : public StaticIcon
 {
  public:
   HeaderIcon(Window *parent, EdgeTxIcon icon);

--- a/radio/src/gui/colorlcd/view_main.h
+++ b/radio/src/gui/colorlcd/view_main.h
@@ -71,8 +71,15 @@ class ViewMain : public NavWindow
 
   void onClicked() override;
   void onCancel() override;
+  void openMenu();
+  void longPress();
 
   void show(bool visible = true) override;
+  void showTopBarEdgeTxButton();
+  void hideTopBarEdgeTxButton();
+
+  bool hasTopbar();
+  bool isAppMode();
 
   void runBackground();
   void refreshWidgetSelectTimer();
@@ -95,8 +102,6 @@ class ViewMain : public NavWindow
 
   // Set topbar visibility [0.0 -> 1.0]
   void setTopbarVisible(float visible);
-
-  void openMenu();
 
   static void long_pressed(lv_event_t* e);
   static void ws_timer(lv_timer_t* t);

--- a/radio/src/gui/colorlcd/widget.cpp
+++ b/radio/src/gui/colorlcd/widget.cpp
@@ -56,6 +56,12 @@ Widget::Widget(const WidgetFactory* factory, Window* parent, const rect_t& rect,
 
 void Widget::openMenu()
 {
+  if (fsAllowed && ViewMain::instance()->isAppMode())
+  {
+    setFullscreen(true);
+    return;
+  }
+
   if (getOptions() || fsAllowed) {
     // Widgets are placed on a full screen window which is underneath the main
     // view menu bar Find the parent of this so that when the popup loads it
@@ -137,8 +143,6 @@ void Widget::setFullscreen(bool enable)
 
   update();
 }
-
-void Widget::disableFullscreen() { fsAllowed = false; }
 
 void Widget::onLongPress()
 {

--- a/radio/src/gui/colorlcd/widget.h
+++ b/radio/src/gui/colorlcd/widget.h
@@ -76,10 +76,6 @@ class Widget : public ButtonBase
   // Set/unset fullscreen mode
   void setFullscreen(bool enable);
 
-  // Disable setting fullscreen mode
-  void disableFullscreen();
-  bool isFullscreenAllowed() { return fsAllowed; }
-
   // Called when the widget options have changed
   virtual void update();
 

--- a/radio/src/gui/colorlcd/widgets_setup.cpp
+++ b/radio/src/gui/colorlcd/widgets_setup.cpp
@@ -115,6 +115,7 @@ SetupWidgetsPage::SetupWidgetsPage(uint8_t customScreenIdx) :
     auto viewMain = ViewMain::instance();
     savedView = viewMain->getCurrentMainView();
     viewMain->setCurrentMainView(customScreenIdx);
+    if (!viewMain->hasTopbar()) viewMain->hideTopBarEdgeTxButton();
   }
 
   SetupWidgetsPageSlot* firstSlot = nullptr;
@@ -148,6 +149,7 @@ void SetupWidgetsPage::deleteLater(bool detach, bool trash)
   if (screen) {
     auto viewMain = ViewMain::instance();
     viewMain->setCurrentMainView(savedView);
+    viewMain->showTopBarEdgeTxButton();
   }
   Window::deleteLater(detach, trash);
   new ScreenMenu(customScreenIdx + 1);


### PR DESCRIPTION
Fixes #4371 & #2629 

Rework the way 'full screen' mode is selected for widgets.

> It uses the 'EdgeTX' button in the top left to differentiate mode - at the moment I need this to have a way to open the quick menu (tapping on the widget will not work).
>
> 'App mode' is enabled by creating a layout with 1 widget (the 'full screen' layout) and turning off the topbar, flight modes, sliders and trims.
>
> - The default 'app mode' view would be the selected widget (full screen); but also still showing the EdgeTX button in the top left corner (visual indicator of mode). Keys and touch events are not passed to the widget. Swiping can be used to change view and enter/touch brings up quick menu.
> - A long ENTER press or long touch on the screen hides the EdgeTX button and directs key and touch events to the widget. The user will not be able to swipe to change views, or open the quick menu.
> - A long press of RTN key shows the EdgeTX button and stops events/touch going to the widget.

TODO:

- [ ] Rename 'Full screen' text to 'App mode'
- [ ] Add 'App mode' control/toggle the screen setup page

