### PR TITLE
feat(radio): prefer UBX over NMEA when both supported

### DIFF
--- a/radio/src/gps_ubx.cpp
+++ b/radio/src/gps_ubx.cpp
@@ -129,10 +129,7 @@ static void configureGps(bool detect)
 {
   static int state = 0;
 
-  if (detect) {
-    state = 0;
-    return;
-  }
+  if (detect) state = 0;
 
   auto txCompleted = gpsSerialDrv->txCompleted;
   if (txCompleted && !txCompleted(gpsSerialCtx)) return;


### PR DESCRIPTION
Summary of changes: When NMEA messages are received (i.e. the baud rate is correct), the handset waits for up to 2 seconds to receive a valid UBX packet. When there are no UBX packets within a 2 second period, NMEA is selected.