### PR TITLE
fix(radio): invalid memory access if SpaceMouse input present but not supported

### DIFF
--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -360,9 +360,13 @@ getvalue_t getValue(mixsrc_t i, bool* valid)
   }
 #endif
 
-#if defined(SPACEMOUSE)
+#if defined(PCBHORUS)
   else if (i >= MIXSRC_FIRST_SPACEMOUSE && i <= MIXSRC_LAST_SPACEMOUSE) {
+#if defined(SPACEMOUSE)
     return get_spacemouse_value(i - MIXSRC_FIRST_SPACEMOUSE);
+#else
+    return 0;
+#endif
   }
 #endif
 


### PR DESCRIPTION
Fix potential crash if source is a 'SpaceMouse' input; but SPACEMOUSE is not defined in the build.

Reported on discord that this combination can crash the simulator in Companion.
Has the potential to cause issues on a radio as well as the code is accessing an invalid memory location.

It is not clear how the user ended up with a space mouse input source on their radio.

Also affects 2.9.x.
