### PR TITLE
fix(telemetry): temperature UNIT conversion when temperature has decimals

### DIFF
--- a/radio/src/gui/128x64/model_telemetry_sensor.cpp
+++ b/radio/src/gui/128x64/model_telemetry_sensor.cpp
@@ -56,7 +56,7 @@ void menuModelSensor(event_t event)
     sensor->type == TELEM_TYPE_CALCULATED ? (uint8_t)0 : (uint8_t)1, // ID / Formula
     // sensor->type == TELEM_TYPE_CALCULATED ? HIDDEN_ROW : READONLY_ROW, // Receiver name
     ((sensor->type == TELEM_TYPE_CALCULATED && (sensor->formula == TELEM_FORMULA_DIST)) || sensor->isConfigurable() ? (uint8_t)0 : HIDDEN_ROW), // Unit
-    (sensor->isPrecConfigurable() && sensor->unit != UNIT_FAHRENHEIT  ? (uint8_t)0 : HIDDEN_ROW), // Precision
+    (sensor->isPrecConfigurable()? (uint8_t)0 : HIDDEN_ROW), // Precision
     (sensor->unit >= UNIT_FIRST_VIRTUAL ? HIDDEN_ROW : (uint8_t)0), // Param1
     (sensor->unit == UNIT_GPS || sensor->unit == UNIT_DATETIME || sensor->unit == UNIT_CELLS || (sensor->type==TELEM_TYPE_CALCULATED && (sensor->formula==TELEM_FORMULA_CONSUMPTION || sensor->formula==TELEM_FORMULA_TOTALIZE)) ? HIDDEN_ROW : (uint8_t)0), // Param2
     (sensor->type == TELEM_TYPE_CALCULATED && sensor->formula < TELEM_FORMULA_MULTIPLY) ? (uint8_t)0 : HIDDEN_ROW, // Param3

--- a/radio/src/gui/212x64/model_telemetry_sensor.cpp
+++ b/radio/src/gui/212x64/model_telemetry_sensor.cpp
@@ -45,7 +45,7 @@ enum SensorFields {
 #define SENSOR_3RD_COLUMN      (18*FW)
 
 #define SENSOR_UNIT_ROWS       ((sensor->type == TELEM_TYPE_CALCULATED && (sensor->formula == TELEM_FORMULA_DIST)) || sensor->isConfigurable() ? (uint8_t)0 : HIDDEN_ROW)
-#define SENSOR_PREC_ROWS       (sensor->isPrecConfigurable() && sensor->unit != UNIT_FAHRENHEIT  ? (uint8_t)0 : HIDDEN_ROW)
+#define SENSOR_PREC_ROWS       (sensor->isPrecConfigurable()? (uint8_t)0 : HIDDEN_ROW)
 #define SENSOR_PARAM1_ROWS     (sensor->unit >= UNIT_FIRST_VIRTUAL ? HIDDEN_ROW : (uint8_t)0)
 #define SENSOR_PARAM2_ROWS     (sensor->unit == UNIT_GPS || sensor->unit == UNIT_DATETIME || sensor->unit == UNIT_CELLS || (sensor->type==TELEM_TYPE_CALCULATED && (sensor->formula==TELEM_FORMULA_CONSUMPTION || sensor->formula==TELEM_FORMULA_TOTALIZE)) ? HIDDEN_ROW : (uint8_t)0)
 #define SENSOR_PARAM3_ROWS     (sensor->type == TELEM_TYPE_CALCULATED && sensor->formula < TELEM_FORMULA_MULTIPLY) ? (uint8_t)0 : HIDDEN_ROW

--- a/radio/src/gui/212x64/model_telemetry_sensor.cpp
+++ b/radio/src/gui/212x64/model_telemetry_sensor.cpp
@@ -45,7 +45,7 @@ enum SensorFields {
 #define SENSOR_3RD_COLUMN      (18*FW)
 
 #define SENSOR_UNIT_ROWS       ((sensor->type == TELEM_TYPE_CALCULATED && (sensor->formula == TELEM_FORMULA_DIST)) || sensor->isConfigurable() ? (uint8_t)0 : HIDDEN_ROW)
-#define SENSOR_PREC_ROWS       (sensor->isPrecConfigurable()? (uint8_t)0 : HIDDEN_ROW)
+#define SENSOR_PREC_ROWS       (sensor->isPrecConfigurable() ? (uint8_t)0 : HIDDEN_ROW)
 #define SENSOR_PARAM1_ROWS     (sensor->unit >= UNIT_FIRST_VIRTUAL ? HIDDEN_ROW : (uint8_t)0)
 #define SENSOR_PARAM2_ROWS     (sensor->unit == UNIT_GPS || sensor->unit == UNIT_DATETIME || sensor->unit == UNIT_CELLS || (sensor->type==TELEM_TYPE_CALCULATED && (sensor->formula==TELEM_FORMULA_CONSUMPTION || sensor->formula==TELEM_FORMULA_TOTALIZE)) ? HIDDEN_ROW : (uint8_t)0)
 #define SENSOR_PARAM3_ROWS     (sensor->type == TELEM_TYPE_CALCULATED && sensor->formula < TELEM_FORMULA_MULTIPLY) ? (uint8_t)0 : HIDDEN_ROW

--- a/radio/src/gui/colorlcd/model_telemetry.cpp
+++ b/radio/src/gui/colorlcd/model_telemetry.cpp
@@ -465,7 +465,7 @@ class SensorEditWindow : public Page {
       }
 
       // Precision
-      if (sensor->isPrecConfigurable() && sensor->unit != UNIT_FAHRENHEIT) {
+      if (sensor->isPrecConfigurable()) {
         lv_obj_clear_flag(paramLines[P_PREC]->getLvObj(), LV_OBJ_FLAG_HIDDEN);
       }
 


### PR DESCRIPTION
Fixes #4723

Summary of changes:
1. Fixes converting from C to F (and vice versa) when the Temperature has decimal places.
2. Optimization: Remove loop to do 10^n, and use a table "Power10[n]" to change from one Prec to another.
3. Optimization: Only do the conversion if needed, i.e, Different UNIT or different Prec
4. Move the exception of not displaying "Precision" on 3 different GUIs when sensor is UNIT_FARENHEITH to a single share code by all GUIs.` TelemetrySensor::isPrecConfigurable()` is only used for this UI purpose, nowhere else.

Left the Precision not been configurable when sensor is UNIT_FARENHEITH, (same behavior as before).  I think this is because is already granular enough compared to UNIT_CELSIOUS.

Examples: Using LemonRX Gen2 who has a temperature sensor embeded.

![image](https://github.com/EdgeTX/edgetx/assets/32604366/11e52c11-33b3-4bf9-973c-70cf4c390bc9)
![image](https://github.com/EdgeTX/edgetx/assets/32604366/06743cc5-88d0-45d3-afbd-e7a00317bb70)
NOTE: Temp was increasing while taking the screenshots.. that's why the little difference.
![image](https://github.com/EdgeTX/edgetx/assets/32604366/40de1e37-94e0-466f-a6ee-301195eb9661)


  