### PR TITLE
fix(color): issues with menus (possible EM, double loading of content)

### DIFF
--- a/radio/src/gui/colorlcd/screen_setup.cpp
+++ b/radio/src/gui/colorlcd/screen_setup.cpp
@@ -69,7 +69,8 @@ class LayoutChoice : public Button
         std::distance(LayoutFactory::getRegisteredLayouts().begin(), it));
 
     menu->setCloseHandler([=]() {
-      update();
+      if (!menu->deleted())
+        update();
     });
   }
 

--- a/radio/src/gui/colorlcd/sourcechoice.cpp
+++ b/radio/src/gui/colorlcd/sourcechoice.cpp
@@ -214,7 +214,7 @@ void SourceChoice::openMenu()
   });
 #endif
 
-  fillMenu(menu);
+  // fillMenu(menu); - called by MenuToolbar
 
   menu->setCloseHandler([=]() { setEditMode(false); });
 }

--- a/radio/src/gui/colorlcd/switchchoice.cpp
+++ b/radio/src/gui/colorlcd/switchchoice.cpp
@@ -161,7 +161,7 @@ void SwitchChoice::openMenu()
   });
 #endif
 
-  fillMenu(menu);
+  // fillMenu(menu); - called by MenuToolbar
 
   menu->setCloseHandler([=]() { setEditMode(false); });
 }

--- a/radio/src/thirdparty/libopenui/src/filechoice.cpp
+++ b/radio/src/thirdparty/libopenui/src/filechoice.cpp
@@ -188,7 +188,7 @@ void FileChoice::openMenu()
     auto tb = new FileChoiceMenuToolbar(this, menu);
     menu->setToolbar(tb);
 
-    fillMenu(menu);
+    // fillMenu(menu); - called by MenuToolbar
 
     menu->setCloseHandler([=]() { setEditMode(false); });
   } else {


### PR DESCRIPTION
Fix EM when shutting down if the layout select menu is open.
Fix double loading of menu content for file, source and switch menus.
Remove extra create/copy overhead on menu lines when building menu.
