### PR TITLE
fix(translation): harmonise TR_ENTER for PCBPL18

### DIFF
--- a/radio/src/translations/da.h
+++ b/radio/src/translations/da.h
@@ -233,7 +233,7 @@
 
 #if defined(PCBFRSKY)
   #define TR_ENTER                     "[ENTER]"
-#elif defined(PCBNV14)
+#elif defined(PCBNV14) || defined(PCBPL18)
   #define TR_ENTER                     "[NÆSTE]"
 #else
   #define TR_ENTER                     "[MENU]"

--- a/radio/src/translations/fi.h
+++ b/radio/src/translations/fi.h
@@ -236,7 +236,7 @@
 
 #if defined(PCBTARANIS) || defined(PCBHORUS)
   #define TR_ENTER                     "[ENTER]"
-#elif defined(PCBNV14)
+#elif defined(PCBNV14) || defined(PCBPL18)
   #define TR_ENTER                     "[NEXT]"
 #else
   #define TR_ENTER                     "[MENU]"

--- a/radio/src/translations/he.h
+++ b/radio/src/translations/he.h
@@ -234,7 +234,7 @@
 
 #if defined(PCBFRSKY)
   #define TR_ENTER                     "[ENTER]"
-#elif defined(PCBNV14)
+#elif defined(PCBNV14) || defined(PCBPL18)
   #define TR_ENTER                     "[NEXT]"
 #else
   #define TR_ENTER                     "[MENU]"

--- a/radio/src/translations/ru.h
+++ b/radio/src/translations/ru.h
@@ -232,7 +232,7 @@
 
 #if defined(PCBFRSKY)
   #define TR_ENTER                     "[ENT]"
-#elif defined(PCBNV14)
+#elif defined(PCBNV14) || defined(PCBPL18)
   #define TR_ENTER                     "[ДАЛЕЕ]"
 #else
   #define TR_ENTER                     "[МЕНЮ]"

--- a/radio/src/translations/se.h
+++ b/radio/src/translations/se.h
@@ -243,7 +243,7 @@
 
 #if defined(PCBFRSKY)
   #define TR_ENTER                      "[ENTER]"
-#elif defined(PCBNV14)
+#elif defined(PCBNV14) || defined(PCBPL18)
   #define TR_ENTER                      "[NÄSTA]"
 #else
   #define TR_ENTER                      "[MENY]"


### PR DESCRIPTION
Align all translations for TR_ENTER on the #if logic used by English and Chinese.