### PR TITLE
fix(color): don't enlarge image in the file preview window.

### DIFF
--- a/radio/src/gui/colorlcd/file_preview.cpp
+++ b/radio/src/gui/colorlcd/file_preview.cpp
@@ -25,6 +25,7 @@ FilePreview::FilePreview(Window *parent, const rect_t &rect) :
     StaticImage(parent, rect)
 {
   hide();
+  dontEnlarge = true;
 }
 
 void FilePreview::setFile(const char *filename)

--- a/radio/src/thirdparty/libopenui/src/static.cpp
+++ b/radio/src/thirdparty/libopenui/src/static.cpp
@@ -235,7 +235,9 @@ void StaticImage::setZoom()
   if (img && img->w && img->h) {
     uint16_t zw = (width() * 256) / img->w;
     uint16_t zh = (height() * 256) / img->h;
-    lv_img_set_zoom(image, min(zw, zh));
+    uint16_t z = min(zw, zh);
+    if (dontEnlarge) z = min(z, (uint16_t)256);
+    lv_img_set_zoom(image, z);
   }
 }
 

--- a/radio/src/thirdparty/libopenui/src/static.h
+++ b/radio/src/thirdparty/libopenui/src/static.h
@@ -154,6 +154,7 @@ class StaticImage : public Window
   bool hasImage() const;
 
  protected:
+  bool dontEnlarge = false;
   lv_obj_t *image = nullptr;
 };
 


### PR DESCRIPTION
Images that are smaller than the preview window size are shown actual size (to match the 2.9 functionality).
