### PR TITLE
fix(radio): close file handle if sound file cannot be played

### DIFF
--- a/radio/src/audio.cpp
+++ b/radio/src/audio.cpp
@@ -551,6 +551,7 @@ int WavContext::mixBuffer(AudioBuffer *buffer, int volume, unsigned int fade)
   }
 
   if (result != FR_OK) {
+    f_close(&state.file);
     clear();
   }
   return 0;


### PR DESCRIPTION
Closes the file handle if a selected file on the SD card cannot be played for any reason.
