### PR TITLE
fix(bw128): telemetry source name overlaps V1 value on logical switch list view

### DIFF
--- a/radio/src/gui/128x64/lcd.cpp
+++ b/radio/src/gui/128x64/lcd.cpp
@@ -704,7 +704,10 @@ void drawSource(coord_t x, coord_t y, mixsrc_t idx, LcdFlags att)
   }
 #endif
   else {
-    lcdDrawText(x, y, getSourceString(idx), att);
+    const char* s = getSourceString(idx);
+    if (idx >= MIXSRC_FIRST_TELEM && idx <= MIXSRC_LAST_TELEM)
+      s += strlen(STR_CHAR_TELEMETRY);
+    lcdDrawText(x, y, s, att);
   }
 }
 


### PR DESCRIPTION
Fixes #5106 

Don't display the telemetry symbol due to limited space available.