### PR TITLE
chore(radio): actually use the defined USB joystick strings

### DIFF
--- a/radio/src/targets/common/arm/stm32/usbd_hid_joystick.c
+++ b/radio/src/targets/common/arm/stm32/usbd_hid_joystick.c
@@ -174,7 +174,7 @@ __ALIGN_BEGIN static uint8_t USBD_HID_CfgDesc[USB_HID_CONFIG_DESC_SIZ] __ALIGN_E
   HIBYTE(USB_HID_CONFIG_DESC_SIZ),
   0x01,                                               /* bNumInterfaces: 1 interface */
   0x01,                                               /* bConfigurationValue: Configuration value */
-  0x00,                                               /* iConfiguration: Index of string descriptor
+  USBD_IDX_CONFIG_STR,                                /* iConfiguration: Index of string descriptor
                                                          describing the configuration */
   0xE0,                                               /* bmAttributes: Bus Powered according to user configuration */
   USBD_MAX_POWER,                                     /* MaxPower (mA) */
@@ -189,7 +189,7 @@ __ALIGN_BEGIN static uint8_t USBD_HID_CfgDesc[USB_HID_CONFIG_DESC_SIZ] __ALIGN_E
   0x03,                                               /* bInterfaceClass: HID */
   0x00,                                               /* bInterfaceSubClass : 1=BOOT, 0=no boot */
   0x00,                                               /* nInterfaceProtocol : 0=none, 1=keyboard, 2=mouse */
-  0,                                                  /* iInterface: Index of string descriptor */
+  USBD_IDX_INTERFACE_STR,                             /* iInterface: Index of string descriptor */
   /******************** HID Descriptor for Joystick ********************/
   /* 18 */
   0x09,                                               /* bLength: HID Descriptor size */


### PR DESCRIPTION
USBD_HID_CONFIGURATION_FS_STRING and USBD_HID_INTERFACE_FS_STRING are defined but never used because the string IDs in the joystick descriptor are 0.


output from `lsusb -d 1209:4f54  -v` before:


> iConfiguration          0
> iInterface              0

output from `lsusb -d 1209:4f54  -v` after:

> iConfiguration          4 HID Config
> iInterface              5 HID Interface

