### PR TITLE
feat: add 0.5 second option to power on/off delays

### DIFF
--- a/companion/src/generaledit/generalsetup.cpp
+++ b/companion/src/generaledit/generalsetup.cpp
@@ -478,6 +478,18 @@ void GeneralSetupPanel::populateRotEncCB(int reCount)
   b->setCurrentIndex(generalSettings.reNavigation);
 }
 
+int pwrDelayFromYaml(int delay)
+{
+  static int8_t vals[] = { 1, 4, 3, 2, 0 };
+  return vals[delay + 2];
+}
+
+int pwrDelayToYaml(int delay)
+{
+  static int8_t vals[] = { 2, -2, 1, 0, -1 };
+  return vals[delay];
+}
+
 void GeneralSetupPanel::setValues()
 {
   ui->beeperCB->setCurrentIndex(generalSettings.beeperMode+2);
@@ -509,8 +521,8 @@ void GeneralSetupPanel::setValues()
     ui->vBatMaxDSB->setValue((double)(generalSettings.vBatMax + 120) / 10);
   }
 
-  ui->pwrOnDelay->setValue(2 - generalSettings.pwrOnSpeed);
-  ui->pwrOffDelay->setValue(2 - generalSettings.pwrOffSpeed);
+  ui->pwrOnDelay->setCurrentIndex(pwrDelayFromYaml(generalSettings.pwrOnSpeed));
+  ui->pwrOffDelay->setCurrentIndex(pwrDelayFromYaml(generalSettings.pwrOffSpeed));
 
   ui->registrationId->setText(generalSettings.registrationId);
 
@@ -632,15 +644,15 @@ void GeneralSetupPanel::on_splashScreenDuration_currentIndexChanged(int index)
   emit modified();
 }
 
-void GeneralSetupPanel::on_pwrOnDelay_valueChanged(int)
+void GeneralSetupPanel::on_pwrOnDelay_currentIndexChanged(int index)
 {
-  generalSettings.pwrOnSpeed = 2 - ui->pwrOnDelay->value();
+  generalSettings.pwrOnSpeed = pwrDelayToYaml(index);
   emit modified();
 }
 
-void GeneralSetupPanel::on_pwrOffDelay_valueChanged(int)
+void GeneralSetupPanel::on_pwrOffDelay_currentIndexChanged(int index)
 {
-  generalSettings.pwrOffSpeed = 2 - ui->pwrOffDelay->value();
+  generalSettings.pwrOffSpeed = pwrDelayToYaml(index);
   emit modified();
 }
 

--- a/companion/src/generaledit/generalsetup.h
+++ b/companion/src/generaledit/generalsetup.h
@@ -91,8 +91,8 @@ class GeneralSetupPanel : public GeneralPanel
     void on_contrastSB_editingFinished();
     void on_registrationId_editingFinished();
 
-    void on_pwrOnDelay_valueChanged(int);
-    void on_pwrOffDelay_valueChanged(int);
+    void on_pwrOnDelay_currentIndexChanged(int);
+    void on_pwrOffDelay_currentIndexChanged(int);
     void on_pwrOnOffHaptic_CB_stateChanged(int);
 
     void on_modelQuickSelect_CB_stateChanged(int);

--- a/companion/src/generaledit/generalsetup.ui
+++ b/companion/src/generaledit/generalsetup.ui
@@ -1368,13 +1368,32 @@ p, li { white-space: pre-wrap; }
       </widget>
      </item>
      <item row="12" column="1">
-      <widget class="QSpinBox" name="pwrOnDelay">
-       <property name="suffix">
-        <string> sec</string>
-       </property>
-       <property name="maximum">
-        <number>3</number>
-       </property>
+      <widget class="QComboBox" name="pwrOnDelay">
+       <item>
+        <property name="text">
+         <string>0s</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>0.5s</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>1s</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>2s</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>3s</string>
+        </property>
+       </item>
       </widget>
      </item>
      <item row="2" column="0">
@@ -1548,13 +1567,32 @@ Acceptable values are 3v..12v</string>
       </widget>
      </item>
      <item row="13" column="1">
-      <widget class="QSpinBox" name="pwrOffDelay">
-       <property name="suffix">
-        <string> sec</string>
-       </property>
-       <property name="maximum">
-        <number>3</number>
-       </property>
+      <widget class="QComboBox" name="pwrOffDelay">
+       <item>
+        <property name="text">
+         <string>0s</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>0.5s</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>1s</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>2s</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>3s</string>
+        </property>
+       </item>
       </widget>
      </item>
      <item row="3" column="1" colspan="2">

--- a/radio/src/gui/128x64/radio_setup.cpp
+++ b/radio/src/gui/128x64/radio_setup.cpp
@@ -585,17 +585,11 @@ void menuRadioSetup(event_t event)
 
 #if defined(PWR_BUTTON_PRESS)
       case ITEM_RADIO_SETUP_PWR_ON_SPEED:
-        lcdDrawTextAlignedLeft(y, STR_PWR_ON_DELAY);
-        lcdDrawNumber(LCD_W-7, y, 2 - g_eeGeneral.pwrOnSpeed, attr|RIGHT);
-        lcdDrawChar(lcdLastRightPos, y, 's');
-        if (attr) CHECK_INCDEC_GENVAR(event, g_eeGeneral.pwrOnSpeed, -1, 2);
+        g_eeGeneral.pwrOnSpeed = pwrDelayToYaml(editChoice(LCD_W-2, y, STR_PWR_ON_DELAY, STR_PWR_OFF_DELAYS, pwrDelayFromYaml(g_eeGeneral.pwrOnSpeed), 0, 4, attr|RIGHT, event));
         break;
 
       case ITEM_RADIO_SETUP_PWR_OFF_SPEED:
-        lcdDrawTextAlignedLeft(y, STR_PWR_OFF_DELAY);
-        lcdDrawNumber(LCD_W-7, y, 2 - g_eeGeneral.pwrOffSpeed, attr|RIGHT);
-        lcdDrawChar(lcdLastRightPos, y, 's');
-        if (attr) CHECK_INCDEC_GENVAR(event, g_eeGeneral.pwrOffSpeed, -1, 2);
+        g_eeGeneral.pwrOffSpeed = pwrDelayToYaml(editChoice(LCD_W-2, y, STR_PWR_OFF_DELAY, STR_PWR_OFF_DELAYS, pwrDelayFromYaml(g_eeGeneral.pwrOffSpeed), 0, 4, attr|RIGHT, event));
         break;
 #endif
 

--- a/radio/src/gui/212x64/radio_setup.cpp
+++ b/radio/src/gui/212x64/radio_setup.cpp
@@ -549,17 +549,11 @@ void menuRadioSetup(event_t event)
 
 #if defined(PWR_BUTTON_PRESS)
       case ITEM_RADIO_SETUP_PWR_ON_SPEED:
-        lcdDrawTextAlignedLeft(y, STR_PWR_ON_DELAY);
-        lcdDrawNumber(RADIO_SETUP_2ND_COLUMN, y, 2 - g_eeGeneral.pwrOnSpeed, attr|LEFT);
-        lcdDrawChar(lcdLastRightPos, y, 's');
-        if (attr) CHECK_INCDEC_GENVAR(event, g_eeGeneral.pwrOnSpeed, -1, 2);
+        g_eeGeneral.pwrOnSpeed = pwrDelayToYaml(editChoice(LCD_W-2, y, STR_PWR_ON_DELAY, STR_PWR_OFF_DELAYS, pwrDelayFromYaml(g_eeGeneral.pwrOnSpeed), 0, 4, attr|RIGHT, event));
         break;
 
       case ITEM_RADIO_SETUP_PWR_OFF_SPEED:
-        lcdDrawTextAlignedLeft(y, STR_PWR_OFF_DELAY);
-        lcdDrawNumber(RADIO_SETUP_2ND_COLUMN, y, 2 - g_eeGeneral.pwrOffSpeed, attr|LEFT);
-        lcdDrawChar(lcdLastRightPos, y, 's');
-        if (attr) CHECK_INCDEC_GENVAR(event, g_eeGeneral.pwrOffSpeed, -1, 2);
+        g_eeGeneral.pwrOffSpeed = pwrDelayToYaml(editChoice(LCD_W-2, y, STR_PWR_OFF_DELAY, STR_PWR_OFF_DELAYS, pwrDelayFromYaml(g_eeGeneral.pwrOffSpeed), 0, 4, attr|RIGHT, event));
         break;
 #endif
 

--- a/radio/src/gui/colorlcd/radio_setup.cpp
+++ b/radio/src/gui/colorlcd/radio_setup.cpp
@@ -760,10 +760,10 @@ static SetupLineDef setupLines[] = {
     STR_PWR_OFF_DELAY,
     [](Window* parent, coord_t x, coord_t y) {
       new Choice(
-          parent, {x, y, 0, EdgeTxStyles::UI_ELEMENT_HEIGHT}, STR_PWR_OFF_DELAYS, 0, 3,
-          [=]() -> int32_t { return 2 - g_eeGeneral.pwrOffSpeed; },
+          parent, {x, y, 0, EdgeTxStyles::UI_ELEMENT_HEIGHT}, STR_PWR_OFF_DELAYS, 0, 4,
+          [=]() -> int32_t { return pwrDelayFromYaml(g_eeGeneral.pwrOffSpeed); },
           [=](int32_t newValue) {
-            g_eeGeneral.pwrOffSpeed = 2 - newValue;
+            g_eeGeneral.pwrOffSpeed = pwrDelayToYaml(newValue);
             SET_DIRTY();
           });
     }

--- a/radio/src/gui/colorlcd/startup_shutdown.cpp
+++ b/radio/src/gui/colorlcd/startup_shutdown.cpp
@@ -247,7 +247,7 @@ void drawShutdownAnimation(uint32_t duration, uint32_t totalDuration,
     }
   }
 
-  int quarter = 3 - duration / (totalDuration / 5);
+  int quarter = 4 - (duration * 5) / totalDuration;
   if (quarter < 0) quarter = 0;
   for (int i = 3; i >= quarter; i -= 1) shutdownAnim[i]->hide();
 

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1231,11 +1231,19 @@ void copyMinMaxToOutputs(uint8_t ch)
   storageDirty(EE_MODEL);
 }
 
+#if defined(PWR_BUTTON_PRESS) || defined(STARTUP_ANIMATION)
+uint32_t pwrDelayTime(int delay)
+{
+  static uint8_t vals[] = { 0, 5, 10, 20, 30 };
+  return vals[pwrDelayFromYaml(delay)] * 10;
+}
+#endif
+
 #if defined(STARTUP_ANIMATION)
 
 inline uint32_t PWR_PRESS_DURATION_MIN()
 {
-  return (2 - g_eeGeneral.pwrOnSpeed) * 100;
+  return pwrDelayTime(g_eeGeneral.pwrOnSpeed);
 }
 
 constexpr uint32_t PWR_PRESS_DURATION_MAX = 500; // 5s
@@ -1608,6 +1616,20 @@ int main()
   tasksStart();
 }
 
+#if defined(PWR_BUTTON_PRESS)
+int pwrDelayFromYaml(int delay)
+{
+  static int8_t vals[] = { 1, 4, 3, 2, 0 };
+  return vals[delay + 2];
+}
+
+int pwrDelayToYaml(int delay)
+{
+  static int8_t vals[] = { 2, -2, 1, 0, -1 };
+  return vals[delay];
+}
+#endif
+
 #if !defined(SIMU)
 #if defined(PWR_BUTTON_PRESS)
 
@@ -1617,19 +1639,17 @@ inline uint32_t PWR_PRESS_SHUTDOWN_DELAY()
   if (pwrForcePressed())
     return 0;
 
-  return (2 - g_eeGeneral.pwrOffSpeed) * 100;
+  return pwrDelayTime(g_eeGeneral.pwrOffSpeed);
 }
 
 uint32_t pwr_press_time = 0;
 
 uint32_t pwrPressedDuration()
 {
-  if (pwr_press_time == 0) {
+  if (pwr_press_time == 0)
     return 0;
-  }
-  else {
-    return get_tmr10ms() - pwr_press_time;
-  }
+
+  return get_tmr10ms() - pwr_press_time;
 }
 
 #if defined(COLORLCD)

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -950,3 +950,6 @@ extern bool modelLSEnabled();
 extern bool modelSFEnabled();
 extern bool modelCustomScriptsEnabled();
 extern bool modelTelemetryEnabled();
+
+int pwrDelayFromYaml(int delay);
+int pwrDelayToYaml(int delay);

--- a/radio/src/translations/untranslated.h
+++ b/radio/src/translations/untranslated.h
@@ -102,7 +102,7 @@
 #define TR_FLYSKY_PULSE_PROTO          "PWM","PPM"
 #define TR_FLYSKY_SERIAL_PROTO         "iBUS","SBUS"
 #define TR_PPM_POL                     "-","+"
-#define TR_PWR_OFF_DELAYS              "0s","1s","2s","4s"
+#define TR_PWR_OFF_DELAYS              "0s","0.5s","1s","2s","3s"
 #if defined(COLORLCD)
 #define TR_SPLASHSCREEN_DELAYS         "1s","2s","3s","4s","6s","8s","10s","15s"
 #endif


### PR DESCRIPTION
Closes #5133

On color LCD also fixes:
- Shutdown animation did not show all four bars
- Highest power off delay option was shown as 4s; but the actual delay is only 3s (as per B&W radios).
