### PR TITLE
fix(telemetry): frsky angles should be be signed (allow negative)

### DIFF
--- a/radio/src/telemetry/frsky_sport.cpp
+++ b/radio/src/telemetry/frsky_sport.cpp
@@ -420,8 +420,8 @@ void sportProcessTelemetryPacketWithoutCrc(uint8_t module, uint8_t origin, const
           }
         }
         else if (dataId >= ANGLE_FIRST_ID && dataId <= ANGLE_LAST_ID) {
-          sportProcessTelemetryPacket(dataId, 0, instance, data & 0xFFFFu);
-          sportProcessTelemetryPacket(dataId, 1, instance, data >> 16u);
+          sportProcessTelemetryPacket(dataId, 0, instance, (int16_t) (data & 0xFFFFu));
+          sportProcessTelemetryPacket(dataId, 1, instance, (int16_t) (data >> 16u));
         }
         else {
           sportProcessTelemetryPacket(dataId, 0, instance, data);


### PR DESCRIPTION
Fixes #4729

Summary of changes:
Bug report that Roll/Pitch should be from -180 to +180, so needs to be a signed 16 bits number.
**Change Angles to be processed as Signed int16** 
