### PR TITLE
fix: serial power port handling

### DIFF
--- a/radio/src/serial.cpp
+++ b/radio/src/serial.cpp
@@ -455,8 +455,13 @@ void serialInit(uint8_t port_nr, int mode)
 
   serialSetupPort(mode, params);
 
-  if (mode == UART_MODE_NONE ||
-      !port || params.baudrate == 0 ||
+  if (mode == UART_MODE_NONE ) {
+    // Even if port has no mode, port power needs to be set
+    serialSetPowerState(port_nr);
+    return;
+  }
+
+  if (!port || params.baudrate == 0 ||
       !port->uart || !port->uart->init)
     return;
   

--- a/radio/src/targets/common/arm/stm32/pwr_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/pwr_driver.cpp
@@ -75,6 +75,14 @@ void pwrInit()
 
   hardwareOptions.pcbrev = PCBREV_VALUE();
 #endif
+
+  // Aux serial port power
+#if defined(AUX_SERIAL_PWR_GPIO)
+  gpio_init(AUX_SERIAL_PWR_GPIO, GPIO_OUT, GPIO_PIN_SPEED_LOW);
+#endif
+#if defined(AUX2_SERIAL_PWR_GPIO)
+  gpio_init(AUX2_SERIAL_PWR_GPIO, GPIO_OUT, GPIO_PIN_SPEED_LOW);
+#endif
 }
 
 void pwrOn()


### PR DESCRIPTION
Fixes power been set when serial mode set to OFF and serial port power also set to OFF

Also fixes ON glitch at power on.

Fixes #5189

