### PR TITLE
fix(pl18): USB detect pin can be uninitialized in bootloader

### DIFF
--- a/radio/src/targets/pl18/board.cpp
+++ b/radio/src/targets/pl18/board.cpp
@@ -21,6 +21,7 @@
  
 #include "stm32_adc.h"
 
+#include "stm32_gpio_driver.h"
 #include "stm32_ws2812.h"
 #include "boards/generic_stm32/rgb_leds.h"
 
@@ -96,6 +97,19 @@ void ledStripOff()
     ws2812_set_color(i, 0, 0, 0);
   }
   ws2812_update(&_led_timer);
+}
+
+void boardBootloaderInit()
+{
+  // USB charger status pins
+  stm32_gpio_enable_clock(UCHARGER_GPIO);
+  GPIO_InitTypeDef GPIO_InitStructure;
+  GPIO_InitStructure.GPIO_Mode = GPIO_Mode_IN;
+  GPIO_InitStructure.GPIO_Speed = GPIO_Speed_2MHz;
+  GPIO_InitStructure.GPIO_OType = GPIO_OType_PP;
+  GPIO_InitStructure.GPIO_PuPd = GPIO_PuPd_NOPULL;
+  GPIO_InitStructure.GPIO_Pin = UCHARGER_GPIO_PIN;
+  GPIO_Init(UCHARGER_GPIO, &GPIO_InitStructure);
 }
 
 void boardInit()

--- a/radio/src/targets/pl18/board.h
+++ b/radio/src/targets/pl18/board.h
@@ -42,6 +42,10 @@ extern uint16_t sessionTimer;
 
 #define SLAVE_MODE()                    (g_model.trainerData.mode == TRAINER_MODE_SLAVE)
 
+// Initilizes the board for the bootloader
+#define HAVE_BOARD_BOOTLOADER_INIT 1
+void boardBootloaderInit();
+
 // Board driver
 void boardInit();
 void boardOff();


### PR DESCRIPTION
When work on some further development, discovered that the USB detection pin in PL18/PL18EV can be uninitialized in bootloader mode, this can cause potential problem.
