### PR TITLE
fix: RTC warning not being shown

### DIFF
--- a/radio/src/gui/colorlcd/radio_hardware.cpp
+++ b/radio/src/gui/colorlcd/radio_hardware.cpp
@@ -61,6 +61,8 @@ RadioHardwarePage::RadioHardwarePage() :
   enableVBatBridge();
 }
 
+void RadioHardwarePage::checkEvents() { enableVBatBridge(); }
+
 void RadioHardwarePage::cleanup()
 {
   disableVBatBridge();
@@ -134,11 +136,11 @@ static SetupLineDef setupLines[] = {
                        GET_SET_INVERTED(g_eeGeneral.disableRtcWarning));
 
       // RTC Batt display
-      std::string s(STR_VALUE);
-      s += " ";
       new DynamicNumber<uint16_t>(
-          parent, {x + ToggleSwitch::TOGGLE_W + PAD_SMALL, y + PAD_SMALL + 1, 0, 0}, [] { return getRTCBatteryVoltage(); },
-          COLOR_THEME_PRIMARY1 | PREC2, s.c_str(), "V");
+          parent,
+          {x + ToggleSwitch::TOGGLE_W + PAD_LARGE, y + PAD_SMALL + 1, 0, 0},
+          [] { return getRTCBatteryVoltage(); }, COLOR_THEME_PRIMARY1 | PREC2,
+          "", "V");
     }
   },
   {

--- a/radio/src/gui/colorlcd/radio_hardware.h
+++ b/radio/src/gui/colorlcd/radio_hardware.h
@@ -25,6 +25,8 @@
 
 class RadioHardwarePage : public PageTab
 {
+  void checkEvents() override;
+
  public:
   RadioHardwarePage();
 

--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -624,7 +624,7 @@ static void checkFailsafe()
 #endif
 
 #if defined(GUI)
-void checkAll()
+void checkAll(bool isBootCheck)
 {
 #if defined(EEPROM_RLC) && !defined(SDCARD_RAW) && !defined(SDCARD_YAML)
   checkLowEEPROM();
@@ -640,9 +640,9 @@ void checkAll()
   checkSwitches();
   checkFailsafe();
 
-
-  if (isVBatBridgeEnabled() && !g_eeGeneral.disableRtcWarning) {
+  if (isBootCheck && !g_eeGeneral.disableRtcWarning) {
     // only done once at board start
+    enableVBatBridge();
     checkRTCBattery();
   }
   disableVBatBridge();
@@ -1533,7 +1533,7 @@ void edgeTxInit()
     }
     else if (!(startOptions & OPENTX_START_NO_CHECKS)) {
       checkAlarm();
-      checkAll();
+      checkAll(true);
       PLAY_MODEL_NAME();
     }
 #endif // defined(GUI)

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -355,7 +355,7 @@ void checkLowEEPROM();
 void checkThrottleStick();
 void checkSwitches();
 void checkAlarm();
-void checkAll();
+void checkAll(bool isBootCheck = false);
 
 void getADC();
 


### PR DESCRIPTION
Summary of changes:

- As in #5207, enable the vBatBridge when needed on the startup run of `checkAll()` so that the RTC battery voltage is actually read. 

- Partially revert change in #5031 re: `enableVBatBridge()` as this needs to be called regularly so that the RTC voltage is actually read. The call to `disableVBatBridge()` while perhaps technically not needed since `adcRead()` will clear it itself once the voltage actually read certainly won't hurt.

- Changes to display of number on hardware page required as was occasionally flashing junk characters and number changing alignment.

Fixes #5203 for main

Tested on TX16S hardware by running separate PSU on RTC battery input to allow for voltage to be adjusted. 


