### PR TITLE
chore: fix ci typo, remove redundant CPU_TYPE

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -131,7 +131,7 @@ jobs:
       - name: Upload ${{ matrix.target }}
         uses: actions/upload-artifact@v4
         with:
-          name: firmare-${{ matrix.target }}
+          name: firmware-${{ matrix.target }}
           path: |
             fw.json
             LICENSE
@@ -152,6 +152,6 @@ jobs:
         uses: actions/upload-artifact/merge@v4
         with:
           name: "${{ env.artifact_name }}"
-          pattern: firmare-*
+          pattern: firmware-*
           delete-merged: true
           retention-days: 15

--- a/radio/src/targets/taranis/CMakeLists.txt
+++ b/radio/src/targets/taranis/CMakeLists.txt
@@ -445,7 +445,6 @@ elseif(PCB STREQUAL XLITE)
   set(MODULE_SIZE_SML YES)
   set(PXX_FREQUENCY "HIGH" CACHE STRING "PXX frequency (LOW / HIGH)") # always use HIGH except on some prototype boards
   set(PWR_BUTTON "PRESS" CACHE STRING "Pwr button type (PRESS/SWITCH)")
-  set(CPU_TYPE STM32F2)
   set(CPU_TYPE_FULL STM32F205xE)
   set(HAPTIC YES)
   set(FLAVOUR xlite)


### PR DESCRIPTION
Summary of changes:
- typo in nightly action
- remove redundant CPU_TYPE
