### PR TITLE
feat(color): delay image load on manage models page

### DIFF
--- a/radio/src/thirdparty/libopenui/src/bitmapbuffer_fileio.cpp
+++ b/radio/src/thirdparty/libopenui/src/bitmapbuffer_fileio.cpp
@@ -16,6 +16,8 @@
  * GNU General Public License for more details.
  */
 
+#pragma GCC optimize("O3")
+
 #include "bitmapbuffer.h"
 #include "libopenui_file.h"
 #include "opentx_helpers.h"

--- a/radio/src/thirdparty/libopenui/src/static.cpp
+++ b/radio/src/thirdparty/libopenui/src/static.cpp
@@ -183,8 +183,8 @@ void StaticIcon::center(coord_t w, coord_t h)
 // Display image from file system using LVGL with LVGL scaling
 //  - LVGL scaling is slow so don't use this if there are many images
 StaticImage::StaticImage(Window* parent, const rect_t& rect,
-                         const char* filename) :
-    Window(parent, rect)
+                         const char* filename, bool dontEnlarge) :
+    Window(parent, rect), dontEnlarge(dontEnlarge)
 {
   setWindowFlag(NO_FOCUS);
 

--- a/radio/src/thirdparty/libopenui/src/static.h
+++ b/radio/src/thirdparty/libopenui/src/static.h
@@ -142,7 +142,7 @@ class StaticImage : public Window
 {
  public:
   StaticImage(Window *parent, const rect_t &rect,
-              const char *filename = nullptr);
+              const char *filename = nullptr, bool dontEnlarge = false);
 
 #if defined(DEBUG_WINDOWS)
   std::string getName() const override { return "StaticImage"; }


### PR DESCRIPTION
Delay load the model images to improve responsiveness of the model select page.

The page loads quickly, instead of waiting for all the model images to be loaded from the SD card.
The model image will then populate after the page loads.
