### PR TITLE
fix(f2): system clock initialisation

### DIFF
--- a/radio/src/targets/common/arm/stm32/stm32f2xx_hal_conf.h
+++ b/radio/src/targets/common/arm/stm32/stm32f2xx_hal_conf.h
@@ -86,7 +86,7 @@
 #endif /* HSE_VALUE */
 
 #if !defined  (HSE_STARTUP_TIMEOUT)
-  #define HSE_STARTUP_TIMEOUT               100U       /*!< Time out for HSE start up, in ms */
+  #define HSE_STARTUP_TIMEOUT              2000U       /*!< Time out for HSE start up, in cycles */
 #endif /* HSE_STARTUP_TIMEOUT */
 
 /**


### PR DESCRIPTION
Fixes the bootloader start speed and USB issues mentioned in https://github.com/EdgeTX/edgetx/pull/5023#issuecomment-2143165097.