### PR TITLE
Trainer: allow Master/SBUS Module mode on S.Port pin

### DIFF
--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -1044,12 +1044,12 @@ bool isTrainerModeAvailable(int mode)
       const etx_module_port_t *port = nullptr;
 
 #if defined(TRAINER_MODULE_SBUS_USART)
-      // check if UART with inverter on heartbeat pin is required and available for (some Taranis radios)
+      // check if UART with inverter on heartbeat pin is required and available for SBUS (some Taranis radios)
       port = modulePortFind(EXTERNAL_MODULE, ETX_MOD_TYPE_SERIAL,
                             ETX_MOD_PORT_UART, ETX_Pol_Normal,
                             ETX_MOD_DIR_RX);
 #else
-      //check if UART with imverter on S.Port pin is available for SBUS (e.g. TX16s, NV14)
+      //check if UART with inverter on S.Port pin is available for SBUS (e.g. TX16s, NV14)
       port = modulePortFind(EXTERNAL_MODULE, ETX_MOD_TYPE_SERIAL,
                             ETX_MOD_PORT_SPORT, ETX_Pol_Normal,
                             ETX_MOD_DIR_RX);

--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -1041,9 +1041,20 @@ bool isTrainerModeAvailable(int mode)
     }
     
     if (mode == TRAINER_MODE_MASTER_SBUS_EXTERNAL_MODULE) {
-      auto port =  modulePortFind(EXTERNAL_MODULE, ETX_MOD_TYPE_SERIAL,
-                                  ETX_MOD_PORT_UART, ETX_Pol_Normal,
-                                  ETX_MOD_DIR_RX);
+      const etx_module_port_t *port = nullptr;
+
+#if defined(TRAINER_MODULE_SBUS_USART)
+      // check if UART with inverter on heartbeat pin is required and available for (some Taranis radios)
+      port = modulePortFind(EXTERNAL_MODULE, ETX_MOD_TYPE_SERIAL,
+                            ETX_MOD_PORT_UART, ETX_Pol_Normal,
+                            ETX_MOD_DIR_RX);
+#else
+      //check if UART with imverter on S.Port pin is available for SBUS (e.g. TX16s, NV14)
+      port = modulePortFind(EXTERNAL_MODULE, ETX_MOD_TYPE_SERIAL,
+                            ETX_MOD_PORT_SPORT, ETX_Pol_Normal,
+                            ETX_MOD_DIR_RX);
+#endif
+
       return port != nullptr;
     }
   }

--- a/radio/src/hal/module_port.h
+++ b/radio/src/hal/module_port.h
@@ -40,11 +40,11 @@
 #define ETX_MOD_TYPE_SERIAL (1 << 1)
 
 enum ModulePort : uint8_t {
-  ETX_MOD_PORT_UART,
-  ETX_MOD_PORT_TIMER,
-  ETX_MOD_PORT_SOFT_INV,
-  ETX_MOD_PORT_SPORT,
-  ETX_MOD_PORT_SPORT_INV,
+  ETX_MOD_PORT_UART,      // UART on heartbeat pin
+  ETX_MOD_PORT_TIMER,     // PPM or TX on CPPM pin
+  ETX_MOD_PORT_SOFT_INV,  // TX soft-serial 
+  ETX_MOD_PORT_SPORT,     // UART on S.Port
+  ETX_MOD_PORT_SPORT_INV, // RX soft-serial sampled bit-by-bit via timer IRQ on S.PORT
   ETX_MOD_PORT_MAX
 };
 

--- a/radio/src/trainer.cpp
+++ b/radio/src/trainer.cpp
@@ -180,8 +180,16 @@ static void trainer_init_module_sbus()
 {
   if (sbus_trainer_mod_st) return;
 
+#if defined(TRAINER_MODULE_SBUS_USART)
+  // check if UART with inverter on heartbeat pin is required and available for (some Taranis radios)
   sbus_trainer_mod_st = modulePortInitSerial(EXTERNAL_MODULE, ETX_MOD_PORT_UART,
                                              &sbusTrainerParams, false);
+#else
+  // check if UART with inverter on S.Port pin is available for SBUS (e.g. TX16s, NV14)
+  if(sbus_trainer_mod_st == nullptr)
+    sbus_trainer_mod_st = modulePortInitSerial(EXTERNAL_MODULE, ETX_MOD_PORT_SPORT,
+                                               &sbusTrainerParams, false);
+#endif
 
   if (sbus_trainer_mod_st) {
     modulePortSetPower(EXTERNAL_MODULE,true);

--- a/radio/src/trainer.cpp
+++ b/radio/src/trainer.cpp
@@ -181,7 +181,7 @@ static void trainer_init_module_sbus()
   if (sbus_trainer_mod_st) return;
 
 #if defined(TRAINER_MODULE_SBUS_USART)
-  // check if UART with inverter on heartbeat pin is required and available for (some Taranis radios)
+  // check if UART with inverter on heartbeat pin is required and available for SBUS (some Taranis radios)
   sbus_trainer_mod_st = modulePortInitSerial(EXTERNAL_MODULE, ETX_MOD_PORT_UART,
                                              &sbusTrainerParams, false);
 #else


### PR DESCRIPTION
... for radios supporting S.Port SBUS input

Fixes https://github.com/EdgeTX/edgetx/issues/3678

Summary of changes:
- adds Master/SBUS Module Trainer mode (true idle low SBUS required) for Tx16s and other radios on S.Port pin
- the few Taranis radios not being able to use the S.Port Pin will still work on the HB pin
- added some comments to radio/src/gui/gui_common.cpp

Tested on NV14 and TX16s