### PR TITLE
fix(t14): charge led sometimes pink at USB connection

### DIFF
--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -153,6 +153,7 @@ void boardInit()
     pwrOn();  // required to get bat adc reads
     INTERNAL_MODULE_OFF();
     EXTERNAL_MODULE_OFF();
+    delay_ms(2000); // let this stabilize
 
     while (usbPlugged()) {
       //    // Let it charge ...


### PR DESCRIPTION
Ensure radio stabilized before trying to measure vbat in charge mode

Fixes #4872

Confirmed ok by manufacturer.

@pfeerick : Please include in 2.10


