### PR TITLE
fix(cpn): battery level incorrect in simulator for B&W radios

### DIFF
--- a/radio/src/targets/simu/adc_driver.cpp
+++ b/radio/src/targets/simu/adc_driver.cpp
@@ -43,8 +43,12 @@ static bool simu_start_conversion()
 
   // set VBAT / RTC_BAT
   if (adcGetMaxInputs(ADC_INPUT_VBAT) > 0) {
-    uint32_t vbat = (BATTERY_MAX + BATTERY_MIN) / 2;
-    vbat = (vbat * BATTERY_DIVIDER) / 100;
+    uint32_t vbat = (BATTERY_MAX + BATTERY_MIN) * 5; // * 10 / 2
+#if defined(BATT_SCALE)
+    vbat = ((vbat - VOLTAGE_DROP) * BATTERY_DIVIDER) / (BATT_SCALE * 128);
+#else
+    vbat = (vbat * BATTERY_DIVIDER) / 1000;
+#endif
     setAnalogValue(adcGetInputOffset(ADC_INPUT_VBAT), vbat * 2);
   }
 


### PR DESCRIPTION
The battery level reported to the simulator is supposed to be halfway between battery min and max.

Fixes the initial value for the battery ADC channel in the simulator to match the code that converts this to a battery voltage.