### PR TITLE
fix(color): displayed image not always cleared when changing folder in SD browser

### DIFF
--- a/radio/src/gui/colorlcd/file_browser.cpp
+++ b/radio/src/gui/colorlcd/file_browser.cpp
@@ -279,6 +279,7 @@ void FileBrowser::onPress(const char* name, bool is_dir)
   const char* fullpath = getFullPath(name);  
   if (is_dir) {
     f_chdir(fullpath);
+    if (fileSelected) fileSelected(nullptr, nullptr, nullptr);
     refresh();
     return;
   }


### PR DESCRIPTION
When using the Radio SD Manager, after an image is selected, the displayed bitmap may not get cleared if the touch screen is used to change folder.
