### PR TITLE
chore(radio): reduce USB string buffer by 414 bytes

### DIFF
--- a/radio/src/targets/common/arm/stm32/usbd_conf.h
+++ b/radio/src/targets/common/arm/stm32/usbd_conf.h
@@ -78,7 +78,7 @@
 /*---------- -----------*/
 #define USBD_MAX_NUM_CONFIGURATION 1U
 /*---------- -----------*/
-#define USBD_MAX_STR_DESC_SIZ      99U
+#define USBD_MAX_STR_DESC_SIZ      98U
 /*---------- -----------*/
 #define USBD_DEBUG_LEVEL           0U
 /*---------- -----------*/

--- a/radio/src/targets/common/arm/stm32/usbd_conf.h
+++ b/radio/src/targets/common/arm/stm32/usbd_conf.h
@@ -78,7 +78,7 @@
 /*---------- -----------*/
 #define USBD_MAX_NUM_CONFIGURATION 1U
 /*---------- -----------*/
-#define USBD_MAX_STR_DESC_SIZ      512U
+#define USBD_MAX_STR_DESC_SIZ      99U
 /*---------- -----------*/
 #define USBD_DEBUG_LEVEL           0U
 /*---------- -----------*/


### PR DESCRIPTION
Currently the longest string encoded by the USB interface is "Radiomaster Pocket Mass Storage".

The USB string descriptor for that is:
66 bytes = 1 (length) + 1 (type) + 32 * 2 (payload in UTF 16)

Reduce the buffer size from 512 to 98.
The longest supported string length thus changes from 255 chars to 48 chars.