### PR TITLE
feat(color): move ADC Filter and Center Beep settings to 'Other' page

### DIFF
--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -22,6 +22,8 @@
 #include "model_setup.h"
 
 #include "button_matrix.h"
+#include "filechoice.h"
+#include "libopenui.h"
 
 #include "hal/adc_driver.h"
 #include "storage/modelslist.h"
@@ -359,33 +361,31 @@ class ModelOtherOptions : public Page
    public:
     ModelOtherOptions() : Page(ICON_MODEL_SETUP)
     {
-      header.setTitle(STR_MENU_MODEL_SETUP);
-      header.setTitle2(STR_MENU_OTHER);
+      header->setTitle(STR_MENU_MODEL_SETUP);
+      header->setTitle2(STR_MENU_OTHER);
 
-      body.padAll(8);
+      body->padAll(PAD_SMALL);
 
-      auto form = new FormWindow(&body, rect_t{});
-      form->setFlexLayout();
-      form->padAll(4);
+      body->setFlexLayout(LV_FLEX_FLOW_COLUMN, PAD_ZERO);
 
-      FlexGridLayout grid(line_col_dsc, line_row_dsc, 2);
+      FlexGridLayout grid(line_col_dsc, line_row_dsc, PAD_SMALL);
 
       // Model ADC jitter filter
-      auto line = form->newLine(&grid);
-      new StaticText(line, rect_t{}, STR_JITTER_FILTER, 0, COLOR_THEME_PRIMARY1);
+      auto line = body->newLine(grid);
+      new StaticText(line, rect_t{}, STR_JITTER_FILTER);
       new Choice(line, rect_t{}, STR_ADCFILTERVALUES, 0, 2,
                 GET_SET_DEFAULT(g_model.jitterFilter));
 
       // Center beeps
-      line = form->newLine(&grid);
-      new StaticText(line, rect_t{}, STR_BEEPCTR, 0, COLOR_THEME_PRIMARY1);
-      line = form->newLine(&grid);
+      line = body->newLine(grid);
+      new StaticText(line, rect_t{}, STR_BEEPCTR);
+      line = body->newLine(grid);
       line->padLeft(4);
       new CenterBeepsMatrix(line, rect_t{});
     }
 };
 
-void ModelSetupPage::build(FormWindow * window)
+void ModelSetupPage::build(Window * window)
 {
   window->setFlexLayout(LV_FLEX_FLOW_COLUMN, 0);
 

--- a/radio/src/gui/colorlcd/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model_setup.cpp
@@ -22,8 +22,14 @@
 #include "model_setup.h"
 
 #include "button_matrix.h"
-#include "filechoice.h"
-#include "libopenui.h"
+
+#include "hal/adc_driver.h"
+#include "storage/modelslist.h"
+#include "trainer_setup.h"
+#include "module_setup.h"
+#include "timer_setup.h"
+#include "trims_setup.h"
+#include "throttle_params.h"
 #include "preflight_checks.h"
 #include "throttle_params.h"
 #include "timer_setup.h"
@@ -264,7 +270,122 @@ class ModelViewOptions : public Page
   }
 };
 
-void ModelSetupPage::build(Window *window)
+#if LCD_W > LCD_H
+#define SW_BTNS 8
+#define SW_BTN_W 56
+#else
+#define SW_BTNS 4
+#define SW_BTN_W 72
+#endif
+
+struct CenterBeepsMatrix : public ButtonMatrix {
+  CenterBeepsMatrix(Window* parent, const rect_t& rect) :
+    ButtonMatrix(parent, rect)
+  {
+    // Setup button layout & texts
+    uint8_t btn_cnt = 0;
+
+    auto max_sticks = adcGetMaxInputs(ADC_INPUT_MAIN);
+    auto max_pots = adcGetMaxInputs(ADC_INPUT_FLEX);
+    max_analogs = max_sticks + max_pots;
+
+    for (uint8_t i = 0; i < max_analogs; i++) {
+      // multipos cannot be centered
+      if (i < max_sticks || (IS_POT_SLIDER_AVAILABLE(i - max_sticks) &&
+                            !IS_POT_MULTIPOS(i - max_sticks))) {
+        ana_idx[btn_cnt] = i;
+        btn_cnt++;
+      }
+    }
+
+    initBtnMap(min((int)btn_cnt, SW_BTNS), btn_cnt);
+
+    uint8_t btn_id = 0;
+    for (uint8_t i = 0; i < max_analogs; i++) {
+      if (i < max_sticks || (IS_POT_SLIDER_AVAILABLE(i - max_sticks) &&
+                            !IS_POT_MULTIPOS(i - max_sticks))) {
+        setTextAndState(btn_id);
+        btn_id++;
+      }
+    }
+
+    update();
+
+    lv_obj_set_width(lvobj, min((int)btn_cnt, SW_BTNS) * SW_BTN_W + 4);
+
+    uint8_t rows = ((btn_cnt - 1) / SW_BTNS) + 1;
+    lv_obj_set_height(lvobj, (rows * 36) + 4);
+
+    lv_obj_set_style_pad_all(lvobj, 4, LV_PART_MAIN);
+
+    lv_obj_set_style_pad_row(lvobj, 4, LV_PART_MAIN);
+    lv_obj_set_style_pad_column(lvobj, 4, LV_PART_MAIN);
+  }
+
+  void onPress(uint8_t btn_id)
+  {
+    if (btn_id >= max_analogs) return;
+    uint8_t i = ana_idx[btn_id];
+    BFBIT_FLIP(g_model.beepANACenter, bfBit<BeepANACenter>(i));
+    setTextAndState(btn_id);
+    SET_DIRTY();
+  }
+
+  bool isActive(uint8_t btn_id)
+  {
+    if (btn_id >= max_analogs) return false;
+    uint8_t i = ana_idx[btn_id];
+    return bfSingleBitGet<BeepANACenter>(g_model.beepANACenter, i) != 0;
+  }
+
+  void setTextAndState(uint8_t btn_id)
+  {
+    auto max_sticks = adcGetMaxInputs(ADC_INPUT_MAIN);
+    if (ana_idx[btn_id] < max_sticks)
+      setText(btn_id, getAnalogShortLabel(ana_idx[btn_id]));
+    else
+      setText(btn_id,
+              getAnalogLabel(ADC_INPUT_FLEX, ana_idx[btn_id] - max_sticks));
+    setChecked(btn_id);
+  }
+
+ private:
+  uint8_t max_analogs;
+  uint8_t ana_idx[MAX_ANALOG_INPUTS];
+};
+
+class ModelOtherOptions : public Page
+{
+   public:
+    ModelOtherOptions() : Page(ICON_MODEL_SETUP)
+    {
+      header.setTitle(STR_MENU_MODEL_SETUP);
+      header.setTitle2(STR_MENU_OTHER);
+
+      body.padAll(8);
+
+      auto form = new FormWindow(&body, rect_t{});
+      form->setFlexLayout();
+      form->padAll(4);
+
+      FlexGridLayout grid(line_col_dsc, line_row_dsc, 2);
+
+      // Model ADC jitter filter
+      auto line = form->newLine(&grid);
+      new StaticText(line, rect_t{}, STR_JITTER_FILTER, 0, COLOR_THEME_PRIMARY1);
+      new Choice(line, rect_t{}, STR_ADCFILTERVALUES, 0, 2,
+                GET_SET_DEFAULT(g_model.jitterFilter));
+
+      // Center beeps
+      line = form->newLine(&grid);
+      new StaticText(line, rect_t{}, STR_BEEPCTR, 0, COLOR_THEME_PRIMARY1);
+      line = form->newLine(&grid);
+      line->padLeft(4);
+      new CenterBeepsMatrix(line, rect_t{});
+    }
+};
+
+void ModelSetupPage::build(FormWindow * window)
 {
   window->setFlexLayout(LV_FLEX_FLOW_COLUMN, 0);
 
@@ -313,14 +434,7 @@ void ModelSetupPage::build(Window *window)
   // TODO: show bitmap thumbnail instead?
   new ModelBitmapEdit(line, rect_t{});
 
-  // Model ADC jitter filter
-  line = window->newLine(grid);
-  new StaticText(line, rect_t{}, STR_JITTER_FILTER);
-  new Choice(line, rect_t{}, STR_ADCFILTERVALUES, 0, 2,
-             GET_SET_DEFAULT(g_model.jitterFilter));
-
-  static const lv_coord_t col_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1),
-                                       LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
+  static const lv_coord_t col_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_FR(1), LV_GRID_TEMPLATE_LAST};
   static const lv_coord_t row_dsc[] = {LV_GRID_CONTENT, LV_GRID_TEMPLATE_LAST};
 
   FlexGridLayout grid2(col_dsc, row_dsc);
@@ -370,4 +484,6 @@ void ModelSetupPage::build(Window *window)
   new SubScreenButton(line, STR_USBJOYSTICK_LABEL,
                       []() { new ModelUSBJoystickPage(); });
 #endif
+
+  new SubScreenButton(line, STR_MENU_OTHER, []() { new ModelOtherOptions(); });
 }

--- a/radio/src/translations/cn.h
+++ b/radio/src/translations/cn.h
@@ -271,7 +271,7 @@
 #define TR_TTRACE                      TR("输入源", INDENT "输入源")
 #define TR_TTRIM                       TR("油门微调仅怠速", INDENT "油门微调只调整怠速")
 #define TR_TTRIM_SW                    TR("微调选择", INDENT "微调选择")
-#define TR_BEEPCTR                     TR("中点蜂鸣", "中点蜂鸣")
+#define TR_BEEPCTR                     TR("中点提示音", "中点蜂鸣提示音")
 #define TR_USE_GLOBAL_FUNCS            TR("全局功能", "全局功能可介入")
 #define TR_PPMFRAME                    INDENT "PPM帧"
 #define TR_REFRESHRATE                 TR(INDENT "刷新率", INDENT "刷新速率")
@@ -1109,7 +1109,7 @@
 #define TR_CURRENTSENSOR               "传感器"
 #define TR_AUTOOFFSET                  "自动偏移值"
 #define TR_ONLYPOSITIVE                "正向"
-#define TR_FILTER                      "滤波"
+#define TR_FILTER                      "滤波器"
 #define TR_TELEMETRYFULL               TR("项目已满!", "回传项目已满!")
 #define TR_INVERTED_SERIAL             INDENT "反向"
 #define TR_IGNORE_INSTANCE             TR(INDENT "忽略ID", INDENT "忽略ID鉴别")
@@ -1153,7 +1153,7 @@
 #define TR_MENU_OTHER                  "其它"
 #define TR_MENU_INVERT                 "反向"
 #define TR_AUDIO_MUTE                  TR("自动静音","音频停播时自动静音")
-#define TR_JITTER_FILTER               "模拟输入滤波"
+#define TR_JITTER_FILTER               "ADC滤波器"
 #define TR_DEAD_ZONE                   "死区"
 #define TR_RTC_CHECK                   TR("检查时间电池", "检查时间驱动电池电压")
 #define TR_AUTH_FAILURE                "验证失败"

--- a/radio/src/translations/cz.h
+++ b/radio/src/translations/cz.h
@@ -285,7 +285,7 @@
 #define TR_TTRACE                      TR("StopaPlynu", INDENT "Stopa plynu")
 #define TR_TTRIM                       TR3("TrimVolnob.", INDENT "Trim jen volnoběh", "Trim jen pro volnoběh")
 #define TR_TTRIM_SW                    TR("T-Trim-Sw", INDENT "Trim spínač")
-#define TR_BEEPCTR                     TR3("Středy \200\201", "Pípat středy \200\201", "Pípat středy")
+#define TR_BEEPCTR                     TR("Pípat střed", "Pípnutí při středové poloze")
 #define TR_USE_GLOBAL_FUNCS            TR("Glob.Funkce", "Použít globální funkce")
 #define TR_PROTOCOL                    "Protokol"
 #define TR_PPMFRAME                    INDENT "PPM modulace"

--- a/radio/src/translations/da.h
+++ b/radio/src/translations/da.h
@@ -278,7 +278,7 @@
 #define TR_TTRACE                      TR("T-kilde", INDENT "kilde")
 #define TR_TTRIM                       TR("T-trim-tomg", INDENT "Trim tomgang alene")
 #define TR_TTRIM_SW                    TR("T-trim-ko", INDENT "Trim kontakt")
-#define TR_BEEPCTR                     TR("Ctr Bip", "Center Bip")
+#define TR_BEEPCTR                     TR("Bip ctr pos", "Bip ved center position")
 #define TR_USE_GLOBAL_FUNCS            TR("Glob.Funk.", "Brug global funk.")
 #define TR_PROTOCOL                    TR("Proto", "Protokol")
 #define TR_PPMFRAME                    INDENT "PPM frame"

--- a/radio/src/translations/de.h
+++ b/radio/src/translations/de.h
@@ -276,7 +276,7 @@
 #define TR_TTRACE                      TR("Gasquelle", INDENT "Gas-Timerquelle")
 #define TR_TTRIM 	       	             TR("Gastrim", INDENT "Gas-Leerlauftrim")
 #define TR_TTRIM_SW                    TR("T-Trim-Sw", INDENT "Trim switch")
-#define TR_BEEPCTR                     TR("MittePieps", "Mittelstell. -Pieps")
+#define TR_BEEPCTR                     TR("MittePieps", "Pieps in Mittelstellung")
 #define TR_USE_GLOBAL_FUNCS            TR("Glob. Funkt.", "Globale Funkt verw.")
 #define TR_PROTOCOL          		       TR("Protok.", "Protokoll")
 #define TR_PPMFRAME          	  	     INDENT "PPM-Frame"

--- a/radio/src/translations/en.h
+++ b/radio/src/translations/en.h
@@ -275,7 +275,7 @@
 #define TR_TTRACE                      TR("T-Source", INDENT "Source")
 #define TR_TTRIM                       TR("T-Trim-Idle", INDENT "Trim idle only")
 #define TR_TTRIM_SW                    TR("T-Trim-Sw", INDENT "Trim switch")
-#define TR_BEEPCTR                     TR("Ctr Beep", "Center Beep")
+#define TR_BEEPCTR                     TR("Ctr Beep", "Beep when centered")
 #define TR_USE_GLOBAL_FUNCS            TR("Glob.Funcs", "Use global funcs")
 #define TR_PROTOCOL                    TR("Proto", "Protocol")
   #define TR_PPMFRAME                  INDENT "PPM frame"

--- a/radio/src/translations/fr.h
+++ b/radio/src/translations/fr.h
@@ -282,7 +282,7 @@
 #define TR_TTRACE                      TR("Source gaz", INDENT "Source")
 #define TR_TTRIM                       TR("Trim gaz", INDENT "Trim ralenti uniq.")
 #define TR_TTRIM_SW                    TR("T-Trim-Sw", INDENT "Trim switch")
-#define TR_BEEPCTR                     TR("Bip centr.", "Bip centrage")
+#define TR_BEEPCTR                     TR("Ctr Beep", "Bip quand centré")
 #define TR_USE_GLOBAL_FUNCS            TR("Fonc. glob.", "Fonct. Globales")
 #define TR_PROTOCOL                    TR("Proto.", "Protocole")
 #define TR_PPMFRAME                    INDENT "Trame PPM"

--- a/radio/src/translations/he.h
+++ b/radio/src/translations/he.h
@@ -279,7 +279,7 @@
 #define TR_TTRACE                      TR("T-Source", INDENT "מקור")
 #define TR_TTRIM                       TR("T-Trim-Idle", INDENT "Trim idle only")
 #define TR_TTRIM_SW                    TR("T-Trim-Sw", INDENT "מתג קיזוז")
-#define TR_BEEPCTR                     TR("Ctr Beep", "Center Beep")
+#define TR_BEEPCTR                     TR("Ctr Beep", "ציפצוף במרכז")
 #define TR_USE_GLOBAL_FUNCS            TR("Glob.Funcs", "שימוש בפונקציות גלובליות")
 #define TR_PROTOCOL                    TR("Proto", "Protocol")
 #define TR_PPMFRAME                    INDENT "PPM frame"

--- a/radio/src/translations/it.h
+++ b/radio/src/translations/it.h
@@ -275,7 +275,7 @@
 #define TR_TTRACE                       TR("Sor. Mot.", INDENT "Sorgente Motore")
 #define TR_TTRIM                        TR("Trim Mot.", INDENT "Trim Motore")
 #define TR_TTRIM_SW                     TR("T-Trim-Sw", INDENT "Trim switch")
-#define TR_BEEPCTR                      TR("Beep al c.", "Beep al centro")
+#define TR_BEEPCTR                      TR("Beep Ctr", "Beep quando centrato")
 #define TR_USE_GLOBAL_FUNCS             TR("Funz. Glob.", "Usa Funz. Globali")
 #define TR_PROTOCOL                     TR("Protoc.", "Protocollo")
 #define TR_PPMFRAME                     INDENT "Frame PPM"

--- a/radio/src/translations/pl.h
+++ b/radio/src/translations/pl.h
@@ -272,7 +272,7 @@
 #define TR_TTRACE              TR("Źród gaz", INDENT "Źródło gazu ")
 #define TR_TTRIM               TR("TryGaz", INDENT "TrymWolnObrotó")
 #define TR_TTRIM_SW            TR("T-Trim-Sw", INDENT "Trim switch")
-#define TR_BEEPCTR             TR("ŚrodBeep", "Pikn.Środka")
+#define TR_BEEPCTR             TR("Dźwięk środ.", "Dźwięk środ. położenia")
 #define TR_USE_GLOBAL_FUNCS    TR("Funk.Glb.","Użyj Funkcji Glb")
 #define TR_PROTOCOL            TR("Proto", "Protokół")
 #define TR_PPMFRAME            INDENT "Ramka PPM"

--- a/radio/src/translations/ru.h
+++ b/radio/src/translations/ru.h
@@ -277,7 +277,7 @@
 #define TR_TTRACE                      TR("Т-источник", INDENT "Источник")
 #define TR_TTRIM                       TR("Т-трим-ХХ", INDENT "Только трим хх")
 #define TR_TTRIM_SW                    TR("Т-трим-перек", INDENT "Трим перек")
-#define TR_BEEPCTR                     TR("Цент. звук", "Звук в центре")
+#define TR_BEEPCTR                     TR("Звук на цен", "Звук на центре")
 #define TR_USE_GLOBAL_FUNCS            TR("Глоб. функц", "Глоб функц")
 #define TR_PROTOCOL                    TR("Проток", "Протокол")
   #define TR_PPMFRAME                  INDENT "Фрейм PPM"

--- a/radio/src/translations/se.h
+++ b/radio/src/translations/se.h
@@ -288,7 +288,7 @@
 #define TR_TTRACE                       TR("Källa", INDENT "Källa")
 #define TR_TTRIM                        TR("Gastrimm", INDENT "Trimma endast tomgång")
 #define TR_TTRIM_SW                     TR("Trimmknp", INDENT "Trimmknapp")
-#define TR_BEEPCTR                      TR("Cent.pip", "Centerpip")
+#define TR_BEEPCTR                      TR("Cntr. pip", "Pip när centrerad")
 #define TR_USE_GLOBAL_FUNCS             TR("Glob.funk.", "Anv. globala funk.")
 #define TR_PROTOCOL                     TR("Proto.", "Protokoll")
 #define TR_PPMFRAME                     INDENT "PPM-paket"

--- a/radio/src/translations/tw.h
+++ b/radio/src/translations/tw.h
@@ -276,7 +276,7 @@
 #define TR_TTRACE                      TR("輸入源", INDENT "輸入源")
 #define TR_TTRIM                       TR("油門微調僅怠速", INDENT "油門微調只調整怠速")
 #define TR_TTRIM_SW                    TR("微調選擇", INDENT "微調選擇")
-#define TR_BEEPCTR                     TR("中點蜂鳴", "中點蜂鳴")
+#define TR_BEEPCTR                     TR("中點提示音", "中點蜂鳴提示音")
 #define TR_USE_GLOBAL_FUNCS            TR("全局功能", "全局功能可介入")
 #define TR_PPMFRAME INDENT             "PPM幀"
 #define TR_REFRESHRATE                 TR(INDENT "刷新率", INDENT "刷新速率")
@@ -1114,7 +1114,7 @@
 #define TR_CURRENTSENSOR               "傳感器"
 #define TR_AUTOOFFSET                  "自動偏移值"
 #define TR_ONLYPOSITIVE                "正向"
-#define TR_FILTER                      "濾波"
+#define TR_FILTER                      "濾波器"
 #define TR_TELEMETRYFULL               TR("項目已滿!", "回傳項目已滿!")
 #define TR_INVERTED_SERIAL             INDENT "反向"
 #define TR_IGNORE_INSTANCE             TR(INDENT "忽略ID", INDENT "忽略ID鑑別")
@@ -1158,7 +1158,7 @@
 #define TR_MENU_OTHER                  "其它"
 #define TR_MENU_INVERT                 "反向"
 #define TR_AUDIO_MUTE                  TR("自動靜音","音頻停播時自動靜音")
-#define TR_JITTER_FILTER               "類比輸入濾波"
+#define TR_JITTER_FILTER               "ADC濾波器"
 #define TR_DEAD_ZONE                   "死區"
 #define TR_RTC_CHECK                   TR("檢查時間電池", "檢查時間驅動電池電壓")
 #define TR_AUTH_FAILURE                "驗證失敗"


### PR DESCRIPTION
The 'Center Beep' setting does not really belong in Pre-start Checks.

This PR moves Center Beep and ADC filter into a new model setup page (to avoid cluttering the main setup page).

![screenshot_tx16s_24-03-14_19-55-52](https://github.com/EdgeTX/edgetx/assets/9474356/db896b31-120b-427c-b37c-1b6dfbfcdd39)
![screenshot_tx16s_24-03-14_19-55-57](https://github.com/EdgeTX/edgetx/assets/9474356/7054389d-e28f-4090-ba99-61a92b436a46)
![screenshot_tx16s_24-03-14_19-56-03](https://github.com/EdgeTX/edgetx/assets/9474356/6a03270d-c343-4f71-b324-470ad6076e9e)

![screenshot_el18_24-03-15_09-29-15](https://github.com/EdgeTX/edgetx/assets/9474356/c1dd8f98-73c3-4267-9f4c-3351e109a046)
![screenshot_el18_24-03-15_09-29-23](https://github.com/EdgeTX/edgetx/assets/9474356/2224f2a0-8119-42ab-b45a-8ed58277c3fd)
