### PR TITLE
chore: all Chinese main menu items on one line

### DIFF
--- a/radio/src/translations/cn.h
+++ b/radio/src/translations/cn.h
@@ -1204,7 +1204,7 @@
 
 // Main menu
 #define TR_MAIN_MENU_SELECT_MODEL     "模型选择"
-#define TR_MAIN_MENU_MANAGE_MODELS    "模型\n管理"
+#define TR_MAIN_MENU_MANAGE_MODELS    "模型管理"
 #define TR_MAIN_MENU_MODEL_NOTES      "模型说明"
 #define TR_MAIN_MENU_CHANNEL_MONITOR  "通道查看"
 #define TR_MAIN_MENU_MODEL_SETTINGS   "模型设置"


### PR DESCRIPTION
For some reason, one item of the main menu in Chinese was using a '\n'

Currently

![image](https://github.com/EdgeTX/edgetx/assets/5167938/9bb726cb-5f59-4637-9515-a023425d31ee)

With this change

![image](https://github.com/EdgeTX/edgetx/assets/5167938/5b7a5e57-d978-4629-86f1-7f70e981d690)

![image](https://github.com/EdgeTX/edgetx/assets/5167938/85e2eb1c-c336-4dd3-a502-3c38298a877f)

Reported by a partner (as you can guess, my Chinese knowledge is non existent)