### PR TITLE
fix(bw): USB popup menu may not close.

### DIFF
--- a/radio/src/main.cpp
+++ b/radio/src/main.cpp
@@ -130,6 +130,7 @@ void openUsbMenu()
 
 void closeUsbMenu()
 {
+  CLEAR_POPUP();
 }
 
 #endif


### PR DESCRIPTION
On B&W radios, when the USB mode is set to 'ask' and a USB cable is connected a popup menu is shown.
If the USB cable is disconnected before a choice is made, the popup menu does not close.

This PR closes the popup menu when the USB cable is disconnected.
