### PR TITLE
fix(cpn): simulator may get stuck on splash screen.

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1331,7 +1331,8 @@ void edgeTxInit()
   TRACE("edgeTxInit");
 
   // Show splash screen (color LCD)
-  startSplash();
+  if (!(startOptions & OPENTX_START_NO_SPLASH))
+    startSplash();
 
 #if defined(HARDWARE_TOUCH) && !defined(PCBFLYSKY) && !defined(SIMU)
   touchPanelInit();


### PR DESCRIPTION
Fixes issue where simulator is stuck on splash screen when started with the 'Simulate model' button.
