### PR TITLE
fix(cpn): crash when going into radio settings due to customisable switch groups source

### DIFF
--- a/companion/src/datamodels/compounditemmodels.cpp
+++ b/companion/src/datamodels/compounditemmodels.cpp
@@ -115,7 +115,8 @@ RawSourceItemModel::RawSourceItemModel(const GeneralSettings * const generalSett
   addItems(SOURCE_TYPE_PPM,            RawSource::SourcesGroup,  -firmware->getCapability(TrainerInputs));
   addItems(SOURCE_TYPE_CYC,            RawSource::SourcesGroup,  -CPN_MAX_CYC);
   addItems(SOURCE_TYPE_CUSTOM_SWITCH,  RawSource::SwitchesGroup, -firmware->getCapability(LogicalSwitches));
-  addItems(SOURCE_TYPE_FUNCTIONSWITCH_GROUP,  RawSource::SourcesGroup,  -CPN_MAX_FUNCTIONSWITCH_GROUP);
+  if (modelData)
+    addItems(SOURCE_TYPE_FUNCTIONSWITCH_GROUP,  RawSource::SourcesGroup,  -CPN_MAX_FUNCTIONSWITCH_GROUP);
   addItems(SOURCE_TYPE_SWITCH,         RawSource::SwitchesGroup, -board->getCapability(Board::Switches));
   addItems(SOURCE_TYPE_MAX,            RawSource::SourcesGroup,  -1);
   addItems(SOURCE_TYPE_MIN,            RawSource::SourcesGroup,  -1);
@@ -137,7 +138,8 @@ RawSourceItemModel::RawSourceItemModel(const GeneralSettings * const generalSett
   addItems(SOURCE_TYPE_MIN,            RawSource::SourcesGroup,  1);
   addItems(SOURCE_TYPE_MAX,            RawSource::SourcesGroup,  1);
   addItems(SOURCE_TYPE_SWITCH,         RawSource::SwitchesGroup, board->getCapability(Board::Switches));
-  addItems(SOURCE_TYPE_FUNCTIONSWITCH_GROUP,  RawSource::SourcesGroup,  CPN_MAX_FUNCTIONSWITCH_GROUP);
+  if (modelData)
+    addItems(SOURCE_TYPE_FUNCTIONSWITCH_GROUP,  RawSource::SourcesGroup,  CPN_MAX_FUNCTIONSWITCH_GROUP);
   addItems(SOURCE_TYPE_CUSTOM_SWITCH,  RawSource::SwitchesGroup, firmware->getCapability(LogicalSwitches));
   addItems(SOURCE_TYPE_CYC,            RawSource::SourcesGroup,  CPN_MAX_CYC);
   addItems(SOURCE_TYPE_PPM,            RawSource::SourcesGroup,  firmware->getCapability(TrainerInputs));

--- a/companion/src/firmwares/rawsource.cpp
+++ b/companion/src/firmwares/rawsource.cpp
@@ -294,7 +294,7 @@ bool RawSource::isAvailable(const ModelData * const model, const GeneralSettings
   if (type == SOURCE_TYPE_CUSTOM_SWITCH && abs(index) > CPN_MAX_LOGICAL_SWITCHES)
     return false;
 
-  if (type == SOURCE_TYPE_FUNCTIONSWITCH_GROUP && model->getFuncGroupSwitchCount(abs(index), CPN_MAX_SWITCHES_FUNCTION) == 0)
+  if (type == SOURCE_TYPE_FUNCTIONSWITCH_GROUP && b.getCapability(Board::FunctionSwitches) && model->getFuncGroupSwitchCount(abs(index), CPN_MAX_SWITCHES_FUNCTION) == 0)
     return false;
 
   if (type == SOURCE_TYPE_LUA_OUTPUT && div(abs(index - 1), 16).quot >= CPN_MAX_SCRIPTS)

--- a/radio/src/gui/colorlcd/sourcechoice.cpp
+++ b/radio/src/gui/colorlcd/sourcechoice.cpp
@@ -83,8 +83,13 @@ class SourceChoiceMenuToolbar : public MenuToolbar
 #endif
     addButton(STR_CHAR_TRIM, MIXSRC_FIRST_TRIM, MIXSRC_LAST_TRIM, nullptr,
               STR_MENU_TRIMS);
+#if defined(FUNCTION_SWITCHES)
+    addButton(STR_CHAR_SWITCH, MIXSRC_FIRST_SWITCH, MIXSRC_LAST_CUSTOMSWITCH_GROUP, nullptr,
+              STR_MENU_SWITCHES);
+#else
     addButton(STR_CHAR_SWITCH, MIXSRC_FIRST_SWITCH, MIXSRC_LAST_SWITCH, nullptr,
               STR_MENU_SWITCHES);
+#endif
     if (modelLSEnabled())
       addButton("LS", MIXSRC_FIRST_LOGICAL_SWITCH, MIXSRC_LAST_LOGICAL_SWITCH,
                 nullptr, STR_MENU_LOGICAL_SWITCHES);


### PR DESCRIPTION
Fixes:
- Companion crashes when editing radio settings for radios without function switches.
- Add GRx sources to switch filter when selecting a source (color radios).

![screenshot_t15_24-06-09_21-59-32](https://github.com/EdgeTX/edgetx/assets/9474356/ab62e5a7-c2dd-4740-9412-0134b74c523a)
