### PR TITLE
fix: hide 'invert' toggle for multipos switches

### DIFF
--- a/companion/src/firmwares/generalsettings.cpp
+++ b/companion/src/firmwares/generalsettings.cpp
@@ -311,7 +311,7 @@ void GeneralSettings::setDefaultControlTypes(Board::Type board)
       Board::InputInfo info =  Boards::getInputInfo(i, board);
       inputConfig[i].type = info.type;
       inputConfig[i].flexType = info.flexType;
-      inputConfig[i].inverted = info.inverted;
+      inputConfig[i].inverted = false; //info.inverted;
     }
   }
 

--- a/companion/src/generaledit/hardware.cpp
+++ b/companion/src/generaledit/hardware.cpp
@@ -442,6 +442,16 @@ void HardwarePanel::addFlex(int index)
           AbstractItemModel *mdl = editorItemModels->getItemModel(AbstractItemModel::IMID_FlexSwitches);
           if (mdl)
             mdl->update(AbstractItemModel::IMUE_FunctionSwitches);
+          if (generalSettings.isInputMultiPosPot(index)) {
+            invertToggles[index - Boards::getCapability(board, Board::Sticks)]->hide();
+            if (generalSettings.inputConfig[index].inverted) {
+              generalSettings.inputConfig[index].inverted = false;
+              invertToggles[index - Boards::getCapability(board, Board::Sticks)]->updateValue();
+              emit modified();
+            }
+          } else {
+            invertToggles[index - Boards::getCapability(board, Board::Sticks)]->show();
+          }
           emit InputFlexTypeChanged();
   });
 
@@ -452,6 +462,15 @@ void HardwarePanel::addFlex(int index)
   AutoCheckBox *inverted = new AutoCheckBox(this);
   inverted->setField(config.inverted, this);
   params->append(inverted);
+  if (generalSettings.isInputMultiPosPot(index)) {
+    inverted->hide();
+    if (config.inverted) {
+      config.inverted = false;
+      inverted->updateValue();
+      emit modified();
+    }
+  }
+  invertToggles.push_back(inverted);
 
   addParams();
 }

--- a/companion/src/generaledit/hardware.h
+++ b/companion/src/generaledit/hardware.h
@@ -28,6 +28,8 @@ class QGridLayout;
 class AutoComboBox;
 class ExclusiveComboGroup;
 
+class AutoCheckBox;
+
 class HardwarePanel : public GeneralPanel
 {
     Q_OBJECT
@@ -58,6 +60,7 @@ class HardwarePanel : public GeneralPanel
     QList<QWidget *> *params;
     int row;
     ExclusiveComboGroup *exclFlexSwitchesGroup;
+    std::vector<AutoCheckBox*> invertToggles;
 
     void addStick(int index);
     void addFlex(int index);

--- a/radio/src/gui/colorlcd/hw_inputs.h
+++ b/radio/src/gui/colorlcd/hw_inputs.h
@@ -25,13 +25,18 @@
 #include "dialog.h"
 #include "form.h"
 
-struct HWSticks : public Window {
+class ToggleSwitch;
+
+class HWSticks : public Window
+{
+ public:
   HWSticks(Window* parent);
 };
 
-struct HWPots : public Window {
+struct HWPots : public Window
+{
+ public:
   HWPots(Window* parent);
-  bool potsChanged;
 
   // Absolute layout for Pots popup - due to performance issues with lv_textarea
   // in a flex layout
@@ -46,9 +51,15 @@ struct HWPots : public Window {
   static LAYOUT_VAL(P_ROW_H, 36, 72)
   static LAYOUT_VAL(P_OFST_Y, 0, 36)
   #define P_Y(i) (i * P_ROW_H + 2)
+
+ protected:
+  bool potsChanged;
+  std::vector<ToggleSwitch*> invertToggles;
 };
 
-struct HWSwitches : public Window {
+class HWSwitches : public Window
+{
+ public:
   HWSwitches(Window* parent);
 
   // Absolute layout for Switches popup - due to performance issues with

--- a/radio/src/gui/colorlcd/hw_inputs.h
+++ b/radio/src/gui/colorlcd/hw_inputs.h
@@ -24,6 +24,7 @@
 #include "button.h"
 #include "dialog.h"
 #include "form.h"
+#include <vector>
 
 class ToggleSwitch;
 

--- a/radio/src/gui/common/stdlcd/radio_hardware.cpp
+++ b/radio/src/gui/common/stdlcd/radio_hardware.cpp
@@ -150,7 +150,7 @@ static void _init_menu_tab_array(uint8_t* tab, size_t len)
   auto max_pots = adcGetMaxInputs(ADC_INPUT_FLEX);
   for (int i = ITEM_RADIO_HARDWARE_POT; i <= ITEM_RADIO_HARDWARE_POT_END; i++) {
     uint8_t idx = i - ITEM_RADIO_HARDWARE_POT;
-    tab[i] = idx < max_pots ? 2 : HIDDEN_ROW;
+    tab[i] = idx < max_pots ? (IS_POT_MULTIPOS(idx) ? 1 : 2) : HIDDEN_ROW;
   }
 
   auto max_switches = switchGetMaxSwitches();
@@ -527,12 +527,17 @@ void menuRadioHardware(event_t event)
           if (checkIncDec_Ret) switchFixFlexConfig();
           setPotType(idx, potType);
 
-          // ADC inversion
-          flags = menuHorizontalPosition == 2 ? attr : 0;
-          bool potinversion = getPotInversion(idx);
-          lcdDrawChar(LCD_W - 8, y, potinversion ? 127 : 126, flags);
-          if (flags & (~RIGHT)) potinversion = checkIncDec(event, potinversion, 0, 1, (isModelMenuDisplayed()) ? EE_MODEL : EE_GENERAL);
-          setPotInversion(idx, potinversion);
+          if (!IS_POT_MULTIPOS(idx)) {
+            // ADC inversion
+            flags = menuHorizontalPosition == 2 ? attr : 0;
+            bool potinversion = getPotInversion(idx);
+            lcdDrawChar(LCD_W - 8, y, potinversion ? 127 : 126, flags);
+            if (flags & (~RIGHT)) potinversion = checkIncDec(event, potinversion, 0, 1, (isModelMenuDisplayed()) ? EE_MODEL : EE_GENERAL);
+            setPotInversion(idx, potinversion);
+          } else if (getPotInversion(idx)) {
+            setPotInversion(idx, 0);
+            storageDirty(EE_GENERAL);
+          }
         }
         else if (k <= ITEM_RADIO_HARDWARE_SWITCH_END) {
           // Switches


### PR DESCRIPTION
Fixes #5144
