### PR TITLE
fix(bw): adjust 128x64 layout to accommodate long switch names

### DIFF
--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -597,13 +597,13 @@ void menuMainView(event_t event)
                                 5 * FH + 1, 4, i);
               }
               else {
-                coord_t x = switch_display.col == 0 ? 2 * FW - 2 : 16 * FW + 7;
+                coord_t x = switch_display.col == 0 ? 3 * FW + 3 : 18 * FW + 1;
                 coord_t y = 33 + switch_display.row * FH;
                 getvalue_t val = getValue(MIXSRC_FIRST_SWITCH + i);
                 getvalue_t sw =
                     ((val < 0) ? 3 * i + 1
                                : ((val == 0) ? 3 * i + 2 : 3 * i + 3));
-                drawSwitch(x, y, sw, 0, false);
+                drawSwitch(x, y, sw, CENTERED, false);
               }
             }
           }

--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -600,6 +600,7 @@ void menuMainView(event_t event)
                 coord_t x = switch_display.col == 0 ? 3 * FW + 3 : 18 * FW + 1;
                 coord_t y = 33 + switch_display.row * FH;
                 getvalue_t val = getValue(MIXSRC_FIRST_SWITCH + i);
+                if (val == 0) x -= 1;
                 getvalue_t sw =
                     ((val < 0) ? 3 * i + 1
                                : ((val == 0) ? 3 * i + 2 : 3 * i + 3));


### PR DESCRIPTION
Fixes #4975 

Summary of changes:
- Adjust position of switch names to allow more room
- Center justify switch names so it looks more balanced.

![screenshot_x7_24-05-07_12-22-48](https://github.com/EdgeTX/edgetx/assets/9474356/f99cf005-1edd-4acf-80ee-182d8a212078)
![screenshot_x7_24-05-07_12-23-06](https://github.com/EdgeTX/edgetx/assets/9474356/ebe1339d-8ba9-4053-98e2-4f03bdb709c8)
