### PR TITLE
fix(color): radio stuck when trying to close nested standalone script

### DIFF
--- a/radio/src/gui/colorlcd/standalone_lua.cpp
+++ b/radio/src/gui/colorlcd/standalone_lua.cpp
@@ -126,7 +126,8 @@ StandaloneLuaWindow::StandaloneLuaWindow(bool useLvgl) :
 
 void StandaloneLuaWindow::setup(bool useLvgl)
 {
-  _instance = new StandaloneLuaWindow(useLvgl);
+  if (_instance == nullptr)
+    _instance = new StandaloneLuaWindow(useLvgl);
 }
 
 StandaloneLuaWindow* StandaloneLuaWindow::instance()


### PR DESCRIPTION
A stand alone script loads can load a second script by returning the script name from the run method.

When the second script exits, or is killed by long pressing the RTN key, the radio gets stuck in the first script instead of exiting back to the TOOLS menu.
