### PR TITLE
fix(color): adjust layout of model labels list to reduce text overlap

### DIFF
--- a/radio/src/gui/colorlcd/listbox.cpp
+++ b/radio/src/gui/colorlcd/listbox.cpp
@@ -217,20 +217,38 @@ void ListBox::onDrawEnd(uint16_t row, uint16_t col, lv_obj_draw_part_dsc_t* dsc)
     return;
 
   lv_area_t coords;
-  lv_coord_t area_h = lv_area_get_height(dsc->draw_area);
 
-  lv_coord_t font_h = getFontHeight(FONT(STD));
+  lv_draw_label_dsc_t label_dsc;
+  lv_draw_label_dsc_init(&label_dsc);
+  label_dsc.font = dsc->label_dsc->font;
+  label_dsc.align = LV_TEXT_ALIGN_RIGHT;
 
   const char* sym = LV_SYMBOL_OK;
   if (getSelectedSymbol)
     sym = getSelectedSymbol(row);
 
-  lv_coord_t w = getTextWidth(sym, FONT(STD));
+  lv_coord_t w = 30;
+  lv_coord_t h = 12;
+  lv_coord_t xo = 1;
+  lv_coord_t yo = 1;
 
-  coords.x1 = dsc->draw_area->x2 - 2 - w;
-  coords.x2 = coords.x1 + w;
-  coords.y1 = dsc->draw_area->y1 + (area_h - font_h) / 2;
-  coords.y2 = coords.y1 + font_h - 1;
+  if (smallSelectMarker) {
+    // Check for non-LVGL symbol
+    if (sym[0] != (char)0xEF) {
+      yo = -2;
+      xo = 0;
+    }
+    label_dsc.font = getFont(FONT(XS));
+  } else {
+    h = getFontHeight(FONT(STD));
+    xo = 2;
+    yo = (lv_area_get_height(dsc->draw_area) - h) / 2;
+  }
 
-  lv_draw_label(dsc->draw_ctx, dsc->label_dsc, &coords, sym, nullptr);
+  coords.x2 = dsc->draw_area->x2 - xo;
+  coords.x1 = coords.x2 - w + 1;
+  coords.y1 = dsc->draw_area->y1 + yo;
+  coords.y2 = coords.y1 + h - 1;
+
+  lv_draw_label(dsc->draw_ctx, &label_dsc, &coords, sym, nullptr);
 }

--- a/radio/src/gui/colorlcd/listbox.h
+++ b/radio/src/gui/colorlcd/listbox.h
@@ -79,6 +79,8 @@ class ListBox : public TableField
     pressHandler = std::move(handler);
   }
 
+  void setSmallSelectMarker() { smallSelectMarker = true; }
+
 #if defined(DEBUG_WINDOWS)
   std::string getName() const override { return "ListBox"; }
 #endif
@@ -87,6 +89,7 @@ class ListBox : public TableField
   static void event_cb(lv_event_t* e);
   int activeItem = -1;
   bool multiSelect = false;
+  bool smallSelectMarker = false;
 
   void onPress(uint16_t row, uint16_t col) override;
   void onLongPressed();

--- a/radio/src/gui/colorlcd/model_select.cpp
+++ b/radio/src/gui/colorlcd/model_select.cpp
@@ -766,6 +766,7 @@ void ModelLabelsWindow::buildBody(Window *window)
                        LV_GRID_ALIGN_STRETCH, LABELS_ROW, 1);
   lblselector =
       new ListBox(box, rect_t{0, 0, LV_PCT(100), LV_PCT(100)}, getLabels());
+  lblselector->setSmallSelectMarker();
   auto lbl_obj = lblselector->getLvObj();
 
   // Sort Button


### PR DESCRIPTION
Move the selected marker / text up and use a smaller font to avoid text overlap.

@pfeerick I don't this will cherry pick cleanly into 2.10. If you think this should go into 2.10.1 let me know and I can create a separate PR.

Fixes: #5071

![screenshot_tx16s_24-05-28_15-46-43](https://github.com/EdgeTX/edgetx/assets/9474356/2c8e0001-7f03-4dca-ac84-a1efaef8785c)
