### PR TITLE
fix(simulator): incorrect initialisation of preflight checks

### DIFF
--- a/radio/src/model_init.cpp
+++ b/radio/src/model_init.cpp
@@ -121,16 +121,16 @@ void applyDefaultTemplate()
   LayoutFactory::loadDefaultLayout();
 
   // enable switch warnings
-  for (int i = 0; i < MAX_SWITCHES; i++) {
+  for (uint64_t i = 0; i < MAX_SWITCHES; i++) {
     if (SWITCH_EXISTS(i)) {
-      g_model.switchWarning |= (1 << (3 * i));
+      g_model.switchWarning |= (1ull << (3ull * i));
     }
   }
 #else
   // enable switch warnings
-  for (int i = 0; i < MAX_SWITCHES; i++) {
+  for (uint64_t i = 0; i < MAX_SWITCHES; i++) {
     if (SWITCH_WARNING_ALLOWED(i))
-      g_model.switchWarning |= (1 << (3 * i));
+      g_model.switchWarning |= (1ull << (3ull * i));
   }
 #endif
 


### PR DESCRIPTION
When creating a new model for the T15 in the simulator the pre-flight checks state for the switches is incorrect.
SA is set to down instead of up.

Happens on MacOS, not tested on Linux or Windows.
