### PR TITLE
fix(color): stop attempt to load themes when in emergency mode

### DIFF
--- a/radio/src/gui/colorlcd/theme_manager.cpp
+++ b/radio/src/gui/colorlcd/theme_manager.cpp
@@ -20,6 +20,7 @@
  */
 #include "theme_manager.h"
 
+#include "hal/abnormal_reboot.h"
 #include "../../storage/sdcard_common.h"
 #include "../../storage/yaml/yaml_bits.h"
 #include "../../storage/yaml/yaml_tree_walker.h"
@@ -327,7 +328,8 @@ void ThemePersistance::scanForThemes()
 
 void ThemePersistance::refresh()
 {
-  scanForThemes();
+  if (!UNEXPECTED_SHUTDOWN())
+    scanForThemes();
   insertDefaultTheme();
 }
 


### PR DESCRIPTION
The load fails because the SD card is not started; but it should not even try.
