### PR TITLE
fix(bw): incorrect navigation in advanced USB setup on X9 radios

### DIFF
--- a/radio/src/gui/common/stdlcd/model_usbjoystick.cpp
+++ b/radio/src/gui/common/stdlcd/model_usbjoystick.cpp
@@ -167,7 +167,7 @@ void menuModelUSBJoystickOne(event_t event)
 
 void onUSBJoystickMenu(const char *result)
 {
-  int8_t sub = menuVerticalPosition - HEADER_LINE;
+  int8_t sub = menuVerticalPosition;
   USBJoystickChData * cs = usbJChAddress(sub);
 
   if (result == STR_EDIT) {
@@ -182,12 +182,12 @@ void onUSBJoystickMenu(const char *result)
 
 void menuModelUSBJoystick(event_t event)
 {
-  check_submenu_simple(event, USBJ_MAX_JOYSTICK_CHANNELS - HEADER_LINE);
+  check_submenu_simple(event, USBJ_MAX_JOYSTICK_CHANNELS);
   title(STR_USBJOYSTICK_LABEL);
 
   if (s_editMode > 0) s_editMode = 0;
 
-  int8_t sub = menuVerticalPosition - HEADER_LINE;
+  int8_t sub = menuVerticalPosition;
 
   coord_t y = 0;
   uint8_t k = 0;


### PR DESCRIPTION
Fixes #4643 

