### PR TITLE
revert: undo SWC/SWE GPIO swap on EL18 for testing purposes

### DIFF
--- a/radio/src/targets/nv14/hal.h
+++ b/radio/src/targets/nv14/hal.h
@@ -110,9 +110,9 @@
 #define ADC_GPIO_PIN_POT1               LL_GPIO_PIN_6      // PA.06 VRA
 #define ADC_GPIO_PIN_POT2               LL_GPIO_PIN_4      // PC.04 VRB
 #define ADC_GPIO_PIN_SWA                LL_GPIO_PIN_1      // PB.01
-#define ADC_GPIO_PIN_SWB                LL_GPIO_PIN_10     // PF.10
+#define ADC_GPIO_PIN_SWB                LL_GPIO_PIN_8      // PF.08
 #define ADC_GPIO_PIN_SWC                LL_GPIO_PIN_0      // PB.00
-#define ADC_GPIO_PIN_SWD                LL_GPIO_PIN_8      // PF.08
+#define ADC_GPIO_PIN_SWD                LL_GPIO_PIN_10     // PF.10
 #define ADC_GPIO_PIN_SWE                LL_GPIO_PIN_0      // PC.00
 #define ADC_GPIO_PIN_SWF                LL_GPIO_PIN_1      // PC.01
 #define ADC_GPIO_PIN_SWG                LL_GPIO_PIN_2      // PC.02
@@ -137,9 +137,9 @@
 #define ADC_CHANNEL_POT1                LL_ADC_CHANNEL_6   // ADC12_IN6  -> ADC1_IN6
 #define ADC_CHANNEL_POT2                LL_ADC_CHANNEL_14  // ADC12_IN14 -> ADC1_IN14
 #define ADC_CHANNEL_SWA                 LL_ADC_CHANNEL_9   // ADC12_IN9  -> ADC1_IN9
-#define ADC_CHANNEL_SWB                 LL_ADC_CHANNEL_8   // ADC3_IN8   -> ADC3_IN8
+#define ADC_CHANNEL_SWB                 LL_ADC_CHANNEL_6   // ADC3_IN6   -> ADC3_IN6
 #define ADC_CHANNEL_SWC                 LL_ADC_CHANNEL_8   // ADC12_IN8  -> ADC1_IN8
-#define ADC_CHANNEL_SWD                 LL_ADC_CHANNEL_6   // ADC3_IN6   -> ADC3_IN6
+#define ADC_CHANNEL_SWD                 LL_ADC_CHANNEL_8   // ADC3_IN8   -> ADC3_IN8
 #define ADC_CHANNEL_SWE                 LL_ADC_CHANNEL_10  // ADC123_IN10-> ADC1_IN10
 #define ADC_CHANNEL_SWF                 LL_ADC_CHANNEL_11  // ADC123_IN11-> ADC1_IN11
 #define ADC_CHANNEL_SWG                 LL_ADC_CHANNEL_12  // ADC123_IN12-> ADC1_IN12


### PR DESCRIPTION
This partially reverts commit 51b4341e82bc2bae24b352444b2b46768fe2846c, to test if this is actually needed post #4563, as it seems there may have been another issue causing the switch swap.

<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #

Summary of changes:
