### PR TITLE
fix(cpn): allow PPM and SBUS on external rf standard size module

### DIFF
--- a/companion/src/firmwares/moduledata.cpp
+++ b/companion/src/firmwares/moduledata.cpp
@@ -580,6 +580,8 @@ bool ModuleData::isProtocolAvailable(int moduleidx, unsigned int protocol, Gener
               case MODULE_TYPE_FLYSKY_AFHDS2A:
               case MODULE_TYPE_FLYSKY_AFHDS3:
               case MODULE_TYPE_LEMON_DSMP:
+              case MODULE_TYPE_PPM:
+              case MODULE_TYPE_SBUS:
                 return true;
               default:
                 return false;


### PR DESCRIPTION
Fixes #4800
