### PR TITLE
fix(color): cosmetic focus issue on text and number edit fields

### DIFF
--- a/radio/src/thirdparty/libopenui/src/numberedit.cpp
+++ b/radio/src/thirdparty/libopenui/src/numberedit.cpp
@@ -38,6 +38,8 @@ class NumberArea : public FormField
   {
     if (rect.w == 0) setWidth(DEF_W);
 
+    lv_obj_clear_flag(lvobj, LV_OBJ_FLAG_CLICK_FOCUSABLE);
+
     etx_obj_add_style(lvobj, styles->text_align_right, LV_PART_MAIN);
 
     // Allow encoder acceleration

--- a/radio/src/thirdparty/libopenui/src/textedit.cpp
+++ b/radio/src/thirdparty/libopenui/src/textedit.cpp
@@ -33,6 +33,8 @@ class TextArea : public FormField
   TextArea(Window* parent, const rect_t& rect, char* value, uint8_t length) :
       FormField(parent, rect, 0, etx_textarea_create), value(value), length(length)
   {
+    lv_obj_clear_flag(lvobj, LV_OBJ_FLAG_CLICK_FOCUSABLE);
+
     lv_textarea_set_max_length(lvobj, length);
     lv_textarea_set_placeholder_text(lvobj, "---");
 
@@ -175,7 +177,6 @@ void TextEdit::preview(bool edited, char* text, uint8_t length)
   lv_obj_clear_flag(lvobj, LV_OBJ_FLAG_CLICKABLE);
   lv_obj_clear_flag(edit->getLvObj(), LV_OBJ_FLAG_CLICKABLE);
   lv_obj_clear_flag(lvobj, LV_OBJ_FLAG_CLICK_FOCUSABLE);
-  lv_obj_clear_flag(edit->getLvObj(), LV_OBJ_FLAG_CLICK_FOCUSABLE);
   lv_obj_add_state(edit->getLvObj(), LV_STATE_FOCUSED);
   if (edited) lv_obj_add_state(edit->getLvObj(), LV_STATE_EDITED);
 }


### PR DESCRIPTION
After a number edit or text edit field is selected for editing, tapping on the same field will cause the background color to briefly flash. Long pressing on the field will change the background color to the non-edit color.

Cosmetic only - does not affect editing.
