### PR TITLE
fix(cpn): save lastDir when opening a file

### DIFF
--- a/companion/src/mainwindow.h
+++ b/companion/src/mainwindow.h
@@ -115,7 +115,7 @@ class MainWindow : public QMainWindow
     void downloads();
     void doUpdates(bool check, bool interactive = true);
 
-    void openFile(const QString & fileName, bool updateLastUsedDir = false);
+    void openFile(const QString & fileName, bool updateLastUsedDir = true);
 
   private:
     QAction * addAct(const QString & icon, const char * slot = NULL, const QKeySequence & shortcut = 0, QObject * slotObj = NULL, const char * signal = NULL);


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #5157 and fixes #4813

Summary of changes:
Ignores `updateLastUsedDir` boolean and updates the last directory used.

I don't know the purpose of not saving the last used directory and I don't know the impact of removing all the code associated with removing this boolean value so I set it true so the directory is updated. Companion hasn't updated the directory location in seven years but these two issues reference the problem and this is a very simple fix.