### PR TITLE
fix: check both SBUS trainer ports regardless of TRAINER_MODULE_SBUS_USART

### DIFF
--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -1058,17 +1058,16 @@ bool isTrainerModeAvailable(int mode)
     if (mode == TRAINER_MODE_MASTER_SBUS_EXTERNAL_MODULE) {
       const etx_module_port_t *port = nullptr;
 
-#if defined(TRAINER_MODULE_SBUS_USART)
-      // check if UART with inverter on heartbeat pin is required and available for SBUS (some Taranis radios)
+      // check if UART with inverter on heartbeat pin is available
       port = modulePortFind(EXTERNAL_MODULE, ETX_MOD_TYPE_SERIAL,
                             ETX_MOD_PORT_UART, ETX_Pol_Normal,
                             ETX_MOD_DIR_RX);
-#else
-      //check if UART with inverter on S.Port pin is available for SBUS (e.g. TX16s, NV14)
-      port = modulePortFind(EXTERNAL_MODULE, ETX_MOD_TYPE_SERIAL,
-                            ETX_MOD_PORT_SPORT, ETX_Pol_Normal,
-                            ETX_MOD_DIR_RX);
-#endif
+      if (!port) {
+        // otherwise fall back to S.Port pin
+        port =
+            modulePortFind(EXTERNAL_MODULE, ETX_MOD_TYPE_SERIAL,
+                           ETX_MOD_PORT_SPORT, ETX_Pol_Normal, ETX_MOD_DIR_RX);
+      }
 
       return port != nullptr;
     }

--- a/radio/src/trainer.cpp
+++ b/radio/src/trainer.cpp
@@ -180,16 +180,14 @@ static void trainer_init_module_sbus()
 {
   if (sbus_trainer_mod_st) return;
 
-#if defined(TRAINER_MODULE_SBUS_USART)
-  // check if UART with inverter on heartbeat pin is required and available for SBUS (some Taranis radios)
+  // check if UART with inverter on heartbeat pin is available
   sbus_trainer_mod_st = modulePortInitSerial(EXTERNAL_MODULE, ETX_MOD_PORT_UART,
                                              &sbusTrainerParams, false);
-#else
-  // check if UART with inverter on S.Port pin is available for SBUS (e.g. TX16s, NV14)
-  if(sbus_trainer_mod_st == nullptr)
-    sbus_trainer_mod_st = modulePortInitSerial(EXTERNAL_MODULE, ETX_MOD_PORT_SPORT,
-                                               &sbusTrainerParams, false);
-#endif
+  if(sbus_trainer_mod_st == nullptr) {
+    // otherwise fall back to S.Port pin
+    sbus_trainer_mod_st = modulePortInitSerial(
+        EXTERNAL_MODULE, ETX_MOD_PORT_SPORT, &sbusTrainerParams, false);
+  }
 
   if (sbus_trainer_mod_st) {
     modulePortSetPower(EXTERNAL_MODULE,true);


### PR DESCRIPTION
Fixes #5139

Summary of changes:
- removed `#if defined(TRAINER_MODULE_SBUS_USART)` and just check presence of potential ports instead.
