### PR TITLE
feat: only allow flash when target matches

### DIFF
--- a/radio/src/io/bootloader_flash.cpp
+++ b/radio/src/io/bootloader_flash.cpp
@@ -43,7 +43,15 @@ bool isBootloader(const char * filename)
     return false;
   }
 
-  return isBootloaderStart(buffer);
+  // Check firmware is for this radio
+  for (int i = 0; i < 1024; i++) {
+    if (memcmp(buffer + i, FLAVOUR, sizeof(FLAVOUR) - 1) == 0) {
+      if (buffer[i + sizeof(FLAVOUR) - 1] == '-')
+        return isBootloaderStart(buffer);;
+      return false;
+    }
+  }
+  return false;
 }
 
 void BootloaderFirmwareUpdate::flashFirmware(const char * filename, ProgressHandler progressHandler)

--- a/radio/src/targets/horus/bootloader/boot_menu.cpp
+++ b/radio/src/targets/horus/bootloader/boot_menu.cpp
@@ -140,16 +140,21 @@ void bootloaderDrawScreen(BootloaderState st, int opt, const char* str)
             memset(&tag, 0, sizeof(tag));
             extractFirmwareVersion(&tag);
 
-            lcd->drawText(168, 138, TR_BL_FORK, RIGHT | BL_FOREGROUND);
-            lcd->drawSizedText(174, 138, tag.fork, 6, BL_FOREGROUND);
+            if (strcmp(tag.flavour, FLAVOUR)) {
+              lcd->drawText(94, 168, LV_SYMBOL_CLOSE " " TR_BL_INVALID_FIRMWARE,
+                      BL_FOREGROUND);
+            } else {
+              lcd->drawText(168, 138, TR_BL_FORK, RIGHT | BL_FOREGROUND);
+              lcd->drawSizedText(174, 138, tag.fork, 6, BL_FOREGROUND);
 
-            lcd->drawText(168, 158, TR_BL_VERSION, RIGHT | BL_FOREGROUND);
-            lcd->drawText(174, 158, tag.version, BL_FOREGROUND);
+              lcd->drawText(168, 158, TR_BL_VERSION, RIGHT | BL_FOREGROUND);
+              lcd->drawText(174, 158, tag.version, BL_FOREGROUND);
 
-            lcd->drawText(168, 178, TR_BL_RADIO, RIGHT | BL_FOREGROUND);
-            lcd->drawText(174, 178, tag.flavour, BL_FOREGROUND);
+              lcd->drawText(168, 178, TR_BL_RADIO, RIGHT | BL_FOREGROUND);
+              lcd->drawText(174, 178, tag.flavour, BL_FOREGROUND);
 
-            lcd->drawText(78, 158, LV_SYMBOL_OK, BL_GREEN);
+              lcd->drawText(78, 158, LV_SYMBOL_OK, BL_GREEN);
+            }
           }
         }
 

--- a/radio/src/targets/nv14/bootloader/boot_menu.cpp
+++ b/radio/src/targets/nv14/bootloader/boot_menu.cpp
@@ -167,27 +167,32 @@ void bootloaderDrawScreen(BootloaderState st, int opt, const char* str)
           memset(&tag, 0, sizeof(tag));
           extractFirmwareVersion(&tag);
 
-          lcd->drawText(LCD_W / 4 + DEFAULT_PADDING,
-                        MESSAGE_TOP - DEFAULT_PADDING,
-                        TR_BL_FORK, RIGHT | BL_FOREGROUND);
-          lcd->drawSizedText(LCD_W / 4 + 6 + DEFAULT_PADDING,
-                             MESSAGE_TOP - DEFAULT_PADDING, tag.fork, 6,
-                             BL_FOREGROUND);
+          if (strcmp(tag.flavour, FLAVOUR)) {
+            lcd->drawText(20, MESSAGE_TOP, LV_SYMBOL_CLOSE " " TR_BL_INVALID_FIRMWARE,
+                    BL_FOREGROUND);
+          } else {
+            lcd->drawText(LCD_W / 4 + DEFAULT_PADDING,
+                          MESSAGE_TOP - DEFAULT_PADDING,
+                          TR_BL_FORK, RIGHT | BL_FOREGROUND);
+            lcd->drawSizedText(LCD_W / 4 + 6 + DEFAULT_PADDING,
+                               MESSAGE_TOP - DEFAULT_PADDING, tag.fork, 6,
+                               BL_FOREGROUND);
 
-          lcd->drawText(LCD_W / 4 + DEFAULT_PADDING, MESSAGE_TOP,
-                        TR_BL_VERSION, RIGHT | BL_FOREGROUND);
-          lcd->drawText(LCD_W / 4 + 6 + DEFAULT_PADDING, MESSAGE_TOP,
-                        tag.version, BL_FOREGROUND);
+            lcd->drawText(LCD_W / 4 + DEFAULT_PADDING, MESSAGE_TOP,
+                          TR_BL_VERSION, RIGHT | BL_FOREGROUND);
+            lcd->drawText(LCD_W / 4 + 6 + DEFAULT_PADDING, MESSAGE_TOP,
+                          tag.version, BL_FOREGROUND);
 
-          lcd->drawText(LCD_W / 4 + DEFAULT_PADDING,
-                        MESSAGE_TOP + DEFAULT_PADDING,
-                        TR_BL_RADIO, RIGHT | BL_FOREGROUND);
-          lcd->drawText(LCD_W / 4 + 6 + DEFAULT_PADDING,
-                        MESSAGE_TOP + DEFAULT_PADDING, tag.flavour,
-                        BL_FOREGROUND);
+            lcd->drawText(LCD_W / 4 + DEFAULT_PADDING,
+                          MESSAGE_TOP + DEFAULT_PADDING,
+                          TR_BL_RADIO, RIGHT | BL_FOREGROUND);
+            lcd->drawText(LCD_W / 4 + 6 + DEFAULT_PADDING,
+                          MESSAGE_TOP + DEFAULT_PADDING, tag.flavour,
+                          BL_FOREGROUND);
 
-          lcd->drawText(LCD_W / 4 + DEFAULT_PADDING - 90, MESSAGE_TOP,
-                        LV_SYMBOL_OK, BL_GREEN);
+            lcd->drawText(LCD_W / 4 + DEFAULT_PADDING - 90, MESSAGE_TOP,
+                          LV_SYMBOL_OK, BL_GREEN);
+          }
         }
       }
 

--- a/radio/src/targets/pl18/bootloader/boot_menu.cpp
+++ b/radio/src/targets/pl18/bootloader/boot_menu.cpp
@@ -187,27 +187,31 @@ void bootloaderDrawScreen(BootloaderState st, int opt, const char* str)
           VersionTag tag;
           memset(&tag, 0, sizeof(tag));
           extractFirmwareVersion(&tag);
+          if (strcmp(tag.flavour, FLAVOUR)) {
+            lcd->drawText(20, MESSAGE_TOP, LV_SYMBOL_CLOSE " " TR_BL_INVALID_FIRMWARE,
+                    BL_FOREGROUND);
+          } else {
+            lcd->drawText(LCD_W / 4 + DEFAULT_PADDING,
+                          MESSAGE_TOP - DEFAULT_PADDING,
+                          TR_BL_FORK, RIGHT | BL_FOREGROUND);
+            lcd->drawSizedText(LCD_W / 4 + 6 + DEFAULT_PADDING,
+                               MESSAGE_TOP - DEFAULT_PADDING, tag.fork, 6,
+                               BL_FOREGROUND);
 
-          lcd->drawText(LCD_W / 4 + DEFAULT_PADDING,
-                        MESSAGE_TOP - DEFAULT_PADDING,
-                        TR_BL_FORK, RIGHT | BL_FOREGROUND);
-          lcd->drawSizedText(LCD_W / 4 + 6 + DEFAULT_PADDING,
-                             MESSAGE_TOP - DEFAULT_PADDING, tag.fork, 6,
-                             BL_FOREGROUND);
+            lcd->drawText(LCD_W / 4 + DEFAULT_PADDING, MESSAGE_TOP,
+                          TR_BL_VERSION, RIGHT | BL_FOREGROUND);
+            lcd->drawText(LCD_W / 4 + 6 + DEFAULT_PADDING, MESSAGE_TOP,
+                          tag.version, BL_FOREGROUND);
 
-          lcd->drawText(LCD_W / 4 + DEFAULT_PADDING, MESSAGE_TOP,
-                        TR_BL_VERSION, RIGHT | BL_FOREGROUND);
-          lcd->drawText(LCD_W / 4 + 6 + DEFAULT_PADDING, MESSAGE_TOP,
-                        tag.version, BL_FOREGROUND);
+            lcd->drawText(LCD_W / 4 + DEFAULT_PADDING,
+                          MESSAGE_TOP + DEFAULT_PADDING,
+                          TR_BL_RADIO, RIGHT | BL_FOREGROUND);
+            lcd->drawText(LCD_W / 4 + 6 + DEFAULT_PADDING,
+                          MESSAGE_TOP + DEFAULT_PADDING, tag.flavour,
+                          BL_FOREGROUND);
 
-          lcd->drawText(LCD_W / 4 + DEFAULT_PADDING,
-                        MESSAGE_TOP + DEFAULT_PADDING,
-                        TR_BL_RADIO, RIGHT | BL_FOREGROUND);
-          lcd->drawText(LCD_W / 4 + 6 + DEFAULT_PADDING,
-                        MESSAGE_TOP + DEFAULT_PADDING, tag.flavour,
-                        BL_FOREGROUND);
-
-          lcd->drawText(DOUBLE_PADDING, MESSAGE_TOP, LV_SYMBOL_OK, BL_GREEN);
+            lcd->drawText(DOUBLE_PADDING, MESSAGE_TOP, LV_SYMBOL_OK, BL_GREEN);
+          }
         }
       }
 


### PR DESCRIPTION
Only allow to flash firmware when firmware target matches radio type

Tested on BW and TX16S

Should be ok but untested on NV14 and PL18
