### PR TITLE
fix(usb): do not wait for send state

### DIFF
--- a/radio/src/cli.cpp
+++ b/radio/src/cli.cpp
@@ -1134,7 +1134,7 @@ int cliSerialPassthrough(const char **argv)
       cliReceiveCallBack = spInternalModuleTx;
 
       // loop until cable disconnected
-      while (cdcConnected) {
+      while (usbPlugged()) {
 
         uint32_t cli_br = cliGetBaudRate();
         if (cli_br && (cli_br != (uint32_t)baudrate)) {

--- a/radio/src/targets/common/arm/stm32/usbd_cdc.cpp
+++ b/radio/src/targets/common/arm/stm32/usbd_cdc.cpp
@@ -336,10 +336,6 @@ void usbSerialPutc(void*, uint8_t c)
   APP_Tx_ptr_in = (APP_Tx_ptr_in + 1) % APP_TX_DATA_SIZE;
 
   if (!prim) __enable_irq();
-  /* USER CODE BEGIN 7 */
-  USBD_CDC_HandleTypeDef *hcdc = (USBD_CDC_HandleTypeDef*)hUsbDeviceFS.pClassData;
-  while (hcdc->TxState != 0);
-  /* USER CODE END 7 */
 }
 
 /**


### PR DESCRIPTION
Fixes #4731
Fixes #4740 

Summary of changes:
- removed wait for send state from `usbSerialPutc()`.
- use `usbPlugged()` instead of `cdcConnected` as the later is updated from the UI task which is blocked while in passthrough mode.
