### PR TITLE
feat(el18): allow for for internal CRSF mods (ELRS/mLRS/etc)

### DIFF
--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -616,9 +616,12 @@ QList<int> Boards::getSupportedInternalModules(Board::Type board)
   } else if (IS_FLYSKY_NV14(board)) {
     modules.append({(int)MODULE_TYPE_FLYSKY_AFHDS2A});
   } else if (IS_FLYSKY_EL18(board)) {
-    modules.append({(int)MODULE_TYPE_FLYSKY_AFHDS3});
-  } else if (IS_FAMILY_HORUS_OR_T16(board) || IS_FAMILY_T12(board)
-             || (IS_TARANIS_SMALL(board) && IS_ACCESS_RADIO(board))) {
+    modules.append({
+        (int)MODULE_TYPE_FLYSKY_AFHDS3,
+        (int)MODULE_TYPE_CROSSFIRE,
+    });
+  } else if (IS_FAMILY_HORUS_OR_T16(board) || IS_FAMILY_T12(board) ||
+             (IS_TARANIS_SMALL(board) && IS_ACCESS_RADIO(board))) {
     modules.append({
         (int)MODULE_TYPE_XJT_PXX1,
         (int)MODULE_TYPE_ISRM_PXX2,

--- a/radio/src/targets/nv14/CMakeLists.txt
+++ b/radio/src/targets/nv14/CMakeLists.txt
@@ -42,7 +42,7 @@ add_definitions(-DBATTERY_CHARGE -DUSE_HATS_AS_KEYS)
 if (PCBREV STREQUAL EL18)
     set(FLAVOUR el18)
     # defines existing internal modules
-    set(INTERNAL_MODULES AFHDS3 CACHE STRING "Internal modules")
+    set(INTERNAL_MODULES AFHDS3;CRSF CACHE STRING "Internal modules")
     set(DEFAULT_INTERNAL_MODULE FLYSKY_AFHDS3 CACHE STRING "Default internal module")
     set(AFHDS3 ON)
 else()


### PR DESCRIPTION
The internal module of EL18 is capable to be flashed into ELRS, the change in this PR is to enable the choice of internal CRSF option in Radio Settings.

The ELRS part of the development will be followed here:
https://github.com/ExpressLRS/ExpressLRS/issues/2778
