### PR TITLE
fix: add missing ua translation strings

### DIFF
--- a/radio/src/translations/ua.h
+++ b/radio/src/translations/ua.h
@@ -704,6 +704,12 @@
 
 #if defined(COLORLCD)
   #define TR_MODEL_QUICK_SELECT        "Швидкий вибір моделі"
+  #define TR_LABELS_SELECT             "Вибір мітки"
+  #define TR_LABELS_MATCH              "Співпад. мітки"
+  #define TR_FAV_MATCH                 "Співпад. улюблен."
+  #define TR_LABELS_SELECT_MODE        "Вибір багат.","Вибір одного"
+  #define TR_LABELS_MATCH_MODE         "Співпад. усіх","Співпад. одного"
+  #define TR_FAV_MATCH_MODE            "Обов'язк. співпад.","Необов'язк. співпад."
 #endif
 
 #define TR_SELECT_TEMPLATE_FOLDER      "Обрати теку моделі"


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Summary of changes:
- some colorlcd translation strings were missing for UA
