### PR TITLE
feat: use only vario sensor for vario source

### DIFF
--- a/radio/src/gui/128x64/model_telemetry.cpp
+++ b/radio/src/gui/128x64/model_telemetry.cpp
@@ -268,7 +268,7 @@ void menuModelTelemetry(event_t event)
         lcdDrawTextAlignedLeft(y, INDENT TR_SOURCE);
         drawSource(TELEM_COL2, y, g_model.varioData.source ? MIXSRC_FIRST_TELEM+3*(g_model.varioData.source-1) : 0, attr);
         if (attr) {
-          g_model.varioData.source = checkIncDec(event, g_model.varioData.source, 0, MAX_TELEMETRY_SENSORS, EE_MODEL|NO_INCDEC_MARKS, isSensorAvailable);
+          g_model.varioData.source = checkIncDec(event, g_model.varioData.source, 0, MAX_TELEMETRY_SENSORS, EE_MODEL|NO_INCDEC_MARKS, isVarioSensorAvailable);
         }
         break;
 

--- a/radio/src/gui/212x64/model_telemetry.cpp
+++ b/radio/src/gui/212x64/model_telemetry.cpp
@@ -253,7 +253,7 @@ void menuModelTelemetry(event_t event)
         lcdDrawTextAlignedLeft(y, INDENT TR_SOURCE);
         drawSource(TELEM_COL2, y, g_model.varioData.source ? MIXSRC_FIRST_TELEM+3*(g_model.varioData.source-1) : 0, attr);
         if (attr) {
-          g_model.varioData.source = checkIncDec(event, g_model.varioData.source, 0, MAX_TELEMETRY_SENSORS, EE_MODEL|NO_INCDEC_MARKS, isSensorAvailable);
+          g_model.varioData.source = checkIncDec(event, g_model.varioData.source, 0, MAX_TELEMETRY_SENSORS, EE_MODEL|NO_INCDEC_MARKS, isVarioSensorAvailable);
         }
         break;
 

--- a/radio/src/gui/colorlcd/model_telemetry.cpp
+++ b/radio/src/gui/colorlcd/model_telemetry.cpp
@@ -1015,7 +1015,7 @@ void ModelTelemetryPage::build(Window* window)
     if (value == MIXSRC_NONE) return true;
     if (value < MIXSRC_FIRST_TELEM) return false;
     auto qr = div(value - MIXSRC_FIRST_TELEM, 3);
-    return qr.rem == 0 && isSensorAvailable(qr.quot + 1);
+    return qr.rem == 0 && isVarioSensorAvailable(qr.quot + 1);
   });
 
   line = window->newLine(grid5);

--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -73,6 +73,15 @@ bool isRssiSensorAvailable(int sensor)
   }
 }
 
+bool isVarioSensorAvailable(int sensor)
+{
+  if (sensor == 0)
+    return true;
+  else {
+    return (isSensorAvailable(sensor) && (isSensorUnit(sensor, UNIT_METERS_PER_SECOND) || isSensorUnit(sensor, UNIT_FEET_PER_SECOND)));
+  }
+}
+
 bool isSensorAvailable(int sensor)
 {
   if (sensor == 0)

--- a/radio/src/gui/gui_common.h
+++ b/radio/src/gui/gui_common.h
@@ -101,6 +101,7 @@ uint8_t getTelemetrySensorsCount();
 bool isTelemetryFieldComparisonAvailable(int index);
 bool isSensorAvailable(int sensor);
 bool isRssiSensorAvailable(int sensor);
+bool isVarioSensorAvailable(int sensor);
 bool hasSportPower();
 
 bool modelHasNotes();


### PR DESCRIPTION
Some people have a tendency to try to select Alt sensors as vario source, this change prevents it