### PR TITLE
fix: add missing t20v2 simulator

### DIFF
--- a/tools/build-companion.sh
+++ b/tools/build-companion.sh
@@ -72,7 +72,7 @@ declare -a simulator_plugins=(x9lite x9lites
                               xlite xlites
                               nv14 el18 pl18 pl18ev
                               x10 x10-access x12s
-                              t16 t18 t20 tx16s)
+                              t16 t18 t20 t20v2 tx16s)
 
 for plugin in "${simulator_plugins[@]}"
 do


### PR DESCRIPTION
Although this is really to add hwdef for cpn

Tested linux build, just waiting for remaining tests before merge. 