### PR TITLE
fix(color): issues with color picker dialog

### DIFF
--- a/radio/src/gui/colorlcd/color_picker.cpp
+++ b/radio/src/gui/colorlcd/color_picker.cpp
@@ -91,6 +91,7 @@ class ColorEditorPopup : public BaseDialog
     updateColor(color);
 
     hbox = new Window(vbox, rect_t{});
+    hbox->padAll(PAD_TINY);
     hbox->setFlexLayout(LV_FLEX_FLOW_ROW, PAD_MEDIUM);
     lv_obj_set_flex_align(hbox->getLvObj(), LV_FLEX_ALIGN_CENTER,
                           LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_SPACE_AROUND);

--- a/radio/src/gui/colorlcd/themes/etx_lv_theme.cpp
+++ b/radio/src/gui/colorlcd/themes/etx_lv_theme.cpp
@@ -239,9 +239,11 @@ EdgeTxStyles::EdgeTxStyles()
   lv_style_init(&border_color_normal);
   lv_style_init(&border_color_focus);
   lv_style_init(&border_color_active);
+  lv_style_init(&border_color_edit);
   lv_style_init(&outline_color_light);
   lv_style_init(&outline_color_normal);
   lv_style_init(&outline_color_focus);
+  lv_style_init(&outline_color_edit);
   lv_style_init(&arc_color);
   lv_style_init(&graph_border);
   lv_style_init(&graph_dashed);
@@ -336,6 +338,8 @@ void EdgeTxStyles::applyColors()
                             makeLvColor(COLOR_THEME_FOCUS));
   lv_style_set_border_color(&border_color_active,
                             makeLvColor(COLOR_THEME_ACTIVE));
+  lv_style_set_border_color(&border_color_edit,
+                            makeLvColor(COLOR_THEME_EDIT));
 
   lv_style_set_outline_color(&outline_color_light,
                              makeLvColor(COLOR_THEME_SECONDARY3));
@@ -343,6 +347,8 @@ void EdgeTxStyles::applyColors()
                              makeLvColor(COLOR_THEME_SECONDARY2));
   lv_style_set_outline_color(&outline_color_focus,
                              makeLvColor(COLOR_THEME_FOCUS));
+  lv_style_set_outline_color(&outline_color_edit,
+                             makeLvColor(COLOR_THEME_EDIT));
 
   lv_style_set_arc_color(&arc_color, makeLvColor(COLOR_THEME_SECONDARY1));
 }

--- a/radio/src/gui/colorlcd/themes/etx_lv_theme.h
+++ b/radio/src/gui/colorlcd/themes/etx_lv_theme.h
@@ -128,9 +128,11 @@ class EdgeTxStyles
   lv_style_t border_color_white;
   lv_style_t border_color_focus;
   lv_style_t border_color_active;
+  lv_style_t border_color_edit;
   lv_style_t outline_color_light;
   lv_style_t outline_color_normal;
   lv_style_t outline_color_focus;
+  lv_style_t outline_color_edit;
   lv_style_t bg_color_grey;
   lv_style_t arc_color;
   lv_style_t graph_border;


### PR DESCRIPTION
Fix padding for buttons on color editor dialog.
Fix color editor not working with rotary encoder.
Show border in EDIT color when changing color property with rotary encoder.

Focused:
![screenshot_tx16s_24-06-21_09-41-04](https://github.com/EdgeTX/edgetx/assets/9474356/9080cf88-add8-4bdc-84d6-136000762d06)

Edited (with rotary encoder):
![screenshot_tx16s_24-06-21_09-41-08](https://github.com/EdgeTX/edgetx/assets/9474356/10359c6f-7ecb-4a01-b1d1-e75540381320)
