### PR TITLE
fix(mt12): bootloader startup uses wrong trim switch direction.

### DIFF
--- a/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
+++ b/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
@@ -44,7 +44,7 @@
 #if defined(PCBXLITE)
   #define BOOTLOADER_KEYS                 0x0F
 #elif defined(RADIO_MT12)
-  #define BOOTLOADER_KEYS                 0x09
+  #define BOOTLOADER_KEYS                 0x06
 #else
   #define BOOTLOADER_KEYS                 0x42
 #endif


### PR DESCRIPTION
Fixes the bootloader startup on the MT12 to be activated by pulling T1 and T2 towards each other.
