### PR TITLE
fix(bw128): long press for outputs page popup menu

### DIFF
--- a/radio/src/gui/128x64/model_outputs.cpp
+++ b/radio/src/gui/128x64/model_outputs.cpp
@@ -231,7 +231,7 @@ void menuModelLimits(event_t event)
     uint8_t k = i+menuVerticalOffset;
     LcdFlags attr = (sub==MAX_OUTPUT_CHANNELS) ? INVERS : 0;
 
-    if (sub==k && event==EVT_KEY_BREAK(KEY_ENTER) && !READ_ONLY() && (k != MAX_OUTPUT_CHANNELS) ) {
+    if (sub==k && ((event == EVT_KEY_BREAK(KEY_ENTER)) || (event == EVT_KEY_LONG(KEY_ENTER))) && !READ_ONLY() && (k != MAX_OUTPUT_CHANNELS) ) {
       s_editMode = 0;
       POPUP_MENU_START(onLimitsMenu, 5, STR_EDIT, STR_RESET, STR_COPY_TRIMS_TO_OFS, STR_COPY_STICKS_TO_OFS, STR_COPY_MIN_MAX_TO_OUTPUTS);
     }

--- a/radio/src/gui/128x64/model_outputs.cpp
+++ b/radio/src/gui/128x64/model_outputs.cpp
@@ -231,9 +231,14 @@ void menuModelLimits(event_t event)
     uint8_t k = i+menuVerticalOffset;
     LcdFlags attr = (sub==MAX_OUTPUT_CHANNELS) ? INVERS : 0;
 
-    if (sub==k && ((event == EVT_KEY_BREAK(KEY_ENTER)) || (event == EVT_KEY_LONG(KEY_ENTER))) && !READ_ONLY() && (k != MAX_OUTPUT_CHANNELS) ) {
+    if (sub == k &&
+        ((event == EVT_KEY_BREAK(KEY_ENTER)) ||
+         (event == EVT_KEY_LONG(KEY_ENTER))) &&
+        !READ_ONLY() && (k != MAX_OUTPUT_CHANNELS)) {
       s_editMode = 0;
-      POPUP_MENU_START(onLimitsMenu, 5, STR_EDIT, STR_RESET, STR_COPY_TRIMS_TO_OFS, STR_COPY_STICKS_TO_OFS, STR_COPY_MIN_MAX_TO_OUTPUTS);
+      POPUP_MENU_START(onLimitsMenu, 5, STR_EDIT, STR_RESET,
+                       STR_COPY_TRIMS_TO_OFS, STR_COPY_STICKS_TO_OFS,
+                       STR_COPY_MIN_MAX_TO_OUTPUTS);
     }
 
     if (k == MAX_OUTPUT_CHANNELS) {


### PR DESCRIPTION
Summary of changes:
- also allow for long press of ENT for popup menu on outputs page
