### PR TITLE
fix: T7/T8 yaml handling

### DIFF
--- a/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
@@ -903,7 +903,9 @@ static const char* trimSwitchNames[] = {
   "TrimThrDown", "TrimThrUp",
   "TrimAilLeft", "TrimAilRight",
   "TrimT5Down", "TrimT5Up",
-  "TrimT6Down", "TrimT6Up"
+  "TrimT6Down", "TrimT6Up",
+  "TrimT7Down", "TrimT7Up",
+  "TrimT8Down", "TrimT8Up",
 };
 
 static uint32_t r_swtchSrc(const YamlNode* node, const char* val, uint8_t val_len)


### PR DESCRIPTION
Fix a crash when wanting to select T7/T8 +- switches (in logical switch for example)
This was happening on T20 for example.