### PR TITLE
fix(usb): report correct version number (#4903)

### DIFF
--- a/radio/src/targets/common/arm/stm32/usbd_desc.c
+++ b/radio/src/targets/common/arm/stm32/usbd_desc.c
@@ -298,9 +298,9 @@ uint8_t * USBD_FS_DeviceDescriptor(USBD_SpeedTypeDef speed, uint16_t *length)
   /* USB Standard Device Descriptor */
   __ALIGN_BEGIN const uint8_t USBD_DeviceDesc[USB_LEN_DEV_DESC] __ALIGN_END =
     {
-        USB_LEN_DEV_DESC,         /*bLength */
+      USB_LEN_DEV_DESC,           /*bLength */
       USB_DESC_TYPE_DEVICE,       /*bDescriptorType*/
-      0x00,                       /*bcdUSB */
+      0x00,                       /*bcdUSB USB specification release number in binary-coded decimal*/
       0x02,
       0x00,                       /*bDeviceClass*/
       0x00,                       /*bDeviceSubClass*/
@@ -308,11 +308,11 @@ uint8_t * USBD_FS_DeviceDescriptor(USBD_SpeedTypeDef speed, uint16_t *length)
       USB_MAX_EP0_SIZE,           /*bMaxPacketSize*/
       LOBYTE(vid),                /*idVendor*/
       HIBYTE(vid),                /*idVendor*/
-      LOBYTE(pid),                /*idVendor*/
-      HIBYTE(pid),                /*idVendor*/
-      0x00,                       /*bcdDevice rel. 2.00*/
-      0x02,
-      USBD_IDX_MFC_STR,           /*Index of manufacturer  string*/
+      LOBYTE(pid),                /*idProduct*/
+      HIBYTE(pid),                /*idProduct*/
+      VERSION_MINOR,              /*bcdDevice device release number in binary-coded decimal*/
+      VERSION_MAJOR,
+      USBD_IDX_MFC_STR,           /*Index of manufacturer string*/
       USBD_IDX_PRODUCT_STR,       /*Index of product string*/
       USBD_IDX_SERIAL_STR,        /*Index of serial number string*/
       USBD_MAX_NUM_CONFIGURATION  /*bNumConfigurations*/

--- a/radio/src/targets/common/arm/stm32/usbd_desc.c
+++ b/radio/src/targets/common/arm/stm32/usbd_desc.c
@@ -26,6 +26,7 @@
 /* USER CODE BEGIN INCLUDE */
 #include "hal/usb_driver.h"
 #include "usb_descriptor.h"
+#include "stamp.h"
 /* USER CODE END INCLUDE */
 
 /* Private typedef -----------------------------------------------------------*/
@@ -295,6 +296,10 @@ uint8_t * USBD_FS_DeviceDescriptor(USBD_SpeedTypeDef speed, uint16_t *length)
       pid = 0;
   }
 
+  /* version has to be bcd coded */
+  uint8_t version_minor = ((VERSION_MINOR / 10) << 4) | (VERSION_MINOR % 10);
+  uint8_t version_major = ((VERSION_MAJOR / 10) << 4) | (VERSION_MAJOR % 10);
+
   /* USB Standard Device Descriptor */
   __ALIGN_BEGIN const uint8_t USBD_DeviceDesc[USB_LEN_DEV_DESC] __ALIGN_END =
     {
@@ -310,8 +315,8 @@ uint8_t * USBD_FS_DeviceDescriptor(USBD_SpeedTypeDef speed, uint16_t *length)
       HIBYTE(vid),                /*idVendor*/
       LOBYTE(pid),                /*idProduct*/
       HIBYTE(pid),                /*idProduct*/
-      VERSION_MINOR,              /*bcdDevice device release number in binary-coded decimal*/
-      VERSION_MAJOR,
+      version_minor,              /*bcdDevice device release number in binary-coded decimal*/
+      version_major,
       USBD_IDX_MFC_STR,           /*Index of manufacturer string*/
       USBD_IDX_PRODUCT_STR,       /*Index of product string*/
       USBD_IDX_SERIAL_STR,        /*Index of serial number string*/


### PR DESCRIPTION
Report the actual EdgeTX version in the USB device descriptor instead of a fixed "2.00"
Fixes #4903


