### PR TITLE
fix(color): remove unnecessary updates of channel bar

### DIFF
--- a/radio/src/gui/colorlcd/channel_bar.cpp
+++ b/radio/src/gui/colorlcd/channel_bar.cpp
@@ -32,8 +32,8 @@
 ChannelBar::ChannelBar(Window* parent, const rect_t& rect, uint8_t channel,
                        std::function<int16_t()> getValueFunc, LcdColorIndex barColorIndex,
                        LcdColorIndex txtColorIndex) :
-    Window(parent, rect), getValue(std::move(getValueFunc)),
-    channel(channel)
+    Window(parent, rect), channel(channel),
+    getValue(std::move(getValueFunc))
 {
   etx_solid_bg(lvobj, COLOR_THEME_PRIMARY2_INDEX);
 
@@ -81,22 +81,25 @@ void ChannelBar::checkEvents()
     else
       s = formatNumberAsString(calcRESXto100(value), 0, 0, "", "%");
 
-    lv_label_set_text(valText, s.c_str());
+    if (s != valStr) {
+      valStr = s;
+      lv_label_set_text(valText, s.c_str());
 
-    if (newValue < 0)
-      lv_obj_clear_state(valText, LV_STATE_USER_1);
-    else
-      lv_obj_add_state(valText, LV_STATE_USER_1);
+      if (s[0] == '-')
+        lv_obj_clear_state(valText, LV_STATE_USER_1);
+      else
+        lv_obj_add_state(valText, LV_STATE_USER_1);
 
-    const int lim = (g_model.extendedLimits ? (1024 * LIMIT_EXT_PERCENT / 100) : 1024);
-    int chanVal = limit<int>(-lim, value, lim);
+      const int lim = (g_model.extendedLimits ? (1024 * LIMIT_EXT_PERCENT / 100) : 1024);
+      int chanVal = limit<int>(-lim, value, lim);
 
-    uint16_t size = divRoundClosest(abs(chanVal) * width(), lim * 2);
+      uint16_t size = divRoundClosest(abs(chanVal) * width(), lim * 2);
 
-    int16_t x = width() / 2 - ((chanVal > 0) ? 0 : size);
+      int16_t x = width() / 2 - ((chanVal > 0) ? 0 : size);
 
-    lv_obj_set_pos(bar, x, 0);
-    lv_obj_set_size(bar, size, height());
+      lv_obj_set_pos(bar, x, 0);
+      lv_obj_set_size(bar, size, height());
+    }
   }
 }
 

--- a/radio/src/gui/colorlcd/channel_bar.h
+++ b/radio/src/gui/colorlcd/channel_bar.h
@@ -43,6 +43,7 @@ class ChannelBar : public Window
  protected:
   uint8_t channel = 0;
   int16_t value = -10000;
+  std::string valStr;
   std::function<int16_t()> getValue;
   lv_obj_t* valText = nullptr;
   lv_point_t divPoints[2];


### PR DESCRIPTION
Small changes in channel value (e.g. noise in gimbals) would trigger an unnecessary refresh of the channel bar.
