### PR TITLE
fix(b&w): ENTER key does not work on main view for T12, T-Lite and LR3PRO

### DIFF
--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -354,14 +354,19 @@ void displayBattVoltage()
 #define EVT_KEY_TELEMETRY              EVT_KEY_LONG(KEY_DOWN)
 #define EVT_KEY_STATISTICS             EVT_KEY_LONG(KEY_UP)
 #else
+#if defined(NAVIGATION_9X)
+#define EVT_KEY_CONTEXT_MENU           EVT_KEY_BREAK(KEY_ENTER)
+#define EVT_KEY_LAST_MENU              EVT_KEY_LONG(KEY_ENTER)
+#else
 #define EVT_KEY_CONTEXT_MENU           EVT_KEY_BREAK(KEY_MENU)
+#define EVT_KEY_LAST_MENU              EVT_KEY_LONG(KEY_MENU)
+#endif
 #define EVT_KEY_PREVIOUS_VIEW          EVT_KEY_BREAK(KEY_UP)
 #define EVT_KEY_NEXT_VIEW              EVT_KEY_BREAK(KEY_DOWN)
 #define EVT_KEY_NEXT_PAGE              EVT_KEY_BREAK(KEY_RIGHT)
 #define EVT_KEY_PREVIOUS_PAGE          EVT_KEY_BREAK(KEY_LEFT)
 #define EVT_KEY_MODEL_MENU             EVT_KEY_LONG(KEY_RIGHT)
 #define EVT_KEY_GENERAL_MENU           EVT_KEY_LONG(KEY_LEFT)
-#define EVT_KEY_LAST_MENU              EVT_KEY_LONG(KEY_MENU)
 #define EVT_KEY_TELEMETRY              EVT_KEY_LONG(KEY_DOWN)
 #define EVT_KEY_STATISTICS             EVT_KEY_LONG(KEY_UP)
 #endif


### PR DESCRIPTION
Fixes #4742 

Fix key mapping on main view for NAVIGATION_TYPE 9X.

