### PR TITLE
chore: missed check for Pocket ModelData size

### DIFF
--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -127,6 +127,7 @@ static inline void check_struct()
   CHKSIZE(ModelData, 6290);
 #elif defined(RADIO_POCKET)
   CHKSIZE(RadioData, 869);
+  CHKSIZE(ModelData, 6265);
 #elif defined(RADIO_TPROV2)
   CHKSIZE(RadioData, 869);
   CHKSIZE(ModelData, 6290);


### PR DESCRIPTION
Summary of changes:
- adds missing ModelData for RM Pocket
- also missing in 2.10, and struct is the same size