### PR TITLE
fix(x9d): incorrect switch positions on main view

### DIFF
--- a/radio/util/hw_defs/switch_config.py
+++ b/radio/util/hw_defs/switch_config.py
@@ -250,10 +250,10 @@ SWITCH_CONFIG = {
         "SE": {"default": "3POS",   "display": [0, 2]},
         "SF": {"default": "2POS",   "display": [0, 3]},
         # right side
-        "SC": {"default": "3POS",   "display": [0, 4]},
-        "SD": {"default": "3POS",   "display": [0, 5]},
-        "SG": {"default": "3POS",   "display": [0, 6]},
-        "SH": {"default": "TOGGLE", "display": [0, 7]}
+        "SC": {"default": "3POS",   "display": [1, 0]},
+        "SD": {"default": "3POS",   "display": [1, 1]},
+        "SG": {"default": "3POS",   "display": [1, 2]},
+        "SH": {"default": "TOGGLE", "display": [1, 3]}
     },
     "x9d+": {
         # left side
@@ -262,10 +262,10 @@ SWITCH_CONFIG = {
         "SE": {"default": "3POS",   "display": [0, 2]},
         "SF": {"default": "2POS",   "display": [0, 3]},
         # right side
-        "SC": {"default": "3POS",   "display": [0, 4]},
-        "SD": {"default": "3POS",   "display": [0, 5]},
-        "SG": {"default": "3POS",   "display": [0, 6]},
-        "SH": {"default": "TOGGLE", "display": [0, 7]}
+        "SC": {"default": "3POS",   "display": [1, 0]},
+        "SD": {"default": "3POS",   "display": [1, 1]},
+        "SG": {"default": "3POS",   "display": [1, 2]},
+        "SH": {"default": "TOGGLE", "display": [1, 3]}
     },
     "x9d+2019": {
         # left side
@@ -275,10 +275,10 @@ SWITCH_CONFIG = {
         "SF": {"default": "2POS",   "display": [0, 3]},
         "SI": {"default": "TOGGLE", "display": [0, 4]},
         # right side
-        "SC": {"default": "3POS",   "display": [0, 5]},
-        "SD": {"default": "3POS",   "display": [0, 6]},
-        "SG": {"default": "3POS",   "display": [0, 7]},
-        "SH": {"default": "TOGGLE", "display": [0, 8]}
+        "SC": {"default": "3POS",   "display": [1, 0]},
+        "SD": {"default": "3POS",   "display": [1, 1]},
+        "SG": {"default": "3POS",   "display": [1, 2]},
+        "SH": {"default": "TOGGLE", "display": [1, 3]}
     },
     "x9e": {
         # left side


### PR DESCRIPTION
Fixes #5092

Move 2nd column of switches back to right side of the display.