### PR TITLE
fix(cpn): initialisation of log viewer x-axis should use log time, not system time

### DIFF
--- a/companion/src/logsdialog.cpp
+++ b/companion/src/logsdialog.cpp
@@ -848,7 +848,7 @@ void LogsDialog::plotLogs()
     rowCount = ui->logTable->rowCount();
   }
 
-  plots.min_x = QDateTime::currentDateTime().toTime_t();
+  plots.min_x = INVALID_MIN;
   plots.max_x = 0;
 
   foreach (QTableWidgetItem *plot, ui->FieldsTW->selectedItems()) {
@@ -891,8 +891,12 @@ void LogsDialog::plotLogs()
           .toTime_t();
       }
       plotCoords.x.push_back(time);
+  
+      if(plots.min_x == INVALID_MIN)
+        plots.min_x = time;
+      else
+        if (plots.min_x > time) plots.min_x = time;
 
-      if (plots.min_x > time) plots.min_x = time;
       if (plots.max_x < time) plots.max_x = time;
     }
 


### PR DESCRIPTION
Fixes #4690

Summary of changes:
- fixed initialization of plots.min_x to no longer check against current time.
