### PR TITLE
fix: customisable switch custom name not displayed

### DIFF
--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -316,7 +316,10 @@ void switchSetCustomName(uint8_t idx, const char* str, size_t len)
 
 const char* switchGetCustomName(uint8_t idx)
 {
-  return _switchNames[idx];
+  if (idx >= switchGetMaxSwitches()) // Switch is a customisable switch
+    return g_model.switchNames[idx - switchGetMaxSwitches()];
+  else
+    return _switchNames[idx];
 }
 
 bool switchHasCustomName(uint8_t idx)

--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -316,9 +316,11 @@ void switchSetCustomName(uint8_t idx, const char* str, size_t len)
 
 const char* switchGetCustomName(uint8_t idx)
 {
+#if defined(FUNCTION_SWITCHES)
   if (idx >= switchGetMaxSwitches()) // Switch is a customisable switch
     return g_model.switchNames[idx - switchGetMaxSwitches()];
   else
+#endif
     return _switchNames[idx];
 }
 


### PR DESCRIPTION
Properly show customisable switch name when one is defined

Fixes #5192

Another victim of ADC refactor 👯‍♂️ 
