### PR TITLE
fix(bw128): column spacing for LS allowing for max values

### DIFF
--- a/radio/src/gui/128x64/model_logical_switches.cpp
+++ b/radio/src/gui/128x64/model_logical_switches.cpp
@@ -34,10 +34,10 @@ enum LogicalSwitchFields {
   LS_FIELD_LAST = LS_FIELD_COUNT-1
 };
 
-#define CSW_1ST_COLUMN  (3*FW-1)
-#define CSW_2ND_COLUMN  (7*FW-1)
-#define CSW_3RD_COLUMN  (13*FW-6)
-#define CSW_4TH_COLUMN  (17*FW)
+#define CSW_1ST_COLUMN  ((3*FW)-1)
+#define CSW_2ND_COLUMN  ((7*FW)-1)
+#define CSW_3RD_COLUMN  ((12*FW))
+#define CSW_4TH_COLUMN  ((21*FW)+3)
 
 void putsEdgeDelayParam(coord_t x, coord_t y, LogicalSwitchData *cs, uint8_t lattr, uint8_t rattr)
 {
@@ -334,7 +334,7 @@ void menuModelLogicalSwitches(event_t event)
       }
 
       // CSW and switch
-      drawSwitch(CSW_4TH_COLUMN, y, cs->andsw, 0);
+      drawSwitch(CSW_4TH_COLUMN, y, cs->andsw, RIGHT);
     }
   }
 }

--- a/radio/src/gui/128x64/model_logical_switches.cpp
+++ b/radio/src/gui/128x64/model_logical_switches.cpp
@@ -34,10 +34,10 @@ enum LogicalSwitchFields {
   LS_FIELD_LAST = LS_FIELD_COUNT-1
 };
 
-#define CSW_1ST_COLUMN  (4*FW-3)
-#define CSW_2ND_COLUMN  (8*FW-3)
+#define CSW_1ST_COLUMN  (3*FW-1)
+#define CSW_2ND_COLUMN  (7*FW-1)
 #define CSW_3RD_COLUMN  (13*FW-6)
-#define CSW_4TH_COLUMN  (18*FW+2)
+#define CSW_4TH_COLUMN  (17*FW)
 
 void putsEdgeDelayParam(coord_t x, coord_t y, LogicalSwitchData *cs, uint8_t lattr, uint8_t rattr)
 {


### PR DESCRIPTION
Summary of changes:

Started with this
![snapshot_02](https://github.com/EdgeTX/edgetx/assets/5500713/c1d2856c-d283-4fb6-96ea-84d4c6eafac2)

then noticed the final SWITCH col didn't take into account possible 4 characters
![snapshot_03](https://github.com/EdgeTX/edgetx/assets/5500713/961a3281-ab51-4e35-a8ae-4b5ca2975d45)

Then tweaked a little more and ended up with
![snapshot_05](https://github.com/EdgeTX/edgetx/assets/5500713/969c74d9-23bb-4691-9242-e26edf3735b0)
![snapshot_06](https://github.com/EdgeTX/edgetx/assets/5500713/8510c91e-4431-4c6b-b248-569aca45d75a)

Not entirely satisfied though as ends up cramped to allow for max possible lengths... but IMO better than overwriting values. 

Open to alternatives ;)