### PR TITLE
fix(radio): properly center analog USB joystick axis

### DIFF
--- a/radio/src/targets/common/arm/stm32/usb_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/usb_driver.cpp
@@ -75,7 +75,7 @@ int usbPlugged()
     debouncedState = state;
   else
     lastState = state;
-  
+
   return debouncedState;
 }
 #endif
@@ -226,11 +226,10 @@ void usbJoystickUpdate()
    //uint8_t * p = HID_Buffer + 1;
    for (int i = 0; i < 8; ++i) {
 
-     int16_t value = channelOutputs[i] + 1023;
-     if ( value > 2046 ) value = 2046;
-     else if ( value < 0 ) value = 0;
+     int16_t value = limit<int16_t>(0, channelOutputs[i] + 1024, 2048);;
+
      HID_Buffer[i*2 +3] = static_cast<uint8_t>(value & 0xFF);
-     HID_Buffer[i*2 +4] = static_cast<uint8_t>((value >> 8) & 0x07);
+     HID_Buffer[i*2 +4] = static_cast<uint8_t>(value >> 8);
 
    }
    USBD_HID_SendReport(&hUsbDeviceFS, HID_Buffer, HID_IN_PACKET);

--- a/radio/src/targets/common/arm/stm32/usb_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/usb_driver.cpp
@@ -226,8 +226,8 @@ void usbJoystickUpdate()
    //uint8_t * p = HID_Buffer + 1;
    for (int i = 0; i < 8; ++i) {
 
-     int16_t value = channelOutputs[i] + 1024;
-     if ( value > 2047 ) value = 2047;
+     int16_t value = channelOutputs[i] + 1023;
+     if ( value > 2046 ) value = 2046;
      else if ( value < 0 ) value = 0;
      HID_Buffer[i*2 +3] = static_cast<uint8_t>(value & 0xFF);
      HID_Buffer[i*2 +4] = static_cast<uint8_t>((value >> 8) & 0x07);

--- a/radio/src/targets/common/arm/stm32/usb_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/usb_driver.cpp
@@ -21,6 +21,8 @@
 
 #if defined(USBJ_EX)
 #include "usb_joystick.h"
+#else
+#include "opentx_helpers.h"
 #endif
 
 extern "C" {

--- a/radio/src/targets/common/arm/stm32/usbd_hid_joystick.c
+++ b/radio/src/targets/common/arm/stm32/usbd_hid_joystick.c
@@ -125,7 +125,7 @@ __ALIGN_BEGIN static const uint8_t HID_JOYSTICK_ReportDesc[] __ALIGN_END =
     0x09, 0x36,                    //         USAGE (Slider)
     0x09, 0x37,                    //         USAGE (Dial)
     0x16, 0x00, 0x00,              //         LOGICAL_MINIMUM (0)
-    0x26, 0xFE, 0x07,              //         LOGICAL_MAXIMUM (2046)
+    0x26, 0x00, 0x08,              //         LOGICAL_MAXIMUM (2048)
     0x75, 0x10,                    //         REPORT_SIZE (16)
     0x95, 0x08,                    //         REPORT_COUNT (8)
     0x81, 0x02,                    //         INPUT (Data,Var,Abs)

--- a/radio/src/targets/common/arm/stm32/usbd_hid_joystick.c
+++ b/radio/src/targets/common/arm/stm32/usbd_hid_joystick.c
@@ -125,7 +125,7 @@ __ALIGN_BEGIN static const uint8_t HID_JOYSTICK_ReportDesc[] __ALIGN_END =
     0x09, 0x36,                    //         USAGE (Slider)
     0x09, 0x37,                    //         USAGE (Dial)
     0x16, 0x00, 0x00,              //         LOGICAL_MINIMUM (0)
-    0x26, 0xFF, 0x07,              //         LOGICAL_MAXIMUM (2047)
+    0x26, 0xFE, 0x07,              //         LOGICAL_MAXIMUM (2046)
     0x75, 0x10,                    //         REPORT_SIZE (16)
     0x95, 0x08,                    //         REPORT_COUNT (8)
     0x81, 0x02,                    //         INPUT (Data,Var,Abs)

--- a/radio/src/usb_joystick.cpp
+++ b/radio/src/usb_joystick.cpp
@@ -104,7 +104,7 @@ static const uint8_t HID_JOYSTICK_ReportDesc[] =
     0x09, 0x36,                    //         USAGE (Slider)
     0x09, 0x37,                    //         USAGE (Dial)
     0x14,                          //         LOGICAL_MINIMUM (0)
-    0x26, 0xFE, 0x07,              //         LOGICAL_MAXIMUM (2046)
+    0x26, 0x00, 0x08,              //         LOGICAL_MAXIMUM (2048)
     0x75, 0x10,                    //         REPORT_SIZE (16)
     0x95, 0x08,                    //         REPORT_COUNT (8)
     0x81, 0x02,                    //         INPUT (Data,Var,Abs)
@@ -145,7 +145,7 @@ int usbJoystickSettingsChanged()
 
   uint32_t oldChecksum = settingsChecksum;
   settingsChecksum = hash((uint8_t*)&g_model.usbJoystickCh, sizeof(g_model.usbJoystickCh));
-  
+
   return oldChecksum != settingsChecksum;
 }
 
@@ -194,7 +194,7 @@ int setupUSBJoystick()
   _usbJoystickButtonCount = 0;
   _usbJoystickAxisCount = 0;
   memset(_usbJoystickAxisPairs, 0xff, sizeof(_usbJoystickAxisPairs));
-  
+
   if (!usbJoystickExtMode()) {
     // Classic USB Joystick report description
     memcpy(_hidReportDesc, HID_JOYSTICK_ReportDesc, sizeof(HID_JOYSTICK_ReportDesc));
@@ -440,11 +440,10 @@ void usbClassicStateUpdate()
   //uint8_t * p = HID_Buffer + 1;
   for (int i = 0; i < 8; ++i) {
 
-    int16_t value = channelOutputs[i] + 1023;
-    if ( value > 2046 ) value = 2046;
-    else if ( value < 0 ) value = 0;
+    int16_t value = limit<int16_t>(0, channelOutputs[i] + 1024, 2048);
+
     _hidReport[i*2 +3] = static_cast<uint8_t>(value & 0xFF);
-    _hidReport[i*2 +4] = static_cast<uint8_t>((value >> 8) & 0x07);
+    _hidReport[i*2 +4] = static_cast<uint8_t>(value >> 8);
 
   }
 
@@ -628,15 +627,13 @@ void usbStateUpdate()
   for (uint8_t i = 0; i < _usbJoystickAxisCount; i++) {
     chix = _usbJS->_usbJoystickAxisChannels[i];
 
-    value = circularCutoutValue(chix) + 1023;
-    if ( value > 2046 ) value = 2046;
-    else if ( value < 0 ) value = 0;
+    value = limit<int16_t>(0, circularCutoutValue(chix) + 1024, 2048);
 
-    if (g_model.usbJoystickCh[chix].inversion) value = 2046 - value;
+    if (g_model.usbJoystickCh[chix].inversion) value = 2048 - value;
 
     _hidReport[i*2 + axis_ix] = static_cast<uint8_t>(value & 0xFF);
-    _hidReport[i*2 + axis_ix+1] = static_cast<uint8_t>((value >> 8) & 0x07);
-  }  
+    _hidReport[i*2 + axis_ix+1] = static_cast<uint8_t>(value >> 8);
+  }
 
   //battery values
   setBatteryBits(_usbJoystickAxisCount*2 + axis_ix);
@@ -655,7 +652,7 @@ struct usbReport_t usbReport()
   } else {
     usbStateUpdate();
   }
-  
+
   usbReport_t res = { _hidReport, _hidReportSize };
   return res;
 }

--- a/radio/src/usb_joystick.cpp
+++ b/radio/src/usb_joystick.cpp
@@ -104,7 +104,7 @@ static const uint8_t HID_JOYSTICK_ReportDesc[] =
     0x09, 0x36,                    //         USAGE (Slider)
     0x09, 0x37,                    //         USAGE (Dial)
     0x14,                          //         LOGICAL_MINIMUM (0)
-    0x26, 0xFF, 0x07,              //         LOGICAL_MAXIMUM (2047)
+    0x26, 0xFE, 0x07,              //         LOGICAL_MAXIMUM (2046)
     0x75, 0x10,                    //         REPORT_SIZE (16)
     0x95, 0x08,                    //         REPORT_COUNT (8)
     0x81, 0x02,                    //         INPUT (Data,Var,Abs)
@@ -440,8 +440,8 @@ void usbClassicStateUpdate()
   //uint8_t * p = HID_Buffer + 1;
   for (int i = 0; i < 8; ++i) {
 
-    int16_t value = channelOutputs[i] + 1024;
-    if ( value > 2047 ) value = 2047;
+    int16_t value = channelOutputs[i] + 1023;
+    if ( value > 2046 ) value = 2046;
     else if ( value < 0 ) value = 0;
     _hidReport[i*2 +3] = static_cast<uint8_t>(value & 0xFF);
     _hidReport[i*2 +4] = static_cast<uint8_t>((value >> 8) & 0x07);
@@ -628,11 +628,11 @@ void usbStateUpdate()
   for (uint8_t i = 0; i < _usbJoystickAxisCount; i++) {
     chix = _usbJS->_usbJoystickAxisChannels[i];
 
-    value = circularCutoutValue(chix) + 1024;
-    if ( value > 2047 ) value = 2047;
+    value = circularCutoutValue(chix) + 1023;
+    if ( value > 2046 ) value = 2046;
     else if ( value < 0 ) value = 0;
 
-    if (g_model.usbJoystickCh[chix].inversion) value = 2047 - value;
+    if (g_model.usbJoystickCh[chix].inversion) value = 2046 - value;
 
     _hidReport[i*2 + axis_ix] = static_cast<uint8_t>(value & 0xFF);
     _hidReport[i*2 + axis_ix+1] = static_cast<uint8_t>((value >> 8) & 0x07);


### PR DESCRIPTION
Analog USB joystick axis are encoded as unsigned integers ranging [0 - 2047]. As a consequence input value 0 is reported as output 1024. This leads to asymmetric output: 1024 values smaller than 0 and 1023 values larger than 0.

mixer.cpp generates values [-1024 to +1024] (11 bit + 1) instead of [-1024 to +1023] (11 bit). Luckily the HID report descriptor  already reserves 16 bits so the shift from 11 bit to 12 bit output is easy.

Fix EdgeTX/edgetx#4881 by changing the joystick range from [0 - 2047] to [0 - 2048]. 
