### PR TITLE
Fix trainer sbus taranis

### DIFF
--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -1058,7 +1058,7 @@ bool isTrainerModeAvailable(int mode)
     if (mode == TRAINER_MODE_MASTER_SBUS_EXTERNAL_MODULE) {
       const etx_module_port_t *port = nullptr;
 
-#if defined(TRAINER_MODULE_SBUS_USART)
+#if defined(TRAINER_MODULE_SBUS)
       // check if UART with inverter on heartbeat pin is required and available for SBUS (some Taranis radios)
       port = modulePortFind(EXTERNAL_MODULE, ETX_MOD_TYPE_SERIAL,
                             ETX_MOD_PORT_UART, ETX_Pol_Normal,

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -2299,6 +2299,7 @@
 #if defined(PCBX9LITE) ||  defined(PCBXLITE)
   #define TRAINER_MODULE_CPPM_TIMER_IRQHandler TIM3_IRQHandler
 #endif
+  #define TRAINER_MODULE_SBUS
 #elif defined(INTMODULE_HEARTBEAT_GPIO) && defined(HARDWARE_EXTERNAL_MODULE)
   // Trainer CPPM input on heartbeat pin
   #define TRAINER_MODULE_CPPM_TIMER               TRAINER_TIMER
@@ -2314,6 +2315,7 @@
   #define TRAINER_MODULE_SBUS_DMA_STREAM          DMA2_Stream1
   #define TRAINER_MODULE_SBUS_DMA_STREAM_LL       LL_DMA_STREAM_1
   #define TRAINER_MODULE_SBUS_DMA_CHANNEL         LL_DMA_CHANNEL_5
+  #define TRAINER_MODULE_SBUS
 #else
   // TODO: replace SBUS trainer with S.PORT pin
 #endif

--- a/radio/src/trainer.cpp
+++ b/radio/src/trainer.cpp
@@ -180,7 +180,9 @@ static void trainer_init_module_sbus()
 {
   if (sbus_trainer_mod_st) return;
 
-#if defined(TRAINER_MODULE_SBUS_USART)
+
+
+#if defined(TRAINER_MODULE_SBUS)
   // check if UART with inverter on heartbeat pin is required and available for SBUS (some Taranis radios)
   sbus_trainer_mod_st = modulePortInitSerial(EXTERNAL_MODULE, ETX_MOD_PORT_UART,
                                              &sbusTrainerParams, false);


### PR DESCRIPTION


Fixes #5139

Summary of changes:
The definition for trainer module sbus/cppm are in the "Trainer / Trainee from the module bay" section of hal.h for Taranis radios. The initialization of the module ports is in trainer_init_module_sbus() (trainer.cpp) and isTrainerMode available (gui_common.cpp). In both files the proper init of the UART is controlled by the identifier TRAINER_MODULE_SBUS_USART which is not defined in the hal section for Taranis radios. Therefore I reintroduced an identifier TARANIS_MODULE_SBUS.
Trainer/SBUS function tested on 2.10.1 and 2.11 with radio Taranis QX7ACCESS. Tested on 2.11 with Tx16s simulator only.