### PR TITLE
fix: timings for MPM update due to faster F4 MCUs

### DIFF
--- a/radio/src/io/multi_firmware_update.cpp
+++ b/radio/src/io/multi_firmware_update.cpp
@@ -181,7 +181,7 @@ bool MultiFirmwareUpdateDriver::checkRxByte(uint8_t byte) const
 const char * MultiFirmwareUpdateDriver::waitForInitialSync()
 {
   uint8_t byte;
-  tmr10ms_t timeout = get_tmr10ms() + 500;
+  uint32_t timer = timersGetMsTick();;
 
 #if defined(DEBUG_EXT_MODULE_FLASH)
   TRACE("[Wait for Sync]");
@@ -197,9 +197,9 @@ const char * MultiFirmwareUpdateDriver::waitForInitialSync()
     getRxByte(byte);
     WDG_RESET();
 
-  } while ((byte != STK_INSYNC) && get_tmr10ms() < timeout);
+  } while ((byte != STK_INSYNC) && ((timersGetMsTick() - timer) < 5000)); // 5secs
 
-  if (get_tmr10ms() > timeout) {
+  if ((timersGetMsTick() - timer) > 5000) {
     return STR_DEVICE_NO_RESPONSE;
   }
 

--- a/radio/src/io/multi_firmware_update.cpp
+++ b/radio/src/io/multi_firmware_update.cpp
@@ -181,7 +181,7 @@ bool MultiFirmwareUpdateDriver::checkRxByte(uint8_t byte) const
 const char * MultiFirmwareUpdateDriver::waitForInitialSync()
 {
   uint8_t byte;
-  int retries = 200;
+  tmr10ms_t timeout = get_tmr10ms() + 500;
 
 #if defined(DEBUG_EXT_MODULE_FLASH)
   TRACE("[Wait for Sync]");
@@ -197,9 +197,9 @@ const char * MultiFirmwareUpdateDriver::waitForInitialSync()
     getRxByte(byte);
     WDG_RESET();
 
-  } while ((byte != STK_INSYNC) && --retries);
+  } while ((byte != STK_INSYNC) && get_tmr10ms() < timeout);
 
-  if (!retries) {
+  if (get_tmr10ms() > timeout) {
     return STR_DEVICE_NO_RESPONSE;
   }
 

--- a/radio/src/io/multi_firmware_update.cpp
+++ b/radio/src/io/multi_firmware_update.cpp
@@ -181,7 +181,7 @@ bool MultiFirmwareUpdateDriver::checkRxByte(uint8_t byte) const
 const char * MultiFirmwareUpdateDriver::waitForInitialSync()
 {
   uint8_t byte;
-  uint32_t timer = timersGetMsTick();;
+  tmr10ms_t now = get_tmr10ms();;
 
 #if defined(DEBUG_EXT_MODULE_FLASH)
   TRACE("[Wait for Sync]");
@@ -197,9 +197,9 @@ const char * MultiFirmwareUpdateDriver::waitForInitialSync()
     getRxByte(byte);
     WDG_RESET();
 
-  } while ((byte != STK_INSYNC) && ((timersGetMsTick() - timer) < 5000)); // 5secs
+  } while ((byte != STK_INSYNC) && ((get_tmr10ms() - now) < 500)); // 5secs
 
-  if ((timersGetMsTick() - timer) > 5000) {
+  if ((get_tmr10ms() - now) > 500) {
     return STR_DEVICE_NO_RESPONSE;
   }
 


### PR DESCRIPTION
Use proper timeout instead of MCU speed dependent loops

This fixes #5110

If confirmed solving the issue, needs to be cherry picked on main too