### PR TITLE
fix(cpn): change the default battery range to match firmware

### DIFF
--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -684,6 +684,65 @@ int Boards::getDefaultInternalModules(Board::Type board)
   }
 }
 
+#define BR(min, max, warn) vmin = min - 90; vmax = max - 120; vwarn = warn;
+
+void Boards::getBattRange(Board::Type board, int& vmin, int& vmax, unsigned int& vwarn)
+{
+  switch (board) {
+    case BOARD_TARANIS_X7:
+    case BOARD_TARANIS_X7_ACCESS:
+    case BOARD_TARANIS_X9D:
+    case BOARD_TARANIS_X9DP:
+    case BOARD_TARANIS_X9DP_2019:
+    case BOARD_TARANIS_X9LITE:
+    case BOARD_TARANIS_X9LITES:
+    case BOARD_RADIOMASTER_TX12:
+    case BOARD_RADIOMASTER_TX12_MK2:
+    case BOARD_RADIOMASTER_BOXER:
+    case BOARD_RADIOMASTER_POCKET:
+    case BOARD_RADIOMASTER_ZORRO:
+    // case BOARD_RADIOMASTER_MT12:   // TODO
+    case BOARD_JUMPER_T12:
+    case BOARD_JUMPER_T14:
+    case BOARD_JUMPER_TPRO:
+    case BOARD_JUMPER_TPROV2:
+    default:
+      BR(60, 80, 65)
+      break;
+    case BOARD_TARANIS_X9E:
+    case BOARD_HORUS_X12S:
+      BR(85, 115, 87)
+      break;
+    case BOARD_TARANIS_XLITE:
+    case BOARD_TARANIS_XLITES:
+    case BOARD_X10:
+    case BOARD_X10_EXPRESS:
+    case BOARD_RADIOMASTER_TX16S:
+    case BOARD_JUMPER_T16:
+    case BOARD_JUMPER_T18:
+    case BOARD_JUMPER_T20:
+    case BOARD_JUMPER_T20V2:
+      BR(67, 83, 66)
+      break;
+    case BOARD_JUMPER_TLITE:
+    case BOARD_JUMPER_TLITE_F4:
+    case BOARD_RADIOMASTER_T8:
+    case BOARD_BETAFPV_LR3PRO:
+      BR(34, 42, 36)
+      break;
+    case BOARD_FLYSKY_NV14:
+    case BOARD_FLYSKY_EL18:
+      BR(35, 42, 37)
+      break;
+    case BOARD_FLYSKY_PL18:
+      BR(35, 43, 37)
+      break;
+    case BOARD_IFLIGHT_COMMANDO8:
+      BR(30, 42, 32)
+      break;
+  }
+}
+
 // static
 int Boards::getDefaultExternalModuleSize(Board::Type board)
 {

--- a/companion/src/firmwares/boards.h
+++ b/companion/src/firmwares/boards.h
@@ -321,6 +321,7 @@ class Boards
     static QList<int> getSupportedInternalModules(Board::Type board);
     static int getDefaultInternalModules(Board::Type board);
     static int getDefaultExternalModuleSize(Board::Type board);
+    static void getBattRange(Board::Type board, int& vmin, int& vmax, unsigned int& vwarn);
     static QString externalModuleSizeToString(int value);
     static AbstractStaticItemModel * externalModuleSizeItemModel();
 

--- a/companion/src/firmwares/generalsettings.cpp
+++ b/companion/src/firmwares/generalsettings.cpp
@@ -166,31 +166,7 @@ void GeneralSettings::init()
   Board::Type board = firmware->getBoard();
 
   // vBatWarn is voltage in 100mV, vBatMin is in 100mV but with -9V offset, vBatMax has a -12V offset
-  vBatWarn  = 90;
-  if (IS_TARANIS_X9E(board) || IS_HORUS_X12S(board)) {
-    // NI-MH 9.6V
-    vBatWarn = 87;
-    vBatMin = -5;   //8,5V
-    vBatMax = -5;   //11,5V
-  }
-  else if (IS_TARANIS_XLITE(board) || IS_HORUS_X10(board) || IS_FAMILY_T16(board)) {
-    // Lipo 2S
-    vBatWarn = 66;
-    vBatMin = -23;  // 6.7V
-    vBatMax = -37;  // 8.3V
-  }
-  else if (IS_JUMPER_TLITE(board)) {
-    // 1S Li-Ion
-    vBatWarn = 32;
-    vBatMin = -60; //3V
-    vBatMax = -78; //4.2V
-  }
-  else if (IS_TARANIS(board)) {
-    // NI-MH 7.2V, X9D, X9D+ and X7
-    vBatWarn = 65;
-    vBatMin = -30; //6V
-    vBatMax = -40; //8V
-  }
+  Boards::getBattRange(board, vBatMin, vBatMax, vBatWarn);
 
   backlightMode = 3; // keys and sticks
   backlightDelay = 2; // 2 * 5 = 10 secs


### PR DESCRIPTION
The default battery range set up in Companion was missing entries (e.g. NV14, EL18, PL18).
If a blank document is created the battery range was set to 9V - 12V - resulting in continuous battery warnings in the simulator,

Moved the battery range settings to boards.cpp and aligned the values with what is currently set in the firmware.
