### PR TITLE
fix(bw): unresponsive rotary encoder after using popup menu on LS page

### DIFF
--- a/radio/src/gui/128x64/model_logical_switches.cpp
+++ b/radio/src/gui/128x64/model_logical_switches.cpp
@@ -274,6 +274,7 @@ void menuModelLogicalSwitches(event_t event)
       pushMenu(menuModelLogicalSwitchOne);
     }
     else {
+      s_editMode = 0; // Was set in 'check' function.
       POPUP_MENU_START(onLogicalSwitchesMenu);
     }
   }


### PR DESCRIPTION
Fixes #5087

Side effect of ENTER key handling arising from changes in #4849
