### PR TITLE
fixcpn): use model semver over radio semver for decoding model sources and switches

### DIFF
--- a/companion/src/firmwares/edgetx/yaml_rawsource.cpp
+++ b/companion/src/firmwares/edgetx/yaml_rawsource.cpp
@@ -263,7 +263,7 @@ RawSource YamlRawSourceDecode(const std::string& src_str)
     std::string ana_str;
     node >> ana_str;
 
-    if (radioSettingsVersion < SemanticVersion(QString(CPN_ADC_REFACTOR_VERSION))) {
+    if (modelSettingsVersion < SemanticVersion(QString(CPN_ADC_REFACTOR_VERSION))) {
       ana_str = Boards::getLegacyAnalogMappedInputTag(ana_str.c_str());
       int idx = Boards::getInputIndex(ana_str.c_str(), Board::LVT_TAG);
       if (idx >= 0 && Boards::isInputStick(idx))
@@ -280,7 +280,7 @@ RawSource YamlRawSourceDecode(const std::string& src_str)
     std::string trim_str;
     node >> trim_str;
 
-    if (radioSettingsVersion < SemanticVersion(QString(CPN_ADC_REFACTOR_VERSION))) {
+    if (modelSettingsVersion < SemanticVersion(QString(CPN_ADC_REFACTOR_VERSION))) {
       int idx = b.getLegacyTrimSourceIndex(src_str.c_str());
       if (idx >= 0)
         trim_str = Boards::getTrimYamlName(idx, BoardJson::YLT_REF).toStdString();
@@ -296,7 +296,7 @@ RawSource YamlRawSourceDecode(const std::string& src_str)
     std::string special_str;
     node >> special_str;
 
-    if (radioSettingsVersion < SemanticVersion(QString(CPN_ADC_REFACTOR_VERSION))) {
+    if (modelSettingsVersion < SemanticVersion(QString(CPN_ADC_REFACTOR_VERSION))) {
       if (special_str.size() == 6 && special_str.substr(0, 5) == "TIMER") {
         special_str = "Tmr" + special_str.substr(5, 1);
       }

--- a/companion/src/firmwares/edgetx/yaml_rawswitch.cpp
+++ b/companion/src/firmwares/edgetx/yaml_rawswitch.cpp
@@ -119,7 +119,7 @@ RawSwitch YamlRawSwitchDecode(const std::string& sw_str)
     try {
       mp_input_index = std::stoi(sw_str_tmp.substr(2, val_len - 3));
 
-      if (radioSettingsVersion < SemanticVersion(QString(CPN_ADC_REFACTOR_VERSION))) {
+      if (modelSettingsVersion < SemanticVersion(QString(CPN_ADC_REFACTOR_VERSION))) {
         if (IS_HORUS_X10(board) || IS_FAMILY_T16(board)) {
           if (mp_input_index > 2)
             mp_input_index += 2;


### PR DESCRIPTION
Fixes #4759 and also display message for each model file where the version is ahead of Companion.
