### PR TITLE
fix(cpn): set input and switch types to none if not configured

### DIFF
--- a/companion/src/firmwares/edgetx/yaml_switchconfig.cpp
+++ b/companion/src/firmwares/edgetx/yaml_switchconfig.cpp
@@ -365,15 +365,6 @@ bool convert<YamlSwitchConfig>::decode(const Node& node, YamlSwitchConfig& rhs)
 
   const int maxcnt = Boards::getCapability(board, Board::Switches);
 
-  // load defaults in case values not in yaml file
-  for (int i = 0; i < maxcnt; i++) {
-    Board::SwitchInfo info =  Boards::getSwitchInfo(i, board);
-    rhs.config[i].tag = info.tag;
-    memset(rhs.config[i].name, 0, sizeof(rhs.config[i].name));
-    rhs.config[i].type = info.dflt;
-    rhs.config[i].inverted = info.inverted;
-  }
-
   for (const auto& kv : node) {
     std::string tag;
     kv.first >> tag;

--- a/companion/src/firmwares/generalsettings.cpp
+++ b/companion/src/firmwares/generalsettings.cpp
@@ -156,6 +156,7 @@ bool GeneralSettings::unassignedInputFlexSwitches() const
 void GeneralSettings::clear()
 {
   memset(reinterpret_cast<void *>(this), 0, sizeof(GeneralSettings));
+  setDefaultControlTypes(getCurrentBoard());
   init();
 }
 
@@ -191,8 +192,6 @@ void GeneralSettings::init()
     vBatMax = -40; //8V
   }
 
-  setDefaultControlTypes(board);
-
   backlightMode = 3; // keys and sticks
   backlightDelay = 2; // 2 * 5 = 10 secs
   inactivityTimer = 10;
@@ -222,12 +221,6 @@ void GeneralSettings::init()
     strcpy(bluetoothName, "horus");
   else if (IS_TARANIS_X9E(board) || IS_TARANIS_SMALL(board))
     strcpy(bluetoothName, "taranis");
-
-  for (uint8_t i = 0; i < 4; i++) {
-    trainer.mix[i].mode = TrainerMix::TRN_MIX_MODE_SUBST;
-    trainer.mix[i].src = i;
-    trainer.mix[i].weight = 100;
-  }
 
   ttsLanguage[0] = 'e';
   ttsLanguage[1] = 'n';
@@ -368,6 +361,12 @@ void GeneralSettings::setDefaultControlTypes(Board::Type board)
     switchConfig[i].type = info.dflt;
     switchConfig[i].inverted = info.inverted;
     switchConfig[i].inputIdx = SWITCH_INPUTINDEX_NONE;
+  }
+
+  for (uint8_t i = 0; i < 4; i++) {
+    trainer.mix[i].mode = TrainerMix::TRN_MIX_MODE_SUBST;
+    trainer.mix[i].src = i;
+    trainer.mix[i].weight = 100;
   }
 }
 


### PR DESCRIPTION
Fixes #5018

Summary of changes:
- set all inputs and switches to None prior to parsing radio.yml
- remove loading default hardware definitions from within general settings init as not always wanted
- remove loading default hardware definitions before parsing switch settings as performed in general settings
- move needs conversion test to after final parse step (housekeeping)
