### PR TITLE
fix: allow selection of axis as a source

### DIFF
--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -129,7 +129,7 @@ void memswap(void * a, void * b, uint8_t size);
 #define IS_SLIDER(x) (POT_CONFIG(x) == FLEX_SLIDER)
 
 #define IS_POT_AVAILABLE(x)						\
-  (POT_CONFIG(x) != FLEX_NONE && POT_CONFIG(x) <= FLEX_MULTIPOS)
+  (POT_CONFIG(x) != FLEX_NONE && POT_CONFIG(x) < FLEX_SWITCH)
 
 #define IS_POT_SLIDER_AVAILABLE(x) (IS_POT_AVAILABLE(x))
 


### PR DESCRIPTION
Fixes an issue reported by Radiomaster in:

https://www.youtube.com/watch?v=18eATbYxygU&t=1s

Where you cannot select Axis as a source.

For 2.10.2 if possible as well please
