### PR TITLE
fix(el18): SWB and SWD swapped

### DIFF
--- a/radio/src/targets/nv14/hal.h
+++ b/radio/src/targets/nv14/hal.h
@@ -110,9 +110,9 @@
 #define ADC_GPIO_PIN_POT1               LL_GPIO_PIN_6      // PA.06 VRA
 #define ADC_GPIO_PIN_POT2               LL_GPIO_PIN_4      // PC.04 VRB
 #define ADC_GPIO_PIN_SWA                LL_GPIO_PIN_1      // PB.01
-#define ADC_GPIO_PIN_SWB                LL_GPIO_PIN_10     // PF.10
+#define ADC_GPIO_PIN_SWB                LL_GPIO_PIN_8      // PF.08
 #define ADC_GPIO_PIN_SWC                LL_GPIO_PIN_0      // PB.00
-#define ADC_GPIO_PIN_SWD                LL_GPIO_PIN_8      // PF.08
+#define ADC_GPIO_PIN_SWD                LL_GPIO_PIN_10     // PF.10
 #define ADC_GPIO_PIN_SWE                LL_GPIO_PIN_0      // PC.00
 #define ADC_GPIO_PIN_SWF                LL_GPIO_PIN_1      // PC.01
 #define ADC_GPIO_PIN_SWG                LL_GPIO_PIN_2      // PC.02
@@ -137,9 +137,9 @@
 #define ADC_CHANNEL_POT1                LL_ADC_CHANNEL_6   // ADC12_IN6  -> ADC1_IN6
 #define ADC_CHANNEL_POT2                LL_ADC_CHANNEL_14  // ADC12_IN14 -> ADC1_IN14
 #define ADC_CHANNEL_SWA                 LL_ADC_CHANNEL_9   // ADC12_IN9  -> ADC1_IN9
-#define ADC_CHANNEL_SWB                 LL_ADC_CHANNEL_8   // ADC3_IN8   -> ADC3_IN8
+#define ADC_CHANNEL_SWB                 LL_ADC_CHANNEL_6   // ADC3_IN6   -> ADC3_IN6
 #define ADC_CHANNEL_SWC                 LL_ADC_CHANNEL_8   // ADC12_IN8  -> ADC1_IN8
-#define ADC_CHANNEL_SWD                 LL_ADC_CHANNEL_6   // ADC3_IN6   -> ADC3_IN6
+#define ADC_CHANNEL_SWD                 LL_ADC_CHANNEL_8   // ADC3_IN8   -> ADC3_IN8
 #define ADC_CHANNEL_SWE                 LL_ADC_CHANNEL_10  // ADC123_IN10-> ADC1_IN10
 #define ADC_CHANNEL_SWF                 LL_ADC_CHANNEL_11  // ADC123_IN11-> ADC1_IN11
 #define ADC_CHANNEL_SWG                 LL_ADC_CHANNEL_12  // ADC123_IN12-> ADC1_IN12


### PR DESCRIPTION
The problem is due to the change in this PR:
https://github.com/EdgeTX/edgetx/pull/3779

when Raphael tested the firmware with his EL18, he found that the SWB and SWD is swapped, so he change the mapping in the above PR.

However, it is found that there are chances that the ext ADC will randomly shift channel when working out the PL18EV target, and this problem is due to improper handling of DMA, and is fixed in the following PR:
https://github.com/EdgeTX/edgetx/pull/4563

Now, I have received a few users reporting the same SWB/SWD swapped and after checking with Flysky.  they confirms the 2.10.0-RC1 has this problem.

This PR restores the correct mapping of SWB and SWD.
 
