### PR TITLE
fix(bw): analog debug page text overlap

### DIFF
--- a/radio/src/gui/128x64/radio_diaganas.cpp
+++ b/radio/src/gui/128x64/radio_diaganas.cpp
@@ -95,15 +95,15 @@ void menuRadioDiagAnalogs(event_t event)
         if (entryCount == 0) {
           lastShownAnalogValue[i] = getAnalogValue(i); // Update value
         }
-        lcdDrawNumber(x+3*FW-1, y, lastShownAnalogValue[i],
+        lcdDrawNumber(x+3*FW+1, y, lastShownAnalogValue[i],
                       LEADING0|LEFT, 4);
         break;
       case (ANAVIEW_CALIB):
       default:
-        lcdDrawNumber(x+3*FW-1, y, anaIn(i), LEADING0|LEFT, 4);
+        lcdDrawNumber(x+3*FW+1, y, anaIn(i), LEADING0|LEFT, 4);
         break;
     }
-    lcdDrawNumber(x+10*FW-1, y,
+    lcdDrawNumber(x+(LCD_W / 2 - INDENT_WIDTH), y,
                   (int16_t)calibratedAnalogs[i]*25/256,
                   RIGHT);
   }


### PR DESCRIPTION
Remove text overlap for line with longer names.

Before:
![screen-2024-05-01-204257](https://github.com/EdgeTX/edgetx/assets/9474356/2d2967cb-ff18-4141-82c4-685afca36221)

After:
![screen-2024-05-01-205150](https://github.com/EdgeTX/edgetx/assets/9474356/5a015354-722b-4867-a459-73ca93f3a04c)
