### PR TITLE
fix(cpn): incorrect initialisation of switch warning state if all switch warnings turned off

### DIFF
--- a/companion/src/firmwares/edgetx/yaml_modeldata.cpp
+++ b/companion/src/firmwares/edgetx/yaml_modeldata.cpp
@@ -1334,6 +1334,9 @@ bool convert<ModelData>::decode(const Node& node, ModelData& rhs)
     node["switchWarningState"] >> switchWarningState.src_str;
     rhs.switchWarningStates = switchWarningState.toCpn();
     rhs.switchWarningEnable = ~switchWarningState.enabled;
+  } else {
+    rhs.switchWarningStates = 0;
+    rhs.switchWarningEnable = ~0;
   }
 
   node["thrTrimSw"] >> rhs.thrTrimSwitch;


### PR DESCRIPTION
Fixes #5059 

Add initialisation to handle case when all warnings are off.
