### PR TITLE
feat(cpn): add inverted sources

### DIFF
--- a/companion/src/constants.h
+++ b/companion/src/constants.h
@@ -90,6 +90,8 @@
 #define CPN_STR_SW_INDICATOR_NEUT      QCoreApplication::translate("RawSwitch", "-")             // Switch neutral (middle) position indicator.
 #define CPN_STR_SW_INDICATOR_REV       QCoreApplication::translate("RawSwitch", "!")             // Switch reversed logic (NOT) indicator.
 
+#define CPN_STR_SRC_INDICATOR_INVERT   QCoreApplication::translate("RawSource", "!")             // Source inverted logic indicator.
+
 #define EDGETX_HOME_PAGE_URL           "https://edgetx.org"
 
 #define CPN_ADC_REFACTOR_VERSION       "2.10.0"

--- a/companion/src/datamodels/compounditemmodels.h
+++ b/companion/src/datamodels/compounditemmodels.h
@@ -197,7 +197,7 @@ class RawSourceItemModel: public AbstractDynamicItemModel
 
   protected:
     virtual void setDynamicItemData(QStandardItem * item, const RawSource & src) const;
-    void addItems(const RawSourceType & type, const int group, const int count, const int start = 0);
+    void addItems(const RawSourceType & type, const int group, int count, const int start = 0);
 };
 
 class RawSwitchItemModel: public AbstractDynamicItemModel

--- a/companion/src/firmwares/adjustmentreference.cpp
+++ b/companion/src/firmwares/adjustmentreference.cpp
@@ -61,7 +61,7 @@ QString AdjustmentReference::toString(const ModelData * model, const bool sign) 
 
   switch(type) {
     case ADJUST_REF_GVAR:
-      ret = RawSource(SOURCE_TYPE_GVAR, abs(value) - 1).toString(model);
+      ret = RawSource(SOURCE_TYPE_GVAR, abs(value)).toString(model);
       if (value < 0)
         ret.prepend("-");
       else if (sign)

--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -80,8 +80,7 @@ Boards::Boards(Board::Type board) :
   legacyTrimSourcesLookupTable(legacyTrimSourcesLut),
   trimSwitchesLookupTable(trimSwitchesLut),
   rawSwitchTypesLookupTable(RawSwitch::getRawSwitchTypesLookupTable()),
-  rawSourceSpecialTypesLookupTable(RawSource::getSpecialTypesLookupTable()),
-  rawSourceCyclicLookupTable(RawSource::getCyclicLookupTable())
+  rawSourceSpecialTypesLookupTable(RawSource::getSpecialTypesLookupTable())
 {
   setBoardType(board);
 }

--- a/companion/src/firmwares/boards.h
+++ b/companion/src/firmwares/boards.h
@@ -352,7 +352,6 @@ class Boards
     STRINGTAGMAPPINGFUNCS(trimSwitchesLookupTable, TrimSwitch);
     STRINGTAGMAPPINGFUNCS(rawSwitchTypesLookupTable, RawSwitchType);
     STRINGTAGMAPPINGFUNCS(rawSourceSpecialTypesLookupTable, RawSourceSpecialType);
-    STRINGTAGMAPPINGFUNCS(rawSourceCyclicLookupTable, RawSourceCyclic);
 
     static bool isInputAvailable(int index, Board::Type board = Board::BOARD_UNKNOWN);
     static bool isInputCalibrated(int index, Board::Type board = Board::BOARD_UNKNOWN);
@@ -379,7 +378,6 @@ class Boards
     const StringTagMappingTable trimSwitchesLookupTable;
     const StringTagMappingTable rawSwitchTypesLookupTable;
     const StringTagMappingTable rawSourceSpecialTypesLookupTable;
-    const StringTagMappingTable rawSourceCyclicLookupTable;
 
     static StringTagMappingTable getLegacyAnalogsLookupTable(Board::Type board = Board::BOARD_UNKNOWN);
 };

--- a/companion/src/firmwares/customfunctiondata.cpp
+++ b/companion/src/firmwares/customfunctiondata.cpp
@@ -62,7 +62,7 @@ QString CustomFunctionData::funcToString(const ModelData * model) const
 QString CustomFunctionData::funcToString(const AssignFunc func, const ModelData * model)
 {
   if (func >= FuncOverrideCH1 && func <= FuncOverrideCHLast)
-    return tr("Override %1").arg(RawSource(SOURCE_TYPE_CH, func).toString(model));
+    return tr("Override %1").arg(RawSource(SOURCE_TYPE_CH, func + 1).toString(model));
   else if (func == FuncTrainer)
     return tr("Trainer Axis");
   else if (func == FuncTrainerRUD)
@@ -84,7 +84,7 @@ QString CustomFunctionData::funcToString(const AssignFunc func, const ModelData 
   else if (func == FuncReset)
     return tr("Reset");
   else if (func >= FuncSetTimer1 && func <= FuncSetTimerLast)
-    return tr("Set %1").arg(RawSource(SOURCE_TYPE_SPECIAL, SOURCE_TYPE_SPECIAL_FIRST_TIMER + func - FuncSetTimer1).toString(model));
+    return tr("Set %1").arg(RawSource(SOURCE_TYPE_TIMER, func - FuncSetTimer1 + 1).toString(model));
   else if (func == FuncVario)
     return tr("Vario");
   else if (func == FuncPlayPrompt)
@@ -108,7 +108,7 @@ QString CustomFunctionData::funcToString(const AssignFunc func, const ModelData 
   else if (func == FuncBackgroundMusicPause)
     return tr("Background Music Pause");
   else if (func >= FuncAdjustGV1 && func <= FuncAdjustGVLast)
-    return tr("Adjust %1").arg(RawSource(SOURCE_TYPE_GVAR, func - FuncAdjustGV1).toString(model));
+    return tr("Adjust %1").arg(RawSource(SOURCE_TYPE_GVAR, func - FuncAdjustGV1 + 1).toString(model));
   else if (func == FuncSetFailsafe)
     return tr("Set Failsafe");
   else if (func == FuncRangeCheckInternalModule)
@@ -281,7 +281,7 @@ QString CustomFunctionData::resetToString(const int value, const ModelData * mod
 
   if (value < step) {
     if (value < firmware->getCapability(Timers))
-      return RawSource(SOURCE_TYPE_SPECIAL, value + SOURCE_TYPE_SPECIAL_FIRST_TIMER).toString(model);
+      return RawSource(SOURCE_TYPE_TIMER, value).toString(model);
     else
       return QString(CPN_STR_UNKNOWN_ITEM);
   }
@@ -293,7 +293,7 @@ QString CustomFunctionData::resetToString(const int value, const ModelData * mod
     return tr("Telemetry");
 
   if (value < step + firmware->getCapability(Sensors))
-    return RawSource(SOURCE_TYPE_TELEMETRY, 3 * (value - step)).toString(model);
+    return RawSource(SOURCE_TYPE_TELEMETRY, 3 * (value - step + 1)).toString(model);
 
   return QString(CPN_STR_UNKNOWN_ITEM);
 }

--- a/companion/src/firmwares/customfunctiondata.h
+++ b/companion/src/firmwares/customfunctiondata.h
@@ -36,7 +36,6 @@ class AbstractStaticItemModel;
 enum AssignFunc {
   FuncOverrideCH1 = 0,
   FuncOverrideCHLast = FuncOverrideCH1 + CPN_MAX_CHNOUT - 1,
-  FuncOverrideCH32 = FuncOverrideCHLast,  //  TODO remove
   FuncTrainer,
   FuncTrainerRUD,
   FuncTrainerELE,
@@ -48,8 +47,6 @@ enum AssignFunc {
   FuncPlayHaptic,
   FuncReset,
   FuncSetTimer1,
-  FuncSetTimer2,  //  TODO remove
-  FuncSetTimer3,  //  TODO remove
   FuncSetTimerLast = FuncSetTimer1 + CPN_MAX_TIMERS - 1,
   FuncVario,
   FuncPlayPrompt,

--- a/companion/src/firmwares/edgetx/yaml_modeldata.cpp
+++ b/companion/src/firmwares/edgetx/yaml_modeldata.cpp
@@ -167,7 +167,7 @@ struct YamlThrTrace {
   YamlThrTrace(unsigned int cpn_value)
   {
     if (cpn_value == 0) {
-      src = RawSource(SOURCE_TYPE_STICK, 2/* throttle */);
+      src = RawSource(SOURCE_TYPE_INPUT, 2/* throttle */);
       return;
     }
     cpn_value--;
@@ -175,7 +175,7 @@ struct YamlThrTrace {
     int pots = board.getCapability(Board::Pots);
     int sliders = board.getCapability(Board::Sliders);
     if (cpn_value < (unsigned int)(pots + sliders)) {
-      src = RawSource(SOURCE_TYPE_STICK, 4/* sticks */ + cpn_value);
+      src = RawSource(SOURCE_TYPE_INPUT, 4/* sticks */ + cpn_value);
     }
     else {
       cpn_value -= pots + sliders;
@@ -186,7 +186,7 @@ struct YamlThrTrace {
   unsigned int toCpn()
   {
     switch (src.type) {
-      case SOURCE_TYPE_STICK:
+      case SOURCE_TYPE_INPUT:
         if (src.index == 2 /* throttle */) {
           return 0;
         } else {

--- a/companion/src/firmwares/edgetx/yaml_rawsource.cpp
+++ b/companion/src/firmwares/edgetx/yaml_rawsource.cpp
@@ -23,37 +23,47 @@
 #include "boardjson.h"
 
 static const YamlLookupTable spacemouseLut = {
-  {  0, "SPACEMOUSE_A"  },
-  {  1, "SPACEMOUSE_B"  },
-  {  2, "SPACEMOUSE_C"  },
-  {  3, "SPACEMOUSE_D"  },
-  {  4, "SPACEMOUSE_E"  },
-  {  5, "SPACEMOUSE_F"  },
+  {  0, "INVALID"       },
+  {  1, "SPACEMOUSE_A"  },
+  {  2, "SPACEMOUSE_B"  },
+  {  3, "SPACEMOUSE_C"  },
+  {  4, "SPACEMOUSE_D"  },
+  {  5, "SPACEMOUSE_E"  },
+  {  6, "SPACEMOUSE_F"  },
 };
-
 
 std::string YamlRawSourceEncode(const RawSource& rhs)
 {
   Board::Type board = getCurrentBoard();
   Boards b = Boards(board);
   std::string src_str;
+  div_t qr;
   char c = 'A';
+
+  int32_t sval = rhs.index;
+
+  if (rhs.index < 0) {
+    sval = -sval;
+    src_str += "!";
+  }
+
   switch (rhs.type) {
     case SOURCE_TYPE_VIRTUAL_INPUT:
-      src_str += "I" + std::to_string(rhs.index);
+      src_str += "I" + std::to_string(sval - 1);
       break;
     case SOURCE_TYPE_LUA_OUTPUT:
+      qr = div(sval - 1, 16);
       src_str += "lua(";
-      src_str += std::to_string(rhs.index / 16);
+      src_str += std::to_string(qr.quot);
       src_str += ",";
-      src_str += std::to_string(rhs.index % 16);
+      src_str += std::to_string(qr.rem);
       src_str += ")";
       break;
-    case SOURCE_TYPE_STICK:
-      src_str = Boards::getInputYamlName(rhs.index, BoardJson::YLT_REF).toStdString();
+    case SOURCE_TYPE_INPUT:
+      src_str += Boards::getInputYamlName(sval - 1, BoardJson::YLT_REF).toStdString();
       break;
     case SOURCE_TYPE_TRIM:
-      src_str = Boards::getTrimYamlName(rhs.index, BoardJson::YLT_REF).toStdString();
+      src_str += Boards::getTrimYamlName(sval - 1, BoardJson::YLT_REF).toStdString();
       break;
     case SOURCE_TYPE_MIN:
       src_str += "MIN";
@@ -62,37 +72,41 @@ std::string YamlRawSourceEncode(const RawSource& rhs)
       src_str += "MAX";
       break;
     case SOURCE_TYPE_SWITCH:
-      src_str += Boards::getSwitchYamlName(rhs.index, BoardJson::YLT_REF).toStdString();
+      src_str += Boards::getSwitchYamlName(sval - 1, BoardJson::YLT_REF).toStdString();
       break;
     case SOURCE_TYPE_CUSTOM_SWITCH:
       src_str += "ls(";
-      src_str += std::to_string(rhs.index + 1);
+      src_str += std::to_string(sval);
       src_str += ")";
       break;
     case SOURCE_TYPE_CYC:
-      src_str = b.getRawSourceCyclicTag(rhs.index);
+      src_str += "CYC" + std::to_string(sval);
       break;
     case SOURCE_TYPE_PPM:
       src_str += "tr(";
-      src_str += std::to_string(rhs.index);
+      src_str += std::to_string(sval - 1);
       src_str += ")";
       break;
     case SOURCE_TYPE_CH:
       src_str += "ch(";
-      src_str += std::to_string(rhs.index);
+      src_str += std::to_string(sval - 1);
       src_str += ")";
       break;
     case SOURCE_TYPE_GVAR:
       src_str += "gv(";
-      src_str += std::to_string(rhs.index);
+      src_str += std::to_string(sval - 1);
       src_str += ")";
       break;
     case SOURCE_TYPE_SPECIAL:
-      src_str = b.getRawSourceSpecialTypeTag(rhs.index);
+      src_str += b.getRawSourceSpecialTypeTag(sval);
+      break;
+    case SOURCE_TYPE_TIMER:
+      src_str += "Tmr" + std::to_string(sval);
       break;
     case SOURCE_TYPE_TELEMETRY:
-      src_str = "tele(";
-      switch (rhs.index % 3) {
+      qr = div(sval - 1, 3);
+      src_str += "tele(";
+      switch (qr.rem) {
         case 0:
           break;
         case 1:
@@ -102,12 +116,12 @@ std::string YamlRawSourceEncode(const RawSource& rhs)
           src_str += '+';
           break;
       }
-      src_str += std::to_string(rhs.index / 3);
+      src_str += std::to_string(qr.quot);
       src_str += ")";
       break;
     case SOURCE_TYPE_SPACEMOUSE:
-      src_str = "SPACEMOUSE_";
-      c += rhs.index;
+      src_str += "SPACEMOUSE_";
+      c += sval - 1;
       src_str += c;
       break;
     default:
@@ -124,13 +138,22 @@ RawSource YamlRawSourceDecode(const std::string& src_str)
   RawSource rhs;
   const char* val = src_str.data();
   size_t val_len = src_str.size();
+  std::string src_str_tmp = src_str;
+  bool neg = false;
+
+  if (val_len > 0 && val[0] == '!') {
+    neg = true;
+    val++;
+    val_len--;
+    src_str_tmp = src_str_tmp.substr(1);
+  }
 
   if (val_len > 1 && val[0] == 'I'
       && (val[1] >= '0') && (val[1] <= '9')) {
 
-    int idx = std::stoi(src_str.substr(1));
+    int idx = std::stoi(src_str_tmp.substr(1));
     if (idx < CPN_MAX_INPUTS) {
-      rhs = RawSource(SOURCE_TYPE_VIRTUAL_INPUT, idx);
+      rhs = RawSource(SOURCE_TYPE_VIRTUAL_INPUT, idx + 1);
     }
 
   } else if ((val_len == 2 &&
@@ -141,9 +164,9 @@ RawSource YamlRawSourceDecode(const std::string& src_str)
               (val[0] == 'S' && val[1] == 'W')) &&
               val[2] >= '1' && val[2] <= '9')) {
 
-    int idx = Boards::getSwitchYamlIndex(src_str.c_str(), BoardJson::YLT_REF);
+    int idx = Boards::getSwitchYamlIndex(src_str_tmp.c_str(), BoardJson::YLT_REF);
     if (idx >= 0) {
-      rhs = RawSource(SOURCE_TYPE_SWITCH, idx);
+      rhs = RawSource(SOURCE_TYPE_SWITCH, idx + 1);
     }
 
   } else if (val_len > 4 &&
@@ -152,24 +175,24 @@ RawSource YamlRawSourceDecode(const std::string& src_str)
              val[2] == 'a' &&
              val[3] == '(') {
 
-    std::stringstream src(src_str.substr(4));
+    std::stringstream src(src_str_tmp.substr(4));
     int script = 0, output = 0;                   //  TODO: check rename outputs to inputs???
     src >> script;
     src.ignore();
     src >> output;
     if (script < CPN_MAX_SCRIPTS && output < CPN_MAX_SCRIPT_INPUTS)
-      rhs = RawSource(SOURCE_TYPE_LUA_OUTPUT, script * 16 + output);
+      rhs = RawSource(SOURCE_TYPE_LUA_OUTPUT, script * 16 + output + 1);
 
   } else if (val_len > 3 &&
              val[0] == 'l' &&
              val[1] == 's' &&
              val[2] == '(') {
 
-    std::stringstream src(src_str.substr(3));
+    std::stringstream src(src_str_tmp.substr(3));
     int ls = 0;
     src >> ls;
     if (ls > 0 && ls <= CPN_MAX_LOGICAL_SWITCHES)
-      rhs = RawSource(SOURCE_TYPE_CUSTOM_SWITCH, ls - 1);
+      rhs = RawSource(SOURCE_TYPE_CUSTOM_SWITCH, ls);
 
     // appears depreciated - maybe early support for T20 as SWn the current std and no match in encode
   } else if (val_len > 3 &&
@@ -177,13 +200,13 @@ RawSource YamlRawSourceDecode(const std::string& src_str)
              val[1] == 's' &&
              val[2] == '(') {
 
-    std::stringstream src(src_str.substr(3));
+    std::stringstream src(src_str_tmp.substr(3));
     int fs = 0;
     src >> fs;
     if (fs > 0) {
       int fsidx = Boards::getSwitchYamlIndex(QString("SW%1").arg(fs), BoardJson::YLT_REF);
       if (fsidx >= 0)
-        rhs = RawSource(SOURCE_TYPE_SWITCH, fsidx);
+        rhs = RawSource(SOURCE_TYPE_SWITCH, fsidx + 1);
     }
 
   } else if (val_len > 3 &&
@@ -191,33 +214,33 @@ RawSource YamlRawSourceDecode(const std::string& src_str)
              val[1] == 'r' &&
              val[2] == '(') {
 
-    std::stringstream src(src_str.substr(3));
+    std::stringstream src(src_str_tmp.substr(3));
     int tr = 0;
     src >> tr;
     if (tr < getCurrentFirmware()->getCapability(TrainerInputs))
-      rhs = RawSource(SOURCE_TYPE_PPM, tr);
+      rhs = RawSource(SOURCE_TYPE_PPM, tr + 1);
 
   } else if (val_len > 3 &&
              val[0] == 'c' &&
              val[1] == 'h' &&
              val[2] == '(') {
 
-    std::stringstream src(src_str.substr(3));
+    std::stringstream src(src_str_tmp.substr(3));
     int ch = 0;
     src >> ch;
     if (ch < CPN_MAX_CHNOUT)
-      rhs = RawSource(SOURCE_TYPE_CH, ch);
+      rhs = RawSource(SOURCE_TYPE_CH, ch + 1);
 
   } else if (val_len > 3 &&
              val[0] == 'g' &&
              val[1] == 'v' &&
              val[2] == '(') {
 
-    std::stringstream src(src_str.substr(3));
+    std::stringstream src(src_str_tmp.substr(3));
     int gv = 0;
     src >> gv;
     if (gv < CPN_MAX_GVARS)
-      rhs = RawSource(SOURCE_TYPE_GVAR, gv);
+      rhs = RawSource(SOURCE_TYPE_GVAR, gv + 1);
 
   } else if (val_len > 5 &&
              val[0] == 't' &&
@@ -226,7 +249,7 @@ RawSource YamlRawSourceDecode(const std::string& src_str)
              val[3] == 'e' &&
              val[4] == '(') {
 
-    std::stringstream src(src_str.substr(5));
+    std::stringstream src(src_str_tmp.substr(5));
 
     // parse sign
     uint8_t sign = 0;
@@ -242,22 +265,32 @@ RawSource YamlRawSourceDecode(const std::string& src_str)
     int sensor = 0;
     src >> sensor;
     if (sensor < CPN_MAX_SENSORS)
-      rhs = RawSource(SOURCE_TYPE_TELEMETRY, sensor * 3 + sign);
+      rhs = RawSource(SOURCE_TYPE_TELEMETRY, sensor * 3 + sign + 1);
+
+  } else if (val_len > 3 &&
+             val[0] == 'C' &&
+             val[1] == 'Y' &&
+             val[2] == 'C' &&
+             val[3] >= '1' && val[3] <= '3') {
+
+    std::stringstream src(src_str_tmp.substr(3));
+    int cyc = 0;
+    src >> cyc;
+    if (cyc <= CPN_MAX_CYC)
+      rhs = RawSource(SOURCE_TYPE_CYC, cyc);
 
   } else {
 
-    YAML::Node node(src_str);
+    YAML::Node node(src_str_tmp);
 
     if (node.IsScalar() && node.as<std::string>() == "MAX") {
       rhs.type = SOURCE_TYPE_MAX;
-      rhs.index = 0;
-      return rhs;
+      rhs.index = 1;
     }
 
     if (node.IsScalar() && node.as<std::string>() == "MIN") {
       rhs.type = SOURCE_TYPE_MIN;
-      rhs.index = 0;
-      return rhs;
+      rhs.index = 1;
     }
 
     std::string ana_str;
@@ -272,16 +305,15 @@ RawSource YamlRawSourceDecode(const std::string& src_str)
 
     int ana_idx = Boards::getInputYamlIndex(ana_str.c_str(), BoardJson::YLT_REF);
     if (ana_idx >= 0) {
-      rhs.type = SOURCE_TYPE_STICK;
-      rhs.index = ana_idx;
-      return rhs;
+      rhs.type = SOURCE_TYPE_INPUT;
+      rhs.index = ana_idx + 1;
     }
 
     std::string trim_str;
     node >> trim_str;
 
     if (radioSettingsVersion < SemanticVersion(QString(CPN_ADC_REFACTOR_VERSION))) {
-      int idx = b.getLegacyTrimSourceIndex(src_str.c_str());
+      int idx = b.getLegacyTrimSourceIndex(src_str_tmp.c_str());
       if (idx >= 0)
         trim_str = Boards::getTrimYamlName(idx, BoardJson::YLT_REF).toStdString();
     }
@@ -289,31 +321,32 @@ RawSource YamlRawSourceDecode(const std::string& src_str)
     int trm_idx = Boards::getTrimYamlIndex(trim_str.c_str(), BoardJson::YLT_REF);
     if (trm_idx >= 0) {
       rhs.type = SOURCE_TYPE_TRIM;
-      rhs.index = trm_idx;
-      return rhs;
+      rhs.index = trm_idx + 1;
+    }
+
+    std::string timer_str;
+    node >> timer_str;
+
+    if (radioSettingsVersion < SemanticVersion(QString(CPN_ADC_REFACTOR_VERSION))) {
+      if (timer_str.size() == 6 && timer_str.substr(0, 5) == "TIMER") {
+        timer_str = "Tmr" + timer_str.substr(5, 1);
+      }
+    }
+
+    if (timer_str.substr(0, 3) == "Tmr" && timer_str.substr(3, 1) >= "1" && timer_str.substr(3, 1) <= "9") {
+      if (std::stoi(timer_str.substr(3, 1)) <= CPN_MAX_TIMERS) {
+        rhs.type = SOURCE_TYPE_TIMER;
+        rhs.index = std::stoi(timer_str.substr(3, 1));
+      }
     }
 
     std::string special_str;
     node >> special_str;
 
-    if (radioSettingsVersion < SemanticVersion(QString(CPN_ADC_REFACTOR_VERSION))) {
-      if (special_str.size() == 6 && special_str.substr(0, 5) == "TIMER") {
-        special_str = "Tmr" + special_str.substr(5, 1);
-      }
-    }
-
     int sp_idx = b.getRawSourceSpecialTypeIndex(special_str.c_str());
-    if (sp_idx >= 0) {
+    if (sp_idx > 0) {
       rhs.type = SOURCE_TYPE_SPECIAL;
       rhs.index = sp_idx;
-      return rhs;
-    }
-
-    int cyc_idx = b.getRawSourceCyclicIndex(src_str.c_str());
-    if (cyc_idx >= 0) {
-      rhs.type = SOURCE_TYPE_CYC;
-      rhs.index = cyc_idx;
-      return rhs;
     }
 
     if (node.IsScalar() && node.as<std::string>().size() == 12 && node.as<std::string>().substr(0, 11) == "SPACEMOUSE_") {
@@ -321,11 +354,13 @@ RawSource YamlRawSourceDecode(const std::string& src_str)
       node >> spacemouseLut >> sm_idx;
       if (sm_idx >= 0) {
         rhs.type = SOURCE_TYPE_SPACEMOUSE;
-        rhs.index = sm_idx;
-        return rhs;
+        rhs.index = sm_idx + 1;
       }
     }
   }
+
+  if (neg)
+    rhs.index = -rhs.index;
 
   return rhs;
 }

--- a/companion/src/firmwares/edgetx/yaml_rawswitch.cpp
+++ b/companion/src/firmwares/edgetx/yaml_rawswitch.cpp
@@ -84,7 +84,8 @@ RawSwitch YamlRawSwitchDecode(const std::string& sw_str)
 
   // yaml-cpp does not escape this
   if (val_len > 0 && val[0] == '\\') {
-    val++; val_len--;
+    val++;
+    val_len--;
     sw_str_tmp = sw_str_tmp.substr(1);
   }
 

--- a/companion/src/firmwares/er9x/er9xeeprom.cpp
+++ b/companion/src/firmwares/er9x/er9xeeprom.cpp
@@ -187,14 +187,14 @@ t_Er9xMixData::operator MixData ()
     c9x.sOffset=gvar;
   } else {
     c9x.sOffset=sOffset;
-  }  
+  }
   c9x.swtch = er9xToSwitch(swtch);
 
   if (srcRaw == 0) {
     c9x.srcRaw = RawSource(SOURCE_TYPE_NONE);
   }
   else if (srcRaw <= 7) {
-    c9x.srcRaw = RawSource(SOURCE_TYPE_STICK, srcRaw-1);
+    c9x.srcRaw = RawSource(SOURCE_TYPE_INPUT, srcRaw-1);
   }
   else if (srcRaw == 8) {
     c9x.srcRaw = RawSource(SOURCE_TYPE_MAX);
@@ -221,9 +221,9 @@ t_Er9xMixData::operator MixData ()
   }
   else if (srcRaw <=37) {
     c9x.srcRaw = RawSource(SOURCE_TYPE_CH, srcRaw-21);
-  } 
+  }
   else {
-    c9x.srcRaw = RawSource(SOURCE_TYPE_GVAR, srcRaw-38);    
+    c9x.srcRaw = RawSource(SOURCE_TYPE_GVAR, srcRaw-38);
   }
 
   if (differential==1) {
@@ -257,7 +257,7 @@ RawSource er9xToSource(int8_t value)
     return RawSource(SOURCE_TYPE_NONE);
   }
   else if (value <= 7) {
-    return RawSource(SOURCE_TYPE_STICK, value - 1);
+    return RawSource(SOURCE_TYPE_INPUT, value - 1);
   }
   else if (value == 8) {
     return RawSource(SOURCE_TYPE_MAX);
@@ -285,7 +285,7 @@ Er9xLogicalSwitchData::operator LogicalSwitchData ()
   c9x.func = func;
   c9x.val1 = v1;
   c9x.val2 = v2;
-  
+
   if ((c9x.func >= LS_FN_VPOS && c9x.func <= LS_FN_ANEG) || c9x.func >= LS_FN_EQUAL) {
     c9x.val1 = er9xToSource(v1).toValue();
   }

--- a/companion/src/firmwares/ersky9x/ersky9xeeprom.cpp
+++ b/companion/src/firmwares/ersky9x/ersky9xeeprom.cpp
@@ -186,7 +186,7 @@ t_Ersky9xMixData_v10::operator MixData ()
     c9x.srcRaw = RawSource(SOURCE_TYPE_NONE);
   }
   else if (srcRaw <= 7) {
-    c9x.srcRaw = RawSource(SOURCE_TYPE_STICK, srcRaw-1);
+    c9x.srcRaw = RawSource(SOURCE_TYPE_INPUT, srcRaw-1);
   }
   else if (srcRaw == 8) {
     c9x.srcRaw = RawSource(SOURCE_TYPE_MAX);
@@ -256,7 +256,7 @@ t_Ersky9xMixData_v11::operator MixData ()
     c9x.srcRaw = RawSource(SOURCE_TYPE_NONE);
   }
   else if (srcRaw <= 7) {
-    c9x.srcRaw = RawSource(SOURCE_TYPE_STICK, srcRaw-1);
+    c9x.srcRaw = RawSource(SOURCE_TYPE_INPUT, srcRaw-1);
   }
   else if (srcRaw == 8) {
     c9x.srcRaw = RawSource(SOURCE_TYPE_MAX);
@@ -318,7 +318,7 @@ RawSource ersky9xToSource_v10(int8_t value)
     return RawSource(SOURCE_TYPE_NONE);
   }
   else if (value <= 7) {
-    return RawSource(SOURCE_TYPE_STICK, value - 1);
+    return RawSource(SOURCE_TYPE_INPUT, value - 1);
   }
   else if (value == 8) {
     return RawSource(SOURCE_TYPE_MAX);
@@ -346,7 +346,7 @@ RawSource ersky9xToSource_v11(int8_t value)
     return RawSource(SOURCE_TYPE_NONE);
   }
   else if (value <= 7) {
-    return RawSource(SOURCE_TYPE_STICK, value - 1);
+    return RawSource(SOURCE_TYPE_INPUT, value - 1);
   }
   else if (value == 8) {
     return RawSource(SOURCE_TYPE_MAX);

--- a/companion/src/firmwares/generalsettings.cpp
+++ b/companion/src/firmwares/generalsettings.cpp
@@ -404,7 +404,7 @@ RawSource GeneralSettings::getDefaultSource(unsigned int channel) const
 {
   int stick = getDefaultStick(channel);
   if (stick >= 0)
-    return RawSource(SOURCE_TYPE_STICK, stick);
+    return RawSource(SOURCE_TYPE_INPUT, stick + 1);
   else
     return RawSource(SOURCE_TYPE_NONE);
 }

--- a/companion/src/firmwares/input_data.cpp
+++ b/companion/src/firmwares/input_data.cpp
@@ -59,7 +59,7 @@ AbstractStaticItemModel * ExpoData::carryTrimItemModel()
   mdl->setName(AIM_EXPO_CARRYTRIM);
   ExpoData tmp = ExpoData();
 
-  tmp.srcRaw = RawSource(SOURCE_TYPE_STICK, 0);
+  tmp.srcRaw = RawSource(SOURCE_TYPE_INPUT, 0);
 
   for (int i = -CARRYTRIM_STICK_OFF; i <= Boards::getBoardCapability(getCurrentBoard(), Board::NumTrims); i++) {
     tmp.carryTrim = -i;

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -210,7 +210,7 @@ void ModelData::setDefaultMixes(const GeneralSettings & settings)
     MixData * mix = &mixData[i];
     mix->destCh = i + 1;
     mix->weight = 100;
-    mix->srcRaw = RawSource(SOURCE_TYPE_VIRTUAL_INPUT, i);
+    mix->srcRaw = RawSource(SOURCE_TYPE_VIRTUAL_INPUT, i + 1);
   }
 }
 
@@ -446,7 +446,7 @@ void ModelData::convert(RadioDataConversionState & cstate)
   cstate.setComponent("Settings", 0);
   if (thrTraceSrc && (int)thrTraceSrc < cstate.fromBoard.getCapability(Board::Pots) + cstate.fromBoard.getCapability(Board::Sliders)) {
     cstate.setSubComp(tr("Throttle Source"));
-    thrTraceSrc = RawSource(SOURCE_TYPE_STICK, (int)thrTraceSrc + 3).convert(cstate).index - 3;
+    thrTraceSrc = RawSource(SOURCE_TYPE_INPUT, (int)thrTraceSrc + 3).convert(cstate).index - 3;
   }
 
   Firmware *fw = getCurrentFirmware();
@@ -603,12 +603,8 @@ int ModelData::updateReference()
       updRefInfo.occurences = 3;
       break;
     case REF_UPD_TYPE_TIMER:
-      updRefInfo.srcType = SOURCE_TYPE_SPECIAL;
+      updRefInfo.srcType = SOURCE_TYPE_TIMER;
       updRefInfo.maxindex = fw->getCapability(Timers);
-      //  rawsource index offset    TODO refactor timers so be own category
-      updRefInfo.index1 += 2;
-      updRefInfo.index2 += 2;
-      updRefInfo.maxindex += 2;
       break;
     default:
       qDebug() << "Error - unhandled reference type:" << updRefInfo.type;
@@ -1030,7 +1026,7 @@ void ModelData::updateAssignFunc(CustomFunctionData * cfd)
   switch (updRefInfo.type)
   {
     case REF_UPD_TYPE_CHANNEL:
-      if(cfd->func < FuncOverrideCH1 || cfd->func > FuncOverrideCH32) //  TODO refactor to FuncOverrideCHLast
+      if(cfd->func < FuncOverrideCH1 || cfd->func > FuncOverrideCHLast)
         return;
       idxAdj = FuncOverrideCH1;
       break;
@@ -1040,9 +1036,9 @@ void ModelData::updateAssignFunc(CustomFunctionData * cfd)
       idxAdj = FuncAdjustGV1;
       break;
     case REF_UPD_TYPE_TIMER:
-      if (cfd->func < FuncSetTimer1 || cfd->func > FuncSetTimer3) //  TODO refactor to FuncSetTimerLast
+      if (cfd->func < FuncSetTimer1 || cfd->func > FuncSetTimerLast)
         return;
-      idxAdj = FuncSetTimer1 - 2;   //  reverse earlier offset required for rawsource
+      idxAdj = FuncSetTimer1;
       break;
     default:
       return;
@@ -1526,7 +1522,7 @@ bool ModelData::isThrTraceSrcAvailable(const GeneralSettings * generalSettings, 
   const Board::Type board = getCurrentBoard();
 
   if (index > 0 && index <= Boards::getCapability(board, Board::Pots) + Boards::getCapability(board, Board::Sliders))
-    return RawSource(SOURCE_TYPE_STICK, index + Boards::getCapability(board, Board::Sticks) - 1).isAvailable(this, generalSettings, board);
+    return RawSource(SOURCE_TYPE_INPUT, index + Boards::getCapability(board, Board::Sticks) - 1).isAvailable(this, generalSettings, board);
   else
     return true;
 }

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -381,13 +381,13 @@ class ModelData {
     void updateTelemetryRef(int & idx);
     void updateTelemetryRef(unsigned int & idx);
     void updateModuleFailsafes(ModuleData * md);
-    inline void updateSourceRef(RawSource & src) { updateTypeIndexRef<RawSource, RawSourceType>(src, updRefInfo.srcType); }
+    inline void updateSourceRef(RawSource & src) { updateTypeIndexRef<RawSource, RawSourceType>(src, updRefInfo.srcType, 1); }
     inline void updateSwitchRef(RawSwitch & swtch) { updateTypeIndexRef<RawSwitch, RawSwitchType>(swtch, updRefInfo.swtchType, 1); }
     inline void updateTimerMode(RawSwitch & swtch) { updateTypeIndexRef<RawSwitch, RawSwitchType>(swtch, updRefInfo.swtchType, 1, false, (int)SWITCH_TYPE_TIMER_MODE, 0); }
     inline void updateSourceIntRef(int & value)
     {
       RawSource src = RawSource(value);
-      updateTypeIndexRef<RawSource, RawSourceType>(src, updRefInfo.srcType);
+      updateTypeIndexRef<RawSource, RawSourceType>(src, updRefInfo.srcType, 1);
       if (value != src.toValue())
         value = src.toValue();
     }

--- a/companion/src/firmwares/rawsource.cpp
+++ b/companion/src/firmwares/rawsource.cpp
@@ -85,7 +85,7 @@ RawSourceRange RawSource::getRange(const ModelData * model, const GeneralSetting
     }
 
     case SOURCE_TYPE_SPECIAL:
-      if (index == 0)  {  //Batt
+      if (index == 0)  {       //Batt
         result.step = 0.1;
         result.decimals = 1;
         result.max = 25.5;
@@ -100,12 +100,13 @@ RawSourceRange RawSource::getRange(const ModelData * model, const GeneralSetting
         result.max = 30000;
         result.min = -result.max;
       }
-      else {      // Timers 1 - 3
-        result.step = 1;
-        result.max = 9 * 60 * 60 - 1;  // 8:59:59 (to match firmware)
-        result.min = -result.max;
-        result.unit = tr("s");
-      }
+      break;
+
+    case SOURCE_TYPE_TIMER:
+      result.step = 1;
+      result.max = 9 * 60 * 60 - 1;  // 8:59:59 (to match firmware)
+      result.min = -result.max;
+      result.unit = tr("s");
       break;
 
     case SOURCE_TYPE_CH:
@@ -128,27 +129,25 @@ RawSourceRange RawSource::getRange(const ModelData * model, const GeneralSetting
 
 QString RawSource::toString(const ModelData * model, const GeneralSettings * const generalSettings, Board::Type board, bool prefixCustomName) const
 {
-  if (board == Board::BOARD_UNKNOWN) {
+  if (index < 0)
+    return CPN_STR_SRC_INDICATOR_INVERT % RawSource(type, -index).toString(model, generalSettings, board, prefixCustomName);
+
+  if (board == Board::BOARD_UNKNOWN)
     board = getCurrentBoard();
-  }
 
   static const QString trims[] = {
-    tr("TrmR"), tr("TrmE"), tr("TrmT"), tr("TrmA"), tr("Trm5"), tr("Trm6"), tr("Trm7"), tr("Trm8")
+    "", tr("TrmR"), tr("TrmE"), tr("TrmT"), tr("TrmA"), tr("Trm5"), tr("Trm6"), tr("Trm7"), tr("Trm8")
   };
 
   static const QString trims2[] = {
-    tr("TrmH"), tr("TrmV")
+    "", tr("TrmH"), tr("TrmV")
   };
 
   static const QString special[] = {
-    tr("Batt"), tr("Time"), tr("GPS"), tr("Reserved1"), tr("Reserved2"), tr("Reserved3"), tr("Reserved4")
+    "", tr("Batt"), tr("Time"), tr("GPS"), tr("Reserved1"), tr("Reserved2"), tr("Reserved3"), tr("Reserved4")
   };
 
-  static const QString rotary[]  = { tr("REa"), tr("REb") };
-
-  if (index < 0) {
-    return QString(CPN_STR_UNKNOWN_ITEM);
-  }
+  static const QString rotary[]  = { "", tr("REa"), tr("REb") };
 
   QString result;
   QString dfltName;
@@ -161,18 +160,21 @@ QString RawSource::toString(const ModelData * model, const GeneralSettings * con
     case SOURCE_TYPE_VIRTUAL_INPUT:
     {
       const char * name = nullptr;
-      if (model)
-        name = model->inputNames[index];
-      return RadioData::getElementName(tr("I", "as in Input"), index + 1, name);
+      if (model && index <= CPN_MAX_INPUTS)
+        name = model->inputNames[index - 1];
+      return RadioData::getElementName(tr("I", "as in Input"), index, name);
     }
 
     case SOURCE_TYPE_LUA_OUTPUT:
-      return tr("LUA%1%2").arg(index / 16 + 1).arg(QChar('a' + index % 16));
+      {
+        div_t qr = div(index - 1, 16);
+        return tr("LUA%1%2").arg(qr.quot + 1).arg(QChar('a' + qr.rem));
+      }
 
-    case SOURCE_TYPE_STICK:
-      dfltName = Boards::getInputName(index, board);
-      if (generalSettings)
-        custName = QString(generalSettings->inputConfig[index].name).trimmed();
+    case SOURCE_TYPE_INPUT:
+      dfltName = Boards::getInputName(index - 1, board);
+      if (generalSettings && index <= CPN_MAX_INPUTS)
+        custName = QString(generalSettings->inputConfig[index - 1].name).trimmed();
       return DataHelpers::getCompositeName(dfltName, custName, prefixCustomName);
 
     case SOURCE_TYPE_TRIM:
@@ -188,53 +190,53 @@ QString RawSource::toString(const ModelData * model, const GeneralSettings * con
       return tr("MAX");
 
     case SOURCE_TYPE_SWITCH:
-      dfltName = Boards::getSwitchInfo(index, board).name.c_str();
-      if (Boards::isSwitchFunc(index, board)) {
-        if (model) {
-          int fsindex = Boards::getSwitchTagNum(index, board) - 1;
+      dfltName = Boards::getSwitchInfo(index - 1, board).name.c_str();
+      if (Boards::isSwitchFunc(index - 1, board)) {
+        if (model && index <= CPN_MAX_SWITCHES_FUNCTION) {
+          int fsindex = Boards::getSwitchTagNum(index - 1, board) - 1;
           custName = QString(model->functionSwitchNames[fsindex]).trimmed();
         }
       }
       else {
-        if (generalSettings) {
-          custName = QString(generalSettings->switchConfig[index].name).trimmed();
+        if (generalSettings && index <= CPN_MAX_SWITCHES) {
+          custName = QString(generalSettings->switchConfig[index - 1].name).trimmed();
         }
       }
 
       return DataHelpers::getCompositeName(dfltName, custName, prefixCustomName);
 
     case SOURCE_TYPE_CUSTOM_SWITCH:
-      return RawSwitch(SWITCH_TYPE_VIRTUAL, index + 1).toString();
+      return RawSwitch(SWITCH_TYPE_VIRTUAL, index).toString();  // RawSwitch uses 1 based index
 
     case SOURCE_TYPE_CYC:
-      return tr("CYC%1").arg(index + 1);
+      return tr("CYC%1").arg(index);
 
     case SOURCE_TYPE_PPM:
-      return RadioData::getElementName(tr("TR", "as in Trainer"), index + 1);
+      return RadioData::getElementName(tr("TR", "as in Trainer"), index);
 
     case SOURCE_TYPE_CH:
-      if (model)
-        result = QString(model->limitData[index].nameToString(index)).trimmed();
+      if (model && index <= CPN_MAX_CHNOUT)
+        result = QString(model->limitData[index - 1].nameToString(index - 1)).trimmed();
       if (result.isEmpty())
-        return LimitData().nameToString(index);
+        return LimitData().nameToString(index - 1);
+
       return result;
 
     case SOURCE_TYPE_SPECIAL:
-      if (index >= SOURCE_TYPE_SPECIAL_FIRST_TIMER && index <= SOURCE_TYPE_SPECIAL_LAST_TIMER) {
-        if (model)
-          result = QString(model->timers[index - SOURCE_TYPE_SPECIAL_FIRST_TIMER].nameToString(index - SOURCE_TYPE_SPECIAL_FIRST_TIMER)).trimmed();
-        if (result.isEmpty())
-          result = TimerData().nameToString(index - SOURCE_TYPE_SPECIAL_FIRST_TIMER);
-      }
-      else
-        result = CHECK_IN_ARRAY(special, index);
+      return CHECK_IN_ARRAY(special, index);
+
+    case SOURCE_TYPE_TIMER:
+      if (model && index <= CPN_MAX_TIMERS)
+        result = QString(model->timers[index - 1].nameToString(index - 1)).trimmed();
+      if (result.isEmpty())
+        result = TimerData().nameToString(index - 1);
 
       return result;
 
     case SOURCE_TYPE_TELEMETRY:
       {
-        div_t qr = div(index, 3);
-        if (model)
+        div_t qr = div(index - 1, 3);
+        if (model && qr.quot < CPN_MAX_SENSORS)
           result = QString(model->sensorData[qr.quot].nameToString(qr.quot)).trimmed();
         if (result.isEmpty())
           result = SensorData().nameToString(qr.quot);
@@ -244,14 +246,14 @@ QString RawSource::toString(const ModelData * model, const GeneralSettings * con
       }
 
     case SOURCE_TYPE_GVAR:
-      if (model)
-        result = QString(model->gvarData[index].nameToString(index)).trimmed();
+      if (model && index <= CPN_MAX_GVARS)
+        result = QString(model->gvarData[index - 1].nameToString(index - 1)).trimmed();
       if (result.isEmpty())
-        result = GVarData().nameToString(index);
+        result = GVarData().nameToString(index - 1);
       return result;
 
     case SOURCE_TYPE_SPACEMOUSE:
-      return tr("sm%1").arg(QChar('A' + index));
+      return tr("sm%1").arg(QChar('A' + (index - 1)));
 
     default:
       return QString(CPN_STR_UNKNOWN_ITEM);
@@ -263,87 +265,100 @@ bool RawSource::isStick(Board::Type board) const
   if (board == Board::BOARD_UNKNOWN)
     board = getCurrentBoard();
 
-  if (type == SOURCE_TYPE_STICK && index < Boards::getCapability(board, Board::Sticks)) {
+  if (type == SOURCE_TYPE_INPUT && index - 1 < Boards::getCapability(board, Board::Sticks)) {
     return true;
   }
   return false;
 }
 
-bool RawSource::isTimeBased(Board::Type board) const
-{
-  return (type == SOURCE_TYPE_SPECIAL && index >= SOURCE_TYPE_SPECIAL_FIRST_TIMER && index <= SOURCE_TYPE_SPECIAL_LAST_TIMER);
-}
-
 bool RawSource::isAvailable(const ModelData * const model, const GeneralSettings * const gs, Board::Type board) const
 {
+  if (type == SOURCE_TYPE_NONE && index == 0)
+    return true;
+
   if (board == Board::BOARD_UNKNOWN)
     board = getCurrentBoard();
 
   Boards b(board);
 
-  if (type == SOURCE_TYPE_STICK && index >= b.getCapability(Board::Inputs))
+  if (type == SOURCE_TYPE_CH && abs(index) > CPN_MAX_CHNOUT)
     return false;
 
-  if (type == SOURCE_TYPE_SWITCH && index >= b.getCapability(Board::Switches))
+  if (type == SOURCE_TYPE_CUSTOM_SWITCH && abs(index) > CPN_MAX_LOGICAL_SWITCHES)
     return false;
 
-  if (type == SOURCE_TYPE_SPECIAL && index >= SOURCE_TYPE_SPECIAL_FIRST_RESERVED && index <= SOURCE_TYPE_SPECIAL_LAST_RESERVED)
-      return false;
+
+  if (type == SOURCE_TYPE_LUA_OUTPUT && div(abs(index - 1), 16).quot >= CPN_MAX_SCRIPTS)
+    return false;
+
+  if (type == SOURCE_TYPE_INPUT && abs(index) > b.getCapability(Board::Inputs))
+    return false;
+
+  if (type == SOURCE_TYPE_SWITCH && abs(index) > b.getCapability(Board::Switches))
+    return false;
+
+  if (type == SOURCE_TYPE_SPECIAL && abs(index) >= SOURCE_TYPE_SPECIAL_FIRST_RESERVED)
+    return false;
+
+  if (type == SOURCE_TYPE_TIMER && abs(index) > CPN_MAX_TIMERS)
+    return false;
+
+  if (type == SOURCE_TYPE_TELEMETRY && div(abs(index), 3).quot > CPN_MAX_SENSORS)
+    return false;
 
   if (model) {
-    if (type == SOURCE_TYPE_SPECIAL && index >= SOURCE_TYPE_SPECIAL_FIRST_TIMER && index <= SOURCE_TYPE_SPECIAL_LAST_TIMER &&
-        model->timers[index - SOURCE_TYPE_SPECIAL_FIRST_TIMER].isModeOff())
+    if (type == SOURCE_TYPE_TIMER && model->timers[abs(index) - 1].isModeOff())
       return false;
 
-    if (type == SOURCE_TYPE_SWITCH && b.isSwitchFunc(index, board) &&
-        !model->isFunctionSwitchSourceAllowed(b.getSwitchTagNum(index, board) - 1))
+    if (type == SOURCE_TYPE_SWITCH && b.isSwitchFunc(abs(index) - 1, board) &&
+        !model->isFunctionSwitchSourceAllowed(b.getSwitchTagNum(abs(index) - 1, board) - 1))
       return false;
 
-    if (type == SOURCE_TYPE_VIRTUAL_INPUT && !model->isInputValid(index))
+    if (type == SOURCE_TYPE_VIRTUAL_INPUT && !model->isInputValid(abs(index) - 1))
       return false;
 
     if (type == SOURCE_TYPE_PPM && model->trainerMode == TRAINER_MODE_OFF)
       return false;
 
-    if (type == SOURCE_TYPE_CUSTOM_SWITCH && model->logicalSw[index].isEmpty())
+    if (type == SOURCE_TYPE_CUSTOM_SWITCH && model->logicalSw[abs(index) - 1].isEmpty())
       return false;
 
     if (type == SOURCE_TYPE_TELEMETRY) {
-      if (!model->sensorData[div(index, 3).quot].isAvailable()) {
+      if (!model->sensorData[div(abs(index) - 1, 3).quot].isAvailable()) {
         return false;
       }
     }
 
-    if (type == SOURCE_TYPE_CH && !model->hasMixes(index))
+    if (type == SOURCE_TYPE_CH && !model->hasMixes(abs(index) - 1))
       return false;
   }
 
   if (gs) {
-    if (type == SOURCE_TYPE_STICK) {
-      if (!gs->isInputAvailable(index))
+    if (type == SOURCE_TYPE_INPUT) {
+      if (!gs->isInputAvailable(abs(index) - 1))
         return false;
-      if (gs->inputConfig[index].flexType == Board::FLEX_SWITCH)
+      if (gs->inputConfig[abs(index) - 1].flexType == Board::FLEX_SWITCH)
         return false;
     }
 
-    if (type == SOURCE_TYPE_SWITCH && !b.isSwitchFunc(index, board) && IS_HORUS_OR_TARANIS(board) &&
-        !gs->switchSourceAllowed(index))
+    if (type == SOURCE_TYPE_SWITCH && !b.isSwitchFunc(abs(index) - 1, board) && IS_HORUS_OR_TARANIS(board) &&
+        !gs->switchSourceAllowed(abs(index) - 1))
       return false;
   }
   else {
-    if (type == SOURCE_TYPE_STICK) {
-      if (!Boards::isInputAvailable(index, board))
+    if (type == SOURCE_TYPE_INPUT) {
+      if (!Boards::isInputAvailable(abs(index) - 1, board))
         return false;
-      if (Boards::getInputInfo(index, board).flexType == Board::FLEX_SWITCH)
+      if (Boards::getInputInfo(abs(index) - 1, board).flexType == Board::FLEX_SWITCH)
         return false;
     }
   }
 
-  if (type == SOURCE_TYPE_TRIM && index >= b.getCapability(Board::NumTrims))
+  if (type == SOURCE_TYPE_TRIM && abs(index) > b.getCapability(Board::NumTrims))
     return false;
 
   if (type == SOURCE_TYPE_SPACEMOUSE &&
-     (index >= CPN_MAX_SPACEMOUSE ||
+     (abs(index) > CPN_MAX_SPACEMOUSE ||
      (!(gs->serialPort[GeneralSettings::SP_AUX1] == GeneralSettings::AUX_SERIAL_SPACEMOUSE ||
         gs->serialPort[GeneralSettings::SP_AUX2] == GeneralSettings::AUX_SERIAL_SPACEMOUSE))))
     return false;
@@ -356,7 +371,7 @@ RawSource RawSource::convert(RadioDataConversionState & cstate)
   cstate.setItemType(tr("SRC"), 1);
   RadioDataConversionState::LogField oldData(index, toString(cstate.fromModel(), cstate.fromGS(), cstate.fromType));
 
-  if (type == SOURCE_TYPE_STICK)
+  if (type == SOURCE_TYPE_INPUT)
     index = Boards::getInputIndex(Boards::getInputTag(oldData.id, cstate.fromType), Board::LVT_TAG, cstate.toType);
   else if (type == SOURCE_TYPE_SWITCH)
     index = Boards::getSwitchIndex(Boards::getSwitchTag(oldData.id, cstate.fromType), Board::LVT_TAG, cstate.toType);
@@ -376,6 +391,7 @@ StringTagMappingTable RawSource::getSpecialTypesLookupTable()
   StringTagMappingTable tbl;
 
 tbl.insert(tbl.end(), {
+                          {std::to_string(SOURCE_TYPE_SPECIAL_NONE),       "NONE"},
                           {std::to_string(SOURCE_TYPE_SPECIAL_TX_BATT),    "TX_VOLTAGE"},
                           {std::to_string(SOURCE_TYPE_SPECIAL_TX_TIME),    "TX_TIME"},
                           {std::to_string(SOURCE_TYPE_SPECIAL_TX_GPS),     "TX_GPS"},
@@ -383,23 +399,6 @@ tbl.insert(tbl.end(), {
                           {std::to_string(SOURCE_TYPE_SPECIAL_RESERVED2),  "RESERVED2"},
                           {std::to_string(SOURCE_TYPE_SPECIAL_RESERVED3),  "RESERVED3"},
                           {std::to_string(SOURCE_TYPE_SPECIAL_RESERVED4),  "RESERVED4"},
-                          {std::to_string(SOURCE_TYPE_SPECIAL_TIMER1),     "Tmr1"},
-                          {std::to_string(SOURCE_TYPE_SPECIAL_TIMER2),     "Tmr2"},
-                          {std::to_string(SOURCE_TYPE_SPECIAL_TIMER3),     "Tmr3"},
-                          });
-
-  return tbl;
-}
-
-// static
-StringTagMappingTable RawSource::getCyclicLookupTable()
-{
-  StringTagMappingTable tbl;
-
-tbl.insert(tbl.end(), {
-                          {"0", "CYC1"},
-                          {"1", "CYC2"},
-                          {"2", "CYC3"},
                           });
 
   return tbl;

--- a/companion/src/firmwares/rawsource.h
+++ b/companion/src/firmwares/rawsource.h
@@ -31,6 +31,7 @@ class ModelData;
 class GeneralSettings;
 class RadioDataConversionState;
 
+// TODO remove and refactor to use dynamic board switches
 enum Switches {
   SWITCH_NONE,
 
@@ -101,6 +102,7 @@ enum HeliSwashTypes {
 };
 
 enum TelemetrySource {
+  TELEMETRY_SOURCE_NONE,
   TELEMETRY_SOURCE_TX_BATT,
   TELEMETRY_SOURCE_TX_TIME,
   TELEMETRY_SOURCE_TIMER1,
@@ -163,7 +165,7 @@ enum RawSourceType {
   SOURCE_TYPE_NONE,
   SOURCE_TYPE_VIRTUAL_INPUT,
   SOURCE_TYPE_LUA_OUTPUT,
-  SOURCE_TYPE_STICK, // and POTS and Flex pots  TODO rename to more appropriate
+  SOURCE_TYPE_INPUT,
   SOURCE_TYPE_ROTARY_ENCODER,
   SOURCE_TYPE_TRIM,
   SOURCE_TYPE_MIN,
@@ -178,10 +180,12 @@ enum RawSourceType {
   SOURCE_TYPE_SPECIAL,
   SOURCE_TYPE_TELEMETRY,
   SOURCE_TYPE_SPACEMOUSE,
+  SOURCE_TYPE_TIMER,
   MAX_SOURCE_TYPE
 };
 
 enum RawSourceTypeSpecial {
+  SOURCE_TYPE_SPECIAL_NONE,
   SOURCE_TYPE_SPECIAL_TX_BATT,
   SOURCE_TYPE_SPECIAL_TX_TIME,
   SOURCE_TYPE_SPECIAL_TX_GPS,
@@ -191,15 +195,10 @@ enum RawSourceTypeSpecial {
   SOURCE_TYPE_SPECIAL_RESERVED3,
   SOURCE_TYPE_SPECIAL_RESERVED4,
   SOURCE_TYPE_SPECIAL_LAST_RESERVED = SOURCE_TYPE_SPECIAL_RESERVED4,
-  SOURCE_TYPE_SPECIAL_FIRST_TIMER,
-  SOURCE_TYPE_SPECIAL_TIMER1 = SOURCE_TYPE_SPECIAL_FIRST_TIMER,
-  SOURCE_TYPE_SPECIAL_TIMER2,
-  SOURCE_TYPE_SPECIAL_TIMER3,
-  SOURCE_TYPE_SPECIAL_LAST_TIMER = SOURCE_TYPE_SPECIAL_TIMER3,
   SOURCE_TYPE_SPECIAL_COUNT
 };
 
-constexpr int SOURCE_TYPE_STICK_THR_IDX { 3 };      //  TODO is there a function to determine index?
+constexpr int SOURCE_TYPE_INPUT_THR_IDX { 3 };      //  TODO is there a function to determine index?
 
 class RawSourceRange
 {
@@ -241,6 +240,8 @@ class RawSource {
       TelemGroup     = 0x020,
       InputsGroup    = 0x040,
       ScriptsGroup   = 0x080,
+      NegativeGroup  = 0x100,
+      PositiveGroup  = 0x200,
 
       InputSourceGroups = NoneGroup | SourcesGroup | TrimsGroup | SwitchesGroup | InputsGroup,
       AllSourceGroups   = InputSourceGroups | GVarsGroup | TelemGroup | ScriptsGroup
@@ -249,14 +250,14 @@ class RawSource {
     RawSource() { clear(); }
 
     explicit RawSource(int value):
-      type(RawSourceType(abs(value)/65536)),
-      index(value >= 0 ? abs(value)%65536 : -(abs(value)%65536))
+      type(RawSourceType(abs(value) / 65536)),
+      index(value >= 0 ? abs(value) % 65536 : -(abs(value) % 65536))
     {
     }
 
-    RawSource(RawSourceType type, int index=0):
+    RawSource(RawSourceType type, int index = 0):
       type(type),
-      index(index)
+      index(type != SOURCE_TYPE_NONE && index == 0 ? 1 : index)
     {
     }
 

--- a/companion/src/modeledit/customfunctions.cpp
+++ b/companion/src/modeledit/customfunctions.cpp
@@ -383,7 +383,7 @@ void CustomFunctionsPanel::refreshCustomFunction(int i, bool modified)
   if (!cfn.isEmpty()) {
     widgetsMask |= CUSTOM_FUNCTION_SHOW_FUNC | CUSTOM_FUNCTION_ENABLE;
 
-    if (func >= FuncOverrideCH1 && func <= FuncOverrideCH32) {
+    if (func >= FuncOverrideCH1 && func <= FuncOverrideCHLast) {
       if (model) {
         int channelsMax = model->getChannelsMax(true);
         fswtchParam[i]->setDecimals(0);
@@ -445,10 +445,10 @@ void CustomFunctionsPanel::refreshCustomFunction(int i, bool modified)
       populateFuncParamCB(fswtchParamT[i], func, cfn.param);
       widgetsMask |= CUSTOM_FUNCTION_SOURCE_PARAM;
     }
-    else if (func >= FuncSetTimer1 && func <= FuncSetTimer3) {
+    else if (func >= FuncSetTimer1 && func <= FuncSetTimerLast) {
       if (modified)
         cfn.param = fswtchParamTime[i]->timeInSeconds();
-      RawSourceRange range = RawSource(SOURCE_TYPE_SPECIAL, func - FuncSetTimer1 + 2).getRange(model, generalSettings);
+      RawSourceRange range = RawSource(SOURCE_TYPE_TIMER, func - FuncSetTimer1 + 1).getRange(model, generalSettings);
       fswtchParamTime[i]->setTimeRange((int)range.min, (int)range.max);
       fswtchParamTime[i]->setTime(cfn.param);
       widgetsMask |= CUSTOM_FUNCTION_TIME_PARAM;
@@ -663,39 +663,50 @@ void CustomFunctionsPanel::populateFuncParamCB(QComboBox *b, uint function, unsi
 {
   QStringList qs;
   b->setModel(new QStandardItemModel(b));  // clear combo box but not any shared item model
+
   if (function == FuncPlaySound) {
     b->setModel(tabModelFactory->getItemModel(playSoundId));
     b->setCurrentIndex(b->findData(value));
+    if (b->currentIndex() < 0)
+      b->setCurrentIndex(0);
   }
   else if (function == FuncPlayHaptic) {
     b->setModel(tabModelFactory->getItemModel(harpicId));
     b->setCurrentIndex(b->findData(value));
+    if (b->currentIndex() < 0)
+      b->setCurrentIndex(0);
   }
   else if (function == FuncReset) {
     b->setModel(tabFilterFactory->getItemModel(funcResetParamId));
     b->setCurrentIndex(b->findData(value));
+    if (b->currentIndex() < 0)
+      b->setCurrentIndex(0);
   }
   else if (function == FuncVolume || function == FuncBacklight) {
     b->setModel(tabFilterFactory->getItemModel(rawSourceInputsId));
     b->setCurrentIndex(b->findData(value));
+    if (b->currentIndex() < 0 && value == 0)
+      b->setCurrentIndex(b->count() / 2); // '----' not in list so set to first positive value
   }
   else if (function == FuncPlayValue) {
     b->setModel(tabFilterFactory->getItemModel(rawSourceAllId));
     b->setCurrentIndex(b->findData(value));
+    if (b->currentIndex() < 0 && value == 0)
+      b->setCurrentIndex(b->count() / 2); // '----' not in list so set to first positive value
   }
   else if (function >= FuncAdjustGV1 && function <= FuncAdjustGVLast) {
     switch (adjustmode) {
       case 1:
         b->setModel(tabFilterFactory->getItemModel(rawSourceInputsId));
         b->setCurrentIndex(b->findData(value));
-        if (b->currentIndex() < 0)
-          b->setCurrentIndex(0);
+        if (b->currentIndex() < 0 && value == 0)
+          b->setCurrentIndex(b->count() / 2); // '----' not in list so set to first positive value
         break;
       case 2:
         b->setModel(tabFilterFactory->getItemModel(rawSourceGVarsId));
         b->setCurrentIndex(b->findData(value));
-        if (b->currentIndex() < 0)
-          b->setCurrentIndex(0);
+        if (b->currentIndex() < 0 && value == 0)
+          b->setCurrentIndex(b->count() / 2); // '----' not in list so set to first positive value
         break;
     }
   }

--- a/companion/src/modeledit/expodialog.cpp
+++ b/companion/src/modeledit/expodialog.cpp
@@ -48,7 +48,7 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
     cb_fp[i] = tmp[i];
   }
 
-  RawSourceType srcType = (firmware->getCapability(VirtualInputs) ? SOURCE_TYPE_VIRTUAL_INPUT : SOURCE_TYPE_STICK);
+  RawSourceType srcType = (firmware->getCapability(VirtualInputs) ? SOURCE_TYPE_VIRTUAL_INPUT : SOURCE_TYPE_INPUT);
   setWindowTitle(tr("Edit %1").arg(RawSource(srcType, ed->chn).toString(&model, &generalSettings)));
 
   id = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_GVarRef)), "GVarRef");
@@ -109,6 +109,8 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
                                                      flags), "RawSource");
     ui->sourceCB->setModel(dialogFilteredItemModels->getItemModel(id));
     ui->sourceCB->setCurrentIndex(ui->sourceCB->findData(ed->srcRaw.toValue()));
+    if (ui->sourceCB->currentIndex() < 0 && ed->srcRaw.toValue() == 0)
+      ui->sourceCB->setCurrentIndex(ui->sourceCB->count() / 2); // '----' not in list so set to first positive entry
     ui->inputName->setValidator(new NameValidator(board, this));
     ui->inputName->setText(inputName);
   }

--- a/companion/src/modeledit/logicalswitches.cpp
+++ b/companion/src/modeledit/logicalswitches.cpp
@@ -277,7 +277,7 @@ bool LogicalSwitchesPanel::offsetChangedAt(int index)
     {
       RawSource source = RawSource(model->logicalSw[index].val1);
       RawSourceRange range = source.getRange(model, generalSettings, model->logicalSw[index].getRangeFlags());
-      double currVal = source.isTimeBased() ? teOffset[index]->timeInSeconds() : dsbOffset[index]->value();
+      double currVal = source.type == SOURCE_TYPE_TIMER ? teOffset[index]->timeInSeconds() : dsbOffset[index]->value();
       value = round((currVal - range.offset) / range.step);
       mod = (mod || value != model->logicalSw[index].val2);
       model->logicalSw[index].val2 = value;
@@ -366,7 +366,7 @@ void LogicalSwitchesPanel::updateLine(int i)
         double value = range.step * model->logicalSw[i].val2 + range.offset;  /* TODO+source.getRawOffset(model)*/
         cbSource1[i]->setModel(rawSourceFilteredModel);
         cbSource1[i]->setCurrentIndex(cbSource1[i]->findData(source.toValue()));
-        if (source.isTimeBased()) {
+        if (source.type == SOURCE_TYPE_TIMER) {
           mask |= VALUE_TO_VISIBLE;
           teOffset[i]->setTimeRange(range.min, range.max);
           teOffset[i]->setSingleStep(range.step);

--- a/companion/src/modeledit/mixerdialog.cpp
+++ b/companion/src/modeledit/mixerdialog.cpp
@@ -55,6 +55,8 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
                                                    "RawSource");
   ui->sourceCB->setModel(dialogFilteredItemModels->getItemModel(id));
   ui->sourceCB->setCurrentIndex(ui->sourceCB->findData(md->srcRaw.toValue()));
+  if (ui->sourceCB->currentIndex() < 0 && md->srcRaw.toValue() == 0)
+    ui->sourceCB->setCurrentIndex(ui->sourceCB->count() / 2); // '----' not in list so set to first positive entry
 
   int limit = firmware->getCapability(OffsetWeight);
 
@@ -206,7 +208,7 @@ void MixerDialog::valuesChanged()
     lock = true;
     md->srcRaw  = RawSource(ui->sourceCB->itemData(ui->sourceCB->currentIndex()).toInt());
     if (firmware->getCapability(HasNoExpo)) {
-      bool drVisible = (md->srcRaw.type == SOURCE_TYPE_STICK && md->srcRaw.index < CPN_MAX_STICKS);
+      bool drVisible = (md->srcRaw.type == SOURCE_TYPE_INPUT && md->srcRaw.index < CPN_MAX_STICKS);
       ui->MixDR_CB->setEnabled(drVisible);
       ui->label_MixDR->setEnabled(drVisible);
     }

--- a/companion/src/modeledit/setup.cpp
+++ b/companion/src/modeledit/setup.cpp
@@ -1610,7 +1610,7 @@ SetupPanel::SetupPanel(QWidget * parent, ModelData & model, GeneralSettings & ge
   const int ttlInputs = ttlSticks + ttlFlexInputs;
 
   for (int i = 0; i < ttlInputs + firmware->getCapability(RotaryEncoders); i++) {
-    RawSource src((i < ttlInputs) ? SOURCE_TYPE_STICK : SOURCE_TYPE_ROTARY_ENCODER, (i < ttlInputs) ? i : ttlInputs - i);
+    RawSource src((i < ttlInputs) ? SOURCE_TYPE_INPUT : SOURCE_TYPE_ROTARY_ENCODER, (i < ttlInputs) ? i : ttlInputs - i);
     QCheckBox * checkbox = new QCheckBox(this);
     checkbox->setProperty("index", i);
     checkbox->setText(src.toString(&model, &generalSettings));
@@ -1674,7 +1674,7 @@ SetupPanel::SetupPanel(QWidget * parent, ModelData & model, GeneralSettings & ge
 
   if (IS_HORUS_OR_TARANIS(board) && ttlInputs > 0) {
     for (int i = ttlSticks; i < ttlInputs; i++) {
-      RawSource src(SOURCE_TYPE_STICK, i);
+      RawSource src(SOURCE_TYPE_INPUT, i);
       QCheckBox * cb = new QCheckBox(this);
       cb->setProperty("index", i - ttlSticks);
       cb->setText(src.toString(&model, &generalSettings));

--- a/companion/src/modeledit/telemetry_customscreens.cpp
+++ b/companion/src/modeledit/telemetry_customscreens.cpp
@@ -158,7 +158,7 @@ void CustomScreen::updateBar(int line)
     float maxVal = screen.body.bars[line].barMax;
     maxVal = range.getValue(maxVal);
 
-    if (source.isTimeBased()) {
+    if (source.type == SOURCE_TYPE_TIMER) {
       minTime[line]->setVisible(true);
       minTime[line]->setTimeRange(range.min, range.max);
       minTime[line]->setSingleStep(range.step);

--- a/companion/src/modelprinter.cpp
+++ b/companion/src/modelprinter.cpp
@@ -159,7 +159,7 @@ QString ModelPrinter::printEEpromSize()
 
 QString ModelPrinter::printChannelName(int idx)
 {
-  QString str = RawSource(SOURCE_TYPE_CH, idx).toString(&model, &generalSettings);
+  QString str = RawSource(SOURCE_TYPE_CH, idx + 1).toString(&model, &generalSettings);
   if (firmware->getCapability(ChannelsName)) {
     str = str.leftJustified(firmware->getCapability(ChannelsName) + 5, ' ', false);
   }
@@ -273,7 +273,7 @@ QString ModelPrinter::printCenterBeep()
 
   for (int i = 0; i < inputs + firmware->getCapability(RotaryEncoders); i++) {
     if (model.beepANACenter & (0x01 << i)) {
-      RawSource src((i < inputs) ? SOURCE_TYPE_STICK : SOURCE_TYPE_ROTARY_ENCODER, (i < inputs) ? i : inputs - i);
+      RawSource src((i < inputs) ? SOURCE_TYPE_INPUT : SOURCE_TYPE_ROTARY_ENCODER, (i < inputs) ? i : inputs - i);
       strl << src.toString(&model, &generalSettings);
     }
   }
@@ -338,8 +338,8 @@ QString ModelPrinter::printRotaryEncoder(int flightModeIndex, int reIndex)
 
 QString ModelPrinter::printInputName(int idx)
 {
-  RawSourceType srcType = (firmware->getCapability(VirtualInputs) ? SOURCE_TYPE_VIRTUAL_INPUT : SOURCE_TYPE_STICK);
-  return RawSource(srcType, idx).toString(&model, &generalSettings).toHtmlEscaped();
+  RawSourceType srcType = (firmware->getCapability(VirtualInputs) ? SOURCE_TYPE_VIRTUAL_INPUT : SOURCE_TYPE_INPUT);
+  return RawSource(srcType, idx + 1).toString(&model, &generalSettings).toHtmlEscaped();
 }
 
 QString ModelPrinter::printInputLine(int idx)
@@ -785,7 +785,7 @@ QString ModelPrinter::printPotWarnings()
     for (int i = Boards::getCapability(board, Board::Sticks); i < Boards::getCapability(board, Board::Inputs); i++) {
       if (generalSettings.isInputAvailable(i) && (generalSettings.isInputPot(i) || generalSettings.isInputSlider(i))) {
         if (model.potsWarnEnabled[i]) {
-          RawSource src(SOURCE_TYPE_STICK, i);
+          RawSource src(SOURCE_TYPE_INPUT, i);
           str += src.toString(&model, &generalSettings);
         }
       }
@@ -1075,7 +1075,7 @@ QString ModelPrinter::printTelemetryScreen(unsigned int idx, unsigned int line, 
     QString unit;
     QString minstr;
     QString maxstr;
-    if (source.isTimeBased()){
+    if (source.type == SOURCE_TYPE_TIMER) {
       minstr = printTimeValue((float)screen.body.bars[line].barMin, MASK_TIMEVALUE_HRSMINS);
       maxstr = printTimeValue((float)screen.body.bars[line].barMax, MASK_TIMEVALUE_HRSMINS);
     }

--- a/companion/src/simulation/joystickdialog.cpp
+++ b/companion/src/simulation/joystickdialog.cpp
@@ -162,7 +162,7 @@ void joystickDialog::populateSourceCombo(QComboBox * cb)
       if (radioSettings.isInputStick(i))
         wname = Boards::getAxisName(i);
       else
-        wname = RawSource(RawSourceType::SOURCE_TYPE_STICK, i).toString(nullptr, &radioSettings);
+        wname = RawSource(RawSourceType::SOURCE_TYPE_INPUT, i).toString(nullptr, &radioSettings);
       cb->addItem(wname, i);
     }
   }

--- a/companion/src/simulation/simulatorwidget.cpp
+++ b/companion/src/simulation/simulatorwidget.cpp
@@ -622,7 +622,7 @@ void SimulatorWidget::setupRadioWidgets()
     if (!(radioSettings.isInputAvailable(i) && radioSettings.isInputPot(i)))
       continue;
 
-    wname = RawSource(RawSourceType::SOURCE_TYPE_STICK, i).toString(nullptr, &radioSettings, Board::BOARD_UNKNOWN, false);
+    wname = RawSource(RawSourceType::SOURCE_TYPE_INPUT, i).toString(nullptr, &radioSettings, Board::BOARD_UNKNOWN, false);
     RadioKnobWidget * pot = new RadioKnobWidget(radioSettings.inputConfig[i].flexType, wname, 0, ui->radioWidgetsHT);
     pot->setIndex(i);
     ui->radioWidgetsHTLayout->insertWidget(midpos++, pot);
@@ -636,7 +636,7 @@ void SimulatorWidget::setupRadioWidgets()
     if (!(radioSettings.isInputAvailable(i) && radioSettings.isInputSlider(i)))
       continue;
 
-    wname = RawSource(RawSourceType::SOURCE_TYPE_STICK, i).toString(nullptr, &radioSettings, Board::BOARD_UNKNOWN, false);
+    wname = RawSource(RawSourceType::SOURCE_TYPE_INPUT, i).toString(nullptr, &radioSettings, Board::BOARD_UNKNOWN, false);
     RadioFaderWidget * sl = new RadioFaderWidget(wname, 0, ui->radioWidgetsVC);
     sl->setIndex(i);
     ui->VCGridLayout->addWidget(sl, 0, fc++, 1, 1);

--- a/companion/src/tests/conversions.cpp
+++ b/companion/src/tests/conversions.cpp
@@ -245,7 +245,7 @@ TEST(Conversions, ConversionX10From22)
 
   EXPECT_EQ(RawSwitch(SWITCH_TYPE_ON), settings.customFn[1].swtch);
   EXPECT_EQ(FuncVolume, settings.customFn[1].func);
-  EXPECT_EQ(RawSource(SOURCE_TYPE_STICK, 4+5+1).toValue(), settings.customFn[1].param); // RS
+  EXPECT_EQ(RawSource(SOURCE_TYPE_INPUT, 4+5+1).toValue(), settings.customFn[1].param); // RS
 
   EXPECT_STREQ("Tes", settings.switchName[0]);
   EXPECT_EQ(Board::SWITCH_3POS, settings.switchConfig[0]);
@@ -265,7 +265,7 @@ TEST(Conversions, ConversionX10From22)
   EXPECT_EQ(0, model.beepANACenter);
   EXPECT_EQ(80, model.mixData[0].weight);
   EXPECT_EQ(RawSource(SOURCE_TYPE_MAX), model.mixData[2].srcRaw); // MAX
-  EXPECT_EQ(RawSource(SOURCE_TYPE_STICK, 4+5), model.mixData[3].srcRaw); // LS
+  EXPECT_EQ(RawSource(SOURCE_TYPE_INPUT, 4+5), model.mixData[3].srcRaw); // LS
   EXPECT_EQ(RawSource(SOURCE_TYPE_PPM, 0), model.mixData[5].srcRaw);
   EXPECT_EQ(RawSwitch(SWITCH_TYPE_TELEMETRY, 1), model.mixData[5].swtch);
   EXPECT_EQ(900, model.limitData[0].max); // -100
@@ -321,7 +321,7 @@ TEST(Conversions, ConversionX12SFrom22)
 
   EXPECT_EQ(RawSwitch(SWITCH_TYPE_ON), settings.customFn[1].swtch);
   EXPECT_EQ(FuncVolume, settings.customFn[1].func);
-  EXPECT_EQ(RawSource(SOURCE_TYPE_STICK, 4+5+1).toValue(), settings.customFn[1].param); // RS
+  EXPECT_EQ(RawSource(SOURCE_TYPE_INPUT, 4+5+1).toValue(), settings.customFn[1].param); // RS
 
   EXPECT_STREQ("Tes", settings.switchName[0]);
   EXPECT_EQ(Board::SWITCH_3POS, settings.switchConfig[0]);
@@ -341,7 +341,7 @@ TEST(Conversions, ConversionX12SFrom22)
   EXPECT_EQ(0, model.beepANACenter);
   EXPECT_EQ(80, model.mixData[0].weight);
   EXPECT_EQ(RawSource(SOURCE_TYPE_MAX), model.mixData[2].srcRaw); // MAX
-  EXPECT_EQ(RawSource(SOURCE_TYPE_STICK, 4+5), model.mixData[3].srcRaw); // LS
+  EXPECT_EQ(RawSource(SOURCE_TYPE_INPUT, 4+5), model.mixData[3].srcRaw); // LS
   EXPECT_EQ(RawSource(SOURCE_TYPE_PPM, 0), model.mixData[5].srcRaw);
   EXPECT_EQ(RawSwitch(SWITCH_TYPE_TELEMETRY, 1), model.mixData[5].swtch);
   EXPECT_EQ(900, model.limitData[0].max); // -100

--- a/companion/src/wizarddata.cpp
+++ b/companion/src/wizarddata.cpp
@@ -54,7 +54,7 @@ void WizMix::maxMixSwitch(char *name, MixData &mix, int channel, int sw, int wei
   strncpy(mix.name, name, sizeof(mix.name)-1);
   mix.destCh = channel;
   mix.srcRaw = RawSource(SOURCE_TYPE_MAX);
-  mix.swtch  = RawSwitch(SWITCH_TYPE_SWITCH, sw);
+  mix.swtch  = RawSwitch(SWITCH_TYPE_SWITCH, sw + 1);
   mix.weight = weight;
 }
 
@@ -63,13 +63,13 @@ void WizMix::addMix(ModelData &model, Input input, int weight, int channel, int 
   if (input != NO_INPUT)  {
     if (input >= RUDDER_INPUT && input <= AILERONS_INPUT) {
       MixData & mix = model.mixData[mixIndex++];
-      mix.destCh = channel+1;
+      mix.destCh = channel + 1;
       if (IS_SKY9X(getCurrentBoard())) {
-        mix.srcRaw = RawSource(SOURCE_TYPE_STICK, input-1);
+        mix.srcRaw = RawSource(SOURCE_TYPE_INPUT, input + 1);
       }
       else {
-        int channel = settings.getDefaultChannel(input-1);
-        mix.srcRaw = RawSource(SOURCE_TYPE_VIRTUAL_INPUT, channel);
+        int channel = settings.getDefaultChannel(input - 1);
+        mix.srcRaw = RawSource(SOURCE_TYPE_VIRTUAL_INPUT, channel + 1);
       }
 
       mix.weight = weight;
@@ -118,7 +118,7 @@ WizMix::operator ModelData()
         // Add the Throttle Cut option
         MixData & mix = model.mixData[mixIndex++];
         mix.destCh = i+1;
-        mix.srcRaw = SOURCE_TYPE_MAX;
+        mix.srcRaw = RawSource(SOURCE_TYPE_MAX);
         mix.weight = -100;
         mix.swtch.type = SWITCH_TYPE_SWITCH;
         mix.swtch.index = IS_SKY9X(getCurrentBoard()) ? SWITCH_THR : SWITCH_SF0;


### PR DESCRIPTION
Summary of Changes
This is the Companion part of #4513 and has been based on latest main and not @philmoz private repo branch. At some point, likely after testing is complete, this branch should be merged into Phil's to create a single feature work unit and this PR closed.

This refactor changes RawSource index from zero to one based to support negative indexes (as RawSwitch).

The opportunity was taken to undertake some overdue housekeeping of RawSource and move timers from source type Special to new Timers. Also rename legacy type SOURCE_TYPE_STICK to SOURCE_TYPE_INPUT as more appropriate.

Status: Testing is a WIP.
