### PR TITLE
fix(color): selected label, model list not correctly updating in single select mode

### DIFF
--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -709,6 +709,8 @@ void ModelLabelsWindow::newLabel()
       auto labels = getLabels();
       lblselector->setNames(labels);
       lblselector->setSelected(newset);
+      if (g_eeGeneral.labelSingleSelect)
+        lblselector->setActiveItem(newlabindex);
       updateFilteredLabels(newset);
     }
   });
@@ -927,6 +929,8 @@ void ModelLabelsWindow::buildBody(FormWindow *window)
                 std::set<uint32_t> newset;
                 lblselector->setNames(labels);
                 lblselector->setSelected(newset);
+                if (g_eeGeneral.labelSingleSelect && selected == lblselector->getActiveItem())
+                  lblselector->setActiveItem(-1);
                 updateFilteredLabels(newset);
               });
           return 0;
@@ -940,6 +944,8 @@ void ModelLabelsWindow::buildBody(FormWindow *window)
               auto labels = getLabels();
               lblselector->setNames(labels);
               lblselector->setSelected(newset);
+              if (g_eeGeneral.labelSingleSelect)
+                lblselector->setActiveItem(selected - 1);
               updateFilteredLabels(newset);
               return 0;
             });
@@ -952,6 +958,8 @@ void ModelLabelsWindow::buildBody(FormWindow *window)
               auto labels = getLabels();
               lblselector->setNames(labels);
               lblselector->setSelected(newset);
+              if (g_eeGeneral.labelSingleSelect)
+                lblselector->setActiveItem(selected + 1);
               updateFilteredLabels(newset);
               return 0;
             });

--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -938,29 +938,13 @@ void ModelLabelsWindow::buildBody(FormWindow *window)
         if (modelslabels.getLabels().size() > 1) {
           if (selected != 0) {
             menu->addLine(STR_MOVE_UP, [=]() {
-              modelslabels.moveLabelTo(selected, selected - 1);
-              std::set<uint32_t> newset;
-              newset.insert(selected - 1);
-              auto labels = getLabels();
-              lblselector->setNames(labels);
-              lblselector->setSelected(newset);
-              if (g_eeGeneral.labelSingleSelect)
-                lblselector->setActiveItem(selected - 1);
-              updateFilteredLabels(newset);
+              moveLabel(selected, -1);
               return 0;
             });
           }
           if (selected != (int)modelslabels.getLabels().size() - 1) {
             menu->addLine(STR_MOVE_DOWN, [=]() {
-              modelslabels.moveLabelTo(selected, selected + 1);
-              std::set<uint32_t> newset;
-              newset.insert(selected + 1);
-              auto labels = getLabels();
-              lblselector->setNames(labels);
-              lblselector->setSelected(newset);
-              if (g_eeGeneral.labelSingleSelect)
-                lblselector->setActiveItem(selected + 1);
-              updateFilteredLabels(newset);
+              moveLabel(selected, 1);
               return 0;
             });
           }
@@ -968,6 +952,42 @@ void ModelLabelsWindow::buildBody(FormWindow *window)
       }
     }
   });
+}
+
+void ModelLabelsWindow::moveLabel(int selected, int direction)
+{
+  int swapSelected = selected + direction;
+
+  modelslabels.moveLabelTo(selected, swapSelected);
+
+  std::set<uint32_t> newset = lblselector->getSelection();
+  bool isSelected = newset.find(selected) != newset.end();
+  bool isSwapSelected = newset.find(swapSelected) != newset.end();
+  if (isSelected && !isSwapSelected) {
+    newset.erase(newset.find(selected));
+    newset.insert(swapSelected);
+  } else if (isSwapSelected && !isSelected) {
+    newset.erase(newset.find(swapSelected));
+    newset.insert(selected);
+  }
+
+  lblselector->setNames(getLabels());
+
+  if (g_eeGeneral.labelSingleSelect) {
+    int active = lblselector->getActiveItem();
+    if (active == selected) {
+      lblselector->setActiveItem(swapSelected);
+      newset.insert(swapSelected);
+    } else if (active == swapSelected) {
+      lblselector->setActiveItem(selected);
+      newset.insert(selected);
+    } else if (active >= 0) {
+      newset.insert(active);
+    }
+  }
+
+  lblselector->setSelected(newset);
+  updateFilteredLabels(newset);
 }
 
 void ModelLabelsWindow::updateFilteredLabels(std::set<uint32_t> selected,

--- a/radio/src/gui/colorlcd/model_select.h
+++ b/radio/src/gui/colorlcd/model_select.h
@@ -58,6 +58,8 @@ class ModelLabelsWindow : public Page
   void labelRefreshRequest();
   void setTitle();
 
+  void moveLabel(int selected, int direction);
+
 #if defined(HARDWARE_KEYS)
   void onPressSYS() override;
   void onLongPressSYS() override;


### PR DESCRIPTION
In single select mode, adding new labels, deleting labels and moving labels does not update the selected label and model list correctly.

This is the fix for 2.10.
