### PR TITLE
fix(cpn): multi protocol and sd card updates

### DIFF
--- a/companion/src/updates/repo.cpp
+++ b/companion/src/updates/repo.cpp
@@ -41,7 +41,7 @@ Repo::~Repo()
 
 bool Repo::getJson(const QString filename, QJsonDocument * json)
 {
-  m_network->downloadJson(m_releases->urlContent(filename), json);
+  m_network->downloadJsonContent(m_releases->urlContent(filename), json);
 
   if (!m_network->isSuccess()) {
     m_status->reportProgress("Unable to download json data", QtDebugMsg);

--- a/companion/src/updates/repoassets.cpp
+++ b/companion/src/updates/repoassets.cpp
@@ -153,7 +153,7 @@ void RepoAssets::dumpItemModel(const QString modelName, const QAbstractItemModel
 
 bool RepoAssets::getJson(QJsonDocument * json)
 {
-  network()->downloadJson(urlAsset(id()), json);
+  network()->downloadJsonAsset(urlAsset(id()), json);
 
   if (!network()->isSuccess()) {
     status()->reportProgress("Unable to download json data", QtDebugMsg);

--- a/companion/src/updates/updatemultiprotocol.cpp
+++ b/companion/src/updates/updatemultiprotocol.cpp
@@ -25,7 +25,7 @@ UpdateMultiProtocol::UpdateMultiProtocol(QWidget * parent) :
   UpdateInterface(parent, CID_MultiProtocol, tr("Multiprotocol"))
 {
   // GitHub REST API default ResultsPerPage = 30
-  init(QString(GH_API_REPOS).append("/pascallanger/DIY-Multiprotocol-TX-Module"), "", 50);
+  init(QString(GH_API_REPOS).append("/pascallanger/DIY-Multiprotocol-TX-Module"), "", 100);
 }
 
 void UpdateMultiProtocol::assetSettingsInit()

--- a/companion/src/updates/updatenetwork.cpp
+++ b/companion/src/updates/updatenetwork.cpp
@@ -26,9 +26,9 @@
 #include <QtNetwork/QNetworkProxyFactory>
 
 constexpr char GH_API_VERSION[]               {"2022-11-28"};
-constexpr char GH_ACCEPT_HEADER_CONTENT[]      {"application/octet-stream"};
+constexpr char GH_ACCEPT_HEADER_CONTENT[]     {"application/octet-stream"};
 constexpr char GH_ACCEPT_HEADER_METADATA[]    {"application/vnd.github+json"};
-// constexpr char GH_ACCEPT_HEADER_RAW[]         {"application/vnd.github.raw"};
+constexpr char GH_ACCEPT_HEADER_RAW[]         {"application/vnd.github.raw+json"};
 
 UpdateNetwork::UpdateNetwork(QObject * parent, UpdateStatus * status) :
   QObject(parent),
@@ -59,6 +59,8 @@ QString UpdateNetwork::downloadDataTypeToString(const DownloadDataType val)
       return "Content";
     case DDT_MetaData:
       return "Meta Data";
+    case DDT_Raw:
+      return "Raw";
     default:
       return CPN_STR_UNKNOWN_ITEM;
   }
@@ -78,10 +80,28 @@ void UpdateNetwork::downloadJson(const QString & url, QJsonDocument * json)
     convertBufferToJson(json);
 }
 
+void UpdateNetwork::downloadJsonAsset(const QString & url, QJsonDocument * json)
+{
+  downloadToBuffer(DDT_Content, url);
+  if (m_success)
+    convertBufferToJson(json);
+}
+
+void UpdateNetwork::downloadJsonContent(const QString & url, QJsonDocument * json)
+{
+  downloadToBuffer(DDT_Raw, url);
+  if (m_success)
+    convertBufferToJson(json);
+}
+
 void UpdateNetwork::downloadToBuffer(const DownloadDataType type, const QString & url)
 {
   m_success = false;
-  download(type, url, type == DDT_MetaData ? GH_ACCEPT_HEADER_METADATA : GH_ACCEPT_HEADER_CONTENT, QString());
+  download(type,
+           url,
+           type == DDT_MetaData ? GH_ACCEPT_HEADER_METADATA :
+                                  type == DDT_Raw ? GH_ACCEPT_HEADER_RAW : GH_ACCEPT_HEADER_CONTENT,
+           QString());
 }
 
 void UpdateNetwork::downloadToFile(const QString & url, const QString & filePath)

--- a/companion/src/updates/updatenetwork.h
+++ b/companion/src/updates/updatenetwork.h
@@ -39,6 +39,7 @@ class UpdateNetwork : public QObject
       DDT_Content,
       DDT_SaveToFile,
       DDT_MetaData,
+      DDT_Raw,
     };
     Q_ENUM(DownloadDataType)
 
@@ -48,6 +49,8 @@ class UpdateNetwork : public QObject
     void convertBufferToJson(QJsonDocument * json);
     void downloadMetaData(const QString & url, QJsonDocument * json);
     void downloadJson(const QString & url, QJsonDocument * json);
+    void downloadJsonAsset(const QString & url, QJsonDocument * json);
+    void downloadJsonContent(const QString & url, QJsonDocument * json);
     void downloadToFile(const QString & url, const QString & filePath);
     void downloadToBuffer(const DownloadDataType type, const QString & url);
     void download(const DownloadDataType type, const QString & urlStr, const char * header, const QString & filePath);


### PR DESCRIPTION
Fixes #4773

Summary of changes:
- increase the maximum results per page from 50 to 100 for multi protocol update
- use different gh media types for repo content and release asset json files (use case sd card fallback to content when no release asset found)