### PR TITLE
fix(telemetry): wrong scaling after changing unit to rpm

### DIFF
--- a/radio/src/telemetry/telemetry_sensors.cpp
+++ b/radio/src/telemetry/telemetry_sensors.cpp
@@ -209,7 +209,7 @@ void TelemetryItem::setValue(const TelemetrySensor &sensor, int32_t val,
     setFresh();
     return;
   }
-  else if (unit == UNIT_RPMS) {
+  else if (sensor.unit == UNIT_RPMS) {
     if (sensor.custom.ratio != 0) {
       newVal = (newVal * sensor.custom.offset) / sensor.custom.ratio;
     }


### PR DESCRIPTION
Fixes #4874 

Summary of changes:
- struct TelemetrySensor holds the true unit after changing the unit manually

Background: All telemetry decoders communicate values and their units based on their intended and therefore constant data structs. At the time of discovery the data is stored to struct TelemetrySensor to be written (in parts) to modelxx.yml. A manual change of the unit will also be reflected in struct TelemetrySensor. At run-time the telemetry decoders call setTelemetryValue() but with the originally defined unit. Further down the call-tree setValue() accepts the value and unit of the telemetry sensor and scans if the unit is one of the "to be treated specially" units, like UNIT_CELLS,  UNIT_DATETIME_YEAR, etc but also UNIT_RPMS which requires a "special" and different scaling that is different to all other manually changeable sensor units. Due to the fact the decoders still communicate the original unit (defined within the decoder) which is not rpm, the "special treatment" scaling for UNIT_RPMS is not applied.

The fix is easier than the explanation why it is necessary. Just use the up-to-date knowledge about the unit to decide if "special treatment" scaling is required.

