### PR TITLE
fix(radio): correct different B&W and colorlcd trainer slave UI behaviour

### DIFF
--- a/radio/src/gui/colorlcd/radio_trainer.cpp
+++ b/radio/src/gui/colorlcd/radio_trainer.cpp
@@ -20,34 +20,36 @@
  */
 
 #include "radio_trainer.h"
-#include "opentx.h"
-#include "libopenui.h"
-#include "input_mapping.h"
 
 #include "hal/adc_driver.h"
+#include "input_mapping.h"
+#include "libopenui.h"
+#include "opentx.h"
 #include "strhelpers.h"
 
-#define SET_DIRTY()     storageDirty(EE_GENERAL)
+#define SET_DIRTY() storageDirty(EE_GENERAL)
 
-RadioTrainerPage::RadioTrainerPage():
-  PageTab(STR_MENUTRAINER, ICON_RADIO_TRAINER)
+RadioTrainerPage::RadioTrainerPage() :
+    PageTab(STR_MENUTRAINER, ICON_RADIO_TRAINER)
 {
 }
 
 #if LCD_W > LCD_H
-static const lv_coord_t col_dsc[] = {LV_GRID_FR(7), LV_GRID_FR(13), LV_GRID_FR(10), LV_GRID_FR(10), LV_GRID_FR(10),
-                                     LV_GRID_TEMPLATE_LAST};
-                                     
+static const lv_coord_t col_dsc[] = {LV_GRID_FR(7),  LV_GRID_FR(13),
+                                     LV_GRID_FR(10), LV_GRID_FR(10),
+                                     LV_GRID_FR(10), LV_GRID_TEMPLATE_LAST};
+
 #define NUM_EDIT_W 80
 #else
-static const lv_coord_t col_dsc[] = {LV_GRID_FR(7), LV_GRID_FR(15), LV_GRID_FR(9), LV_GRID_FR(9),
+static const lv_coord_t col_dsc[] = {LV_GRID_FR(7), LV_GRID_FR(15),
+                                     LV_GRID_FR(9), LV_GRID_FR(9),
                                      LV_GRID_TEMPLATE_LAST};
 #define NUM_EDIT_W 65
 #endif
 
 static const lv_coord_t row_dsc[] = {LV_GRID_CONTENT, LV_GRID_TEMPLATE_LAST};
 
-void RadioTrainerPage::build(Window * form)
+void RadioTrainerPage::build(Window* form)
 {
   form->padAll(PAD_SMALL);
 
@@ -70,7 +72,7 @@ void RadioTrainerPage::build(Window * form)
       new Choice(line, rect_t{}, STR_TRNMODE, 0, 2, GET_SET_DEFAULT(td->mode));
       new Choice(line, rect_t{}, STR_TRNCHN, 0, 3, GET_SET_DEFAULT(td->srcChn));
       auto weight = new NumberEdit(line, rect_t{0, 0, NUM_EDIT_W, 0}, -125, 125,
-                                  GET_SET_DEFAULT(td->studWeight));
+                                   GET_SET_DEFAULT(td->studWeight));
       weight->setSuffix("%");
 
 #if LCD_H > LCD_W
@@ -80,11 +82,13 @@ void RadioTrainerPage::build(Window * form)
 #endif
 
       LcdFlags flags = LEFT | COLOR_THEME_PRIMARY1;
-      if (g_eeGeneral.ppmunit == PPM_PERCENT_PREC1)
-        flags |= PREC1;
+      if (g_eeGeneral.ppmunit == PPM_PERCENT_PREC1) flags |= PREC1;
 
-      new DynamicNumber<int16_t>(line, rect_t{},
-          [=]() { return (trainerInput[i] - g_eeGeneral.trainer.calib[i]) * 2; },
+      new DynamicNumber<int16_t>(
+          line, rect_t{},
+          [=]() {
+            return (trainerInput[i] - g_eeGeneral.trainer.calib[i]) * 2;
+          },
           flags);
     }
 
@@ -98,13 +102,16 @@ void RadioTrainerPage::build(Window * form)
     // Trainer multiplier
     auto lbl = new StaticText(line, rect_t{}, STR_MULTIPLIER);
     lbl->padRight(4);
-    lv_obj_set_grid_cell(lbl->getLvObj(), LV_GRID_ALIGN_END, 0, 2, LV_GRID_ALIGN_CENTER, 0, 1);
+    lv_obj_set_grid_cell(lbl->getLvObj(), LV_GRID_ALIGN_END, 0, 2,
+                         LV_GRID_ALIGN_CENTER, 0, 1);
 
-    auto multiplier = new NumberEdit(line, rect_t{0, 0, NUM_EDIT_W, 0}, -10, 40,
-                                    GET_SET_DEFAULT(g_eeGeneral.PPM_Multiplier));
+    auto multiplier =
+        new NumberEdit(line, rect_t{0, 0, NUM_EDIT_W, 0}, -10, 40,
+                       GET_SET_DEFAULT(g_eeGeneral.PPM_Multiplier));
     multiplier->setDisplayHandler(
         [](int32_t value) { return formatNumberAsString(value + 10, PREC1); });
-    lv_obj_set_grid_cell(multiplier->getLvObj(), LV_GRID_ALIGN_START, 2, 1, LV_GRID_ALIGN_CENTER, 0, 1);
+    lv_obj_set_grid_cell(multiplier->getLvObj(), LV_GRID_ALIGN_START, 2, 1,
+                         LV_GRID_ALIGN_CENTER, 0, 1);
 
 #if LCD_H > LCD_W
     line = form->newLine(grid);
@@ -112,16 +119,19 @@ void RadioTrainerPage::build(Window * form)
 #endif
 
     // Trainer calibration
-    auto btn = new TextButton(line, rect_t{}, std::string(STR_CALIBRATION), [=]() -> uint8_t {
-      memcpy(g_eeGeneral.trainer.calib, trainerInput,
-            sizeof(g_eeGeneral.trainer.calib));
-      SET_DIRTY();
-      return 0;
-    });
+    auto btn = new TextButton(line, rect_t{}, std::string(STR_CALIBRATION),
+                              [=]() -> uint8_t {
+                                memcpy(g_eeGeneral.trainer.calib, trainerInput,
+                                       sizeof(g_eeGeneral.trainer.calib));
+                                SET_DIRTY();
+                                return 0;
+                              });
 #if LCD_H > LCD_W
-    lv_obj_set_grid_cell(btn->getLvObj(), LV_GRID_ALIGN_STRETCH, 1, 2, LV_GRID_ALIGN_CENTER, 0, 1);
+    lv_obj_set_grid_cell(btn->getLvObj(), LV_GRID_ALIGN_STRETCH, 1, 2,
+                         LV_GRID_ALIGN_CENTER, 0, 1);
 #else
-    lv_obj_set_grid_cell(btn->getLvObj(), LV_GRID_ALIGN_START, 3, 2, LV_GRID_ALIGN_CENTER, 0, 1);
+    lv_obj_set_grid_cell(btn->getLvObj(), LV_GRID_ALIGN_START, 3, 2,
+                         LV_GRID_ALIGN_CENTER, 0, 1);
 #endif
   }
 }

--- a/radio/src/gui/colorlcd/radio_trainer.cpp
+++ b/radio/src/gui/colorlcd/radio_trainer.cpp
@@ -53,68 +53,75 @@ void RadioTrainerPage::build(Window * form)
   form->setFlexLayout();
   form->padAll(PAD_SMALL);
 
-  auto max_sticks = adcGetMaxInputs(ADC_INPUT_MAIN);
-  for (uint8_t i = 0; i < max_sticks; i++) {
-    uint8_t chan = inputMappingChannelOrder(i);
-    TrainerMix* td = &g_eeGeneral.trainer.mix[chan];
+  bool slave = SLAVE_MODE();
+
+  if (slave) {
+    auto line = form->newLine(grid);
+    new StaticText(line, rect_t{}, STR_SLAVE);
+  } else {
+    auto max_sticks = adcGetMaxInputs(ADC_INPUT_MAIN);
+    for (uint8_t i = 0; i < max_sticks; i++) {
+      uint8_t chan = inputMappingChannelOrder(i);
+      TrainerMix* td = &g_eeGeneral.trainer.mix[chan];
+
+      auto line = form->newLine(grid);
+      new StaticText(line, rect_t{}, getMainControlLabel(chan));
+
+      new Choice(line, rect_t{}, STR_TRNMODE, 0, 2, GET_SET_DEFAULT(td->mode));
+      new Choice(line, rect_t{}, STR_TRNCHN, 0, 3, GET_SET_DEFAULT(td->srcChn));
+      auto weight = new NumberEdit(line, rect_t{0, 0, NUM_EDIT_W, 0}, -125, 125,
+                                  GET_SET_DEFAULT(td->studWeight));
+      weight->setSuffix("%");
+
+  #if LCD_H > LCD_W
+      line = form->newLine(grid);
+      line->padLeft(30);
+      line->padBottom(8);
+  #endif
+
+      LcdFlags flags = LEFT | COLOR_THEME_PRIMARY1;
+      if (g_eeGeneral.ppmunit == PPM_PERCENT_PREC1)
+        flags |= PREC1;
+
+      new DynamicNumber<int16_t>(line, rect_t{},
+          [=]() { return (trainerInput[i] - g_eeGeneral.trainer.calib[i]) * 2; },
+          flags);
+    }
 
     auto line = form->newLine(grid);
-    new StaticText(line, rect_t{}, getMainControlLabel(chan));
+  #if LCD_H > LCD_W
+    line->padTop(10);
+  #else
+    line->padTop(6);
+  #endif
 
-    new Choice(line, rect_t{}, STR_TRNMODE, 0, 2, GET_SET_DEFAULT(td->mode));
-    new Choice(line, rect_t{}, STR_TRNCHN, 0, 3, GET_SET_DEFAULT(td->srcChn));
-    auto weight = new NumberEdit(line, rect_t{0, 0, NUM_EDIT_W, 0}, -125, 125,
-                                 GET_SET_DEFAULT(td->studWeight));
-    weight->setSuffix("%");
+    // Trainer multiplier
+    auto lbl = new StaticText(line, rect_t{}, STR_MULTIPLIER);
+    lbl->padRight(4);
+    lv_obj_set_grid_cell(lbl->getLvObj(), LV_GRID_ALIGN_END, 0, 2, LV_GRID_ALIGN_CENTER, 0, 1);
 
-#if LCD_H > LCD_W
+    auto multiplier = new NumberEdit(line, rect_t{0, 0, NUM_EDIT_W, 0}, -10, 40,
+                                    GET_SET_DEFAULT(g_eeGeneral.PPM_Multiplier));
+    multiplier->setDisplayHandler(
+        [](int32_t value) { return formatNumberAsString(value + 10, PREC1); });
+    lv_obj_set_grid_cell(multiplier->getLvObj(), LV_GRID_ALIGN_START, 2, 1, LV_GRID_ALIGN_CENTER, 0, 1);
+
+  #if LCD_H > LCD_W
     line = form->newLine(grid);
-    line->padLeft(30);
-    line->padBottom(8);
-#endif
+    line->padTop(10);
+  #endif
 
-    LcdFlags flags = LEFT | COLOR_THEME_PRIMARY1;
-    if (g_eeGeneral.ppmunit == PPM_PERCENT_PREC1)
-      flags |= PREC1;
-
-    new DynamicNumber<int16_t>(line, rect_t{},
-        [=]() { return (trainerInput[i] - g_eeGeneral.trainer.calib[i]) * 2; },
-        flags);
+    // Trainer calibration
+    auto btn = new TextButton(line, rect_t{}, std::string(STR_CALIBRATION), [=]() -> uint8_t {
+      memcpy(g_eeGeneral.trainer.calib, trainerInput,
+            sizeof(g_eeGeneral.trainer.calib));
+      SET_DIRTY();
+      return 0;
+    });
+  #if LCD_H > LCD_W
+    lv_obj_set_grid_cell(btn->getLvObj(), LV_GRID_ALIGN_STRETCH, 1, 2, LV_GRID_ALIGN_CENTER, 0, 1);
+  #else
+    lv_obj_set_grid_cell(btn->getLvObj(), LV_GRID_ALIGN_START, 3, 2, LV_GRID_ALIGN_CENTER, 0, 1);
+  #endif
   }
-
-  auto line = form->newLine(grid);
-#if LCD_H > LCD_W
-  line->padTop(10);
-#else
-  line->padTop(6);
-#endif
-
-  // Trainer multiplier
-  auto lbl = new StaticText(line, rect_t{}, STR_MULTIPLIER);
-  lbl->padRight(4);
-  lv_obj_set_grid_cell(lbl->getLvObj(), LV_GRID_ALIGN_END, 0, 2, LV_GRID_ALIGN_CENTER, 0, 1);
-
-  auto multiplier = new NumberEdit(line, rect_t{0, 0, NUM_EDIT_W, 0}, -10, 40,
-                                   GET_SET_DEFAULT(g_eeGeneral.PPM_Multiplier));
-  multiplier->setDisplayHandler(
-      [](int32_t value) { return formatNumberAsString(value + 10, PREC1); });
-  lv_obj_set_grid_cell(multiplier->getLvObj(), LV_GRID_ALIGN_START, 2, 1, LV_GRID_ALIGN_CENTER, 0, 1);
-
-#if LCD_H > LCD_W
-  line = form->newLine(grid);
-  line->padTop(10);
-#endif
-
-  // Trainer calibration
-  auto btn = new TextButton(line, rect_t{}, std::string(STR_CALIBRATION), [=]() -> uint8_t {
-    memcpy(g_eeGeneral.trainer.calib, trainerInput,
-           sizeof(g_eeGeneral.trainer.calib));
-    SET_DIRTY();
-    return 0;
-  });
-#if LCD_H > LCD_W
-  lv_obj_set_grid_cell(btn->getLvObj(), LV_GRID_ALIGN_STRETCH, 1, 2, LV_GRID_ALIGN_CENTER, 0, 1);
-#else
-  lv_obj_set_grid_cell(btn->getLvObj(), LV_GRID_ALIGN_START, 3, 2, LV_GRID_ALIGN_CENTER, 0, 1);
-#endif
 }

--- a/radio/src/gui/colorlcd/radio_trainer.cpp
+++ b/radio/src/gui/colorlcd/radio_trainer.cpp
@@ -49,16 +49,16 @@ static const lv_coord_t row_dsc[] = {LV_GRID_CONTENT, LV_GRID_TEMPLATE_LAST};
 
 void RadioTrainerPage::build(Window * form)
 {
-  FlexGridLayout grid(col_dsc, row_dsc, PAD_TINY);
-  form->setFlexLayout();
   form->padAll(PAD_SMALL);
 
-  bool slave = SLAVE_MODE();
-
-  if (slave) {
-    auto line = form->newLine(grid);
-    new StaticText(line, rect_t{}, STR_SLAVE);
+  if (SLAVE_MODE()) {
+    form->setHeight(MENU_BODY_HEIGHT);
+    auto txt = new StaticText(form, rect_t{}, STR_SLAVE, FONT(L));
+    lv_obj_align(txt->getLvObj(), LV_ALIGN_CENTER, 0, 0);
   } else {
+    FlexGridLayout grid(col_dsc, row_dsc, PAD_TINY);
+    form->setFlexLayout();
+
     auto max_sticks = adcGetMaxInputs(ADC_INPUT_MAIN);
     for (uint8_t i = 0; i < max_sticks; i++) {
       uint8_t chan = inputMappingChannelOrder(i);
@@ -73,11 +73,11 @@ void RadioTrainerPage::build(Window * form)
                                   GET_SET_DEFAULT(td->studWeight));
       weight->setSuffix("%");
 
-  #if LCD_H > LCD_W
+#if LCD_H > LCD_W
       line = form->newLine(grid);
       line->padLeft(30);
       line->padBottom(8);
-  #endif
+#endif
 
       LcdFlags flags = LEFT | COLOR_THEME_PRIMARY1;
       if (g_eeGeneral.ppmunit == PPM_PERCENT_PREC1)
@@ -89,11 +89,11 @@ void RadioTrainerPage::build(Window * form)
     }
 
     auto line = form->newLine(grid);
-  #if LCD_H > LCD_W
+#if LCD_H > LCD_W
     line->padTop(10);
-  #else
+#else
     line->padTop(6);
-  #endif
+#endif
 
     // Trainer multiplier
     auto lbl = new StaticText(line, rect_t{}, STR_MULTIPLIER);
@@ -106,10 +106,10 @@ void RadioTrainerPage::build(Window * form)
         [](int32_t value) { return formatNumberAsString(value + 10, PREC1); });
     lv_obj_set_grid_cell(multiplier->getLvObj(), LV_GRID_ALIGN_START, 2, 1, LV_GRID_ALIGN_CENTER, 0, 1);
 
-  #if LCD_H > LCD_W
+#if LCD_H > LCD_W
     line = form->newLine(grid);
     line->padTop(10);
-  #endif
+#endif
 
     // Trainer calibration
     auto btn = new TextButton(line, rect_t{}, std::string(STR_CALIBRATION), [=]() -> uint8_t {
@@ -118,10 +118,10 @@ void RadioTrainerPage::build(Window * form)
       SET_DIRTY();
       return 0;
     });
-  #if LCD_H > LCD_W
+#if LCD_H > LCD_W
     lv_obj_set_grid_cell(btn->getLvObj(), LV_GRID_ALIGN_STRETCH, 1, 2, LV_GRID_ALIGN_CENTER, 0, 1);
-  #else
+#else
     lv_obj_set_grid_cell(btn->getLvObj(), LV_GRID_ALIGN_START, 3, 2, LV_GRID_ALIGN_CENTER, 0, 1);
-  #endif
+#endif
   }
 }

--- a/radio/src/translations/cn.h
+++ b/radio/src/translations/cn.h
@@ -394,7 +394,7 @@
 #define TR_POTS                        "电位器"
 #define TR_SWITCHES                    "开关"
 #define TR_SWITCHES_DELAY              TR("开关经过延时", "延时播放(开关经过)")
-#define TR_SLAVE                       CENTER "从机"
+#define TR_SLAVE                       "从机"
 #define TR_MODESRC                     "Mode\006% Source"
 #define TR_MULTIPLIER                  "倍率"
 #define TR_CAL                         "校准"

--- a/radio/src/translations/da.h
+++ b/radio/src/translations/da.h
@@ -404,7 +404,7 @@
 #define TR_POTS                        "Drejekontakt"
 #define TR_SWITCHES                    "Kontakter"
 #define TR_SWITCHES_DELAY              TR("Cen forsink", "Center forsinkelse")
-#define TR_SLAVE                       CENTER "Slave"
+#define TR_SLAVE                       "Slave"
 #define TR_MODESRC                     "Mode\006% Kilde"
 #define TR_MULTIPLIER                  "Multiplier"
 #define TR_CAL                         "Kal"

--- a/radio/src/translations/en.h
+++ b/radio/src/translations/en.h
@@ -399,7 +399,7 @@
 #define TR_POTS                        "Pots"
 #define TR_SWITCHES                    "Switches"
 #define TR_SWITCHES_DELAY              TR("Play delay", "Play delay (sw. mid pos)")
-#define TR_SLAVE                       CENTER "Slave"
+#define TR_SLAVE                       "Slave"
 #define TR_MODESRC                     "Mode\006% Source"
 #define TR_MULTIPLIER                  "Multiplier"
 #define TR_CAL                         "Cal"

--- a/radio/src/translations/he.h
+++ b/radio/src/translations/he.h
@@ -403,7 +403,7 @@
 #define TR_POTS                        "גלגלות"
 #define TR_SWITCHES                    "מתגים"
 #define TR_SWITCHES_DELAY              TR("Play delay", "השהיית השמעת מתג")
-#define TR_SLAVE                       CENTER "Slave"
+#define TR_SLAVE                       "Slave"
 #define TR_MODESRC                     "Mode\006% Source"
 #define TR_MULTIPLIER                  "Multiplier"
 #define TR_CAL                         "Cal"

--- a/radio/src/translations/jp.h
+++ b/radio/src/translations/jp.h
@@ -398,7 +398,7 @@
 #define TR_POTS                        "ダイヤル"
 #define TR_SWITCHES                    "スイッチ"
 #define TR_SWITCHES_DELAY              TR("Play delay", "遅延(スイッチ位置)")
-#define TR_SLAVE                       CENTER "スレーブ"
+#define TR_SLAVE                       "スレーブ"
 #define TR_MODESRC                     "モード\006% ソース"
 #define TR_MULTIPLIER                  "倍率"
 #define TR_CAL                         "設定"

--- a/radio/src/translations/nl.h
+++ b/radio/src/translations/nl.h
@@ -397,7 +397,7 @@
 #define TR_POTS                "Pots"
 #define TR_SWITCHES            TR("Switches","Schakelaars")
 #define TR_SWITCHES_DELAY      "Vertraging"
-#define TR_SLAVE               CENTER "Leerling"
+#define TR_SLAVE               "Leerling"
 #define TR_MODESRC             "Mode\006% Source"
 #define TR_MULTIPLIER          "Multiplier"
 #define TR_CAL                 "Cal"

--- a/radio/src/translations/pt.h
+++ b/radio/src/translations/pt.h
@@ -402,7 +402,7 @@
 #define TR_POTS                        "Pots"
 #define TR_SWITCHES                    "Chaves"
 #define TR_SWITCHES_DELAY              TR("Play delay", "Play delay (sw. mid pos)")
-#define TR_SLAVE                       CENTER "Escravo"
+#define TR_SLAVE                       "Escravo"
 #define TR_MODESRC                     "Mode\006% Source"
 #define TR_MULTIPLIER                  "Multiplier"
 #define TR_CAL                         "Cal"

--- a/radio/src/translations/ru.h
+++ b/radio/src/translations/ru.h
@@ -401,7 +401,7 @@
 #define TR_POTS                        "Потенциом"
 #define TR_SWITCHES                    "Тумблеры"
 #define TR_SWITCHES_DELAY              TR("Зад воспр", "Задерж воспр (средн. полож. тумбл.)")
-#define TR_SLAVE                       CENTER "Рабочий"
+#define TR_SLAVE                       "Рабочий"
 #define TR_MODESRC                     "Mode\006% Source"
 #define TR_MULTIPLIER                  "Множитель"
 #define TR_CAL                         "Звонок"

--- a/radio/src/translations/ua.h
+++ b/radio/src/translations/ua.h
@@ -401,7 +401,7 @@
 #define TR_POTS                        "Потенціометри"
 #define TR_SWITCHES                    "Перемикачі"
 #define TR_SWITCHES_DELAY              TR("Затримка відтвор.", "Затримка відтворення (середнє полож. перем.)")
-#define TR_SLAVE                       CENTER "Slave"		/* use english */
+#define TR_SLAVE                       "Slave"		/* use english */
 #define TR_MODESRC                     "Mode\006% Source"		/* use english */
 #define TR_MULTIPLIER                  "Множник"	
 #define TR_CAL                         "Калібрув."


### PR DESCRIPTION
Summary of changes:
 - on bw212, the "Slave" text was off-center due to double centering. had no effect on bw128
- on colorlcd, master trainer settings were still visible when in master mode, whereas hidden on B&W
