### PR TITLE
fix(tlite): default switch configuration wrong

### DIFF
--- a/radio/util/hw_defs/switch_config.py
+++ b/radio/util/hw_defs/switch_config.py
@@ -128,17 +128,17 @@ SWITCH_CONFIG = {
     "tlite": {
         # left side
         "SA": {"default": "3POS",   "display": [0, 0]},
-        "SC": {"default": "3POS",   "display": [0, 1]},
+        "SC": {"default": "2POS",   "display": [0, 1]},
         # right side
-        "SB": {"default": "2POS",   "display": [1, 0]},
+        "SB": {"default": "3POS",   "display": [1, 0]},
         "SD": {"default": "2POS",   "display": [1, 1]}
     },
     "tlitef4": {
         # left side
         "SA": {"default": "3POS",   "display": [0, 0]},
-        "SC": {"default": "3POS",   "display": [0, 1]},
+        "SC": {"default": "2POS",   "display": [0, 1]},
         # right side
-        "SB": {"default": "2POS",   "display": [1, 0]},
+        "SB": {"default": "3POS",   "display": [1, 0]},
         "SD": {"default": "2POS",   "display": [1, 1]}
     },
     "tpro": {


### PR DESCRIPTION
Summary of changes:
- Default switch configuration is are swapped for TLite for SB and SC (1x 3POS and 1x 2POS on each side, not the 3POS switches on the left and 2POS on the right right)
