### PR TITLE
chore: redefinition warning for `INTMODULE_BOOTCMD_GPIO`

### DIFF
--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -2033,7 +2033,6 @@
   #define INTMODULE_BOOTCMD_DEFAULT     0 // RESET
 #else
   #define INTMODULE_PWR_GPIO_PIN        GPIO_Pin_4  // PC.04
-  #define INTMODULE_BOOTCMD_GPIO        GPIOB
 #if defined(RADIO_T14)
   #define INTMODULE_BOOTCMD_GPIO        GPIOE
   #define INTMODULE_BOOTCMD_GPIO_PIN    GPIO_Pin_14 // PE.14


### PR DESCRIPTION
Remove redefinition warning