### PR TITLE
fix: custom switches startup position need to be loaded on model change

### DIFF
--- a/radio/src/storage/storage_common.cpp
+++ b/radio/src/storage/storage_common.cpp
@@ -181,6 +181,10 @@ void postModelLoad(bool alarms)
   g_model.modelGVDisabled = false;
 #endif
 
+#if defined(FUNCTION_SWITCHES)
+  setFSStartupPosition();
+#endif
+
   // Convert 'noGlobalFunctions' to 'radioGFDisabled'
   // TODO: Remove sometime in the future (and remove 'noGlobalFunctions' property)
   if (g_model.noGlobalFunctions) {


### PR DESCRIPTION
While initial position was loaded on radio startup, "someone" forgot to load it on model changes too ...

Sorry