### PR TITLE
fix: Stack overflow in some non-English language versions.

### DIFF
--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -1078,7 +1078,7 @@ bool isTrainerModeAvailable(int mode)
 
 bool modelHasNotes()
 {
-  char filename[sizeof(MODELS_PATH)+1+sizeof(g_model.header.name)+sizeof(TEXT_EXT)] = MODELS_PATH "/";
+  char filename[sizeof(MODELS_PATH)+1+LEN_MODEL_NAME*3+sizeof(TEXT_EXT)] = MODELS_PATH "/";
   char *buf = strcat_currentmodelname(&filename[sizeof(MODELS_PATH)], 0);
   strcpy(buf, TEXT_EXT);
   if (isFileAvailable(filename)) {


### PR DESCRIPTION
The modelHasNotes() function allocates a string on the stack that is only long enough to handle the English version of STR_MODEL.

When using a non-English language build where the STR_MODEL string has unicode characters encoded with 2-byte or 3-byte character sequences, the modelHasNotes() function will cause a stack overflow.
