### PR TITLE
fix(radio): various issues with rotary encoder.

### DIFF
--- a/radio/src/gui/colorlcd/LvglWrapper.cpp
+++ b/radio/src/gui/colorlcd/LvglWrapper.cpp
@@ -274,12 +274,12 @@ static void rotaryDriverRead(lv_indev_drv_t *drv, lv_indev_data_t *data)
 
   rotenc_t newPos = rotaryEncoderGetValue();
   rotenc_t diff = newPos - prevPos;
-  prevPos = newPos;
 
   data->enc_diff = (int16_t)diff;
   data->state = LV_INDEV_STATE_RELEASED;
 
   if (diff != 0) {
+    prevPos = newPos;
     reset_inactivity();
 
     int8_t dir = 0;

--- a/radio/src/gui/colorlcd/LvglWrapper.cpp
+++ b/radio/src/gui/colorlcd/LvglWrapper.cpp
@@ -272,9 +272,9 @@ static void rotaryDriverRead(lv_indev_drv_t *drv, lv_indev_data_t *data)
   static int8_t prevDir = 0;
   static uint32_t lastDt = 0;
 
-  rotenc_t newPos = rotaryEncoderGetRawValue();
-  rotenc_t diff = (newPos - prevPos) / ROTARY_ENCODER_GRANULARITY;
-  prevPos += diff * ROTARY_ENCODER_GRANULARITY;
+  rotenc_t newPos = rotaryEncoderGetValue();
+  rotenc_t diff = newPos - prevPos;
+  prevPos = newPos;
 
   data->enc_diff = (int16_t)diff;
   data->state = LV_INDEV_STATE_RELEASED;

--- a/radio/src/hal/rotary_encoder.h
+++ b/radio/src/hal/rotary_encoder.h
@@ -40,9 +40,5 @@ void rotaryEncoderInit();
 // return impulses / granularity
 rotenc_t rotaryEncoderGetValue();
 
-// returns raw # impulses
-rotenc_t rotaryEncoderGetRawValue();
-
-
 int8_t rotaryEncoderGetAccel();
 void rotaryEncoderResetAccel();

--- a/radio/src/targets/horus/hal.h
+++ b/radio/src/targets/horus/hal.h
@@ -111,10 +111,6 @@
     #define ROTARY_ENCODER_INVERTED
 #endif
 
-#if defined(RADIO_FAMILY_T16) && !defined(RADIO_T18) && !defined(RADIO_T15)
-  #define ROTARY_ENCODER_SUPPORT_BUGGY_WIRING
-#endif
-
 // Switches
 #if defined(RADIO_T15)
   #define STORAGE_SWITCH_A

--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -63,8 +63,6 @@ rotenc_t rotaryEncoderGetValue()
   return rotencValue / ROTARY_ENCODER_GRANULARITY;
 }
 
-rotenc_t rotaryEncoderGetRawValue() { return rotencValue; }
-
 // TODO: remove all STM32 defs
 
 extern const etx_hal_adc_driver_t simu_adc_driver;

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -303,9 +303,6 @@
     #define USE_EXTI15_10_IRQ
     #define EXTI15_10_IRQ_Priority 5
   #endif
-  #if defined(RADIO_TX12)
-    #define ROTARY_ENCODER_SUPPORT_BUGGY_WIRING
-  #endif
   #if defined(RADIO_TX12MK2) || defined(RADIO_BOXER) || defined(RADIO_ZORRO) || defined(RADIO_MT12) || defined(RADIO_POCKET) || defined(RADIO_T14)
     #define ROTARY_ENCODER_INVERTED
   #endif


### PR DESCRIPTION
Re-write rotary encoder logic and update Lvgl driver to fix:
- detection of initial direction of encoder after startup
- change of direction issue on radios with incorrectly wired encoder
- handle all wiring variations (without needing special #defines)

May fix #3409 

Candidate for 2.10.2

