### PR TITLE
fix(color): extra sliders and trims on main view after creating a new model.

### DIFF
--- a/radio/src/storage/sdcard_common.cpp
+++ b/radio/src/storage/sdcard_common.cpp
@@ -130,6 +130,10 @@ const char * createModel()
     storageDirty(EE_GENERAL);
     storageDirty(EE_MODEL);
     storageCheck(true);
+#if defined(COLORLCD)
+    // Default layout loaded when setting model defaults - neeed to remove it.
+    LayoutFactory::deleteCustomScreens();
+#endif
   }
   postModelLoad(false);
 


### PR DESCRIPTION
Fixes an issue where, after creating a new model, two copies of the first model screen are added to the main view.

Can be reproduced by:
- select a model with all trims and sliders showing on main view
- create a new model using the 'Wing' wizard.
- note the duplicated trim/slider widgets on the main view.
