### PR TITLE
chore: bump macos runner version

### DIFF
--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -35,17 +35,10 @@ jobs:
     runs-on: macos-12
 
     steps:
-      - name: Install XCode 11.7
-        uses: sinoru/actions-setup-xcode@v2
-        with:
-          xcode-version: '11.7' # Exact version of a Xcode version to use
-          apple-id: ${{ secrets.APPLE_ID }}
-          apple-id-password: ${{ secrets.APPLE_ID_PASSWORD }}
-    
       - name: Select XCode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '11.7'
+          xcode-version: '13.2.1'
 
       - name: Check out the repo
         uses: actions/checkout@v4
@@ -80,18 +73,8 @@ jobs:
       - name: Install dfu-util
         run:  brew install dfu-util
 
-      - name: Select XCode version
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '13.2.1'
-
       - name: Install SDL2
         run:  brew install SDL2
-
-      - name: Select XCode version
-        uses: maxim-lobanov/setup-xcode@v1
-        with:
-          xcode-version: '11.7'
 
       - name: Build
         working-directory: ${{github.workspace}}

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -35,6 +35,13 @@ jobs:
     runs-on: macos-12
 
     steps:
+      - name: Install XCode 11.7
+        uses: sinoru/actions-setup-xcode@v2
+        with:
+          xcode-version: '11.7' # Exact version of a Xcode version to use
+          apple-id: ${{ secrets.APPLE_ID }}
+          apple-id-password: ${{ secrets.APPLE_ID_PASSWORD }}
+    
       - name: Select XCode version
         uses: maxim-lobanov/setup-xcode@v1
         with:

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -32,7 +32,7 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: macos-11
+    runs-on: macos-12
 
     steps:
       - name: Select XCode version

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -64,9 +64,6 @@ jobs:
       - name: Install dependencies
         run: python3 -m pip install --upgrade pip Pillow lz4 clang jinja2
 
-      - name: Patch GitHub macOS build
-        run:  brew install pkg-config
-
       - name: Install libusb
         run:  brew install libusb
 


### PR DESCRIPTION
The macOS 11 runner image will be removed on 28th of June 2024.

https://github.blog/changelog/2024-05-20-actions-upcoming-changes-to-github-hosted-macos-runners/

This does unfortunately mean that while the prior minimum version of macOS for companion was anywhere between macOS 10.12 (Sierra, Sept 2016) and 10.15 (Catalina, Oct 2019), it is now either macOS 11 (Big Sur, Nov 2020)  or macOS 12 (Monteray, June 2021). There is no simple way around this, as we no longer have access to macOS runners for 11. Whether the minimum version is macOS 11 or macOS 12 I have no idea... QT6 says it uses weak links to allow for running on lower versions than you build on, but it will determine on runtime whether to spit the dummy or not, hence the uncertainly as to what the minimum versions is since I don't run macOS myself or have access to multiple versions to test with. The QT docs suggest macOS 11 is now the minimum version, but real world testing will be the proof, as one of the dependencies could throw a spanner in the works. 