### PR TITLE
fix(b&w): Long ENTER not working correctly when using ADJUST GV SF

### DIFF
--- a/radio/src/gui/128x64/model_special_functions.cpp
+++ b/radio/src/gui/128x64/model_special_functions.cpp
@@ -413,6 +413,8 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
                 break;
             }
 
+#if !defined(NAVIGATION_X7)
+            // For X7 type navigation the ENTER long press is handled below
             if (attr && event==EVT_KEY_LONG(KEY_ENTER)) {
               killEvents(event);
               s_editMode = !s_editMode;
@@ -421,6 +423,7 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
               CFN_GVAR_MODE(cfn) &= 0x03;
               val_displayed = 0;
             }
+#endif
           }
 #endif // GVARS
           else if (attr) {


### PR DESCRIPTION
As reported on Discord.

Two different code blocks were trying to handle the long press Enter key. The resulting conflict made it very hard to figure out how to adjust the value.

This looks like it has been an issue for a long time.
If there is going to be a 2.9 update then it should be applied there as well as to 2.10 and 2.11.
