### PR TITLE
chore(color): remove unused heading from UI

### DIFF
--- a/radio/src/gui/colorlcd/function_switches.cpp
+++ b/radio/src/gui/colorlcd/function_switches.cpp
@@ -236,8 +236,6 @@ ModelFunctionSwitches::ModelFunctionSwitches() : Page(ICON_MODEL_SETUP)
   new StaticText(line, rect_t{}, STR_SWITCH_TYPE,
                  COLOR_THEME_PRIMARY1 | FONT(XS));
   new StaticText(line, rect_t{}, STR_GROUP, COLOR_THEME_PRIMARY1 | FONT(XS));
-  new StaticText(line, rect_t{}, STR_SWITCH_STARTUP,
-                 COLOR_THEME_PRIMARY1 | FONT(XS));
 
   for (uint8_t i = 0; i < NUM_FUNCTIONS_SWITCHES; i += 1) {
     new FunctionSwitch(body, i);


### PR DESCRIPTION
Remove top line "Startup" text now unused in customisable switches

![image](https://github.com/EdgeTX/edgetx/assets/5167938/7cbbde9b-4cd7-4e54-a458-b9064c35387e)

