### PR TITLE
fix: reduce file system corruption from standalone Lua scripts

### DIFF
--- a/radio/src/targets/common/arm/stm32/diskio_sdio.cpp
+++ b/radio/src/targets/common/arm/stm32/diskio_sdio.cpp
@@ -270,15 +270,12 @@ static DRESULT sdio_read(BYTE lun, BYTE * buff, DWORD sector, UINT count)
   res = _read_dma(buff, sector, count);
   if (res != RES_OK) return res;
 
-  uint32_t timeout = HAL_GetTick();
-  while((HAL_GetTick() - timeout) < SD_TIMEOUT) {
-    if (sdio_check_card_state() == SD_TRANSFER_OK) {
-      return RES_OK;
-    }
+  if (sdio_check_card_state_with_timeout(SD_TIMEOUT) < 0) {
+    TRACE("SD getstatus timeout, s:%u c:%u", sector, (uint32_t)count);
+    return RES_ERROR;
   }
 
-  TRACE("SD getstatus timeout, s:%u c:%u", sector, (uint32_t)count);
-  return RES_ERROR;
+  return RES_OK;
 }
 
 static DRESULT _write_dma(const BYTE *buff, DWORD sector, UINT count)
@@ -329,16 +326,13 @@ static DRESULT sdio_write(BYTE lun, const BYTE *buff, DWORD sector, UINT count)
 
   res = _write_dma(buff, sector, count);
   if (res != RES_OK) return res;
-  
-  uint32_t timeout = HAL_GetTick();
-  while((HAL_GetTick() - timeout) < SD_TIMEOUT) {
-    if (sdio_check_card_state() == SD_TRANSFER_OK) {
-      return RES_OK;
-    }
+
+  if (sdio_check_card_state_with_timeout(SD_TIMEOUT) < 0) {
+    TRACE("SD getstatus timeout, s:%u c: %u", sector, (uint32_t)count);
+    return RES_ERROR;
   }
 
-  TRACE("SD getstatus timeout, s:%u c: %u", sector, (uint32_t)count);
-  return RES_ERROR;
+  return RES_OK;
 }
 
 static DRESULT sdio_get_sector_count(DWORD* sectors)

--- a/radio/src/thirdparty/FatFs/ffconf.h
+++ b/radio/src/thirdparty/FatFs/ffconf.h
@@ -235,7 +235,7 @@
 / System Configurations
 /---------------------------------------------------------------------------*/
 
-#define FF_FS_TINY		0
+#define FF_FS_TINY		1
 /* This option switches tiny buffer configuration. (0:Normal or 1:Tiny)
 /  At the tiny configuration, size of file object (FIL) is shrinked FF_MAX_SS bytes.
 /  Instead of private sector buffer eliminated from the file object, common sector


### PR DESCRIPTION
This possibly fixes LUA sd corruption. This PR is raised to allow easier testing

While at it, use more sdio_check_card_state_with_timeout();

Finding by @philmoz 

This fixes #5077
