### PR TITLE
chore(radio): cleanup -Wzero-as-null-pointer-constant warnings

### DIFF
--- a/radio/src/audio.h
+++ b/radio/src/audio.h
@@ -491,7 +491,7 @@ class AudioFragmentFifo
         }
         return result;
       }
-      return 0;
+      return nullptr;
     }
 
     void push(const AudioFragment & fragment)

--- a/radio/src/bin_allocator.cpp
+++ b/radio/src/bin_allocator.cpp
@@ -46,14 +46,14 @@ void * bin_malloc(size_t size) {
 
 void * bin_realloc(void * ptr, size_t size)
 {
-  if (ptr == 0) {
+  if (ptr == nullptr) {
     //no previous data, try our malloc
     return bin_malloc(size);
   }
   else {
     if (! (slots1.is_member(ptr) || slots2.is_member(ptr)) ) {
       // not our data, leave it to libc realloc
-      return 0;
+      return nullptr;
     }
 
     //we have existing data
@@ -70,13 +70,13 @@ void * bin_realloc(void * ptr, size_t size)
 
     //we need a bigger slot
     void * res = bin_malloc(size);
-    if (res == 0) {
+    if (res == nullptr) {
       // we don't have the space, use libc malloc
       // TRACE("bin_malloc [%lu] FAILURE", size);
       res = malloc(size);
-      if (res == 0) {
+      if (res == nullptr) {
         TRACE("libc malloc [%lu] FAILURE", size);  
-        return 0;
+        return nullptr;
       }
     }
     //copy data
@@ -119,7 +119,7 @@ void *bin_l_alloc (void *ud, void *ptr, size_t osize, size_t nsize)
     if (res && ptr) {
       // TRACE("OUR realloc %p[%lu] -> %p[%lu]", ptr, osize, res, nsize); 
     }
-    if (res == 0) {
+    if (res == nullptr) {
       res = realloc(ptr, nsize);
       // TRACE("libc realloc %p[%lu] -> %p[%lu]", ptr, osize, res, nsize);
       // if (res == 0 ){

--- a/radio/src/bin_allocator.h
+++ b/radio/src/bin_allocator.h
@@ -53,11 +53,11 @@ public:
   void * malloc(size_t size) {
     if (size > SIZE_SLOT) {
       // TRACE("BinAllocator<%d> malloc [%lu] size > SIZE_SLOT", SIZE_SLOT, size);
-      return 0;
+      return nullptr;
     }
     if (NoUsedBins >= NUM_BINS) {
       // TRACE("BinAllocator<%d> malloc [%lu] no free slots", SIZE_SLOT, size);
-      return 0;
+      return nullptr;
     }
     for (size_t n = 0; n < NUM_BINS; ++n) {
       if (!Bins[n].Used) {
@@ -68,7 +68,7 @@ public:
       }
     }
     // TRACE("BinAllocator<%d> malloc [%lu] no free slots", SIZE_SLOT , size);
-    return 0;
+    return nullptr;
   }
   size_t size(void * ptr) {
     return is_member(ptr) ? SIZE_SLOT : 0;

--- a/radio/src/cli.cpp
+++ b/radio/src/cli.cpp
@@ -461,14 +461,14 @@ int cliTestSD(const char ** argv)
 
 int cliTestNew()
 {
-  char * tmp = 0;
+  char * tmp = nullptr;
   cliSerialPrint("Allocating 1kB with new()");
   RTOS_WAIT_MS(200);
   tmp = new char[1024];
   if (tmp) {
     cliSerialPrint("\tsuccess");
     delete[] tmp;
-    tmp = 0;
+    tmp = nullptr;
   }
   else {
     cliSerialPrint("\tFAILURE");
@@ -480,7 +480,7 @@ int cliTestNew()
   if (tmp) {
     cliSerialPrint("\tFAILURE, tmp = %p", tmp);
     delete[] tmp;
-    tmp = 0;
+    tmp = nullptr;
   }
   else {
     cliSerialPrint("\tsuccess, allocaton failed, tmp = 0");
@@ -492,7 +492,7 @@ int cliTestNew()
   if (tmp) {
     cliSerialPrint("\tFAILURE, tmp = %p", tmp);
     delete[] tmp;
-    tmp = 0;
+    tmp = nullptr;
   }
   else {
     cliSerialPrint("\tsuccess, allocaton failed, tmp = 0");

--- a/radio/src/gui/navigation/common.cpp
+++ b/radio/src/gui/navigation/common.cpp
@@ -125,5 +125,5 @@ void check_submenu_simple(event_t event, uint8_t rowcount)
 
 void check_simple(event_t event, uint8_t curr, const MenuHandler *menuTab, uint8_t menuTabSize, vertpos_t rowcount)
 {
-  check(event, curr, menuTab, menuTabSize, 0, 0, rowcount);
+  check(event, curr, menuTab, menuTabSize, nullptr, 0, rowcount);
 }

--- a/radio/src/hal/fatfs_diskio.cpp
+++ b/radio/src/hal/fatfs_diskio.cpp
@@ -63,7 +63,7 @@ void fatfsUnregisterDrivers()
   for (uint8_t i = 0; i < _fatfs_n_drives; i++) {
     auto& drive = _fatfs_drives[i];
     if (drive.initialized) {
-      disk_ioctl(i, CTRL_SYNC, 0);
+      disk_ioctl(i, CTRL_SYNC, nullptr);
       if (drive.drv->deinit) {
         drive.drv->deinit(drive.lun);
       }

--- a/radio/src/logs.cpp
+++ b/radio/src/logs.cpp
@@ -185,7 +185,7 @@ void logsClose()
   if (g_oLogFile.obj.fs && sdMounted()) {
     if (f_close(&g_oLogFile) != FR_OK) {
       // close failed, forget file
-      g_oLogFile.obj.fs = 0;
+      g_oLogFile.obj.fs = nullptr;
     }
     lastLogTime = 0;
   }

--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -74,7 +74,7 @@ uint8_t instructionsPercent = 0;
 tmr10ms_t luaCycleStart;
 char lua_warning_info[LUA_WARNING_INFO_LEN+1];
 uint8_t errorState;
-struct our_longjmp * global_lj = 0;
+struct our_longjmp * global_lj = nullptr;
 #if defined(COLORLCD)
 uint32_t luaExtraMemoryUsage = 0;
 #endif
@@ -932,7 +932,7 @@ static void luaLoadScripts(bool init, const char * filename = nullptr)
     // 1. run chunk() 2. run init(), if available:
     do {
       // Resume running the coroutine
-      luaStatus = lua_resume(lsScripts, 0, 0);
+      luaStatus = lua_resume(lsScripts, nullptr, 0);
      
       if (luaStatus == LUA_YIELD) {
         // Coroutine yielded - wait for the next cycle
@@ -1156,7 +1156,7 @@ static bool resumeLua(bool init, bool allowLcdUsage)
     fullGC = false;
 
     // Resume running the coroutine
-    luaStatus = lua_resume(lsScripts, 0, inputsCount);
+    luaStatus = lua_resume(lsScripts, nullptr, inputsCount);
 
     if (luaStatus == LUA_YIELD) {
       // Coroutine yielded - wait for the next cycle

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -399,7 +399,7 @@ inline int calcRESXto100(int x)
 
 int expo(int x, int k);
 
-extern void getMixSrcRange(const int source, int16_t & valMin, int16_t & valMax, LcdFlags * flags = 0);
+extern void getMixSrcRange(const int source, int16_t & valMin, int16_t & valMax, LcdFlags * flags = nullptr);
 
 void applyExpos(int16_t * anas, uint8_t mode, uint8_t ovwrIdx=0, int16_t ovwrValue=0);
 int16_t applyLimits(uint8_t channel, int32_t value);

--- a/radio/src/pulses/crossfire.cpp
+++ b/radio/src/pulses/crossfire.cpp
@@ -280,7 +280,7 @@ static void* crossfireInit(uint8_t module)
 
 #if !defined(SIMU)
       if (drv && ctx && drv->setIdleCb) {
-        drv->setIdleCb(ctx, _crsf_intmodule_frame_received, 0);
+        drv->setIdleCb(ctx, _crsf_intmodule_frame_received, nullptr);
       }
 #endif
     }
@@ -301,7 +301,7 @@ static void* crossfireInit(uint8_t module)
 
 #if !defined(SIMU)
       if (drv && ctx && drv->setIdleCb) {
-        drv->setIdleCb(ctx, _soft_irq_trigger, 0);
+        drv->setIdleCb(ctx, _soft_irq_trigger, nullptr);
         stm32_exti_enable(TELEMETRY_RX_FRAME_EXTI_LINE, 0,
                           _crsf_extmodule_frame_received);
       }

--- a/radio/src/rtos.h
+++ b/radio/src/rtos.h
@@ -197,7 +197,7 @@ extern "C++" {
                                        UBaseType_t uxPriority)
   {
     h->rtos_handle = xTaskCreateStatic(
-        pxTaskCode, name, ulStackDepth, 0, uxPriority,
+        pxTaskCode, name, ulStackDepth, NULL, uxPriority,
         puxStackBuffer, &h->task_struct);
   }
 

--- a/radio/src/sdcard.cpp
+++ b/radio/src/sdcard.cpp
@@ -401,7 +401,7 @@ const char * sdMoveFile(const char * srcPath, const char * destPath)
 {
   const char *result;
   result = sdCopyFile(srcPath, destPath);
-  if(result != 0) {
+  if(result != nullptr) {
     return result;
   }
 
@@ -417,7 +417,7 @@ const char * sdMoveFile(const char * srcFilename, const char * srcDir, const cha
 {
   const char *result;
   result = sdCopyFile(srcFilename, srcDir, destFilename, destDir);
-  if(result != 0) {
+  if(result != nullptr) {
     return result;
   }
 

--- a/radio/src/targets/common/arm/stm32/audio_dac_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/audio_dac_driver.cpp
@@ -22,7 +22,7 @@
 #include "opentx.h"
 
 #if !defined(SIMU)
-const AudioBuffer * nextBuffer = 0;
+const AudioBuffer * nextBuffer = nullptr;
 
 void setSampleRate(uint32_t frequency)
 {

--- a/radio/src/targets/common/arm/stm32/bootloader/bin_files.cpp
+++ b/radio/src/targets/common/arm/stm32/bootloader/bin_files.cpp
@@ -52,7 +52,7 @@ void sdInit(void)
 void sdDone()
 {
   // unmount
-  f_mount(0, "", 0);
+  f_mount(nullptr, "", 0);
   storageDeInit();
 }
 

--- a/radio/src/targets/common/arm/stm32/sdcard_spi.cpp
+++ b/radio/src/targets/common/arm/stm32/sdcard_spi.cpp
@@ -190,7 +190,7 @@ static uint8_t sdcard_spi_send_cmd(const stm32_spi_t* spi, uint8_t sd_cmd_idx,
       continue;
     }
 
-    if (_transfer_bytes(spi, cmd_data, 0, sizeof(cmd_data)) != sizeof(cmd_data)) {
+    if (_transfer_bytes(spi, cmd_data, nullptr, sizeof(cmd_data)) != sizeof(cmd_data)) {
       TRACE("sdcard_spi_send_cmd: _transfer_bytes: send cmd [%d]: [ERROR]",
             sd_cmd_idx);
       r1_resu = SD_INVALID_R1_RESPONSE;
@@ -323,7 +323,7 @@ static sd_init_fsm_state_t _init_sd_fsm_step(const stm32_spi_t* spi,
 
         uint8_t r7[4];
 
-        if (_transfer_bytes(spi, 0, &r7[0], sizeof(r7)) == sizeof(r7)) {
+        if (_transfer_bytes(spi, nullptr, &r7[0], sizeof(r7)) == sizeof(r7)) {
           TRACE("R7 response: 0x%02x 0x%02x 0x%02x 0x%02x", r7[0], r7[1], r7[2], r7[3]);
           /* check if lower 12 bits (voltage range and check pattern) of
              response and arg are equal to verify compatibility and
@@ -404,7 +404,7 @@ static sd_init_fsm_state_t _init_sd_fsm_step(const stm32_spi_t* spi,
         card->card_type = SD_V2;
 
         uint8_t r3[4];
-        if (_transfer_bytes(spi, 0, r3, sizeof(r3)) == sizeof(r3)) {
+        if (_transfer_bytes(spi, nullptr, r3, sizeof(r3)) == sizeof(r3)) {
           uint32_t ocr = ((uint32_t)r3[0] << (3 * 8)) |
             ((uint32_t)r3[1] << (2 * 8)) | (r3[2] << 8) | r3[3];
           TRACE("R3 RESPONSE: 0x%02x 0x%02x 0x%02x 0x%02x",
@@ -526,7 +526,7 @@ static sd_rw_response_t _read_data_packet(const stm32_spi_t* spi, uint8_t token,
   if (stm32_spi_dma_receive_bytes(spi, data, size) == size) {
 
     uint8_t crc_bytes[2];
-    if (_transfer_bytes(spi, 0, crc_bytes, sizeof(crc_bytes)) == sizeof(crc_bytes)) {
+    if (_transfer_bytes(spi, nullptr, crc_bytes, sizeof(crc_bytes)) == sizeof(crc_bytes)) {
 
 #if defined(SD_CARD_SPI_ENABLE_CRC)
       uint16_t data_crc16 = (crc_bytes[0] << 8) | crc_bytes[1];
@@ -622,7 +622,7 @@ static sd_rw_response_t _write_data_packet(const stm32_spi_t* spi, uint8_t token
   uint8_t crc[sizeof(uint16_t)] = { 0xFF, 0xFF };
 #endif
 
-  if (_transfer_bytes(spi, crc, 0, sizeof(crc)) != sizeof(crc)) {
+  if (_transfer_bytes(spi, crc, nullptr, sizeof(crc)) != sizeof(crc)) {
     TRACE("_write_data_packet: [RX_TX_ERROR] (while transmitting CRC16)");
     return SD_RW_RX_TX_ERROR;
   }

--- a/radio/src/targets/common/arm/stm32/stm32_exti_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_exti_driver.cpp
@@ -28,7 +28,7 @@
 #define _PR_MASK(first, last) (((1 << (last - first + 1))-1))
 
 #define _DEFINE_EXTI_IRQ_HANDLER(irq_name, first, last)    \
-  static stm32_exti_handler_t _EXTI_HANDLERS(irq_name) [last - first + 1] = { 0 }; \
+  static stm32_exti_handler_t _EXTI_HANDLERS(irq_name) [last - first + 1] = { nullptr }; \
   extern "C" void irq_name ## Handler()                                 \
   {                                                                     \
     /* Read Pending register */                                         \

--- a/radio/src/targets/common/arm/stm32/stm32_spi.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_spi.cpp
@@ -267,7 +267,7 @@ uint16_t stm32_spi_dma_receive_bytes(const stm32_spi_t* spi,
 {
 #if defined(USE_SPI_DMA)
   if (!spi->DMA) {
-    return stm32_spi_transfer_bytes(spi, 0, data, length);
+    return stm32_spi_transfer_bytes(spi, nullptr, data, length);
   }
 
   if (((uintptr_t)data < SRAM_BASE) || ((uintptr_t)data & 3)) {
@@ -300,7 +300,7 @@ uint16_t stm32_spi_dma_receive_bytes(const stm32_spi_t* spi,
   
   return length;
 #else
-  return stm32_spi_transfer_bytes(spi, 0, data, length);
+  return stm32_spi_transfer_bytes(spi, nullptr, data, length);
 #endif
 }
 
@@ -309,7 +309,7 @@ uint16_t stm32_spi_dma_transmit_bytes(const stm32_spi_t* spi,
 {
 #if defined(USE_SPI_DMA)
   if (!spi->DMA) {
-    return stm32_spi_transfer_bytes(spi, data, 0, length);
+    return stm32_spi_transfer_bytes(spi, data, nullptr, length);
   }
 
   if (((uintptr_t)data < SRAM_BASE) || ((uintptr_t)data & 3)) {


### PR DESCRIPTION
clean up uncritical compiler warnings where `0`  was used instead of `nullptr` / `NULL` 