### PR TITLE
feat: option to disable power on/off haptic

### DIFF
--- a/companion/src/firmwares/edgetx/yaml_generalsettings.cpp
+++ b/companion/src/firmwares/edgetx/yaml_generalsettings.cpp
@@ -279,6 +279,7 @@ Node convert<GeneralSettings>::encode(const GeneralSettings& rhs)
   node["antennaMode"] = antennaModeLut << rhs.antennaMode;
   node["pwrOnSpeed"] = rhs.pwrOnSpeed;
   node["pwrOffSpeed"] = rhs.pwrOffSpeed;
+  node["disablePwrOnOffHaptic"] == (int)rhs.disablePwrOnOffHaptic;
 
   for (int i = 0; i < CPN_MAX_SPECIAL_FUNCTIONS; i++) {
     const CustomFunctionData& fn = rhs.customFn[i];
@@ -557,6 +558,7 @@ bool convert<GeneralSettings>::decode(const Node& node, GeneralSettings& rhs)
   node["backlightColor"] >> rhs.backlightColor;
   node["pwrOnSpeed"] >> rhs.pwrOnSpeed;
   node["pwrOffSpeed"] >> rhs.pwrOffSpeed;
+  node["disablePwrOnOffHaptic"] >> rhs.disablePwrOnOffHaptic;
 
   if (node["customFn"]) {
     // decode common for radio GF and model SF and conversion test assumes decoding a model

--- a/companion/src/firmwares/edgetx/yaml_generalsettings.cpp
+++ b/companion/src/firmwares/edgetx/yaml_generalsettings.cpp
@@ -279,7 +279,7 @@ Node convert<GeneralSettings>::encode(const GeneralSettings& rhs)
   node["antennaMode"] = antennaModeLut << rhs.antennaMode;
   node["pwrOnSpeed"] = rhs.pwrOnSpeed;
   node["pwrOffSpeed"] = rhs.pwrOffSpeed;
-  node["disablePwrOnOffHaptic"] == (int)rhs.disablePwrOnOffHaptic;
+  node["disablePwrOnOffHaptic"] = (int)rhs.disablePwrOnOffHaptic;
 
   for (int i = 0; i < CPN_MAX_SPECIAL_FUNCTIONS; i++) {
     const CustomFunctionData& fn = rhs.customFn[i];

--- a/companion/src/firmwares/generalsettings.h
+++ b/companion/src/firmwares/generalsettings.h
@@ -296,6 +296,7 @@ class GeneralSettings {
 
     int pwrOnSpeed;
     int pwrOffSpeed;
+    bool disablePwrOnOffHaptic;
 
     char selectedTheme[SELECTED_THEME_NAME_LEN + 1];
 

--- a/companion/src/generaledit/generalsetup.cpp
+++ b/companion/src/generaledit/generalsetup.cpp
@@ -289,7 +289,7 @@ ui(new Ui::GeneralSetup)
     ui->pwrOnDelay->hide();
   }
 
-  ui->disablePwrOnOffHapticChkB->setChecked(!generalSettings.disablePwrOnOffHaptic); // Default is zero=checked
+  ui->pwrOnOffHaptic_CB->setChecked(!generalSettings.disablePwrOnOffHaptic); // Default is zero=checked
 
   ui->registrationId->setValidator(new NameValidator(board, this));
   ui->registrationId->setMaxLength(REGISTRATION_ID_LEN);
@@ -644,9 +644,9 @@ void GeneralSetupPanel::on_pwrOffDelay_valueChanged(int)
   emit modified();
 }
 
-void GeneralSetupPanel::on_disablePwrOnOffHapticChkB_stateChanged(int)
+void GeneralSetupPanel::on_pwrOnOffHaptic_CB_stateChanged(int)
 {
-  generalSettings.disablePwrOnOffHaptic = ui->disablePwrOnOffHapticChkB->isChecked() ? 0 : 1;
+  generalSettings.disablePwrOnOffHaptic = ui->pwrOnOffHaptic_CB->isChecked() ? 0 : 1;
   emit modified();
 }
 

--- a/companion/src/generaledit/generalsetup.cpp
+++ b/companion/src/generaledit/generalsetup.cpp
@@ -289,6 +289,8 @@ ui(new Ui::GeneralSetup)
     ui->pwrOnDelay->hide();
   }
 
+  ui->disablePwrOnOffHapticChkB->setChecked(!generalSettings.disablePwrOnOffHaptic); // Default is zero=checked
+
   ui->registrationId->setValidator(new NameValidator(board, this));
   ui->registrationId->setMaxLength(REGISTRATION_ID_LEN);
 
@@ -639,6 +641,12 @@ void GeneralSetupPanel::on_pwrOnDelay_valueChanged(int)
 void GeneralSetupPanel::on_pwrOffDelay_valueChanged(int)
 {
   generalSettings.pwrOffSpeed = 2 - ui->pwrOffDelay->value();
+  emit modified();
+}
+
+void GeneralSetupPanel::on_disablePwrOnOffHapticChkB_stateChanged(int)
+{
+  generalSettings.disablePwrOnOffHaptic = ui->disablePwrOnOffHapticChkB->isChecked() ? 0 : 1;
   emit modified();
 }
 

--- a/companion/src/generaledit/generalsetup.h
+++ b/companion/src/generaledit/generalsetup.h
@@ -93,7 +93,7 @@ class GeneralSetupPanel : public GeneralPanel
 
     void on_pwrOnDelay_valueChanged(int);
     void on_pwrOffDelay_valueChanged(int);
-    void on_disablePwrOnOffHapticChkB_stateChanged(int);
+    void on_pwrOnOffHaptic_CB_stateChanged(int);
 
     void on_modelQuickSelect_CB_stateChanged(int);
     void on_startSoundCB_stateChanged(int);

--- a/companion/src/generaledit/generalsetup.h
+++ b/companion/src/generaledit/generalsetup.h
@@ -93,6 +93,7 @@ class GeneralSetupPanel : public GeneralPanel
 
     void on_pwrOnDelay_valueChanged(int);
     void on_pwrOffDelay_valueChanged(int);
+    void on_disablePwrOnOffHapticChkB_stateChanged(int);
 
     void on_modelQuickSelect_CB_stateChanged(int);
     void on_startSoundCB_stateChanged(int);

--- a/companion/src/generaledit/generalsetup.ui
+++ b/companion/src/generaledit/generalsetup.ui
@@ -20,14 +20,14 @@
       <string>Readonly Unlock</string>
      </property>
      <property name="alignment">
-      <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+      <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
      </property>
     </widget>
    </item>
    <item row="1" column="1" colspan="3">
     <layout class="QGridLayout" name="TaranisReadOnlyUnlock" rowstretch="0,0" columnstretch="0,0,0,0,0,0,0,0,0">
      <property name="sizeConstraint">
-      <enum>QLayout::SetMinimumSize</enum>
+      <enum>QLayout::SizeConstraint::SetMinimumSize</enum>
      </property>
      <property name="topMargin">
       <number>0</number>
@@ -47,7 +47,7 @@
         <string>SC</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignCenter</set>
+        <set>Qt::AlignmentFlag::AlignCenter</set>
        </property>
       </widget>
      </item>
@@ -84,13 +84,13 @@
         <number>0</number>
        </property>
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="invertedAppearance">
         <bool>true</bool>
        </property>
        <property name="tickPosition">
-        <enum>QSlider::TicksBothSides</enum>
+        <enum>QSlider::TickPosition::TicksBothSides</enum>
        </property>
        <property name="tickInterval">
         <number>1</number>
@@ -109,7 +109,7 @@
         <string>SE</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignCenter</set>
+        <set>Qt::AlignmentFlag::AlignCenter</set>
        </property>
       </widget>
      </item>
@@ -149,13 +149,13 @@
         <number>0</number>
        </property>
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="invertedAppearance">
         <bool>true</bool>
        </property>
        <property name="tickPosition">
-        <enum>QSlider::TicksBothSides</enum>
+        <enum>QSlider::TickPosition::TicksBothSides</enum>
        </property>
        <property name="tickInterval">
         <number>1</number>
@@ -195,13 +195,13 @@
         <number>0</number>
        </property>
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="invertedAppearance">
         <bool>true</bool>
        </property>
        <property name="tickPosition">
-        <enum>QSlider::TicksBothSides</enum>
+        <enum>QSlider::TickPosition::TicksBothSides</enum>
        </property>
        <property name="tickInterval">
         <number>1</number>
@@ -241,13 +241,13 @@
         <number>0</number>
        </property>
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="invertedAppearance">
         <bool>true</bool>
        </property>
        <property name="tickPosition">
-        <enum>QSlider::TicksBothSides</enum>
+        <enum>QSlider::TickPosition::TicksBothSides</enum>
        </property>
        <property name="tickInterval">
         <number>1</number>
@@ -287,13 +287,13 @@
         <number>0</number>
        </property>
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="invertedAppearance">
         <bool>true</bool>
        </property>
        <property name="tickPosition">
-        <enum>QSlider::TicksBothSides</enum>
+        <enum>QSlider::TickPosition::TicksBothSides</enum>
        </property>
        <property name="tickInterval">
         <number>1</number>
@@ -333,13 +333,13 @@
         <number>0</number>
        </property>
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="invertedAppearance">
         <bool>true</bool>
        </property>
        <property name="tickPosition">
-        <enum>QSlider::TicksBothSides</enum>
+        <enum>QSlider::TickPosition::TicksBothSides</enum>
        </property>
        <property name="tickInterval">
         <number>1</number>
@@ -379,13 +379,13 @@
         <number>0</number>
        </property>
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="invertedAppearance">
         <bool>true</bool>
        </property>
        <property name="tickPosition">
-        <enum>QSlider::TicksBothSides</enum>
+        <enum>QSlider::TickPosition::TicksBothSides</enum>
        </property>
        <property name="tickInterval">
         <number>1</number>
@@ -404,7 +404,7 @@
         <string>SA</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignCenter</set>
+        <set>Qt::AlignmentFlag::AlignCenter</set>
        </property>
       </widget>
      </item>
@@ -420,7 +420,7 @@
         <string>SF</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignCenter</set>
+        <set>Qt::AlignmentFlag::AlignCenter</set>
        </property>
       </widget>
      </item>
@@ -436,7 +436,7 @@
         <string>SH</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignCenter</set>
+        <set>Qt::AlignmentFlag::AlignCenter</set>
        </property>
       </widget>
      </item>
@@ -452,7 +452,7 @@
         <string>SD</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignCenter</set>
+        <set>Qt::AlignmentFlag::AlignCenter</set>
        </property>
       </widget>
      </item>
@@ -468,7 +468,7 @@
         <string>SB</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignCenter</set>
+        <set>Qt::AlignmentFlag::AlignCenter</set>
        </property>
       </widget>
      </item>
@@ -508,13 +508,13 @@
         <number>0</number>
        </property>
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="invertedAppearance">
         <bool>true</bool>
        </property>
        <property name="tickPosition">
-        <enum>QSlider::TicksBothSides</enum>
+        <enum>QSlider::TickPosition::TicksBothSides</enum>
        </property>
        <property name="tickInterval">
         <number>1</number>
@@ -533,14 +533,14 @@
         <string>SG</string>
        </property>
        <property name="alignment">
-        <set>Qt::AlignCenter</set>
+        <set>Qt::AlignmentFlag::AlignCenter</set>
        </property>
       </widget>
      </item>
      <item row="1" column="8">
       <spacer name="horizontalSpacer_6">
        <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+        <enum>Qt::Orientation::Horizontal</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -585,7 +585,7 @@
           <number>1</number>
          </property>
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
         </widget>
        </item>
@@ -608,7 +608,7 @@
           <number>1</number>
          </property>
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
         </widget>
        </item>
@@ -631,7 +631,7 @@
           <number>1</number>
          </property>
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
         </widget>
        </item>
@@ -654,7 +654,7 @@
           <number>1</number>
          </property>
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
         </widget>
        </item>
@@ -885,7 +885,7 @@ p, li { white-space: pre-wrap; }
      <item row="29" column="0">
       <spacer name="verticalSpacer_3">
        <property name="orientation">
-        <enum>Qt::Vertical</enum>
+        <enum>Qt::Orientation::Vertical</enum>
        </property>
        <property name="sizeHint" stdset="0">
         <size>
@@ -1069,7 +1069,7 @@ p, li { white-space: pre-wrap; }
           <string>Automatically adjust the radio's clock if a GPS is connected to telemetry.</string>
          </property>
          <property name="layoutDirection">
-          <enum>Qt::RightToLeft</enum>
+          <enum>Qt::LayoutDirection::RightToLeft</enum>
          </property>
          <property name="text">
           <string>Adjust RTC</string>
@@ -1153,7 +1153,7 @@ p, li { white-space: pre-wrap; }
           <number>5</number>
          </property>
          <property name="orientation">
-          <enum>Qt::Horizontal</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
         </widget>
        </item>
@@ -1272,554 +1272,8 @@ p, li { white-space: pre-wrap; }
    <item row="0" column="0" colspan="2">
     <layout class="QGridLayout" name="gridLayout_2">
      <property name="sizeConstraint">
-      <enum>QLayout::SetDefaultConstraint</enum>
+      <enum>QLayout::SizeConstraint::SetDefaultConstraint</enum>
      </property>
-     <item row="21" column="0">
-      <widget class="QLabel" name="units_label">
-       <property name="text">
-        <string>Measurement Units</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="label_hapticStrengthSB">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Haptic Strength</string>
-       </property>
-      </widget>
-     </item>
-     <item row="25" column="0">
-      <widget class="QLabel" name="jackModeLabel">
-       <property name="text">
-        <string>Jack Mode</string>
-       </property>
-      </widget>
-     </item>
-     <item row="22" column="0">
-      <widget class="QLabel" name="gpsFormatLabel">
-       <property name="text">
-        <string>GPS Coordinates</string>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="0">
-      <widget class="QLabel" name="splashScreenLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Show Splash Screen on Startup</string>
-       </property>
-      </widget>
-     </item>
-     <item row="18" column="0">
-      <widget class="QLabel" name="mavbaud_label">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>MAVLink Baud Rate</string>
-       </property>
-      </widget>
-     </item>
-     <item row="15" column="1" colspan="2">
-      <widget class="QCheckBox" name="memwarnChkB">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="whatsThis">
-        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;Warnings&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;These will define startup warnings.&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Throttle warning - will alert if the throttle is not at idle during startup&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Switch warning - will alert if switches are not in their defaul position&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Memory warning - will alert if there's not a lot of memory left&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Silent mode warning - will alert you if the beeper is set to quiet (0)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="18" column="1" colspan="2">
-      <widget class="QComboBox" name="mavbaud_CB">
-       <item>
-        <property name="text">
-         <string>4800 Baud</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>9600 Baud</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>14400 Baud</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>19200 Baud</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>38400 Baud</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>57600 Baud</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>76800 Baud</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>115200 Baud</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="8" column="1" colspan="2">
-      <widget class="QComboBox" name="displayTypeCB">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>22</height>
-        </size>
-       </property>
-       <item>
-        <property name="text">
-         <string>Standard</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Optrex</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="23" column="1">
-      <widget class="QSpinBox" name="switchesDelay">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="statusTip">
-        <string/>
-       </property>
-       <property name="whatsThis">
-        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;LCD Screen Contrast&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Values can be 20-45&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="suffix">
-        <string> ms</string>
-       </property>
-       <property name="minimum">
-        <number>0</number>
-       </property>
-       <property name="maximum">
-        <number>1000</number>
-       </property>
-       <property name="singleStep">
-        <number>10</number>
-       </property>
-       <property name="value">
-        <number>0</number>
-       </property>
-      </widget>
-     </item>
-     <item row="19" column="1">
-      <widget class="QComboBox" name="stickmodeCB">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="statusTip">
-        <string/>
-       </property>
-       <property name="whatsThis">
-        <string>Mode selection:
-
-Mode 1:
-  Left stick:  Elevator, Rudder
-  Right stick:  Throttle, Aileron
-
-Mode 2:
-  Left stick:  Throttle, Rudder
-  Right stick:  Elevator, Aileron
-
-Mode 3:
-  Left stick:  Elevator, Aileron
-  Right stick:  Throttle, Rudder
-
-Mode 4:
-  Left stick:  Throttle, Aileron
-  Right stick:  Elevator, Rudder
-
-</string>
-       </property>
-       <property name="currentIndex">
-        <number>1</number>
-       </property>
-       <item>
-        <property name="text">
-         <string>Mode 1 (RUD ELE THR AIL)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Mode 2 (RUD THR ELE AIL)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Mode 3 (AIL ELE THR RUD)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Mode 4 (AIL THR ELE RUD)</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="26" column="0">
-      <widget class="QLabel" name="hatsModeLabel">
-       <property name="text">
-        <string>Hats Mode</string>
-       </property>
-      </widget>
-     </item>
-     <item row="24" column="1">
-      <widget class="QComboBox" name="usbModeCB">
-       <item>
-        <property name="text">
-         <string>Ask on Connect</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Joystick (HID)</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>USB Mass Storage</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>USB Serial (CDC)</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="25" column="1">
-      <widget class="QComboBox" name="jackModeCB">
-       <item>
-        <property name="text">
-         <string>Ask on Connect</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Audio</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Trainer</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="15" column="0">
-      <widget class="QLabel" name="label_11">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Low EEPROM Warning</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_beeperlen">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Beeper Length</string>
-       </property>
-      </widget>
-     </item>
-     <item row="14" column="0">
-      <widget class="QLabel" name="label_27">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>&quot;No Sound&quot; Warning</string>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="1" colspan="2">
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <item>
-        <widget class="QComboBox" name="splashScreenDuration">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <item>
-          <property name="text">
-           <string>---</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>2s</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>3s</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>4s</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>6s</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>8s</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>10s</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>15s</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item row="27" column="0">
-      <widget class="QLabel" name="ppm_units_label">
-       <property name="text">
-        <string>PPM Units</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1" colspan="2">
-      <widget class="QSlider" name="hapticStrength">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>22</height>
-        </size>
-       </property>
-       <property name="minimum">
-        <number>-2</number>
-       </property>
-       <property name="maximum">
-        <number>2</number>
-       </property>
-       <property name="pageStep">
-        <number>1</number>
-       </property>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="16" column="1">
-      <widget class="QCheckBox" name="rssiPowerOffWarnChkB">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="whatsThis">
-        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;Warnings&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;These will define startup warnings.&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Throttle warning - will alert if the throttle is not at idle during startup&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Switch warning - will alert if switches are not in their defaul position&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Memory warning - will alert if there's not a lot of memory left&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Silent mode warning - will alert you if the beeper is set to quiet (0)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QComboBox" name="beeperCB">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>22</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="statusTip">
-        <string/>
-       </property>
-       <property name="whatsThis">
-        <string>Beeper volume
-
-0 - Quiet.  No beeps at all.
-1 - No Keys.  Normal beeps but menu keys do not beep.
-2 - Normal.
-3 - Loud.
-4 - Extra loud.</string>
-       </property>
-       <item>
-        <property name="text">
-         <string>Quiet</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Alarms Only</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>No Keys</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>All</string>
-        </property>
-       </item>
-      </widget>
-     </item>
      <item row="2" column="1" colspan="2">
       <widget class="QComboBox" name="hapticmodeCB">
        <property name="sizePolicy">
@@ -1856,70 +1310,193 @@ p, li { white-space: pre-wrap; }
        </item>
       </widget>
      </item>
-     <item row="7" column="1" colspan="2">
-      <layout class="QHBoxLayout" name="batMeterRangeLayout" stretch="0,1,0,1">
-       <item>
-        <widget class="QLabel" name="HasBatMeterMinRangeLabel">
-         <property name="text">
-          <string>Min</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QDoubleSpinBox" name="vBatMinDSB">
-         <property name="suffix">
-          <string>v</string>
-         </property>
-         <property name="decimals">
-          <number>1</number>
-         </property>
-         <property name="minimum">
-          <double>3.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>16.000000000000000</double>
-         </property>
-         <property name="singleStep">
-          <double>0.100000000000000</double>
-         </property>
-         <property name="value">
-          <double>9.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QLabel" name="HasBatMeterMaxRangeLabel">
-         <property name="text">
-          <string>Max</string>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QDoubleSpinBox" name="vBatMaxDSB">
-         <property name="suffix">
-          <string>v</string>
-         </property>
-         <property name="decimals">
-          <number>1</number>
-         </property>
-         <property name="minimum">
-          <double>3.000000000000000</double>
-         </property>
-         <property name="maximum">
-          <double>16.000000000000000</double>
-         </property>
-         <property name="singleStep">
-          <double>0.100000000000000</double>
-         </property>
-         <property name="value">
-          <double>12.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-      </layout>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_hapticStrengthSB">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Haptic Strength</string>
+       </property>
+      </widget>
      </item>
      <item row="26" column="1">
-      <widget class="AutoComboBox" name="hatsModeCB" native="true"/>
+      <widget class="QComboBox" name="jackModeCB">
+       <item>
+        <property name="text">
+         <string>Ask on Connect</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Audio</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Trainer</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="9" column="0">
+      <widget class="QLabel" name="label_6">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Inactivity Timer</string>
+       </property>
+      </widget>
+     </item>
+     <item row="12" column="1">
+      <widget class="QSpinBox" name="pwrOnDelay">
+       <property name="suffix">
+        <string> sec</string>
+       </property>
+       <property name="maximum">
+        <number>3</number>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_hapticmode">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Haptic Mode</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_beeperlen">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Beeper Length</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QComboBox" name="beeperlenCB">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>22</height>
+        </size>
+       </property>
+       <item>
+        <property name="text">
+         <string>X-Short</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Short</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Normal</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Long</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>X-Long</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="12" column="0">
+      <widget class="QLabel" name="pwrOnDelayLabel">
+       <property name="text">
+        <string>Power On Delay</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>20</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string extracomment="Low Battery Voltage warning [5v-10v]"/>
+       </property>
+       <property name="text">
+        <string>Battery Warning</string>
+       </property>
+      </widget>
+     </item>
+     <item row="24" column="0">
+      <widget class="QLabel" name="switchesDelayLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Play Delay (switch mid position)</string>
+       </property>
+      </widget>
      </item>
      <item row="6" column="1">
       <widget class="QDoubleSpinBox" name="battwarningDSB">
@@ -1970,202 +1547,8 @@ Acceptable values are 3v..12v</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_hapticmode">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Haptic Mode</string>
-       </property>
-      </widget>
-     </item>
-     <item row="14" column="1" colspan="2">
-      <widget class="QCheckBox" name="alarmwarnChkB">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>22</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="whatsThis">
-        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;Warnings&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;These will define startup warnings.&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Throttle warning - will alert if the throttle is not at idle during startup&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Switch warning - will alert if switches are not in their defaul position&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Memory warning - will alert if there's not a lot of memory left&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Silent mode warning - will alert you if the beeper is set to quiet (0)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="checked">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1">
-      <widget class="QSpinBox" name="contrastSB">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>22</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="statusTip">
-        <string/>
-       </property>
-       <property name="whatsThis">
-        <string/>
-       </property>
-       <property name="minimum">
-        <number>10</number>
-       </property>
-       <property name="maximum">
-        <number>45</number>
-       </property>
-       <property name="value">
-        <number>25</number>
-       </property>
-      </widget>
-     </item>
-     <item row="11" column="1">
-      <widget class="QCheckBox" name="startSoundCB">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="13" column="0">
-      <widget class="QLabel" name="pwrOffDelayLabel">
-       <property name="text">
-        <string>Power Off Delay</string>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="0">
-      <widget class="QLabel" name="label_displayType">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>LCD Display Type</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QComboBox" name="beeperlenCB">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>22</height>
-        </size>
-       </property>
-       <item>
-        <property name="text">
-         <string>X-Short</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Short</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Normal</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>Long</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>X-Long</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="11" column="0">
-      <widget class="QLabel" name="label_playStartSound">
-       <property name="text">
-        <string>Play Startup Sound</string>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="0">
-      <widget class="QLabel" name="label_6">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Inactivity Timer</string>
-       </property>
-      </widget>
-     </item>
-     <item row="12" column="1">
-      <widget class="QSpinBox" name="pwrOnDelay">
+     <item row="13" column="1">
+      <widget class="QSpinBox" name="pwrOffDelay">
        <property name="suffix">
         <string> sec</string>
        </property>
@@ -2215,10 +1598,83 @@ p, li { white-space: pre-wrap; }
        </item>
       </widget>
      </item>
-     <item row="12" column="0">
-      <widget class="QLabel" name="pwrOnDelayLabel">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_12">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="text">
-        <string>Power On Delay</string>
+        <string>Beeper Mode</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1" colspan="2">
+      <widget class="QSlider" name="hapticStrength">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>22</height>
+        </size>
+       </property>
+       <property name="minimum">
+        <number>-2</number>
+       </property>
+       <property name="maximum">
+        <number>2</number>
+       </property>
+       <property name="pageStep">
+        <number>1</number>
+       </property>
+       <property name="orientation">
+        <enum>Qt::Orientation::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="24" column="1">
+      <widget class="QSpinBox" name="switchesDelay">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="statusTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;LCD Screen Contrast&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Values can be 20-45&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="suffix">
+        <string> ms</string>
+       </property>
+       <property name="minimum">
+        <number>0</number>
+       </property>
+       <property name="maximum">
+        <number>1000</number>
+       </property>
+       <property name="singleStep">
+        <number>10</number>
+       </property>
+       <property name="value">
+        <number>0</number>
        </property>
       </widget>
      </item>
@@ -2241,153 +1697,7 @@ p, li { white-space: pre-wrap; }
        </property>
       </widget>
      </item>
-     <item row="6" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>20</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string extracomment="Low Battery Voltage warning [5v-10v]"/>
-       </property>
-       <property name="text">
-        <string>Battery Warning</string>
-       </property>
-      </widget>
-     </item>
-     <item row="16" column="0">
-      <widget class="QLabel" name="label_15">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>RSSI Poweroff Warning</string>
-       </property>
-      </widget>
-     </item>
-     <item row="23" column="0">
-      <widget class="QLabel" name="switchesDelayLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Play Delay (switch mid position)</string>
-       </property>
-      </widget>
-     </item>
-     <item row="13" column="1">
-      <widget class="QSpinBox" name="pwrOffDelay">
-       <property name="suffix">
-        <string> sec</string>
-       </property>
-       <property name="maximum">
-        <number>3</number>
-       </property>
-      </widget>
-     </item>
-     <item row="24" column="0">
-      <widget class="QLabel" name="usbModeLabel">
-       <property name="text">
-        <string>USB Mode</string>
-       </property>
-      </widget>
-     </item>
-     <item row="20" column="0">
-      <widget class="QLabel" name="label_13">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Default Channel Order</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label_12">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Beeper Mode</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="label_contrast">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="toolTip">
-        <string extracomment="Screen Contrast [20-45]"/>
-       </property>
-       <property name="text">
-        <string>Contrast</string>
-       </property>
-      </widget>
-     </item>
-     <item row="19" column="0">
-      <widget class="QLabel" name="label_14">
-       <property name="text">
-        <string>Stick Mode</string>
-       </property>
-      </widget>
-     </item>
-     <item row="22" column="1">
-      <widget class="QComboBox" name="gpsFormatCB">
-       <item>
-        <property name="text">
-         <string>DMS</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>NMEA</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="20" column="1">
+     <item row="21" column="1">
       <widget class="QComboBox" name="channelorderCB">
        <property name="toolTip">
         <string/>
@@ -2523,7 +1833,410 @@ p, li { white-space: pre-wrap; }
        </item>
       </widget>
      </item>
-     <item row="21" column="1">
+     <item row="25" column="1">
+      <widget class="QComboBox" name="usbModeCB">
+       <item>
+        <property name="text">
+         <string>Ask on Connect</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Joystick (HID)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>USB Mass Storage</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>USB Serial (CDC)</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="16" column="0">
+      <widget class="QLabel" name="label_11">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Low EEPROM Warning</string>
+       </property>
+      </widget>
+     </item>
+     <item row="25" column="0">
+      <widget class="QLabel" name="usbModeLabel">
+       <property name="text">
+        <string>USB Mode</string>
+       </property>
+      </widget>
+     </item>
+     <item row="15" column="1" colspan="2">
+      <widget class="QCheckBox" name="alarmwarnChkB">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>22</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="whatsThis">
+        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;Warnings&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;These will define startup warnings.&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Throttle warning - will alert if the throttle is not at idle during startup&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Switch warning - will alert if switches are not in their defaul position&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Memory warning - will alert if there's not a lot of memory left&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Silent mode warning - will alert you if the beeper is set to quiet (0)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="1">
+      <widget class="QCheckBox" name="startSoundCB">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="19" column="1" colspan="2">
+      <widget class="QComboBox" name="mavbaud_CB">
+       <item>
+        <property name="text">
+         <string>4800 Baud</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>9600 Baud</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>14400 Baud</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>19200 Baud</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>38400 Baud</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>57600 Baud</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>76800 Baud</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>115200 Baud</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QComboBox" name="beeperCB">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>22</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="statusTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string>Beeper volume
+
+0 - Quiet.  No beeps at all.
+1 - No Keys.  Normal beeps but menu keys do not beep.
+2 - Normal.
+3 - Loud.
+4 - Extra loud.</string>
+       </property>
+       <item>
+        <property name="text">
+         <string>Quiet</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Alarms Only</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>No Keys</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>All</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="13" column="0">
+      <widget class="QLabel" name="pwrOffDelayLabel">
+       <property name="text">
+        <string>Power Off Delay</string>
+       </property>
+      </widget>
+     </item>
+     <item row="19" column="0">
+      <widget class="QLabel" name="mavbaud_label">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>MAVLink Baud Rate</string>
+       </property>
+      </widget>
+     </item>
+     <item row="22" column="0">
+      <widget class="QLabel" name="units_label">
+       <property name="text">
+        <string>Measurement Units</string>
+       </property>
+      </widget>
+     </item>
+     <item row="18" column="1">
+      <widget class="QCheckBox" name="trainerPowerOffWarnChkB">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="18" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Trainer Poweroff Warning</string>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="0">
+      <widget class="QLabel" name="label_playStartSound">
+       <property name="text">
+        <string>Play Startup Sound</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="label_contrast">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string extracomment="Screen Contrast [20-45]"/>
+       </property>
+       <property name="text">
+        <string>Contrast</string>
+       </property>
+      </widget>
+     </item>
+     <item row="17" column="0">
+      <widget class="QLabel" name="label_15">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>RSSI Poweroff Warning</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="label_displayType">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>LCD Display Type</string>
+       </property>
+      </widget>
+     </item>
+     <item row="23" column="0">
+      <widget class="QLabel" name="gpsFormatLabel">
+       <property name="text">
+        <string>GPS Coordinates</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1" colspan="2">
+      <layout class="QHBoxLayout" name="batMeterRangeLayout" stretch="0,1,0,1">
+       <item>
+        <widget class="QLabel" name="HasBatMeterMinRangeLabel">
+         <property name="text">
+          <string>Min</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QDoubleSpinBox" name="vBatMinDSB">
+         <property name="suffix">
+          <string>v</string>
+         </property>
+         <property name="decimals">
+          <number>1</number>
+         </property>
+         <property name="minimum">
+          <double>3.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>16.000000000000000</double>
+         </property>
+         <property name="singleStep">
+          <double>0.100000000000000</double>
+         </property>
+         <property name="value">
+          <double>9.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="HasBatMeterMaxRangeLabel">
+         <property name="text">
+          <string>Max</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QDoubleSpinBox" name="vBatMaxDSB">
+         <property name="suffix">
+          <string>v</string>
+         </property>
+         <property name="decimals">
+          <number>1</number>
+         </property>
+         <property name="minimum">
+          <double>3.000000000000000</double>
+         </property>
+         <property name="maximum">
+          <double>16.000000000000000</double>
+         </property>
+         <property name="singleStep">
+          <double>0.100000000000000</double>
+         </property>
+         <property name="value">
+          <double>12.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="28" column="0">
+      <widget class="QLabel" name="ppm_units_label">
+       <property name="text">
+        <string>PPM Units</string>
+       </property>
+      </widget>
+     </item>
+     <item row="20" column="0">
+      <widget class="QLabel" name="label_14">
+       <property name="text">
+        <string>Stick Mode</string>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="0">
+      <widget class="QLabel" name="splashScreenLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="text">
+        <string>Show Splash Screen on Startup</string>
+       </property>
+      </widget>
+     </item>
+     <item row="22" column="1">
       <widget class="QComboBox" name="units_CB">
        <item>
         <property name="text">
@@ -2533,6 +2246,103 @@ p, li { white-space: pre-wrap; }
        <item>
         <property name="text">
          <string>Imperial</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="20" column="1">
+      <widget class="QComboBox" name="stickmodeCB">
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="statusTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string>Mode selection:
+
+Mode 1:
+  Left stick:  Elevator, Rudder
+  Right stick:  Throttle, Aileron
+
+Mode 2:
+  Left stick:  Throttle, Rudder
+  Right stick:  Elevator, Aileron
+
+Mode 3:
+  Left stick:  Elevator, Aileron
+  Right stick:  Throttle, Rudder
+
+Mode 4:
+  Left stick:  Throttle, Aileron
+  Right stick:  Elevator, Rudder
+
+</string>
+       </property>
+       <property name="currentIndex">
+        <number>1</number>
+       </property>
+       <item>
+        <property name="text">
+         <string>Mode 1 (RUD ELE THR AIL)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Mode 2 (RUD THR ELE AIL)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Mode 3 (AIL ELE THR RUD)</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Mode 4 (AIL THR ELE RUD)</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="27" column="0">
+      <widget class="QLabel" name="hatsModeLabel">
+       <property name="text">
+        <string>Hats Mode</string>
+       </property>
+      </widget>
+     </item>
+     <item row="23" column="1">
+      <widget class="QComboBox" name="gpsFormatCB">
+       <item>
+        <property name="text">
+         <string>DMS</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>NMEA</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="28" column="1">
+      <widget class="QComboBox" name="ppm_units_CB">
+       <property name="currentText">
+        <string>0.--</string>
+       </property>
+       <item>
+        <property name="text">
+         <string>0.--</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>0.0</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>us</string>
         </property>
        </item>
       </widget>
@@ -2568,6 +2378,86 @@ p, li { white-space: pre-wrap; }
        </property>
       </widget>
      </item>
+     <item row="29" column="0">
+      <spacer name="verticalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Orientation::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="26" column="0">
+      <widget class="QLabel" name="jackModeLabel">
+       <property name="text">
+        <string>Jack Mode</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QSpinBox" name="contrastSB">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>22</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string/>
+       </property>
+       <property name="statusTip">
+        <string/>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="minimum">
+        <number>10</number>
+       </property>
+       <property name="maximum">
+        <number>45</number>
+       </property>
+       <property name="value">
+        <number>25</number>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1" colspan="2">
+      <widget class="QComboBox" name="displayTypeCB">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>22</height>
+        </size>
+       </property>
+       <item>
+        <property name="text">
+         <string>Standard</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Optrex</string>
+        </property>
+       </item>
+      </widget>
+     </item>
      <item row="7" column="0">
       <widget class="QLabel" name="batMeterRangeLabel">
        <property name="sizePolicy">
@@ -2587,52 +2477,210 @@ p, li { white-space: pre-wrap; }
        </property>
       </widget>
      </item>
+     <item row="10" column="1" colspan="2">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QComboBox" name="splashScreenDuration">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <item>
+          <property name="text">
+           <string>---</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>2s</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>3s</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>4s</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>6s</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>8s</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>10s</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>15s</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+      </layout>
+     </item>
      <item row="27" column="1">
-      <widget class="QComboBox" name="ppm_units_CB">
-       <property name="currentText">
-        <string>0.--</string>
+      <widget class="AutoComboBox" name="hatsModeCB" native="true"/>
+     </item>
+     <item row="21" column="0">
+      <widget class="QLabel" name="label_13">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <item>
-        <property name="text">
-         <string>0.--</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>0.0</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>us</string>
-        </property>
-       </item>
+       <property name="text">
+        <string>Default Channel Order</string>
+       </property>
       </widget>
      </item>
-     <item row="28" column="0">
-      <spacer name="verticalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Vertical</enum>
+     <item row="15" column="0">
+      <widget class="QLabel" name="label_27">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <property name="sizeHint" stdset="0">
+       <property name="minimumSize">
         <size>
-         <width>20</width>
-         <height>40</height>
+         <width>0</width>
+         <height>0</height>
         </size>
        </property>
-      </spacer>
-     </item>
-     <item row="17" column="0">
-      <widget class="QLabel" name="label">
        <property name="text">
-        <string>Trainer Poweroff Warning</string>
+        <string>&quot;No Sound&quot; Warning</string>
        </property>
       </widget>
      </item>
      <item row="17" column="1">
-      <widget class="QCheckBox" name="trainerPowerOffWarnChkB">
+      <widget class="QCheckBox" name="rssiPowerOffWarnChkB">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="whatsThis">
+        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;Warnings&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;These will define startup warnings.&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Throttle warning - will alert if the throttle is not at idle during startup&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Switch warning - will alert if switches are not in their defaul position&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Memory warning - will alert if there's not a lot of memory left&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Silent mode warning - will alert you if the beeper is set to quiet (0)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
        <property name="text">
         <string/>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="16" column="1" colspan="2">
+      <widget class="QCheckBox" name="memwarnChkB">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="whatsThis">
+        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;Warnings&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;These will define startup warnings.&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Throttle warning - will alert if the throttle is not at idle during startup&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Switch warning - will alert if switches are not in their defaul position&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Memory warning - will alert if there's not a lot of memory left&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Silent mode warning - will alert you if the beeper is set to quiet (0)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="14" column="0">
+      <widget class="QLabel" name="pwrOnOffHapticLabel">
+       <property name="text">
+        <string>Power ON/OFF Haptic</string>
+       </property>
+      </widget>
+     </item>
+     <item row="14" column="1">
+      <widget class="QCheckBox" name="pwrOnOffHaptic_CB">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>22</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="whatsThis">
+        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;Warnings&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;These will define startup warnings.&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Throttle warning - will alert if the throttle is not at idle during startup&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Switch warning - will alert if switches are not in their defaul position&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Memory warning - will alert if there's not a lot of memory left&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Silent mode warning - will alert you if the beeper is set to quiet (0)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
        </property>
       </widget>
      </item>
@@ -2641,7 +2689,7 @@ p, li { white-space: pre-wrap; }
    <item row="0" column="2">
     <spacer name="horizontalSpacer">
      <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+      <enum>Qt::Orientation::Horizontal</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
@@ -2654,7 +2702,7 @@ p, li { white-space: pre-wrap; }
    <item row="2" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
-      <enum>Qt::Vertical</enum>
+      <enum>Qt::Orientation::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>

--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -117,40 +117,40 @@ static inline void check_struct()
   CHKSIZE(TrainerData, 16);
 
 #if defined(PCBXLITES)
-  CHKSIZE(RadioData, 872);
+  CHKSIZE(RadioData, 871);
   CHKSIZE(ModelData, 6265);
 #elif defined(PCBXLITE)
-  CHKSIZE(RadioData, 870);
+  CHKSIZE(RadioData, 869);
   CHKSIZE(ModelData, 6265);
 #elif defined(RADIO_TPRO)
-  CHKSIZE(RadioData, 870);
+  CHKSIZE(RadioData, 869);
   CHKSIZE(ModelData, 6290);
 #elif defined(RADIO_POCKET)
-  CHKSIZE(RadioData, 870);
+  CHKSIZE(RadioData, 869);
   CHKSIZE(ModelData, 6265);
 #elif defined(RADIO_TPROV2)
-  CHKSIZE(RadioData, 870);
+  CHKSIZE(RadioData, 869);
   CHKSIZE(ModelData, 6290);
 #elif defined(RADIO_T14)
-  CHKSIZE(RadioData, 870);
+  CHKSIZE(RadioData, 869);
   CHKSIZE(ModelData, 6265);
 #elif defined(RADIO_FAMILY_T20)
-  CHKSIZE(RadioData, 870);
+  CHKSIZE(RadioData, 869);
   CHKSIZE(ModelData, 6326);
 #elif defined(RADIO_BOXER)
-  CHKSIZE(RadioData, 870);
+  CHKSIZE(RadioData, 869);
   CHKSIZE(ModelData, 6265);
 #elif defined(RADIO_MT12)
-  CHKSIZE(RadioData, 870);
+  CHKSIZE(RadioData, 869);
   CHKSIZE(ModelData, 6265);
 #elif defined(PCBX7)
-  CHKSIZE(RadioData, 870);
+  CHKSIZE(RadioData, 869);
   CHKSIZE(ModelData, 6265);
 #elif defined(PCBX9E)
-  CHKSIZE(RadioData, 870);
+  CHKSIZE(RadioData, 869);
   CHKSIZE(ModelData, 6707);
 #elif defined(PCBX9D) || defined(PCBX9DP)
-  CHKSIZE(RadioData, 870);
+  CHKSIZE(RadioData, 869);
   CHKSIZE(ModelData, 6706);
 #elif defined(PCBHORUS)
   #if defined(RADIO_T15)

--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -117,40 +117,40 @@ static inline void check_struct()
   CHKSIZE(TrainerData, 16);
 
 #if defined(PCBXLITES)
-  CHKSIZE(RadioData, 871);
+  CHKSIZE(RadioData, 872);
   CHKSIZE(ModelData, 6265);
 #elif defined(PCBXLITE)
-  CHKSIZE(RadioData, 869);
+  CHKSIZE(RadioData, 870);
   CHKSIZE(ModelData, 6265);
 #elif defined(RADIO_TPRO)
-  CHKSIZE(RadioData, 869);
+  CHKSIZE(RadioData, 870);
   CHKSIZE(ModelData, 6290);
 #elif defined(RADIO_POCKET)
-  CHKSIZE(RadioData, 869);
+  CHKSIZE(RadioData, 870);
   CHKSIZE(ModelData, 6265);
 #elif defined(RADIO_TPROV2)
-  CHKSIZE(RadioData, 869);
+  CHKSIZE(RadioData, 870);
   CHKSIZE(ModelData, 6290);
 #elif defined(RADIO_T14)
-  CHKSIZE(RadioData, 869);
+  CHKSIZE(RadioData, 870);
   CHKSIZE(ModelData, 6265);
 #elif defined(RADIO_FAMILY_T20)
-  CHKSIZE(RadioData, 869);
+  CHKSIZE(RadioData, 870);
   CHKSIZE(ModelData, 6326);
 #elif defined(RADIO_BOXER)
-  CHKSIZE(RadioData, 869);
+  CHKSIZE(RadioData, 870);
   CHKSIZE(ModelData, 6265);
 #elif defined(RADIO_MT12)
-  CHKSIZE(RadioData, 869);
+  CHKSIZE(RadioData, 870);
   CHKSIZE(ModelData, 6265);
 #elif defined(PCBX7)
-  CHKSIZE(RadioData, 869);
+  CHKSIZE(RadioData, 870);
   CHKSIZE(ModelData, 6265);
 #elif defined(PCBX9E)
-  CHKSIZE(RadioData, 869);
+  CHKSIZE(RadioData, 870);
   CHKSIZE(ModelData, 6707);
 #elif defined(PCBX9D) || defined(PCBX9DP)
-  CHKSIZE(RadioData, 869);
+  CHKSIZE(RadioData, 870);
   CHKSIZE(ModelData, 6706);
 #elif defined(PCBHORUS)
   #if defined(RADIO_T15)

--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -969,19 +969,16 @@ PACK(struct RadioData {
   NOBACKUP(uint8_t modelTelemetryDisabled:1);
 
   NOBACKUP(uint8_t disableTrainerPoweroffAlarm:1);
-#if defined(HAPTIC)
-  NOBACKUP(uint8_t disablePwrOnOffHaptic:1);
-#endif  
-#if LCD_W == 128
-  uint8_t invertLCD:1;          // Invert B&W LCD display
-#endif
 
-#if (defined(HAPTIC) && (LCD_W == 128))
-  NOBACKUP(uint8_t spare:5 SKIP);
-#elif (defined(HAPTIC) || (LCD_W == 128))
+  NOBACKUP(uint8_t disablePwrOnOffHaptic:1);
+
+#if defined(COLORLCD)
   NOBACKUP(uint8_t spare:6 SKIP);
+#elif LCD_W == 128
+  uint8_t invertLCD:1;          // Invert B&W LCD display
+  NOBACKUP(uint8_t spare:3 SKIP);
 #else
-  NOBACKUP(uint8_t spare:7 SKIP);
+  NOBACKUP(uint8_t spare:4 SKIP);
 #endif
 
   NOBACKUP(uint8_t getBrightness() const

--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -969,12 +969,13 @@ PACK(struct RadioData {
   NOBACKUP(uint8_t modelTelemetryDisabled:1);
 
   NOBACKUP(uint8_t disableTrainerPoweroffAlarm:1);
+  NOBACKUP(uint8_t  disablePwrOnOffHaptic:1);
 
 #if defined(COLORLCD)
-  NOBACKUP(uint8_t space:7 SKIP);
+  NOBACKUP(uint8_t space:6 SKIP);
 #elif LCD_W == 128
   uint8_t invertLCD:1;          // Invert B&W LCD display
-  NOBACKUP(uint8_t spare:4 SKIP);
+  NOBACKUP(uint8_t spare:3 SKIP);
 #else
   NOBACKUP(uint8_t spare:5 SKIP);
 #endif

--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -969,15 +969,19 @@ PACK(struct RadioData {
   NOBACKUP(uint8_t modelTelemetryDisabled:1);
 
   NOBACKUP(uint8_t disableTrainerPoweroffAlarm:1);
-  NOBACKUP(uint8_t  disablePwrOnOffHaptic:1);
-
-#if defined(COLORLCD)
-  NOBACKUP(uint8_t space:6 SKIP);
-#elif LCD_W == 128
+#if defined(HAPTIC)
+  NOBACKUP(uint8_t disablePwrOnOffHaptic:1);
+#endif  
+#if LCD_W == 128
   uint8_t invertLCD:1;          // Invert B&W LCD display
-  NOBACKUP(uint8_t spare:3 SKIP);
-#else
+#endif
+
+#if (defined(HAPTIC) && (LCD_W == 128))
   NOBACKUP(uint8_t spare:5 SKIP);
+#elif (defined(HAPTIC) || (LCD_W == 128))
+  NOBACKUP(uint8_t spare:6 SKIP);
+#else
+  NOBACKUP(uint8_t spare:7 SKIP);
 #endif
 
   NOBACKUP(uint8_t getBrightness() const

--- a/radio/src/gui/128x64/radio_setup.cpp
+++ b/radio/src/gui/128x64/radio_setup.cpp
@@ -93,6 +93,7 @@ enum {
   ITEM_RADIO_SETUP_START_SOUND,
   CASE_PWR_BUTTON_PRESS(ITEM_RADIO_SETUP_PWR_ON_SPEED)
   CASE_PWR_BUTTON_PRESS(ITEM_RADIO_SETUP_PWR_OFF_SPEED)
+  CASE_HAPTIC(ITEM_RADIO_SETUP_PWR_ON_OFF_HAPTIC)
   CASE_PXX2(ITEM_RADIO_SETUP_OWNER_ID)
   CASE_GPS(ITEM_RADIO_SETUP_LABEL_GPS)
   CASE_GPS(ITEM_RADIO_SETUP_TIMEZONE)
@@ -191,6 +192,7 @@ void menuRadioSetup(event_t event)
     0,
     CASE_PWR_BUTTON_PRESS(0)
     CASE_PWR_BUTTON_PRESS(0)
+    CASE_HAPTIC(0) // power on/off haptic
     CASE_PXX2(0) /* owner registration ID */
 
     CASE_GPS(0)
@@ -595,6 +597,16 @@ void menuRadioSetup(event_t event)
         lcdDrawChar(lcdLastRightPos, y, 's');
         if (attr) CHECK_INCDEC_GENVAR(event, g_eeGeneral.pwrOffSpeed, -1, 2);
         break;
+#endif
+
+#if defined(HAPTIC)
+      case ITEM_RADIO_SETUP_PWR_ON_OFF_HAPTIC: {
+        lcdDrawTextAlignedLeft(y, STR_PWR_ON_OFF_HAPTIC);
+        g_eeGeneral.disablePwrOnOffHaptic =
+            !editCheckBox(!g_eeGeneral.disablePwrOnOffHaptic, LCD_W - 9, y,
+                          nullptr, attr, event);
+        break;
+      }
 #endif
 
 #if defined(PXX2)

--- a/radio/src/gui/212x64/radio_setup.cpp
+++ b/radio/src/gui/212x64/radio_setup.cpp
@@ -82,6 +82,7 @@ enum MenuRadioSetupItems {
   ITEM_RADIO_SETUP_START_SOUND,
   CASE_PWR_BUTTON_PRESS(ITEM_RADIO_SETUP_PWR_ON_SPEED)
   CASE_PWR_BUTTON_PRESS(ITEM_RADIO_SETUP_PWR_OFF_SPEED)
+  CASE_HAPTIC(ITEM_RADIO_SETUP_PWR_ON_OFF_HAPTIC)
 #if defined(PXX2)
   ITEM_RADIO_SETUP_OWNER_ID,
 #endif
@@ -194,6 +195,7 @@ void menuRadioSetup(event_t event)
     0,
     CASE_PWR_BUTTON_PRESS(0) // pwr on speed
     CASE_PWR_BUTTON_PRESS(0) // pwr off speed
+    CASE_HAPTIC(0) // power on/off haptic
     CASE_PXX2(0) // owner registration ID
     CASE_GPS(LABEL(GPS))
       CASE_GPS(0) // timezone
@@ -559,6 +561,16 @@ void menuRadioSetup(event_t event)
         lcdDrawChar(lcdLastRightPos, y, 's');
         if (attr) CHECK_INCDEC_GENVAR(event, g_eeGeneral.pwrOffSpeed, -1, 2);
         break;
+#endif
+
+#if defined(HAPTIC)
+      case ITEM_RADIO_SETUP_PWR_ON_OFF_HAPTIC: {
+        lcdDrawTextAlignedLeft(y, STR_PWR_ON_OFF_HAPTIC);
+        g_eeGeneral.disablePwrOnOffHaptic =
+            !editCheckBox(!g_eeGeneral.disablePwrOnOffHaptic,
+                          RADIO_SETUP_2ND_COLUMN, y, nullptr, attr, event);
+        break;
+      }
 #endif
 
 #if defined(GPS)

--- a/radio/src/gui/colorlcd/radio_setup.cpp
+++ b/radio/src/gui/colorlcd/radio_setup.cpp
@@ -769,6 +769,15 @@ static SetupLineDef setupLines[] = {
     }
   },
 #endif
+#if defined(HAPTIC)
+  {
+    // Power on/off haptic alarm
+      STR_PWR_ON_OFF_HAPTIC,
+      [](Window* parent, coord_t x, coord_t y) {
+        new ToggleSwitch(parent, {x, y, 0, EdgeTxStyles::UI_ELEMENT_HEIGHT}, GET_SET_INVERTED(g_eeGeneral.disablePwrOnOffHaptic));
+      }
+  },
+#endif
 #if defined(PXX2)
   {
     // Owner ID

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1259,7 +1259,8 @@ void runStartupAnimation()
       isPowerOn = true;
       pwrOn();
 #if defined(HAPTIC)
-      if (g_eeGeneral.hapticMode != e_mode_quiet)
+      if (!g_eeGeneral.disablePwrOnOffHaptic &&
+          (g_eeGeneral.hapticMode != e_mode_quiet))
         haptic.play(15, 3, PLAY_NOW);
 #endif
     }
@@ -1373,7 +1374,8 @@ void edgeTxInit()
 #else // defined(STARTUP_ANIMATION)
   pwrOn();
 #if defined(HAPTIC)
-  if (g_eeGeneral.hapticMode != e_mode_quiet)
+  if (!g_eeGeneral.disablePwrOnOffHaptic &&
+      (g_eeGeneral.hapticMode != e_mode_quiet))
     haptic.play(15, 3, PLAY_NOW);
 #endif
 #endif
@@ -1771,7 +1773,8 @@ uint32_t pwrCheck()
         }
 
 #if defined(HAPTIC)
-        if (g_eeGeneral.hapticMode != e_mode_quiet)
+        if (!g_eeGeneral.disablePwrOnOffHaptic &&
+            (g_eeGeneral.hapticMode != e_mode_quiet))
           haptic.play(15, 3, PLAY_NOW);
 #endif
         pwr_check_state = PWR_CHECK_OFF;

--- a/radio/src/storage/yaml/yaml_datastructs_128x64.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_128x64.cpp
@@ -331,6 +331,7 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_SIGNED_CUST( "varioPitch", 8, r_vPitch, w_vPitch ),
   YAML_SIGNED_CUST( "varioRange", 8, r_vPitch, w_vPitch ),
   YAML_SIGNED( "varioRepeat", 8 ),
+  YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_ARRAY("customFn", 88, 64, struct_CustomFunctionData, cfn_is_active),
   YAML_CUSTOM("auxSerialMode",r_serialMode,nullptr),
   YAML_CUSTOM("aux2SerialMode",r_serialMode,nullptr),

--- a/radio/src/storage/yaml/yaml_datastructs_128x64.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_128x64.cpp
@@ -331,7 +331,6 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_SIGNED_CUST( "varioPitch", 8, r_vPitch, w_vPitch ),
   YAML_SIGNED_CUST( "varioRange", 8, r_vPitch, w_vPitch ),
   YAML_SIGNED( "varioRepeat", 8 ),
-  YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_ARRAY("customFn", 88, 64, struct_CustomFunctionData, cfn_is_active),
   YAML_CUSTOM("auxSerialMode",r_serialMode,nullptr),
   YAML_CUSTOM("aux2SerialMode",r_serialMode,nullptr),
@@ -359,8 +358,9 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "modelCustomScriptsDisabled", 1 ),
   YAML_UNSIGNED( "modelTelemetryDisabled", 1 ),
   YAML_UNSIGNED( "disableTrainerPoweroffAlarm", 1 ),
+  YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_UNSIGNED( "invertLCD", 1 ),
-  YAML_PADDING( 4 ),
+  YAML_PADDING( 5 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_128x64.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_128x64.cpp
@@ -360,7 +360,7 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "disableTrainerPoweroffAlarm", 1 ),
   YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_UNSIGNED( "invertLCD", 1 ),
-  YAML_PADDING( 5 ),
+  YAML_PADDING( 3 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
@@ -383,7 +383,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "modelCustomScriptsDisabled", 1 ),
   YAML_UNSIGNED( "modelTelemetryDisabled", 1 ),
   YAML_UNSIGNED( "disableTrainerPoweroffAlarm", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
+  YAML_PADDING( 6 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_pl18.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_pl18.cpp
@@ -383,7 +383,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "modelCustomScriptsDisabled", 1 ),
   YAML_UNSIGNED( "modelTelemetryDisabled", 1 ),
   YAML_UNSIGNED( "disableTrainerPoweroffAlarm", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
+  YAML_PADDING( 6 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_t15.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t15.cpp
@@ -385,7 +385,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "modelCustomScriptsDisabled", 1 ),
   YAML_UNSIGNED( "modelTelemetryDisabled", 1 ),
   YAML_UNSIGNED( "disableTrainerPoweroffAlarm", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
+  YAML_PADDING( 6 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_t20.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t20.cpp
@@ -331,6 +331,7 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_SIGNED_CUST( "varioPitch", 8, r_vPitch, w_vPitch ),
   YAML_SIGNED_CUST( "varioRange", 8, r_vPitch, w_vPitch ),
   YAML_SIGNED( "varioRepeat", 8 ),
+  YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_ARRAY("customFn", 88, 64, struct_CustomFunctionData, cfn_is_active),
   YAML_CUSTOM("auxSerialMode",r_serialMode,nullptr),
   YAML_CUSTOM("aux2SerialMode",r_serialMode,nullptr),

--- a/radio/src/storage/yaml/yaml_datastructs_t20.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t20.cpp
@@ -331,7 +331,6 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_SIGNED_CUST( "varioPitch", 8, r_vPitch, w_vPitch ),
   YAML_SIGNED_CUST( "varioRange", 8, r_vPitch, w_vPitch ),
   YAML_SIGNED( "varioRepeat", 8 ),
-  YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_ARRAY("customFn", 88, 64, struct_CustomFunctionData, cfn_is_active),
   YAML_CUSTOM("auxSerialMode",r_serialMode,nullptr),
   YAML_CUSTOM("aux2SerialMode",r_serialMode,nullptr),
@@ -359,8 +358,9 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "modelCustomScriptsDisabled", 1 ),
   YAML_UNSIGNED( "modelTelemetryDisabled", 1 ),
   YAML_UNSIGNED( "disableTrainerPoweroffAlarm", 1 ),
+  YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_UNSIGNED( "invertLCD", 1 ),
-  YAML_PADDING( 4 ),
+  YAML_PADDING( 5 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_t20.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t20.cpp
@@ -360,7 +360,7 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "disableTrainerPoweroffAlarm", 1 ),
   YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_UNSIGNED( "invertLCD", 1 ),
-  YAML_PADDING( 5 ),
+  YAML_PADDING( 3 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_tpro.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tpro.cpp
@@ -331,6 +331,7 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_SIGNED_CUST( "varioPitch", 8, r_vPitch, w_vPitch ),
   YAML_SIGNED_CUST( "varioRange", 8, r_vPitch, w_vPitch ),
   YAML_SIGNED( "varioRepeat", 8 ),
+  YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_ARRAY("customFn", 88, 64, struct_CustomFunctionData, cfn_is_active),
   YAML_CUSTOM("auxSerialMode",r_serialMode,nullptr),
   YAML_CUSTOM("aux2SerialMode",r_serialMode,nullptr),

--- a/radio/src/storage/yaml/yaml_datastructs_tpro.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tpro.cpp
@@ -331,7 +331,6 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_SIGNED_CUST( "varioPitch", 8, r_vPitch, w_vPitch ),
   YAML_SIGNED_CUST( "varioRange", 8, r_vPitch, w_vPitch ),
   YAML_SIGNED( "varioRepeat", 8 ),
-  YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_ARRAY("customFn", 88, 64, struct_CustomFunctionData, cfn_is_active),
   YAML_CUSTOM("auxSerialMode",r_serialMode,nullptr),
   YAML_CUSTOM("aux2SerialMode",r_serialMode,nullptr),
@@ -359,8 +358,9 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "modelCustomScriptsDisabled", 1 ),
   YAML_UNSIGNED( "modelTelemetryDisabled", 1 ),
   YAML_UNSIGNED( "disableTrainerPoweroffAlarm", 1 ),
+  YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_UNSIGNED( "invertLCD", 1 ),
-  YAML_PADDING( 4 ),
+  YAML_PADDING( 5 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_tpro.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tpro.cpp
@@ -360,7 +360,7 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "disableTrainerPoweroffAlarm", 1 ),
   YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_UNSIGNED( "invertLCD", 1 ),
-  YAML_PADDING( 5 ),
+  YAML_PADDING( 3 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_x10.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x10.cpp
@@ -385,7 +385,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "modelCustomScriptsDisabled", 1 ),
   YAML_UNSIGNED( "modelTelemetryDisabled", 1 ),
   YAML_UNSIGNED( "disableTrainerPoweroffAlarm", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
+  YAML_PADDING( 6 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
@@ -385,7 +385,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "modelCustomScriptsDisabled", 1 ),
   YAML_UNSIGNED( "modelTelemetryDisabled", 1 ),
   YAML_UNSIGNED( "disableTrainerPoweroffAlarm", 1 ),
-  YAML_PADDING( 7 ),
+  YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
+  YAML_PADDING( 6 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
@@ -331,6 +331,7 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_SIGNED_CUST( "varioPitch", 8, r_vPitch, w_vPitch ),
   YAML_SIGNED_CUST( "varioRange", 8, r_vPitch, w_vPitch ),
   YAML_SIGNED( "varioRepeat", 8 ),
+  YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_ARRAY("customFn", 88, 64, struct_CustomFunctionData, cfn_is_active),
   YAML_CUSTOM("auxSerialMode",r_serialMode,nullptr),
   YAML_CUSTOM("aux2SerialMode",r_serialMode,nullptr),

--- a/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
@@ -358,7 +358,7 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "modelTelemetryDisabled", 1 ),
   YAML_UNSIGNED( "disableTrainerPoweroffAlarm", 1 ),
   YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
-  YAML_PADDING( 6 ),
+  YAML_PADDING( 4 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
@@ -331,7 +331,6 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_SIGNED_CUST( "varioPitch", 8, r_vPitch, w_vPitch ),
   YAML_SIGNED_CUST( "varioRange", 8, r_vPitch, w_vPitch ),
   YAML_SIGNED( "varioRepeat", 8 ),
-  YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_ARRAY("customFn", 88, 64, struct_CustomFunctionData, cfn_is_active),
   YAML_CUSTOM("auxSerialMode",r_serialMode,nullptr),
   YAML_CUSTOM("aux2SerialMode",r_serialMode,nullptr),
@@ -358,7 +357,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "modelCustomScriptsDisabled", 1 ),
   YAML_UNSIGNED( "modelTelemetryDisabled", 1 ),
   YAML_UNSIGNED( "disableTrainerPoweroffAlarm", 1 ),
-  YAML_PADDING( 5 ),
+  YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
+  YAML_PADDING( 6 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
@@ -331,6 +331,7 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_SIGNED_CUST( "varioPitch", 8, r_vPitch, w_vPitch ),
   YAML_SIGNED_CUST( "varioRange", 8, r_vPitch, w_vPitch ),
   YAML_SIGNED( "varioRepeat", 8 ),
+  YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_ARRAY("customFn", 88, 64, struct_CustomFunctionData, cfn_is_active),
   YAML_CUSTOM("auxSerialMode",r_serialMode,nullptr),
   YAML_CUSTOM("aux2SerialMode",r_serialMode,nullptr),

--- a/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
@@ -359,7 +359,7 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "modelTelemetryDisabled", 1 ),
   YAML_UNSIGNED( "disableTrainerPoweroffAlarm", 1 ),
   YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
-  YAML_PADDING( 6 ),
+  YAML_PADDING( 4 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
@@ -331,7 +331,6 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_SIGNED_CUST( "varioPitch", 8, r_vPitch, w_vPitch ),
   YAML_SIGNED_CUST( "varioRange", 8, r_vPitch, w_vPitch ),
   YAML_SIGNED( "varioRepeat", 8 ),
-  YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_ARRAY("customFn", 88, 64, struct_CustomFunctionData, cfn_is_active),
   YAML_CUSTOM("auxSerialMode",r_serialMode,nullptr),
   YAML_CUSTOM("aux2SerialMode",r_serialMode,nullptr),
@@ -359,7 +358,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "modelCustomScriptsDisabled", 1 ),
   YAML_UNSIGNED( "modelTelemetryDisabled", 1 ),
   YAML_UNSIGNED( "disableTrainerPoweroffAlarm", 1 ),
-  YAML_PADDING( 5 ),
+  YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
+  YAML_PADDING( 6 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
@@ -333,6 +333,7 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_SIGNED_CUST( "varioPitch", 8, r_vPitch, w_vPitch ),
   YAML_SIGNED_CUST( "varioRange", 8, r_vPitch, w_vPitch ),
   YAML_SIGNED( "varioRepeat", 8 ),
+  YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_ARRAY("customFn", 88, 64, struct_CustomFunctionData, cfn_is_active),
   YAML_CUSTOM("auxSerialMode",r_serialMode,nullptr),
   YAML_CUSTOM("aux2SerialMode",r_serialMode,nullptr),

--- a/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
@@ -363,7 +363,7 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "disableTrainerPoweroffAlarm", 1 ),
   YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_UNSIGNED( "invertLCD", 1 ),
-  YAML_PADDING( 5 ),
+  YAML_PADDING( 3 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
@@ -333,7 +333,6 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_SIGNED_CUST( "varioPitch", 8, r_vPitch, w_vPitch ),
   YAML_SIGNED_CUST( "varioRange", 8, r_vPitch, w_vPitch ),
   YAML_SIGNED( "varioRepeat", 8 ),
-  YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_ARRAY("customFn", 88, 64, struct_CustomFunctionData, cfn_is_active),
   YAML_CUSTOM("auxSerialMode",r_serialMode,nullptr),
   YAML_CUSTOM("aux2SerialMode",r_serialMode,nullptr),
@@ -362,8 +361,9 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "modelCustomScriptsDisabled", 1 ),
   YAML_UNSIGNED( "modelTelemetryDisabled", 1 ),
   YAML_UNSIGNED( "disableTrainerPoweroffAlarm", 1 ),
+  YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_UNSIGNED( "invertLCD", 1 ),
-  YAML_PADDING( 4 ),
+  YAML_PADDING( 5 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/translations.cpp
+++ b/radio/src/translations.cpp
@@ -832,6 +832,9 @@ const char STR_BEEP_PITCH[] = TR_BEEP_PITCH;
 const char STR_PWR_ON_OFF_HAPTIC[] = TR_PWR_ON_OFF_HAPTIC;
 const char STR_HAPTIC_LABEL[] = TR_HAPTIC_LABEL;
 const char STR_STRENGTH[] = TR_STRENGTH;
+#endif
+
+#if defined(IMU)
 const char STR_IMU_LABEL[] = TR_IMU_LABEL;
 const char STR_IMU_OFFSET[] = TR_IMU_OFFSET;
 const char STR_IMU_MAX[] = TR_IMU_MAX;

--- a/radio/src/translations.cpp
+++ b/radio/src/translations.cpp
@@ -829,6 +829,7 @@ const char STR_BEEP_PITCH[] = TR_BEEP_PITCH;
 #endif
 
 #if defined(HAPTIC)
+const char STR_PWR_ON_OFF_HAPTIC[] = TR_PWR_ON_OFF_HAPTIC;
 const char STR_HAPTIC_LABEL[] = TR_HAPTIC_LABEL;
 const char STR_STRENGTH[] = TR_STRENGTH;
 const char STR_IMU_LABEL[] = TR_IMU_LABEL;

--- a/radio/src/translations.h
+++ b/radio/src/translations.h
@@ -377,8 +377,6 @@ extern const char STR_SOUND_LABEL[];
 extern const char STR_LENGTH[];
 extern const char STR_BEEP_LENGTH[];
 extern const char STR_BEEP_PITCH[];
-extern const char STR_HAPTIC_LABEL[];
-extern const char STR_STRENGTH[];
 extern const char STR_IMU_LABEL[];
 extern const char STR_IMU_OFFSET[];
 extern const char STR_IMU_MAX[];
@@ -422,6 +420,11 @@ extern const char* const STR_SPLASHSCREEN_DELAYS[];
 extern const char STR_PWR_ON_DELAY[];
 extern const char STR_PWR_OFF_DELAY[];
 extern const char* const STR_PWR_OFF_DELAYS[];
+#endif
+#if defined(HAPTIC)
+extern const char STR_PWR_ON_OFF_HAPTIC[];
+extern const char STR_HAPTIC_LABEL[];
+extern const char STR_STRENGTH[];
 #endif
 extern const char STR_THROTTLE_WARNING[];
 extern const char STR_CUSTOM_THROTTLE_WARNING[];

--- a/radio/src/translations.h
+++ b/radio/src/translations.h
@@ -377,9 +377,6 @@ extern const char STR_SOUND_LABEL[];
 extern const char STR_LENGTH[];
 extern const char STR_BEEP_LENGTH[];
 extern const char STR_BEEP_PITCH[];
-extern const char STR_IMU_LABEL[];
-extern const char STR_IMU_OFFSET[];
-extern const char STR_IMU_MAX[];
 extern const char STR_CONTRAST[];
 extern const char STR_ALARMS_LABEL[];
 extern const char STR_BATTERY_RANGE[];
@@ -425,6 +422,11 @@ extern const char* const STR_PWR_OFF_DELAYS[];
 extern const char STR_PWR_ON_OFF_HAPTIC[];
 extern const char STR_HAPTIC_LABEL[];
 extern const char STR_STRENGTH[];
+#endif
+#if defined(IMU)
+extern const char STR_IMU_LABEL[];
+extern const char STR_IMU_OFFSET[];
+extern const char STR_IMU_MAX[];
 #endif
 extern const char STR_THROTTLE_WARNING[];
 extern const char STR_CUSTOM_THROTTLE_WARNING[];

--- a/radio/src/translations/cn.h
+++ b/radio/src/translations/cn.h
@@ -388,7 +388,7 @@
 #define TR_PLAY_HELLO                  "开机语音"
 #define TR_PWR_ON_DELAY                "开机延迟"
 #define TR_PWR_OFF_DELAY               "关机延迟"
-#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
+#define TR_PWR_ON_OFF_HAPTIC           TR("开关机震动","开关机震动提示")
 #define TR_THROTTLE_WARNING            TR("油门状态", "油门状态")
 #define TR_CUSTOM_THROTTLE_WARNING     TR("自定位置", "自定油门位置?")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL TR("位置 %", "油门位置 %")

--- a/radio/src/translations/cn.h
+++ b/radio/src/translations/cn.h
@@ -388,6 +388,7 @@
 #define TR_PLAY_HELLO                  "开机语音"
 #define TR_PWR_ON_DELAY                "开机延迟"
 #define TR_PWR_OFF_DELAY               "关机延迟"
+#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
 #define TR_THROTTLE_WARNING            TR("油门状态", "油门状态")
 #define TR_CUSTOM_THROTTLE_WARNING     TR("自定位置", "自定油门位置?")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL TR("位置 %", "油门位置 %")

--- a/radio/src/translations/cz.h
+++ b/radio/src/translations/cz.h
@@ -404,6 +404,7 @@
 #define TR_PLAY_HELLO                  "Zvuk při spuštění"
 #define TR_PWR_ON_DELAY                "Zpoždění zapnutí"
 #define TR_PWR_OFF_DELAY               "Zpoždění vypnutí"
+#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
 #define TR_THROTTLE_WARNING            TR("* Plyn", "Kontrola plynu")
 #define TR_CUSTOM_THROTTLE_WARNING     TR("Vlas-Poz", "Vlastní pozice?")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL TR("Poz. %", "Pozice %")

--- a/radio/src/translations/cz.h
+++ b/radio/src/translations/cz.h
@@ -404,7 +404,7 @@
 #define TR_PLAY_HELLO                  "Zvuk při spuštění"
 #define TR_PWR_ON_DELAY                "Zpoždění zapnutí"
 #define TR_PWR_OFF_DELAY               "Zpoždění vypnutí"
-#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
+#define TR_PWR_ON_OFF_HAPTIC           TR("Zap ON/OFF vibrace","Zapnutí ON/OFF vibrace")
 #define TR_THROTTLE_WARNING            TR("* Plyn", "Kontrola plynu")
 #define TR_CUSTOM_THROTTLE_WARNING     TR("Vlas-Poz", "Vlastní pozice?")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL TR("Poz. %", "Pozice %")

--- a/radio/src/translations/da.h
+++ b/radio/src/translations/da.h
@@ -398,6 +398,7 @@
 #define TR_PLAY_HELLO                  "Startop lyd"
 #define TR_PWR_ON_DELAY                "Forsinkelse ved tænd"
 #define TR_PWR_OFF_DELAY               "Forsinkelse ved sluk"
+#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
 #define TR_THROTTLE_WARNING            TR("Gas adv", "Gas advarsel")
 #define TR_CUSTOM_THROTTLE_WARNING     TR("Tilp-Pos", "Tilpasset position?")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL TR("Pos. %", "Position %")

--- a/radio/src/translations/da.h
+++ b/radio/src/translations/da.h
@@ -398,7 +398,7 @@
 #define TR_PLAY_HELLO                  "Startop lyd"
 #define TR_PWR_ON_DELAY                "Forsinkelse ved tænd"
 #define TR_PWR_OFF_DELAY               "Forsinkelse ved sluk"
-#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
+#define TR_PWR_ON_OFF_HAPTIC           TR("Vib. strøm til/fra","Vibrator strøm til/fra")
 #define TR_THROTTLE_WARNING            TR("Gas adv", "Gas advarsel")
 #define TR_CUSTOM_THROTTLE_WARNING     TR("Tilp-Pos", "Tilpasset position?")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL TR("Pos. %", "Position %")

--- a/radio/src/translations/de.h
+++ b/radio/src/translations/de.h
@@ -395,7 +395,7 @@
 #define TR_PLAY_HELLO                  "Startton abspielen"
 #define TR_PWR_ON_DELAY                "PWR EIN Verzög."
 #define TR_PWR_OFF_DELAY               "PWR AUS Verzög."
-#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
+#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr AN/AUS Haptik","Power AN/AUS Haptik")
 #define TR_THROTTLE_WARNING            TR("Gasalarm", "Gas Alarm")
 #define TR_CUSTOM_THROTTLE_WARNING     TR("Cust-Pos", "Custom position?")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL TR("Pos. %", "Position %")

--- a/radio/src/translations/de.h
+++ b/radio/src/translations/de.h
@@ -395,6 +395,7 @@
 #define TR_PLAY_HELLO                  "Startton abspielen"
 #define TR_PWR_ON_DELAY                "PWR EIN Verzög."
 #define TR_PWR_OFF_DELAY               "PWR AUS Verzög."
+#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
 #define TR_THROTTLE_WARNING            TR("Gasalarm", "Gas Alarm")
 #define TR_CUSTOM_THROTTLE_WARNING     TR("Cust-Pos", "Custom position?")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL TR("Pos. %", "Position %")

--- a/radio/src/translations/en.h
+++ b/radio/src/translations/en.h
@@ -391,6 +391,7 @@
 #define TR_PLAY_HELLO                  "Startup Sound"
 #define TR_PWR_ON_DELAY                "Pwr On delay"
 #define TR_PWR_OFF_DELAY               "Pwr Off delay"
+#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
 #define TR_THROTTLE_WARNING            TR("T-Warning", "Throttle state")
 #define TR_CUSTOM_THROTTLE_WARNING     TR("Cust-Pos", "Custom position?")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL TR("Pos. %", "Position %")

--- a/radio/src/translations/es.h
+++ b/radio/src/translations/es.h
@@ -391,6 +391,7 @@
 #define TR_PLAY_HELLO                  "Startup Sound"
 #define TR_PWR_ON_DELAY        TR("Atraso On", "Atraso encendido")
 #define TR_PWR_OFF_DELAY       TR("Atraso Off", "Atraso apagado")
+#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
 #define TR_THROTTLE_WARNING    TR("Aviso-A", "Aviso acelerador")
 #define TR_CUSTOM_THROTTLE_WARNING     TR("Cust-Pos", "Custom position?")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL TR("Pos. %", "Position %")

--- a/radio/src/translations/fi.h
+++ b/radio/src/translations/fi.h
@@ -405,6 +405,7 @@
 #define TR_PLAY_HELLO                  "Startup Sound"
 #define TR_PWR_ON_DELAY                "Pwr On delay"
 #define TR_PWR_OFF_DELAY               "Pwr Off delay"
+#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
 #define TR_THROTTLE_WARNING            TR("T-Warning", "Throttle Warning")
 #define TR_CUSTOM_THROTTLE_WARNING     TR("Cust-Pos", "Custom position?")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL TR("Pos. %", "Position %")

--- a/radio/src/translations/fr.h
+++ b/radio/src/translations/fr.h
@@ -399,6 +399,7 @@
 #define TR_PLAY_HELLO                  "Son de démarrage"
 #define TR_PWR_ON_DELAY                "Délai btn ON"
 #define TR_PWR_OFF_DELAY               "Délai btn OFF"
+#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
 #define TR_THROTTLE_WARNING             TR("Alerte gaz", "Alerte gaz")
 #define TR_CUSTOM_THROTTLE_WARNING     TR("Pos. Perso", "Position perso ?")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL TR("Pos. %", "Position %")

--- a/radio/src/translations/fr.h
+++ b/radio/src/translations/fr.h
@@ -399,8 +399,8 @@
 #define TR_PLAY_HELLO                  "Son de démarrage"
 #define TR_PWR_ON_DELAY                "Délai btn ON"
 #define TR_PWR_OFF_DELAY               "Délai btn OFF"
-#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
-#define TR_THROTTLE_WARNING             TR("Alerte gaz", "Alerte gaz")
+#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Vibreur","Power ON/OFF Vibreur")
+#define TR_THROTTLE_WARNING            TR("Alerte gaz", "Alerte gaz")
 #define TR_CUSTOM_THROTTLE_WARNING     TR("Pos. Perso", "Position perso ?")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL TR("Pos. %", "Position %")
 #define TR_SWITCHWARNING               TR("Alerte int", "Pos. Interrupteurs")

--- a/radio/src/translations/he.h
+++ b/radio/src/translations/he.h
@@ -397,6 +397,7 @@
 #define TR_PLAY_HELLO                  "צליל אתחול"
 #define TR_PWR_ON_DELAY                "השהיית הפעלה פעיל"
 #define TR_PWR_OFF_DELAY               "משך לחיצה לכיבוי השלט"
+#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
 #define TR_THROTTLE_WARNING            TR("T-Warning", "התראת מצערת פתוחה")
 #define TR_CUSTOM_THROTTLE_WARNING     TR("Cust-Pos", "עריכת מיקום ידנית")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL TR("Pos. %", "Position %")

--- a/radio/src/translations/it.h
+++ b/radio/src/translations/it.h
@@ -393,7 +393,7 @@
 #define TR_PLAY_HELLO                   "Suono all'accensione"
 #define TR_PWR_ON_DELAY                 "Rit. accens."
 #define TR_PWR_OFF_DELAY                "Rit. spegni."
-#define TR_PWR_ON_OFF_HAPTIC            TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
+#define TR_PWR_ON_OFF_HAPTIC            TR("Vibraz. Pwr ON/OFF","Vibrazione Pwr ON/OFF")
 #define TR_THROTTLE_WARNING             TR("All. Mot.", "Allarme Motore")
 #define TR_CUSTOM_THROTTLE_WARNING      TR("Cust-Pos", "Custom position?")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL  TR("Pos. %", "Position %")

--- a/radio/src/translations/it.h
+++ b/radio/src/translations/it.h
@@ -393,6 +393,7 @@
 #define TR_PLAY_HELLO                   "Suono all'accensione"
 #define TR_PWR_ON_DELAY                 "Rit. accens."
 #define TR_PWR_OFF_DELAY                "Rit. spegni."
+#define TR_PWR_ON_OFF_HAPTIC            TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
 #define TR_THROTTLE_WARNING             TR("All. Mot.", "Allarme Motore")
 #define TR_CUSTOM_THROTTLE_WARNING      TR("Cust-Pos", "Custom position?")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL  TR("Pos. %", "Position %")

--- a/radio/src/translations/jp.h
+++ b/radio/src/translations/jp.h
@@ -392,6 +392,7 @@
 #define TR_PLAY_HELLO                  "起動時サウンド"
 #define TR_PWR_ON_DELAY                "電源ON遅延"
 #define TR_PWR_OFF_DELAY               "電源OFF遅延"
+#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
 #define TR_THROTTLE_WARNING            TR("T-Warning", "Throttle状態")
 #define TR_CUSTOM_THROTTLE_WARNING     TR("Cust-Pos", "カスタム位置？")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL TR("Pos. %", "位置 %")

--- a/radio/src/translations/jp.h
+++ b/radio/src/translations/jp.h
@@ -392,7 +392,7 @@
 #define TR_PLAY_HELLO                  "起動時サウンド"
 #define TR_PWR_ON_DELAY                "電源ON遅延"
 #define TR_PWR_OFF_DELAY               "電源OFF遅延"
-#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
+#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","電源 ON/OFF 時のバイブ")
 #define TR_THROTTLE_WARNING            TR("T-Warning", "Throttle状態")
 #define TR_CUSTOM_THROTTLE_WARNING     TR("Cust-Pos", "カスタム位置？")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL TR("Pos. %", "位置 %")

--- a/radio/src/translations/nl.h
+++ b/radio/src/translations/nl.h
@@ -391,6 +391,7 @@
 #define TR_PLAY_HELLO                  "Startup Sound"
 #define TR_PWR_ON_DELAY        "Pwr On delay"
 #define TR_PWR_OFF_DELAY       "Pwr Off delay"
+#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
 #define TR_THROTTLE_WARNING    TR("T-Warning", "Throttle Status")
 #define TR_CUSTOM_THROTTLE_WARNING     TR("Cust-Pos", "Custom position?")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL TR("Pos. %", "Position %")

--- a/radio/src/translations/pl.h
+++ b/radio/src/translations/pl.h
@@ -390,7 +390,7 @@
 #define TR_PLAY_HELLO                  "Dźwięk uruchomienia"
 #define TR_PWR_ON_DELAY                "Pwr On delay"
 #define TR_PWR_OFF_DELAY               "Pwr Off delay"
-#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
+#define TR_PWR_ON_OFF_HAPTIC    TR("Wibracja włączania","Wibracja włączania")
 #define TR_THROTTLE_WARNING     TR("OstrzGaz", "OstrzeżenieGaz")
 #define TR_CUSTOM_THROTTLE_WARNING     TR("InnePoł", "Inne położenie?")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL TR("Poł. %", "Położenie %")

--- a/radio/src/translations/pl.h
+++ b/radio/src/translations/pl.h
@@ -390,6 +390,7 @@
 #define TR_PLAY_HELLO                  "Dźwięk uruchomienia"
 #define TR_PWR_ON_DELAY                "Pwr On delay"
 #define TR_PWR_OFF_DELAY               "Pwr Off delay"
+#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
 #define TR_THROTTLE_WARNING     TR("OstrzGaz", "OstrzeżenieGaz")
 #define TR_CUSTOM_THROTTLE_WARNING     TR("InnePoł", "Inne położenie?")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL TR("Poł. %", "Położenie %")

--- a/radio/src/translations/pt.h
+++ b/radio/src/translations/pt.h
@@ -396,7 +396,7 @@
 #define TR_PLAY_HELLO                  "Som ao ligar"
 #define TR_PWR_ON_DELAY                "Delay para LIGA"
 #define TR_PWR_OFF_DELAY               "Delay para DESL"
-#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
+#define TR_PWR_ON_OFF_HAPTIC           TR("Vibra ao LIG/DESL", "Vibrar ao Lig/Desl")
 #define TR_THROTTLE_WARNING            TR("A-Aceler.", "Pos do acelerador")
 #define TR_CUSTOM_THROTTLE_WARNING     TR("Cust-Pos", "Custom position?")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL TR("Pos. %", "Position %")

--- a/radio/src/translations/pt.h
+++ b/radio/src/translations/pt.h
@@ -396,6 +396,7 @@
 #define TR_PLAY_HELLO                  "Som ao ligar"
 #define TR_PWR_ON_DELAY                "Delay para LIGA"
 #define TR_PWR_OFF_DELAY               "Delay para DESL"
+#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
 #define TR_THROTTLE_WARNING            TR("A-Aceler.", "Pos do acelerador")
 #define TR_CUSTOM_THROTTLE_WARNING     TR("Cust-Pos", "Custom position?")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL TR("Pos. %", "Position %")

--- a/radio/src/translations/ru.h
+++ b/radio/src/translations/ru.h
@@ -395,6 +395,7 @@
 #define TR_PLAY_HELLO                  "Звук запуска"
 #define TR_PWR_ON_DELAY                "Время включ"
 #define TR_PWR_OFF_DELAY               "Время выключ"
+#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
 #define TR_THROTTLE_WARNING            TR("Г-Предупр", "Статис газа")
 #define TR_CUSTOM_THROTTLE_WARNING     TR("Свое пол", "Свое пол?")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL TR("Пол. %", "Положение %")

--- a/radio/src/translations/se.h
+++ b/radio/src/translations/se.h
@@ -407,7 +407,7 @@
 #define TR_PLAY_HELLO                   "Startljud"
 #define TR_PWR_ON_DELAY                 "Fördröj start"
 #define TR_PWR_OFF_DELAY                "Fördröj avslut"
-#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
+#define TR_PWR_ON_OFF_HAPTIC            TR("Tx AV/PÅ vibr.","Radio AV/PÅ vibration")
 #define TR_BLCOLOR                      "Färg"
 #define TR_THROTTLE_WARNING             TR("Gasvarn.", "Gasvarning")
 #define TR_CUSTOM_THROTTLE_WARNING      TR("Egen pos", "Egen position?")

--- a/radio/src/translations/se.h
+++ b/radio/src/translations/se.h
@@ -407,6 +407,7 @@
 #define TR_PLAY_HELLO                   "Startljud"
 #define TR_PWR_ON_DELAY                 "Fördröj start"
 #define TR_PWR_OFF_DELAY                "Fördröj avslut"
+#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
 #define TR_BLCOLOR                      "Färg"
 #define TR_THROTTLE_WARNING             TR("Gasvarn.", "Gasvarning")
 #define TR_CUSTOM_THROTTLE_WARNING      TR("Egen pos", "Egen position?")

--- a/radio/src/translations/tw.h
+++ b/radio/src/translations/tw.h
@@ -393,6 +393,7 @@
 #define TR_PLAY_HELLO                  "開機語音"
 #define TR_PWR_ON_DELAY                "開機延遲"
 #define TR_PWR_OFF_DELAY               "關機延遲"
+#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
 #define TR_THROTTLE_WARNING            TR("油門狀態", "油門狀態")
 #define TR_CUSTOM_THROTTLE_WARNING     TR("自定位置", "自定油門位置?")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL TR("位置 %", "油門位置 %")

--- a/radio/src/translations/tw.h
+++ b/radio/src/translations/tw.h
@@ -393,7 +393,7 @@
 #define TR_PLAY_HELLO                  "開機語音"
 #define TR_PWR_ON_DELAY                "開機延遲"
 #define TR_PWR_OFF_DELAY               "關機延遲"
-#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
+#define TR_PWR_ON_OFF_HAPTIC           TR("開關機震動","開關機震動提示")
 #define TR_THROTTLE_WARNING            TR("油門狀態", "油門狀態")
 #define TR_CUSTOM_THROTTLE_WARNING     TR("自定位置", "自定油門位置?")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL TR("位置 %", "油門位置 %")

--- a/radio/src/translations/ua.h
+++ b/radio/src/translations/ua.h
@@ -395,6 +395,7 @@
 #define TR_PLAY_HELLO                  "Звук запуску"
 #define TR_PWR_ON_DELAY                "Pwr On затримка"
 #define TR_PWR_OFF_DELAY               "Pwr Off затримка"
+#define TR_PWR_ON_OFF_HAPTIC           TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
 #define TR_THROTTLE_WARNING            TR("Г-попер.", "Стан Газу")
 #define TR_CUSTOM_THROTTLE_WARNING     TR("Користув. полож.", "Користувацьке положення?")
 #define TR_CUSTOM_THROTTLE_WARNING_VAL TR("Полож. %", "Положення %")


### PR DESCRIPTION
Summary of changes:
 - Adds an option to Radio Settings that allows for the haptic on power on and off to be disabled. It is on by default, preserving existing behaviour of radios. 

Text for the menu entry is currently
```cpp
TR("Pwr ON/OFF Haptic","Power ON/OFF Haptic")
```
unless there is any suggested alternative. 

Has been tested on 
- Boxer
- LR3Pro
- TPro
- TX16S
- X9D+2019