### PR TITLE
fix(color): incorrect size of number edit in widget settings for portrait layout.

### DIFF
--- a/radio/src/gui/colorlcd/widget_settings.cpp
+++ b/radio/src/gui/colorlcd/widget_settings.cpp
@@ -62,7 +62,7 @@ WidgetSettings::WidgetSettings(Window* parent, Widget* widget) :
     switch (option.type) {
       case ZoneOption::Integer:
         (new NumberEdit(
-            line, rect_t{}, option.min.signedValue,
+            line, {0, 0, 100, 0}, option.min.signedValue,
             option.max.signedValue,
             [=]() -> int {
               return widget->getOptionValue(optIdx)->signedValue;


### PR DESCRIPTION
Use fixed size for number edit field.