### PR TITLE
feat(color): support PPM_US setting

### DIFF
--- a/radio/src/gui/colorlcd/channel_bar.h
+++ b/radio/src/gui/colorlcd/channel_bar.h
@@ -31,11 +31,12 @@ constexpr coord_t TMARGIN = 2;
 class ChannelBar : public Window
 {
  public:
-  ChannelBar(Window* parent, const rect_t& rect,
-             std::function<int16_t()> getValue, LcdFlags barColor,
-             LcdFlags textColor = COLOR_THEME_SECONDARY1);
+  ChannelBar(Window* parent, const rect_t& rect, uint8_t channel,
+             std::function<int16_t()> getValue, LcdColorIndex barColorIndex,
+             LcdColorIndex textColorIndex = COLOR_THEME_SECONDARY1_INDEX);
 
  protected:
+  uint8_t channel = 0;
   int16_t value = -10000;
   std::function<int16_t()> getValue;
   lv_obj_t* valText = nullptr;
@@ -58,7 +59,6 @@ class OutputChannelBar : public ChannelBar
                    bool editColor = false, bool drawLimits = true);
 
  protected:
-  uint8_t channel = 0;
   int limMax = 0;
   int limMin = 0;
   bool drawLimits = true;

--- a/radio/src/gui/colorlcd/gvar_numberedit.cpp
+++ b/radio/src/gui/colorlcd/gvar_numberedit.cpp
@@ -153,3 +153,8 @@ void GVarNumberEdit::update()
     lv_group_focus_obj(act_obj);
   }
 }
+
+void GVarNumberEdit::setDisplayHandler(std::function<std::string(int value)> function)
+{
+  num_field->setDisplayHandler(function);
+}

--- a/radio/src/gui/colorlcd/gvar_numberedit.h
+++ b/radio/src/gui/colorlcd/gvar_numberedit.h
@@ -43,7 +43,8 @@ class GVarNumberEdit : public Window
 
   void setFastStep(int value) { num_field->setFastStep(value); }
   void setAccelFactor(int value) { num_field->setAccelFactor(value); }
-  
+  void setDisplayHandler(std::function<std::string(int value)> function);
+
  protected:
   Choice* gvar_field = nullptr;
   NumberEdit* num_field = nullptr;

--- a/radio/src/gui/colorlcd/model_outputs.cpp
+++ b/radio/src/gui/colorlcd/model_outputs.cpp
@@ -188,11 +188,11 @@ class OutputLineButton : public ListLineButton
 
     char s[32];
     getValueOrGVarString(s, sizeof(s), output->min, -GV_RANGELARGE, 0, PREC1,
-                         nullptr, -LIMITS_MIN_MAX_OFFSET);
+                         nullptr, -LIMITS_MIN_MAX_OFFSET, true);
     lv_label_set_text(min, s);
 
     getValueOrGVarString(s, sizeof(s), output->max, 0, GV_RANGELARGE, PREC1,
-                         nullptr, +LIMITS_MIN_MAX_OFFSET);
+                         nullptr, +LIMITS_MIN_MAX_OFFSET, true);
     lv_label_set_text(max, s);
 
     getValueOrGVarString(s, sizeof(s), output->offset, -LIMIT_STD_MAX,

--- a/radio/src/gui/colorlcd/output_edit.cpp
+++ b/radio/src/gui/colorlcd/output_edit.cpp
@@ -155,6 +155,11 @@ void OutputEditWindow::buildBody(Window *form)
   etx_font(minEdit->getLvObj(), FONT_BOLD_INDEX, ETX_STATE_MINMAX_HIGHLIGHT);
   minEdit->setFastStep(20);
   minEdit->setAccelFactor(16);
+  minEdit->setDisplayHandler([=](int value) {
+    if (g_eeGeneral.ppmunit == PPM_US)
+      value = value * 128 / 25;
+    return formatNumberAsString(value, PREC1);
+  });
 
   // Max
   maxText = new StaticText(line, rect_t{}, TR_MAX);
@@ -166,6 +171,11 @@ void OutputEditWindow::buildBody(Window *form)
   etx_font(maxEdit->getLvObj(), FONT_BOLD_INDEX, ETX_STATE_MINMAX_HIGHLIGHT);
   maxEdit->setFastStep(20);
   maxEdit->setAccelFactor(16);
+  maxEdit->setDisplayHandler([=](int value) {
+    if (g_eeGeneral.ppmunit == PPM_US)
+      value = value * 128 / 25;
+    return formatNumberAsString(value, PREC1);
+  });
 
   // Direction
   line = form->newLine(grid);

--- a/radio/src/gui/colorlcd/radio_setup.cpp
+++ b/radio/src/gui/colorlcd/radio_setup.cpp
@@ -877,7 +877,7 @@ void RadioSetupPage::build(Window* window)
   // PPM units
   line = window->newLine(grid);
   new StaticText(line, rect_t{}, STR_UNITS_PPM);
-  new Choice(line, rect_t{}, STR_PPMUNIT, PPM_PERCENT_PREC0, PPM_PERCENT_PREC1,
+  new Choice(line, rect_t{}, STR_PPMUNIT, PPM_PERCENT_PREC0, PPM_US,
              GET_SET_DEFAULT(g_eeGeneral.ppmunit));
 
 #if defined(FAI_CHOICE)

--- a/radio/src/gui/colorlcd/widgets/outputs.cpp
+++ b/radio/src/gui/colorlcd/widgets/outputs.cpp
@@ -101,17 +101,25 @@ class ChannelValue : public Window
 
   void checkEvents() override
   {
-    int16_t value = calcRESXto100(channelOutputs[channel]);
+    int16_t value = channelOutputs[channel];
     if (value != lastValue) {
       lastValue = value;
 
-      lv_label_set_text(valueLabel,
-                        formatNumberAsString(lastValue, 0, 0, 0, "%").c_str());
+      std::string s;
+      if (g_eeGeneral.ppmunit == PPM_US)
+        s = formatNumberAsString(PPM_CH_CENTER(channel) + value / 2, 0, 0, "", STR_US);
+      else if (g_eeGeneral.ppmunit == PPM_PERCENT_PREC1)
+        s = formatNumberAsString(calcRESXto1000(value), PREC1, 0, "", "%");
+      else
+        s = formatNumberAsString(calcRESXto100(value), 0, 0, "", "%");
 
+      lv_label_set_text(valueLabel, s.c_str());
+
+      const int lim = (g_model.extendedLimits ? (1024 * LIMIT_EXT_PERCENT / 100) : 1024);
       uint16_t w = width() - 2;
       uint16_t fillW = divRoundClosest(
-          w * limit<int16_t>(0, abs(lastValue), VIEW_CHANNELS_LIMIT_PCT),
-          VIEW_CHANNELS_LIMIT_PCT * 2);
+          w * limit<int16_t>(0, abs(lastValue), lim),
+          lim * 2);
       uint16_t x = lastValue > 0 ? w / 2 : w / 2 - fillW + 1;
 
       lv_obj_set_pos(bar, x, 0);

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -401,7 +401,7 @@ char *getGVarString(char *dest, int idx)
 #if defined(LIBOPENUI)
 char *getValueOrGVarString(char *dest, size_t len, gvar_t value, gvar_t vmin,
                            gvar_t vmax, LcdFlags flags, const char *suffix,
-                           gvar_t offset)
+                           gvar_t offset, bool usePPMUnit)
 {
   if (GV_IS_GV_VALUE(value, vmin, vmax)) {
     int index = GV_INDEX_CALC_DELTA(value, GV_GET_GV1_VALUE(vmin, vmax));
@@ -409,6 +409,8 @@ char *getValueOrGVarString(char *dest, size_t len, gvar_t value, gvar_t vmin,
   }
 
   value += offset;
+  if (usePPMUnit && g_eeGeneral.ppmunit == PPM_US)
+    value = value * 128 / 25;
   formatNumberAsString(dest, len, value, flags, 0, nullptr, suffix);
   return dest;
 }

--- a/radio/src/strhelpers.h
+++ b/radio/src/strhelpers.h
@@ -95,7 +95,7 @@ char *getGVarString(char *dest, int idx);
 char *getGVarString(int idx);
 char *getValueOrGVarString(char *dest, size_t len, gvar_t value, gvar_t vmin,
                            gvar_t vmax, LcdFlags flags = 0,
-                           const char *suffix = nullptr, gvar_t offset = 0);
+                           const char *suffix = nullptr, gvar_t offset = 0, bool usePPMUnit = false);
 const char *getSwitchWarnSymbol(uint8_t pos);
 const char *getSwitchPositionSymbol(uint8_t pos);
 char *getSwitchPositionName(char *dest, swsrc_t idx);


### PR DESCRIPTION
Fixes #4977 and #3163

I've tried to match all the places that the PPM_US setting is used on B&W radios.

Channel monitor. Note if using PPM_US setting the value at the right above each channel changes to % instead of showing us value.
![screenshot_tx16s_24-05-11_14-40-39](https://github.com/EdgeTX/edgetx/assets/9474356/c36f48e3-5c8a-4147-8789-723a9880aee2)

Custom failsafe settings:
![screenshot_tx16s_24-05-11_14-41-11](https://github.com/EdgeTX/edgetx/assets/9474356/59a4d0f6-6c4d-4d4f-b71b-13def7d7db55)

Outputs list (min/max values):
![screenshot_tx16s_24-05-11_15-11-22](https://github.com/EdgeTX/edgetx/assets/9474356/f20e9759-1deb-4ba6-bc75-ae079c0c5f10)

Outputs widget:
![screenshot_tx16s_24-05-11_14-47-50](https://github.com/EdgeTX/edgetx/assets/9474356/c8aa0892-4e45-4ec1-86c0-d2b16a7a7324)

