### PR TITLE
fix(bootloader): use ASCII only strings for NV14/EL18

### DIFF
--- a/radio/src/targets/nv14/bootloader/boot_menu.cpp
+++ b/radio/src/targets/nv14/bootloader/boot_menu.cpp
@@ -229,7 +229,7 @@ void bootloaderDrawScreen(BootloaderState st, int opt, const char* str)
       bootloaderDrawTitle(TR_BL_RF_USB_ACCESS);
 
       lcd->drawText(62, 75, LV_SYMBOL_USB, BL_FOREGROUND);
-      coord_t pos = lcd->drawText(84, 75, rfUsbAccess ? TR_DISABLE : TR_ENABLE, BL_FOREGROUND);
+      coord_t pos = lcd->drawText(84, 75, rfUsbAccess ? TR_BL_DISABLE : TR_BL_ENABLE, BL_FOREGROUND);
       pos += 8;
 
       lcd->drawText(60, 110, LV_SYMBOL_NEW_LINE, BL_FOREGROUND);

--- a/radio/src/translations/cn.h
+++ b/radio/src/translations/cn.h
@@ -1040,6 +1040,8 @@
   #define TR_BL_HOLD_ENTER_TO_START    "\012Hold [ENT] to start writing"
   #define TR_BL_INVALID_FIRMWARE       "\011Not a valid firmware file!        "
   #define TR_BL_INVALID_EEPROM         "\011Not a valid EEPROM file!          "
+  #define TR_BL_ENABLE                 "Enable"
+  #define TR_BL_DISABLE                "Disable"
 #else
   #define TR_BL_OR_PLUGIN_USB_CABLE    TR_BL_USB_PLUGIN
   #define TR_BL_HOLD_ENTER_TO_START    "\006Hold [ENT] to start"

--- a/radio/src/translations/cz.h
+++ b/radio/src/translations/cz.h
@@ -1082,6 +1082,8 @@
   #define TR_BL_SELECT_KEY            "[R TRIM] pro vybrani souboru"
   #define TR_BL_FLASH_KEY             "Drzet dlouze [R TRIM] pro nahrani"
   #define TR_BL_EXIT_KEY              " [L TRIM] pro ukonceni"
+  #define TR_BL_ENABLE                "Povoleno"
+  #define TR_BL_DISABLE               "Zakazano"
 #elif defined(PCBPL18)
    // Bootloader PL18 specific - Ascii only
   #define TR_BL_RF_USB_ACCESS         "RF USB access"

--- a/radio/src/translations/da.h
+++ b/radio/src/translations/da.h
@@ -1070,6 +1070,8 @@
   #define TR_BL_SELECT_KEY            "[R TRIM] for at bruge fil"
   #define TR_BL_FLASH_KEY             "[R TRIM] længe, for at starte"
   #define TR_BL_EXIT_KEY              "[L TRIM] for at forlade"
+  #define TR_BL_ENABLE                "Aktiver"
+  #define TR_BL_DISABLE               "Deaktiver"
 #elif defined(PCBPL18)
    // Bootloader PL18 specific - Ascii only
   #define TR_BL_RF_USB_ACCESS         "RF USB adgang"

--- a/radio/src/translations/de.h
+++ b/radio/src/translations/de.h
@@ -1058,6 +1058,8 @@
   #define TR_BL_SELECT_KEY            "[R TRIM] um Datei auszuwählen"
   #define TR_BL_FLASH_KEY             "Halte [R TRIM] gedrückt, zum schreiben"
   #define TR_BL_EXIT_KEY              " [L TRIM] zum beenden"
+  #define TR_BL_ENABLE                "Aktivieren"
+  #define TR_BL_DISABLE               "Deaktivieren"
 #elif defined(PCBPL18)
    // Bootloader PL18 specific - Ascii only
   #define TR_BL_RF_USB_ACCESS         "RF USB access"

--- a/radio/src/translations/en.h
+++ b/radio/src/translations/en.h
@@ -1069,6 +1069,8 @@
   #define TR_BL_SELECT_KEY            "[R TRIM] to select file"
   #define TR_BL_FLASH_KEY             "Hold [R TRIM] long to flash"
   #define TR_BL_EXIT_KEY              " [L TRIM] to exit"
+  #define TR_BL_ENABLE                "Enable"
+  #define TR_BL_DISABLE               "Disable"
 #elif defined(PCBPL18)
    // Bootloader PL18 specific - Ascii only
   #define TR_BL_RF_USB_ACCESS         "RF USB access"

--- a/radio/src/translations/es.h
+++ b/radio/src/translations/es.h
@@ -1068,6 +1068,8 @@
   #define TR_BL_SELECT_KEY            "[R TRIM] to select file"
   #define TR_BL_FLASH_KEY             "Hold [R TRIM] long to flash"
   #define TR_BL_EXIT_KEY              " [L TRIM] to exit"
+  #define TR_BL_ENABLE                "Enable"
+  #define TR_BL_DISABLE               "Disable"
 #elif defined(PCBPL18)
    // Bootloader PL18 specific - Ascii only
   #define TR_BL_RF_USB_ACCESS         "RF USB access"

--- a/radio/src/translations/fi.h
+++ b/radio/src/translations/fi.h
@@ -1081,6 +1081,8 @@
   #define TR_BL_SELECT_KEY            "[R TRIM] to select file"
   #define TR_BL_FLASH_KEY             "Hold [R TRIM] long to flash"
   #define TR_BL_EXIT_KEY              " [L TRIM] to exit"
+  #define TR_BL_ENABLE                "Enable"
+  #define TR_BL_DISABLE               "Disable"
 #elif defined(PCBPL18)
    // Bootloader PL18 specific - Ascii only
   #define TR_BL_RF_USB_ACCESS         "RF USB access"

--- a/radio/src/translations/fr.h
+++ b/radio/src/translations/fr.h
@@ -1080,6 +1080,8 @@
   #define TR_BL_SELECT_KEY            "[R TRIM] pour sélect. fichier"
   #define TR_BL_FLASH_KEY             "Appui long [R TRIM] pour flasher"
   #define TR_BL_EXIT_KEY              " [L TRIM] pour quitter"
+  #define TR_BL_ENABLE                "Activer"
+  #define TR_BL_DISABLE               "Désactiver"
 #elif defined(PCBPL18)
    // Bootloader PL18 specific - Ascii only
   #define TR_BL_RF_USB_ACCESS         "RF USB access"

--- a/radio/src/translations/he.h
+++ b/radio/src/translations/he.h
@@ -1070,6 +1070,8 @@
   #define TR_BL_SELECT_KEY            "[R TRIM] to select file"
   #define TR_BL_FLASH_KEY             "Hold [R TRIM] long to flash"
   #define TR_BL_EXIT_KEY              " [L TRIM] to exit"
+  #define TR_BL_ENABLE                "Enable"
+  #define TR_BL_DISABLE               "Disable"
 #elif defined(PCBPL18)
    // Bootloader PL18 specific - Ascii only
   #define TR_BL_RF_USB_ACCESS         "RF USB access"

--- a/radio/src/translations/it.h
+++ b/radio/src/translations/it.h
@@ -1065,6 +1065,8 @@
   #define TR_BL_SELECT_KEY            "[R TRIM] per scegliere il file"
   #define TR_BL_FLASH_KEY             "Tener premuto [R TRIM] per scrivere"
   #define TR_BL_EXIT_KEY              " [L TRIM] per uscire"
+  #define TR_BL_ENABLE                "Abilita"
+  #define TR_BL_DISABLE               "Disabilita"
 #elif defined(PCBPL18)
    // Bootloader PL18 specific - Ascii only
   #define TR_BL_RF_USB_ACCESS         "RF USB access"

--- a/radio/src/translations/jp.h
+++ b/radio/src/translations/jp.h
@@ -1070,6 +1070,8 @@
   #define TR_BL_SELECT_KEY            "[R TRIM] to select file"
   #define TR_BL_FLASH_KEY             "Hold [R TRIM] long to flash"
   #define TR_BL_EXIT_KEY              " [L TRIM] to exit"
+  #define TR_BL_ENABLE                "Enable"
+  #define TR_BL_DISABLE               "Disable"
 #elif defined(PCBPL18)
    // Bootloader PL18 specific - Ascii only
   #define TR_BL_RF_USB_ACCESS         "RF USB access"

--- a/radio/src/translations/nl.h
+++ b/radio/src/translations/nl.h
@@ -1073,6 +1073,8 @@
   #define TR_BL_SELECT_KEY            "[R TRIM] to select file"
   #define TR_BL_FLASH_KEY             "Hold [R TRIM] long to flash"
   #define TR_BL_EXIT_KEY              " [L TRIM] to exit"
+  #define TR_BL_ENABLE                "Enable"
+  #define TR_BL_DISABLE               "Disable"
 #elif defined(PCBPL18)
    // Bootloader PL18 specific - Ascii only
   #define TR_BL_RF_USB_ACCESS         "RF USB access"

--- a/radio/src/translations/pl.h
+++ b/radio/src/translations/pl.h
@@ -1068,6 +1068,8 @@
   #define TR_BL_SELECT_KEY            "[R TRIM] aby wybrac plik"
   #define TR_BL_FLASH_KEY             "Przytrzymaj [R TRIM] aby flashowac"
   #define TR_BL_EXIT_KEY              " [L TRIM] aby wyjsc"
+  #define TR_BL_ENABLE                "Enable"
+  #define TR_BL_DISABLE               "Disable"
 #elif defined(PCBPL18)
    // Bootloader PL18 specific - Ascii only
   #define TR_BL_RF_USB_ACCESS         "RF USB access"

--- a/radio/src/translations/pt.h
+++ b/radio/src/translations/pt.h
@@ -1074,6 +1074,8 @@
   #define TR_BL_SELECT_KEY            "[R TRIM] to select file"
   #define TR_BL_FLASH_KEY             "Hold [R TRIM] long to flash"
   #define TR_BL_EXIT_KEY              " [L TRIM] to exit"
+  #define TR_BL_ENABLE                "Enable"
+  #define TR_BL_DISABLE               "Desativar"
 #elif defined(PCBPL18)
    // Bootloader PL18 specific - Ascii only
   #define TR_BL_RF_USB_ACCESS         "RF USB access"

--- a/radio/src/translations/ru.h
+++ b/radio/src/translations/ru.h
@@ -1073,6 +1073,8 @@
   #define TR_BL_SELECT_KEY            "[R TRIM] to select file"
   #define TR_BL_FLASH_KEY             "Hold [R TRIM] long to flash"
   #define TR_BL_EXIT_KEY              " [L TRIM] to exit"
+  #define TR_BL_ENABLE                "Enable"
+  #define TR_BL_DISABLE               "Disable"
 #elif defined(PCBPL18)
    // Bootloader PL18 specific - Ascii only
   #define TR_BL_RF_USB_ACCESS         "RF USB access"

--- a/radio/src/translations/se.h
+++ b/radio/src/translations/se.h
@@ -1095,6 +1095,8 @@
   #define TR_BL_SELECT_KEY              "[R TRIM] foer att vaelja fil"
   #define TR_BL_FLASH_KEY               "Tryck [R TRIM] foer att flasha"
   #define TR_BL_EXIT_KEY                " [L TRIM] för att avsluta"
+  #define TR_BL_ENABLE                  "Aktivera"
+  #define TR_BL_DISABLE                 "Inaktivera"
 #elif defined(PCBPL18)
    // Bootloader PL18 specific - Ascii only
   #define TR_BL_RF_USB_ACCESS         "RF USB access"

--- a/radio/src/translations/tw.h
+++ b/radio/src/translations/tw.h
@@ -1023,7 +1023,7 @@
   #define TR_WIDGET_VALUE              "數值"
 #endif
 
-// Bootloader common
+// Bootloader common - Ascii only
 #define TR_BL_USB_CONNECTED           "USB Connected"
 #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
 #define TR_BL_USB_MASS_STORE          "for mass storage"
@@ -1053,24 +1053,26 @@
 #endif
 
 #if defined(PCBTARANIS)
-   // Bootloader Taranis specific
+   // Bootloader Taranis specific - Ascii only
   #define TR_BL_RESTORE_EEPROM        "Restore EEPROM"
   #if defined(RADIO_COMMANDO8)
     #define TR_BL_POWER_KEY           "Press the power button."
     #define TR_BL_FLASH_EXIT          "Exit the flashing mode."
   #endif
 #elif defined(PCBHORUS)
-   // Bootloader Horus specific
+   // Bootloader Horus specific - Ascii only
   #define TR_BL_SELECT_KEY            "[ENT] to select file"
   #define TR_BL_FLASH_KEY             "Hold [ENT] long to flash"
   #define TR_BL_EXIT_KEY              "[RTN] to exit"
 #elif defined(PCBNV14)
-   // Bootloader NV14 specific
+   // Bootloader NV14 specific - Ascii only
   #define TR_BL_RF_USB_ACCESS         "RF USB access"
   #define TR_BL_CURRENT_FW            "Current Firmware:"
   #define TR_BL_SELECT_KEY            "[R TRIM] to select file"
   #define TR_BL_FLASH_KEY             "Hold [R TRIM] long to flash"
   #define TR_BL_EXIT_KEY              " [L TRIM] to exit"
+  #define TR_BL_ENABLE                "Enable"
+  #define TR_BL_DISABLE               "Disable"
 #elif defined(PCBPL18)
    // Bootloader PL18 specific - Ascii only
   #define TR_BL_RF_USB_ACCESS         "RF USB access"

--- a/radio/src/translations/ua.h
+++ b/radio/src/translations/ua.h
@@ -1073,6 +1073,8 @@
   #define TR_BL_SELECT_KEY            "[R TRIM] to select file"
   #define TR_BL_FLASH_KEY             "Hold [R TRIM] long to flash"
   #define TR_BL_EXIT_KEY              " [L TRIM] to exit"
+  #define TR_BL_ENABLE                "Enable"
+  #define TR_BL_DISABLE               "Disable"
 #elif defined(PCBPL18)
    // Bootloader PL18 specific - Ascii only
   #define TR_BL_RF_USB_ACCESS         "RF USB access"


### PR DESCRIPTION
Add bootloader specific strings for 'Enable' and 'Disable' used on NV14 and EL18.
