### PR TITLE
fix(bw): multiple issues with menu navigation for 9X type radios

### DIFF
--- a/radio/src/gui/128x64/model_flightmodes.cpp
+++ b/radio/src/gui/128x64/model_flightmodes.cpp
@@ -90,7 +90,7 @@ void menuModelFlightModeOne(event_t event)
 #endif
   0, 0,(uint8_t)-1, 2, 2, 2, 2, 2};
 
-  check(event, 0, nullptr, 0, (s_currIdx == 0) ? mstate_tab_fm1 : mstate_tab_others, DIM(mstate_tab_others)-1, ITEM_MODEL_FLIGHT_MODE_MAX - HEADER_LINE - (s_currIdx==0 ? (ITEM_MODEL_FLIGHT_MODE_FADE_IN-ITEM_MODEL_FLIGHT_MODE_SWITCH-TRIMS_LINES) : 0));
+  check(event, 0, nullptr, 0, (s_currIdx == 0) ? mstate_tab_fm1 : mstate_tab_others, DIM(mstate_tab_others)-1, ITEM_MODEL_FLIGHT_MODE_MAX - (s_currIdx==0 ? (ITEM_MODEL_FLIGHT_MODE_FADE_IN-ITEM_MODEL_FLIGHT_MODE_SWITCH-TRIMS_LINES) : 0));
 
   title(STR_MENUFLIGHTMODE);
 

--- a/radio/src/gui/128x64/model_select.cpp
+++ b/radio/src/gui/128x64/model_select.cpp
@@ -124,7 +124,7 @@ void menuModelSelect(event_t event)
 
   int8_t oldSub = menuVerticalPosition;
 
-  check_submenu_simple(_event_, MAX_MODELS - HEADER_LINE);
+  check_submenu_simple(_event_, MAX_MODELS);
 
   if (s_editMode > 0) s_editMode = 0;
 

--- a/radio/src/gui/common/stdlcd/menus.cpp
+++ b/radio/src/gui/common/stdlcd/menus.cpp
@@ -24,10 +24,13 @@
 MenuHandlerFunc menuHandlers[5];
 event_t menuEvent = 0;
 uint8_t menuVerticalPositions[4];
+uint8_t menuVerticalOffsets[4];
 uint8_t menuLevel = 0;
 
 void popMenu()
 {
+  killEvents(KEY_EXIT);
+
   assert(menuLevel > 0);
   menuLevel = menuLevel - 1;
   menuEvent = EVT_ENTRY_UP;
@@ -63,6 +66,7 @@ void pushMenu(MenuHandlerFunc newMenu)
   else {
     menuVerticalPositions[menuLevel] = menuVerticalPosition;
   }
+  menuVerticalOffsets[menuLevel] = menuVerticalOffset;
 
   menuLevel++;
 

--- a/radio/src/gui/common/stdlcd/menus.h
+++ b/radio/src/gui/common/stdlcd/menus.h
@@ -49,6 +49,7 @@ extern vertpos_t menuVerticalOffset;
 extern uint8_t menuCalibrationState;
 extern MenuHandlerFunc menuHandlers[5];
 extern uint8_t menuVerticalPositions[4];
+extern uint8_t menuVerticalOffsets[4];
 extern uint8_t menuLevel;
 extern event_t menuEvent;
 

--- a/radio/src/gui/navigation/navigation_9x.cpp
+++ b/radio/src/gui/navigation/navigation_9x.cpp
@@ -148,7 +148,8 @@ int checkIncDec(event_t event, int val, int i_min, int i_max,
 
 tmr10ms_t menuEntryTime;
 
-#define MAXCOL(row)                    (horTab ? *(horTab+min(row, (vertpos_t)horTabMax)) : (const uint8_t)0)
+#define MAXCOL_RAW(row)                (horTab ? *(horTab+min(row, (vertpos_t)horTabMax)) : (const uint8_t)0)
+#define MAXCOL(row)                    (MAXCOL_RAW(row) >= HIDDEN_ROW ? MAXCOL_RAW(row) : (const uint8_t)(MAXCOL_RAW(row) & (~NAVIGATION_LINE_BY_LINE)))
 #define POS_HORZ_INIT(posVert)         0
 
 uint8_t chgMenu(uint8_t curr, const MenuHandler * menuTab, uint8_t menuTabSize, int direction)
@@ -272,7 +273,7 @@ void check(event_t event, uint8_t curr, const MenuHandler *menuTab,
     case EVT_KEY_FIRST(KEY_DOWN):
       if (s_editMode>0) break;
       do {
-        INC(l_posVert, 0, maxrow);
+        INC(l_posVert, 0, maxrow - 1);
       } while (CURSOR_NOT_ALLOWED_IN_ROW(l_posVert));
       l_posHorz = min<horzpos_t>(l_posHorz, MAXCOL(l_posVert));
       break;
@@ -293,7 +294,7 @@ void check(event_t event, uint8_t curr, const MenuHandler *menuTab,
       if (s_editMode>0) break;
 
       do {
-        DEC(l_posVert, 0, maxrow);
+        DEC(l_posVert, 0, maxrow - 1);
       } while (CURSOR_NOT_ALLOWED_IN_ROW(l_posVert));
       l_posHorz = min((uint8_t)l_posHorz, MAXCOL(l_posVert));
       break;

--- a/radio/src/keys.h
+++ b/radio/src/keys.h
@@ -148,14 +148,14 @@ inline bool IS_KEY_EVT(event_t evt, uint8_t key)
 
 inline bool IS_NEXT_EVENT(event_t evt)
 {
-  return evt == EVT_KEY_FIRST(KEY_DOWN) || evt == EVT_KEY_REPT(KEY_DOWN) ||
+  return evt == EVT_KEY_FIRST(KEY_RIGHT) || evt == EVT_KEY_REPT(KEY_RIGHT) ||
          evt == EVT_KEY_FIRST(KEY_MINUS) || evt == EVT_KEY_REPT(KEY_MINUS) ||
          evt == EVT_ROTARY_RIGHT;
 }
 
 inline bool IS_PREVIOUS_EVENT(event_t evt)
 {
-  return evt == EVT_KEY_FIRST(KEY_UP) || evt == EVT_KEY_REPT(KEY_UP) ||
+  return evt == EVT_KEY_FIRST(KEY_LEFT) || evt == EVT_KEY_REPT(KEY_LEFT) ||
          evt == EVT_KEY_FIRST(KEY_PLUS) || evt == EVT_KEY_REPT(KEY_PLUS) ||
          evt == EVT_ROTARY_LEFT;
 }

--- a/radio/src/main.cpp
+++ b/radio/src/main.cpp
@@ -492,8 +492,14 @@ void guiMain(event_t evt)
 
   if (menuEvent) {
     // we have a popupMenuActive entry or exit event
-    menuVerticalPosition =
-        (menuEvent == EVT_ENTRY_UP) ? menuVerticalPositions[menuLevel] : 0;
+    if (menuEvent == EVT_ENTRY_UP) {
+      menuVerticalPosition = menuVerticalPositions[menuLevel];
+      menuVerticalOffset = menuVerticalOffsets[menuLevel];
+    } else {
+      menuVerticalPosition = 0;
+      menuVerticalOffset = 0;
+    }
+
     menuHorizontalPosition = 0;
     evt = menuEvent;
     menuEvent = 0;


### PR DESCRIPTION
From 2.10 the menu navigation on 9X style radios (T-Lite, T12 and LR3Pro) does not work correctly.

Issues:
- Horizontal navigation on the SF/GF list does not work. Cannot select all properties for each SF/GF type.
- The FM list view has too many lines. Scrolling up from the top shows two blank lines at the bottom.
- Returning from the FM edit page to the FM list view may show the list view with the wrong scroll position if the edit page was scrolled to the bottom before exiting. Also affects other B&W radios when using long press to exit FM edit page.
- The short press of the EXIT key following a long press to exit a subpage was not being killed resulting in spurious activation of the EXIT key. Also affects other B&W radios.

Fixing the above issues caused other issues requiring more fixes (Model select page was one row short and FM edit page was missing G9 entry).
