### PR TITLE
fix: some cppcheck errors

### DIFF
--- a/radio/src/gui/colorlcd/afhds2a_settings.cpp
+++ b/radio/src/gui/colorlcd/afhds2a_settings.cpp
@@ -93,8 +93,8 @@ AFHDS2ASettings::AFHDS2ASettings(Window* parent, const FlexGridLayout& g,
                                        md->flysky.rfPower = newValue;
                                        resetPulsesAFHDS2();
                                      });
+  }                                     
 #endif
-  }
 
   hideAFHDS2Options();
 }

--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -1340,7 +1340,7 @@ void luaInit()
 #if defined(USE_BIN_ALLOCATOR)
     L = lua_newstate(bin_l_alloc, nullptr);   //we use our own allocator!
 #elif defined(LUA_ALLOCATOR_TRACER)
-    memclear(&lsScriptsTrace, sizeof(lsScriptsTrace);
+    memclear(&lsScriptsTrace, sizeof(lsScriptsTrace));
     lsScriptsTrace.script = "lua_newstate(scripts)";
     L = lua_newstate(tracer_alloc, &lsScriptsTrace);   //we use tracer allocator
 #else


### PR DESCRIPTION
Looks like there was a missing `)` on some normally unused debug code, and a `}` in the wrong place for the NV14. 

The latter fix is probably needed in 2.10