### PR TITLE
fix(color): restore previous startup and shutdown functionality.

### DIFF
--- a/radio/src/gui/colorlcd/startup_shutdown.cpp
+++ b/radio/src/gui/colorlcd/startup_shutdown.cpp
@@ -194,7 +194,7 @@ void drawSleepBitmap()
   } else {
     shutdownWindow = new Window(MainWindow::instance(), {0, 0, LCD_W, LCD_H});
     shutdownWindow->setWindowFlag(OPAQUE);
-    etx_solid_bg(shutdownWindow->getLvObj(), COLOR_BLACK_INDEX);
+    etx_solid_bg(shutdownWindow->getLvObj(), COLOR_THEME_PRIMARY1_INDEX);
   }
 
   (new StaticIcon(shutdownWindow, 0, 0, ICON_SHUTDOWN, COLOR_THEME_PRIMARY2))
@@ -221,7 +221,7 @@ void drawShutdownAnimation(uint32_t duration, uint32_t totalDuration,
   if (shutdownWindow == nullptr) {
     shutdownWindow = new Window(MainWindow::instance(), {0, 0, LCD_W, LCD_H});
     shutdownWindow->setWindowFlag(OPAQUE);
-    etx_solid_bg(shutdownWindow->getLvObj(), COLOR_BLACK_INDEX);
+    etx_solid_bg(shutdownWindow->getLvObj(), COLOR_THEME_PRIMARY1_INDEX);
 
     if (sdMounted() && !shutdownSplashImg)
       shutdownSplashImg = BitmapBuffer::loadBitmap(

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1482,8 +1482,7 @@ void edgeTxInit()
 
 #if defined(GUI)
     if (!calibration_needed && !(startOptions & OPENTX_START_NO_SPLASH)) {
-      if (!g_eeGeneral.dontPlayHello)
-        AUDIO_HELLO();
+      if (!g_eeGeneral.dontPlayHello) AUDIO_HELLO();
 
       waitSplash();
     }

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1484,6 +1484,8 @@ void edgeTxInit()
     if (!calibration_needed && !(startOptions & OPENTX_START_NO_SPLASH)) {
       if (!g_eeGeneral.dontPlayHello)
         AUDIO_HELLO();
+
+      waitSplash();
     }
 #endif // defined(GUI)
 

--- a/radio/src/tasks.cpp
+++ b/radio/src/tasks.cpp
@@ -56,8 +56,6 @@ TASK_FUNCTION(menusTask)
 
   mixerTaskInit();
 
-  waitSplash();
-
 #if defined(PWR_BUTTON_PRESS)
   while (true) {
     uint32_t pwr_check = pwrCheck();


### PR DESCRIPTION
Wait for splash screen to finish before showing throttle and switch alerts.
Use theme color for shutdown animation background.

Fixes #4855
