### PR TITLE
fix: possible ghaction crash fix

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -84,6 +84,7 @@ jobs:
           FLAVOR: ${{ matrix.target }}
         run: |
           echo "Running commit tests"
+          sysctl vm.mmap_rnd_bits=28
           ./tools/commit-tests.sh
 
 
@@ -126,6 +127,7 @@ jobs:
           FLAVOR: ${{ matrix.target }}
         run: |
           echo "Running firmware build"
+          sysctl vm.mmap_rnd_bits=28
           ./tools/build-gh.sh
 
       - name: Upload ${{ matrix.target }}

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -73,6 +73,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}:/src
     steps:
+      - run: sudo sysctl -w vm.mmap_rnd_bits=28
       - name: Check out the repo
         uses: actions/checkout@v4
         with:
@@ -84,7 +85,6 @@ jobs:
           FLAVOR: ${{ matrix.target }}
         run: |
           echo "Running commit tests"
-          sysctl vm.mmap_rnd_bits=28
           ./tools/commit-tests.sh
 
 
@@ -117,6 +117,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}:/src
     steps:
+      - run: sudo sysctl -w vm.mmap_rnd_bits=28
       - name: Check out the repo
         uses: actions/checkout@v4
         with:
@@ -127,7 +128,6 @@ jobs:
           FLAVOR: ${{ matrix.target }}
         run: |
           echo "Running firmware build"
-          sysctl vm.mmap_rnd_bits=28
           ./tools/build-gh.sh
 
       - name: Upload ${{ matrix.target }}

--- a/.github/workflows/linux_cpn.yml
+++ b/.github/workflows/linux_cpn.yml
@@ -43,6 +43,7 @@ jobs:
         working-directory: ${{github.workspace}}
         shell: bash
         run: |
+          sysctl vm.mmap_rnd_bits=28 &&
           mkdir output && \
           tools/build-companion.sh "$(pwd)" "$(pwd)/output/"
 

--- a/.github/workflows/linux_cpn.yml
+++ b/.github/workflows/linux_cpn.yml
@@ -34,6 +34,7 @@ jobs:
         - ${{ github.workspace }}:/src
 
     steps:
+      - run: sudo sysctl -w vm.mmap_rnd_bits=28
       - name: Check out the repo
         uses: actions/checkout@v4
         with:
@@ -43,7 +44,6 @@ jobs:
         working-directory: ${{github.workspace}}
         shell: bash
         run: |
-          sysctl vm.mmap_rnd_bits=28 &&
           mkdir output && \
           tools/build-companion.sh "$(pwd)" "$(pwd)/output/"
 

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -38,6 +38,7 @@ jobs:
       volumes:
         - ${{ github.workspace }}:/src
     steps:
+      - run: sudo sysctl -w vm.mmap_rnd_bits=28
       - name: Check out the repo
         uses: actions/checkout@v4
         with:
@@ -48,7 +49,6 @@ jobs:
           FLAVOR: ${{ matrix.target }}
           EDGETX_VERSION_SUFFIX: nightly
         run: |
-          sysctl vm.mmap_rnd_bits=28
           ./tools/build-gh.sh
 
       - name: Package firmware ${{ matrix.target }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -47,7 +47,9 @@ jobs:
         env:
           FLAVOR: ${{ matrix.target }}
           EDGETX_VERSION_SUFFIX: nightly
-        run: ./tools/build-gh.sh
+        run: |
+          sysctl vm.mmap_rnd_bits=28
+          ./tools/build-gh.sh
 
       - name: Package firmware ${{ matrix.target }}
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
Summary of changes:
- linux gh actions have been randomly crashing for the last 4 days, seemingly due to either resource starvation or network issues, even though there has been no change on our end at all. It is actually possible it is due to a updated gh actions linux image. This is schedule to be fixed next week, so this is a test of a stopgap measure that may work in the meantime. 


