### PR TITLE
fix(lua): ignore potential unwanted key events

### DIFF
--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -1191,6 +1191,7 @@ static bool resumeLua(bool init, bool allowLcdUsage)
          
           if (scriptResult != 0) {
             TRACE("Script finished with status %d", scriptResult);
+            killAllEvents();
             luaState = INTERPRETER_RELOAD_PERMANENT_SCRIPTS;
           }
           else if (luaDisplayStatistics) {

--- a/radio/src/main.cpp
+++ b/radio/src/main.cpp
@@ -438,7 +438,16 @@ bool handleGui(event_t event) {
       menuHandlers[menuLevel] == menuViewTelemetry &&
       TELEMETRY_SCREEN_TYPE(s_frsky_view) == TELEMETRY_SCREEN_TYPE_SCRIPT;
   bool isStandalone = scriptInternalData[0].reference == SCRIPT_STANDALONE;
-  if (isTelemView || isStandalone) luaPushEvent(event);
+  if ((isTelemView || isStandalone) && event) {
+#if !defined(KEYS_GPIO_REG_PAGEUP)
+    // For radios with a single PAGE key, kill the
+    // EVT_KEY_BREAK event after a long press of the PAGE key.
+    if (event == EVT_KEY_LONG(KEY_PAGE)) {
+      killEvents(KEY_PAGE);
+    }
+#endif
+    luaPushEvent(event);
+  }
   refreshNeeded = luaTask(true);
   if (isTelemView)
     menuHandlers[menuLevel](event);


### PR DESCRIPTION
Ignore unwanted key events when using Lua scripts:
- For B&W radios with a single PAGE key, kill the EVT_KEY_BREAK event after a long press of the PAGE key (duplicates #2668 functionality for B&W radios).
- For all radios, when a Lua standalone script exits, kill all pending events. Prevents the script from restarting if a long press of the ENTER key is used to exit the script.
