### PR TITLE
fix(nv14/el18): Battery charging

### DIFF
--- a/radio/src/gui/colorlcd/lcd.cpp
+++ b/radio/src/gui/colorlcd/lcd.cpp
@@ -46,9 +46,10 @@ BitmapBuffer* lcd = &lcdBuffer2;
 static lv_disp_draw_buf_t disp_buf;
 static lv_disp_drv_t disp_drv;
 
-#if defined(BOOT)
+// Fix EL18 charging TODO: need restore after battery recharging rework
+//#if defined(BOOT)
 static lv_disp_t disp;
-#endif
+//#endif
 
 static lv_area_t screen_area = {0, 0, LCD_W - 1, LCD_H - 1};
 
@@ -198,7 +199,10 @@ void lcdInitDisplayDriver()
   //  - this prevents LVGL overwritting things drawn directly into the bitmap
   //  buffer
   lv_disp_set_bg_opa(d, LV_OPA_TRANSP);
-#else
+
+// Fix EL18 charging TODO: need restore after battery recharging rework
+#endif
+//#else
   // allow drawing at any moment
   lv_memset_00(&disp, sizeof(lv_disp_t));
   disp.driver = &disp_drv;
@@ -212,7 +216,7 @@ void lcdInitDisplayDriver()
     disp_drv.draw_ctx_init(&disp_drv, draw_ctx);
     disp_drv.draw_ctx = draw_ctx;
   }
-#endif
+//#endif
 
   lv_draw_ctx_t* draw_ctx = disp_drv.draw_ctx;
   lcd->setDrawCtx(draw_ctx);

--- a/radio/src/targets/common/arm/stm32/usb_conf.h
+++ b/radio/src/targets/common/arm/stm32/usb_conf.h
@@ -95,7 +95,7 @@
 #endif
 
 /****************** USB OTG MISC CONFIGURATION ********************************/
-#if defined(USB_GPIO_PIN_VBUS)
+#if defined(USB_GPIO_VBUS)
 #define VBUS_SENSING_ENABLED
 #endif
 

--- a/radio/src/targets/nv14/hal.h
+++ b/radio/src/targets/nv14/hal.h
@@ -234,7 +234,7 @@
 // USB
 #define USB_RCC_AHB1Periph_GPIO         RCC_AHB1Periph_GPIOA
 #define USB_GPIO                        GPIOA
-#define USB_GPIO_VBUS                   GPIO_PIN(GPIOA,9)   // PA.09
+#define USB_GPIO_VBUS                   GPIO_PIN(GPIOA, 9)  // PA.09
 #define USB_GPIO_DM                     GPIO_PIN(GPIOA, 11) // PA.11
 #define USB_GPIO_DP                     GPIO_PIN(GPIOA, 12) // PA.12
 #define USB_GPIO_AF                     GPIO_AF10


### PR DESCRIPTION
This PR disables the use of direct drawing for firmware:

https://github.com/EdgeTX/edgetx/pull/5068

which breaks the charging UI in Flysky radios (NV14, EL18, PL18, PL18EV, etc.)

This PR provide a quick fix, the charging mechanism will be reworked later on according to

https://github.com/EdgeTX/edgetx/issues/2794

Replaced by a better implementation:
https://github.com/EdgeTX/edgetx/pull/5237
