### PR TITLE
fix(cpn): T20V2 simulator uses the 9X UI in Companion.

### DIFF
--- a/companion/src/simulation/simulatorwidget.cpp
+++ b/companion/src/simulation/simulatorwidget.cpp
@@ -115,6 +115,7 @@ SimulatorWidget::SimulatorWidget(QWidget * parent, SimulatorInterface * simulato
       radioUiWidget = new SimulatedUIWidgetJumperT18(simulator, this);
       break;
     case Board::BOARD_JUMPER_T20:
+    case Board::BOARD_JUMPER_T20V2:
       radioUiWidget = new SimulatedUIWidgetJumperT20(simulator, this);
       break;
     case Board::BOARD_RADIOMASTER_TX12:


### PR DESCRIPTION
Use T20 simulator UI for T20V2.
