### PR TITLE
chore: Do not display trims position when trim is set as 3POS

### DIFF
--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -162,7 +162,7 @@ void displayTrims(uint8_t phase)
     uint8_t att = ROUND;
     int16_t val = getTrimValue(phase, i);
 
-    if (getRawTrimValue(phase, i).mode == TRIM_MODE_NONE)
+    if (getRawTrimValue(phase, i).mode == TRIM_MODE_NONE || getRawTrimValue(phase, i).mode == TRIM_MODE_3POS)
       continue;
 
     int16_t dir = val;

--- a/radio/src/gui/212x64/view_main.cpp
+++ b/radio/src/gui/212x64/view_main.cpp
@@ -124,7 +124,7 @@ void displayTrims(uint8_t phase)
     int32_t val = trim;
     bool exttrim = false;
 
-    if(getRawTrimValue(phase, i).mode == TRIM_MODE_NONE)
+    if(getRawTrimValue(phase, i).mode == TRIM_MODE_NONE || getRawTrimValue(phase, i).mode == TRIM_MODE_3POS)
       continue;
 
     if (val < TRIM_MIN || val > TRIM_MAX) {

--- a/radio/src/gui/colorlcd/layouts/trims.cpp
+++ b/radio/src/gui/colorlcd/layouts/trims.cpp
@@ -48,6 +48,18 @@ void MainViewTrim::checkEvents()
 {
   Window::checkEvents();
   int8_t stickIndex = inputMappingConvertMode(idx);
+
+  trim_t v = getRawTrimValue(mixerCurrentFlightMode, stickIndex);
+  if (v.mode == TRIM_MODE_NONE || v.mode == TRIM_MODE_3POS) {
+    // Hide trim if not being used
+    if (!lv_obj_has_flag(lvobj, LV_OBJ_FLAG_HIDDEN))
+      lv_obj_add_flag(lvobj, LV_OBJ_FLAG_HIDDEN);
+    return;
+  } else {
+    if (lv_obj_has_flag(lvobj, LV_OBJ_FLAG_HIDDEN))
+      lv_obj_clear_flag(lvobj, LV_OBJ_FLAG_HIDDEN);
+  }
+
   int newValue = getTrimValue(mixerCurrentFlightMode, stickIndex);
 
   setRange();


### PR DESCRIPTION
Do not draw the trim position indicator when trims are set to 3POS