### PR TITLE
fix(color): last interactive checklist line not shown if EoF not newline

### DIFF
--- a/radio/src/gui/colorlcd/view_text.cpp
+++ b/radio/src/gui/colorlcd/view_text.cpp
@@ -348,8 +348,10 @@ class ViewChecklistWindow : public ViewTextWindow
 
       size_t cur = 0;
 
-      for (size_t i = 0; i < bufSize; ++i) {
-        if (buffer[i] == '\n' || buffer[i] == '\r') {
+      for (size_t i = 0; i <= bufSize; ++i) {
+        if (buffer[i] == '\n' || buffer[i] == '\r' || buffer[i] == 0) {
+          // Check for end of line & end of file
+          if (buffer[i] == 0 && cur == i) break;
           buffer[i] = 0;
           if (buffer[i] == '\r' && buffer[i + 1] == '\n') i += 1;
 


### PR DESCRIPTION
Discovered by John on RC Video Reviews.