### PR TITLE
fix(debug): don't initalise SP_AUX1 if not exist

### DIFF
--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -104,7 +104,7 @@ void boardInit()
 
   __enable_irq();
 
-#if defined(DEBUG)
+#if defined(DEBUG) && defined(AUX_SERIAL)
   serialSetMode(SP_AUX1, UART_MODE_DEBUG);                // indicate AUX1 is used
   serialInit(SP_AUX1, UART_MODE_DEBUG);                   // early AUX1 init
 #endif

--- a/radio/src/targets/nv14/board.cpp
+++ b/radio/src/targets/nv14/board.cpp
@@ -161,7 +161,7 @@ void boardInit()
   // detect NV14 vs EL18
   hardwareOptions.pcbrev = boardGetPcbRev();
 
-#if defined(DEBUG)
+#if defined(DEBUG) && defined(AUX_SERIAL)
   serialSetMode(SP_AUX1, UART_MODE_DEBUG);                // indicate AUX1 is used
   serialInit(SP_AUX1, UART_MODE_DEBUG);                   // early AUX1 init
 #endif

--- a/radio/src/targets/nv14/board.h
+++ b/radio/src/targets/nv14/board.h
@@ -242,7 +242,6 @@ void hapticOff();
 void hapticOn(uint32_t pwmPercent);
 
 // Second serial port driver
-//#define AUX_SERIAL
 #define DEBUG_BAUDRATE                  115200
 #define LUA_DEFAULT_BAUDRATE            115200
 

--- a/radio/src/targets/pl18/board.cpp
+++ b/radio/src/targets/pl18/board.cpp
@@ -128,7 +128,7 @@ void boardInit()
   __enable_irq();
 #endif
 
-#if defined(DEBUG)
+#if defined(DEBUG) && defined(AUX_SERIAL)
   serialSetMode(SP_AUX1, UART_MODE_DEBUG);                // indicate AUX1 is used
   serialInit(SP_AUX1, UART_MODE_DEBUG);                   // early AUX1 init
 #endif

--- a/radio/src/targets/pl18/board.h
+++ b/radio/src/targets/pl18/board.h
@@ -226,7 +226,6 @@ void hapticOff();
 void hapticOn(uint32_t pwmPercent);
 
 // Second serial port driver
-//#define AUX_SERIAL
 #define DEBUG_BAUDRATE                  115200
 #define LUA_DEFAULT_BAUDRATE            115200
 

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -215,7 +215,7 @@ void boardInit()
   ws2812_update(&_led_timer);
 #endif
 
-#if defined(DEBUG)
+#if defined(DEBUG) && defined(AUX_SERIAL)
   serialSetMode(SP_AUX1, UART_MODE_DEBUG);                // indicate AUX1 is used
   serialInit(SP_AUX1, UART_MODE_DEBUG);                   // early AUX1 init
 #endif


### PR DESCRIPTION
Fixes #4958

**Summary of changes:**

 #3814 implicitly exposed an assumption whereby AUX1 was being initialised for use for debugging when not available, and thus locking "Debug" out as an option for USB-VCP on radios with no available AUX1. Therefore, check if AUX_SERIAL is defined as well as DEBUG. 
