### PR TITLE
fix: menu up/down on 9x nav

### DIFF
--- a/radio/src/keys.h
+++ b/radio/src/keys.h
@@ -148,14 +148,16 @@ inline bool IS_KEY_EVT(event_t evt, uint8_t key)
 
 inline bool IS_NEXT_EVENT(event_t evt)
 {
-  return evt == EVT_KEY_FIRST(KEY_RIGHT) || evt == EVT_KEY_REPT(KEY_RIGHT) ||
+  return evt == EVT_KEY_FIRST(KEY_DOWN) || evt == EVT_KEY_REPT(KEY_DOWN) ||
+         evt == EVT_KEY_FIRST(KEY_RIGHT) || evt == EVT_KEY_REPT(KEY_RIGHT) ||
          evt == EVT_KEY_FIRST(KEY_MINUS) || evt == EVT_KEY_REPT(KEY_MINUS) ||
          evt == EVT_ROTARY_RIGHT;
 }
 
 inline bool IS_PREVIOUS_EVENT(event_t evt)
 {
-  return evt == EVT_KEY_FIRST(KEY_LEFT) || evt == EVT_KEY_REPT(KEY_LEFT) ||
+  return evt == EVT_KEY_FIRST(KEY_UP) || evt == EVT_KEY_REPT(KEY_UP) ||
+         evt == EVT_KEY_FIRST(KEY_LEFT) || evt == EVT_KEY_REPT(KEY_LEFT) ||
          evt == EVT_KEY_FIRST(KEY_PLUS) || evt == EVT_KEY_REPT(KEY_PLUS) ||
          evt == EVT_ROTARY_LEFT;
 }


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes regression introduced in #4884 whereby popup menu navigation is using L/R rather than Up/Down. Which may be trying to fix something in the navigation broken back in #3715 or earlier. 