### PR TITLE
fix(b&w): dial/slider bars can overlap on main view

### DIFF
--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -114,9 +114,9 @@ void drawPotsBars()
   for (uint8_t i = 0; i < max_pots; i++) {
     if (IS_POT_SLIDER_AVAILABLE(i)) {
       coord_t x = xstart + (i % cols) * 5;
-      coord_t y = lines == 1 ? (LCD_H - 8) : i >= cols ? (LCD_H - 8) : (LCD_H - 8 - BAR_HEIGHT / 2);
+      coord_t y = lines == 1 ? (LCD_H - 8) : i >= cols ? (LCD_H - 8) : (LCD_H - 8 - BAR_HEIGHT / 2 - 1);
       auto v = calibratedAnalogs[offset + i] + RESX;
-      uint8_t len = (v * BAR_HEIGHT / (RESX * 2 * lines)) + 1l;
+      uint8_t len = (v * (BAR_HEIGHT - 1) / (RESX * 2 * lines)) + 1l;
       V_BAR(x, y, len);
     }
   }

--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -116,7 +116,7 @@ void drawPotsBars()
       coord_t x = xstart + (i % cols) * 5;
       coord_t y = lines == 1 ? (LCD_H - 8) : i >= cols ? (LCD_H - 8) : (LCD_H - 8 - BAR_HEIGHT / 2 - 1);
       auto v = calibratedAnalogs[offset + i] + RESX;
-      uint8_t len = (v * (BAR_HEIGHT - 1) / (RESX * 2 * lines)) + 1l;
+      uint8_t len = (v * (BAR_HEIGHT - (lines - 1)) / (RESX * 2 * lines)) + 1l;
       V_BAR(x, y, len);
     }
   }


### PR DESCRIPTION
On radios like the T20, where there are more than 3 dials/sliders, the bottom row of bars can overlap the top row.

When a bar on the bottom row is at maximum value it overlaps the top row by 1 pixel.

This PR adjust the position and size of the bars so there is always a 1 pixel gap between the two rows.

Before - note the uneven appearance of the bottom point for the top row of bars.
![screenshot_t20v2_24-03-22_15-36-39](https://github.com/EdgeTX/edgetx/assets/9474356/03e9a2fa-5ed6-4000-9446-3668f605b236)

After - consistent display with 1 pixel gap.
![screenshot_t20v2_24-03-22_15-37-40](https://github.com/EdgeTX/edgetx/assets/9474356/1dbd1588-d701-47c0-99b4-fb0c6b5eb803)
