### PR TITLE
chore: auto select radio fastest supported baudrate for elrs

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -292,8 +292,8 @@ void generalDefault()
 
 #if defined(DEFAULT_INTERNAL_MODULE)
     g_eeGeneral.internalModule = DEFAULT_INTERNAL_MODULE;
-    if (g_eeGeneral.internalModule == MODULE_TYPE_CROSSFIRE)
-      g_eeGeneral.internalModuleBaudrate = min(1, (int)CROSSFIRE_MAX_INTERNAL_BAUDRATE);  // 921k if possible
+    if (DEFAULT_INTERNAL_MODULE == MODULE_TYPE_CROSSFIRE)
+       g_eeGeneral.internalModuleBaudrate = CROSSFIRE_MAX_INTERNAL_BAUDRATE;
 #endif
 
   adcCalibDefaults();


### PR DESCRIPTION
This revisit #4523 based on latest info from ELRS team.

This only affect radio that go through the process of radio.yaml recreation