### PR TITLE
fix(bw): editing names on 9x/xlite nav radios & popup menu using wrong keys/events

### DIFF
--- a/radio/src/gui/navigation/common.cpp
+++ b/radio/src/gui/navigation/common.cpp
@@ -48,7 +48,7 @@ int checkIncDecSelection = 0;
 
 void repeatLastCursorMove(event_t event)
 {
-  if (IS_PREVIOUS_EVENT(event) || IS_NEXT_EVENT(event)) {
+  if (IS_PREVIOUS_MOVE_EVENT(event) || IS_NEXT_MOVE_EVENT(event)) {
     pushEvent(event);
   }
   else {

--- a/radio/src/keys.h
+++ b/radio/src/keys.h
@@ -149,12 +149,26 @@ inline bool IS_KEY_EVT(event_t evt, uint8_t key)
 inline bool IS_NEXT_EVENT(event_t evt)
 {
   return evt == EVT_KEY_FIRST(KEY_DOWN) || evt == EVT_KEY_REPT(KEY_DOWN) ||
-         evt == EVT_KEY_FIRST(KEY_RIGHT) || evt == EVT_KEY_REPT(KEY_RIGHT) ||
          evt == EVT_KEY_FIRST(KEY_MINUS) || evt == EVT_KEY_REPT(KEY_MINUS) ||
          evt == EVT_ROTARY_RIGHT;
 }
 
 inline bool IS_PREVIOUS_EVENT(event_t evt)
+{
+  return evt == EVT_KEY_FIRST(KEY_UP) || evt == EVT_KEY_REPT(KEY_UP) ||
+         evt == EVT_KEY_FIRST(KEY_PLUS) || evt == EVT_KEY_REPT(KEY_PLUS) ||
+         evt == EVT_ROTARY_LEFT;
+}
+
+inline bool IS_NEXT_MOVE_EVENT(event_t evt)
+{
+  return evt == EVT_KEY_FIRST(KEY_DOWN) || evt == EVT_KEY_REPT(KEY_DOWN) ||
+         evt == EVT_KEY_FIRST(KEY_RIGHT) || evt == EVT_KEY_REPT(KEY_RIGHT) ||
+         evt == EVT_KEY_FIRST(KEY_MINUS) || evt == EVT_KEY_REPT(KEY_MINUS) ||
+         evt == EVT_ROTARY_RIGHT;
+}
+
+inline bool IS_PREVIOUS_MOVE_EVENT(event_t evt)
 {
   return evt == EVT_KEY_FIRST(KEY_UP) || evt == EVT_KEY_REPT(KEY_UP) ||
          evt == EVT_KEY_FIRST(KEY_LEFT) || evt == EVT_KEY_REPT(KEY_LEFT) ||


### PR DESCRIPTION
Fixes #4965 

