### PR TITLE
feat: use any source for expo/weight/offset etc

### DIFF
--- a/companion/src/constants.h
+++ b/companion/src/constants.h
@@ -93,7 +93,7 @@
 #define CPN_STR_SW_INDICATOR_NEUT      QCoreApplication::translate("RawSwitch", "-")             // Switch neutral (middle) position indicator.
 #define CPN_STR_SW_INDICATOR_REV       QCoreApplication::translate("RawSwitch", "!")             // Switch reversed logic (NOT) indicator.
 
-#define CPN_STR_SRC_INDICATOR_INVERT   QCoreApplication::translate("RawSource", "!")             // Source inverted logic indicator.
+#define CPN_STR_SRC_INDICATOR_NEG      QCoreApplication::translate("RawSource", "-")             // Source negative value indicator.
 
 #define EDGETX_HOME_PAGE_URL           "https://edgetx.org"
 

--- a/companion/src/constants.h
+++ b/companion/src/constants.h
@@ -94,6 +94,7 @@
 #define CPN_STR_SW_INDICATOR_REV       QCoreApplication::translate("RawSwitch", "!")             // Switch reversed logic (NOT) indicator.
 
 #define CPN_STR_SRC_INDICATOR_INVERT   QCoreApplication::translate("RawSource", "!")             // Source inverted logic indicator.
+#define CPN_STR_SRC_INDICATOR_NEG      QCoreApplication::translate("RawSource", "-")             // Source negative value indicator.
 
 #define EDGETX_HOME_PAGE_URL           "https://edgetx.org"
 

--- a/companion/src/constants.h
+++ b/companion/src/constants.h
@@ -94,7 +94,6 @@
 #define CPN_STR_SW_INDICATOR_REV       QCoreApplication::translate("RawSwitch", "!")             // Switch reversed logic (NOT) indicator.
 
 #define CPN_STR_SRC_INDICATOR_INVERT   QCoreApplication::translate("RawSource", "!")             // Source inverted logic indicator.
-#define CPN_STR_SRC_INDICATOR_NEG      QCoreApplication::translate("RawSource", "-")             // Source negative value indicator.
 
 #define EDGETX_HOME_PAGE_URL           "https://edgetx.org"
 

--- a/companion/src/datamodels/compounditemmodels.cpp
+++ b/companion/src/datamodels/compounditemmodels.cpp
@@ -52,8 +52,6 @@ QString AbstractItemModel::idToString(const int value)
       return "CurveRefFunc";
     case IMID_FlexSwitches:
       return "FlexSwitches";
-    case IMID_SourceValues:
-      return "SourceValues";
     default:
       return "Custom";
   }
@@ -102,15 +100,13 @@ void AbstractStaticItemModel::loadItemList()
 //
 
 RawSourceItemModel::RawSourceItemModel(const GeneralSettings * const generalSettings, const ModelData * const modelData,
-                                       Firmware * firmware, const Boards * const board, const Board::Type boardType,
-                                       const ItemModelId itemModelId, const bool useInvertIndicator) :
-  AbstractDynamicItemModel(generalSettings, modelData, firmware, board, boardType),
-  useInvertIndicator(useInvertIndicator)
+                                       Firmware * firmware, const Boards * const board, const Board::Type boardType) :
+  AbstractDynamicItemModel(generalSettings, modelData, firmware, board, boardType)
 {
-  setId(itemModelId);
+  setId(IMID_RawSource);
   setUpdateMask(IMUE_All &~ (IMUE_Curves | IMUE_Scripts));
 
-  // Descending source direction
+  // Descending source direction: inverted (!) sources
   addItems(SOURCE_TYPE_TELEMETRY,      RawSource::TelemGroup,    -firmware->getCapability(Sensors) * 3);
   addItems(SOURCE_TYPE_TIMER,          RawSource::TelemGroup,    -firmware->getCapability(Timers));
   addItems(SOURCE_TYPE_SPECIAL,        RawSource::TelemGroup,    -(SOURCE_TYPE_SPECIAL_COUNT - 1));
@@ -156,7 +152,7 @@ RawSourceItemModel::RawSourceItemModel(const GeneralSettings * const generalSett
 
 void RawSourceItemModel::setDynamicItemData(QStandardItem * item, const RawSource & src) const
 {
-  item->setText(src.toString(modelData, generalSettings, boardType, true, useInvertIndicator));
+  item->setText(src.toString(modelData, generalSettings, boardType));
   item->setData(src.isAvailable(modelData, generalSettings, boardType), IMDR_Available);
 }
 
@@ -681,7 +677,7 @@ void CompoundItemModelFactory::addItemModel(const int id)
 {
   switch (id) {
     case AbstractItemModel::IMID_RawSource:
-      registerItemModel(new RawSourceItemModel(generalSettings, modelData, firmware, board, boardType, AbstractItemModel::IMID_RawSource, true));
+      registerItemModel(new RawSourceItemModel(generalSettings, modelData, firmware, board, boardType));
       break;
     case AbstractItemModel::IMID_RawSwitch:
       registerItemModel(new RawSwitchItemModel(generalSettings, modelData, firmware, board, boardType));
@@ -712,9 +708,6 @@ void CompoundItemModelFactory::addItemModel(const int id)
       break;
     case AbstractItemModel::IMID_FlexSwitches:
       registerItemModel(new FlexSwitchesItemModel(generalSettings, modelData, firmware, board, boardType));
-      break;
-    case AbstractItemModel::IMID_SourceValues:
-      registerItemModel(new RawSourceItemModel(generalSettings, modelData, firmware, board, boardType, AbstractItemModel::IMID_SourceValues, false));
       break;
     default:
       qDebug() << "Error: unknown item model: id";

--- a/companion/src/datamodels/compounditemmodels.cpp
+++ b/companion/src/datamodels/compounditemmodels.cpp
@@ -52,6 +52,8 @@ QString AbstractItemModel::idToString(const int value)
       return "CurveRefFunc";
     case IMID_FlexSwitches:
       return "FlexSwitches";
+    case IMID_SourceValues:
+      return "SourceValues";
     default:
       return "Custom";
   }
@@ -100,13 +102,15 @@ void AbstractStaticItemModel::loadItemList()
 //
 
 RawSourceItemModel::RawSourceItemModel(const GeneralSettings * const generalSettings, const ModelData * const modelData,
-                                       Firmware * firmware, const Boards * const board, const Board::Type boardType) :
-  AbstractDynamicItemModel(generalSettings, modelData, firmware, board, boardType)
+                                       Firmware * firmware, const Boards * const board, const Board::Type boardType,
+                                       const ItemModelId itemModelId, const bool useInvertIndicator) :
+  AbstractDynamicItemModel(generalSettings, modelData, firmware, board, boardType),
+  useInvertIndicator(useInvertIndicator)
 {
-  setId(IMID_RawSource);
+  setId(itemModelId);
   setUpdateMask(IMUE_All &~ (IMUE_Curves | IMUE_Scripts));
 
-  // Descending source direction: inverted (!) sources
+  // Descending source direction
   addItems(SOURCE_TYPE_TELEMETRY,      RawSource::TelemGroup,    -firmware->getCapability(Sensors) * 3);
   addItems(SOURCE_TYPE_TIMER,          RawSource::TelemGroup,    -firmware->getCapability(Timers));
   addItems(SOURCE_TYPE_SPECIAL,        RawSource::TelemGroup,    -(SOURCE_TYPE_SPECIAL_COUNT - 1));
@@ -152,7 +156,7 @@ RawSourceItemModel::RawSourceItemModel(const GeneralSettings * const generalSett
 
 void RawSourceItemModel::setDynamicItemData(QStandardItem * item, const RawSource & src) const
 {
-  item->setText(src.toString(modelData, generalSettings, boardType));
+  item->setText(src.toString(modelData, generalSettings, boardType, true, useInvertIndicator));
   item->setData(src.isAvailable(modelData, generalSettings, boardType), IMDR_Available);
 }
 
@@ -677,7 +681,7 @@ void CompoundItemModelFactory::addItemModel(const int id)
 {
   switch (id) {
     case AbstractItemModel::IMID_RawSource:
-      registerItemModel(new RawSourceItemModel(generalSettings, modelData, firmware, board, boardType));
+      registerItemModel(new RawSourceItemModel(generalSettings, modelData, firmware, board, boardType, AbstractItemModel::IMID_RawSource, true));
       break;
     case AbstractItemModel::IMID_RawSwitch:
       registerItemModel(new RawSwitchItemModel(generalSettings, modelData, firmware, board, boardType));
@@ -708,6 +712,9 @@ void CompoundItemModelFactory::addItemModel(const int id)
       break;
     case AbstractItemModel::IMID_FlexSwitches:
       registerItemModel(new FlexSwitchesItemModel(generalSettings, modelData, firmware, board, boardType));
+      break;
+    case AbstractItemModel::IMID_SourceValues:
+      registerItemModel(new RawSourceItemModel(generalSettings, modelData, firmware, board, boardType, AbstractItemModel::IMID_SourceValues, false));
       break;
     default:
       qDebug() << "Error: unknown item model: id";

--- a/companion/src/datamodels/compounditemmodels.h
+++ b/companion/src/datamodels/compounditemmodels.h
@@ -46,6 +46,7 @@ class AbstractItemModel: public QStandardItemModel
       IMID_CurveRefType,
       IMID_CurveRefFunc,
       IMID_FlexSwitches,
+      IMID_SourceValues,
       IMID_ReservedCount,
       IMID_Custom
     };
@@ -189,7 +190,8 @@ class RawSourceItemModel: public AbstractDynamicItemModel
     Q_OBJECT
   public:
     explicit RawSourceItemModel(const GeneralSettings * const generalSettings, const ModelData * const modelData,
-                                Firmware * firmware, const Boards * const board, const Board::Type boardType);
+                                Firmware * firmware, const Boards * const board, const Board::Type boardType,
+                                const ItemModelId itemModelId, const bool useInvertIndicator);
     virtual ~RawSourceItemModel() {};
 
   public slots:
@@ -198,6 +200,9 @@ class RawSourceItemModel: public AbstractDynamicItemModel
   protected:
     virtual void setDynamicItemData(QStandardItem * item, const RawSource & src) const;
     void addItems(const RawSourceType & type, const int group, int count, const int start = 0);
+
+  private:
+    const bool useInvertIndicator;
 };
 
 class RawSwitchItemModel: public AbstractDynamicItemModel
@@ -347,7 +352,6 @@ class FlexSwitchesItemModel: public AbstractDynamicItemModel
   protected:
     virtual void setDynamicItemData(QStandardItem * item, const int value) const;
 };
-
 
 //
 //  CompoundItemModelFactory

--- a/companion/src/datamodels/compounditemmodels.h
+++ b/companion/src/datamodels/compounditemmodels.h
@@ -46,7 +46,6 @@ class AbstractItemModel: public QStandardItemModel
       IMID_CurveRefType,
       IMID_CurveRefFunc,
       IMID_FlexSwitches,
-      IMID_SourceValues,
       IMID_ReservedCount,
       IMID_Custom
     };
@@ -190,8 +189,7 @@ class RawSourceItemModel: public AbstractDynamicItemModel
     Q_OBJECT
   public:
     explicit RawSourceItemModel(const GeneralSettings * const generalSettings, const ModelData * const modelData,
-                                Firmware * firmware, const Boards * const board, const Board::Type boardType,
-                                const ItemModelId itemModelId, const bool useInvertIndicator);
+                                Firmware * firmware, const Boards * const board, const Board::Type boardType);
     virtual ~RawSourceItemModel() {};
 
   public slots:
@@ -200,9 +198,6 @@ class RawSourceItemModel: public AbstractDynamicItemModel
   protected:
     virtual void setDynamicItemData(QStandardItem * item, const RawSource & src) const;
     void addItems(const RawSourceType & type, const int group, int count, const int start = 0);
-
-  private:
-    const bool useInvertIndicator;
 };
 
 class RawSwitchItemModel: public AbstractDynamicItemModel
@@ -352,6 +347,7 @@ class FlexSwitchesItemModel: public AbstractDynamicItemModel
   protected:
     virtual void setDynamicItemData(QStandardItem * item, const int value) const;
 };
+
 
 //
 //  CompoundItemModelFactory

--- a/companion/src/datamodels/filtereditemmodels.cpp
+++ b/companion/src/datamodels/filtereditemmodels.cpp
@@ -222,8 +222,6 @@ CurveRefFilteredFactory::CurveRefFilteredFactory(CompoundItemModelFactory * shar
 
   registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_Curve), curveFlags),
                                           fidToString(CRFIM_CURVE), CRFIM_CURVE);
-  registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_GVarRef), gvarRefFlags),
-                                          fidToString(CRFIM_GVARREF), CRFIM_GVARREF);
   registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_CurveRefType)),
                                           fidToString(CRFIM_TYPE), CRFIM_TYPE);
   registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_CurveRefFunc)),

--- a/companion/src/firmwares/CMakeLists.txt
+++ b/companion/src/firmwares/CMakeLists.txt
@@ -28,6 +28,7 @@ set(${PROJECT_NAME}_NAMES
   rawsource
   rawswitch
   sensordata
+  sourcenumref
   telem_data
   timerdata
   ersky9x/ersky9xeeprom

--- a/companion/src/firmwares/curvereference.cpp
+++ b/companion/src/firmwares/curvereference.cpp
@@ -50,7 +50,7 @@ const QString CurveReference::toString(const ModelData * model, bool verbose, co
       else
         ret = CurveData().nameToString(idx);
       if (value < 0)
-        ret.prepend(CPN_STR_SRC_INDICATOR_NEG);
+        ret.prepend(CPN_STR_SW_INDICATOR_REV);
       break;
     default:
       return CPN_STR_UNKNOWN_ITEM;

--- a/companion/src/firmwares/curvereference.cpp
+++ b/companion/src/firmwares/curvereference.cpp
@@ -19,7 +19,6 @@
  */
 
 #include "curvereference.h"
-#include "adjustmentreference.h"
 #include "helpers.h"
 #include "modeldata.h"
 #include "generalsettings.h"
@@ -65,7 +64,7 @@ const QString CurveReference::toString(const ModelData * model, bool verbose, co
 
 const bool CurveReference::isValueNumber() const
 {
-  return (type == CURVE_REF_DIFF || type == CURVE_REF_EXPO) && AdjustmentReference(value).type == AdjustmentReference::ADJUST_REF_VALUE;
+  return (type == CURVE_REF_DIFF || type == CURVE_REF_EXPO) && SourceNumRef(value).isNumber();
 }
 
 const bool CurveReference::isAvailable() const
@@ -77,7 +76,7 @@ const bool CurveReference::isAvailable() const
 int CurveReference::getDefaultValue(const CurveRefType type, const bool isGVar)
 {
   if (isGVar && (type == CURVE_REF_DIFF || type == CURVE_REF_EXPO))
-    return AdjustmentReference(AdjustmentReference::ADJUST_REF_GVAR, 1).toValue();
+    return SourceNumRef(SOURCE_TYPE_GVAR, 1).toValue();
   else if (type == CURVE_REF_FUNC)
     return 1;
   else
@@ -223,18 +222,6 @@ void CurveReferenceUIManager::update()
 
   if (cboType)
     cboType->setCurrentIndex(cboType->findData(curveRef.type));
-
-
-/*
-  if (chkUseSource)
-    chkUseSource->setVisible(widgetsMask & CURVE_REF_UI_SRC_SHOW);
-
-  if (cboSource)
-    cboSource->setVisible(widgetsMask & CURVE_REF_UI_SRC_SHOW);
-
-  if (sbxValue)
-    sbxValue->setVisible(widgetsMask & CURVE_REF_UI_VALUE_SHOW);
-*/
 
   if (cboCurveFunc) {
     if (curveRef.isValueReference())

--- a/companion/src/firmwares/curvereference.cpp
+++ b/companion/src/firmwares/curvereference.cpp
@@ -22,12 +22,14 @@
 #include "adjustmentreference.h"
 #include "helpers.h"
 #include "modeldata.h"
+#include "generalsettings.h"
 #include "filtereditemmodels.h"
 #include "curveimagewidget.h"
 #include "curvedialog.h"
 #include "sourcenumref.h"
 
-const QString CurveReference::toString(const ModelData * model, bool verbose) const
+const QString CurveReference::toString(const ModelData * model, bool verbose, const GeneralSettings * const generalSettings,
+                                       Board::Type board, bool prefixCustomName) const
 {
   if (value == 0)
     return CPN_STR_NONE_ITEM;
@@ -38,7 +40,7 @@ const QString CurveReference::toString(const ModelData * model, bool verbose) co
   switch(type) {
     case CURVE_REF_DIFF:
     case CURVE_REF_EXPO:
-      ret = AdjustmentReference(value).toString(model);
+      ret = SourceNumRef(value).toString(model, generalSettings, board, prefixCustomName);
       break;
     case CURVE_REF_FUNC:
       ret = functionToString(value);

--- a/companion/src/firmwares/curvereference.cpp
+++ b/companion/src/firmwares/curvereference.cpp
@@ -50,7 +50,7 @@ const QString CurveReference::toString(const ModelData * model, bool verbose, co
       else
         ret = CurveData().nameToString(idx);
       if (value < 0)
-        ret.prepend(CPN_STR_SW_INDICATOR_REV);
+        ret.prepend(CPN_STR_SRC_INDICATOR_NEG);
       break;
     default:
       return CPN_STR_UNKNOWN_ITEM;

--- a/companion/src/firmwares/curvereference.h
+++ b/companion/src/firmwares/curvereference.h
@@ -20,6 +20,8 @@
 
 #pragma once
 
+#include "rawsource.h"
+
 #include <QtCore>
 #include <QComboBox>
 #include <QCheckBox>
@@ -27,6 +29,7 @@
 #include <QSpinBox>
 #include <QStandardItemModel>
 
+class GeneralSettings;
 class ModelData;
 class CurveRefFilteredFactory;
 class CompoundItemModelFactory;
@@ -65,7 +68,8 @@ class CurveReference {
     const bool isSet() const { return !isEmpty(); }
     const bool isValueNumber() const;
     const bool isValueReference() const { return !isValueNumber(); }
-    const QString toString(const ModelData * model = nullptr, bool verbose = true) const;
+    const QString toString(const ModelData * model = nullptr, bool verbose = true, const GeneralSettings * const generalSettings = nullptr,
+                           Board::Type board = Board::BOARD_UNKNOWN, bool prefixCustomName = true) const;
     const bool isAvailable() const;
 
     CurveRefType type;

--- a/companion/src/firmwares/curvereference.h
+++ b/companion/src/firmwares/curvereference.h
@@ -32,6 +32,7 @@ class CurveRefFilteredFactory;
 class CompoundItemModelFactory;
 class FilteredItemModel;
 class CurveImageWidget;
+class SourceNumRefEditor;
 
 class CurveReference {
 
@@ -91,13 +92,17 @@ class CurveReferenceUIManager : public QObject {
   Q_OBJECT
 
   public:
-    explicit CurveReferenceUIManager(QComboBox *curveTypeCB, QCheckBox *curveGVarCB, QSpinBox *curveValueSB, QComboBox *curveValueCB,
-                            QLabel *curveImage, CurveReference & curve, ModelData & model, CompoundItemModelFactory * sharedItemModels,
-                            CurveRefFilteredFactory * curveRefFilteredFactory, QObject * parent = nullptr);
+    explicit CurveReferenceUIManager(QComboBox * cboType, QCheckBox * chkUseSource, QSpinBox * sbxValue, QComboBox * cboSource,
+                                     QComboBox * cboCurveFunc, CurveImageWidget * curveImage, CurveReference & curveRef,
+                                     ModelData & model, CompoundItemModelFactory * sharedItemModels,
+                                     CurveRefFilteredFactory * curveRefFilteredFactory, FilteredItemModel * sourceItemModel,
+                                     QObject * parent = nullptr);
 
-    explicit CurveReferenceUIManager(QComboBox *curveValueCB, CurveReference & curve, ModelData & model, CompoundItemModelFactory * sharedItemModels,
-                            CurveRefFilteredFactory * curveRefFilteredFactory, QObject * parent = nullptr) :
-                CurveReferenceUIManager(nullptr, nullptr, nullptr, curveValueCB, nullptr, curve, model, sharedItemModels, curveRefFilteredFactory, parent) {}
+    explicit CurveReferenceUIManager(QComboBox *cboCurveFunc, CurveReference & curveRef, ModelData & model,
+                                     CompoundItemModelFactory * sharedItemModels, CurveRefFilteredFactory * curveRefFilteredFactory,
+                                     FilteredItemModel * sourceItemModel, QObject * parent = nullptr) :
+                CurveReferenceUIManager(nullptr, nullptr, nullptr, nullptr, cboCurveFunc, nullptr, curveRef, model, sharedItemModels,
+                                        curveRefFilteredFactory, nullptr, parent) {}
 
     virtual ~CurveReferenceUIManager();
 
@@ -105,28 +110,25 @@ class CurveReferenceUIManager : public QObject {
     void resized();
 
   protected slots:
-    void gvarCBChanged(int);
-    void typeChanged(int);
-    void valueSBChanged();
-    void valueCBChanged();
+    void cboTypeChanged(int);
+    void cboCurveFuncChanged(int);
     void update();
     void curveImageDoubleClicked();
     void onItemModelAboutToBeUpdated();
     void onItemModelUpdateComplete();
 
   private:
-    QComboBox *curveTypeCB;
-    QCheckBox *curveGVarCB;
-    QSpinBox *curveValueSB;
-    QComboBox *curveValueCB;
-    CurveReference & curveRef;
-    ModelData & model;
-    CompoundItemModelFactory *sharedItemModels;
+    QComboBox *cboType;
+    QCheckBox *chkUseSource;
+    QSpinBox *sbxValue;
+    QComboBox *cboSource;
+    QComboBox *cboCurveFunc;
+    CurveImageWidget *curveImage;
+    CurveReference &curveRef;
+    ModelData &model;
     CurveRefFilteredFactory *filteredModelFactory;
     bool lock;
-    CurveImageWidget *curveImageWidget = nullptr;
-
-    bool hasCapabilityGvars;
+    SourceNumRefEditor *srcNumRefEditor;
 
     void connectItemModelEvents(const FilteredItemModel * itemModel);
     void populateValueCB(QComboBox * cb);

--- a/companion/src/firmwares/curvereference.h
+++ b/companion/src/firmwares/curvereference.h
@@ -102,10 +102,10 @@ class CurveReferenceUIManager : public QObject {
                                      CurveRefFilteredFactory * curveRefFilteredFactory, FilteredItemModel * sourceItemModel,
                                      QObject * parent = nullptr);
 
-    explicit CurveReferenceUIManager(QComboBox *cboCurveFunc, CurveReference & curveRef, ModelData & model,
+    explicit CurveReferenceUIManager(QComboBox *cboCurveFunc, CurveImageWidget * curveImage, CurveReference & curveRef, ModelData & model,
                                      CompoundItemModelFactory * sharedItemModels, CurveRefFilteredFactory * curveRefFilteredFactory,
-                                     FilteredItemModel * sourceItemModel, QObject * parent = nullptr) :
-                CurveReferenceUIManager(nullptr, nullptr, nullptr, nullptr, cboCurveFunc, nullptr, curveRef, model, sharedItemModels,
+                                     QObject * parent = nullptr) :
+                CurveReferenceUIManager(nullptr, nullptr, nullptr, nullptr, cboCurveFunc, curveImage, curveRef, model, sharedItemModels,
                                         curveRefFilteredFactory, nullptr, parent) {}
 
     virtual ~CurveReferenceUIManager();

--- a/companion/src/firmwares/edgetx/yaml_expodata.cpp
+++ b/companion/src/firmwares/edgetx/yaml_expodata.cpp
@@ -35,8 +35,8 @@ Node convert<ExpoData>::encode(const ExpoData& rhs)
   node["chn"] = rhs.chn;
   node["swtch"] = rhs.swtch;
   node["flightModes"] = YamlWriteFlightModes(rhs.flightModes);
-  node["weight"] = YamlWriteMixWeight(rhs.weight);
-  node["offset"] = YamlWriteMixWeight(rhs.offset);
+  node["weight"] = YamlSourceNumRefEncode(rhs.weight);
+  node["offset"] = YamlSourceNumRefEncode(rhs.offset);
   node["curve"] = rhs.curve;
   node["trimSource"] = rhs.carryTrim; // temporary for 2.8.1, trimSource in 2.9
   node["name"] = rhs.name;
@@ -54,10 +54,10 @@ bool convert<ExpoData>::decode(const Node& node, ExpoData& rhs)
     rhs.flightModes = YamlReadFlightModes(node["flightModes"]);
   }
   if (node["weight"]) {
-    rhs.weight = YamlReadMixWeight(node["weight"]);
+    rhs.weight = YamlSourceNumRefDecode(node["weight"]);
   }
   if (node["offset"]) {
-    rhs.offset = YamlReadMixWeight(node["offset"]);
+    rhs.offset = YamlSourceNumRefDecode(node["offset"]);
   }
   node["curve"] >> rhs.curve;
 if (node["carryTrim"]) { // 2.9 - change bugged carryTrim to trimSource

--- a/companion/src/firmwares/edgetx/yaml_mixdata.cpp
+++ b/companion/src/firmwares/edgetx/yaml_mixdata.cpp
@@ -33,48 +33,6 @@ static const YamlLookupTable mixMultiplexLut = {
 #define GVAR_SMALL 128
 #define CPN_GV1 1024
 
-int32_t YamlReadMixWeight(const YAML::Node& node)
-{
-  std::string val = node.as<std::string>();
-  if ((val.size() >= 4)
-      && (val[0] == '-')
-      && (val[1] == 'G')
-      && (val[2] == 'V')
-      && (val[3] >= '1')
-      && (val[3] <= '9')) {
-
-      return -10000 - std::stoi(val.substr(3));
-  }
-
-  if ((val.size() >= 3)
-      && (val[0] == 'G')
-      && (val[1] == 'V')
-      && (val[2] >= '1')
-      && (val[2] <= '9')) {
-
-    return 10000 + std::stoi(val.substr(2));
-  }
-
-  try {
-    return std::stoi(val);
-  } catch(...) {
-    throw YAML::TypedBadConversion<int>(node.Mark());
-  }
-}
-
-std::string YamlWriteMixWeight(int32_t sval)
-{
-  if (sval < -10000) {
-    int n = -sval - 10000;
-    return std::string("-GV") + std::to_string(n);
-  } else if (sval > 10000) {
-    int n = sval - 10000;
-    return std::string("GV") + std::to_string(n);
-  }
-
-  return std::to_string(sval);
-}
-
 int32_t YamlSourceNumRefDecode(const YAML::Node& node)
 {
   std::string val = node.as<std::string>();

--- a/companion/src/firmwares/edgetx/yaml_mixdata.cpp
+++ b/companion/src/firmwares/edgetx/yaml_mixdata.cpp
@@ -37,26 +37,32 @@ int32_t YamlSourceNumRefDecode(const YAML::Node& node)
 {
   std::string val = node.as<std::string>();
 
-  // start legacy for pre 2.11
-  if ((val.size() >= 4)
-    && (val[0] == '-')
-    && (val[1] == 'G')
-    && (val[2] == 'V')
-    && (val[3] >= '1')
-    && (val[3] <= '9')) {
+  if (modelSettingsVersion < SemanticVersion(QString("2.11.0"))) {
+    if ((val.size() >= 4)
+      && (val[0] == '-')
+      && (val[1] == 'G')
+      && (val[2] == 'V')
+      && (val[3] >= '1')
+      && (val[3] <= '9')) {
 
-    return RawSource(SOURCE_TYPE_GVAR, val[3]).toValue();
+      std::stringstream src(val.substr(3));
+      int gv = 0;
+      src >> gv;
+      return RawSource(SOURCE_TYPE_GVAR, gv).toValue() * -1;
+    }
+
+    if ((val.size() >= 3)
+      && (val[0] == 'G')
+      && (val[1] == 'V')
+      && (val[2] >= '1')
+      && (val[2] <= '9')) {
+
+      std::stringstream src(val.substr(2));
+      int gv = 0;
+      src >> gv;
+      return RawSource(SOURCE_TYPE_GVAR, gv).toValue();
+    }
   }
-
-  if ((val.size() >= 3)
-    && (val[0] == 'G')
-    && (val[1] == 'V')
-    && (val[2] >= '1')
-    && (val[2] <= '9')) {
-
-    return RawSource(SOURCE_TYPE_GVAR, val[2]).toValue();
-  }
-  // end legacy for pre 2.11
 
   int i = val[0] == '-' ? 1 : 0;
 

--- a/companion/src/firmwares/edgetx/yaml_mixdata.h
+++ b/companion/src/firmwares/edgetx/yaml_mixdata.h
@@ -24,6 +24,9 @@
 int32_t YamlReadMixWeight(const YAML::Node& node);
 std::string YamlWriteMixWeight(int32_t sval);
 
+int32_t YamlSourceNumRefDecode(const YAML::Node& node);
+std::string YamlSourceNumRefEncode(int32_t sval);
+
 uint32_t YamlReadFlightModes(const YAML::Node& node);
 std::string YamlWriteFlightModes(uint32_t val);
 

--- a/companion/src/firmwares/edgetx/yaml_mixdata.h
+++ b/companion/src/firmwares/edgetx/yaml_mixdata.h
@@ -21,9 +21,6 @@
 #include "yaml_ops.h"
 #include "mixdata.h"
 
-int32_t YamlReadMixWeight(const YAML::Node& node);
-std::string YamlWriteMixWeight(int32_t sval);
-
 int32_t YamlSourceNumRefDecode(const YAML::Node& node);
 std::string YamlSourceNumRefEncode(int32_t sval);
 

--- a/companion/src/firmwares/edgetx/yaml_modeldata.cpp
+++ b/companion/src/firmwares/edgetx/yaml_modeldata.cpp
@@ -546,6 +546,7 @@ struct convert<LimitData> {
     node["symetrical"] = (int)rhs.symetrical;
     node["name"] = rhs.name;
     node["curve"] = rhs.curve.value;
+    // rhs.curve.type is not encoded
     return node;
   }
 
@@ -565,6 +566,7 @@ struct convert<LimitData> {
     node["symetrical"] >> rhs.symetrical;
     node["name"] >> rhs.name;
     node["curve"] >> rhs.curve.value;
+    rhs.curve.type = CurveReference::CURVE_REF_CUSTOM;  // this is not encoded but needed internally so force type
     return true;
   }
 };

--- a/companion/src/firmwares/opentx/opentxeeprom.cpp
+++ b/companion/src/firmwares/opentx/opentxeeprom.cpp
@@ -808,7 +808,8 @@ class CurveReferenceField: public TransformedField {
       curve.type = (CurveReference::CurveRefType)_curve_type;
       curve.value = smallGvarExport(_curve_value);
       //  2,11 num or gvar changed to SourceNumRef
-      if ((curve.type == CurveReference::CURVE_REF_DIFF || curve.type == CurveReference::CURVE_REF_EXPO) && curve.isValueReference())
+      if ((curve.type == CurveReference::CURVE_REF_DIFF || curve.type == CurveReference::CURVE_REF_EXPO) &&
+          AdjustmentReference(curve.value).type == AdjustmentReference::ADJUST_REF_GVAR)
         curve.value = RawSource(SOURCE_TYPE_GVAR, AdjustmentReference(curve.value).value).toValue();
 
       qCDebug(eepromImport) << QString("imported CurveReference(%1)").arg(curve.toString());
@@ -1121,7 +1122,8 @@ class MixField: public TransformedField {
       }
 
       //  2.11
-      if ((mix.curve.type == CurveReference::CURVE_REF_DIFF || mix.curve.type == CurveReference::CURVE_REF_EXPO) && mix.curve.isValueReference())
+      if ((mix.curve.type == CurveReference::CURVE_REF_DIFF || mix.curve.type == CurveReference::CURVE_REF_EXPO) &&
+          AdjustmentReference(mix.curve.value).type == AdjustmentReference::ADJUST_REF_GVAR)
         mix.curve.value = RawSource(SOURCE_TYPE_GVAR, AdjustmentReference(mix.curve.value).value).toValue();
 
       importGvarParam(mix.weight, _weight, version);
@@ -1260,7 +1262,8 @@ class InputField: public TransformedField {
       }
 
       //  2.11
-      if ((expo.curve.type == CurveReference::CURVE_REF_DIFF || expo.curve.type == CurveReference::CURVE_REF_EXPO) && expo.curve.isValueReference())
+      if ((expo.curve.type == CurveReference::CURVE_REF_DIFF || expo.curve.type == CurveReference::CURVE_REF_EXPO) &&
+          AdjustmentReference(expo.curve.value).type == AdjustmentReference::ADJUST_REF_GVAR)
         expo.curve.value = RawSource(SOURCE_TYPE_GVAR, AdjustmentReference(expo.curve.value).value).toValue();
 
 

--- a/companion/src/firmwares/opentx/opentxeeprom.cpp
+++ b/companion/src/firmwares/opentx/opentxeeprom.cpp
@@ -25,6 +25,8 @@
 #include "opentxeeprom.h"
 #include "customdebug.h"
 #include "opentxinterface.h"
+#include "sourcenumref.h"
+#include "adjustmentreference.h"
 
 using namespace Board;
 
@@ -805,6 +807,10 @@ class CurveReferenceField: public TransformedField {
     {
       curve.type = (CurveReference::CurveRefType)_curve_type;
       curve.value = smallGvarExport(_curve_value);
+      //  2,11 num or gvar changed to SourceNumRef
+      if ((curve.type == CurveReference::CURVE_REF_DIFF || curve.type == CurveReference::CURVE_REF_EXPO) && curve.isValueReference())
+        curve.value = RawSource(SOURCE_TYPE_GVAR, AdjustmentReference(curve.value).value).toValue();
+
       qCDebug(eepromImport) << QString("imported CurveReference(%1)").arg(curve.toString());
     }
 
@@ -1114,8 +1120,19 @@ class MixField: public TransformedField {
         }
       }
 
+      //  2.11
+      if ((mix.curve.type == CurveReference::CURVE_REF_DIFF || mix.curve.type == CurveReference::CURVE_REF_EXPO) && mix.curve.isValueReference())
+        mix.curve.value = RawSource(SOURCE_TYPE_GVAR, AdjustmentReference(mix.curve.value).value).toValue();
+
       importGvarParam(mix.weight, _weight, version);
+      //  2.11
+      if (AdjustmentReference(mix.weight).type == AdjustmentReference::ADJUST_REF_GVAR)
+        mix.weight = RawSource(SOURCE_TYPE_GVAR, AdjustmentReference(mix.weight).value).toValue();
+
       importGvarParam(mix.sOffset, _offset, version);
+      //  2.11
+      if (AdjustmentReference(mix.sOffset).type == AdjustmentReference::ADJUST_REF_GVAR)
+        mix.sOffset = RawSource(SOURCE_TYPE_GVAR, AdjustmentReference(mix.sOffset).value).toValue();
 
       qCDebug(eepromImport) << QString("imported %1: ch %2, name '%3'").arg(internalField.getName()).arg(mix.destCh).arg(mix.name);
     }
@@ -1222,9 +1239,15 @@ class InputField: public TransformedField {
       }
 
       expo.weight = smallGvarExport(_weight);
+      //  2.11
+      if (AdjustmentReference(expo.weight).type == AdjustmentReference::ADJUST_REF_GVAR)
+        expo.weight = RawSource(SOURCE_TYPE_GVAR, AdjustmentReference(expo.weight).value).toValue();
 
       if (IS_STM32(board) || version >= 218) {
         expo.offset = smallGvarExport(_offset);
+        //  2.11
+        if (AdjustmentReference(expo.offset).type == AdjustmentReference::ADJUST_REF_GVAR)
+          expo.offset = RawSource(SOURCE_TYPE_GVAR, AdjustmentReference(expo.offset).value).toValue();
       }
 
       if (!IS_TARANIS(board) && version < 218) {
@@ -1235,6 +1258,12 @@ class InputField: public TransformedField {
         else
           expo.curve = CurveReference(CurveReference::CURVE_REF_FUNC, _curveParam);
       }
+
+      //  2.11
+      if ((expo.curve.type == CurveReference::CURVE_REF_DIFF || expo.curve.type == CurveReference::CURVE_REF_EXPO) && expo.curve.isValueReference())
+        expo.curve.value = RawSource(SOURCE_TYPE_GVAR, AdjustmentReference(expo.curve.value).value).toValue();
+
+
       qCDebug(eepromImport) << QString("imported %1: ch %2 name '%3'").arg(internalField.getName()).arg(expo.chn).arg(expo.name);
     }
 

--- a/companion/src/firmwares/rawsource.cpp
+++ b/companion/src/firmwares/rawsource.cpp
@@ -131,7 +131,7 @@ RawSourceRange RawSource::getRange(const ModelData * model, const GeneralSetting
 QString RawSource::toString(const ModelData * model, const GeneralSettings * const generalSettings, Board::Type board, bool prefixCustomName) const
 {
   if (index < 0)
-    return CPN_STR_SRC_INDICATOR_INVERT % RawSource(type, -index).toString(model, generalSettings, board, prefixCustomName);
+    return CPN_STR_SRC_INDICATOR_NEG % RawSource(type, -index).toString(model, generalSettings, board, prefixCustomName);
 
   if (board == Board::BOARD_UNKNOWN)
     board = getCurrentBoard();

--- a/companion/src/firmwares/rawsource.cpp
+++ b/companion/src/firmwares/rawsource.cpp
@@ -128,10 +128,12 @@ RawSourceRange RawSource::getRange(const ModelData * model, const GeneralSetting
   return result;
 }
 
-QString RawSource::toString(const ModelData * model, const GeneralSettings * const generalSettings, Board::Type board, bool prefixCustomName) const
+QString RawSource::toString(const ModelData * model, const GeneralSettings * const generalSettings, Board::Type board,
+                            bool prefixCustomName, bool useInvertIndicator) const
 {
   if (index < 0)
-    return CPN_STR_SRC_INDICATOR_INVERT % RawSource(type, -index).toString(model, generalSettings, board, prefixCustomName);
+    return (useInvertIndicator ? CPN_STR_SRC_INDICATOR_INVERT : CPN_STR_SRC_INDICATOR_NEG) %
+            RawSource(type, -index).toString(model, generalSettings, board, prefixCustomName);
 
   if (board == Board::BOARD_UNKNOWN)
     board = getCurrentBoard();

--- a/companion/src/firmwares/rawsource.cpp
+++ b/companion/src/firmwares/rawsource.cpp
@@ -128,12 +128,10 @@ RawSourceRange RawSource::getRange(const ModelData * model, const GeneralSetting
   return result;
 }
 
-QString RawSource::toString(const ModelData * model, const GeneralSettings * const generalSettings, Board::Type board,
-                            bool prefixCustomName, bool useInvertIndicator) const
+QString RawSource::toString(const ModelData * model, const GeneralSettings * const generalSettings, Board::Type board, bool prefixCustomName) const
 {
   if (index < 0)
-    return (useInvertIndicator ? CPN_STR_SRC_INDICATOR_INVERT : CPN_STR_SRC_INDICATOR_NEG) %
-            RawSource(type, -index).toString(model, generalSettings, board, prefixCustomName);
+    return CPN_STR_SRC_INDICATOR_INVERT % RawSource(type, -index).toString(model, generalSettings, board, prefixCustomName);
 
   if (board == Board::BOARD_UNKNOWN)
     board = getCurrentBoard();

--- a/companion/src/firmwares/rawsource.h
+++ b/companion/src/firmwares/rawsource.h
@@ -268,7 +268,7 @@ class RawSource {
     }
 
     RawSource convert(RadioDataConversionState & cstate);
-    QString toString(const ModelData * model = nullptr, const GeneralSettings * const generalSettings = nullptr, Board::Type board = Board::BOARD_UNKNOWN, bool prefixCustomName = true, bool useInvertIndicator = true) const;
+    QString toString(const ModelData * model = nullptr, const GeneralSettings * const generalSettings = nullptr, Board::Type board = Board::BOARD_UNKNOWN, bool prefixCustomName = true) const;
     RawSourceRange getRange(const ModelData * model, const GeneralSettings & settings, unsigned int flags=0) const;
     bool isStick(Board::Type board = Board::BOARD_UNKNOWN) const;
     bool isTimeBased(Board::Type board = Board::BOARD_UNKNOWN) const;

--- a/companion/src/firmwares/rawsource.h
+++ b/companion/src/firmwares/rawsource.h
@@ -268,7 +268,7 @@ class RawSource {
     }
 
     RawSource convert(RadioDataConversionState & cstate);
-    QString toString(const ModelData * model = nullptr, const GeneralSettings * const generalSettings = nullptr, Board::Type board = Board::BOARD_UNKNOWN, bool prefixCustomName = true) const;
+    QString toString(const ModelData * model = nullptr, const GeneralSettings * const generalSettings = nullptr, Board::Type board = Board::BOARD_UNKNOWN, bool prefixCustomName = true, bool useInvertIndicator = true) const;
     RawSourceRange getRange(const ModelData * model, const GeneralSettings & settings, unsigned int flags=0) const;
     bool isStick(Board::Type board = Board::BOARD_UNKNOWN) const;
     bool isTimeBased(Board::Type board = Board::BOARD_UNKNOWN) const;

--- a/companion/src/firmwares/sourcenumref.cpp
+++ b/companion/src/firmwares/sourcenumref.cpp
@@ -21,6 +21,7 @@
 
 #include "sourcenumref.h"
 #include "filtereditemmodels.h"
+#include "helpers.h"
 
 QString SourceNumRef::toString(const ModelData * model, const GeneralSettings * const generalSettings,
                      Board::Type board, bool prefixCustomName) const
@@ -35,7 +36,7 @@ QString SourceNumRef::toString(const ModelData * model, const GeneralSettings * 
 int SourceNumRef::getDefault(int useSource, int dflt)
 {
   if (useSource)
-    return RawSource(SOURCE_TYPE_GVAR, 1).toValue();  // backwards compatibility
+    return 0;
   else
     return dflt;
 }
@@ -73,7 +74,7 @@ SourceNumRefEditor::SourceNumRefEditor(int & srcNumValue, QCheckBox * chkUseSour
     cboValue->setModel(sourceItemModel);
     cboValue->setSizeAdjustPolicy(QComboBox::AdjustToContents);
     cboValue->setMaxVisibleItems(10);
-    cboValue->setCurrentIndex(cboValue->count() / 2); // '----' not in list so set to first positive entry
+    cboValue->setCurrentIndex(Helpers::getFirstPosValueIndex(cboValue));
     connect(cboValue, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SourceNumRefEditor::cboValueChanged);
   }
 
@@ -84,10 +85,15 @@ void SourceNumRefEditor::chkUseSourceChanged(int state)
 {
   if (!lock) {
     srcNumValue = SourceNumRef::getDefault(state, defValue);
-    if (SourceNumRef(srcNumValue).isSource())
+
+    if (state == Qt::Checked) {
       cboValue->setCurrentIndex(cboValue->findData(srcNumValue));
+      if (cboValue->currentIndex() < 0)
+        cboValue->setCurrentIndex(Helpers::getFirstPosValueIndex(cboValue));
+    }
     else
       sbxValue->setValue(srcNumValue);
+
     update();
   }
 }

--- a/companion/src/firmwares/sourcenumref.cpp
+++ b/companion/src/firmwares/sourcenumref.cpp
@@ -114,6 +114,13 @@ void SourceNumRefEditor::cboValueChanged(int index)
   }
 }
 
+void SourceNumRefEditor::setVisible(bool state)
+{
+  chkUseSource->setVisible(state);
+  cboValue->setVisible(state);
+  sbxValue->setVisible(state);
+}
+
 void SourceNumRefEditor::update()
 {
   lock = true;

--- a/companion/src/firmwares/sourcenumref.cpp
+++ b/companion/src/firmwares/sourcenumref.cpp
@@ -1,0 +1,140 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "sourcenumref.h"
+#include "filtereditemmodels.h"
+
+QString SourceNumRef::toString(const ModelData * model, const GeneralSettings * const generalSettings,
+                     Board::Type board, bool prefixCustomName) const
+{
+  if (srcNum.type == SOURCE_TYPE_NONE)
+    return QString::number(srcNum.index);
+  else
+    return srcNum.toString(model, generalSettings, board, prefixCustomName);
+}
+
+// static
+int SourceNumRef::getDefault(int useSource)
+{
+  if (useSource)
+    return RawSource(SOURCE_TYPE_GVAR, 1).toValue();  // backwards compatibility
+  else
+    return 0;
+}
+
+
+/*
+ * SourceNumRefEditor
+*/
+
+SourceNumRefEditor::SourceNumRefEditor(int & srcNumValue, QCheckBox * chkUseSource, QSpinBox * sbxValue, QComboBox * cboValue,
+                                       int defValue, int minValue, int maxValue, int step,
+                                       ModelData & model, FilteredItemModel * sourceItemModel, QObject * parent) :
+  QObject(parent),
+  srcNumValue(srcNumValue),
+  chkUseSource(chkUseSource),
+  sbxValue(sbxValue),
+  cboValue(cboValue),
+  model(model),
+  lock(false)
+{
+  if (chkUseSource) {
+    connect(chkUseSource, &QCheckBox::stateChanged, this, &SourceNumRefEditor::chkUseSourceChanged);
+  }
+
+  if (sbxValue) {
+    sbxValue->setMinimum(minValue);
+    sbxValue->setMaximum(maxValue);
+    sbxValue->setSingleStep(step);
+    sbxValue->setValue(defValue);
+    connect(sbxValue, &QSpinBox::editingFinished, this, &SourceNumRefEditor::sbxValueChanged);
+  }
+
+  if (cboValue) {
+    cboValue->setModel(sourceItemModel);
+    cboValue->setSizeAdjustPolicy(QComboBox::AdjustToContents);
+    cboValue->setMaxVisibleItems(10);
+    cboValue->setCurrentIndex(cboValue->count() / 2); // '----' not in list so set to first positive entry
+    connect(cboValue, QOverload<int>::of(&QComboBox::currentIndexChanged), this, &SourceNumRefEditor::cboValueChanged);
+  }
+
+  update();
+}
+
+void SourceNumRefEditor::chkUseSourceChanged(int state)
+{
+  if (!lock) {
+    srcNumValue = SourceNumRef::getDefault(state);
+    if (SourceNumRef(srcNumValue).isSource())
+      cboValue->setCurrentIndex(cboValue->count() / 2);
+    update();
+  }
+}
+
+void SourceNumRefEditor::sbxValueChanged()
+{
+  if (!lock) {
+    srcNumValue = sbxValue->value();
+    update();
+  }
+}
+
+void SourceNumRefEditor::cboValueChanged(int index)
+{
+  if (!lock) {
+    srcNumValue = cboValue->itemData(index).toInt();
+    update();
+  }
+}
+
+void SourceNumRefEditor::update()
+{
+  lock = true;
+
+  if (SourceNumRef(srcNumValue).isNumber()) {
+    if (chkUseSource)
+      chkUseSource->setChecked(false);
+
+    if (sbxValue) {
+      sbxValue->setValue(srcNumValue);
+      sbxValue->setVisible(true);
+    }
+
+    if (cboValue)
+      cboValue->setVisible(false);
+  }
+  else {
+    if (chkUseSource)
+      chkUseSource->setChecked(true);
+
+    if (sbxValue)
+      sbxValue->setVisible(false);
+
+    if (cboValue) {
+      cboValue->setCurrentIndex(cboValue->findData(srcNumValue));
+      cboValue->setVisible(true);
+    }
+  }
+
+  emit resized();
+
+  lock = false;
+}

--- a/companion/src/firmwares/sourcenumref.cpp
+++ b/companion/src/firmwares/sourcenumref.cpp
@@ -32,12 +32,12 @@ QString SourceNumRef::toString(const ModelData * model, const GeneralSettings * 
 }
 
 // static
-int SourceNumRef::getDefault(int useSource)
+int SourceNumRef::getDefault(int useSource, int dflt)
 {
   if (useSource)
     return RawSource(SOURCE_TYPE_GVAR, 1).toValue();  // backwards compatibility
   else
-    return 0;
+    return dflt;
 }
 
 
@@ -53,6 +53,7 @@ SourceNumRefEditor::SourceNumRefEditor(int & srcNumValue, QCheckBox * chkUseSour
   chkUseSource(chkUseSource),
   sbxValue(sbxValue),
   cboValue(cboValue),
+  defValue(defValue),
   model(model),
   lock(false)
 {
@@ -82,9 +83,11 @@ SourceNumRefEditor::SourceNumRefEditor(int & srcNumValue, QCheckBox * chkUseSour
 void SourceNumRefEditor::chkUseSourceChanged(int state)
 {
   if (!lock) {
-    srcNumValue = SourceNumRef::getDefault(state);
+    srcNumValue = SourceNumRef::getDefault(state, defValue);
     if (SourceNumRef(srcNumValue).isSource())
-      cboValue->setCurrentIndex(cboValue->count() / 2);
+      cboValue->setCurrentIndex(cboValue->findData(srcNumValue));
+    else
+      sbxValue->setValue(srcNumValue);
     update();
   }
 }

--- a/companion/src/firmwares/sourcenumref.cpp
+++ b/companion/src/firmwares/sourcenumref.cpp
@@ -29,7 +29,7 @@ QString SourceNumRef::toString(const ModelData * model, const GeneralSettings * 
   if (srcNum.type == SOURCE_TYPE_NONE)
     return QString::number(srcNum.index);
   else
-    return srcNum.toString(model, generalSettings, board, prefixCustomName, false);
+    return srcNum.toString(model, generalSettings, board, prefixCustomName);
 }
 
 // static

--- a/companion/src/firmwares/sourcenumref.cpp
+++ b/companion/src/firmwares/sourcenumref.cpp
@@ -29,7 +29,7 @@ QString SourceNumRef::toString(const ModelData * model, const GeneralSettings * 
   if (srcNum.type == SOURCE_TYPE_NONE)
     return QString::number(srcNum.index);
   else
-    return srcNum.toString(model, generalSettings, board, prefixCustomName);
+    return srcNum.toString(model, generalSettings, board, prefixCustomName, false);
 }
 
 // static

--- a/companion/src/firmwares/sourcenumref.h
+++ b/companion/src/firmwares/sourcenumref.h
@@ -73,11 +73,14 @@ class SourceNumRefEditor : public QObject {
 
     virtual ~SourceNumRefEditor() {}
 
+    void setLock(bool state) { lock = state; }
+    void setVisible(bool state);
+    void update();
+
   signals:
     void resized();
 
   protected slots:
-    void update();
     void chkUseSourceChanged(int state);
     void sbxValueChanged();
     void cboValueChanged(int index);

--- a/companion/src/firmwares/sourcenumref.h
+++ b/companion/src/firmwares/sourcenumref.h
@@ -56,7 +56,7 @@ class SourceNumRef {
 
     const bool isNumber() const { return srcNum.type == SOURCE_TYPE_NONE; }
     const bool isSource() const { return srcNum.type != SOURCE_TYPE_NONE; }
-    static int getDefault(int useSource);
+    static int getDefault(int useSource, int dflt = 0);
 
   private:
     RawSource srcNum;
@@ -87,6 +87,7 @@ class SourceNumRefEditor : public QObject {
     QCheckBox *chkUseSource;
     QSpinBox *sbxValue;
     QComboBox *cboValue;
+    int defValue;
     ModelData & model;
     bool lock;
 };

--- a/companion/src/firmwares/sourcenumref.h
+++ b/companion/src/firmwares/sourcenumref.h
@@ -56,7 +56,7 @@ class SourceNumRef {
 
     const bool isNumber() const { return srcNum.type == SOURCE_TYPE_NONE; }
     const bool isSource() const { return srcNum.type != SOURCE_TYPE_NONE; }
-    static int getDefault(int useSource, int dflt = 0);
+    static int getDefault(int useSource, int dflt);
 
   private:
     RawSource srcNum;
@@ -88,6 +88,6 @@ class SourceNumRefEditor : public QObject {
     QSpinBox *sbxValue;
     QComboBox *cboValue;
     int defValue;
-    ModelData & model;
+    ModelData &model;
     bool lock;
 };

--- a/companion/src/firmwares/sourcenumref.h
+++ b/companion/src/firmwares/sourcenumref.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include "rawsource.h"
+
+#include <QtCore>
+#include <QCheckBox>
+#include <QComboBox>
+#include <QSpinBox>
+
+class FilteredItemModel;
+
+/*
+  This class takes advantage of RawSource's assumption that small values must be SOURCE_TYPE_NONE ie zero
+  albeit anything other than value zero is unexpected. However there is no setter validation to stop unknown values.
+
+  Also SOURCE_TYPE_NONE must be excluded from selection lists.
+  It would not make sense anyway as it equates to value 0 and thus ambiguous.
+*/
+
+class SourceNumRef {
+
+  Q_DECLARE_TR_FUNCTIONS(SourceNumRef)
+
+  public:
+    SourceNumRef() : srcNum(RawSource()) {}
+    explicit SourceNumRef(int value) : srcNum(RawSource(value)) {}
+    SourceNumRef(RawSourceType type, int index = 0) : srcNum(RawSource(type, index)) {}
+
+    virtual ~SourceNumRef() {}
+
+    int toValue() { return srcNum.toValue(); }
+
+    QString toString(const ModelData * model = nullptr, const GeneralSettings * const generalSettings = nullptr,
+                     Board::Type board = Board::BOARD_UNKNOWN, bool prefixCustomName = true) const;
+
+    const bool isNumber() const { return srcNum.type == SOURCE_TYPE_NONE; }
+    const bool isSource() const { return srcNum.type != SOURCE_TYPE_NONE; }
+    static int getDefault(int useSource);
+
+  private:
+    RawSource srcNum;
+};
+
+class SourceNumRefEditor : public QObject {
+
+  Q_OBJECT
+
+  public:
+    explicit SourceNumRefEditor(int & srcNumValue, QCheckBox * chkUseSource, QSpinBox * sbxValue, QComboBox * cboValue,
+                                int defValue, int minValue, int maxValue, int step,
+                                ModelData & model, FilteredItemModel * sourceItemModel, QObject * parent = nullptr);
+
+    virtual ~SourceNumRefEditor() {}
+
+  signals:
+    void resized();
+
+  protected slots:
+    void update();
+    void chkUseSourceChanged(int state);
+    void sbxValueChanged();
+    void cboValueChanged(int index);
+
+  protected:
+    int &srcNumValue;
+    QCheckBox *chkUseSource;
+    QSpinBox *sbxValue;
+    QComboBox *cboValue;
+    ModelData & model;
+    bool lock;
+};

--- a/companion/src/helpers.cpp
+++ b/companion/src/helpers.cpp
@@ -324,6 +324,37 @@ void Helpers::setBitmappedValue(unsigned int & field, unsigned int value, unsign
   field = (field & ~fieldmask) | (value << (numbits * index + offset));
 }
 
+// return index of 'none' ie zero or first positive data entry in potentially an asymetrical list
+int Helpers::getFirstPosValueIndex(QComboBox * cbo)
+{
+  const int cnt = cbo->count();
+  if (cnt == 0)
+    return -1;
+
+  const int idx = cnt / 2;
+  const int val = cbo->itemData(idx).toInt();
+
+  if (val == 0)
+    return idx;
+
+  const int step = val > 0 ? -1 : 1;
+
+  for (int i = idx + step; i >= 0 && i < cbo->count(); i += step) {
+    if (cbo->findData(i) == 0)
+      return i;
+    else if (step < 0 && cbo->itemData(i).toInt() < 0) {
+      if (i++ < cbo->count())
+        return i++;
+      else
+        return -1;
+    }
+    else if (step > 0 && cbo->itemData(i).toInt() > 0)
+      return i;
+  }
+
+  return -1;
+}
+
 #ifdef __APPLE__
 // Flag when simulator is running
 static bool simulatorRunning = false;

--- a/companion/src/helpers.h
+++ b/companion/src/helpers.h
@@ -30,6 +30,7 @@
 #include <QElapsedTimer>
 #include <QStandardItemModel>
 #include <QDialog>
+#include <QComboBox>
 
 extern const QColor colors[CPN_MAX_CURVES];
 
@@ -117,6 +118,7 @@ namespace Helpers
   QString removeAccents(const QString & str);
   unsigned int getBitmappedValue(const unsigned int & field, const unsigned int index = 0, const unsigned int numbits = 1, const unsigned int offset = 0);
   void setBitmappedValue(unsigned int & field, unsigned int value, unsigned int index = 0, unsigned int numbits = 1, unsigned int offset = 0);
+  int getFirstPosValueIndex(QComboBox * cbo);
 
 }  // namespace Helpers
 

--- a/companion/src/modeledit/channels.h
+++ b/companion/src/modeledit/channels.h
@@ -70,7 +70,6 @@ class ChannelsPanel : public ModelPanel
     void symlimitsEdited();
     void nameEdited();
     void invEdited();
-    void curveEdited();
     void ppmcenterEdited();
     void update();
     void updateLine(int index);
@@ -86,7 +85,6 @@ class ChannelsPanel : public ModelPanel
     void onCustomContextMenuRequested(QPoint pos);
     void onItemModelAboutToBeUpdated();
     void onItemModelUpdateComplete();
-    void on_curveImageDoubleClicked();
 
   private:
     QLineEdit *name[CPN_MAX_CHNOUT];
@@ -102,6 +100,8 @@ class ChannelsPanel : public ModelPanel
     int chnCapability;
     CompoundItemModelFactory *sharedItemModels;
     FilteredItemModelFactory *dialogFilteredItemModels;
+    CurveRefFilteredFactory *curveRefFilteredItemModels;
+    CurveReferenceUIManager *curveGroup[CPN_MAX_CHNOUT];
 
     bool hasClipboardData(QByteArray * data = nullptr) const;
     bool insertAllowed() const;

--- a/companion/src/modeledit/curves.cpp
+++ b/companion/src/modeledit/curves.cpp
@@ -55,7 +55,7 @@ CurvesPanel::CurvesPanel(QWidget * parent, ModelData & model, GeneralSettings & 
     tableLayout->addWidget(i, col++, label);
 
     image[i] = new CurveImageWidget(this);
-    image[i]->set(&model, firmware, sharedItemModels, i, colors[i], 3);
+    image[i]->set(&model, firmware, sharedItemModels, i + 1, colors[i], 3);
     image[i]->setGrid(Qt::gray, 2);
     image[i]->setProperty("index", i);
     image[i]->setFixedSize(QSize(100, 100));

--- a/companion/src/modeledit/expodialog.cpp
+++ b/companion/src/modeledit/expodialog.cpp
@@ -51,7 +51,7 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
   RawSourceType srcType = (firmware->getCapability(VirtualInputs) ? SOURCE_TYPE_VIRTUAL_INPUT : SOURCE_TYPE_INPUT);
   setWindowTitle(tr("Edit %1").arg(RawSource(srcType, ed->chn).toString(&model, &generalSettings)));
 
-  int imId = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_SourceValues),
+  int imId = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_RawSource),
                                 (RawSource::AllSourceGroups & ~RawSource::NoneGroup & ~RawSource::ScriptsGroup & ~RawSource::InputsGroup)),
                                 "EditorSource");
 

--- a/companion/src/modeledit/expodialog.cpp
+++ b/companion/src/modeledit/expodialog.cpp
@@ -52,8 +52,8 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
   setWindowTitle(tr("Edit %1").arg(RawSource(srcType, ed->chn).toString(&model, &generalSettings)));
 
   int imId = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_RawSource),
-                                                                           (RawSource::InputSourceGroups & ~RawSource::NoneGroup)),
-                                                     "EditorSource");
+                                (RawSource::AllSourceGroups & ~RawSource::NoneGroup & ~RawSource::ScriptsGroup & ~RawSource::InputsGroup)),
+                                "EditorSource");
 
   weightEditor = new SourceNumRefEditor(ed->weight, ui->chkWeightUseSource, ui->sbWeightValue, ui->cboWeightSource, 100, -100, 100, 1.0,
                                         model, dialogFilteredItemModels->getItemModel(imId));

--- a/companion/src/modeledit/expodialog.cpp
+++ b/companion/src/modeledit/expodialog.cpp
@@ -190,6 +190,7 @@ ExpoDialog::~ExpoDialog()
   delete weightEditor;
   delete offsetEditor;
   delete dialogFilteredItemModels;
+  delete curveRefFilteredItemModels;
 }
 
 void ExpoDialog::updateScale()

--- a/companion/src/modeledit/expodialog.cpp
+++ b/companion/src/modeledit/expodialog.cpp
@@ -51,7 +51,7 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
   RawSourceType srcType = (firmware->getCapability(VirtualInputs) ? SOURCE_TYPE_VIRTUAL_INPUT : SOURCE_TYPE_INPUT);
   setWindowTitle(tr("Edit %1").arg(RawSource(srcType, ed->chn).toString(&model, &generalSettings)));
 
-  int imId = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_RawSource),
+  int imId = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_SourceValues),
                                 (RawSource::AllSourceGroups & ~RawSource::NoneGroup & ~RawSource::ScriptsGroup & ~RawSource::InputsGroup)),
                                 "EditorSource");
 

--- a/companion/src/modeledit/expodialog.cpp
+++ b/companion/src/modeledit/expodialog.cpp
@@ -1,7 +1,8 @@
 /*
- * Copyright (C) OpenTX
+ * Copyright (C) EdgeTX
  *
  * Based on code named
+ *   opentx - https://github.com/opentx/opentx
  *   th9x - http://code.google.com/p/th9x
  *   er9x - http://code.google.com/p/er9x
  *   gruvin9x - http://code.google.com/p/gruvin9x
@@ -23,6 +24,7 @@
 #include "filtereditemmodels.h"
 #include "helpers.h"
 #include "namevalidator.h"
+#include "sourcenumref.h"
 
 ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, GeneralSettings & generalSettings,
                        Firmware * firmware, QString & inputName, CompoundItemModelFactory * sharedItemModels) :
@@ -33,14 +35,12 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
   firmware(firmware),
   ed(expoData),
   inputName(inputName),
-  modelPrinter(firmware, generalSettings, model),
   lock(false)
 {
   ui->setupUi(this);
 
   Board::Type board = firmware->getBoard();
   dialogFilteredItemModels = new FilteredItemModelFactory();
-  int id;
 
   QLabel * lb_fp[CPN_MAX_FLIGHT_MODES] = {ui->lb_FP0, ui->lb_FP1, ui->lb_FP2, ui->lb_FP3, ui->lb_FP4, ui->lb_FP5, ui->lb_FP6, ui->lb_FP7, ui->lb_FP8 };
   QCheckBox * tmp[CPN_MAX_FLIGHT_MODES] = {ui->cb_FP0, ui->cb_FP1, ui->cb_FP2, ui->cb_FP3, ui->cb_FP4, ui->cb_FP5, ui->cb_FP6, ui->cb_FP7, ui->cb_FP8 };
@@ -51,17 +51,20 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
   RawSourceType srcType = (firmware->getCapability(VirtualInputs) ? SOURCE_TYPE_VIRTUAL_INPUT : SOURCE_TYPE_INPUT);
   setWindowTitle(tr("Edit %1").arg(RawSource(srcType, ed->chn).toString(&model, &generalSettings)));
 
-  id = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_GVarRef)), "GVarRef");
-  gvWeightGroup = new GVarGroup(ui->weightGV, ui->weightSB, ui->weightCB, ed->weight, model, 100, -100, 100, 1.0,
-                                dialogFilteredItemModels->getItemModel(id));
+  int imId = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_RawSource),
+                                                                           (RawSource::InputSourceGroups & ~RawSource::NoneGroup)),
+                                                     "EditorSource");
 
-  gvOffsetGroup = new GVarGroup(ui->offsetGV, ui->offsetSB, ui->offsetCB, ed->offset, model, 0, -100, 100, 1.0,
-                                dialogFilteredItemModels->getItemModel(id));
+  weightEditor = new SourceNumRefEditor(ed->weight, ui->chkWeightUseSource, ui->sbWeightValue, ui->cboWeightSource, 100, -100, 100, 1.0,
+                                        model, dialogFilteredItemModels->getItemModel(imId));
+
+  offsetEditor = new SourceNumRefEditor(ed->offset, ui->chkOffsetUseSource, ui->sbOffsetValue, ui->cboOffsetSource, 0, -100, 100, 1.0,
+                                        model, dialogFilteredItemModels->getItemModel(imId));
 
   curveRefFilteredItemModels = new CurveRefFilteredFactory(sharedItemModels,
                                                            firmware->getCapability(HasInputDiff) ? 0 : FilteredItemModel::PositiveFilter);
 
-  curveGroup = new CurveReferenceUIManager(ui->curveTypeCB, ui->curveGVarCB, ui->curveValueSB, ui->curveValueCB, ui->curveImage, ed->curve, model,
+  curveGroup = new CurveReferenceUIManager(ui->cboCurveType, ui->chkCurveUseSource, ui->sbCurveValue, ui->cboCurveFunc, ui->imgCurve, ed->curve, model,
                                            sharedItemModels, curveRefFilteredItemModels, this);
 
 
@@ -70,9 +73,9 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
           this->adjustSize(); // second call seems to be required when hidden fields otherwise not all padding removed
   });
 
-  id = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_RawSwitch),
+  imId = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_RawSwitch),
                                                                          RawSwitch::MixesContext), "RawSwitch");
-  ui->switchesCB->setModel(dialogFilteredItemModels->getItemModel(id));
+  ui->switchesCB->setModel(dialogFilteredItemModels->getItemModel(imId));
   ui->switchesCB->setCurrentIndex(ui->switchesCB->findData(ed->swtch.toValue()));
 
   ui->sideCB->setCurrentIndex(ed->mode - 1);
@@ -105,9 +108,9 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
     ui->inputName->setMaxLength(firmware->getCapability(InputsLength));
     int flags = RawSource::InputSourceGroups & ~RawSource::NoneGroup & ~RawSource::InputsGroup;
     flags |= RawSource::GVarsGroup | RawSource::TelemGroup;
-    id = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_RawSource),
+    imId = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_RawSource),
                                                      flags), "RawSource");
-    ui->sourceCB->setModel(dialogFilteredItemModels->getItemModel(id));
+    ui->sourceCB->setModel(dialogFilteredItemModels->getItemModel(imId));
     ui->sourceCB->setCurrentIndex(ui->sourceCB->findData(ed->srcRaw.toValue()));
     if (ui->sourceCB->currentIndex() < 0 && ed->srcRaw.toValue() == 0)
       ui->sourceCB->setCurrentIndex(ui->sourceCB->count() / 2); // '----' not in list so set to first positive entry
@@ -170,8 +173,8 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
 ExpoDialog::~ExpoDialog()
 {
   delete ui;
-  delete gvWeightGroup;
-  delete gvOffsetGroup;
+  delete weightEditor;
+  delete offsetEditor;
   delete dialogFilteredItemModels;
 }
 

--- a/companion/src/modeledit/expodialog.cpp
+++ b/companion/src/modeledit/expodialog.cpp
@@ -55,17 +55,19 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
                                 (RawSource::AllSourceGroups & ~RawSource::NoneGroup & ~RawSource::ScriptsGroup & ~RawSource::InputsGroup)),
                                 "EditorSource");
 
+  FilteredItemModel *esMdl = dialogFilteredItemModels->getItemModel(imId);
+
   weightEditor = new SourceNumRefEditor(ed->weight, ui->chkWeightUseSource, ui->sbWeightValue, ui->cboWeightSource, 100, -100, 100, 1.0,
-                                        model, dialogFilteredItemModels->getItemModel(imId));
+                                        model, esMdl);
 
   offsetEditor = new SourceNumRefEditor(ed->offset, ui->chkOffsetUseSource, ui->sbOffsetValue, ui->cboOffsetSource, 0, -100, 100, 1.0,
-                                        model, dialogFilteredItemModels->getItemModel(imId));
+                                        model, esMdl);
 
   curveRefFilteredItemModels = new CurveRefFilteredFactory(sharedItemModels,
                                                            firmware->getCapability(HasInputDiff) ? 0 : FilteredItemModel::PositiveFilter);
 
-  curveGroup = new CurveReferenceUIManager(ui->cboCurveType, ui->chkCurveUseSource, ui->sbCurveValue, ui->cboCurveFunc, ui->imgCurve, ed->curve, model,
-                                           sharedItemModels, curveRefFilteredItemModels, this);
+  curveGroup = new CurveReferenceUIManager(ui->cboCurveType, ui->chkCurveUseSource, ui->sbCurveValue, ui->cboCurveSource, ui->cboCurveFunc,
+                                           ui->imgCurve, ed->curve, model, sharedItemModels, curveRefFilteredItemModels, esMdl, this);
 
 
   connect(curveGroup, &CurveReferenceUIManager::resized, this, [=] () {

--- a/companion/src/modeledit/expodialog.cpp
+++ b/companion/src/modeledit/expodialog.cpp
@@ -113,7 +113,7 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
     ui->sourceCB->setModel(dialogFilteredItemModels->getItemModel(imId));
     ui->sourceCB->setCurrentIndex(ui->sourceCB->findData(ed->srcRaw.toValue()));
     if (ui->sourceCB->currentIndex() < 0 && ed->srcRaw.toValue() == 0)
-      ui->sourceCB->setCurrentIndex(ui->sourceCB->count() / 2); // '----' not in list so set to first positive entry
+      ui->sourceCB->setCurrentIndex(Helpers::getFirstPosValueIndex(ui->sourceCB));
     ui->inputName->setValidator(new NameValidator(board, this));
     ui->inputName->setText(inputName);
   }

--- a/companion/src/modeledit/expodialog.cpp
+++ b/companion/src/modeledit/expodialog.cpp
@@ -60,8 +60,18 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
   weightEditor = new SourceNumRefEditor(ed->weight, ui->chkWeightUseSource, ui->sbWeightValue, ui->cboWeightSource, 100, -100, 100, 1.0,
                                         model, esMdl);
 
+  connect(weightEditor, &SourceNumRefEditor::resized, this, [=] () {
+          this->adjustSize();
+          this->adjustSize(); // second call seems to be required when hidden fields otherwise not all padding removed
+  });
+
   offsetEditor = new SourceNumRefEditor(ed->offset, ui->chkOffsetUseSource, ui->sbOffsetValue, ui->cboOffsetSource, 0, -100, 100, 1.0,
                                         model, esMdl);
+
+  connect(offsetEditor, &SourceNumRefEditor::resized, this, [=] () {
+          this->adjustSize();
+          this->adjustSize(); // second call seems to be required when hidden fields otherwise not all padding removed
+  });
 
   curveRefFilteredItemModels = new CurveRefFilteredFactory(sharedItemModels,
                                                            firmware->getCapability(HasInputDiff) ? 0 : FilteredItemModel::PositiveFilter);
@@ -77,6 +87,7 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
 
   imId = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_RawSwitch),
                                                                          RawSwitch::MixesContext), "RawSwitch");
+  ui->switchesCB->setSizeAdjustPolicy(QComboBox::AdjustToContents);
   ui->switchesCB->setModel(dialogFilteredItemModels->getItemModel(imId));
   ui->switchesCB->setCurrentIndex(ui->switchesCB->findData(ed->swtch.toValue()));
 
@@ -112,6 +123,7 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
     flags |= RawSource::GVarsGroup | RawSource::TelemGroup;
     imId = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_RawSource),
                                                      flags), "RawSource");
+    ui->sourceCB->setSizeAdjustPolicy(QComboBox::AdjustToContents);
     ui->sourceCB->setModel(dialogFilteredItemModels->getItemModel(imId));
     ui->sourceCB->setCurrentIndex(ui->sourceCB->findData(ed->srcRaw.toValue()));
     if (ui->sourceCB->currentIndex() < 0 && ed->srcRaw.toValue() == 0)

--- a/companion/src/modeledit/expodialog.cpp
+++ b/companion/src/modeledit/expodialog.cpp
@@ -60,18 +60,12 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
   weightEditor = new SourceNumRefEditor(ed->weight, ui->chkWeightUseSource, ui->sbWeightValue, ui->cboWeightSource, 100, -100, 100, 1.0,
                                         model, esMdl);
 
-  connect(weightEditor, &SourceNumRefEditor::resized, this, [=] () {
-          this->adjustSize();
-          this->adjustSize(); // second call seems to be required when hidden fields otherwise not all padding removed
-  });
+  connect(weightEditor, &SourceNumRefEditor::resized, this, [=] () { shrink(); });
 
   offsetEditor = new SourceNumRefEditor(ed->offset, ui->chkOffsetUseSource, ui->sbOffsetValue, ui->cboOffsetSource, 0, -100, 100, 1.0,
                                         model, esMdl);
 
-  connect(offsetEditor, &SourceNumRefEditor::resized, this, [=] () {
-          this->adjustSize();
-          this->adjustSize(); // second call seems to be required when hidden fields otherwise not all padding removed
-  });
+  connect(offsetEditor, &SourceNumRefEditor::resized, this, [=] () { shrink(); });
 
   curveRefFilteredItemModels = new CurveRefFilteredFactory(sharedItemModels,
                                                            firmware->getCapability(HasInputDiff) ? 0 : FilteredItemModel::PositiveFilter);
@@ -80,10 +74,7 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
                                            ui->imgCurve, ed->curve, model, sharedItemModels, curveRefFilteredItemModels, esMdl, this);
 
 
-  connect(curveGroup, &CurveReferenceUIManager::resized, this, [=] () {
-          this->adjustSize();
-          this->adjustSize(); // second call seems to be required when hidden fields otherwise not all padding removed
-  });
+  connect(curveGroup, &CurveReferenceUIManager::resized, this, [=] () { shrink(); });
 
   imId = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_RawSwitch),
                                                                          RawSwitch::MixesContext), "RawSwitch");
@@ -181,7 +172,7 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
     connect(ui->inputName, SIGNAL(editingFinished()), this, SLOT(valuesChanged()));
   }
 
-  adjustSize();
+  shrink();
 }
 
 ExpoDialog::~ExpoDialog()
@@ -295,4 +286,10 @@ void ExpoDialog::fmInvertAll()
   }
   lock = false;
   valuesChanged();
+}
+
+void ExpoDialog::shrink()
+{
+  this->adjustSize();
+  this->resize(0, 0);
 }

--- a/companion/src/modeledit/expodialog.h
+++ b/companion/src/modeledit/expodialog.h
@@ -1,7 +1,8 @@
 /*
- * Copyright (C) OpenTX
+ * Copyright (C) EdgeTX
  *
  * Based on code named
+ *   opentx - https://github.com/opentx/opentx
  *   th9x - http://code.google.com/p/th9x
  *   er9x - http://code.google.com/p/er9x
  *   gruvin9x - http://code.google.com/p/gruvin9x
@@ -20,15 +21,15 @@
 
 #pragma once
 
-#include <QtWidgets>
 #include "eeprominterface.h"
-#include "modelprinter.h"
 
-class GVarGroup;
+#include <QtWidgets>
+
 class CompoundItemModelFactory;
 class FilteredItemModelFactory;
 class CurveRefFilteredFactory;
 class CurveReferenceUIManager;
+class SourceNumRefEditor;
 
 namespace Ui {
   class ExpoDialog;
@@ -58,10 +59,9 @@ class ExpoDialog : public QDialog {
     Firmware * firmware;
     ExpoData * ed;
     QString & inputName;
-    GVarGroup * gvWeightGroup;
-    GVarGroup * gvOffsetGroup;
+    SourceNumRefEditor * weightEditor;
+    SourceNumRefEditor * offsetEditor;
     CurveReferenceUIManager * curveGroup;
-    ModelPrinter modelPrinter;
     bool lock;
     QCheckBox * cb_fp[CPN_MAX_FLIGHT_MODES];
     FilteredItemModelFactory *dialogFilteredItemModels;

--- a/companion/src/modeledit/expodialog.h
+++ b/companion/src/modeledit/expodialog.h
@@ -67,4 +67,6 @@ class ExpoDialog : public QDialog {
     FilteredItemModelFactory *dialogFilteredItemModels;
     CurveRefFilteredFactory *curveRefFilteredItemModels;
     int carryTrimFilterFlags = 0;
+
+    void shrink();
 };

--- a/companion/src/modeledit/expodialog.ui
+++ b/companion/src/modeledit/expodialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>669</width>
-    <height>497</height>
+    <width>671</width>
+    <height>490</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -29,17 +29,445 @@
    <iconset resource="../companion.qrc">
     <normaloff>:/icon.png</normaloff>:/icon.png</iconset>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="0">
-    <widget class="QLabel" name="lblScale">
-     <property name="text">
-      <string>Scale</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
-     <item>
+  <layout class="QGridLayout" name="gridLayout_3">
+   <item row="0" column="0">
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="2" column="0">
+      <widget class="QLabel" name="sourceLabel">
+       <property name="text">
+        <string>Source</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Weight</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="trimLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Include Trim</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="lblScale">
+       <property name="text">
+        <string>Scale</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="lineNameLabel">
+       <property name="text">
+        <string>Line name</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="inputNameLabel">
+       <property name="text">
+        <string>Input name</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="label_phases">
+       <property name="text">
+        <string>Flight modes</string>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="0">
+      <widget class="QLabel" name="sideLabel">
+       <property name="text">
+        <string>Stick Side</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="0">
+      <widget class="QLabel" name="label_curves">
+       <property name="text">
+        <string>Curve</string>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="offsetLabel">
+       <property name="text">
+        <string>Offset</string>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Switch</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1" colspan="2">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <item>
+        <widget class="QDoubleSpinBox" name="dsbScale">
+         <property name="whatsThis">
+          <string/>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+         </property>
+         <property name="decimals">
+          <number>1</number>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="lblScaleUnit">
+         <property name="text">
+          <string>unit</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="5" column="1" colspan="3">
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QCheckBox" name="chkWeightUseSource">
+         <property name="text">
+          <string>Source</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSpinBox" name="sbWeightValue"/>
+       </item>
+       <item>
+        <widget class="QComboBox" name="cboWeightSource">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="whatsThis">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item row="8" column="1" colspan="4">
+      <layout class="QGridLayout" name="gridLayout_2">
+       <item row="0" column="1">
+        <widget class="QLabel" name="lb_FP1">
+         <property name="text">
+          <string notr="true">1</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="6">
+        <widget class="QLabel" name="lb_FP6">
+         <property name="text">
+          <string notr="true">6</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QCheckBox" name="cb_FP1">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="7">
+        <widget class="QLabel" name="lb_FP7">
+         <property name="text">
+          <string notr="true">7</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="lb_FP0">
+         <property name="text">
+          <string notr="true">0</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="3">
+        <widget class="QCheckBox" name="cb_FP3">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QCheckBox" name="cb_FP0">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="8">
+        <widget class="QCheckBox" name="cb_FP8">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="6">
+        <widget class="QCheckBox" name="cb_FP6">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="4">
+        <widget class="QCheckBox" name="cb_FP4">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="8">
+        <widget class="QLabel" name="lb_FP8">
+         <property name="text">
+          <string notr="true">8</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="QCheckBox" name="cb_FP2">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <widget class="QLabel" name="lb_FP2">
+         <property name="text">
+          <string notr="true">2</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="4">
+        <widget class="QLabel" name="lb_FP4">
+         <property name="text">
+          <string notr="true">4</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="5">
+        <widget class="QLabel" name="lb_FP5">
+         <property name="text">
+          <string notr="true">5</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="5">
+        <widget class="QCheckBox" name="cb_FP5">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="7">
+        <widget class="QCheckBox" name="cb_FP7">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="3">
+        <widget class="QLabel" name="lb_FP3">
+         <property name="text">
+          <string notr="true">3</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="9">
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item row="7" column="1" colspan="4">
+      <layout class="QHBoxLayout" name="horizontalLayout_4">
+       <item>
+        <widget class="QComboBox" name="cboCurveType">
+         <property name="toolTip">
+          <string/>
+         </property>
+         <property name="whatsThis">
+          <string>Curve applied to the source.</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="chkCurveUseSource">
+         <property name="text">
+          <string>Source</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSpinBox" name="sbCurveValue"/>
+       </item>
+       <item>
+        <widget class="QComboBox" name="cboCurveFunc"/>
+       </item>
+       <item>
+        <widget class="QComboBox" name="cboCurveSource">
+         <property name="whatsThis">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="CurveImageWidget" name="imgCurve">
+         <property name="minimumSize">
+          <size>
+           <width>100</width>
+           <height>100</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>100</width>
+           <height>100</height>
+          </size>
+         </property>
+         <property name="text">
+          <string>image</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_5">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item row="6" column="1" colspan="3">
+      <layout class="QHBoxLayout" name="horizontalLayout_3">
+       <item>
+        <widget class="QCheckBox" name="chkOffsetUseSource">
+         <property name="text">
+          <string>Source</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QSpinBox" name="sbOffsetValue"/>
+       </item>
+       <item>
+        <widget class="QComboBox" name="cboOffsetSource">
+         <property name="minimumSize">
+          <size>
+           <width>0</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>16777215</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="whatsThis">
+          <string>The source for the mixer</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item row="0" column="1">
       <widget class="QLineEdit" name="inputName">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -49,24 +477,17 @@
        </property>
       </widget>
      </item>
-     <item>
-      <spacer name="horizontalSpacer_9">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="lineName">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
+      </widget>
      </item>
-    </layout>
-   </item>
-   <item row="7" column="1" rowspan="2">
-    <layout class="QHBoxLayout" name="includeTrimLayout" stretch="0,0">
-     <item>
+     <item row="4" column="1">
       <widget class="QComboBox" name="trimCB">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -76,24 +497,10 @@
        </property>
       </widget>
      </item>
-     <item>
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
+     <item row="9" column="1">
+      <widget class="QComboBox" name="switchesCB"/>
      </item>
-    </layout>
-   </item>
-   <item row="15" column="1">
-    <layout class="QHBoxLayout" name="sideLayout">
-     <item>
+     <item row="10" column="1">
       <widget class="QComboBox" name="sideCB">
        <item>
         <property name="text">
@@ -112,430 +519,12 @@
        </item>
       </widget>
      </item>
-     <item>
-      <spacer name="horizontalSpacer_6">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
+     <item row="2" column="1">
+      <widget class="QComboBox" name="sourceCB"/>
      </item>
     </layout>
-   </item>
-   <item row="14" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Switch</string>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="1">
-    <layout class="QHBoxLayout" name="weightLayout" stretch="0,0,1,0">
-     <item>
-      <widget class="QCheckBox" name="chkWeightUseSource">
-       <property name="text">
-        <string>Source</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSpinBox" name="sbWeightValue"/>
-     </item>
-     <item>
-      <widget class="QComboBox" name="cboWeightSource">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>350</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="whatsThis">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item row="10" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Weight</string>
-     </property>
-    </widget>
    </item>
    <item row="1" column="0">
-    <widget class="QLabel" name="lineNameLabel">
-     <property name="text">
-      <string>Line name</string>
-     </property>
-    </widget>
-   </item>
-   <item row="15" column="0">
-    <widget class="QLabel" name="sideLabel">
-     <property name="text">
-      <string>Stick Side</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <layout class="QHBoxLayout" name="scaleLayout">
-     <item>
-      <widget class="QDoubleSpinBox" name="dsbScale">
-       <property name="whatsThis">
-        <string/>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="decimals">
-        <number>1</number>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLabel" name="lblScaleUnit">
-       <property name="text">
-        <string>unit</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item row="13" column="0">
-    <widget class="QLabel" name="label_phases">
-     <property name="text">
-      <string>Flight modes</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_2">
-     <item>
-      <widget class="QLineEdit" name="lineName">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_8">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item row="12" column="1">
-    <layout class="QHBoxLayout" name="curveLayout" stretch="1,0,1,0,0,0,0">
-     <item>
-      <widget class="QComboBox" name="cboCurveType">
-       <property name="toolTip">
-        <string/>
-       </property>
-       <property name="whatsThis">
-        <string>Curve applied to the source.</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QCheckBox" name="chkCurveUseSource">
-       <property name="text">
-        <string>Source</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="cboCurveSource">
-       <property name="whatsThis">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSpinBox" name="sbCurveValue"/>
-     </item>
-     <item>
-      <widget class="QComboBox" name="cboCurveFunc"/>
-     </item>
-     <item>
-      <widget class="CurveImageWidget" name="imgCurve">
-       <property name="minimumSize">
-        <size>
-         <width>100</width>
-         <height>100</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>100</width>
-         <height>100</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>image</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_4">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item row="7" column="0" rowspan="2">
-    <widget class="QLabel" name="trimLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Include Trim</string>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="1">
-    <layout class="QGridLayout" name="flightModesLayout">
-     <item row="1" column="7">
-      <widget class="QCheckBox" name="cb_FP7">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="6">
-      <widget class="QLabel" name="lb_FP6">
-       <property name="text">
-        <string notr="true">6</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLabel" name="lb_FP1">
-       <property name="text">
-        <string notr="true">1</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="3">
-      <widget class="QLabel" name="lb_FP3">
-       <property name="text">
-        <string notr="true">3</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QCheckBox" name="cb_FP0">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="0">
-      <widget class="QLabel" name="lb_FP0">
-       <property name="text">
-        <string notr="true">0</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="8">
-      <widget class="QLabel" name="lb_FP8">
-       <property name="text">
-        <string notr="true">8</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="2">
-      <widget class="QCheckBox" name="cb_FP2">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="8">
-      <widget class="QCheckBox" name="cb_FP8">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="5">
-      <widget class="QCheckBox" name="cb_FP5">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="4">
-      <widget class="QCheckBox" name="cb_FP4">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="3">
-      <widget class="QCheckBox" name="cb_FP3">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QCheckBox" name="cb_FP1">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="7">
-      <widget class="QLabel" name="lb_FP7">
-       <property name="text">
-        <string notr="true">7</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="5">
-      <widget class="QLabel" name="lb_FP5">
-       <property name="text">
-        <string notr="true">5</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="4">
-      <widget class="QLabel" name="lb_FP4">
-       <property name="text">
-        <string notr="true">4</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="2">
-      <widget class="QLabel" name="lb_FP2">
-       <property name="text">
-        <string notr="true">2</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="6">
-      <widget class="QCheckBox" name="cb_FP6">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="9">
-      <spacer name="horizontalSpacer_10">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item row="11" column="0">
-    <widget class="QLabel" name="offsetLabel">
-     <property name="text">
-      <string>Offset</string>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="0">
-    <widget class="QLabel" name="label_curves">
-     <property name="text">
-      <string>Curve</string>
-     </property>
-    </widget>
-   </item>
-   <item row="16" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="minimumSize">
       <size>
@@ -554,109 +543,6 @@
      </property>
     </widget>
    </item>
-   <item row="14" column="1">
-    <layout class="QHBoxLayout" name="switchLayout">
-     <item>
-      <widget class="QComboBox" name="switchesCB"/>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_5">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item row="2" column="1">
-    <layout class="QHBoxLayout" name="sourceLayout">
-     <item>
-      <widget class="QComboBox" name="sourceCB"/>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_7">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item row="11" column="1">
-    <layout class="QHBoxLayout" name="offsetLayout" stretch="0,0,1,0">
-     <item>
-      <widget class="QCheckBox" name="chkOffsetUseSource">
-       <property name="text">
-        <string>Source</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSpinBox" name="sbOffsetValue"/>
-     </item>
-     <item>
-      <widget class="QComboBox" name="cboOffsetSource">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="whatsThis">
-        <string>The source for the mixer</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="offsetSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Expanding</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>0</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="sourceLabel">
-     <property name="text">
-      <string>Source</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="inputNameLabel">
-     <property name="text">
-      <string>Input name</string>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -667,17 +553,6 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>dsbScale</tabstop>
-  <tabstop>chkWeightUseSource</tabstop>
-  <tabstop>sbWeightValue</tabstop>
-  <tabstop>cboWeightSource</tabstop>
-  <tabstop>chkOffsetUseSource</tabstop>
-  <tabstop>sbOffsetValue</tabstop>
-  <tabstop>cboOffsetSource</tabstop>
-  <tabstop>cboCurveType</tabstop>
-  <tabstop>chkCurveUseSource</tabstop>
-  <tabstop>cboCurveSource</tabstop>
-  <tabstop>sbCurveValue</tabstop>
   <tabstop>cb_FP0</tabstop>
   <tabstop>cb_FP1</tabstop>
   <tabstop>cb_FP2</tabstop>
@@ -686,7 +561,6 @@
   <tabstop>cb_FP5</tabstop>
   <tabstop>cb_FP6</tabstop>
   <tabstop>cb_FP7</tabstop>
-  <tabstop>cb_FP8</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources>

--- a/companion/src/modeledit/expodialog.ui
+++ b/companion/src/modeledit/expodialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>623</width>
+    <width>669</width>
     <height>487</height>
    </rect>
   </property>
@@ -140,7 +140,7 @@
        </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>120</width>
+         <width>200</width>
          <height>20</height>
         </size>
        </property>
@@ -361,7 +361,7 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</string
     </widget>
    </item>
    <item row="12" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0,1,0,0,0">
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0,1,0,0,0,0">
      <item>
       <widget class="QComboBox" name="cboCurveType">
        <property name="toolTip">
@@ -410,6 +410,19 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</string
         <string>image</string>
        </property>
       </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>200</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
      </item>
     </layout>
    </item>
@@ -475,7 +488,7 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</string
        </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>120</width>
+         <width>200</width>
          <height>0</height>
         </size>
        </property>

--- a/companion/src/modeledit/expodialog.ui
+++ b/companion/src/modeledit/expodialog.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>669</width>
-    <height>487</height>
+    <height>497</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -30,51 +30,27 @@
     <normaloff>:/icon.png</normaloff>:/icon.png</iconset>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="10" column="0">
-    <widget class="QLabel" name="label_3">
+   <item row="3" column="0">
+    <widget class="QLabel" name="lblScale">
      <property name="text">
-      <string>Weight</string>
+      <string>Scale</string>
      </property>
     </widget>
    </item>
-   <item row="12" column="0">
-    <widget class="QLabel" name="label_curves">
-     <property name="text">
-      <string>Curve</string>
-     </property>
-    </widget>
-   </item>
-   <item row="16" column="0">
-    <widget class="QLabel" name="sideLabel">
-     <property name="text">
-      <string>Stick Side</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
+   <item row="0" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
-      <widget class="QDoubleSpinBox" name="dsbScale">
-       <property name="whatsThis">
-        <string/>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="decimals">
-        <number>1</number>
+      <widget class="QLineEdit" name="inputName">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QLabel" name="lblScaleUnit">
-       <property name="text">
-        <string>unit</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_2">
+      <spacer name="horizontalSpacer_9">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
@@ -88,22 +64,78 @@
      </item>
     </layout>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="lblScale">
-     <property name="text">
-      <string>Scale</string>
-     </property>
-    </widget>
+   <item row="7" column="1" rowspan="2">
+    <layout class="QHBoxLayout" name="includeTrimLayout" stretch="0,0">
+     <item>
+      <widget class="QComboBox" name="trimCB">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="sourceLabel">
+   <item row="15" column="1">
+    <layout class="QHBoxLayout" name="sideLayout">
+     <item>
+      <widget class="QComboBox" name="sideCB">
+       <item>
+        <property name="text">
+         <string>NEG</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>POS</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>ALL</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_6">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="14" column="0">
+    <widget class="QLabel" name="label">
      <property name="text">
-      <string>Source</string>
+      <string>Switch</string>
      </property>
     </widget>
    </item>
    <item row="10" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0,1,0">
+    <layout class="QHBoxLayout" name="weightLayout" stretch="0,0,1,0">
      <item>
       <widget class="QCheckBox" name="chkWeightUseSource">
        <property name="text">
@@ -140,7 +172,7 @@
        </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>200</width>
+         <width>40</width>
          <height>20</height>
         </size>
        </property>
@@ -148,29 +180,10 @@
      </item>
     </layout>
    </item>
-   <item row="16" column="1">
-    <widget class="QComboBox" name="sideCB">
-     <item>
-      <property name="text">
-       <string>NEG</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>POS</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>ALL</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="14" column="0">
-    <widget class="QLabel" name="label_7">
+   <item row="10" column="0">
+    <widget class="QLabel" name="label_3">
      <property name="text">
-      <string>Switch</string>
+      <string>Weight</string>
      </property>
     </widget>
    </item>
@@ -181,187 +194,86 @@
      </property>
     </widget>
    </item>
-   <item row="13" column="1">
-    <layout class="QGridLayout" name="gridLayout_4">
-     <item row="0" column="0">
-      <widget class="QLabel" name="lb_FP0">
-       <property name="text">
-        <string notr="true">0</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLabel" name="lb_FP1">
-       <property name="text">
-        <string notr="true">1</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="2">
-      <widget class="QLabel" name="lb_FP2">
-       <property name="text">
-        <string notr="true">2</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="3">
-      <widget class="QLabel" name="lb_FP3">
-       <property name="text">
-        <string notr="true">3</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="4">
-      <widget class="QLabel" name="lb_FP4">
-       <property name="text">
-        <string notr="true">4</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="5">
-      <widget class="QLabel" name="lb_FP5">
-       <property name="text">
-        <string notr="true">5</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="6">
-      <widget class="QLabel" name="lb_FP6">
-       <property name="text">
-        <string notr="true">6</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="7">
-      <widget class="QLabel" name="lb_FP7">
-       <property name="text">
-        <string notr="true">7</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="8">
-      <widget class="QLabel" name="lb_FP8">
-       <property name="text">
-        <string notr="true">8</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QCheckBox" name="cb_FP0">
-       <property name="text">
+   <item row="15" column="0">
+    <widget class="QLabel" name="sideLabel">
+     <property name="text">
+      <string>Stick Side</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <layout class="QHBoxLayout" name="scaleLayout">
+     <item>
+      <widget class="QDoubleSpinBox" name="dsbScale">
+       <property name="whatsThis">
         <string/>
        </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QCheckBox" name="cb_FP1">
-       <property name="text">
-        <string/>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="decimals">
+        <number>1</number>
        </property>
       </widget>
      </item>
-     <item row="1" column="2">
-      <widget class="QCheckBox" name="cb_FP2">
+     <item>
+      <widget class="QLabel" name="lblScaleUnit">
        <property name="text">
-        <string/>
+        <string>unit</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="3">
-      <widget class="QCheckBox" name="cb_FP3">
-       <property name="text">
-        <string/>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
        </property>
-      </widget>
-     </item>
-     <item row="1" column="4">
-      <widget class="QCheckBox" name="cb_FP4">
-       <property name="text">
-        <string/>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
        </property>
-      </widget>
-     </item>
-     <item row="1" column="5">
-      <widget class="QCheckBox" name="cb_FP5">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="6">
-      <widget class="QCheckBox" name="cb_FP6">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="7">
-      <widget class="QCheckBox" name="cb_FP7">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="8">
-      <widget class="QCheckBox" name="cb_FP8">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
+      </spacer>
      </item>
     </layout>
    </item>
-   <item row="14" column="1">
-    <widget class="QComboBox" name="switchesCB">
-     <property name="whatsThis">
-      <string>Switch used to enable the line.
-If blank then the input is considered to be &quot;ON&quot; all the time.</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="inputNameLabel">
+   <item row="13" column="0">
+    <widget class="QLabel" name="label_phases">
      <property name="text">
-      <string>Input name</string>
+      <string>Flight modes</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QComboBox" name="sourceCB">
-     <property name="whatsThis">
-      <string>Source for the mixer.</string>
-     </property>
-    </widget>
+   <item row="1" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QLineEdit" name="lineName">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_8">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
    <item row="12" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0,1,0,0,0,0">
+    <layout class="QHBoxLayout" name="curveLayout" stretch="1,0,1,0,0,0,0">
      <item>
       <widget class="QComboBox" name="cboCurveType">
        <property name="toolTip">
@@ -418,7 +330,7 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</string
        </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>200</width>
+         <width>40</width>
          <height>20</height>
         </size>
        </property>
@@ -426,19 +338,188 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</string
      </item>
     </layout>
    </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="lineName">
-     <property name="maxLength">
-      <number>6</number>
+   <item row="7" column="0" rowspan="2">
+    <widget class="QLabel" name="trimLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Include Trim</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
-    <widget class="QLineEdit" name="inputName">
-     <property name="maxLength">
-      <number>6</number>
-     </property>
-    </widget>
+   <item row="13" column="1">
+    <layout class="QGridLayout" name="flightModesLayout">
+     <item row="1" column="7">
+      <widget class="QCheckBox" name="cb_FP7">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="6">
+      <widget class="QLabel" name="lb_FP6">
+       <property name="text">
+        <string notr="true">6</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="lb_FP1">
+       <property name="text">
+        <string notr="true">1</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3">
+      <widget class="QLabel" name="lb_FP3">
+       <property name="text">
+        <string notr="true">3</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QCheckBox" name="cb_FP0">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="lb_FP0">
+       <property name="text">
+        <string notr="true">0</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="8">
+      <widget class="QLabel" name="lb_FP8">
+       <property name="text">
+        <string notr="true">8</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QCheckBox" name="cb_FP2">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="8">
+      <widget class="QCheckBox" name="cb_FP8">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="5">
+      <widget class="QCheckBox" name="cb_FP5">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="4">
+      <widget class="QCheckBox" name="cb_FP4">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="3">
+      <widget class="QCheckBox" name="cb_FP3">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QCheckBox" name="cb_FP1">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="7">
+      <widget class="QLabel" name="lb_FP7">
+       <property name="text">
+        <string notr="true">7</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="5">
+      <widget class="QLabel" name="lb_FP5">
+       <property name="text">
+        <string notr="true">5</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="4">
+      <widget class="QLabel" name="lb_FP4">
+       <property name="text">
+        <string notr="true">4</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QLabel" name="lb_FP2">
+       <property name="text">
+        <string notr="true">2</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="6">
+      <widget class="QCheckBox" name="cb_FP6">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="9">
+      <spacer name="horizontalSpacer_10">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
    <item row="11" column="0">
     <widget class="QLabel" name="offsetLabel">
@@ -446,6 +527,72 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</string
       <string>Offset</string>
      </property>
     </widget>
+   </item>
+   <item row="12" column="0">
+    <widget class="QLabel" name="label_curves">
+     <property name="text">
+      <string>Curve</string>
+     </property>
+    </widget>
+   </item>
+   <item row="16" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>25</height>
+      </size>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>false</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="1">
+    <layout class="QHBoxLayout" name="switchLayout">
+     <item>
+      <widget class="QComboBox" name="switchesCB"/>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_5">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="1">
+    <layout class="QHBoxLayout" name="sourceLayout">
+     <item>
+      <widget class="QComboBox" name="sourceCB"/>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_7">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
    <item row="11" column="1">
     <layout class="QHBoxLayout" name="offsetLayout" stretch="0,0,1,0">
@@ -488,7 +635,7 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</string
        </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>200</width>
+         <width>40</width>
          <height>0</height>
         </size>
        </property>
@@ -496,69 +643,17 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</string
      </item>
     </layout>
    </item>
-   <item row="17" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>25</height>
-      </size>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-     <property name="centerButtons">
-      <bool>true</bool>
+   <item row="2" column="0">
+    <widget class="QLabel" name="sourceLabel">
+     <property name="text">
+      <string>Source</string>
      </property>
     </widget>
    </item>
-   <item row="13" column="0">
-    <widget class="QLabel" name="label_phases">
+   <item row="0" column="0">
+    <widget class="QLabel" name="inputNameLabel">
      <property name="text">
-      <string>Flight modes</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1" rowspan="2">
-    <layout class="QHBoxLayout" name="horizontalLayout_6" stretch="0,0">
-     <item>
-      <widget class="QComboBox" name="trimCB">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item row="7" column="0" rowspan="2">
-    <widget class="QLabel" name="trimLabel">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="text">
-      <string>Include Trim</string>
+      <string>Input name</string>
      </property>
     </widget>
    </item>
@@ -572,9 +667,6 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</string
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>inputName</tabstop>
-  <tabstop>lineName</tabstop>
-  <tabstop>sourceCB</tabstop>
   <tabstop>dsbScale</tabstop>
   <tabstop>chkWeightUseSource</tabstop>
   <tabstop>sbWeightValue</tabstop>
@@ -595,8 +687,6 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</string
   <tabstop>cb_FP6</tabstop>
   <tabstop>cb_FP7</tabstop>
   <tabstop>cb_FP8</tabstop>
-  <tabstop>switchesCB</tabstop>
-  <tabstop>sideCB</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources>

--- a/companion/src/modeledit/expodialog.ui
+++ b/companion/src/modeledit/expodialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>643</width>
-    <height>485</height>
+    <width>623</width>
+    <height>487</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -30,139 +30,79 @@
     <normaloff>:/icon.png</normaloff>:/icon.png</iconset>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="13" column="1">
-    <widget class="QComboBox" name="sideCB">
-     <item>
-      <property name="text">
-       <string>NEG</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>POS</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>ALL</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="8" column="1">
-    <layout class="QHBoxLayout" name="offsetLayout" stretch="0,0,1,0">
-     <item>
-      <widget class="QCheckBox" name="chkOffsetUseSource">
-       <property name="text">
-        <string>Source</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSpinBox" name="sbOffsetValue"/>
-     </item>
-     <item>
-      <widget class="QComboBox" name="cboOffsetSource">
-       <property name="minimumSize">
-        <size>
-         <width>0</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>16777215</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="whatsThis">
-        <string>The source for the mixer</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="offsetSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Expanding</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>120</width>
-         <height>0</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
-   </item>
-   <item row="14" column="0" colspan="2">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>25</height>
-      </size>
-     </property>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-     <property name="centerButtons">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1">
-    <widget class="QComboBox" name="trimCB"/>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="lineName">
-     <property name="maxLength">
-      <number>6</number>
-     </property>
-    </widget>
-   </item>
-   <item row="9" column="0">
-    <widget class="QLabel" name="label_curves">
-     <property name="text">
-      <string>Curve</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="0">
-    <widget class="QLabel" name="label_7">
-     <property name="text">
-      <string>Switch</string>
-     </property>
-    </widget>
-   </item>
    <item row="10" column="0">
-    <widget class="QLabel" name="label_phases">
-     <property name="text">
-      <string>Flight modes</string>
-     </property>
-    </widget>
-   </item>
-   <item row="13" column="0">
-    <widget class="QLabel" name="sideLabel">
-     <property name="text">
-      <string>Stick Side</string>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="0">
     <widget class="QLabel" name="label_3">
      <property name="text">
       <string>Weight</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="12" column="0">
+    <widget class="QLabel" name="label_curves">
+     <property name="text">
+      <string>Curve</string>
+     </property>
+    </widget>
+   </item>
+   <item row="16" column="0">
+    <widget class="QLabel" name="sideLabel">
+     <property name="text">
+      <string>Stick Side</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QDoubleSpinBox" name="dsbScale">
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="decimals">
+        <number>1</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLabel" name="lblScaleUnit">
+       <property name="text">
+        <string>unit</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="lblScale">
+     <property name="text">
+      <string>Scale</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="sourceLabel">
+     <property name="text">
+      <string>Source</string>
+     </property>
+    </widget>
+   </item>
+   <item row="10" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0,1,0">
      <item>
       <widget class="QCheckBox" name="chkWeightUseSource">
@@ -208,87 +148,40 @@
      </item>
     </layout>
    </item>
-   <item row="11" column="1">
-    <widget class="QComboBox" name="switchesCB">
-     <property name="whatsThis">
-      <string>Switch used to enable the line.
-If blank then the input is considered to be &quot;ON&quot; all the time.</string>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="offsetLabel">
-     <property name="text">
-      <string>Offset</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="sourceLabel">
-     <property name="text">
-      <string>Source</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="inputNameLabel">
-     <property name="text">
-      <string>Input name</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QComboBox" name="sourceCB">
-     <property name="whatsThis">
-      <string>Source for the mixer.</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QLineEdit" name="inputName">
-     <property name="maxLength">
-      <number>6</number>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout_3">
+   <item row="16" column="1">
+    <widget class="QComboBox" name="sideCB">
      <item>
-      <widget class="QDoubleSpinBox" name="dsbScale">
-       <property name="whatsThis">
-        <string/>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="decimals">
-        <number>1</number>
-       </property>
-      </widget>
+      <property name="text">
+       <string>NEG</string>
+      </property>
      </item>
      <item>
-      <widget class="QLabel" name="lblScaleUnit">
-       <property name="text">
-        <string>unit</string>
-       </property>
-      </widget>
+      <property name="text">
+       <string>POS</string>
+      </property>
      </item>
      <item>
-      <spacer name="horizontalSpacer_2">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
+      <property name="text">
+       <string>ALL</string>
+      </property>
      </item>
-    </layout>
+    </widget>
    </item>
-   <item row="10" column="1">
+   <item row="14" column="0">
+    <widget class="QLabel" name="label_7">
+     <property name="text">
+      <string>Switch</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="lineNameLabel">
+     <property name="text">
+      <string>Line name</string>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="1">
     <layout class="QGridLayout" name="gridLayout_4">
      <item row="0" column="0">
       <widget class="QLabel" name="lb_FP0">
@@ -445,14 +338,29 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</string
      </item>
     </layout>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="lblScale">
-     <property name="text">
-      <string>Scale</string>
+   <item row="14" column="1">
+    <widget class="QComboBox" name="switchesCB">
+     <property name="whatsThis">
+      <string>Switch used to enable the line.
+If blank then the input is considered to be &quot;ON&quot; all the time.</string>
      </property>
     </widget>
    </item>
-   <item row="9" column="1">
+   <item row="0" column="0">
+    <widget class="QLabel" name="inputNameLabel">
+     <property name="text">
+      <string>Input name</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QComboBox" name="sourceCB">
+     <property name="whatsThis">
+      <string>Source for the mixer.</string>
+     </property>
+    </widget>
+   </item>
+   <item row="12" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0,1,0,0,0">
      <item>
       <widget class="QComboBox" name="cboCurveType">
@@ -505,17 +413,139 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</string
      </item>
     </layout>
    </item>
-   <item row="6" column="0">
-    <widget class="QLabel" name="trimLabel">
-     <property name="text">
-      <string>Include Trim</string>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="lineName">
+     <property name="maxLength">
+      <number>6</number>
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="lineNameLabel">
+   <item row="0" column="1">
+    <widget class="QLineEdit" name="inputName">
+     <property name="maxLength">
+      <number>6</number>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0">
+    <widget class="QLabel" name="offsetLabel">
      <property name="text">
-      <string>Line name</string>
+      <string>Offset</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="1">
+    <layout class="QHBoxLayout" name="offsetLayout" stretch="0,0,1,0">
+     <item>
+      <widget class="QCheckBox" name="chkOffsetUseSource">
+       <property name="text">
+        <string>Source</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QSpinBox" name="sbOffsetValue"/>
+     </item>
+     <item>
+      <widget class="QComboBox" name="cboOffsetSource">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="whatsThis">
+        <string>The source for the mixer</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="offsetSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Expanding</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>120</width>
+         <height>0</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="17" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>25</height>
+      </size>
+     </property>
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+     <property name="centerButtons">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="13" column="0">
+    <widget class="QLabel" name="label_phases">
+     <property name="text">
+      <string>Flight modes</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="1" rowspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout_6" stretch="0,0">
+     <item>
+      <widget class="QComboBox" name="trimCB">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item row="7" column="0" rowspan="2">
+    <widget class="QLabel" name="trimLabel">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="text">
+      <string>Include Trim</string>
      </property>
     </widget>
    </item>
@@ -533,7 +563,6 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</string
   <tabstop>lineName</tabstop>
   <tabstop>sourceCB</tabstop>
   <tabstop>dsbScale</tabstop>
-  <tabstop>trimCB</tabstop>
   <tabstop>chkWeightUseSource</tabstop>
   <tabstop>sbWeightValue</tabstop>
   <tabstop>cboWeightSource</tabstop>

--- a/companion/src/modeledit/expodialog.ui
+++ b/companion/src/modeledit/expodialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>442</width>
-    <height>411</height>
+    <width>643</width>
+    <height>485</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -52,17 +52,29 @@
    <item row="8" column="1">
     <layout class="QHBoxLayout" name="offsetLayout" stretch="0,0,1,0">
      <item>
-      <widget class="QCheckBox" name="offsetGV">
+      <widget class="QCheckBox" name="chkOffsetUseSource">
        <property name="text">
-        <string>GV</string>
+        <string>Source</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QSpinBox" name="offsetSB"/>
+      <widget class="QSpinBox" name="sbOffsetValue"/>
      </item>
      <item>
-      <widget class="QComboBox" name="offsetCB">
+      <widget class="QComboBox" name="cboOffsetSource">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>16777215</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="whatsThis">
         <string>The source for the mixer</string>
        </property>
@@ -73,9 +85,12 @@
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Expanding</enum>
+       </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>40</width>
+         <width>120</width>
          <height>0</height>
         </size>
        </property>
@@ -150,17 +165,29 @@
    <item row="7" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0,1,0">
      <item>
-      <widget class="QCheckBox" name="weightGV">
+      <widget class="QCheckBox" name="chkWeightUseSource">
        <property name="text">
-        <string>GV</string>
+        <string>Source</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QSpinBox" name="weightSB"/>
+      <widget class="QSpinBox" name="sbWeightValue"/>
      </item>
      <item>
-      <widget class="QComboBox" name="weightCB">
+      <widget class="QComboBox" name="cboWeightSource">
+       <property name="minimumSize">
+        <size>
+         <width>0</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="maximumSize">
+        <size>
+         <width>350</width>
+         <height>16777215</height>
+        </size>
+       </property>
        <property name="whatsThis">
         <string/>
        </property>
@@ -173,7 +200,7 @@
        </property>
        <property name="sizeHint" stdset="0">
         <size>
-         <width>40</width>
+         <width>120</width>
          <height>20</height>
         </size>
        </property>
@@ -426,9 +453,9 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</string
     </widget>
    </item>
    <item row="9" column="1">
-    <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0,1,0,0">
+    <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,0,1,0,0,0">
      <item>
-      <widget class="QComboBox" name="curveTypeCB">
+      <widget class="QComboBox" name="cboCurveType">
        <property name="toolTip">
         <string/>
        </property>
@@ -438,24 +465,27 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</string
       </widget>
      </item>
      <item>
-      <widget class="QCheckBox" name="curveGVarCB">
+      <widget class="QCheckBox" name="chkCurveUseSource">
        <property name="text">
-        <string>GV</string>
+        <string>Source</string>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="curveValueCB">
+      <widget class="QComboBox" name="cboCurveSource">
        <property name="whatsThis">
         <string/>
        </property>
       </widget>
      </item>
      <item>
-      <widget class="QSpinBox" name="curveValueSB"/>
+      <widget class="QSpinBox" name="sbCurveValue"/>
      </item>
      <item>
-      <widget class="CurveImageWidget" name="curveImage">
+      <widget class="QComboBox" name="cboCurveFunc"/>
+     </item>
+     <item>
+      <widget class="CurveImageWidget" name="imgCurve">
        <property name="minimumSize">
         <size>
          <width>100</width>
@@ -504,16 +534,16 @@ If blank then the input is considered to be &quot;ON&quot; all the time.</string
   <tabstop>sourceCB</tabstop>
   <tabstop>dsbScale</tabstop>
   <tabstop>trimCB</tabstop>
-  <tabstop>weightGV</tabstop>
-  <tabstop>weightSB</tabstop>
-  <tabstop>weightCB</tabstop>
-  <tabstop>offsetGV</tabstop>
-  <tabstop>offsetSB</tabstop>
-  <tabstop>offsetCB</tabstop>
-  <tabstop>curveTypeCB</tabstop>
-  <tabstop>curveGVarCB</tabstop>
-  <tabstop>curveValueCB</tabstop>
-  <tabstop>curveValueSB</tabstop>
+  <tabstop>chkWeightUseSource</tabstop>
+  <tabstop>sbWeightValue</tabstop>
+  <tabstop>cboWeightSource</tabstop>
+  <tabstop>chkOffsetUseSource</tabstop>
+  <tabstop>sbOffsetValue</tabstop>
+  <tabstop>cboOffsetSource</tabstop>
+  <tabstop>cboCurveType</tabstop>
+  <tabstop>chkCurveUseSource</tabstop>
+  <tabstop>cboCurveSource</tabstop>
+  <tabstop>sbCurveValue</tabstop>
   <tabstop>cb_FP0</tabstop>
   <tabstop>cb_FP1</tabstop>
   <tabstop>cb_FP2</tabstop>

--- a/companion/src/modeledit/mixerdialog.cpp
+++ b/companion/src/modeledit/mixerdialog.cpp
@@ -66,17 +66,19 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
                                                                            (RawSource::AllSourceGroups & ~RawSource::NoneGroup & ~RawSource::ScriptsGroup)),
                                                      "EditorSource");
 
+  FilteredItemModel *esMdl = dialogFilteredItemModels->getItemModel(imId);
+
   weightEditor = new SourceNumRefEditor(md->weight, ui->chkWeightUseSource, ui->sbWeightValue, ui->cboWeightSource, 100, -limit, limit, 1,
-                                        model, dialogFilteredItemModels->getItemModel(imId));
+                                        model, esMdl, this);
 
   offsetEditor = new SourceNumRefEditor(md->sOffset, ui->chkOffsetUseSource, ui->sbOffsetValue, ui->cboOffsetSource, 0, -limit, limit, 1,
-                                        model, dialogFilteredItemModels->getItemModel(imId));
+                                        model, esMdl, this);
 
   curveRefFilteredItemModels = new CurveRefFilteredFactory(sharedItemModels,
                                                            firmware->getCapability(HasMixerExpo) ? 0 : FilteredItemModel::PositiveFilter);
 
-  curveGroup = new CurveReferenceUIManager(ui->cboCurveType, ui->chkCurveUseSource, ui->sbCurveValue, ui->cboCurveFunc, ui->imgCurve, md->curve,
-                                           model, sharedItemModels, curveRefFilteredItemModels, this);
+  curveGroup = new CurveReferenceUIManager(ui->cboCurveType, ui->chkCurveUseSource, ui->sbCurveValue, ui->cboCurveSource, ui->cboCurveFunc, ui->imgCurve, md->curve,
+                                           model, sharedItemModels, curveRefFilteredItemModels, esMdl, this);
 
   connect(curveGroup, &CurveReferenceUIManager::resized, this, [=] () {
           this->adjustSize();

--- a/companion/src/modeledit/mixerdialog.cpp
+++ b/companion/src/modeledit/mixerdialog.cpp
@@ -63,7 +63,7 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
 
   int limit = firmware->getCapability(OffsetWeight);
 
-  imId = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_RawSource),
+  imId = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_SourceValues),
                                                                            (RawSource::AllSourceGroups & ~RawSource::NoneGroup & ~RawSource::ScriptsGroup)),
                                                      "EditorSource");
 

--- a/companion/src/modeledit/mixerdialog.cpp
+++ b/companion/src/modeledit/mixerdialog.cpp
@@ -63,7 +63,7 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
   int limit = firmware->getCapability(OffsetWeight);
 
   imId = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_RawSource),
-                                                                           (RawSource::InputSourceGroups & ~RawSource::NoneGroup)),
+                                                                           (RawSource::AllSourceGroups & ~RawSource::NoneGroup & ~RawSource::ScriptsGroup)),
                                                      "EditorSource");
 
   weightEditor = new SourceNumRefEditor(md->weight, ui->chkWeightUseSource, ui->sbWeightValue, ui->cboWeightSource, 100, -limit, limit, 1,

--- a/companion/src/modeledit/mixerdialog.cpp
+++ b/companion/src/modeledit/mixerdialog.cpp
@@ -72,18 +72,12 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
   weightEditor = new SourceNumRefEditor(md->weight, ui->chkWeightUseSource, ui->sbWeightValue, ui->cboWeightSource, 100, -limit, limit, 1,
                                         model, esMdl, this);
 
-  connect(weightEditor, &SourceNumRefEditor::resized, this, [=] () {
-          this->adjustSize();
-          this->adjustSize(); // second call seems to be required when hidden fields otherwise not all padding removed
-  });
+  connect(weightEditor, &SourceNumRefEditor::resized, this, [=] () { shrink(); });
 
   offsetEditor = new SourceNumRefEditor(md->sOffset, ui->chkOffsetUseSource, ui->sbOffsetValue, ui->cboOffsetSource, 0, -limit, limit, 1,
                                         model, esMdl, this);
 
-  connect(offsetEditor, &SourceNumRefEditor::resized, this, [=] () {
-          this->adjustSize();
-          this->adjustSize(); // second call seems to be required when hidden fields otherwise not all padding removed
-  });
+  connect(offsetEditor, &SourceNumRefEditor::resized, this, [=] () { shrink(); });
 
   curveRefFilteredItemModels = new CurveRefFilteredFactory(sharedItemModels,
                                                            firmware->getCapability(HasMixerExpo) ? 0 : FilteredItemModel::PositiveFilter);
@@ -91,10 +85,7 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
   curveGroup = new CurveReferenceUIManager(ui->cboCurveType, ui->chkCurveUseSource, ui->sbCurveValue, ui->cboCurveSource, ui->cboCurveFunc,
                                            ui->imgCurve, md->curve, model, sharedItemModels, curveRefFilteredItemModels, esMdl, this);
 
-  connect(curveGroup, &CurveReferenceUIManager::resized, this, [=] () {
-          this->adjustSize();
-          this->adjustSize(); // second call seems to be required when hidden fields otherwise not all padding removed
-  });
+  connect(curveGroup, &CurveReferenceUIManager::resized, this, [=] () { shrink(); });
 
   ui->MixDR_CB->setChecked(md->noExpo == 0);
 
@@ -197,7 +188,7 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
     connect(cb_fp[i], SIGNAL(toggled(bool)), this, SLOT(valuesChanged()));
   }
 
-  adjustSize();
+  shrink();
 }
 
 MixerDialog::~MixerDialog()
@@ -315,4 +306,10 @@ void MixerDialog::fmInvertAll()
   }
   lock = false;
   valuesChanged();
+}
+
+void MixerDialog::shrink()
+{
+  this->adjustSize();
+  this->resize(0, 0);
 }

--- a/companion/src/modeledit/mixerdialog.cpp
+++ b/companion/src/modeledit/mixerdialog.cpp
@@ -1,7 +1,8 @@
 /*
- * Copyright (C) OpenTX
+ * Copyright (C) EdgeTX
  *
  * Based on code named
+ *   opentx - https://github.com/opentx/opentx
  *   th9x - http://code.google.com/p/th9x
  *   er9x - http://code.google.com/p/er9x
  *   gruvin9x - http://code.google.com/p/gruvin9x
@@ -24,6 +25,7 @@
 #include "filtereditemmodels.h"
 #include "helpers.h"
 #include "namevalidator.h"
+#include "sourcenumref.h"
 
 MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, GeneralSettings & generalSettings, Firmware * firmware,
                          CompoundItemModelFactory * sharedItemModels) :
@@ -40,7 +42,6 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
   Board::Type board = firmware->getBoard();
 
   dialogFilteredItemModels = new FilteredItemModelFactory();
-  int id;
 
   QLabel * lb_fp[CPN_MAX_FLIGHT_MODES] = {ui->lb_FP0, ui->lb_FP1, ui->lb_FP2, ui->lb_FP3, ui->lb_FP4, ui->lb_FP5, ui->lb_FP6, ui->lb_FP7, ui->lb_FP8 };
   QCheckBox * tmp[CPN_MAX_FLIGHT_MODES] = {ui->cb_FP0, ui->cb_FP1, ui->cb_FP2, ui->cb_FP3, ui->cb_FP4, ui->cb_FP5, ui->cb_FP6, ui->cb_FP7, ui->cb_FP8 };
@@ -50,28 +51,31 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
 
   this->setWindowTitle(tr("DEST -> %1").arg(RawSource(SOURCE_TYPE_CH, md->destCh - 1).toString(&model, &generalSettings)));
 
-  id = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_RawSource),
-                                                         (RawSource::InputSourceGroups & ~RawSource::NoneGroup) | RawSource::ScriptsGroup),
-                                                   "RawSource");
-  ui->sourceCB->setModel(dialogFilteredItemModels->getItemModel(id));
+  int imId = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_RawSource),
+                                                              (RawSource::InputSourceGroups & ~RawSource::NoneGroup) | RawSource::ScriptsGroup),
+                                                         "RawSource");
+
+  ui->sourceCB->setModel(dialogFilteredItemModels->getItemModel(imId));
   ui->sourceCB->setCurrentIndex(ui->sourceCB->findData(md->srcRaw.toValue()));
   if (ui->sourceCB->currentIndex() < 0 && md->srcRaw.toValue() == 0)
     ui->sourceCB->setCurrentIndex(ui->sourceCB->count() / 2); // '----' not in list so set to first positive entry
 
   int limit = firmware->getCapability(OffsetWeight);
 
-  id = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_GVarRef)), "GVarRef");
+  imId = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_RawSource),
+                                                                           (RawSource::InputSourceGroups & ~RawSource::NoneGroup)),
+                                                     "EditorSource");
 
-  gvWeightGroup = new GVarGroup(ui->weightGV, ui->weightSB, ui->weightCB, md->weight, model, 100, -limit, limit, 1.0,
-                                dialogFilteredItemModels->getItemModel(id));
+  weightEditor = new SourceNumRefEditor(md->weight, ui->chkWeightUseSource, ui->sbWeightValue, ui->cboWeightSource, 100, -limit, limit, 1,
+                                        model, dialogFilteredItemModels->getItemModel(imId));
 
-  gvOffsetGroup = new GVarGroup(ui->offsetGV, ui->offsetSB, ui->offsetCB, md->sOffset, model, 0, -limit, limit, 1.0,
-                                dialogFilteredItemModels->getItemModel(id));
+  offsetEditor = new SourceNumRefEditor(md->sOffset, ui->chkOffsetUseSource, ui->sbOffsetValue, ui->cboOffsetSource, 0, -limit, limit, 1,
+                                        model, dialogFilteredItemModels->getItemModel(imId));
 
   curveRefFilteredItemModels = new CurveRefFilteredFactory(sharedItemModels,
                                                            firmware->getCapability(HasMixerExpo) ? 0 : FilteredItemModel::PositiveFilter);
 
-  curveGroup = new CurveReferenceUIManager(ui->curveTypeCB, ui->curveGVarCB, ui->curveValueSB, ui->curveValueCB, ui->curveImage, md->curve,
+  curveGroup = new CurveReferenceUIManager(ui->cboCurveType, ui->chkCurveUseSource, ui->sbCurveValue, ui->cboCurveFunc, ui->imgCurve, md->curve,
                                            model, sharedItemModels, curveRefFilteredItemModels, this);
 
   connect(curveGroup, &CurveReferenceUIManager::resized, this, [=] () {
@@ -129,9 +133,10 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
     }
   }
 
-  id = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_RawSwitch),
-                                                                         RawSwitch::MixesContext), "RawSwitch");
-  ui->switchesCB->setModel(dialogFilteredItemModels->getItemModel(id));
+  imId = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_RawSwitch),
+                                                                           RawSwitch::MixesContext),
+                                                     "RawSwitch");
+  ui->switchesCB->setModel(dialogFilteredItemModels->getItemModel(imId));
   ui->switchesCB->setCurrentIndex(ui->switchesCB->findData(md->swtch.toValue()));
   ui->warningCB->setCurrentIndex(md->mixWarn);
   ui->mltpxCB->setCurrentIndex(md->mltpx);
@@ -161,21 +166,21 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
 
   valuesChanged();
 
-  connect(ui->mixerName,SIGNAL(editingFinished()),this,SLOT(valuesChanged()));
-  connect(ui->sourceCB,SIGNAL(currentIndexChanged(int)),this,SLOT(valuesChanged()));
-  connect(ui->trimCB,SIGNAL(currentIndexChanged(int)),this,SLOT(valuesChanged()));
-  connect(ui->MixDR_CB,SIGNAL(toggled(bool)),this,SLOT(valuesChanged()));
-  connect(ui->switchesCB,SIGNAL(currentIndexChanged(int)),this,SLOT(valuesChanged()));
-  connect(ui->warningCB,SIGNAL(currentIndexChanged(int)),this,SLOT(valuesChanged()));
-  connect(ui->mltpxCB,SIGNAL(currentIndexChanged(int)),this,SLOT(valuesChanged()));
-  connect(ui->delayDownSB,SIGNAL(editingFinished()),this,SLOT(valuesChanged()));
-  connect(ui->delayUpSB,SIGNAL(editingFinished()),this,SLOT(valuesChanged()));
-  connect(ui->speedPrecCB,SIGNAL(currentIndexChanged(int)),this,SLOT(valuesChanged()));
-  connect(ui->slowDownSB,SIGNAL(editingFinished()),this,SLOT(valuesChanged()));
-  connect(ui->slowUpSB,SIGNAL(editingFinished()),this,SLOT(valuesChanged()));
+  connect(ui->mixerName, SIGNAL(editingFinished()), this, SLOT(valuesChanged()));
+  connect(ui->sourceCB, SIGNAL(currentIndexChanged(int)), this, SLOT(valuesChanged()));
+  connect(ui->trimCB, SIGNAL(currentIndexChanged(int)), this, SLOT(valuesChanged()));
+  connect(ui->MixDR_CB, SIGNAL(toggled(bool)), this, SLOT(valuesChanged()));
+  connect(ui->switchesCB, SIGNAL(currentIndexChanged(int)), this, SLOT(valuesChanged()));
+  connect(ui->warningCB, SIGNAL(currentIndexChanged(int)), this, SLOT(valuesChanged()));
+  connect(ui->mltpxCB, SIGNAL(currentIndexChanged(int)), this, SLOT(valuesChanged()));
+  connect(ui->delayDownSB, SIGNAL(editingFinished()), this, SLOT(valuesChanged()));
+  connect(ui->delayUpSB, SIGNAL(editingFinished()), this, SLOT(valuesChanged()));
+  connect(ui->speedPrecCB, SIGNAL(currentIndexChanged(int)), this, SLOT(valuesChanged()));
+  connect(ui->slowDownSB, SIGNAL(editingFinished()), this, SLOT(valuesChanged()));
+  connect(ui->slowUpSB, SIGNAL(editingFinished()), this, SLOT(valuesChanged()));
 
-  for (int i=0; i<CPN_MAX_FLIGHT_MODES; i++) {
-    connect(cb_fp[i],SIGNAL(toggled(bool)),this,SLOT(valuesChanged()));
+  for (int i = 0; i < CPN_MAX_FLIGHT_MODES; i++) {
+    connect(cb_fp[i], SIGNAL(toggled(bool)), this, SLOT(valuesChanged()));
   }
 
   adjustSize();
@@ -184,8 +189,8 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
 MixerDialog::~MixerDialog()
 {
   delete ui;
-  delete gvWeightGroup;
-  delete gvOffsetGroup;
+  delete weightEditor;
+  delete offsetEditor;
   delete dialogFilteredItemModels;
 }
 

--- a/companion/src/modeledit/mixerdialog.cpp
+++ b/companion/src/modeledit/mixerdialog.cpp
@@ -58,7 +58,7 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
   ui->sourceCB->setModel(dialogFilteredItemModels->getItemModel(imId));
   ui->sourceCB->setCurrentIndex(ui->sourceCB->findData(md->srcRaw.toValue()));
   if (ui->sourceCB->currentIndex() < 0 && md->srcRaw.toValue() == 0)
-    ui->sourceCB->setCurrentIndex(ui->sourceCB->count() / 2); // '----' not in list so set to first positive entry
+    ui->sourceCB->setCurrentIndex(Helpers::getFirstPosValueIndex(ui->sourceCB));
 
   int limit = firmware->getCapability(OffsetWeight);
 

--- a/companion/src/modeledit/mixerdialog.cpp
+++ b/companion/src/modeledit/mixerdialog.cpp
@@ -63,7 +63,7 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
 
   int limit = firmware->getCapability(OffsetWeight);
 
-  imId = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_SourceValues),
+  imId = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_RawSource),
                                                                            (RawSource::AllSourceGroups & ~RawSource::NoneGroup & ~RawSource::ScriptsGroup)),
                                                      "EditorSource");
 

--- a/companion/src/modeledit/mixerdialog.cpp
+++ b/companion/src/modeledit/mixerdialog.cpp
@@ -55,6 +55,7 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
                                                               (RawSource::InputSourceGroups & ~RawSource::NoneGroup) | RawSource::ScriptsGroup),
                                                          "RawSource");
 
+  ui->sourceCB->setSizeAdjustPolicy(QComboBox::AdjustToContents);
   ui->sourceCB->setModel(dialogFilteredItemModels->getItemModel(imId));
   ui->sourceCB->setCurrentIndex(ui->sourceCB->findData(md->srcRaw.toValue()));
   if (ui->sourceCB->currentIndex() < 0 && md->srcRaw.toValue() == 0)
@@ -71,8 +72,18 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
   weightEditor = new SourceNumRefEditor(md->weight, ui->chkWeightUseSource, ui->sbWeightValue, ui->cboWeightSource, 100, -limit, limit, 1,
                                         model, esMdl, this);
 
+  connect(weightEditor, &SourceNumRefEditor::resized, this, [=] () {
+          this->adjustSize();
+          this->adjustSize(); // second call seems to be required when hidden fields otherwise not all padding removed
+  });
+
   offsetEditor = new SourceNumRefEditor(md->sOffset, ui->chkOffsetUseSource, ui->sbOffsetValue, ui->cboOffsetSource, 0, -limit, limit, 1,
                                         model, esMdl, this);
+
+  connect(offsetEditor, &SourceNumRefEditor::resized, this, [=] () {
+          this->adjustSize();
+          this->adjustSize(); // second call seems to be required when hidden fields otherwise not all padding removed
+  });
 
   curveRefFilteredItemModels = new CurveRefFilteredFactory(sharedItemModels,
                                                            firmware->getCapability(HasMixerExpo) ? 0 : FilteredItemModel::PositiveFilter);
@@ -138,6 +149,7 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
   imId = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_RawSwitch),
                                                                            RawSwitch::MixesContext),
                                                      "RawSwitch");
+  ui->switchesCB->setSizeAdjustPolicy(QComboBox::AdjustToContents);
   ui->switchesCB->setModel(dialogFilteredItemModels->getItemModel(imId));
   ui->switchesCB->setCurrentIndex(ui->switchesCB->findData(md->swtch.toValue()));
   ui->warningCB->setCurrentIndex(md->mixWarn);

--- a/companion/src/modeledit/mixerdialog.cpp
+++ b/companion/src/modeledit/mixerdialog.cpp
@@ -88,8 +88,8 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
   curveRefFilteredItemModels = new CurveRefFilteredFactory(sharedItemModels,
                                                            firmware->getCapability(HasMixerExpo) ? 0 : FilteredItemModel::PositiveFilter);
 
-  curveGroup = new CurveReferenceUIManager(ui->cboCurveType, ui->chkCurveUseSource, ui->sbCurveValue, ui->cboCurveSource, ui->cboCurveFunc, ui->imgCurve, md->curve,
-                                           model, sharedItemModels, curveRefFilteredItemModels, esMdl, this);
+  curveGroup = new CurveReferenceUIManager(ui->cboCurveType, ui->chkCurveUseSource, ui->sbCurveValue, ui->cboCurveSource, ui->cboCurveFunc,
+                                           ui->imgCurve, md->curve, model, sharedItemModels, curveRefFilteredItemModels, esMdl, this);
 
   connect(curveGroup, &CurveReferenceUIManager::resized, this, [=] () {
           this->adjustSize();
@@ -206,6 +206,7 @@ MixerDialog::~MixerDialog()
   delete weightEditor;
   delete offsetEditor;
   delete dialogFilteredItemModels;
+  delete curveRefFilteredItemModels;
 }
 
 void MixerDialog::changeEvent(QEvent *e)

--- a/companion/src/modeledit/mixerdialog.h
+++ b/companion/src/modeledit/mixerdialog.h
@@ -1,7 +1,8 @@
 /*
- * Copyright (C) OpenTX
+ * Copyright (C) EdgeTX
  *
  * Based on code named
+ *   opentx - https://github.com/opentx/opentx
  *   th9x - http://code.google.com/p/th9x
  *   er9x - http://code.google.com/p/er9x
  *   gruvin9x - http://code.google.com/p/gruvin9x
@@ -23,11 +24,11 @@
 #include <QtWidgets>
 #include "eeprominterface.h"
 
-class GVarGroup;
 class CompoundItemModelFactory;
 class FilteredItemModelFactory;
 class CurveRefFilteredFactory;
 class CurveReferenceUIManager;
+class SourceNumRefEditor;
 
 namespace Ui {
   class MixerDialog;
@@ -57,8 +58,8 @@ class MixerDialog : public QDialog {
     Firmware * firmware;
     MixData *md;
     bool lock;
-    GVarGroup * gvWeightGroup;
-    GVarGroup * gvOffsetGroup;
+    SourceNumRefEditor * weightEditor;
+    SourceNumRefEditor * offsetEditor;
     CurveReferenceUIManager * curveGroup;
     QCheckBox * cb_fp[CPN_MAX_FLIGHT_MODES];
     FilteredItemModelFactory *dialogFilteredItemModels;

--- a/companion/src/modeledit/mixerdialog.h
+++ b/companion/src/modeledit/mixerdialog.h
@@ -64,4 +64,6 @@ class MixerDialog : public QDialog {
     QCheckBox * cb_fp[CPN_MAX_FLIGHT_MODES];
     FilteredItemModelFactory *dialogFilteredItemModels;
     CurveRefFilteredFactory *curveRefFilteredItemModels;
+
+    void shrink();
 };

--- a/companion/src/modeledit/mixerdialog.ui
+++ b/companion/src/modeledit/mixerdialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>650</width>
+    <width>752</width>
     <height>623</height>
    </rect>
   </property>
@@ -29,28 +29,6 @@
    </property>
    <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0,0">
-     <item row="8" column="1" colspan="2">
-      <widget class="QComboBox" name="switchesCB">
-       <property name="whatsThis">
-        <string>Switch used by the mix.
-If blank then the mix is considered to be &quot;ON&quot; all the time.</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1" colspan="2">
-      <widget class="QComboBox" name="sourceCB">
-       <property name="whatsThis">
-        <string>The source for the mixer</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="label_curve">
-       <property name="text">
-        <string>Curve</string>
-       </property>
-      </widget>
-     </item>
      <item row="2" column="1" colspan="2">
       <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,1">
        <item>
@@ -85,33 +63,39 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</string>
        </item>
       </layout>
      </item>
-     <item row="10" column="1" colspan="2">
-      <widget class="QComboBox" name="mltpxCB">
-       <property name="whatsThis">
-        <string>Multiplexer
-
-This determines how mixer values are added.
-
-&quot;+&quot; means the value of the current mix is added to the previous mixes in the same channel.
-&quot;*&quot; means the value of the current mix is amultiplied with the previous mixes in the same channel.
-&quot;R&quot; means the value replaces the previous values.  If the switch is off the value will be ignored.</string>
+     <item row="11" column="0">
+      <widget class="QLabel" name="label_15">
+       <property name="text">
+        <string>Slow up/dn prec</string>
        </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QComboBox" name="sourceCB"/>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="trimLabel">
+       <property name="text">
+        <string>Include Trim</string>
+       </property>
+      </widget>
+     </item>
+     <item row="11" column="1">
+      <widget class="QComboBox" name="speedPrecCB">
        <item>
         <property name="text">
-         <string>ADD</string>
+         <string>0.0</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>MULTIPLY</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>REPLACE</string>
+         <string>0.00</string>
         </property>
        </item>
       </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="QComboBox" name="switchesCB"/>
      </item>
      <item row="3" column="1" colspan="2">
       <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0,0,1">
@@ -147,6 +131,77 @@ This determines how mixer values are added.
        </item>
       </layout>
      </item>
+     <item row="9" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Warning</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Weight</string>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Switch</string>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="1">
+      <widget class="QComboBox" name="mltpxCB">
+       <item>
+        <property name="text">
+         <string>ADD</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>MULTIPLY</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>REPLACE</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="label_MixDR">
+       <property name="text">
+        <string>Include DR/Expo</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_10">
+       <property name="text">
+        <string>Source</string>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="0">
+      <widget class="QLabel" name="label_7">
+       <property name="text">
+        <string>Multiplex</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_curve">
+       <property name="text">
+        <string>Curve</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="mixerName"/>
+     </item>
      <item row="5" column="1">
       <widget class="QComboBox" name="trimCB">
        <item>
@@ -161,69 +216,6 @@ This determines how mixer values are added.
        </item>
       </widget>
      </item>
-     <item row="9" column="1" colspan="2">
-      <widget class="QComboBox" name="warningCB">
-       <property name="whatsThis">
-        <string>Mixer warning.
-Setting this value will cause a beep to be emmitted when this value is active.</string>
-       </property>
-       <item>
-        <property name="text">
-         <string>OFF</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>1 Beep</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>2 Beep</string>
-        </property>
-       </item>
-       <item>
-        <property name="text">
-         <string>3 Beep</string>
-        </property>
-       </item>
-      </widget>
-     </item>
-     <item row="6" column="1">
-      <widget class="QCheckBox" name="MixDR_CB">
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="0">
-      <widget class="QLabel" name="label_7">
-       <property name="text">
-        <string>Switch</string>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="label_phases">
-       <property name="text">
-        <string>Flight modes</string>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="0">
-      <widget class="QLabel" name="label_MixDR">
-       <property name="text">
-        <string>Include DR/Expo</string>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="0">
-      <widget class="QLabel" name="label_8">
-       <property name="text">
-        <string>Warning</string>
-       </property>
-      </widget>
-     </item>
      <item row="4" column="1">
       <widget class="QComboBox" name="cboCurveType">
        <property name="whatsThis">
@@ -231,17 +223,10 @@ Setting this value will cause a beep to be emmitted when this value is active.</
        </property>
       </widget>
      </item>
-     <item row="10" column="0">
-      <widget class="QLabel" name="label_9">
+     <item row="6" column="1">
+      <widget class="QCheckBox" name="MixDR_CB">
        <property name="text">
-        <string>Multiplex</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Source</string>
+        <string/>
        </property>
       </widget>
      </item>
@@ -252,193 +237,8 @@ Setting this value will cause a beep to be emmitted when this value is active.</
        </property>
       </widget>
      </item>
-     <item row="7" column="1" colspan="2">
-      <layout class="QGridLayout" name="gridLayout_4">
-       <item row="0" column="0">
-        <widget class="QLabel" name="lb_FP0">
-         <property name="text">
-          <string notr="true">0</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QLabel" name="lb_FP1">
-         <property name="text">
-          <string notr="true">1</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="2">
-        <widget class="QLabel" name="lb_FP2">
-         <property name="text">
-          <string notr="true">2</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="3">
-        <widget class="QLabel" name="lb_FP3">
-         <property name="text">
-          <string notr="true">3</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="4">
-        <widget class="QLabel" name="lb_FP4">
-         <property name="text">
-          <string notr="true">4</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="5">
-        <widget class="QLabel" name="lb_FP5">
-         <property name="text">
-          <string notr="true">5</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="6">
-        <widget class="QLabel" name="lb_FP6">
-         <property name="text">
-          <string notr="true">6</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="7">
-        <widget class="QLabel" name="lb_FP7">
-         <property name="text">
-          <string notr="true">7</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="8">
-        <widget class="QLabel" name="lb_FP8">
-         <property name="text">
-          <string notr="true">8</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0">
-        <widget class="QCheckBox" name="cb_FP0">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QCheckBox" name="cb_FP1">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="2">
-        <widget class="QCheckBox" name="cb_FP2">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="3">
-        <widget class="QCheckBox" name="cb_FP3">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="4">
-        <widget class="QCheckBox" name="cb_FP4">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="5">
-        <widget class="QCheckBox" name="cb_FP5">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="6">
-        <widget class="QCheckBox" name="cb_FP6">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="7">
-        <widget class="QCheckBox" name="cb_FP7">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="8">
-        <widget class="QCheckBox" name="cb_FP8">
-         <property name="text">
-          <string/>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_3">
-       <property name="text">
-        <string>Weight</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="label_4">
-       <property name="text">
-        <string>Offset</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="trimLabel">
-       <property name="text">
-        <string>Include Trim</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1" colspan="2">
-      <widget class="QLineEdit" name="mixerName">
-       <property name="maxLength">
-        <number>6</number>
-       </property>
-      </widget>
-     </item>
      <item row="4" column="2">
-      <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0,0,0,0">
+      <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0,0,0,0,0">
        <item>
         <widget class="QCheckBox" name="chkCurveUseSource">
          <property name="text">
@@ -478,27 +278,227 @@ Setting this value will cause a beep to be emmitted when this value is active.</
          </property>
         </widget>
        </item>
+       <item>
+        <spacer name="horizontalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
       </layout>
      </item>
-     <item row="11" column="0">
-      <widget class="QLabel" name="label">
+     <item row="7" column="0">
+      <widget class="QLabel" name="label_phases">
        <property name="text">
-        <string>Slow up/dn prec</string>
+        <string>Flight modes</string>
        </property>
       </widget>
      </item>
-     <item row="11" column="1" colspan="2">
-      <widget class="QComboBox" name="speedPrecCB">
+     <item row="9" column="1">
+      <widget class="QComboBox" name="warningCB">
        <item>
         <property name="text">
-         <string>0.0</string>
+         <string>OFF</string>
         </property>
        </item>
        <item>
         <property name="text">
-         <string>0.00</string>
+         <string>1 Beep</string>
         </property>
        </item>
+       <item>
+        <property name="text">
+         <string>2 Beeps</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>3 Beeps</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item row="7" column="1" colspan="2">
+      <layout class="QGridLayout" name="gridLayout_4">
+       <item row="0" column="4">
+        <widget class="QLabel" name="lb_FP4">
+         <property name="text">
+          <string notr="true">4</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="3">
+        <widget class="QLabel" name="lb_FP3">
+         <property name="text">
+          <string notr="true">3</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="7">
+        <widget class="QLabel" name="lb_FP7">
+         <property name="text">
+          <string notr="true">7</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QCheckBox" name="cb_FP0">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <widget class="QLabel" name="lb_FP2">
+         <property name="text">
+          <string notr="true">2</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="6">
+        <widget class="QCheckBox" name="cb_FP6">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="8">
+        <widget class="QCheckBox" name="cb_FP8">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="8">
+        <widget class="QLabel" name="lb_FP8">
+         <property name="text">
+          <string notr="true">8</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="7">
+        <widget class="QCheckBox" name="cb_FP7">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QCheckBox" name="cb_FP1">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="5">
+        <widget class="QCheckBox" name="cb_FP5">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLabel" name="lb_FP1">
+         <property name="text">
+          <string notr="true">1</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="0">
+        <widget class="QLabel" name="lb_FP0">
+         <property name="text">
+          <string notr="true">0</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="6">
+        <widget class="QLabel" name="lb_FP6">
+         <property name="text">
+          <string notr="true">6</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="2">
+        <widget class="QCheckBox" name="cb_FP2">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="5">
+        <widget class="QLabel" name="lb_FP5">
+         <property name="text">
+          <string notr="true">5</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="4">
+        <widget class="QCheckBox" name="cb_FP4">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="3">
+        <widget class="QCheckBox" name="cb_FP3">
+         <property name="text">
+          <string/>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="9">
+        <spacer name="horizontalSpacer_4">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+      </layout>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Offset</string>
+       </property>
       </widget>
      </item>
     </layout>
@@ -520,72 +520,9 @@ Setting this value will cause a beep to be emmitted when this value is active.</
     </widget>
    </item>
    <item row="1" column="0">
-    <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0">
-     <item row="0" column="1">
-      <widget class="QLabel" name="label_13">
-       <property name="text">
-        <string>Delay</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="2">
-      <widget class="QLabel" name="label_14">
-       <property name="text">
-        <string>Slow</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_12">
-       <property name="text">
-        <string>Up</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_11">
-       <property name="text">
-        <string>Down</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-      </widget>
-     </item>
+    <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0,0">
      <item row="1" column="2">
       <widget class="QDoubleSpinBox" name="slowUpSB">
-       <property name="whatsThis">
-        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Delay ans Slow&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-weight:600; text-decoration: underline;&quot;&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;These values control the speed and delay of the output of the mix.  &lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If Delay is not zero the actuation of the mix will be delayed by the specified amount of seconds.&lt;/p&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If Slow is not zero then the speed of the mix will be set by the value specified -&amp;gt; the value states the number of seconds it takes to transit from -100 to 100.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="decimals">
-        <number>1</number>
-       </property>
-       <property name="maximum">
-        <double>7.500000000000000</double>
-       </property>
-       <property name="singleStep">
-        <double>0.500000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="2">
-      <widget class="QDoubleSpinBox" name="slowDownSB">
        <property name="whatsThis">
         <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
@@ -636,6 +573,76 @@ p, li { white-space: pre-wrap; }
        </property>
       </widget>
      </item>
+     <item row="2" column="2">
+      <widget class="QDoubleSpinBox" name="slowDownSB">
+       <property name="whatsThis">
+        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;Delay ans Slow&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-weight:600; text-decoration: underline;&quot;&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;These values control the speed and delay of the output of the mix.  &lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If Delay is not zero the actuation of the mix will be delayed by the specified amount of seconds.&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If Slow is not zero then the speed of the mix will be set by the value specified -&amp;gt; the value states the number of seconds it takes to transit from -100 to 100.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="decimals">
+        <number>1</number>
+       </property>
+       <property name="maximum">
+        <double>7.500000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>0.500000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="3">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_11">
+       <property name="text">
+        <string>Down</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_12">
+       <property name="text">
+        <string>Up</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLabel" name="label_13">
+       <property name="text">
+        <string>Delay</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="2">
+      <widget class="QLabel" name="label_14">
+       <property name="text">
+        <string>Slow</string>
+       </property>
+      </widget>
+     </item>
      <item row="2" column="1">
       <widget class="QDoubleSpinBox" name="delayDownSB">
        <property name="whatsThis">
@@ -671,8 +678,6 @@ p, li { white-space: pre-wrap; }
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>mixerName</tabstop>
-  <tabstop>sourceCB</tabstop>
   <tabstop>chkWeightUseSource</tabstop>
   <tabstop>cboWeightSource</tabstop>
   <tabstop>sbWeightValue</tabstop>
@@ -694,9 +699,6 @@ p, li { white-space: pre-wrap; }
   <tabstop>cb_FP6</tabstop>
   <tabstop>cb_FP7</tabstop>
   <tabstop>cb_FP8</tabstop>
-  <tabstop>switchesCB</tabstop>
-  <tabstop>warningCB</tabstop>
-  <tabstop>mltpxCB</tabstop>
   <tabstop>delayUpSB</tabstop>
   <tabstop>delayDownSB</tabstop>
   <tabstop>slowUpSB</tabstop>

--- a/companion/src/modeledit/mixerdialog.ui
+++ b/companion/src/modeledit/mixerdialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>556</width>
+    <width>650</width>
     <height>623</height>
    </rect>
   </property>
@@ -54,21 +54,21 @@ If blank then the mix is considered to be &quot;ON&quot; all the time.</string>
      <item row="2" column="1" colspan="2">
       <layout class="QHBoxLayout" name="horizontalLayout" stretch="0,0,0,1">
        <item>
-        <widget class="QCheckBox" name="weightGV">
+        <widget class="QCheckBox" name="chkWeightUseSource">
          <property name="text">
-          <string>GV</string>
+          <string>Source</string>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QComboBox" name="weightCB">
+        <widget class="QComboBox" name="cboWeightSource">
          <property name="whatsThis">
           <string>The source for the mixer</string>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QSpinBox" name="weightSB"/>
+        <widget class="QSpinBox" name="sbWeightValue"/>
        </item>
        <item>
         <spacer name="horizontalSpacer_2">
@@ -116,21 +116,21 @@ This determines how mixer values are added.
      <item row="3" column="1" colspan="2">
       <layout class="QHBoxLayout" name="horizontalLayout_2" stretch="0,0,0,1">
        <item>
-        <widget class="QCheckBox" name="offsetGV">
+        <widget class="QCheckBox" name="chkOffsetUseSource">
          <property name="text">
-          <string>GV</string>
+          <string>Source</string>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QComboBox" name="offsetCB">
+        <widget class="QComboBox" name="cboOffsetSource">
          <property name="whatsThis">
           <string>The source for the mixer</string>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QSpinBox" name="offsetSB"/>
+        <widget class="QSpinBox" name="sbOffsetValue"/>
        </item>
        <item>
         <spacer name="horizontalSpacer">
@@ -225,7 +225,7 @@ Setting this value will cause a beep to be emmitted when this value is active.</
       </widget>
      </item>
      <item row="4" column="1">
-      <widget class="QComboBox" name="curveTypeCB">
+      <widget class="QComboBox" name="cboCurveType">
        <property name="whatsThis">
         <string>The curve used by the mix</string>
        </property>
@@ -438,26 +438,29 @@ Setting this value will cause a beep to be emmitted when this value is active.</
       </widget>
      </item>
      <item row="4" column="2">
-      <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0,0,0">
+      <layout class="QHBoxLayout" name="horizontalLayout_3" stretch="0,0,0,0,0">
        <item>
-        <widget class="QCheckBox" name="curveGVarCB">
+        <widget class="QCheckBox" name="chkCurveUseSource">
          <property name="text">
-          <string>GV</string>
+          <string>Source</string>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QComboBox" name="curveValueCB">
+        <widget class="QComboBox" name="cboCurveSource">
          <property name="whatsThis">
           <string>The source for the mixer</string>
          </property>
         </widget>
        </item>
        <item>
-        <widget class="QSpinBox" name="curveValueSB"/>
+        <widget class="QSpinBox" name="sbCurveValue"/>
        </item>
        <item>
-        <widget class="CurveImageWidget" name="curveImage">
+        <widget class="QComboBox" name="cboCurveFunc"/>
+       </item>
+       <item>
+        <widget class="CurveImageWidget" name="imgCurve">
          <property name="minimumSize">
           <size>
            <width>100</width>
@@ -670,16 +673,16 @@ p, li { white-space: pre-wrap; }
  <tabstops>
   <tabstop>mixerName</tabstop>
   <tabstop>sourceCB</tabstop>
-  <tabstop>weightGV</tabstop>
-  <tabstop>weightCB</tabstop>
-  <tabstop>weightSB</tabstop>
-  <tabstop>offsetGV</tabstop>
-  <tabstop>offsetCB</tabstop>
-  <tabstop>offsetSB</tabstop>
-  <tabstop>curveTypeCB</tabstop>
-  <tabstop>curveGVarCB</tabstop>
-  <tabstop>curveValueCB</tabstop>
-  <tabstop>curveValueSB</tabstop>
+  <tabstop>chkWeightUseSource</tabstop>
+  <tabstop>cboWeightSource</tabstop>
+  <tabstop>sbWeightValue</tabstop>
+  <tabstop>chkOffsetUseSource</tabstop>
+  <tabstop>cboOffsetSource</tabstop>
+  <tabstop>sbOffsetValue</tabstop>
+  <tabstop>cboCurveType</tabstop>
+  <tabstop>chkCurveUseSource</tabstop>
+  <tabstop>cboCurveSource</tabstop>
+  <tabstop>sbCurveValue</tabstop>
   <tabstop>trimCB</tabstop>
   <tabstop>MixDR_CB</tabstop>
   <tabstop>cb_FP0</tabstop>

--- a/companion/src/modeledit/modeledit.cpp
+++ b/companion/src/modeledit/modeledit.cpp
@@ -68,7 +68,6 @@ ModelEdit::ModelEdit(QWidget * parent, RadioData & radioData, int modelId, Firmw
   sharedItemModels->addItemModel(AbstractItemModel::IMID_TeleSource);
   sharedItemModels->addItemModel(AbstractItemModel::IMID_CurveRefType);
   sharedItemModels->addItemModel(AbstractItemModel::IMID_CurveRefFunc);
-  sharedItemModels->addItemModel(AbstractItemModel::IMID_SourceValues);
 
   s1.report("Init");
 

--- a/companion/src/modeledit/modeledit.cpp
+++ b/companion/src/modeledit/modeledit.cpp
@@ -68,6 +68,7 @@ ModelEdit::ModelEdit(QWidget * parent, RadioData & radioData, int modelId, Firmw
   sharedItemModels->addItemModel(AbstractItemModel::IMID_TeleSource);
   sharedItemModels->addItemModel(AbstractItemModel::IMID_CurveRefType);
   sharedItemModels->addItemModel(AbstractItemModel::IMID_CurveRefFunc);
+  sharedItemModels->addItemModel(AbstractItemModel::IMID_SourceValues);
 
   s1.report("Init");
 

--- a/companion/src/modelprinter.cpp
+++ b/companion/src/modelprinter.cpp
@@ -26,6 +26,7 @@
 #include "appdata.h"
 #include "adjustmentreference.h"
 #include "curveimage.h"
+#include "sourcenumref.h"
 
 #include <QApplication>
 #include <QPainter>
@@ -366,9 +367,9 @@ QString ModelPrinter::printInputLine(const ExpoData & input)
     str += " " + tr("Scale(%1)").arg(input.scale * range.step).toHtmlEscaped();
   }
 
-  str += " " + tr("Weight(%1)").arg(AdjustmentReference(input.weight).toString(&model, true)).toHtmlEscaped();
+  str += " " + tr("Weight(%1)").arg(SourceNumRef(input.weight).toString(&model, &generalSettings)).toHtmlEscaped();
   if (input.curve.value)
-    str += " " + input.curve.toString(&model).toHtmlEscaped();
+    str += " " + input.curve.toString(&model, true, &generalSettings).toHtmlEscaped();
 
   QString flightModesStr = printFlightModes(input.flightModes);
   if (!flightModesStr.isEmpty())
@@ -386,7 +387,7 @@ QString ModelPrinter::printInputLine(const ExpoData & input)
   }
 
   if (input.offset)
-    str += " " + tr("Offset(%1)").arg(AdjustmentReference(input.offset).toString(&model)).toHtmlEscaped();
+    str += " " + tr("Offset(%1)").arg(SourceNumRef(input.offset).toString(&model, &generalSettings)).toHtmlEscaped();
   if (firmware->getCapability(HasExpoNames) && input.name[0])
     str += QString(" [%1]").arg(input.name).toHtmlEscaped();
 
@@ -417,7 +418,7 @@ QString ModelPrinter::printMixerLine(const MixData & mix, bool showMultiplex, in
   if (mix.mltpx == MLTPX_MUL && !showMultiplex)
     str += " " + tr("MULT!").toHtmlEscaped();
   else
-    str += " " + tr("Weight(%1)").arg(AdjustmentReference(mix.weight).toString(&model, true)).toHtmlEscaped();
+    str += " " + tr("Weight(%1)").arg(SourceNumRef(mix.weight).toString(&model, &generalSettings)).toHtmlEscaped();
 
   QString flightModesStr = printFlightModes(mix.flightModes);
   if (!flightModesStr.isEmpty())
@@ -434,9 +435,9 @@ QString ModelPrinter::printMixerLine(const MixData & mix, bool showMultiplex, in
   if (firmware->getCapability(HasNoExpo) && mix.noExpo)
     str += " " + tr("No DR/Expo").toHtmlEscaped();
   if (mix.sOffset)
-    str += " " + tr("Offset(%1)").arg(AdjustmentReference(mix.sOffset).toString(&model)).toHtmlEscaped();
+    str += " " + tr("Offset(%1)").arg(SourceNumRef(mix.sOffset).toString(&model, &generalSettings)).toHtmlEscaped();
   if (mix.curve.value)
-    str += " " + mix.curve.toString(&model).toHtmlEscaped();
+    str += " " + mix.curve.toString(&model, true, &generalSettings).toHtmlEscaped();
   int scale = firmware->getCapability(SlowScale);
   if (scale == 0)
     scale = 1;

--- a/companion/src/shared/curveimagewidget.cpp
+++ b/companion/src/shared/curveimagewidget.cpp
@@ -80,7 +80,7 @@ void CurveImageWidget::draw()
 
     QImage image = curveImage->get();
     if (index < 0)
-      image = image.mirrored(false, true);
+      image = image.mirrored(true, false);
     setPixmap(QPixmap::fromImage(image.scaled(height(), width())));
 
     delete curveImage;

--- a/companion/src/shared/curveimagewidget.cpp
+++ b/companion/src/shared/curveimagewidget.cpp
@@ -44,7 +44,7 @@ void CurveImageWidget::set(ModelData * model, Firmware * firmware, CompoundItemM
 
 void CurveImageWidget::setIndex(int index)
 {
-  this->index = (index >= 0 && index < CPN_MAX_CURVES) ? index : -1;
+  this->index = index;
 }
 
 void CurveImageWidget::setGrid(QColor color, qreal width)
@@ -63,8 +63,8 @@ int CurveImageWidget::edit()
 {
   int ret = 0;
 
-  if (index >= 0 && index < CPN_MAX_CURVES) {
-    CurveDialog *dlg = new CurveDialog(this, *model, index, firmware, sharedItemModels);
+  if (abs(index) > 0 && abs(index) <= CPN_MAX_CURVES) {
+    CurveDialog *dlg = new CurveDialog(this, *model, abs(index) - 1, firmware, sharedItemModels);
     ret = dlg->exec();
     delete dlg;
   }
@@ -74,11 +74,13 @@ int CurveImageWidget::edit()
 
 void CurveImageWidget::draw()
 {
-  if (index >= 0 && index < CPN_MAX_CURVES) {
+  if (abs(index) > 0 && abs(index) <= CPN_MAX_CURVES) {
     CurveImage *curveImage = new CurveImage(gridColor, gridWidth);
-    curveImage->drawCurve(model->curves[index], penColor, penWidth);
+    curveImage->drawCurve(model->curves[abs(index) - 1], penColor, penWidth);
 
     QImage image = curveImage->get();
+    if (index < 0)
+      image = image.mirrored(false, true);
     setPixmap(QPixmap::fromImage(image.scaled(height(), width())));
 
     delete curveImage;

--- a/companion/src/shared/curveimagewidget.h
+++ b/companion/src/shared/curveimagewidget.h
@@ -34,7 +34,8 @@ class CurveImageWidget : public QLabel
     CurveImageWidget(QWidget * parent);
     virtual ~CurveImageWidget() {}
 
-    void set(ModelData * model, Firmware * firmware, CompoundItemModelFactory * sharedItemModels, int index, QColor penColor = Qt::black, qreal penWidth = 2);
+    void set(ModelData * model, Firmware * firmware, CompoundItemModelFactory * sharedItemModels, int index, QColor penColor = Qt::black,
+             qreal penWidth = 2);
     void setIndex(int index);
     void setGrid(QColor color = Qt::darkGray, qreal width = 1);
     void setPen(QColor color = Qt::black, qreal width = 2);

--- a/radio/src/curves.cpp
+++ b/radio/src/curves.cpp
@@ -25,6 +25,8 @@
   #include "libopenui.h"
 #endif
 
+extern int32_t getSourceNumFieldValue(int16_t val, int16_t min, int16_t max);
+
 constexpr int DEFAULT_POINTS = 5;
 constexpr int STD_CURVE_POINTS(int p) { return p + DEFAULT_POINTS; }
 constexpr int CUSTOM_CURVE_POINTS(int p) { return 2 * p + (2 * DEFAULT_POINTS - 2); }
@@ -321,7 +323,7 @@ int applyCurve(int x, CurveRef & curve)
   switch (curve.type) {
     case CURVE_REF_DIFF:
     {
-      int curveParam = GET_GVAR_PREC1(curve.value, -100, 100, mixerCurrentFlightMode);
+      int curveParam = getSourceNumFieldValue(curve.value, -100, 100);
       if (curveParam > 0 && x < 0)
         x = (x * (1000 - curveParam)) / 1000;
       else if (curveParam < 0 && x > 0)
@@ -331,7 +333,7 @@ int applyCurve(int x, CurveRef & curve)
 
     case CURVE_REF_EXPO:
     {
-      int curveParam = GET_GVAR_PREC1(curve.value, -100, 100, mixerCurrentFlightMode) / 10;
+      int curveParam = getSourceNumFieldValue(curve.value, -100, 100) / 10;
       return expo(x, curveParam);
     }
 
@@ -427,12 +429,12 @@ char *getCurveRefString(char *dest, size_t len, const CurveRef& curve)
     switch (curve.type) {
       case CURVE_REF_DIFF:
         *(s++) = 'D'; if (--len == 0) return dest;
-        getValueOrGVarString(s, len, curve.value, -100, 100, 0, "%");
+        getValueOrSrcVarString(s, len, curve.value, -100, 100, 0, "%");
         return dest;
 
       case CURVE_REF_EXPO:
         *(s++) = 'E'; if (--len == 0) return dest;
-        getValueOrGVarString(s, len, curve.value, -100, 100, 0, "%");
+        getValueOrSrcVarString(s, len, curve.value, -100, 100, 0, "%");
         return dest;
 
       case CURVE_REF_FUNC:

--- a/radio/src/curves.cpp
+++ b/radio/src/curves.cpp
@@ -320,6 +320,9 @@ int intpol(int x, uint8_t idx) // -100, -75, -50, -25, 0 ,25 ,50, 75, 100
 
 int applyCurve(int x, CurveRef & curve)
 {
+  SourceNumVal v;
+  v.rawValue = curve.value;
+
   switch (curve.type) {
     case CURVE_REF_DIFF:
     {
@@ -338,7 +341,7 @@ int applyCurve(int x, CurveRef & curve)
     }
 
     case CURVE_REF_FUNC:
-      switch (curve.value) {
+      switch (v.value) {
         case CURVE_X_GT0:
           if (x < 0) x = 0; //x|x>0
           return x;
@@ -358,7 +361,7 @@ int applyCurve(int x, CurveRef & curve)
 
     case CURVE_REF_CUSTOM:
     {
-      int curveParam = curve.value;
+      int curveParam = v.value;
       if (curveParam < 0) {
         x = -x;
         curveParam = -curveParam;

--- a/radio/src/curves.cpp
+++ b/radio/src/curves.cpp
@@ -425,7 +425,10 @@ char *getCurveRefString(char *dest, size_t len, const CurveRef& curve)
   if (!len) return dest;
   char *s = dest;
 
-  if (curve.value != 0) {
+  SourceNumVal v;
+  v.rawValue = curve.value;
+
+  if (v.value != 0) {
     switch (curve.type) {
       case CURVE_REF_DIFF:
         *(s++) = 'D'; if (--len == 0) return dest;
@@ -438,11 +441,11 @@ char *getCurveRefString(char *dest, size_t len, const CurveRef& curve)
         return dest;
 
       case CURVE_REF_FUNC:
-        strAppend(dest, STR_VCURVEFUNC[curve.value], len);
+        strAppend(dest, STR_VCURVEFUNC[v.value], len);
         return dest;
 
       case CURVE_REF_CUSTOM:
-        return getCurveString(dest, curve.value);
+        return getCurveString(dest, v.value);
     }
   }
 

--- a/radio/src/dataconstants.h
+++ b/radio/src/dataconstants.h
@@ -541,6 +541,7 @@ enum MixSources {
   MIXSRC_LAST_TELEM SKIP = MIXSRC_FIRST_TELEM + 3 * MAX_TELEMETRY_SENSORS - 1,
 
   MIXSRC_INVERT SKIP,
+  MIXSRC_VALUE SKIP,  // Special case to trigger source as value conversion
 };
 
 

--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -42,7 +42,7 @@ static inline void check_struct()
   CHKSIZE(CurveRef, 2);
   CHKSIZE(VarioData, 5);
   CHKSIZE(MixData, 20);
-  CHKSIZE(ExpoData, 17);
+  CHKSIZE(ExpoData, 18);
   CHKSIZE(SwashRingData, 8);
   CHKSIZE(CurveHeader, 4);
   CHKSIZE(LogicalSwitchData, 9);
@@ -91,23 +91,23 @@ static inline void check_struct()
 #endif
 
 #if defined(RADIO_TPRO) || defined(RADIO_TPROV2)
-  CHKSIZE(ModelData, 6290);
+  CHKSIZE(ModelData, 6354);
 #elif defined(RADIO_FAMILY_T20)
-  CHKSIZE(ModelData, 6326);
+  CHKSIZE(ModelData, 6390);
 #elif defined(PCBX9E)
-  CHKSIZE(ModelData, 6707);
+  CHKSIZE(ModelData, 6771);
 #elif defined(PCBX9D) || defined(PCBX9DP)
-  CHKSIZE(ModelData, 6706);
+  CHKSIZE(ModelData, 6770);
 #elif defined(PCBX7) || defined(PCBXLITE) || defined(PCBX9LITE)
-  CHKSIZE(ModelData, 6265);
+  CHKSIZE(ModelData, 6329);
 #elif defined(PCBNV14)
-  CHKSIZE(ModelData, 15591);
+  CHKSIZE(ModelData, 15655);
 #elif defined(PCBPL18)
-  CHKSIZE(ModelData, 15771);
+  CHKSIZE(ModelData, 15835);
 #elif defined(RADIO_T15)
-  CHKSIZE(ModelData, 15760);
+  CHKSIZE(ModelData, 15824);
 #elif defined(PCBHORUS)
-  CHKSIZE(ModelData, 15735);
+  CHKSIZE(ModelData, 15799);
 #else
   #error CHKSIZE not set up
 #endif

--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -70,6 +70,12 @@ PACK(union SourceNumVal {
   uint16_t rawValue:11;
 });
 
+inline uint16_t makeSourceNumVal(int16_t val, bool isSource = false)
+{
+  SourceNumVal v = { .value = val, .isSource= isSource };
+  return v.rawValue;
+}
+
 /*
  * Mixer structure
  */

--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -72,7 +72,9 @@ PACK(union SourceNumVal {
 
 inline uint16_t makeSourceNumVal(int16_t val, bool isSource = false)
 {
-  SourceNumVal v = { .value = val, .isSource= isSource };
+  SourceNumVal v;
+  v.value = val;
+  v.isSource= isSource;
   return v.rawValue;
 }
 

--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -62,26 +62,35 @@
 
 #include "storage/yaml/yaml_defs.h"
 
+PACK(union SourceNumVal {
+  struct {
+    int16_t value:10;
+    bool isSource:1;
+  };
+  uint16_t rawValue:11;
+});
+
 /*
  * Mixer structure
  */
 
 PACK(struct CurveRef {
-  uint8_t type;
-  int8_t  value CUST(in_read_weight,in_write_weight);
+  uint16_t type:5;
+  int16_t  value:11 CUST(in_read_sourcenumval,in_write_sourcenumval);
 });
 
 PACK(struct MixData {
-  int16_t  weight:11 CUST(in_read_weight,in_write_weight);       // GV1=-1024, -GV1=1023
+  int16_t  weight:11 CUST(in_read_sourcenumval,in_write_sourcenumval);
   uint16_t destCh:5;
   int16_t  srcRaw:10 CUST(r_mixSrcRawEx,w_mixSrcRawEx); // srcRaw=0 means not used
   uint16_t carryTrim:1;
   uint16_t mixWarn:2;       // mixer warning
   uint16_t mltpx:2 ENUM(MixerMultiplex);
   uint16_t speedPrec:1;
-  int32_t  offset:13 CUST(in_read_weight,in_write_weight);
+  int32_t  offset:11 CUST(in_read_sourcenumval,in_write_sourcenumval);
   int32_t  swtch:10 CUST(r_swtchSrc,w_swtchSrc);
   uint32_t flightModes:9 CUST(r_flightModes, w_flightModes);
+  uint32_t spare:2;
   CurveRef curve;
   uint8_t  delayUp;
   uint8_t  delayDown;
@@ -100,13 +109,14 @@ PACK(struct ExpoData {
   CUST_ATTR(carryTrim, r_carryTrim, nullptr); //pre 2.9
   int16_t  trimSource:6;
   int16_t  srcRaw:10 ENUM(MixSources) CUST(r_mixSrcRawEx,w_mixSrcRawEx);
-  uint32_t chn:5;
+  int32_t  weight:11 CUST(in_read_sourcenumval,in_write_sourcenumval);
+  int32_t  offset:11 CUST(in_read_sourcenumval,in_write_sourcenumval);
   int32_t  swtch:10 CUST(r_swtchSrc,w_swtchSrc);
-  uint32_t flightModes:9 CUST(r_flightModes, w_flightModes);
-  int32_t  weight:8 CUST(in_read_weight,in_write_weight);
-  NOBACKUP(char name[LEN_EXPOMIX_NAME]);
-  int8_t   offset CUST(in_read_weight,in_write_weight);
   CurveRef curve;
+  uint16_t chn:5;
+  uint16_t flightModes:9 CUST(r_flightModes, w_flightModes);
+  uint16_t spare:2;
+  NOBACKUP(char name[LEN_EXPOMIX_NAME]);
 });
 
 /*

--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -84,21 +84,21 @@ inline uint16_t makeSourceNumVal(int16_t val, bool isSource = false)
 
 PACK(struct CurveRef {
   uint16_t type:5;
-  int16_t  value:11 CUST(in_read_sourcenumval,in_write_sourcenumval);
+  int16_t  value:11 CUST(r_sourceNumVal,w_sourceNumVal);
 });
 
 PACK(struct MixData {
-  int16_t  weight:11 CUST(in_read_sourcenumval,in_write_sourcenumval);
   uint16_t destCh:5;
   int16_t  srcRaw:10 CUST(r_mixSrcRawEx,w_mixSrcRawEx); // srcRaw=0 means not used
   uint16_t carryTrim:1;
   uint16_t mixWarn:2;       // mixer warning
   uint16_t mltpx:2 ENUM(MixerMultiplex);
   uint16_t speedPrec:1;
-  int32_t  offset:11 CUST(in_read_sourcenumval,in_write_sourcenumval);
-  int32_t  swtch:10 CUST(r_swtchSrc,w_swtchSrc);
   uint32_t flightModes:9 CUST(r_flightModes, w_flightModes);
   uint32_t spare:2;
+  uint32_t weight:11 CUST(r_sourceNumVal,w_sourceNumVal);
+  uint32_t offset:11 CUST(r_sourceNumVal,w_sourceNumVal);
+  int32_t  swtch:10 CUST(r_swtchSrc,w_swtchSrc);
   CurveRef curve;
   uint8_t  delayUp;
   uint8_t  delayDown;
@@ -117,8 +117,8 @@ PACK(struct ExpoData {
   CUST_ATTR(carryTrim, r_carryTrim, nullptr); //pre 2.9
   int16_t  trimSource:6;
   int16_t  srcRaw:10 ENUM(MixSources) CUST(r_mixSrcRawEx,w_mixSrcRawEx);
-  int32_t  weight:11 CUST(in_read_sourcenumval,in_write_sourcenumval);
-  int32_t  offset:11 CUST(in_read_sourcenumval,in_write_sourcenumval);
+  uint32_t weight:11 CUST(r_sourceNumVal,w_sourceNumVal);
+  uint32_t offset:11 CUST(r_sourceNumVal,w_sourceNumVal);
   int32_t  swtch:10 CUST(r_swtchSrc,w_swtchSrc);
   CurveRef curve;
   uint16_t chn:5;

--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -94,8 +94,8 @@ PACK(struct MixData {
   uint16_t mixWarn:2;       // mixer warning
   uint16_t mltpx:2 ENUM(MixerMultiplex);
   uint16_t speedPrec:1;
-  uint32_t flightModes:9 CUST(r_flightModes, w_flightModes);
-  uint32_t spare:2;
+  uint16_t flightModes:9 CUST(r_flightModes, w_flightModes);
+  uint16_t spare:2;
   uint32_t weight:11 CUST(r_sourceNumVal,w_sourceNumVal);
   uint32_t offset:11 CUST(r_sourceNumVal,w_sourceNumVal);
   int32_t  swtch:10 CUST(r_swtchSrc,w_swtchSrc);

--- a/radio/src/gui/128x64/gui.h
+++ b/radio/src/gui/128x64/gui.h
@@ -47,7 +47,7 @@
 #define CURVE_CENTER_X                 (LCD_W-CURVE_SIDE_WIDTH-3)
 #define CURVE_CENTER_Y                 (LCD_H/2)
 
-#define MIXES_2ND_COLUMN               (12*FW)
+#define MIXES_2ND_COLUMN               (10*FW)
 
 // Temporary no highlight
 extern uint8_t noHighlightCounter;
@@ -79,6 +79,10 @@ uint8_t editCheckBox(uint8_t value, coord_t x, coord_t y, const char *label,
 
 swsrc_t editSwitch(coord_t x, coord_t y, swsrc_t value, LcdFlags attr,
                    event_t event);
+
+uint16_t editSrcVarFieldValue(coord_t x, coord_t y, const char* title, uint16_t value,
+                              int16_t min, int16_t max, LcdFlags attr, event_t event,
+                              IsValueAvailable isValueAvailable, int16_t sourceMin);
 
 #if defined(GVARS)
 
@@ -198,7 +202,8 @@ void showAlertBox(const char * title, const char * text, const char * action , u
 #define IS_TELEMETRY_VIEW_DISPLAYED()  menuHandlers[0] == menuViewTelemetry
 #define IS_OTHER_VIEW_DISPLAYED()      menuHandlers[0] == menuChannelsView
 
-void editCurveRef(coord_t x, coord_t y, CurveRef & curve, event_t event, LcdFlags flags);
+void editCurveRef(coord_t x, coord_t y, CurveRef & curve, event_t event, LcdFlags flags,
+                  IsValueAvailable isValueAvailable, int16_t sourceMin);
 
 #if defined(FLIGHT_MODES)
 void displayFlightModes(coord_t x, coord_t y, FlightModesType value);

--- a/radio/src/gui/128x64/gui.h
+++ b/radio/src/gui/128x64/gui.h
@@ -114,8 +114,6 @@ int16_t editGVarFieldValue(coord_t x, coord_t y, int16_t value, int16_t min,
 
 #endif
 
-void gvarWeightItem(coord_t x, coord_t y, MixData * md, LcdFlags attr, event_t event);
-
 void editName(coord_t x, coord_t y, char *name, uint8_t size, event_t event,
               uint8_t active, LcdFlags attr, uint8_t old_editMode);
 

--- a/radio/src/gui/128x64/lcd.cpp
+++ b/radio/src/gui/128x64/lcd.cpp
@@ -662,55 +662,6 @@ void putsVBat(coord_t x, coord_t y, LcdFlags att)
   putsVolts(x, y, g_vbat100mV, att);
 }
 
-void drawSource(coord_t x, coord_t y, mixsrc_t idx, LcdFlags att)
-{
-  uint16_t aidx = abs(idx);
-  bool inverted = idx < 0;
-
-  if (aidx == MIXSRC_NONE) {
-    lcdDrawText(x, y, STR_EMPTY, att);
-  }
-  else if (aidx <= MIXSRC_LAST_INPUT) {
-    if (inverted) {
-      lcdDrawChar(x, y, '-');
-      x += 2;
-    }
-    lcdDrawChar(x+2, y+1, CHR_INPUT, TINSIZE);
-    lcdDrawSolidFilledRect(x, y, 7, 7);
-    if (g_model.inputNames[aidx-MIXSRC_FIRST_INPUT][0])
-      lcdDrawSizedText(x+8, y, g_model.inputNames[aidx-MIXSRC_FIRST_INPUT], LEN_INPUT_NAME, att);
-    else
-      lcdDrawNumber(x+8, y, aidx, att|LEADING0|LEFT, 2);
-  }
-#if defined(LUA_INPUTS)
-  else if (aidx <= MIXSRC_LAST_LUA) {
-    div_t qr = div((uint16_t)(aidx-MIXSRC_FIRST_LUA), MAX_SCRIPT_OUTPUTS);
-#if defined(LUA_MODEL_SCRIPTS)
-    if (inverted) {
-      lcdDrawChar(x, y, '-');
-      x += 2;
-    }
-    if (qr.quot < MAX_SCRIPTS && qr.rem < scriptInputsOutputs[qr.quot].outputsCount) {
-      lcdDrawChar(x+2, y+1, '1'+qr.quot, TINSIZE);
-      lcdDrawFilledRect(x, y, 7, 7, 0);
-      lcdDrawSizedText(x+8, y, scriptInputsOutputs[qr.quot].outputs[qr.rem].name, att & STREXPANDED ? 9 : 4, att);
-    }
-    else
-#endif
-    {
-      drawStringWithIndex(x, y, "LUA", qr.quot+1, att);
-      lcdDrawChar(lcdLastRightPos, y, 'a' + qr.rem, att);
-    }
-  }
-#endif
-  else {
-    const char* s = getSourceString(idx);
-    if (idx >= MIXSRC_FIRST_TELEM && idx <= MIXSRC_LAST_TELEM)
-      s += strlen(STR_CHAR_TELEMETRY);
-    lcdDrawText(x, y, s, att);
-  }
-}
-
 void putsChnLetter(coord_t x, coord_t y, uint8_t idx, LcdFlags att)
 {
   lcdDrawText(x, y, getAnalogShortLabel(idx), att);

--- a/radio/src/gui/128x64/lcd.cpp
+++ b/radio/src/gui/128x64/lcd.cpp
@@ -672,7 +672,7 @@ void drawSource(coord_t x, coord_t y, mixsrc_t idx, LcdFlags att)
   }
   else if (aidx <= MIXSRC_LAST_INPUT) {
     if (inverted) {
-      lcdDrawChar(x, y, '!');
+      lcdDrawChar(x, y, '-');
       x += 2;
     }
     lcdDrawChar(x+2, y+1, CHR_INPUT, TINSIZE);
@@ -687,7 +687,7 @@ void drawSource(coord_t x, coord_t y, mixsrc_t idx, LcdFlags att)
     div_t qr = div((uint16_t)(aidx-MIXSRC_FIRST_LUA), MAX_SCRIPT_OUTPUTS);
 #if defined(LUA_MODEL_SCRIPTS)
     if (inverted) {
-      lcdDrawChar(x, y, '!');
+      lcdDrawChar(x, y, '-');
       x += 2;
     }
     if (qr.quot < MAX_SCRIPTS && qr.rem < scriptInputsOutputs[qr.quot].outputsCount) {

--- a/radio/src/gui/128x64/lcd.h
+++ b/radio/src/gui/128x64/lcd.h
@@ -116,7 +116,6 @@ void lcdDraw8bitsNumber(coord_t x, coord_t y, int8_t val);
 void drawModelName(coord_t x, coord_t y, char * name, uint8_t id, LcdFlags att);
 #if !defined(BOOT) // TODO not here ...
 void drawSwitch(coord_t x, coord_t y, swsrc_t swtch, LcdFlags att=0, bool autoBold = true);
-void drawSource(coord_t x, coord_t y, mixsrc_t idx, LcdFlags att=0);
 #endif
 void drawCurveName(coord_t x, coord_t y, int8_t idx, LcdFlags att=0);
 void drawTimerMode(coord_t x, coord_t y, swsrc_t mode, LcdFlags att=0);

--- a/radio/src/gui/128x64/model_input_edit.cpp
+++ b/radio/src/gui/128x64/model_input_edit.cpp
@@ -117,11 +117,13 @@ void menuModelExpoOne(event_t event)
         break;
 
       case EXPO_FIELD_WEIGHT:
-        ed->weight = editSrcVarFieldValue(EXPO_ONE_2ND_COLUMN, y, STR_WEIGHT, ed->weight, -100, 100, attr | RIGHT, event, isSourceAvailableInInputs, INPUTSRC_FIRST);
+        ed->weight = editSrcVarFieldValue(EXPO_ONE_2ND_COLUMN, y, STR_WEIGHT, ed->weight,
+                        -100, 100, attr | RIGHT, event, isSourceAvailableInInputs, INPUTSRC_FIRST);
         break;
 
       case EXPO_FIELD_OFFSET:
-        ed->offset = editSrcVarFieldValue(EXPO_ONE_2ND_COLUMN, y, STR_OFFSET, ed->offset, -100, 100, attr | RIGHT, event, isSourceAvailableInInputs, INPUTSRC_FIRST);
+        ed->offset = editSrcVarFieldValue(EXPO_ONE_2ND_COLUMN, y, STR_OFFSET, ed->offset,
+                        -100, 100, attr | RIGHT, event, isSourceAvailableInInputs, INPUTSRC_FIRST);
         break;
 
       case EXPO_FIELD_CURVE_LABEL:

--- a/radio/src/gui/128x64/model_input_edit.cpp
+++ b/radio/src/gui/128x64/model_input_edit.cpp
@@ -117,13 +117,11 @@ void menuModelExpoOne(event_t event)
         break;
 
       case EXPO_FIELD_WEIGHT:
-        lcdDrawTextAlignedLeft(y, STR_WEIGHT);
-        ed->weight = GVAR_MENU_ITEM(EXPO_ONE_2ND_COLUMN, y, ed->weight, -100, 100, RIGHT | attr, 0, event);
+        ed->weight = editSrcVarFieldValue(EXPO_ONE_2ND_COLUMN, y, STR_WEIGHT, ed->weight, -100, 100, attr | RIGHT, event, isSourceAvailableInInputs, INPUTSRC_FIRST);
         break;
 
       case EXPO_FIELD_OFFSET:
-        lcdDrawTextAlignedLeft(y, STR_OFFSET);
-        ed->offset = GVAR_MENU_ITEM(EXPO_ONE_2ND_COLUMN, y, ed->offset, -100, 100, RIGHT | attr, 0, event);
+        ed->offset = editSrcVarFieldValue(EXPO_ONE_2ND_COLUMN, y, STR_OFFSET, ed->offset, -100, 100, attr | RIGHT, event, isSourceAvailableInInputs, INPUTSRC_FIRST);
         break;
 
       case EXPO_FIELD_CURVE_LABEL:
@@ -131,7 +129,7 @@ void menuModelExpoOne(event_t event)
         break;
 
       case EXPO_FIELD_CURVE:
-        editCurveRef(EXPO_ONE_2ND_COLUMN, y, ed->curve, event, RIGHT | attr);
+        editCurveRef(EXPO_ONE_2ND_COLUMN, y, ed->curve, event, RIGHT | attr, isSourceAvailableInInputs, INPUTSRC_FIRST);
         break;
 
 #if defined(FLIGHT_MODES)

--- a/radio/src/gui/128x64/model_input_edit.cpp
+++ b/radio/src/gui/128x64/model_input_edit.cpp
@@ -21,7 +21,7 @@
 
 #include "opentx.h"
 
-#define EXPO_ONE_2ND_COLUMN (7*FW+3*FW+2)
+#define EXPO_ONE_2ND_COLUMN (6*FW+1)
 
 int expoFn(int x)
 {
@@ -91,39 +91,39 @@ void menuModelExpoOne(event_t event)
 
     switch (i) {
       case EXPO_FIELD_INPUT_NAME:
-        editSingleName(EXPO_ONE_2ND_COLUMN - LEN_INPUT_NAME * FW, y,
+        editSingleName(EXPO_ONE_2ND_COLUMN, y,
                        STR_INPUTNAME, g_model.inputNames[ed->chn],
                        LEN_INPUT_NAME, event, (attr != 0), old_editMode);
         break;
 
       case EXPO_FIELD_LINE_NAME:
-        editSingleName(EXPO_ONE_2ND_COLUMN - LEN_EXPOMIX_NAME * FW, y,
+        editSingleName(EXPO_ONE_2ND_COLUMN, y,
                        STR_EXPONAME, ed->name, LEN_EXPOMIX_NAME, event,
                        (attr != 0), old_editMode);
         break;
 
       case EXPO_FIELD_SOURCE:
         lcdDrawTextAlignedLeft(y, STR_SOURCE);
-        drawSource(EXPO_ONE_2ND_COLUMN, y, ed->srcRaw, RIGHT|STREXPANDED|attr);
+        drawSource(EXPO_ONE_2ND_COLUMN, y, ed->srcRaw, STREXPANDED|attr);
         if (attr)
           ed->srcRaw = checkIncDec(event, ed->srcRaw, INPUTSRC_FIRST, INPUTSRC_LAST, EE_MODEL|INCDEC_SOURCE|INCDEC_SOURCE_INVERT|NO_INCDEC_MARKS, isSourceAvailableInInputs);
         break;
 
       case EXPO_FIELD_SCALE:
         lcdDrawTextAlignedLeft(y, STR_SCALE);
-        drawSensorCustomValue(EXPO_ONE_2ND_COLUMN, y, (abs(ed->srcRaw) - MIXSRC_FIRST_TELEM)/3, convertTelemValue(abs(ed->srcRaw) - MIXSRC_FIRST_TELEM + 1, ed->scale),  RIGHT | attr);
+        drawSensorCustomValue(EXPO_ONE_2ND_COLUMN, y, (abs(ed->srcRaw) - MIXSRC_FIRST_TELEM)/3, convertTelemValue(abs(ed->srcRaw) - MIXSRC_FIRST_TELEM + 1, ed->scale),  attr);
         if (attr)
           ed->scale = checkIncDec(event, ed->scale, 0, maxTelemValue(abs(ed->srcRaw) - MIXSRC_FIRST_TELEM + 1), EE_MODEL);
         break;
 
       case EXPO_FIELD_WEIGHT:
         ed->weight = editSrcVarFieldValue(EXPO_ONE_2ND_COLUMN, y, STR_WEIGHT, ed->weight,
-                        -100, 100, attr | RIGHT, event, isSourceAvailableInInputs, INPUTSRC_FIRST);
+                        -100, 100, attr, event, isSourceAvailableInInputs, INPUTSRC_FIRST);
         break;
 
       case EXPO_FIELD_OFFSET:
         ed->offset = editSrcVarFieldValue(EXPO_ONE_2ND_COLUMN, y, STR_OFFSET, ed->offset,
-                        -100, 100, attr | RIGHT, event, isSourceAvailableInInputs, INPUTSRC_FIRST);
+                        -100, 100, attr, event, isSourceAvailableInInputs, INPUTSRC_FIRST);
         break;
 
       case EXPO_FIELD_CURVE_LABEL:
@@ -131,7 +131,7 @@ void menuModelExpoOne(event_t event)
         break;
 
       case EXPO_FIELD_CURVE:
-        editCurveRef(EXPO_ONE_2ND_COLUMN, y, ed->curve, event, RIGHT | attr, isSourceAvailableInInputs, INPUTSRC_FIRST);
+        editCurveRef(FW + 1, y, ed->curve, event, attr, isSourceAvailableInInputs, INPUTSRC_FIRST);
         break;
 
 #if defined(FLIGHT_MODES)
@@ -140,23 +140,23 @@ void menuModelExpoOne(event_t event)
         break;
 
       case EXPO_FIELD_FLIGHT_MODES:
-        ed->flightModes = editFlightModes(EXPO_ONE_2ND_COLUMN-9*FW+1, y, event, ed->flightModes, attr);
+        ed->flightModes = editFlightModes(EXPO_ONE_2ND_COLUMN-5*FW-2, y, event, ed->flightModes, attr);
         break;
 #endif
 
       case EXPO_FIELD_SWITCH:
-        ed->swtch = editSwitch(EXPO_ONE_2ND_COLUMN, y, ed->swtch, RIGHT | attr, event);
+        ed->swtch = editSwitch(EXPO_ONE_2ND_COLUMN, y, ed->swtch, attr, event);
         break;
 
       case EXPO_FIELD_SIDE:
-        ed->mode = 4 - editChoice(EXPO_ONE_2ND_COLUMN, y, STR_SIDE, STR_VCURVEFUNC, 4-ed->mode, 1, 3, RIGHT | attr, event);
+        ed->mode = 4 - editChoice(EXPO_ONE_2ND_COLUMN, y, STR_SIDE, STR_VCURVEFUNC, 4-ed->mode, 1, 3, attr, event);
         break;
 
       case EXPO_FIELD_TRIM:
         lcdDrawTextAlignedLeft(y, STR_TRIM);
         {
           const char* trim_str = getTrimSourceLabel(abs(ed->srcRaw), ed->trimSource);
-          LcdFlags flags = RIGHT | (menuHorizontalPosition==0 ? attr : 0);
+          LcdFlags flags = (menuHorizontalPosition==0 ? attr : 0);
           lcdDrawText(EXPO_ONE_2ND_COLUMN, y, trim_str, flags);
 
           if (attr) {

--- a/radio/src/gui/128x64/model_mix_edit.cpp
+++ b/radio/src/gui/128x64/model_mix_edit.cpp
@@ -139,11 +139,13 @@ void menuModelMixOne(event_t event)
         break;
 
       case MIX_FIELD_WEIGHT:
-        md2->weight = editSrcVarFieldValue(MIXES_2ND_COLUMN, y, STR_WEIGHT, md2->weight, MIX_WEIGHT_MIN, MIX_WEIGHT_MAX, attr, event, isSourceAvailable, 1);
+        md2->weight = editSrcVarFieldValue(MIXES_2ND_COLUMN, y, STR_WEIGHT, md2->weight, 
+                        MIX_WEIGHT_MIN, MIX_WEIGHT_MAX, attr, event, isSourceAvailable, 1);
         break;
 
       case MIX_FIELD_OFFSET:
-        md2->offset = editSrcVarFieldValue(MIXES_2ND_COLUMN, y, STR_OFFSET, md2->offset, MIX_OFFSET_MIN, MIX_OFFSET_MAX, attr, event, isSourceAvailable, 1);
+        md2->offset = editSrcVarFieldValue(MIXES_2ND_COLUMN, y, STR_OFFSET, md2->offset,
+                        MIX_OFFSET_MIN, MIX_OFFSET_MAX, attr, event, isSourceAvailable, 1);
         drawOffsetBar(LCD_W - 33, y, md2);
         break;
 

--- a/radio/src/gui/128x64/model_mix_edit.cpp
+++ b/radio/src/gui/128x64/model_mix_edit.cpp
@@ -43,13 +43,15 @@ enum MixFields {
 
 extern uint8_t FM_ROW(uint8_t);
 
+extern int32_t getSourceNumFieldValue(int16_t val, int16_t min, int16_t max);
+
 void drawOffsetBar(uint8_t x, uint8_t y, MixData * md)
 {
   const int gaugeWidth = 33;
   const int gaugeHeight = 6;
 
-  int offset = GET_GVAR(MD_OFFSET(md), GV_RANGELARGE_NEG, GV_RANGELARGE, mixerCurrentFlightMode);
-  int weight = GET_GVAR(MD_WEIGHT(md), GV_RANGELARGE_NEG, GV_RANGELARGE, mixerCurrentFlightMode);
+  int offset = getSourceNumFieldValue(md->offset, MIX_OFFSET_MIN, MIX_OFFSET_MAX) / 10;
+  int weight = getSourceNumFieldValue(md->weight, MIX_WEIGHT_MIN, MIX_WEIGHT_MAX) / 10;
   int barMin = offset - weight;
   int barMax = offset + weight;
   if (y > 15) {
@@ -137,20 +139,13 @@ void menuModelMixOne(event_t event)
         break;
 
       case MIX_FIELD_WEIGHT:
-        lcdDrawTextAlignedLeft(y, STR_WEIGHT);
-        gvarWeightItem(MIXES_2ND_COLUMN, y, md2, attr|LEFT, event);
+        md2->weight = editSrcVarFieldValue(MIXES_2ND_COLUMN, y, STR_WEIGHT, md2->weight, MIX_WEIGHT_MIN, MIX_WEIGHT_MAX, attr, event, isSourceAvailable, 1);
         break;
 
       case MIX_FIELD_OFFSET:
-      {
-        lcdDrawTextAlignedLeft(y, STR_OFFSET);
-        u_int8int16_t offset;
-        MD_OFFSET_TO_UNION(md2, offset);
-        offset.word = GVAR_MENU_ITEM(MIXES_2ND_COLUMN, y, offset.word, MIX_OFFSET_MIN, MIX_OFFSET_MAX, attr|LEFT, 0, event);
-        MD_UNION_TO_OFFSET(offset, md2);
-        drawOffsetBar(MIXES_2ND_COLUMN+22, y, md2);
+        md2->offset = editSrcVarFieldValue(MIXES_2ND_COLUMN, y, STR_OFFSET, md2->offset, MIX_OFFSET_MIN, MIX_OFFSET_MAX, attr, event, isSourceAvailable, 1);
+        drawOffsetBar(LCD_W - 33, y, md2);
         break;
-      }
 
       case MIX_FIELD_TRIM:
         lcdDrawTextAlignedLeft(y, STR_TRIM);
@@ -162,7 +157,7 @@ void menuModelMixOne(event_t event)
         lcdDrawTextAlignedLeft(y, STR_CURVE);
         s_currSrcRaw = md2->srcRaw;
         s_currScale = 0;
-        editCurveRef(MIXES_2ND_COLUMN, y, md2->curve, event, attr);
+        editCurveRef(MIXES_2ND_COLUMN, y, md2->curve, event, attr, isSourceAvailable, 1);
         break;
 
 #if defined(FLIGHT_MODES)

--- a/radio/src/gui/128x64/widgets.cpp
+++ b/radio/src/gui/128x64/widgets.cpp
@@ -162,6 +162,28 @@ void drawSlider(coord_t x, coord_t y, uint8_t value, uint8_t max, uint8_t attr)
   drawSlider(x, y, 5*FW - 1, value, max, attr);
 }
 
+uint16_t editSrcVarFieldValue(coord_t x, coord_t y, const char* title, uint16_t value,
+                              int16_t min, int16_t max, LcdFlags attr, event_t event,
+                              IsValueAvailable isValueAvailable, int16_t sourceMin)
+{
+  if (title)
+    lcdDrawTextAlignedLeft(y, title);
+  SourceNumVal v;
+  v.rawValue = value;
+  if (v.isSource) {
+    drawSource(x, y, v.value, attr);
+    if (attr & (~RIGHT)) {
+      value = checkIncDec(event, value, sourceMin, MIXSRC_LAST, EE_MODEL|INCDEC_SOURCE|INCDEC_SOURCE_VALUE|INCDEC_SOURCE_INVERT|NO_INCDEC_MARKS, isValueAvailable);
+    }
+  } else {
+    lcdDrawNumber(x, y, v.value, attr);
+    if (attr & (~RIGHT)) {
+      value = checkIncDec(event, value, min, max, EE_MODEL|INCDEC_SOURCE_VALUE|NO_INCDEC_MARKS);
+    }
+  }
+  return value;
+}
+
 #if defined(GVARS)
 void drawGVarValue(coord_t x, coord_t y, uint8_t gvar, gvar_t value, LcdFlags flags)
 {

--- a/radio/src/gui/128x64/widgets.cpp
+++ b/radio/src/gui/128x64/widgets.cpp
@@ -173,12 +173,14 @@ uint16_t editSrcVarFieldValue(coord_t x, coord_t y, const char* title, uint16_t 
   if (v.isSource) {
     drawSource(x, y, v.value, attr);
     if (attr & (~RIGHT)) {
-      value = checkIncDec(event, value, sourceMin, MIXSRC_LAST, EE_MODEL|INCDEC_SOURCE|INCDEC_SOURCE_VALUE|INCDEC_SOURCE_INVERT|NO_INCDEC_MARKS, isValueAvailable);
+      value = checkIncDec(event, value, sourceMin, MIXSRC_LAST,
+                EE_MODEL|INCDEC_SOURCE|INCDEC_SOURCE_VALUE|INCDEC_SOURCE_INVERT|NO_INCDEC_MARKS, isValueAvailable);
     }
   } else {
     lcdDrawNumber(x, y, v.value, attr);
     if (attr & (~RIGHT)) {
-      value = checkIncDec(event, value, min, max, EE_MODEL|INCDEC_SOURCE_VALUE|NO_INCDEC_MARKS, isValueAvailable);
+      value = checkIncDec(event, value, min, max,
+                EE_MODEL|INCDEC_SOURCE_VALUE|NO_INCDEC_MARKS|(sourceMin == INPUTSRC_FIRST ? INCDEC_SOURCE_NOINPUTS : 0));
     }
   }
   return value;

--- a/radio/src/gui/128x64/widgets.cpp
+++ b/radio/src/gui/128x64/widgets.cpp
@@ -178,7 +178,7 @@ uint16_t editSrcVarFieldValue(coord_t x, coord_t y, const char* title, uint16_t 
   } else {
     lcdDrawNumber(x, y, v.value, attr);
     if (attr & (~RIGHT)) {
-      value = checkIncDec(event, value, min, max, EE_MODEL|INCDEC_SOURCE_VALUE|NO_INCDEC_MARKS);
+      value = checkIncDec(event, value, min, max, EE_MODEL|INCDEC_SOURCE_VALUE|NO_INCDEC_MARKS, isValueAvailable);
     }
   }
   return value;

--- a/radio/src/gui/212x64/gui.h
+++ b/radio/src/gui/212x64/gui.h
@@ -91,6 +91,10 @@ uint8_t editCheckBox(uint8_t value, coord_t x, coord_t y, const char *label,
 swsrc_t editSwitch(coord_t x, coord_t y, swsrc_t value, LcdFlags attr,
                    event_t event);
 
+uint16_t editSrcVarFieldValue(coord_t x, coord_t y, const char* title, uint16_t value,
+                              int16_t min, int16_t max, LcdFlags attr, event_t event,
+                              IsValueAvailable isValueAvailable, int16_t sourceMin);
+
 #if defined(GVARS)
 void drawGVarValue(coord_t x, coord_t y, uint8_t gvar, gvar_t value,
                    LcdFlags flags = 0);
@@ -119,7 +123,8 @@ int16_t editGVarFieldValue(coord_t x, coord_t y, int16_t value, int16_t min,
 
 void gvarWeightItem(coord_t x, coord_t y, MixData * md, LcdFlags attr, event_t event);
 
-void editCurveRef(coord_t x, coord_t y, CurveRef & curve, event_t event, LcdFlags flags);
+void editCurveRef(coord_t x, coord_t y, CurveRef & curve, event_t event, LcdFlags flags,
+                  IsValueAvailable isValueAvailable, int16_t sourceMin);
 
 extern uint8_t editNameCursorPos;
 

--- a/radio/src/gui/212x64/gui.h
+++ b/radio/src/gui/212x64/gui.h
@@ -121,8 +121,6 @@ int16_t editGVarFieldValue(coord_t x, coord_t y, int16_t value, int16_t min,
 
 #endif
 
-void gvarWeightItem(coord_t x, coord_t y, MixData * md, LcdFlags attr, event_t event);
-
 void editCurveRef(coord_t x, coord_t y, CurveRef & curve, event_t event, LcdFlags flags,
                   IsValueAvailable isValueAvailable, int16_t sourceMin);
 

--- a/radio/src/gui/212x64/lcd.cpp
+++ b/radio/src/gui/212x64/lcd.cpp
@@ -632,51 +632,6 @@ void drawMainControlLabel(coord_t x, coord_t y, uint8_t idx, LcdFlags att)
   lcdDrawSizedText(x, y, getMainControlLabel(idx), UINT8_MAX, att);
 }
 
-void drawSource(coord_t x, coord_t y, mixsrc_t idx, LcdFlags att)
-{
-  uint16_t aidx = abs(idx);
-  bool inverted = idx < 0;
-
-  if (aidx == MIXSRC_NONE) {
-    lcdDrawText(x, y, STR_EMPTY, att);
-  }
-  else if (aidx <= MIXSRC_LAST_INPUT) {
-    if (inverted) {
-      lcdDrawChar(x, y, '-');
-      x += 2;
-    }
-    lcdDrawChar(x+2, y+1, CHR_INPUT, TINSIZE);
-    lcdDrawFilledRect(x, y, 7, 7);
-    if (ZEXIST(g_model.inputNames[aidx-MIXSRC_FIRST_INPUT]))
-      lcdDrawSizedText(x+8, y, g_model.inputNames[aidx-MIXSRC_FIRST_INPUT], LEN_INPUT_NAME, att);
-    else
-      lcdDrawNumber(x+8, y, aidx, att|LEADING0|LEFT, 2);
-  }
-
-  else if (aidx <= MIXSRC_LAST_LUA) {
-    div_t qr = div((uint16_t)(aidx-MIXSRC_FIRST_LUA), MAX_SCRIPT_OUTPUTS);
-#if defined(LUA_MODEL_SCRIPTS)
-    if (inverted) {
-      lcdDrawChar(x, y, '-');
-      x += 2;
-    }
-    if (qr.quot < MAX_SCRIPTS && qr.rem < scriptInputsOutputs[qr.quot].outputsCount) {
-      lcdDrawChar(x+2, y+1, '1'+qr.quot, TINSIZE);
-      lcdDrawFilledRect(x, y, 7, 7);
-      lcdDrawSizedText(x+8, y, scriptInputsOutputs[qr.quot].outputs[qr.rem].name, att & STREXPANDED ? 9 : 4, att);
-    }
-    else
-#endif
-    {
-      drawStringWithIndex(x, y, "LUA", qr.quot+1, att);
-      lcdDrawChar(lcdLastRightPos, y, 'a'+qr.rem, att);
-    }
-  }
-  else {
-    lcdDrawText(x, y, getSourceString(idx), att);
-  }
-}
-
 void putsChnLetter(coord_t x, coord_t y, uint8_t idx, LcdFlags att)
 {
   lcdDrawText(x, y, getAnalogShortLabel(idx), att);

--- a/radio/src/gui/212x64/lcd.cpp
+++ b/radio/src/gui/212x64/lcd.cpp
@@ -642,7 +642,7 @@ void drawSource(coord_t x, coord_t y, mixsrc_t idx, LcdFlags att)
   }
   else if (aidx <= MIXSRC_LAST_INPUT) {
     if (inverted) {
-      lcdDrawChar(x, y, '!');
+      lcdDrawChar(x, y, '-');
       x += 2;
     }
     lcdDrawChar(x+2, y+1, CHR_INPUT, TINSIZE);
@@ -657,7 +657,7 @@ void drawSource(coord_t x, coord_t y, mixsrc_t idx, LcdFlags att)
     div_t qr = div((uint16_t)(aidx-MIXSRC_FIRST_LUA), MAX_SCRIPT_OUTPUTS);
 #if defined(LUA_MODEL_SCRIPTS)
     if (inverted) {
-      lcdDrawChar(x, y, '!');
+      lcdDrawChar(x, y, '-');
       x += 2;
     }
     if (qr.quot < MAX_SCRIPTS && qr.rem < scriptInputsOutputs[qr.quot].outputsCount) {

--- a/radio/src/gui/212x64/lcd.h
+++ b/radio/src/gui/212x64/lcd.h
@@ -114,7 +114,6 @@ void lcdDrawNumber(coord_t x, coord_t y, int32_t val, LcdFlags mode=0);
 void drawModelName(coord_t x, coord_t y, char *name, uint8_t id, LcdFlags att);
 void drawSwitch(coord_t x, coord_t y, int32_t swtch, LcdFlags att=0, bool autoBold = true);
 void drawMainControlLabel(coord_t x, coord_t y, uint8_t idx, LcdFlags att=0);
-void drawSource(coord_t x, coord_t y, mixsrc_t idx, LcdFlags att=0);
 void drawCurveName(coord_t x, coord_t y, int8_t idx, LcdFlags att=0);
 void drawTimerMode(coord_t x, coord_t y, swsrc_t mode, LcdFlags att=0);
 

--- a/radio/src/gui/212x64/model_input_edit.cpp
+++ b/radio/src/gui/212x64/model_input_edit.cpp
@@ -119,18 +119,18 @@ void menuModelExpoOne(event_t event)
         break;
 
       case EXPO_FIELD_WEIGHT:
-        lcdDrawTextAlignedLeft(y, STR_WEIGHT);
-        ed->weight = GVAR_MENU_ITEM(EXPO_ONE_2ND_COLUMN, y, ed->weight, -100, 100, LEFT|attr, 0, event);
+        ed->weight = editSrcVarFieldValue(EXPO_ONE_2ND_COLUMN, y, STR_WEIGHT, ed->weight,
+                        -100, 100, attr, event, isSourceAvailableInInputs, INPUTSRC_FIRST);
         break;
 
       case EXPO_FIELD_OFFSET:
-        lcdDrawTextAlignedLeft(y, STR_OFFSET);
-        ed->offset = GVAR_MENU_ITEM(EXPO_ONE_2ND_COLUMN, y, ed->offset, -100, 100, LEFT|attr, 0, event);
+        ed->offset = editSrcVarFieldValue(EXPO_ONE_2ND_COLUMN, y, STR_OFFSET, ed->offset,
+                        -100, 100, attr, event, isSourceAvailableInInputs, INPUTSRC_FIRST);
         break;
 
       case EXPO_FIELD_CURVE:
         lcdDrawTextAlignedLeft(y, STR_CURVE);
-        editCurveRef(EXPO_ONE_2ND_COLUMN, y, ed->curve, event, attr);
+        editCurveRef(EXPO_ONE_2ND_COLUMN, y, ed->curve, event, attr, isSourceAvailableInInputs, INPUTSRC_FIRST);
         break;
 
 #if defined(FLIGHT_MODES)

--- a/radio/src/gui/212x64/model_mix_edit.cpp
+++ b/radio/src/gui/212x64/model_mix_edit.cpp
@@ -43,13 +43,15 @@ enum MixFields {
 
 extern uint8_t FM_ROW(uint8_t);
 
+extern int32_t getSourceNumFieldValue(int16_t val, int16_t min, int16_t max);
+
 void drawOffsetBar(uint8_t x, uint8_t y, MixData * md)
 {
   const int gaugeWidth = 33;
   const int gaugeHeight = 6;
 
-  int offset = GET_GVAR(MD_OFFSET(md), GV_RANGELARGE_NEG, GV_RANGELARGE, mixerCurrentFlightMode);
-  int weight = GET_GVAR(MD_WEIGHT(md), GV_RANGELARGE_NEG, GV_RANGELARGE, mixerCurrentFlightMode);
+  int offset = getSourceNumFieldValue(md->offset, MIX_OFFSET_MIN, MIX_OFFSET_MAX) / 10;
+  int weight = getSourceNumFieldValue(md->weight, MIX_WEIGHT_MIN, MIX_WEIGHT_MAX) / 10;
   int barMin = offset - weight;
   int barMax = offset + weight;
   if (y > 15) {
@@ -130,20 +132,15 @@ void menuModelMixOne(event_t event)
         break;
 
       case MIX_FIELD_WEIGHT:
-        lcdDrawTextAlignedLeft(y, STR_WEIGHT);
-        gvarWeightItem(MIXES_2ND_COLUMN, y, md2, attr|LEFT, event);
+        md2->weight = editSrcVarFieldValue(MIXES_2ND_COLUMN, y, STR_WEIGHT, md2->weight, 
+                        MIX_WEIGHT_MIN, MIX_WEIGHT_MAX, attr, event, isSourceAvailable, 1);
         break;
 
       case MIX_FIELD_OFFSET:
-      {
-        lcdDrawTextAlignedLeft(y, STR_OFFSET);
-        u_int8int16_t offset;
-        MD_OFFSET_TO_UNION(md2, offset);
-        offset.word = GVAR_MENU_ITEM(MIXES_2ND_COLUMN, y, offset.word, MIX_OFFSET_MIN, MIX_OFFSET_MAX, attr|LEFT, 0, event);
-        MD_UNION_TO_OFFSET(offset, md2);
+        md2->offset = editSrcVarFieldValue(MIXES_2ND_COLUMN, y, STR_OFFSET, md2->offset,
+                        MIX_OFFSET_MIN, MIX_OFFSET_MAX, attr, event, isSourceAvailable, 1);
         drawOffsetBar(MIXES_2ND_COLUMN+35, y, md2);
         break;
-      }
 
       case MIX_FIELD_TRIM:
         lcdDrawTextAlignedLeft(y, STR_TRIM);
@@ -157,7 +154,7 @@ void menuModelMixOne(event_t event)
         lcdDrawTextAlignedLeft(y, STR_CURVE);
         s_currSrcRaw = md2->srcRaw;
         s_currScale = 0;
-        editCurveRef(MIXES_2ND_COLUMN, y, md2->curve, event, attr);
+        editCurveRef(MIXES_2ND_COLUMN, y, md2->curve, event, attr, isSourceAvailable, 1);
         break;
 
 #if defined(FLIGHT_MODES)

--- a/radio/src/gui/212x64/widgets.cpp
+++ b/radio/src/gui/212x64/widgets.cpp
@@ -120,6 +120,28 @@ void drawSlider(coord_t x, coord_t y, uint8_t value, uint8_t max, uint8_t attr)
   if (attr && (!(attr & BLINK) || !BLINK_ON_PHASE)) lcdDrawFilledRect(x, y, 5*FW-1, FH-1);
 }
 
+uint16_t editSrcVarFieldValue(coord_t x, coord_t y, const char* title, uint16_t value,
+                              int16_t min, int16_t max, LcdFlags attr, event_t event,
+                              IsValueAvailable isValueAvailable, int16_t sourceMin)
+{
+  if (title)
+    lcdDrawTextAlignedLeft(y, title);
+  SourceNumVal v;
+  v.rawValue = value;
+  if (v.isSource) {
+    drawSource(x, y, v.value, attr);
+    if (attr & (~RIGHT)) {
+      value = checkIncDec(event, value, sourceMin, MIXSRC_LAST, EE_MODEL|INCDEC_SOURCE|INCDEC_SOURCE_VALUE|INCDEC_SOURCE_INVERT|NO_INCDEC_MARKS, isValueAvailable);
+    }
+  } else {
+    lcdDrawNumber(x, y, v.value, attr);
+    if (attr & (~RIGHT)) {
+      value = checkIncDec(event, value, min, max, EE_MODEL|INCDEC_SOURCE_VALUE|NO_INCDEC_MARKS);
+    }
+  }
+  return value;
+}
+
 #if defined(GVARS)
 void drawGVarValue(coord_t x, coord_t y, uint8_t gvar, gvar_t value, LcdFlags flags)
 {

--- a/radio/src/gui/212x64/widgets.cpp
+++ b/radio/src/gui/212x64/widgets.cpp
@@ -131,12 +131,14 @@ uint16_t editSrcVarFieldValue(coord_t x, coord_t y, const char* title, uint16_t 
   if (v.isSource) {
     drawSource(x, y, v.value, attr);
     if (attr & (~RIGHT)) {
-      value = checkIncDec(event, value, sourceMin, MIXSRC_LAST, EE_MODEL|INCDEC_SOURCE|INCDEC_SOURCE_VALUE|INCDEC_SOURCE_INVERT|NO_INCDEC_MARKS, isValueAvailable);
+      value = checkIncDec(event, value, sourceMin,
+                MIXSRC_LAST, EE_MODEL|INCDEC_SOURCE|INCDEC_SOURCE_VALUE|INCDEC_SOURCE_INVERT|NO_INCDEC_MARKS, isValueAvailable);
     }
   } else {
     lcdDrawNumber(x, y, v.value, attr);
     if (attr & (~RIGHT)) {
-      value = checkIncDec(event, value, min, max, EE_MODEL|INCDEC_SOURCE_VALUE|NO_INCDEC_MARKS, isValueAvailable);
+      value = checkIncDec(event, value, min, max,
+                EE_MODEL|INCDEC_SOURCE_VALUE|NO_INCDEC_MARKS|(sourceMin == INPUTSRC_FIRST ? INCDEC_SOURCE_NOINPUTS : 0));
     }
   }
   return value;

--- a/radio/src/gui/212x64/widgets.cpp
+++ b/radio/src/gui/212x64/widgets.cpp
@@ -136,7 +136,7 @@ uint16_t editSrcVarFieldValue(coord_t x, coord_t y, const char* title, uint16_t 
   } else {
     lcdDrawNumber(x, y, v.value, attr);
     if (attr & (~RIGHT)) {
-      value = checkIncDec(event, value, min, max, EE_MODEL|INCDEC_SOURCE_VALUE|NO_INCDEC_MARKS);
+      value = checkIncDec(event, value, min, max, EE_MODEL|INCDEC_SOURCE_VALUE|NO_INCDEC_MARKS, isValueAvailable);
     }
   }
   return value;

--- a/radio/src/gui/colorlcd/CMakeLists.txt
+++ b/radio/src/gui/colorlcd/CMakeLists.txt
@@ -111,6 +111,7 @@ set(GUI_SRC
   radio_tools.cpp
   radio_trainer.cpp
   radio_version.cpp
+  source_numberedit.cpp
   )
 
 macro(add_gui_src src)

--- a/radio/src/gui/colorlcd/curve.cpp
+++ b/radio/src/gui/colorlcd/curve.cpp
@@ -243,7 +243,11 @@ void Curve::clearPoints()
   update();
 }
 
-void Curve::update() { base.update(); }
+void Curve::update()
+{
+  base.update();
+  updatePosition();
+}
 
 void Curve::checkEvents()
 {

--- a/radio/src/gui/colorlcd/curve_param.cpp
+++ b/radio/src/gui/colorlcd/curve_param.cpp
@@ -22,6 +22,7 @@
 #include "curve_param.h"
 
 #include "gvar_numberedit.h"
+#include "source_numberedit.h"
 #include "model_curves.h"
 #include "opentx.h"
 
@@ -92,7 +93,7 @@ CurveParam::CurveParam(Window* parent, const rect_t& rect, CurveRef* ref,
 
   // CURVE_REF_DIFF
   // CURVE_REF_EXPO
-  auto gv = new GVarNumberEdit(this, -100, 100, GET_DEFAULT(ref->value), setRefValue);
+  auto gv = new SourceNumberEdit(this, -100, 100, GET_DEFAULT(ref->value), setRefValue);
   gv->setSuffix("%");
   value_edit = gv;
 

--- a/radio/src/gui/colorlcd/curve_param.cpp
+++ b/radio/src/gui/colorlcd/curve_param.cpp
@@ -73,7 +73,8 @@ class CurveChoice : public Choice
 };
 
 CurveParam::CurveParam(Window* parent, const rect_t& rect, CurveRef* ref,
-                       std::function<void(int32_t)> setRefValue, std::function<void(void)> refreshView) :
+                       std::function<void(int32_t)> setRefValue, int16_t sourceMin,
+                       std::function<void(void)> refreshView) :
     Window(parent, rect), ref(ref)
 {
   padAll(PAD_TINY);
@@ -93,7 +94,7 @@ CurveParam::CurveParam(Window* parent, const rect_t& rect, CurveRef* ref,
 
   // CURVE_REF_DIFF
   // CURVE_REF_EXPO
-  auto gv = new SourceNumberEdit(this, -100, 100, GET_DEFAULT(ref->value), setRefValue);
+  auto gv = new SourceNumberEdit(this, -100, 100, GET_DEFAULT(ref->value), setRefValue, sourceMin);
   gv->setSuffix("%");
   value_edit = gv;
 

--- a/radio/src/gui/colorlcd/curve_param.h
+++ b/radio/src/gui/colorlcd/curve_param.h
@@ -43,5 +43,6 @@ class CurveParam : public Window
  public:
   CurveParam(Window* parent, const rect_t& rect, CurveRef* ref,
              std::function<void(int32_t)> setRefValue,
+             int16_t sourceMin,
              std::function<void(void)> refreshView = nullptr);
 };

--- a/radio/src/gui/colorlcd/curve_param.h
+++ b/radio/src/gui/colorlcd/curve_param.h
@@ -24,25 +24,30 @@
 #include "window.h"
 
 struct CurveRef;
+class Choice;
+class SourceNumberEdit;
 
 class CurveParam : public Window
 {
-  // Curve
-  CurveRef* ref;
-
-  // Controls
-  Window* value_edit;
-  Window* func_choice;
-  Window* cust_choice;
-  Window* act_field = nullptr;
-
-  void update();
-  static void value_changed(lv_event_t* e);
-  static void LongPressHandler(void* data);
-
  public:
   CurveParam(Window* parent, const rect_t& rect, CurveRef* ref,
              std::function<void(int32_t)> setRefValue,
              int16_t sourceMin,
              std::function<void(void)> refreshView = nullptr);
+
+ protected:
+  // Curve
+  CurveRef* ref;
+
+  // Controls
+  SourceNumberEdit* value_edit;
+  Choice* func_choice;
+  Choice* cust_choice;
+  Window* act_field = nullptr;
+
+  std::function<void(void)> refreshView;
+
+  void update();
+
+  static void LongPressHandler(void* data);
 };

--- a/radio/src/gui/colorlcd/input_edit.cpp
+++ b/radio/src/gui/colorlcd/input_edit.cpp
@@ -24,6 +24,7 @@
 #include "curve_param.h"
 #include "curveedit.h"
 #include "gvar_numberedit.h"
+#include "source_numberedit.h"
 #include "input_edit_adv.h"
 #include "input_source.h"
 #include "opentx.h"
@@ -106,23 +107,23 @@ void InputEditWindow::buildBody(Window* form)
   line = form->newLine(grid);
   new StaticText(line, rect_t{}, STR_WEIGHT);
   auto gvar =
-      new GVarNumberEdit(line, -100, 100, GET_DEFAULT(input->weight),
-                         [=](int32_t newValue) {
-                           input->weight = newValue;
-                           preview->update();
-                           SET_DIRTY();
-                         });
+      new SourceNumberEdit(line, -100, 100, GET_DEFAULT(input->weight),
+                           [=](int32_t newValue) {
+                             input->weight = newValue;
+                             preview->update();
+                             SET_DIRTY();
+                           });
   gvar->setSuffix("%");
 
   // Offset
   line = form->newLine(grid);
   new StaticText(line, rect_t{}, STR_OFFSET);
-  gvar = new GVarNumberEdit(line, -100, 100,
-                            GET_DEFAULT(input->offset), [=](int32_t newValue) {
-                              input->offset = newValue;
-                              preview->update();
-                              SET_DIRTY();
-                            });
+  gvar = new SourceNumberEdit(line, -100, 100,
+                              GET_DEFAULT(input->offset), [=](int32_t newValue) {
+                                input->offset = newValue;
+                                preview->update();
+                                SET_DIRTY();
+                              });
   gvar->setSuffix("%");
 
   // Switch
@@ -163,4 +164,45 @@ void InputEditWindow::deleteLater(bool detach, bool trash)
     CurveEdit::SetCurrentSource(0);
     Page::deleteLater(detach, trash);
   }
+}
+
+void InputEditWindow::checkEvents()
+{
+  ExpoData* input = expoAddress(index);
+
+  bool updatePreview = false;
+  getvalue_t val;
+  SourceNumVal v;
+
+  v.rawValue = input->weight;
+  if (v.isSource) {
+    val = getValue(v.value);
+    if (val != lastWeightVal) {
+      lastWeightVal = val;
+      updatePreview = true;
+    }
+  }
+
+  v.rawValue = input->offset;
+  if (v.isSource) {
+    val = getValue(v.value);
+    if (val != lastOffsetVal) {
+      lastOffsetVal = val;
+      updatePreview = true;
+    }
+  }
+
+  v.rawValue = input->curve.value;
+  if (v.isSource) {
+    val = getValue(v.value);
+    if (val != lastCurveVal) {
+      lastCurveVal = val;
+      updatePreview = true;
+    }
+  }
+
+  if (updatePreview)
+    preview->update();
+
+  Page::checkEvents();
 }

--- a/radio/src/gui/colorlcd/input_edit.cpp
+++ b/radio/src/gui/colorlcd/input_edit.cpp
@@ -112,7 +112,7 @@ void InputEditWindow::buildBody(Window* form)
                              input->weight = newValue;
                              preview->update();
                              SET_DIRTY();
-                           });
+                           }, INPUTSRC_FIRST);
   gvar->setSuffix("%");
 
   // Offset
@@ -123,7 +123,7 @@ void InputEditWindow::buildBody(Window* form)
                                 input->offset = newValue;
                                 preview->update();
                                 SET_DIRTY();
-                              });
+                              }, INPUTSRC_FIRST);
   gvar->setSuffix("%");
 
   // Switch
@@ -141,7 +141,7 @@ void InputEditWindow::buildBody(Window* form)
           input->curve.value = newValue;
           preview->update();
           SET_DIRTY();
-        },
+        }, INPUTSRC_FIRST,
         [=]() {
           preview->update();
         });

--- a/radio/src/gui/colorlcd/input_edit.cpp
+++ b/radio/src/gui/colorlcd/input_edit.cpp
@@ -139,11 +139,13 @@ void InputEditWindow::buildBody(Window* form)
       new CurveParam(line, rect_t{}, &input->curve,
         [=](int32_t newValue) {
           input->curve.value = newValue;
-          preview->update();
+          if (preview)
+            preview->update();
           SET_DIRTY();
         }, INPUTSRC_FIRST,
         [=]() {
-          preview->update();
+          if (preview)
+            preview->update();
         });
   lv_obj_set_style_grid_cell_x_align(param->getLvObj(), LV_GRID_ALIGN_STRETCH,
                                      0);

--- a/radio/src/gui/colorlcd/input_edit.h
+++ b/radio/src/gui/colorlcd/input_edit.h
@@ -39,8 +39,12 @@ class InputEditWindow : public Page
   uint8_t input;
   uint8_t index;
   Curve* preview;
+  getvalue_t lastWeightVal = 0;
+  getvalue_t lastOffsetVal = 0;
+  getvalue_t lastCurveVal = 0;
 
   void buildBody(Window *window);
 
+  void checkEvents() override;
   void deleteLater(bool detach = true, bool trash = true) override;
 };

--- a/radio/src/gui/colorlcd/input_edit.h
+++ b/radio/src/gui/colorlcd/input_edit.h
@@ -38,7 +38,7 @@ class InputEditWindow : public Page
  protected:
   uint8_t input;
   uint8_t index;
-  Curve* preview;
+  Curve* preview = nullptr;
   getvalue_t lastWeightVal = 0;
   getvalue_t lastOffsetVal = 0;
   getvalue_t lastCurveVal = 0;

--- a/radio/src/gui/colorlcd/list_line_button.cpp
+++ b/radio/src/gui/colorlcd/list_line_button.cpp
@@ -71,6 +71,7 @@ InputMixButtonBase::InputMixButtonBase(Window* parent, uint8_t index) :
   weight = lv_label_create(lvobj);
   lv_obj_set_pos(weight, WGT_X, WGT_Y);
   lv_obj_set_size(weight, WGT_W, WGT_H);
+  etx_font(weight, FONT_XS_INDEX, LV_STATE_USER_1);
 
   source = lv_label_create(lvobj);
   lv_obj_set_pos(source, SRC_X, SRC_Y);
@@ -79,6 +80,7 @@ InputMixButtonBase::InputMixButtonBase(Window* parent, uint8_t index) :
   opts = lv_label_create(lvobj);
   lv_obj_set_pos(opts, OPT_X, OPT_Y);
   lv_obj_set_size(opts, OPT_W, OPT_H);
+  etx_font(opts, FONT_XS_INDEX, LV_STATE_USER_1);
 }
 
 InputMixButtonBase::~InputMixButtonBase()
@@ -89,7 +91,12 @@ InputMixButtonBase::~InputMixButtonBase()
 void InputMixButtonBase::setWeight(gvar_t value, gvar_t min, gvar_t max)
 {
   char s[32];
-  getValueOrGVarString(s, sizeof(s), value, min, max, 0, "%");
+  getValueOrSrcVarString(s, sizeof(s), value, min, max, 0, "%");
+  if (getTextWidth(s, 0, FONT(STD)) > WGT_W)
+    lv_obj_add_state(weight, LV_STATE_USER_1);
+  else
+    lv_obj_clear_state(weight, LV_STATE_USER_1);
+
   lv_label_set_text(weight, s);
 }
 
@@ -97,6 +104,16 @@ void InputMixButtonBase::setSource(mixsrc_t idx)
 {
   char* s = getSourceString(idx);
   lv_label_set_text(source, s);
+}
+
+void InputMixButtonBase::setOpts(const char* s)
+{
+  if (getTextWidth(s, 0, FONT(STD)) > OPT_W)
+    lv_obj_add_state(opts, LV_STATE_USER_1);
+  else
+    lv_obj_clear_state(opts, LV_STATE_USER_1);
+
+  lv_label_set_text(opts, s);
 }
 
 void InputMixButtonBase::setFlightModes(uint16_t modes)

--- a/radio/src/gui/colorlcd/list_line_button.h
+++ b/radio/src/gui/colorlcd/list_line_button.h
@@ -54,6 +54,7 @@ class InputMixButtonBase : public ListLineButton
 
   void setWeight(gvar_t value, gvar_t min, gvar_t max);
   void setSource(mixsrc_t idx);
+  void setOpts(const char* s);
   void setFlightModes(uint16_t modes);
 
   virtual void updatePos(coord_t x, coord_t y) = 0;
@@ -66,7 +67,7 @@ class InputMixButtonBase : public ListLineButton
   static LAYOUT_VAL(BTN_W, 389, 229)
   static constexpr coord_t WGT_X = PAD_TINY;
   static constexpr coord_t WGT_Y = PAD_TINY;
-  static LAYOUT_VAL(WGT_W, 43, 43)
+  static LAYOUT_VAL(WGT_W, 50, 50)
   static LAYOUT_VAL(WGT_H, 21, 21)
   static constexpr coord_t SRC_X = WGT_X + WGT_W + PAD_TINY;
   static constexpr coord_t SRC_Y = WGT_Y;
@@ -74,7 +75,7 @@ class InputMixButtonBase : public ListLineButton
   static constexpr coord_t SRC_H = WGT_H;
   static constexpr coord_t OPT_X = SRC_X + SRC_W + PAD_TINY;
   static constexpr coord_t OPT_Y = WGT_Y;
-  static LAYOUT_VAL(OPT_W, 171, 106)
+  static LAYOUT_VAL(OPT_W, 164, 99)
   static constexpr coord_t OPT_H = WGT_H;
   static LAYOUT_VAL(LN_X, 73, 73)
   static LAYOUT_VAL(FM_X, (OPT_X + OPT_W + PAD_TINY), 12)

--- a/radio/src/gui/colorlcd/mixer_edit.cpp
+++ b/radio/src/gui/colorlcd/mixer_edit.cpp
@@ -22,8 +22,9 @@
 #include "mixer_edit.h"
 
 #include "channel_bar.h"
-#include "curve_param.h"
 #include "gvar_numberedit.h"
+#include "source_numberedit.h"
+#include "curve_param.h"
 #include "mixer_edit_adv.h"
 #include "mixes.h"
 #include "opentx.h"
@@ -108,14 +109,14 @@ void MixEditWindow::buildBody(Window *form)
   // Weight
   line = form->newLine(grid);
   new StaticText(line, rect_t{}, STR_WEIGHT);
-  auto gvar = new GVarNumberEdit(line, MIX_WEIGHT_MIN, MIX_WEIGHT_MAX,
-                                 GET_SET_DEFAULT(mix->weight));
-  gvar->setSuffix("%");
+  auto svar = new SourceNumberEdit(line, MIX_WEIGHT_MIN, MIX_WEIGHT_MAX,
+                                   GET_SET_DEFAULT(mix->weight));
+  svar->setSuffix("%");
 
   // Offset
   new StaticText(line, rect_t{}, STR_OFFSET);
-  gvar = new GVarNumberEdit(line, MIX_OFFSET_MIN, MIX_OFFSET_MAX,
-                            GET_SET_DEFAULT(mix->offset));
+  auto gvar = new SourceNumberEdit(line, MIX_OFFSET_MIN, MIX_OFFSET_MAX,
+                                   GET_SET_DEFAULT(mix->offset));
   gvar->setSuffix("%");
 
   // Switch

--- a/radio/src/gui/colorlcd/mixer_edit.cpp
+++ b/radio/src/gui/colorlcd/mixer_edit.cpp
@@ -110,13 +110,13 @@ void MixEditWindow::buildBody(Window *form)
   line = form->newLine(grid);
   new StaticText(line, rect_t{}, STR_WEIGHT);
   auto svar = new SourceNumberEdit(line, MIX_WEIGHT_MIN, MIX_WEIGHT_MAX,
-                                   GET_SET_DEFAULT(mix->weight));
+                                   GET_SET_DEFAULT(mix->weight), 0);
   svar->setSuffix("%");
 
   // Offset
   new StaticText(line, rect_t{}, STR_OFFSET);
   auto gvar = new SourceNumberEdit(line, MIX_OFFSET_MIN, MIX_OFFSET_MAX,
-                                   GET_SET_DEFAULT(mix->offset));
+                                   GET_SET_DEFAULT(mix->offset), 0);
   gvar->setSuffix("%");
 
   // Switch
@@ -127,7 +127,7 @@ void MixEditWindow::buildBody(Window *form)
 
   // Curve
   new StaticText(line, rect_t{}, STR_CURVE);
-  new CurveParam(line, rect_t{}, &mix->curve, SET_DEFAULT(mix->curve.value));
+  new CurveParam(line, rect_t{}, &mix->curve, SET_DEFAULT(mix->curve.value), 0);
 
   line = form->newLine(grid);
   line->padAll(PAD_LARGE);

--- a/radio/src/gui/colorlcd/model_inputs.cpp
+++ b/radio/src/gui/colorlcd/model_inputs.cpp
@@ -129,29 +129,29 @@ class InputLineButton : public InputMixButtonBase
       }
     }
 
-    if (line.swtch || line.curve.value) {
-      if (line.swtch) {
-        char* sw_pos = getSwitchPositionName(line.swtch);
-        int cnt = lv_snprintf(s, maxlen, "%s ", sw_pos);
-        if ((size_t)cnt >= maxlen)
-          maxlen = 0;
-        else {
-          maxlen -= cnt;
-          s += cnt;
-        }
-      }
-      if (line.curve.value != 0) {
-        getCurveRefString(s, maxlen, line.curve);
-        int cnt = strnlen(s, maxlen);
-        if ((size_t)cnt >= maxlen)
-          maxlen = 0;
-        else {
-          maxlen -= cnt;
-          s += cnt;
-        }
+    if (line.swtch) {
+      char* sw_pos = getSwitchPositionName(line.swtch);
+      int cnt = lv_snprintf(s, maxlen, "%s ", sw_pos);
+      if ((size_t)cnt >= maxlen)
+        maxlen = 0;
+      else {
+        maxlen -= cnt;
+        s += cnt;
       }
     }
-    lv_label_set_text_fmt(opts, "%.*s", (int)sizeof(tmp_str), tmp_str);
+
+    if (line.curve.value != 0) {
+      getCurveRefString(s, maxlen, line.curve);
+      int cnt = strnlen(s, maxlen);
+      if ((size_t)cnt >= maxlen)
+        maxlen = 0;
+      else {
+        maxlen -= cnt;
+        s += cnt;
+      }
+    }
+
+    setOpts(s);
 
     setFlightModes(line.flightModes);
   }

--- a/radio/src/gui/colorlcd/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model_mixes.cpp
@@ -98,32 +98,25 @@ class MixLineButton : public InputMixButtonBase
     setSource(line.srcRaw);
 
     char tmp_str[64];
-    size_t maxlen = sizeof(tmp_str);
-
     char *s = tmp_str;
     *s = '\0';
 
     if (line.name[0]) {
-      int cnt = lv_snprintf(s, maxlen, "%.*s ", (int)sizeof(line.name), line.name);
-      if ((size_t)cnt >= maxlen) maxlen = 0;
-      else { maxlen -= cnt; s += cnt; }
+      s = strAppend(s, line.name, LEN_EXPOMIX_NAME);
     }
 
-    if (line.swtch || line.curve.value) {
-      if (line.swtch) {
-        char* sw_pos = getSwitchPositionName(line.swtch);
-        int cnt = lv_snprintf(s, maxlen, "%s ", sw_pos);
-        if ((size_t)cnt >= maxlen) maxlen = 0;
-        else { maxlen -= cnt; s += cnt; }
-      }
-      if (line.curve.value != 0) {
-        getCurveRefString(s, maxlen, line.curve);
-        int cnt = strnlen(s, maxlen);
-        if ((size_t)cnt >= maxlen) maxlen = 0;
-        else { maxlen -= cnt; s += cnt; }
-      }
+    if (line.swtch) {
+      if (tmp_str[0]) s = strAppend(s, " ");
+      char* sw_pos = getSwitchPositionName(line.swtch);
+      s = strAppend(s, sw_pos);
     }
-    lv_label_set_text_fmt(opts, "%.*s", (int)sizeof(tmp_str), tmp_str);
+
+    if (line.curve.value != 0) {
+      if (tmp_str[0]) s = strAppend(s, " ");
+      getCurveRefString(s, sizeof(tmp_str) - (s - tmp_str), line.curve);
+    }
+
+    setOpts(tmp_str);
 
     mplex->refresh();
 

--- a/radio/src/gui/colorlcd/source_numberedit.cpp
+++ b/radio/src/gui/colorlcd/source_numberedit.cpp
@@ -37,6 +37,7 @@ SourceNumberEdit::SourceNumberEdit(Window* parent,
                                    int32_t vmin, int32_t vmax,
                                    std::function<int32_t()> getValue,
                                    std::function<void(int32_t)> setValue,
+                                   int16_t sourceMin,
                                    LcdFlags textFlags, int32_t voffset,
                                    int32_t vdefault) :
     Window(parent, {0, 0, NUM_EDIT_W + SRC_BTN_W + PAD_TINY * 3, EdgeTxStyles::UI_ELEMENT_HEIGHT + PAD_TINY * 2}),
@@ -54,7 +55,7 @@ SourceNumberEdit::SourceNumberEdit(Window* parent,
 
   // Source field
   source_field = new SourceChoice(
-      this, {0, 0, NUM_EDIT_W, 0}, 0, INPUTSRC_LAST,
+      this, {0, 0, NUM_EDIT_W, 0}, sourceMin, INPUTSRC_LAST,
       [=]() {
         SourceNumVal v;
         v.rawValue = getValue();

--- a/radio/src/gui/colorlcd/source_numberedit.cpp
+++ b/radio/src/gui/colorlcd/source_numberedit.cpp
@@ -1,0 +1,148 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "source_numberedit.h"
+
+#include "opentx.h"
+#include "sourcechoice.h"
+
+void SourceNumberEdit::value_changed(lv_event_t* e)
+{
+  auto obj = lv_event_get_target(e);
+  auto edit = (SourceNumberEdit*)lv_obj_get_user_data(obj);
+  if (!edit) return;
+
+  edit->update();
+}
+
+SourceNumberEdit::SourceNumberEdit(Window* parent,
+                                   int32_t vmin, int32_t vmax,
+                                   std::function<int32_t()> getValue,
+                                   std::function<void(int32_t)> setValue,
+                                   LcdFlags textFlags, int32_t voffset,
+                                   int32_t vdefault) :
+    Window(parent, {0, 0, NUM_EDIT_W + SRC_BTN_W + PAD_TINY * 3, EdgeTxStyles::UI_ELEMENT_HEIGHT + PAD_TINY * 2}),
+    vmin(vmin),
+    vmax(vmax),
+    getValue(getValue),
+    setValue(setValue),
+    textFlags(textFlags),
+    voffset(voffset)
+{
+  padAll(PAD_TINY);
+  lv_obj_set_flex_flow(lvobj, LV_FLEX_FLOW_ROW_WRAP);
+  lv_obj_set_style_flex_cross_place(lvobj, LV_FLEX_ALIGN_CENTER, 0);
+  lv_obj_set_size(lvobj, LV_SIZE_CONTENT, LV_SIZE_CONTENT);
+
+  // Source field
+  source_field = new SourceChoice(
+      this, {0, 0, NUM_EDIT_W, 0}, 0, INPUTSRC_LAST,
+      [=]() {
+        SourceNumVal v;
+        v.rawValue = getValue();
+        return v.value;
+      },
+      [=](int newValue) {
+        SourceNumVal v = {(int16_t)newValue, true};
+        setValue(v.rawValue);
+      }, true);
+
+  num_field = new NumberEdit(
+      this, {0, 0, NUM_EDIT_W, 0}, vmin, vmax,
+      [=]() {
+        SourceNumVal v;
+        v.rawValue = getValue();
+        return v.value;
+      },
+      [=](int newValue) {
+        SourceNumVal v = {(int16_t)newValue, false};
+        setValue(v.rawValue);
+      },
+      textFlags);
+  num_field->setDefault(vdefault);
+
+  // The Source button
+  m_srcBtn = new TextButton(this, {NUM_EDIT_W + PAD_TINY, 0, SRC_BTN_W, 0}, "SRC", [=]() {
+    switchSourceMode();
+    return isSource();
+  });
+  m_srcBtn->check(isSource());
+
+  lv_obj_add_event_cb(lvobj, SourceNumberEdit::value_changed,
+                      LV_EVENT_VALUE_CHANGED, nullptr);
+
+  // update field type based on value
+  update();
+}
+
+bool SourceNumberEdit::isSource()
+{
+  SourceNumVal v;
+  v.rawValue = getValue();
+  return v.isSource;
+}
+
+void SourceNumberEdit::switchSourceMode()
+{
+  SourceNumVal v;
+  v.rawValue = getValue();
+  v.isSource = !v.isSource;
+  // TODO: convert value???
+  v.value = 0;
+  setValue(v.rawValue);
+  if (v.isSource)
+    source_field->update();
+  else
+    num_field->update();
+
+  m_srcBtn->check(isSource());
+
+  // update field type based on value
+  update();
+}
+
+void SourceNumberEdit::setSuffix(std::string value)
+{
+  num_field->setSuffix(value);
+}
+
+void SourceNumberEdit::update()
+{
+  bool has_focus = act_field && act_field->hasFocus();
+
+  source_field->hide();
+  num_field->hide();
+
+  if (isSource()) {
+    // Source mode
+    act_field = source_field;
+    source_field->show();
+    lv_event_send(source_field->getLvObj(), LV_EVENT_VALUE_CHANGED, nullptr);
+  } else {
+    // number edit mode
+    act_field = num_field;
+    num_field->show();
+  }
+
+  if (has_focus) {
+    lv_group_focus_obj(act_field->getLvObj());
+  }
+}

--- a/radio/src/gui/colorlcd/source_numberedit.cpp
+++ b/radio/src/gui/colorlcd/source_numberedit.cpp
@@ -109,10 +109,6 @@ void SourceNumberEdit::switchSourceMode()
   // TODO: convert value???
   v.value = 0;
   setValue(v.rawValue);
-  if (v.isSource)
-    source_field->update();
-  else
-    num_field->update();
 
   // update field type based on value
   update();
@@ -134,11 +130,13 @@ void SourceNumberEdit::update()
     // Source mode
     act_field = source_field;
     source_field->show();
+    source_field->update();
     lv_event_send(source_field->getLvObj(), LV_EVENT_VALUE_CHANGED, nullptr);
   } else {
     // number edit mode
     act_field = num_field;
     num_field->show();
+    num_field->update();
   }
 
   m_srcBtn->check(isSource());

--- a/radio/src/gui/colorlcd/source_numberedit.cpp
+++ b/radio/src/gui/colorlcd/source_numberedit.cpp
@@ -114,8 +114,6 @@ void SourceNumberEdit::switchSourceMode()
   else
     num_field->update();
 
-  m_srcBtn->check(isSource());
-
   // update field type based on value
   update();
 }
@@ -142,6 +140,8 @@ void SourceNumberEdit::update()
     act_field = num_field;
     num_field->show();
   }
+
+  m_srcBtn->check(isSource());
 
   if (has_focus) {
     lv_group_focus_obj(act_field->getLvObj());

--- a/radio/src/gui/colorlcd/source_numberedit.h
+++ b/radio/src/gui/colorlcd/source_numberedit.h
@@ -33,6 +33,7 @@ class SourceNumberEdit : public Window
   SourceNumberEdit(Window* parent, int32_t vmin, int32_t vmax,
                    std::function<int32_t()> getValue,
                    std::function<void(int32_t)> setValue,
+                   int16_t sourceMin,
                    LcdFlags textFlags = 0, int32_t voffset = 0,
                    int32_t vdefault = 0);
 

--- a/radio/src/gui/colorlcd/source_numberedit.h
+++ b/radio/src/gui/colorlcd/source_numberedit.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include "choice.h"
+#include "form.h"
+#include "numberedit.h"
+
+class TextButton;
+
+class SourceNumberEdit : public Window
+{
+ public:
+  SourceNumberEdit(Window* parent, int32_t vmin, int32_t vmax,
+                   std::function<int32_t()> getValue,
+                   std::function<void(int32_t)> setValue,
+                   LcdFlags textFlags = 0, int32_t voffset = 0,
+                   int32_t vdefault = 0);
+
+  void switchSourceMode();
+  void setSuffix(std::string value);
+
+  void setFastStep(int value) { num_field->setFastStep(value); }
+  void setAccelFactor(int value) { num_field->setAccelFactor(value); }
+
+  static LAYOUT_VAL(NUM_EDIT_W, 84, 74)
+  static LAYOUT_VAL(SRC_BTN_W, 38, 38)
+
+ protected:
+  Choice* source_field = nullptr;
+  NumberEdit* num_field = nullptr;
+  FormField* act_field = nullptr;
+  TextButton* m_srcBtn = nullptr;
+
+  int32_t vmin;
+  int32_t vmax;
+  std::function<int32_t()> getValue;
+  std::function<void(int32_t)> setValue;
+  LcdFlags textFlags;
+  int32_t voffset;
+
+  bool isSource();
+
+  void update();
+
+  static void value_changed(lv_event_t* e);
+};

--- a/radio/src/gui/colorlcd/source_numberedit.h
+++ b/radio/src/gui/colorlcd/source_numberedit.h
@@ -43,6 +43,8 @@ class SourceNumberEdit : public Window
   void setFastStep(int value) { num_field->setFastStep(value); }
   void setAccelFactor(int value) { num_field->setAccelFactor(value); }
 
+  void update();
+
   static LAYOUT_VAL(NUM_EDIT_W, 84, 74)
   static LAYOUT_VAL(SRC_BTN_W, 38, 38)
 
@@ -60,8 +62,6 @@ class SourceNumberEdit : public Window
   int32_t voffset;
 
   bool isSource();
-
-  void update();
 
   static void value_changed(lv_event_t* e);
 };

--- a/radio/src/gui/common/stdlcd/draw_functions.cpp
+++ b/radio/src/gui/common/stdlcd/draw_functions.cpp
@@ -405,12 +405,12 @@ void drawCurveRef(coord_t x, coord_t y, CurveRef & curve, LcdFlags att)
     switch (curve.type) {
       case CURVE_REF_DIFF:
         lcdDrawText(x, y, "D", att);
-        GVAR_MENU_ITEM(lcdNextPos, y, curve.value, -100, 100, LEFT|att, 0, 0);
+        editSrcVarFieldValue(lcdNextPos, y, nullptr, curve.value, -100, 100, LEFT|att, 0, 0, 0);
         break;
 
       case CURVE_REF_EXPO:
         lcdDrawText(x, y, "E", att);
-        GVAR_MENU_ITEM(lcdNextPos, y, curve.value, -100, 100, LEFT|att, 0, 0);
+        editSrcVarFieldValue(lcdNextPos, y, nullptr, curve.value, -100, 100, LEFT|att, 0, 0, 0);
         break;
 
       case CURVE_REF_FUNC:

--- a/radio/src/gui/common/stdlcd/draw_functions.cpp
+++ b/radio/src/gui/common/stdlcd/draw_functions.cpp
@@ -535,3 +535,88 @@ void runFatalErrorScreen(const char * message)
     }
   }
 }
+
+void drawSource(coord_t x, coord_t y, mixsrc_t idx, LcdFlags att)
+{
+  uint16_t aidx = abs(idx);
+  bool inverted = idx < 0;
+
+  if (aidx == MIXSRC_NONE) {
+    lcdDrawText(x, y, STR_EMPTY, att);
+  }
+  else if (aidx <= MIXSRC_LAST_INPUT) {
+    if (att & RIGHT) {
+      if (g_model.inputNames[aidx-MIXSRC_FIRST_INPUT][0])
+        lcdDrawSizedText(x, y, g_model.inputNames[aidx-MIXSRC_FIRST_INPUT], LEN_INPUT_NAME, att);
+      else
+        lcdDrawNumber(x, y, aidx, att|LEADING0, 2);
+      x = lcdLastLeftPos - 5;
+      if (inverted)
+        lcdDrawChar(x-5, y, '-');
+      lcdDrawChar(x, y+1, CHR_INPUT, RIGHT|TINSIZE);
+      lcdDrawSolidFilledRect(x-1, y, 5, 7);
+    } else {
+      if (inverted) {
+        lcdDrawChar(x-1, y, '-');
+        x += 3;
+      }
+      lcdDrawChar(x+1, y+1, CHR_INPUT, TINSIZE);
+      lcdDrawSolidFilledRect(x, y, 5, 7);
+      if (g_model.inputNames[aidx-MIXSRC_FIRST_INPUT][0])
+        lcdDrawSizedText(x+6, y, g_model.inputNames[aidx-MIXSRC_FIRST_INPUT], LEN_INPUT_NAME, att);
+      else
+        lcdDrawNumber(x+6, y, aidx, att|LEADING0, 2);
+    }
+  }
+#if defined(LUA_INPUTS)
+  else if (aidx <= MIXSRC_LAST_LUA) {
+    div_t qr = div((uint16_t)(aidx-MIXSRC_FIRST_LUA), MAX_SCRIPT_OUTPUTS);
+    if (att & RIGHT) {
+#if defined(LUA_MODEL_SCRIPTS)
+      if (qr.quot < MAX_SCRIPTS && qr.rem < scriptInputsOutputs[qr.quot].outputsCount) {
+        lcdDrawSizedText(x, y, scriptInputsOutputs[qr.quot].outputs[qr.rem].name, att & STREXPANDED ? 9 : 4, att);
+        x = lcdLastLeftPos - 4;
+        if (inverted)
+          lcdDrawChar(x-5, y, '-');
+        lcdDrawChar(x, y+1, '1'+qr.quot, TINSIZE);
+        lcdDrawFilledRect(x-1, y, 5, 7, SOLID);
+      }
+      else
+#endif
+      {
+        lcdDrawChar(x, y, 'a' + qr.rem, att);
+        drawStringWithIndex(lcdLastLeftPos, y, "LUA", qr.quot+1, att);
+#if defined(LUA_MODEL_SCRIPTS)
+        if (inverted)
+          lcdDrawChar(lcdLastLeftPos, y, '-', att);
+#endif
+      }
+    } else {
+#if defined(LUA_MODEL_SCRIPTS)
+      if (inverted) {
+        lcdDrawChar(x-1, y, '-');
+        x += 3;
+      }
+      if (qr.quot < MAX_SCRIPTS && qr.rem < scriptInputsOutputs[qr.quot].outputsCount) {
+        lcdDrawChar(x+1, y+1, '1'+qr.quot, TINSIZE);
+        lcdDrawFilledRect(x, y, 5, 7, SOLID);
+        lcdDrawSizedText(x+5, y, scriptInputsOutputs[qr.quot].outputs[qr.rem].name, att & STREXPANDED ? 9 : 4, att);
+      }
+      else
+#endif
+      {
+        drawStringWithIndex(x, y, "LUA", qr.quot+1, att);
+        lcdDrawChar(lcdLastRightPos, y, 'a' + qr.rem, att);
+      }
+    }
+  }
+#endif
+  else {
+    const char* s = getSourceString(idx);
+#if LCD_W < 212
+    if (idx >= MIXSRC_FIRST_TELEM && idx <= MIXSRC_LAST_TELEM)
+      s += strlen(STR_CHAR_TELEMETRY);
+#endif
+    lcdDrawText(x, y, s, att);
+  }
+}

--- a/radio/src/gui/common/stdlcd/draw_functions.cpp
+++ b/radio/src/gui/common/stdlcd/draw_functions.cpp
@@ -292,14 +292,6 @@ void editName(coord_t x, coord_t y, char* name, uint8_t size, event_t event,
   }
 }
 
-void gvarWeightItem(coord_t x, coord_t y, MixData * md, LcdFlags attr, event_t event)
-{
-  u_int8int16_t weight;
-  MD_WEIGHT_TO_UNION(md, weight);
-  weight.word = GVAR_MENU_ITEM(x, y, weight.word, MIX_WEIGHT_MIN, MIX_WEIGHT_MAX, attr, 0, event);
-  MD_UNION_TO_WEIGHT(weight, md);
-}
-
 void drawGVarName(coord_t x, coord_t y, int8_t idx, LcdFlags flags)
 {
   char s[8];

--- a/radio/src/gui/common/stdlcd/draw_functions.h
+++ b/radio/src/gui/common/stdlcd/draw_functions.h
@@ -19,8 +19,7 @@
  * GNU General Public License for more details.
  */
 
-#ifndef _STDLCD_DRAW_FUNCTIONS_H_
-#define _STDLCD_DRAW_FUNCTIONS_H_
+#pragma once
 
 #include "lcd.h"
 void lcdDrawMultiProtocolString(coord_t x, coord_t y, uint8_t moduleIdx, uint8_t protocol, LcdFlags flags = 0);
@@ -55,4 +54,4 @@ void drawFunction(FnFuncP fn, uint8_t offset = 0);
 void drawCursor(FnFuncP fn, uint8_t offset = 0);
 void drawCurve(coord_t offset = 0);
 
-#endif // _STDLCD_DRAW_FUNCTIONS_H_
+void drawSource(coord_t x, coord_t y, mixsrc_t idx, LcdFlags att=0);

--- a/radio/src/gui/common/stdlcd/model_curves.cpp
+++ b/radio/src/gui/common/stdlcd/model_curves.cpp
@@ -96,7 +96,8 @@ void menuModelCurvesAll(event_t event)
   }
 }
 
-void editCurveRef(coord_t x, coord_t y, CurveRef & curve, event_t event, LcdFlags flags)
+void editCurveRef(coord_t x, coord_t y, CurveRef & curve, event_t event, LcdFlags flags,
+                  IsValueAvailable isValueAvailable, int16_t sourceMin)
 {
   coord_t x1 = x;
   LcdFlags flags1 = flags;
@@ -126,7 +127,7 @@ void editCurveRef(coord_t x, coord_t y, CurveRef & curve, event_t event, LcdFlag
   switch (curve.type) {
     case CURVE_REF_DIFF:
     case CURVE_REF_EXPO:
-      curve.value = GVAR_MENU_ITEM(x, y, curve.value, -100, 100, LEFT | flags, 0, event);
+      curve.value = editSrcVarFieldValue(x, y, nullptr, curve.value, -100, 100, flags, event, isValueAvailable, sourceMin);
       break;
     case CURVE_REF_FUNC:
       lcdDrawTextAtIndex(x, y, STR_VCURVEFUNC, curve.value, flags);

--- a/radio/src/gui/common/stdlcd/model_curves.cpp
+++ b/radio/src/gui/common/stdlcd/model_curves.cpp
@@ -130,21 +130,33 @@ void editCurveRef(coord_t x, coord_t y, CurveRef & curve, event_t event, LcdFlag
       curve.value = editSrcVarFieldValue(x, y, nullptr, curve.value, -100, 100, flags, event, isValueAvailable, sourceMin);
       break;
     case CURVE_REF_FUNC:
-      lcdDrawTextAtIndex(x, y, STR_VCURVEFUNC, curve.value, flags);
-      if (active && menuHorizontalPosition==1) CHECK_INCDEC_MODELVAR_ZERO(event, curve.value, CURVE_BASE-1);
+    {
+      SourceNumVal v;
+      v.rawValue = curve.value;
+      lcdDrawTextAtIndex(x, y, STR_VCURVEFUNC, v.value, flags);
+      if (active && menuHorizontalPosition==1) {
+        CHECK_INCDEC_MODELVAR_ZERO(event, v.value, CURVE_BASE-1);
+        curve.value = v.rawValue;
+      }
       break;
+    }
     case CURVE_REF_CUSTOM:
-      drawCurveName(x, y, curve.value, flags);
+    {
+      SourceNumVal v;
+      v.rawValue = curve.value;
+      drawCurveName(x, y, v.value, flags);
       if (active && menuHorizontalPosition == 1) {
-        if (event == EVT_KEY_LONG(KEY_ENTER) && curve.value != 0) {
+        if (event == EVT_KEY_LONG(KEY_ENTER) && v.value != 0) {
           s_currIdxSubMenu = abs(curve.value) - 1;
           pushMenu(menuModelCurveOne);
         }
         else {
-          CHECK_INCDEC_MODELVAR(event, curve.value, -MAX_CURVES, MAX_CURVES);
+          CHECK_INCDEC_MODELVAR(event, v.value, -MAX_CURVES, MAX_CURVES);
+          curve.value = v.rawValue;
         }
       }
       break;
+    }
   }
 }
 

--- a/radio/src/gui/common/stdlcd/model_inputs.cpp
+++ b/radio/src/gui/common/stdlcd/model_inputs.cpp
@@ -410,7 +410,7 @@ void menuModelExposAll(event_t event)
           s_currIdx = i;
         }
         if (cur-menuVerticalOffset >= 0 && cur-menuVerticalOffset < NUM_BODY_LINES) {
-          editSrcVarFieldValue(EXPO_LINE_WEIGHT_POS, y, nullptr, ed->weight, 
+          editSrcVarFieldValue(EXPO_LINE_WEIGHT_POS, y, nullptr, ed->weight,
                         -100, 100, 0 | (isExpoActive(i) ? BOLD : 0),
                         0, 0, 0);
           displayExpoLine(y, ed, 0);
@@ -427,6 +427,9 @@ void menuModelExposAll(event_t event)
           }
         }
         cur++; y+=FH; mixCnt++; i++; ed++;
+        if (sub == cur) {
+          lcdDrawText(INDENT_WIDTH, y, "->", ((s_copyMode || sub != cur) ? 0 : INVERS));
+        }
       } while (i<MAX_EXPOS && ed->chn+1 == ch && EXPO_VALID(ed));
       if (s_copyMode == MOVE_MODE && cur-menuVerticalOffset >= 0 && cur-menuVerticalOffset < NUM_BODY_LINES && s_copySrcCh == ch && i == (s_copySrcIdx + (s_copyTgtOfs<0))) {
         lcdDrawRect(EXPO_LINE_SELECT_POS, y-1, LCD_W-EXPO_LINE_SELECT_POS, 9, DOTTED);

--- a/radio/src/gui/common/stdlcd/model_inputs.cpp
+++ b/radio/src/gui/common/stdlcd/model_inputs.cpp
@@ -391,7 +391,7 @@ void menuModelExposAll(event_t event)
     coord_t y = MENU_HEADER_HEIGHT+1+(cur-menuVerticalOffset)*FH;
     if (i<MAX_EXPOS && (ed=expoAddress(i))->chn+1 == ch && EXPO_VALID(ed)) {
       if (cur-menuVerticalOffset >= 0 && cur-menuVerticalOffset < NUM_BODY_LINES) {
-        drawSource(0, y, ch, 0);
+        drawSource(0, y, ch, ((s_copyMode || sub != cur) ? 0 : INVERS));
       }
       uint8_t mixCnt = 0;
       do {
@@ -410,12 +410,10 @@ void menuModelExposAll(event_t event)
           s_currIdx = i;
         }
         if (cur-menuVerticalOffset >= 0 && cur-menuVerticalOffset < NUM_BODY_LINES) {
-          LcdFlags attr = ((s_copyMode || sub != cur) ? 0 : INVERS);
-          
           editSrcVarFieldValue(EXPO_LINE_WEIGHT_POS, y, nullptr, ed->weight, 
-                        -100, 100, attr | (isExpoActive(i) ? BOLD : 0),
+                        -100, 100, 0 | (isExpoActive(i) ? BOLD : 0),
                         0, 0, 0);
-          displayExpoLine(y, ed, attr);
+          displayExpoLine(y, ed, 0);
           
           if (s_copyMode) {
             if ((s_copyMode==COPY_MODE || s_copyTgtOfs == 0) && s_copySrcCh == ch && i == (s_copySrcIdx + (s_copyTgtOfs<0))) {
@@ -424,7 +422,7 @@ void menuModelExposAll(event_t event)
             }
             if (cur == sub) {
               /* invert the raw when it's the current one */
-              lcdDrawSolidFilledRect(EXPO_LINE_SELECT_POS+1, y, LCD_W-EXPO_LINE_SELECT_POS-2, 7);
+              lcdDrawSolidFilledRect(0, y, LCD_W, 7);
             }
           }
         }

--- a/radio/src/gui/common/stdlcd/model_inputs.cpp
+++ b/radio/src/gui/common/stdlcd/model_inputs.cpp
@@ -168,7 +168,7 @@ void onExposMenu(const char * result)
 }
 
 #if LCD_W >= 212
-#define EXPO_LINE_WEIGHT_POS           8*FW+8
+#define EXPO_LINE_WEIGHT_POS           4*FW+3
 #define EXPO_LINE_SRC_POS              9*FW+3
 #define EXPO_LINE_CURVE_POS            12*FW+11
 #define EXPO_LINE_TRIM_POS             19*FW-2
@@ -213,7 +213,7 @@ void displayExpoLine(coord_t y, ExpoData * ed, LcdFlags attr)
 #endif
 }
 #else // LCD_W < 212
-#define EXPO_LINE_WEIGHT_POS           7*FW+8
+#define EXPO_LINE_WEIGHT_POS           4*FW+3
 #define EXPO_LINE_SRC_POS              8*FW+3
 #define EXPO_LINE_INFOS_POS            11*FW+11
 #define EXPO_LINE_CURVE_POS            11*FW+11
@@ -412,7 +412,9 @@ void menuModelExposAll(event_t event)
         if (cur-menuVerticalOffset >= 0 && cur-menuVerticalOffset < NUM_BODY_LINES) {
           LcdFlags attr = ((s_copyMode || sub != cur) ? 0 : INVERS);
           
-          GVAR_MENU_ITEM(EXPO_LINE_WEIGHT_POS, y, ed->weight, -100, 100, RIGHT | attr | (isExpoActive(i) ? BOLD : 0), 0, 0);
+          editSrcVarFieldValue(EXPO_LINE_WEIGHT_POS, y, nullptr, ed->weight, 
+                        -100, 100, attr | (isExpoActive(i) ? BOLD : 0),
+                        0, 0, 0);
           displayExpoLine(y, ed, attr);
           
           if (s_copyMode) {

--- a/radio/src/gui/common/stdlcd/model_inputs.cpp
+++ b/radio/src/gui/common/stdlcd/model_inputs.cpp
@@ -427,7 +427,7 @@ void menuModelExposAll(event_t event)
           }
         }
         cur++; y+=FH; mixCnt++; i++; ed++;
-        if (sub == cur) {
+        if (sub == cur && ed->chn+1 == ch) {
           lcdDrawText(INDENT_WIDTH, y, "->", ((s_copyMode || sub != cur) ? 0 : INVERS));
         }
       } while (i<MAX_EXPOS && ed->chn+1 == ch && EXPO_VALID(ed));

--- a/radio/src/gui/common/stdlcd/model_inputs.cpp
+++ b/radio/src/gui/common/stdlcd/model_inputs.cpp
@@ -168,7 +168,7 @@ void onExposMenu(const char * result)
 }
 
 #if LCD_W >= 212
-#define EXPO_LINE_WEIGHT_POS           4*FW+3
+#define EXPO_LINE_WEIGHT_POS           8*FW+8
 #define EXPO_LINE_SRC_POS              9*FW+3
 #define EXPO_LINE_CURVE_POS            12*FW+11
 #define EXPO_LINE_TRIM_POS             19*FW-2
@@ -213,7 +213,7 @@ void displayExpoLine(coord_t y, ExpoData * ed, LcdFlags attr)
 #endif
 }
 #else // LCD_W < 212
-#define EXPO_LINE_WEIGHT_POS           4*FW+3
+#define EXPO_LINE_WEIGHT_POS           7*FW+8
 #define EXPO_LINE_SRC_POS              8*FW+3
 #define EXPO_LINE_INFOS_POS            11*FW+11
 #define EXPO_LINE_CURVE_POS            11*FW+11
@@ -411,7 +411,7 @@ void menuModelExposAll(event_t event)
         }
         if (cur-menuVerticalOffset >= 0 && cur-menuVerticalOffset < NUM_BODY_LINES) {
           editSrcVarFieldValue(EXPO_LINE_WEIGHT_POS, y, nullptr, ed->weight,
-                        -100, 100, 0 | (isExpoActive(i) ? BOLD : 0),
+                        -100, 100, RIGHT | (isExpoActive(i) ? BOLD : 0),
                         0, 0, 0);
           displayExpoLine(y, ed, 0);
           

--- a/radio/src/gui/common/stdlcd/model_mixes.cpp
+++ b/radio/src/gui/common/stdlcd/model_mixes.cpp
@@ -326,7 +326,7 @@ void menuModelMixAll(event_t event)
           s_currIdx = i;
         }
         if (cur-menuVerticalOffset >= 0 && cur-menuVerticalOffset < NUM_BODY_LINES) {
-          if (mixCnt > 0) lcdDrawTextAtIndex(FW, y, STR_VMLTPX2, md->mltpx, 0);
+          if (mixCnt > 0) lcdDrawTextAtIndex(FW, y, STR_VMLTPX2, md->mltpx, ((s_copyMode || sub != cur) ? 0 : INVERS));
 
           drawSource(MIX_LINE_SRC_POS, y, md->srcRaw, 0);
 

--- a/radio/src/gui/common/stdlcd/model_mixes.cpp
+++ b/radio/src/gui/common/stdlcd/model_mixes.cpp
@@ -307,7 +307,7 @@ void menuModelMixAll(event_t event)
     MixData * md = mixAddress(i);
     if (i < getMixCount() && (md->destCh + 1 == ch)) {
       if (cur-menuVerticalOffset >= 0 && cur-menuVerticalOffset < NUM_BODY_LINES) {
-        putsChn(0, y, ch, 0); // show CHx
+        putsChn(0, y, ch, ((s_copyMode || sub != cur) ? 0 : INVERS)); // show CHx
       }
       uint8_t mixCnt = 0;
       do {
@@ -326,18 +326,16 @@ void menuModelMixAll(event_t event)
           s_currIdx = i;
         }
         if (cur-menuVerticalOffset >= 0 && cur-menuVerticalOffset < NUM_BODY_LINES) {
-          LcdFlags attr = ((s_copyMode || sub != cur) ? 0 : INVERS);
-
           if (mixCnt > 0) lcdDrawTextAtIndex(FW, y, STR_VMLTPX2, md->mltpx, 0);
 
           drawSource(MIX_LINE_SRC_POS, y, md->srcRaw, 0);
 
           if (mixCnt == 0 && md->mltpx == 1) {
-            lcdDrawText(MIX_LINE_WEIGHT_POS, y, "MULT!", attr | (isMixActive(i) ? BOLD : 0));
+            lcdDrawText(MIX_LINE_WEIGHT_POS, y, "MULT!", (isMixActive(i) ? BOLD : 0));
           }
           else {
             editSrcVarFieldValue(MIX_LINE_WEIGHT_POS, y, nullptr, md->weight, 
-                        MIX_WEIGHT_MIN, MIX_WEIGHT_MAX, attr | (isMixActive(i) ? BOLD : 0),
+                        MIX_WEIGHT_MIN, MIX_WEIGHT_MAX, (isMixActive(i) ? BOLD : 0),
                         0, 0, 0);
           }
 
@@ -354,7 +352,7 @@ void menuModelMixAll(event_t event)
             }
             if (cur == sub) {
               /* invert the raw when it's the current one */
-              lcdDrawSolidFilledRect(23, y, LCD_W-24, 7);
+              lcdDrawSolidFilledRect(0, y, LCD_W, 7);
             }
           }
         }

--- a/radio/src/gui/common/stdlcd/model_mixes.cpp
+++ b/radio/src/gui/common/stdlcd/model_mixes.cpp
@@ -64,7 +64,7 @@ void onMixesMenu(const char * result)
 }
 
 #if LCD_W >= 212
-#define MIX_LINE_WEIGHT_POS            2*FW+34
+#define MIX_LINE_WEIGHT_POS            3*FW+1
 #define MIX_LINE_SRC_POS               7*FW+5
 #define MIX_LINE_CURVE_POS             13*FW+3
 #define MIX_LINE_SWITCH_POS            19*FW+1
@@ -106,7 +106,7 @@ void displayMixLine(coord_t y, MixData * md)
   lcdDrawChar(MIX_LINE_DELAY_POS, y, cs);
 }
 #else // LCD_W >= 212
-#define MIX_LINE_WEIGHT_POS            6*FW+8
+#define MIX_LINE_WEIGHT_POS            3*FW+1
 #define MIX_LINE_SRC_POS               7*FW+3
 #define MIX_LINE_CURVE_POS             12*FW+3
 #define MIX_LINE_SWITCH_POS            16*FW+5
@@ -333,11 +333,11 @@ void menuModelMixAll(event_t event)
           drawSource(MIX_LINE_SRC_POS, y, md->srcRaw, 0);
 
           if (mixCnt == 0 && md->mltpx == 1) {
-            lcdDrawText(MIX_LINE_WEIGHT_POS, y, "MULT!", RIGHT | attr | (isMixActive(i) ? BOLD : 0));
+            lcdDrawText(MIX_LINE_WEIGHT_POS, y, "MULT!", attr | (isMixActive(i) ? BOLD : 0));
           }
           else {
             editSrcVarFieldValue(MIX_LINE_WEIGHT_POS, y, nullptr, md->weight, 
-                        MIX_WEIGHT_MIN, MIX_WEIGHT_MAX, RIGHT | attr | (isMixActive(i) ? BOLD : 0),
+                        MIX_WEIGHT_MIN, MIX_WEIGHT_MAX, attr | (isMixActive(i) ? BOLD : 0),
                         0, 0, 0);
           }
 

--- a/radio/src/gui/common/stdlcd/model_mixes.cpp
+++ b/radio/src/gui/common/stdlcd/model_mixes.cpp
@@ -336,7 +336,9 @@ void menuModelMixAll(event_t event)
             lcdDrawText(MIX_LINE_WEIGHT_POS, y, "MULT!", RIGHT | attr | (isMixActive(i) ? BOLD : 0));
           }
           else {
-            gvarWeightItem(MIX_LINE_WEIGHT_POS, y, md, RIGHT | attr | (isMixActive(i) ? BOLD : 0), 0);
+            editSrcVarFieldValue(MIX_LINE_WEIGHT_POS, y, nullptr, md->weight, 
+                        MIX_WEIGHT_MIN, MIX_WEIGHT_MAX, RIGHT | attr | (isMixActive(i) ? BOLD : 0),
+                        0, 0, 0);
           }
 
 #if LCD_W >= 212

--- a/radio/src/gui/common/stdlcd/model_mixes.cpp
+++ b/radio/src/gui/common/stdlcd/model_mixes.cpp
@@ -64,7 +64,7 @@ void onMixesMenu(const char * result)
 }
 
 #if LCD_W >= 212
-#define MIX_LINE_WEIGHT_POS            3*FW+1
+#define MIX_LINE_WEIGHT_POS            2*FW+34
 #define MIX_LINE_SRC_POS               7*FW+5
 #define MIX_LINE_CURVE_POS             13*FW+3
 #define MIX_LINE_SWITCH_POS            19*FW+1
@@ -106,7 +106,7 @@ void displayMixLine(coord_t y, MixData * md)
   lcdDrawChar(MIX_LINE_DELAY_POS, y, cs);
 }
 #else // LCD_W >= 212
-#define MIX_LINE_WEIGHT_POS            3*FW+1
+#define MIX_LINE_WEIGHT_POS            6*FW+8
 #define MIX_LINE_SRC_POS               7*FW+3
 #define MIX_LINE_CURVE_POS             12*FW+3
 #define MIX_LINE_SWITCH_POS            16*FW+5
@@ -331,11 +331,11 @@ void menuModelMixAll(event_t event)
           drawSource(MIX_LINE_SRC_POS, y, md->srcRaw, 0);
 
           if (mixCnt == 0 && md->mltpx == 1) {
-            lcdDrawText(MIX_LINE_WEIGHT_POS, y, "MULT!", (isMixActive(i) ? BOLD : 0));
+            lcdDrawText(MIX_LINE_WEIGHT_POS, y, "MULT!", RIGHT | ((isMixActive(i) ? BOLD : 0)));
           }
           else {
             editSrcVarFieldValue(MIX_LINE_WEIGHT_POS, y, nullptr, md->weight, 
-                        MIX_WEIGHT_MIN, MIX_WEIGHT_MAX, (isMixActive(i) ? BOLD : 0),
+                        MIX_WEIGHT_MIN, MIX_WEIGHT_MAX, RIGHT | ((isMixActive(i) ? BOLD : 0)),
                         0, 0, 0);
           }
 

--- a/radio/src/gui/navigation/common.cpp
+++ b/radio/src/gui/navigation/common.cpp
@@ -117,6 +117,8 @@ void onSourceLongEnterPress(const char * result)
     }
   } else if (result == STR_MENU_INVERT) {
     checkIncDecSelection = MIXSRC_INVERT;
+  } else if (result == STR_CONSTANT) {
+    checkIncDecSelection = MIXSRC_VALUE;
   }
 }
 

--- a/radio/src/gui/navigation/navigation.h
+++ b/radio/src/gui/navigation/navigation.h
@@ -75,6 +75,7 @@ extern int8_t s_editMode; // global editmode
 #define NO_DBLKEYS                     0x80
 #define INCDEC_SOURCE_INVERT           0x100
 #define INCDEC_SOURCE_VALUE            0x200  // Field can be source or value
+#define INCDEC_SOURCE_NOINPUTS         0x400  // Do not allow Inputs in source selection
 
 int checkIncDec(event_t event, int val, int i_min, int i_max,
                 unsigned int i_flags = 0, IsValueAvailable isValueAvailable = nullptr,

--- a/radio/src/gui/navigation/navigation.h
+++ b/radio/src/gui/navigation/navigation.h
@@ -74,6 +74,7 @@ extern int8_t s_editMode; // global editmode
 #define INCDEC_REP10                   0x40
 #define NO_DBLKEYS                     0x80
 #define INCDEC_SOURCE_INVERT           0x100
+#define INCDEC_SOURCE_VALUE            0x200  // Field can be source or value
 
 int checkIncDec(event_t event, int val, int i_min, int i_max,
                 unsigned int i_flags = 0, IsValueAvailable isValueAvailable = nullptr,

--- a/radio/src/gui/navigation/navigation_9x.cpp
+++ b/radio/src/gui/navigation/navigation_9x.cpp
@@ -157,7 +157,8 @@ int checkIncDec(event_t event, int val, int i_min, int i_max,
       }
 
       if (i_min <= MIXSRC_FIRST_INPUT && i_max >= MIXSRC_FIRST_INPUT) {
-        if (getFirstAvailable(MIXSRC_FIRST_INPUT, MIXSRC_LAST_INPUT, isInputAvailable) != MIXSRC_NONE) {
+        if (getFirstAvailable(MIXSRC_FIRST_INPUT, MIXSRC_LAST_INPUT, isInputAvailable) != MIXSRC_NONE &&
+            (!isValueAvailable || isValueAvailable(MIXSRC_FIRST_INPUT))) {
           POPUP_MENU_ADD_ITEM(STR_MENU_INPUTS);
         }
       }

--- a/radio/src/gui/navigation/navigation_9x.cpp
+++ b/radio/src/gui/navigation/navigation_9x.cpp
@@ -158,7 +158,7 @@ int checkIncDec(event_t event, int val, int i_min, int i_max,
 
       if (i_min <= MIXSRC_FIRST_INPUT && i_max >= MIXSRC_FIRST_INPUT) {
         if (getFirstAvailable(MIXSRC_FIRST_INPUT, MIXSRC_LAST_INPUT, isInputAvailable) != MIXSRC_NONE &&
-            (!isValueAvailable || isValueAvailable(MIXSRC_FIRST_INPUT))) {
+            (i_flags & INCDEC_SOURCE_NOINPUTS) == 0) {
           POPUP_MENU_ADD_ITEM(STR_MENU_INPUTS);
         }
       }

--- a/radio/src/gui/navigation/navigation_x7.cpp
+++ b/radio/src/gui/navigation/navigation_x7.cpp
@@ -167,7 +167,8 @@ int checkIncDec(event_t event, int val, int i_min, int i_max,
       }
 
       if (i_min <= MIXSRC_FIRST_INPUT && i_max >= MIXSRC_FIRST_INPUT) {
-        if (getFirstAvailable(MIXSRC_FIRST_INPUT, MIXSRC_LAST_INPUT, isInputAvailable) != MIXSRC_NONE) {
+        if (getFirstAvailable(MIXSRC_FIRST_INPUT, MIXSRC_LAST_INPUT, isInputAvailable) != MIXSRC_NONE &&
+            (!isValueAvailable || isValueAvailable(MIXSRC_FIRST_INPUT))) {
           POPUP_MENU_ADD_ITEM(STR_MENU_INPUTS);
         }
       }

--- a/radio/src/gui/navigation/navigation_x7.cpp
+++ b/radio/src/gui/navigation/navigation_x7.cpp
@@ -60,6 +60,18 @@ int checkIncDec(event_t event, int val, int i_min, int i_max,
   }
 #endif
 
+  bool isSource = false;
+  bool origIsSource = false;
+  if (i_flags & INCDEC_SOURCE_VALUE) {
+    SourceNumVal v;
+    v.rawValue = val;
+    // Save isSource flag;
+    origIsSource = isSource = v.isSource;
+    // Remove isSource flag;
+    val = v.value;
+    newval = v.value;
+  }
+
   if (s_editMode > 0) {
     bool invert = false;
     if ((i_flags & INCDEC_SOURCE_INVERT) && (newval < 0)) {
@@ -111,10 +123,17 @@ int checkIncDec(event_t event, int val, int i_min, int i_max,
 #endif
 
 #if defined(AUTOSOURCE)
-    if (i_flags & INCDEC_SOURCE) {
+    if (i_flags & (INCDEC_SOURCE|INCDEC_SOURCE_VALUE)) {
       int source = GET_MOVED_SOURCE(i_min, i_max);
       if (source) {
-        newval = source;
+        if (i_flags & INCDEC_SOURCE_VALUE) {
+          if (isSource) {
+            // Only use moved source if already a source value
+            newval = source;
+          }
+        } else {
+          newval = source;
+        }
       }
 #if defined(AUTOSWITCH)
       else {
@@ -139,9 +158,13 @@ int checkIncDec(event_t event, int val, int i_min, int i_max,
     newval = !val;
   }
 
-  if (i_flags & INCDEC_SOURCE) {
+  if (i_flags & (INCDEC_SOURCE | INCDEC_SOURCE_VALUE)) {
     if (event == EVT_KEY_LONG(KEY_ENTER)) {
       checkIncDecSelection = MIXSRC_NONE;
+
+      if (i_flags & INCDEC_SOURCE_VALUE && isSource) {
+        POPUP_MENU_ADD_ITEM(STR_CONSTANT);
+      }
 
       if (i_min <= MIXSRC_FIRST_INPUT && i_max >= MIXSRC_FIRST_INPUT) {
         if (getFirstAvailable(MIXSRC_FIRST_INPUT, MIXSRC_LAST_INPUT, isInputAvailable) != MIXSRC_NONE) {
@@ -185,7 +208,18 @@ int checkIncDec(event_t event, int val, int i_min, int i_max,
       POPUP_MENU_START(onSourceLongEnterPress);
     }
     if (checkIncDecSelection != 0) {
-      newval = (checkIncDecSelection == MIXSRC_INVERT ? -newval : checkIncDecSelection);
+      if (i_flags & INCDEC_SOURCE_VALUE) {
+        if (checkIncDecSelection == MIXSRC_VALUE) {
+          newval = 0;
+          isSource = false;
+        } else {
+          newval = (checkIncDecSelection == MIXSRC_INVERT ? -newval : checkIncDecSelection);
+          if (checkIncDecSelection != MIXSRC_INVERT)
+            isSource = true;
+        }
+      } else {
+        newval = (checkIncDecSelection == MIXSRC_INVERT ? -newval : checkIncDecSelection);
+      }
       if (checkIncDecSelection != MIXSRC_MIN && checkIncDecSelection != MIXSRC_MAX)
         s_editMode = EDIT_MODIFY_FIELD;
       checkIncDecSelection = 0;
@@ -216,12 +250,19 @@ int checkIncDec(event_t event, int val, int i_min, int i_max,
     }
   }
 
-  if (newval != val) {
+  if (newval != val || isSource != origIsSource) {
     storageDirty(i_flags & (EE_GENERAL|EE_MODEL));
     checkIncDec_Ret = (newval > val ? 1 : -1);
   }
   else {
     checkIncDec_Ret = 0;
+  }
+
+  if (i_flags & INCDEC_SOURCE_VALUE) {
+    SourceNumVal v;
+    v.isSource = isSource;
+    v.value = newval;
+    newval = v.rawValue;
   }
 
   return newval;

--- a/radio/src/gui/navigation/navigation_x7.cpp
+++ b/radio/src/gui/navigation/navigation_x7.cpp
@@ -168,7 +168,7 @@ int checkIncDec(event_t event, int val, int i_min, int i_max,
 
       if (i_min <= MIXSRC_FIRST_INPUT && i_max >= MIXSRC_FIRST_INPUT) {
         if (getFirstAvailable(MIXSRC_FIRST_INPUT, MIXSRC_LAST_INPUT, isInputAvailable) != MIXSRC_NONE &&
-            (!isValueAvailable || isValueAvailable(MIXSRC_FIRST_INPUT))) {
+            (i_flags & INCDEC_SOURCE_NOINPUTS) == 0) {
           POPUP_MENU_ADD_ITEM(STR_MENU_INPUTS);
         }
       }

--- a/radio/src/gui/navigation/navigation_x7.cpp
+++ b/radio/src/gui/navigation/navigation_x7.cpp
@@ -174,7 +174,8 @@ int checkIncDec(event_t event, int val, int i_min, int i_max,
       }
 #if defined(LUA_MODEL_SCRIPTS)
       if (i_min <= MIXSRC_FIRST_LUA && i_max >= MIXSRC_FIRST_LUA) {
-        if (getFirstAvailable(MIXSRC_FIRST_LUA, MIXSRC_LAST_LUA, isSourceAvailable) != MIXSRC_NONE) {
+        if (getFirstAvailable(MIXSRC_FIRST_LUA, MIXSRC_LAST_LUA, isSourceAvailable) != MIXSRC_NONE &&
+            (i_flags & INCDEC_SOURCE_NOINPUTS) == 0) {
           POPUP_MENU_ADD_ITEM(STR_MENU_LUA);
         }
       }

--- a/radio/src/gui/navigation/navigation_x9d.cpp
+++ b/radio/src/gui/navigation/navigation_x9d.cpp
@@ -167,7 +167,8 @@ int checkIncDec(event_t event, int val, int i_min, int i_max,
       }
 
       if (i_min <= MIXSRC_FIRST_INPUT && i_max >= MIXSRC_FIRST_INPUT) {
-        if (getFirstAvailable(MIXSRC_FIRST_INPUT, MIXSRC_LAST_INPUT, isInputAvailable) != MIXSRC_NONE) {
+        if (getFirstAvailable(MIXSRC_FIRST_INPUT, MIXSRC_LAST_INPUT, isInputAvailable) != MIXSRC_NONE &&
+            (!isValueAvailable || isValueAvailable(MIXSRC_FIRST_INPUT))) {
           POPUP_MENU_ADD_ITEM(STR_MENU_INPUTS);
         }
       }

--- a/radio/src/gui/navigation/navigation_x9d.cpp
+++ b/radio/src/gui/navigation/navigation_x9d.cpp
@@ -168,7 +168,7 @@ int checkIncDec(event_t event, int val, int i_min, int i_max,
 
       if (i_min <= MIXSRC_FIRST_INPUT && i_max >= MIXSRC_FIRST_INPUT) {
         if (getFirstAvailable(MIXSRC_FIRST_INPUT, MIXSRC_LAST_INPUT, isInputAvailable) != MIXSRC_NONE &&
-            (!isValueAvailable || isValueAvailable(MIXSRC_FIRST_INPUT))) {
+            (i_flags & INCDEC_SOURCE_NOINPUTS) == 0) {
           POPUP_MENU_ADD_ITEM(STR_MENU_INPUTS);
         }
       }

--- a/radio/src/gui/navigation/navigation_x9d.cpp
+++ b/radio/src/gui/navigation/navigation_x9d.cpp
@@ -60,6 +60,18 @@ int checkIncDec(event_t event, int val, int i_min, int i_max,
   }
 #endif
 
+  bool isSource = false;
+  bool origIsSource = false;
+  if (i_flags & INCDEC_SOURCE_VALUE) {
+    SourceNumVal v;
+    v.rawValue = val;
+    // Save isSource flag;
+    origIsSource = isSource = v.isSource;
+    // Remove isSource flag;
+    val = v.value;
+    newval = v.value;
+  }
+
   if (s_editMode > 0) {
     bool invert = false;
     if ((i_flags & INCDEC_SOURCE_INVERT) && (newval < 0)) {
@@ -111,10 +123,17 @@ int checkIncDec(event_t event, int val, int i_min, int i_max,
 #endif
 
 #if defined(AUTOSOURCE)
-    if (i_flags & INCDEC_SOURCE) {
+    if (i_flags & (INCDEC_SOURCE|INCDEC_SOURCE_VALUE)) {
       int source = GET_MOVED_SOURCE(i_min, i_max);
       if (source) {
-        newval = source;
+        if (i_flags & INCDEC_SOURCE_VALUE) {
+          if (isSource) {
+            // Only use moved source if already a source value
+            newval = source;
+          }
+        } else {
+          newval = source;
+        }
       }
 #if defined(AUTOSWITCH)
       else {
@@ -139,9 +158,13 @@ int checkIncDec(event_t event, int val, int i_min, int i_max,
     newval = !val;
   }
 
-  if (i_flags & INCDEC_SOURCE) {
+  if (i_flags & (INCDEC_SOURCE | INCDEC_SOURCE_VALUE)) {
     if (event == EVT_KEY_LONG(KEY_ENTER)) {
       checkIncDecSelection = MIXSRC_NONE;
+
+      if (i_flags & INCDEC_SOURCE_VALUE && isSource) {
+        POPUP_MENU_ADD_ITEM(STR_CONSTANT);
+      }
 
       if (i_min <= MIXSRC_FIRST_INPUT && i_max >= MIXSRC_FIRST_INPUT) {
         if (getFirstAvailable(MIXSRC_FIRST_INPUT, MIXSRC_LAST_INPUT, isInputAvailable) != MIXSRC_NONE) {
@@ -185,7 +208,18 @@ int checkIncDec(event_t event, int val, int i_min, int i_max,
       POPUP_MENU_START(onSourceLongEnterPress);
     }
     if (checkIncDecSelection != 0) {
-      newval = (checkIncDecSelection == MIXSRC_INVERT ? -newval : checkIncDecSelection);
+      if (i_flags & INCDEC_SOURCE_VALUE) {
+        if (checkIncDecSelection == MIXSRC_VALUE) {
+          newval = 0;
+          isSource = false;
+        } else {
+          newval = (checkIncDecSelection == MIXSRC_INVERT ? -newval : checkIncDecSelection);
+          if (checkIncDecSelection != MIXSRC_INVERT)
+            isSource = true;
+        }
+      } else {
+        newval = (checkIncDecSelection == MIXSRC_INVERT ? -newval : checkIncDecSelection);
+      }
       if (checkIncDecSelection != MIXSRC_MIN && checkIncDecSelection != MIXSRC_MAX)
         s_editMode = EDIT_MODIFY_FIELD;
       checkIncDecSelection = 0;
@@ -256,6 +290,13 @@ int checkIncDec(event_t event, int val, int i_min, int i_max,
   }
   else {
     checkIncDec_Ret = 0;
+  }
+
+  if (i_flags & INCDEC_SOURCE_VALUE) {
+    SourceNumVal v;
+    v.isSource = isSource;
+    v.value = newval;
+    newval = v.rawValue;
   }
 
   return newval;

--- a/radio/src/gui/navigation/navigation_xlite.cpp
+++ b/radio/src/gui/navigation/navigation_xlite.cpp
@@ -176,7 +176,8 @@ int checkIncDec(event_t event, int val, int i_min, int i_max,
       }
 
       if (i_min <= MIXSRC_FIRST_INPUT && i_max >= MIXSRC_FIRST_INPUT) {
-        if (getFirstAvailable(MIXSRC_FIRST_INPUT, MIXSRC_LAST_INPUT, isInputAvailable) != MIXSRC_NONE) {
+        if (getFirstAvailable(MIXSRC_FIRST_INPUT, MIXSRC_LAST_INPUT, isInputAvailable) != MIXSRC_NONE &&
+            (!isValueAvailable || isValueAvailable(MIXSRC_FIRST_INPUT))) {
           POPUP_MENU_ADD_ITEM(STR_MENU_INPUTS);
         }
       }

--- a/radio/src/gui/navigation/navigation_xlite.cpp
+++ b/radio/src/gui/navigation/navigation_xlite.cpp
@@ -177,7 +177,7 @@ int checkIncDec(event_t event, int val, int i_min, int i_max,
 
       if (i_min <= MIXSRC_FIRST_INPUT && i_max >= MIXSRC_FIRST_INPUT) {
         if (getFirstAvailable(MIXSRC_FIRST_INPUT, MIXSRC_LAST_INPUT, isInputAvailable) != MIXSRC_NONE &&
-            (!isValueAvailable || isValueAvailable(MIXSRC_FIRST_INPUT))) {
+            (i_flags & INCDEC_SOURCE_NOINPUTS) == 0) {
           POPUP_MENU_ADD_ITEM(STR_MENU_INPUTS);
         }
       }

--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -681,10 +681,18 @@ static int luaModelInsertInput(lua_State *L)
         expo->scale = luaL_checkinteger(L, -1);
       }
       else if (!strcmp(key, "weight")) {
-        expo->weight = luaL_checkinteger(L, -1);
+        int val = luaL_checkinteger(L, -1);
+        SourceNumVal v;
+        v.isSource = (abs(val) >= 1024);
+        v.value = val;
+        expo->weight = v.rawValue;
       }
       else if (!strcmp(key, "offset")) {
-        expo->offset = luaL_checkinteger(L, -1);
+        int val = luaL_checkinteger(L, -1);
+        SourceNumVal v;
+        v.isSource = (abs(val) >= 1024);
+        v.value = val;
+        expo->offset = v.rawValue;
       }
       else if (!strcmp(key, "switch")) {
         expo->swtch = luaL_checkinteger(L, -1);
@@ -693,7 +701,11 @@ static int luaModelInsertInput(lua_State *L)
         expo->curve.type = luaL_checkinteger(L, -1);
       }
       else if (!strcmp(key, "curveValue")) {
-        expo->curve.value = luaL_checkinteger(L, -1);
+        int val = luaL_checkinteger(L, -1);
+        SourceNumVal v;
+        v.isSource = (abs(val) >= 1024);
+        v.value = val;
+        expo->curve.value = v.rawValue;
       }
       else if (!strcmp(key, "trimSource")) {
         expo->trimSource = - luaL_checkinteger(L, -1);
@@ -904,10 +916,18 @@ static int luaModelInsertMix(lua_State *L)
         mix->srcRaw = luaL_checkinteger(L, -1);
       }
       else if (!strcmp(key, "weight")) {
-        mix->weight = luaL_checkinteger(L, -1);
+        int val = luaL_checkinteger(L, -1);
+        SourceNumVal v;
+        v.isSource = (abs(val) >= 1024);
+        v.value = val;
+        mix->weight = v.rawValue;
       }
       else if (!strcmp(key, "offset")) {
-        mix->offset = luaL_checkinteger(L, -1);
+        int val = luaL_checkinteger(L, -1);
+        SourceNumVal v;
+        v.isSource = (abs(val) >= 1024);
+        v.value = val;
+        mix->offset = v.rawValue;
       }
       else if (!strcmp(key, "switch")) {
         mix->swtch = luaL_checkinteger(L, -1);
@@ -916,7 +936,11 @@ static int luaModelInsertMix(lua_State *L)
         mix->curve.type = luaL_checkinteger(L, -1);
       }
       else if (!strcmp(key, "curveValue")) {
-        mix->curve.value = luaL_checkinteger(L, -1);
+        int val = luaL_checkinteger(L, -1);
+        SourceNumVal v;
+        v.isSource = (abs(val) >= 1024);
+        v.value = val;
+        mix->curve.value = v.rawValue;
       }
       else if (!strcmp(key, "multiplex")) {
         mix->mltpx = luaL_checkinteger(L, -1);

--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -56,19 +56,20 @@ int16_t cyc_anas[3] = {0};
 // TOOD: find better home for this.
 int32_t getSourceNumFieldValue(int16_t val, int16_t min, int16_t max)
 {
+  int32_t result;
   SourceNumVal v; v.rawValue = val;
   if (v.isSource) {
-    val = getValue(v.value);
+    result = getValue(v.value);
     if (v.value >= MIXSRC_FIRST_GVAR && v.value <= MIXSRC_LAST_GVAR) {
       // Mimic behviour of GET_GVAR_PREC1
-      val = val * 10;
+      result = result * 10;
     } else {
-      val = calcRESXto1000(val);
+      result = calcRESXto1000(val);
     }
   } else {
-    val = v.value * 10;
+    result = v.value * 10;
   }
-  return limit<int>(min * 10, val, max * 10);
+  return limit<int>(min * 10, result, max * 10);
 }
 
 // #define EXTENDED_EXPO

--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -64,7 +64,7 @@ int32_t getSourceNumFieldValue(int16_t val, int16_t min, int16_t max)
       // Mimic behviour of GET_GVAR_PREC1
       result = result * 10;
     } else {
-      result = calcRESXto1000(val);
+      result = calcRESXto1000(result);
     }
   } else {
     result = v.value * 10;

--- a/radio/src/myeeprom.h
+++ b/radio/src/myeeprom.h
@@ -272,14 +272,6 @@ enum DisplayTrims
 extern RadioData g_eeGeneral;
 extern ModelData g_model;
 
-PACK(union u_int8int16_t {
-  struct {
-    int8_t  lo;
-    uint8_t hi;
-  } bytes_t;
-  int16_t word;
-});
-
 constexpr uint8_t EE_GENERAL = 0x01;
 constexpr uint8_t EE_MODEL = 0x02;
 constexpr uint8_t EE_LABELS = 0x04;

--- a/radio/src/storage/yaml/yaml_datastructs_128x64.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_128x64.cpp
@@ -391,21 +391,22 @@ static const struct YamlNode struct_TimerData[] = {
   YAML_END
 };
 static const struct YamlNode struct_CurveRef[] = {
-  YAML_UNSIGNED( "type", 8 ),
-  YAML_SIGNED_CUST( "value", 8, in_read_weight, in_write_weight ),
+  YAML_UNSIGNED( "type", 5 ),
+  YAML_SIGNED_CUST( "value", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_END
 };
 static const struct YamlNode struct_MixData[] = {
-  YAML_SIGNED_CUST( "weight", 11, in_read_weight, in_write_weight ),
+  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_UNSIGNED( "destCh", 5 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
   YAML_UNSIGNED( "carryTrim", 1 ),
   YAML_UNSIGNED( "mixWarn", 2 ),
   YAML_ENUM("mltpx", 2, enum_MixerMultiplex),
   YAML_UNSIGNED( "speedPrec", 1 ),
-  YAML_SIGNED_CUST( "offset", 13, in_read_weight, in_write_weight ),
+  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
+  YAML_UNSIGNED( "spare", 2 ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "delayUp", 8 ),
   YAML_UNSIGNED( "delayDown", 8 ),
@@ -433,13 +434,14 @@ static const struct YamlNode struct_ExpoData[] = {
   YAML_CUSTOM("carryTrim",r_carryTrim,nullptr),
   YAML_SIGNED( "trimSource", 6 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
-  YAML_UNSIGNED( "chn", 5 ),
+  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
-  YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
-  YAML_SIGNED_CUST( "weight", 8, in_read_weight, in_write_weight ),
-  YAML_STRING("name", 6),
-  YAML_SIGNED_CUST( "offset", 8, in_read_weight, in_write_weight ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
+  YAML_UNSIGNED( "chn", 5 ),
+  YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
+  YAML_UNSIGNED( "spare", 2 ),
+  YAML_STRING("name", 6),
   YAML_END
 };
 static const struct YamlNode struct_CurveHeader[] = {
@@ -798,7 +800,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
   YAML_ARRAY("limitData", 88, 32, struct_LimitData, NULL),
-  YAML_ARRAY("expoData", 136, 64, struct_ExpoData, NULL),
+  YAML_ARRAY("expoData", 144, 64, struct_ExpoData, NULL),
   YAML_ARRAY("curves", 32, 32, struct_CurveHeader, NULL),
   YAML_ARRAY("points", 8, 512, struct_signed_8, NULL),
   YAML_ARRAY("logicalSw", 72, 64, struct_LogicalSwitchData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_128x64.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_128x64.cpp
@@ -392,21 +392,21 @@ static const struct YamlNode struct_TimerData[] = {
 };
 static const struct YamlNode struct_CurveRef[] = {
   YAML_UNSIGNED( "type", 5 ),
-  YAML_SIGNED_CUST( "value", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_SIGNED_CUST( "value", 11, r_sourceNumVal, w_sourceNumVal ),
   YAML_END
 };
 static const struct YamlNode struct_MixData[] = {
-  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_UNSIGNED( "destCh", 5 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
   YAML_UNSIGNED( "carryTrim", 1 ),
   YAML_UNSIGNED( "mixWarn", 2 ),
   YAML_ENUM("mltpx", 2, enum_MixerMultiplex),
   YAML_UNSIGNED( "speedPrec", 1 ),
-  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
-  YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
   YAML_UNSIGNED( "spare", 2 ),
+  YAML_UNSIGNED_CUST( "weight", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_UNSIGNED_CUST( "offset", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "delayUp", 8 ),
   YAML_UNSIGNED( "delayDown", 8 ),
@@ -434,8 +434,8 @@ static const struct YamlNode struct_ExpoData[] = {
   YAML_CUSTOM("carryTrim",r_carryTrim,nullptr),
   YAML_SIGNED( "trimSource", 6 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
-  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
-  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_UNSIGNED_CUST( "weight", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_UNSIGNED_CUST( "offset", 11, r_sourceNumVal, w_sourceNumVal ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "chn", 5 ),

--- a/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
@@ -463,7 +463,7 @@ static bool w_mixSrcRawEx(const YamlNode* node, uint32_t val, yaml_writer_func w
   return wf(opaque, "\"", 1);
 }
 
-static uint32_t in_read_sourcenumval(const YamlNode* node, const char* val, uint8_t val_len)
+static uint32_t r_sourceNumVal(const YamlNode* node, const char* val, uint8_t val_len)
 {
   SourceNumVal v;
 
@@ -484,7 +484,7 @@ static uint32_t in_read_sourcenumval(const YamlNode* node, const char* val, uint
   return v.rawValue;
 }
 
-bool in_write_sourcenumval(const YamlNode* node, uint32_t val, yaml_writer_func wf,
+bool w_sourceNumVal(const YamlNode* node, uint32_t val, yaml_writer_func wf,
                      void* opaque)
 {
   SourceNumVal v;

--- a/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
@@ -463,6 +463,40 @@ static bool w_mixSrcRawEx(const YamlNode* node, uint32_t val, yaml_writer_func w
   return wf(opaque, "\"", 1);
 }
 
+static uint32_t in_read_sourcenumval(const YamlNode* node, const char* val, uint8_t val_len)
+{
+  SourceNumVal v;
+
+  if (((val[0] == '-') && (val[1] >= '0' && val[1] <= '9')) || (val[0] >= '0' && val[0] <= '9')) {
+    v.isSource = 0;
+    v.value = (uint32_t)yaml_str2int(val, val_len);
+  } else if ((val[0] == '-') && (val[1] == 'G')) {
+    v.isSource = 1;
+    v.value = -((val[3] - '0') + MIXSRC_FIRST_GVAR - 1);
+  } else if (val[0] == 'G') {
+    v.isSource = 1;
+    v.value = (val[2] - '0') + MIXSRC_FIRST_GVAR - 1;
+  } else {
+    v.isSource = 1;
+    v.value = r_mixSrcRawEx(node, val, val_len);
+  }
+
+  return v.rawValue;
+}
+
+bool in_write_sourcenumval(const YamlNode* node, uint32_t val, yaml_writer_func wf,
+                     void* opaque)
+{
+  SourceNumVal v;
+  v.rawValue = val;
+
+  if (v.isSource)
+    return w_mixSrcRawEx(node, v.value, wf, opaque);
+
+  char* s = yaml_signed2str(v.value);
+  return wf(opaque, s, strlen(s));
+}
+
 static void r_rssiDisabled(void* user, uint8_t* data, uint32_t bitoffs,
                            const char* val, uint8_t val_len)
 {

--- a/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
@@ -418,21 +418,21 @@ static const struct YamlNode struct_TimerData[] = {
 };
 static const struct YamlNode struct_CurveRef[] = {
   YAML_UNSIGNED( "type", 5 ),
-  YAML_SIGNED_CUST( "value", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_SIGNED_CUST( "value", 11, r_sourceNumVal, w_sourceNumVal ),
   YAML_END
 };
 static const struct YamlNode struct_MixData[] = {
-  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_UNSIGNED( "destCh", 5 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
   YAML_UNSIGNED( "carryTrim", 1 ),
   YAML_UNSIGNED( "mixWarn", 2 ),
   YAML_ENUM("mltpx", 2, enum_MixerMultiplex),
   YAML_UNSIGNED( "speedPrec", 1 ),
-  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
-  YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
   YAML_UNSIGNED( "spare", 2 ),
+  YAML_UNSIGNED_CUST( "weight", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_UNSIGNED_CUST( "offset", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "delayUp", 8 ),
   YAML_UNSIGNED( "delayDown", 8 ),
@@ -460,8 +460,8 @@ static const struct YamlNode struct_ExpoData[] = {
   YAML_CUSTOM("carryTrim",r_carryTrim,nullptr),
   YAML_SIGNED( "trimSource", 6 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
-  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
-  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_UNSIGNED_CUST( "weight", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_UNSIGNED_CUST( "offset", 11, r_sourceNumVal, w_sourceNumVal ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "chn", 5 ),

--- a/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
@@ -417,21 +417,22 @@ static const struct YamlNode struct_TimerData[] = {
   YAML_END
 };
 static const struct YamlNode struct_CurveRef[] = {
-  YAML_UNSIGNED( "type", 8 ),
-  YAML_SIGNED_CUST( "value", 8, in_read_weight, in_write_weight ),
+  YAML_UNSIGNED( "type", 5 ),
+  YAML_SIGNED_CUST( "value", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_END
 };
 static const struct YamlNode struct_MixData[] = {
-  YAML_SIGNED_CUST( "weight", 11, in_read_weight, in_write_weight ),
+  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_UNSIGNED( "destCh", 5 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
   YAML_UNSIGNED( "carryTrim", 1 ),
   YAML_UNSIGNED( "mixWarn", 2 ),
   YAML_ENUM("mltpx", 2, enum_MixerMultiplex),
   YAML_UNSIGNED( "speedPrec", 1 ),
-  YAML_SIGNED_CUST( "offset", 13, in_read_weight, in_write_weight ),
+  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
+  YAML_UNSIGNED( "spare", 2 ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "delayUp", 8 ),
   YAML_UNSIGNED( "delayDown", 8 ),
@@ -459,13 +460,14 @@ static const struct YamlNode struct_ExpoData[] = {
   YAML_CUSTOM("carryTrim",r_carryTrim,nullptr),
   YAML_SIGNED( "trimSource", 6 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
-  YAML_UNSIGNED( "chn", 5 ),
+  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
-  YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
-  YAML_SIGNED_CUST( "weight", 8, in_read_weight, in_write_weight ),
-  YAML_STRING("name", 6),
-  YAML_SIGNED_CUST( "offset", 8, in_read_weight, in_write_weight ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
+  YAML_UNSIGNED( "chn", 5 ),
+  YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
+  YAML_UNSIGNED( "spare", 2 ),
+  YAML_STRING("name", 6),
   YAML_END
 };
 static const struct YamlNode struct_CurveHeader[] = {
@@ -832,7 +834,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
   YAML_ARRAY("limitData", 104, 32, struct_LimitData, NULL),
-  YAML_ARRAY("expoData", 136, 64, struct_ExpoData, NULL),
+  YAML_ARRAY("expoData", 144, 64, struct_ExpoData, NULL),
   YAML_ARRAY("curves", 32, 32, struct_CurveHeader, NULL),
   YAML_ARRAY("points", 8, 512, struct_signed_8, NULL),
   YAML_ARRAY("logicalSw", 72, 64, struct_LogicalSwitchData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_pl18.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_pl18.cpp
@@ -418,21 +418,21 @@ static const struct YamlNode struct_TimerData[] = {
 };
 static const struct YamlNode struct_CurveRef[] = {
   YAML_UNSIGNED( "type", 5 ),
-  YAML_SIGNED_CUST( "value", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_SIGNED_CUST( "value", 11, r_sourceNumVal, w_sourceNumVal ),
   YAML_END
 };
 static const struct YamlNode struct_MixData[] = {
-  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_UNSIGNED( "destCh", 5 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
   YAML_UNSIGNED( "carryTrim", 1 ),
   YAML_UNSIGNED( "mixWarn", 2 ),
   YAML_ENUM("mltpx", 2, enum_MixerMultiplex),
   YAML_UNSIGNED( "speedPrec", 1 ),
-  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
-  YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
   YAML_UNSIGNED( "spare", 2 ),
+  YAML_UNSIGNED_CUST( "weight", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_UNSIGNED_CUST( "offset", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "delayUp", 8 ),
   YAML_UNSIGNED( "delayDown", 8 ),
@@ -460,8 +460,8 @@ static const struct YamlNode struct_ExpoData[] = {
   YAML_CUSTOM("carryTrim",r_carryTrim,nullptr),
   YAML_SIGNED( "trimSource", 6 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
-  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
-  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_UNSIGNED_CUST( "weight", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_UNSIGNED_CUST( "offset", 11, r_sourceNumVal, w_sourceNumVal ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "chn", 5 ),

--- a/radio/src/storage/yaml/yaml_datastructs_pl18.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_pl18.cpp
@@ -417,21 +417,22 @@ static const struct YamlNode struct_TimerData[] = {
   YAML_END
 };
 static const struct YamlNode struct_CurveRef[] = {
-  YAML_UNSIGNED( "type", 8 ),
-  YAML_SIGNED_CUST( "value", 8, in_read_weight, in_write_weight ),
+  YAML_UNSIGNED( "type", 5 ),
+  YAML_SIGNED_CUST( "value", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_END
 };
 static const struct YamlNode struct_MixData[] = {
-  YAML_SIGNED_CUST( "weight", 11, in_read_weight, in_write_weight ),
+  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_UNSIGNED( "destCh", 5 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
   YAML_UNSIGNED( "carryTrim", 1 ),
   YAML_UNSIGNED( "mixWarn", 2 ),
   YAML_ENUM("mltpx", 2, enum_MixerMultiplex),
   YAML_UNSIGNED( "speedPrec", 1 ),
-  YAML_SIGNED_CUST( "offset", 13, in_read_weight, in_write_weight ),
+  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
+  YAML_UNSIGNED( "spare", 2 ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "delayUp", 8 ),
   YAML_UNSIGNED( "delayDown", 8 ),
@@ -459,13 +460,14 @@ static const struct YamlNode struct_ExpoData[] = {
   YAML_CUSTOM("carryTrim",r_carryTrim,nullptr),
   YAML_SIGNED( "trimSource", 6 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
-  YAML_UNSIGNED( "chn", 5 ),
+  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
-  YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
-  YAML_SIGNED_CUST( "weight", 8, in_read_weight, in_write_weight ),
-  YAML_STRING("name", 6),
-  YAML_SIGNED_CUST( "offset", 8, in_read_weight, in_write_weight ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
+  YAML_UNSIGNED( "chn", 5 ),
+  YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
+  YAML_UNSIGNED( "spare", 2 ),
+  YAML_STRING("name", 6),
   YAML_END
 };
 static const struct YamlNode struct_CurveHeader[] = {
@@ -832,7 +834,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
   YAML_ARRAY("limitData", 104, 32, struct_LimitData, NULL),
-  YAML_ARRAY("expoData", 136, 64, struct_ExpoData, NULL),
+  YAML_ARRAY("expoData", 144, 64, struct_ExpoData, NULL),
   YAML_ARRAY("curves", 32, 32, struct_CurveHeader, NULL),
   YAML_ARRAY("points", 8, 512, struct_signed_8, NULL),
   YAML_ARRAY("logicalSw", 72, 64, struct_LogicalSwitchData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_t15.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t15.cpp
@@ -420,21 +420,21 @@ static const struct YamlNode struct_TimerData[] = {
 };
 static const struct YamlNode struct_CurveRef[] = {
   YAML_UNSIGNED( "type", 5 ),
-  YAML_SIGNED_CUST( "value", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_SIGNED_CUST( "value", 11, r_sourceNumVal, w_sourceNumVal ),
   YAML_END
 };
 static const struct YamlNode struct_MixData[] = {
-  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_UNSIGNED( "destCh", 5 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
   YAML_UNSIGNED( "carryTrim", 1 ),
   YAML_UNSIGNED( "mixWarn", 2 ),
   YAML_ENUM("mltpx", 2, enum_MixerMultiplex),
   YAML_UNSIGNED( "speedPrec", 1 ),
-  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
-  YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
   YAML_UNSIGNED( "spare", 2 ),
+  YAML_UNSIGNED_CUST( "weight", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_UNSIGNED_CUST( "offset", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "delayUp", 8 ),
   YAML_UNSIGNED( "delayDown", 8 ),
@@ -462,8 +462,8 @@ static const struct YamlNode struct_ExpoData[] = {
   YAML_CUSTOM("carryTrim",r_carryTrim,nullptr),
   YAML_SIGNED( "trimSource", 6 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
-  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
-  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_UNSIGNED_CUST( "weight", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_UNSIGNED_CUST( "offset", 11, r_sourceNumVal, w_sourceNumVal ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "chn", 5 ),

--- a/radio/src/storage/yaml/yaml_datastructs_t15.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t15.cpp
@@ -419,21 +419,22 @@ static const struct YamlNode struct_TimerData[] = {
   YAML_END
 };
 static const struct YamlNode struct_CurveRef[] = {
-  YAML_UNSIGNED( "type", 8 ),
-  YAML_SIGNED_CUST( "value", 8, in_read_weight, in_write_weight ),
+  YAML_UNSIGNED( "type", 5 ),
+  YAML_SIGNED_CUST( "value", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_END
 };
 static const struct YamlNode struct_MixData[] = {
-  YAML_SIGNED_CUST( "weight", 11, in_read_weight, in_write_weight ),
+  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_UNSIGNED( "destCh", 5 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
   YAML_UNSIGNED( "carryTrim", 1 ),
   YAML_UNSIGNED( "mixWarn", 2 ),
   YAML_ENUM("mltpx", 2, enum_MixerMultiplex),
   YAML_UNSIGNED( "speedPrec", 1 ),
-  YAML_SIGNED_CUST( "offset", 13, in_read_weight, in_write_weight ),
+  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
+  YAML_UNSIGNED( "spare", 2 ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "delayUp", 8 ),
   YAML_UNSIGNED( "delayDown", 8 ),
@@ -461,13 +462,14 @@ static const struct YamlNode struct_ExpoData[] = {
   YAML_CUSTOM("carryTrim",r_carryTrim,nullptr),
   YAML_SIGNED( "trimSource", 6 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
-  YAML_UNSIGNED( "chn", 5 ),
+  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
-  YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
-  YAML_SIGNED_CUST( "weight", 8, in_read_weight, in_write_weight ),
-  YAML_STRING("name", 6),
-  YAML_SIGNED_CUST( "offset", 8, in_read_weight, in_write_weight ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
+  YAML_UNSIGNED( "chn", 5 ),
+  YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
+  YAML_UNSIGNED( "spare", 2 ),
+  YAML_STRING("name", 6),
   YAML_END
 };
 static const struct YamlNode struct_CurveHeader[] = {
@@ -838,7 +840,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
   YAML_ARRAY("limitData", 104, 32, struct_LimitData, NULL),
-  YAML_ARRAY("expoData", 136, 64, struct_ExpoData, NULL),
+  YAML_ARRAY("expoData", 144, 64, struct_ExpoData, NULL),
   YAML_ARRAY("curves", 32, 32, struct_CurveHeader, NULL),
   YAML_ARRAY("points", 8, 512, struct_signed_8, NULL),
   YAML_ARRAY("logicalSw", 72, 64, struct_LogicalSwitchData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_t20.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t20.cpp
@@ -391,21 +391,22 @@ static const struct YamlNode struct_TimerData[] = {
   YAML_END
 };
 static const struct YamlNode struct_CurveRef[] = {
-  YAML_UNSIGNED( "type", 8 ),
-  YAML_SIGNED_CUST( "value", 8, in_read_weight, in_write_weight ),
+  YAML_UNSIGNED( "type", 5 ),
+  YAML_SIGNED_CUST( "value", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_END
 };
 static const struct YamlNode struct_MixData[] = {
-  YAML_SIGNED_CUST( "weight", 11, in_read_weight, in_write_weight ),
+  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_UNSIGNED( "destCh", 5 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
   YAML_UNSIGNED( "carryTrim", 1 ),
   YAML_UNSIGNED( "mixWarn", 2 ),
   YAML_ENUM("mltpx", 2, enum_MixerMultiplex),
   YAML_UNSIGNED( "speedPrec", 1 ),
-  YAML_SIGNED_CUST( "offset", 13, in_read_weight, in_write_weight ),
+  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
+  YAML_UNSIGNED( "spare", 2 ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "delayUp", 8 ),
   YAML_UNSIGNED( "delayDown", 8 ),
@@ -433,13 +434,14 @@ static const struct YamlNode struct_ExpoData[] = {
   YAML_CUSTOM("carryTrim",r_carryTrim,nullptr),
   YAML_SIGNED( "trimSource", 6 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
-  YAML_UNSIGNED( "chn", 5 ),
+  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
-  YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
-  YAML_SIGNED_CUST( "weight", 8, in_read_weight, in_write_weight ),
-  YAML_STRING("name", 6),
-  YAML_SIGNED_CUST( "offset", 8, in_read_weight, in_write_weight ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
+  YAML_UNSIGNED( "chn", 5 ),
+  YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
+  YAML_UNSIGNED( "spare", 2 ),
+  YAML_STRING("name", 6),
   YAML_END
 };
 static const struct YamlNode struct_CurveHeader[] = {
@@ -798,7 +800,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
   YAML_ARRAY("limitData", 88, 32, struct_LimitData, NULL),
-  YAML_ARRAY("expoData", 136, 64, struct_ExpoData, NULL),
+  YAML_ARRAY("expoData", 144, 64, struct_ExpoData, NULL),
   YAML_ARRAY("curves", 32, 32, struct_CurveHeader, NULL),
   YAML_ARRAY("points", 8, 512, struct_signed_8, NULL),
   YAML_ARRAY("logicalSw", 72, 64, struct_LogicalSwitchData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_t20.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t20.cpp
@@ -392,21 +392,21 @@ static const struct YamlNode struct_TimerData[] = {
 };
 static const struct YamlNode struct_CurveRef[] = {
   YAML_UNSIGNED( "type", 5 ),
-  YAML_SIGNED_CUST( "value", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_SIGNED_CUST( "value", 11, r_sourceNumVal, w_sourceNumVal ),
   YAML_END
 };
 static const struct YamlNode struct_MixData[] = {
-  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_UNSIGNED( "destCh", 5 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
   YAML_UNSIGNED( "carryTrim", 1 ),
   YAML_UNSIGNED( "mixWarn", 2 ),
   YAML_ENUM("mltpx", 2, enum_MixerMultiplex),
   YAML_UNSIGNED( "speedPrec", 1 ),
-  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
-  YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
   YAML_UNSIGNED( "spare", 2 ),
+  YAML_UNSIGNED_CUST( "weight", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_UNSIGNED_CUST( "offset", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "delayUp", 8 ),
   YAML_UNSIGNED( "delayDown", 8 ),
@@ -434,8 +434,8 @@ static const struct YamlNode struct_ExpoData[] = {
   YAML_CUSTOM("carryTrim",r_carryTrim,nullptr),
   YAML_SIGNED( "trimSource", 6 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
-  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
-  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_UNSIGNED_CUST( "weight", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_UNSIGNED_CUST( "offset", 11, r_sourceNumVal, w_sourceNumVal ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "chn", 5 ),

--- a/radio/src/storage/yaml/yaml_datastructs_tpro.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tpro.cpp
@@ -391,21 +391,22 @@ static const struct YamlNode struct_TimerData[] = {
   YAML_END
 };
 static const struct YamlNode struct_CurveRef[] = {
-  YAML_UNSIGNED( "type", 8 ),
-  YAML_SIGNED_CUST( "value", 8, in_read_weight, in_write_weight ),
+  YAML_UNSIGNED( "type", 5 ),
+  YAML_SIGNED_CUST( "value", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_END
 };
 static const struct YamlNode struct_MixData[] = {
-  YAML_SIGNED_CUST( "weight", 11, in_read_weight, in_write_weight ),
+  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_UNSIGNED( "destCh", 5 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
   YAML_UNSIGNED( "carryTrim", 1 ),
   YAML_UNSIGNED( "mixWarn", 2 ),
   YAML_ENUM("mltpx", 2, enum_MixerMultiplex),
   YAML_UNSIGNED( "speedPrec", 1 ),
-  YAML_SIGNED_CUST( "offset", 13, in_read_weight, in_write_weight ),
+  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
+  YAML_UNSIGNED( "spare", 2 ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "delayUp", 8 ),
   YAML_UNSIGNED( "delayDown", 8 ),
@@ -433,13 +434,14 @@ static const struct YamlNode struct_ExpoData[] = {
   YAML_CUSTOM("carryTrim",r_carryTrim,nullptr),
   YAML_SIGNED( "trimSource", 6 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
-  YAML_UNSIGNED( "chn", 5 ),
+  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
-  YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
-  YAML_SIGNED_CUST( "weight", 8, in_read_weight, in_write_weight ),
-  YAML_STRING("name", 6),
-  YAML_SIGNED_CUST( "offset", 8, in_read_weight, in_write_weight ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
+  YAML_UNSIGNED( "chn", 5 ),
+  YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
+  YAML_UNSIGNED( "spare", 2 ),
+  YAML_STRING("name", 6),
   YAML_END
 };
 static const struct YamlNode struct_CurveHeader[] = {
@@ -798,7 +800,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
   YAML_ARRAY("limitData", 88, 32, struct_LimitData, NULL),
-  YAML_ARRAY("expoData", 136, 64, struct_ExpoData, NULL),
+  YAML_ARRAY("expoData", 144, 64, struct_ExpoData, NULL),
   YAML_ARRAY("curves", 32, 32, struct_CurveHeader, NULL),
   YAML_ARRAY("points", 8, 512, struct_signed_8, NULL),
   YAML_ARRAY("logicalSw", 72, 64, struct_LogicalSwitchData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_tpro.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tpro.cpp
@@ -392,21 +392,21 @@ static const struct YamlNode struct_TimerData[] = {
 };
 static const struct YamlNode struct_CurveRef[] = {
   YAML_UNSIGNED( "type", 5 ),
-  YAML_SIGNED_CUST( "value", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_SIGNED_CUST( "value", 11, r_sourceNumVal, w_sourceNumVal ),
   YAML_END
 };
 static const struct YamlNode struct_MixData[] = {
-  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_UNSIGNED( "destCh", 5 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
   YAML_UNSIGNED( "carryTrim", 1 ),
   YAML_UNSIGNED( "mixWarn", 2 ),
   YAML_ENUM("mltpx", 2, enum_MixerMultiplex),
   YAML_UNSIGNED( "speedPrec", 1 ),
-  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
-  YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
   YAML_UNSIGNED( "spare", 2 ),
+  YAML_UNSIGNED_CUST( "weight", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_UNSIGNED_CUST( "offset", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "delayUp", 8 ),
   YAML_UNSIGNED( "delayDown", 8 ),
@@ -434,8 +434,8 @@ static const struct YamlNode struct_ExpoData[] = {
   YAML_CUSTOM("carryTrim",r_carryTrim,nullptr),
   YAML_SIGNED( "trimSource", 6 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
-  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
-  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_UNSIGNED_CUST( "weight", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_UNSIGNED_CUST( "offset", 11, r_sourceNumVal, w_sourceNumVal ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "chn", 5 ),

--- a/radio/src/storage/yaml/yaml_datastructs_x10.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x10.cpp
@@ -419,21 +419,22 @@ static const struct YamlNode struct_TimerData[] = {
   YAML_END
 };
 static const struct YamlNode struct_CurveRef[] = {
-  YAML_UNSIGNED( "type", 8 ),
-  YAML_SIGNED_CUST( "value", 8, in_read_weight, in_write_weight ),
+  YAML_UNSIGNED( "type", 5 ),
+  YAML_SIGNED_CUST( "value", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_END
 };
 static const struct YamlNode struct_MixData[] = {
-  YAML_SIGNED_CUST( "weight", 11, in_read_weight, in_write_weight ),
+  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_UNSIGNED( "destCh", 5 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
   YAML_UNSIGNED( "carryTrim", 1 ),
   YAML_UNSIGNED( "mixWarn", 2 ),
   YAML_ENUM("mltpx", 2, enum_MixerMultiplex),
   YAML_UNSIGNED( "speedPrec", 1 ),
-  YAML_SIGNED_CUST( "offset", 13, in_read_weight, in_write_weight ),
+  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
+  YAML_UNSIGNED( "spare", 2 ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "delayUp", 8 ),
   YAML_UNSIGNED( "delayDown", 8 ),
@@ -461,13 +462,14 @@ static const struct YamlNode struct_ExpoData[] = {
   YAML_CUSTOM("carryTrim",r_carryTrim,nullptr),
   YAML_SIGNED( "trimSource", 6 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
-  YAML_UNSIGNED( "chn", 5 ),
+  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
-  YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
-  YAML_SIGNED_CUST( "weight", 8, in_read_weight, in_write_weight ),
-  YAML_STRING("name", 6),
-  YAML_SIGNED_CUST( "offset", 8, in_read_weight, in_write_weight ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
+  YAML_UNSIGNED( "chn", 5 ),
+  YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
+  YAML_UNSIGNED( "spare", 2 ),
+  YAML_STRING("name", 6),
   YAML_END
 };
 static const struct YamlNode struct_CurveHeader[] = {
@@ -833,7 +835,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
   YAML_ARRAY("limitData", 104, 32, struct_LimitData, NULL),
-  YAML_ARRAY("expoData", 136, 64, struct_ExpoData, NULL),
+  YAML_ARRAY("expoData", 144, 64, struct_ExpoData, NULL),
   YAML_ARRAY("curves", 32, 32, struct_CurveHeader, NULL),
   YAML_ARRAY("points", 8, 512, struct_signed_8, NULL),
   YAML_ARRAY("logicalSw", 72, 64, struct_LogicalSwitchData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_x10.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x10.cpp
@@ -420,21 +420,21 @@ static const struct YamlNode struct_TimerData[] = {
 };
 static const struct YamlNode struct_CurveRef[] = {
   YAML_UNSIGNED( "type", 5 ),
-  YAML_SIGNED_CUST( "value", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_SIGNED_CUST( "value", 11, r_sourceNumVal, w_sourceNumVal ),
   YAML_END
 };
 static const struct YamlNode struct_MixData[] = {
-  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_UNSIGNED( "destCh", 5 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
   YAML_UNSIGNED( "carryTrim", 1 ),
   YAML_UNSIGNED( "mixWarn", 2 ),
   YAML_ENUM("mltpx", 2, enum_MixerMultiplex),
   YAML_UNSIGNED( "speedPrec", 1 ),
-  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
-  YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
   YAML_UNSIGNED( "spare", 2 ),
+  YAML_UNSIGNED_CUST( "weight", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_UNSIGNED_CUST( "offset", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "delayUp", 8 ),
   YAML_UNSIGNED( "delayDown", 8 ),
@@ -462,8 +462,8 @@ static const struct YamlNode struct_ExpoData[] = {
   YAML_CUSTOM("carryTrim",r_carryTrim,nullptr),
   YAML_SIGNED( "trimSource", 6 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
-  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
-  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_UNSIGNED_CUST( "weight", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_UNSIGNED_CUST( "offset", 11, r_sourceNumVal, w_sourceNumVal ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "chn", 5 ),

--- a/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
@@ -419,21 +419,22 @@ static const struct YamlNode struct_TimerData[] = {
   YAML_END
 };
 static const struct YamlNode struct_CurveRef[] = {
-  YAML_UNSIGNED( "type", 8 ),
-  YAML_SIGNED_CUST( "value", 8, in_read_weight, in_write_weight ),
+  YAML_UNSIGNED( "type", 5 ),
+  YAML_SIGNED_CUST( "value", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_END
 };
 static const struct YamlNode struct_MixData[] = {
-  YAML_SIGNED_CUST( "weight", 11, in_read_weight, in_write_weight ),
+  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_UNSIGNED( "destCh", 5 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
   YAML_UNSIGNED( "carryTrim", 1 ),
   YAML_UNSIGNED( "mixWarn", 2 ),
   YAML_ENUM("mltpx", 2, enum_MixerMultiplex),
   YAML_UNSIGNED( "speedPrec", 1 ),
-  YAML_SIGNED_CUST( "offset", 13, in_read_weight, in_write_weight ),
+  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
+  YAML_UNSIGNED( "spare", 2 ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "delayUp", 8 ),
   YAML_UNSIGNED( "delayDown", 8 ),
@@ -461,13 +462,14 @@ static const struct YamlNode struct_ExpoData[] = {
   YAML_CUSTOM("carryTrim",r_carryTrim,nullptr),
   YAML_SIGNED( "trimSource", 6 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
-  YAML_UNSIGNED( "chn", 5 ),
+  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
-  YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
-  YAML_SIGNED_CUST( "weight", 8, in_read_weight, in_write_weight ),
-  YAML_STRING("name", 6),
-  YAML_SIGNED_CUST( "offset", 8, in_read_weight, in_write_weight ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
+  YAML_UNSIGNED( "chn", 5 ),
+  YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
+  YAML_UNSIGNED( "spare", 2 ),
+  YAML_STRING("name", 6),
   YAML_END
 };
 static const struct YamlNode struct_CurveHeader[] = {
@@ -833,7 +835,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
   YAML_ARRAY("limitData", 104, 32, struct_LimitData, NULL),
-  YAML_ARRAY("expoData", 136, 64, struct_ExpoData, NULL),
+  YAML_ARRAY("expoData", 144, 64, struct_ExpoData, NULL),
   YAML_ARRAY("curves", 32, 32, struct_CurveHeader, NULL),
   YAML_ARRAY("points", 8, 512, struct_signed_8, NULL),
   YAML_ARRAY("logicalSw", 72, 64, struct_LogicalSwitchData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x12s.cpp
@@ -420,21 +420,21 @@ static const struct YamlNode struct_TimerData[] = {
 };
 static const struct YamlNode struct_CurveRef[] = {
   YAML_UNSIGNED( "type", 5 ),
-  YAML_SIGNED_CUST( "value", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_SIGNED_CUST( "value", 11, r_sourceNumVal, w_sourceNumVal ),
   YAML_END
 };
 static const struct YamlNode struct_MixData[] = {
-  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_UNSIGNED( "destCh", 5 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
   YAML_UNSIGNED( "carryTrim", 1 ),
   YAML_UNSIGNED( "mixWarn", 2 ),
   YAML_ENUM("mltpx", 2, enum_MixerMultiplex),
   YAML_UNSIGNED( "speedPrec", 1 ),
-  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
-  YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
   YAML_UNSIGNED( "spare", 2 ),
+  YAML_UNSIGNED_CUST( "weight", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_UNSIGNED_CUST( "offset", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "delayUp", 8 ),
   YAML_UNSIGNED( "delayDown", 8 ),
@@ -462,8 +462,8 @@ static const struct YamlNode struct_ExpoData[] = {
   YAML_CUSTOM("carryTrim",r_carryTrim,nullptr),
   YAML_SIGNED( "trimSource", 6 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
-  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
-  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_UNSIGNED_CUST( "weight", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_UNSIGNED_CUST( "offset", 11, r_sourceNumVal, w_sourceNumVal ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "chn", 5 ),

--- a/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
@@ -391,21 +391,21 @@ static const struct YamlNode struct_TimerData[] = {
 };
 static const struct YamlNode struct_CurveRef[] = {
   YAML_UNSIGNED( "type", 5 ),
-  YAML_SIGNED_CUST( "value", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_SIGNED_CUST( "value", 11, r_sourceNumVal, w_sourceNumVal ),
   YAML_END
 };
 static const struct YamlNode struct_MixData[] = {
-  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_UNSIGNED( "destCh", 5 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
   YAML_UNSIGNED( "carryTrim", 1 ),
   YAML_UNSIGNED( "mixWarn", 2 ),
   YAML_ENUM("mltpx", 2, enum_MixerMultiplex),
   YAML_UNSIGNED( "speedPrec", 1 ),
-  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
-  YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
   YAML_UNSIGNED( "spare", 2 ),
+  YAML_UNSIGNED_CUST( "weight", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_UNSIGNED_CUST( "offset", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "delayUp", 8 ),
   YAML_UNSIGNED( "delayDown", 8 ),
@@ -433,8 +433,8 @@ static const struct YamlNode struct_ExpoData[] = {
   YAML_CUSTOM("carryTrim",r_carryTrim,nullptr),
   YAML_SIGNED( "trimSource", 6 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
-  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
-  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_UNSIGNED_CUST( "weight", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_UNSIGNED_CUST( "offset", 11, r_sourceNumVal, w_sourceNumVal ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "chn", 5 ),

--- a/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
@@ -390,21 +390,22 @@ static const struct YamlNode struct_TimerData[] = {
   YAML_END
 };
 static const struct YamlNode struct_CurveRef[] = {
-  YAML_UNSIGNED( "type", 8 ),
-  YAML_SIGNED_CUST( "value", 8, in_read_weight, in_write_weight ),
+  YAML_UNSIGNED( "type", 5 ),
+  YAML_SIGNED_CUST( "value", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_END
 };
 static const struct YamlNode struct_MixData[] = {
-  YAML_SIGNED_CUST( "weight", 11, in_read_weight, in_write_weight ),
+  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_UNSIGNED( "destCh", 5 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
   YAML_UNSIGNED( "carryTrim", 1 ),
   YAML_UNSIGNED( "mixWarn", 2 ),
   YAML_ENUM("mltpx", 2, enum_MixerMultiplex),
   YAML_UNSIGNED( "speedPrec", 1 ),
-  YAML_SIGNED_CUST( "offset", 13, in_read_weight, in_write_weight ),
+  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
+  YAML_UNSIGNED( "spare", 2 ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "delayUp", 8 ),
   YAML_UNSIGNED( "delayDown", 8 ),
@@ -432,13 +433,14 @@ static const struct YamlNode struct_ExpoData[] = {
   YAML_CUSTOM("carryTrim",r_carryTrim,nullptr),
   YAML_SIGNED( "trimSource", 6 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
-  YAML_UNSIGNED( "chn", 5 ),
+  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
-  YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
-  YAML_SIGNED_CUST( "weight", 8, in_read_weight, in_write_weight ),
-  YAML_STRING("name", 6),
-  YAML_SIGNED_CUST( "offset", 8, in_read_weight, in_write_weight ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
+  YAML_UNSIGNED( "chn", 5 ),
+  YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
+  YAML_UNSIGNED( "spare", 2 ),
+  YAML_STRING("name", 6),
   YAML_END
 };
 static const struct YamlNode struct_CurveHeader[] = {
@@ -797,7 +799,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
   YAML_ARRAY("limitData", 104, 32, struct_LimitData, NULL),
-  YAML_ARRAY("expoData", 136, 64, struct_ExpoData, NULL),
+  YAML_ARRAY("expoData", 144, 64, struct_ExpoData, NULL),
   YAML_ARRAY("curves", 32, 32, struct_CurveHeader, NULL),
   YAML_ARRAY("points", 8, 512, struct_signed_8, NULL),
   YAML_ARRAY("logicalSw", 72, 64, struct_LogicalSwitchData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
@@ -391,21 +391,22 @@ static const struct YamlNode struct_TimerData[] = {
   YAML_END
 };
 static const struct YamlNode struct_CurveRef[] = {
-  YAML_UNSIGNED( "type", 8 ),
-  YAML_SIGNED_CUST( "value", 8, in_read_weight, in_write_weight ),
+  YAML_UNSIGNED( "type", 5 ),
+  YAML_SIGNED_CUST( "value", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_END
 };
 static const struct YamlNode struct_MixData[] = {
-  YAML_SIGNED_CUST( "weight", 11, in_read_weight, in_write_weight ),
+  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_UNSIGNED( "destCh", 5 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
   YAML_UNSIGNED( "carryTrim", 1 ),
   YAML_UNSIGNED( "mixWarn", 2 ),
   YAML_ENUM("mltpx", 2, enum_MixerMultiplex),
   YAML_UNSIGNED( "speedPrec", 1 ),
-  YAML_SIGNED_CUST( "offset", 13, in_read_weight, in_write_weight ),
+  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
+  YAML_UNSIGNED( "spare", 2 ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "delayUp", 8 ),
   YAML_UNSIGNED( "delayDown", 8 ),
@@ -433,13 +434,14 @@ static const struct YamlNode struct_ExpoData[] = {
   YAML_CUSTOM("carryTrim",r_carryTrim,nullptr),
   YAML_SIGNED( "trimSource", 6 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
-  YAML_UNSIGNED( "chn", 5 ),
+  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
-  YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
-  YAML_SIGNED_CUST( "weight", 8, in_read_weight, in_write_weight ),
-  YAML_STRING("name", 6),
-  YAML_SIGNED_CUST( "offset", 8, in_read_weight, in_write_weight ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
+  YAML_UNSIGNED( "chn", 5 ),
+  YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
+  YAML_UNSIGNED( "spare", 2 ),
+  YAML_STRING("name", 6),
   YAML_END
 };
 static const struct YamlNode struct_CurveHeader[] = {
@@ -798,7 +800,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
   YAML_ARRAY("limitData", 104, 32, struct_LimitData, NULL),
-  YAML_ARRAY("expoData", 136, 64, struct_ExpoData, NULL),
+  YAML_ARRAY("expoData", 144, 64, struct_ExpoData, NULL),
   YAML_ARRAY("curves", 32, 32, struct_CurveHeader, NULL),
   YAML_ARRAY("points", 8, 512, struct_signed_8, NULL),
   YAML_ARRAY("logicalSw", 72, 64, struct_LogicalSwitchData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
@@ -392,21 +392,21 @@ static const struct YamlNode struct_TimerData[] = {
 };
 static const struct YamlNode struct_CurveRef[] = {
   YAML_UNSIGNED( "type", 5 ),
-  YAML_SIGNED_CUST( "value", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_SIGNED_CUST( "value", 11, r_sourceNumVal, w_sourceNumVal ),
   YAML_END
 };
 static const struct YamlNode struct_MixData[] = {
-  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_UNSIGNED( "destCh", 5 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
   YAML_UNSIGNED( "carryTrim", 1 ),
   YAML_UNSIGNED( "mixWarn", 2 ),
   YAML_ENUM("mltpx", 2, enum_MixerMultiplex),
   YAML_UNSIGNED( "speedPrec", 1 ),
-  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
-  YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
   YAML_UNSIGNED( "spare", 2 ),
+  YAML_UNSIGNED_CUST( "weight", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_UNSIGNED_CUST( "offset", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "delayUp", 8 ),
   YAML_UNSIGNED( "delayDown", 8 ),
@@ -434,8 +434,8 @@ static const struct YamlNode struct_ExpoData[] = {
   YAML_CUSTOM("carryTrim",r_carryTrim,nullptr),
   YAML_SIGNED( "trimSource", 6 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
-  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
-  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_UNSIGNED_CUST( "weight", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_UNSIGNED_CUST( "offset", 11, r_sourceNumVal, w_sourceNumVal ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "chn", 5 ),

--- a/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
@@ -394,21 +394,22 @@ static const struct YamlNode struct_TimerData[] = {
   YAML_END
 };
 static const struct YamlNode struct_CurveRef[] = {
-  YAML_UNSIGNED( "type", 8 ),
-  YAML_SIGNED_CUST( "value", 8, in_read_weight, in_write_weight ),
+  YAML_UNSIGNED( "type", 5 ),
+  YAML_SIGNED_CUST( "value", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_END
 };
 static const struct YamlNode struct_MixData[] = {
-  YAML_SIGNED_CUST( "weight", 11, in_read_weight, in_write_weight ),
+  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_UNSIGNED( "destCh", 5 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
   YAML_UNSIGNED( "carryTrim", 1 ),
   YAML_UNSIGNED( "mixWarn", 2 ),
   YAML_ENUM("mltpx", 2, enum_MixerMultiplex),
   YAML_UNSIGNED( "speedPrec", 1 ),
-  YAML_SIGNED_CUST( "offset", 13, in_read_weight, in_write_weight ),
+  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
+  YAML_UNSIGNED( "spare", 2 ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "delayUp", 8 ),
   YAML_UNSIGNED( "delayDown", 8 ),
@@ -436,13 +437,14 @@ static const struct YamlNode struct_ExpoData[] = {
   YAML_CUSTOM("carryTrim",r_carryTrim,nullptr),
   YAML_SIGNED( "trimSource", 6 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
-  YAML_UNSIGNED( "chn", 5 ),
+  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
-  YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
-  YAML_SIGNED_CUST( "weight", 8, in_read_weight, in_write_weight ),
-  YAML_STRING("name", 6),
-  YAML_SIGNED_CUST( "offset", 8, in_read_weight, in_write_weight ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
+  YAML_UNSIGNED( "chn", 5 ),
+  YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
+  YAML_UNSIGNED( "spare", 2 ),
+  YAML_STRING("name", 6),
   YAML_END
 };
 static const struct YamlNode struct_CurveHeader[] = {
@@ -801,7 +803,7 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "beepANACenter", 16 ),
   YAML_ARRAY("mixData", 160, 64, struct_MixData, NULL),
   YAML_ARRAY("limitData", 88, 32, struct_LimitData, NULL),
-  YAML_ARRAY("expoData", 136, 64, struct_ExpoData, NULL),
+  YAML_ARRAY("expoData", 144, 64, struct_ExpoData, NULL),
   YAML_ARRAY("curves", 32, 32, struct_CurveHeader, NULL),
   YAML_ARRAY("points", 8, 512, struct_signed_8, NULL),
   YAML_ARRAY("logicalSw", 72, 64, struct_LogicalSwitchData, NULL),

--- a/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
@@ -395,21 +395,21 @@ static const struct YamlNode struct_TimerData[] = {
 };
 static const struct YamlNode struct_CurveRef[] = {
   YAML_UNSIGNED( "type", 5 ),
-  YAML_SIGNED_CUST( "value", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_SIGNED_CUST( "value", 11, r_sourceNumVal, w_sourceNumVal ),
   YAML_END
 };
 static const struct YamlNode struct_MixData[] = {
-  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
   YAML_UNSIGNED( "destCh", 5 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
   YAML_UNSIGNED( "carryTrim", 1 ),
   YAML_UNSIGNED( "mixWarn", 2 ),
   YAML_ENUM("mltpx", 2, enum_MixerMultiplex),
   YAML_UNSIGNED( "speedPrec", 1 ),
-  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
-  YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_UNSIGNED_CUST( "flightModes", 9, r_flightModes, w_flightModes ),
   YAML_UNSIGNED( "spare", 2 ),
+  YAML_UNSIGNED_CUST( "weight", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_UNSIGNED_CUST( "offset", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "delayUp", 8 ),
   YAML_UNSIGNED( "delayDown", 8 ),
@@ -437,8 +437,8 @@ static const struct YamlNode struct_ExpoData[] = {
   YAML_CUSTOM("carryTrim",r_carryTrim,nullptr),
   YAML_SIGNED( "trimSource", 6 ),
   YAML_SIGNED_CUST( "srcRaw", 10, r_mixSrcRawEx, w_mixSrcRawEx ),
-  YAML_SIGNED_CUST( "weight", 11, in_read_sourcenumval, in_write_sourcenumval ),
-  YAML_SIGNED_CUST( "offset", 11, in_read_sourcenumval, in_write_sourcenumval ),
+  YAML_UNSIGNED_CUST( "weight", 11, r_sourceNumVal, w_sourceNumVal ),
+  YAML_UNSIGNED_CUST( "offset", 11, r_sourceNumVal, w_sourceNumVal ),
   YAML_SIGNED_CUST( "swtch", 10, r_swtchSrc, w_swtchSrc ),
   YAML_STRUCT("curve", 16, struct_CurveRef, NULL),
   YAML_UNSIGNED( "chn", 5 ),

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -429,6 +429,24 @@ char *getValueOrGVarString(char *dest, size_t len, gvar_t value, gvar_t vmin,
   formatNumberAsString(dest, len, value, flags, 0, nullptr, suffix);
   return dest;
 }
+
+char *getValueOrSrcVarString(char *dest, size_t len, gvar_t value, gvar_t vmin,
+                           gvar_t vmax, LcdFlags flags, const char *suffix,
+                           gvar_t offset, bool usePPMUnit)
+{
+  SourceNumVal v;
+  v.rawValue = value;
+  if (v.isSource) {
+    const char* s = getSourceString(v.value);
+    strncpy(dest, s, len);
+  } else {
+    value += offset;
+    if (usePPMUnit && g_eeGeneral.ppmunit == PPM_US)
+      value = value * 128 / 25;
+    formatNumberAsString(dest, len, value, flags, 0, nullptr, suffix);
+  }
+  return dest;
+}
 #endif
 
 char *getFlightModeString(char *dest, int8_t idx)

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -380,7 +380,7 @@ char *getCurveString(char *dest, int idx)
 
   char *s = dest;
   if (idx < 0) {
-    *s++ = '!';
+    *s++ = '-';
     idx = -idx;
   }
 

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -658,7 +658,7 @@ char *getSourceString(char (&destRef)[L], mixsrc_t idx)
 
   if (idx < 0) {
     idx = -idx;
-    dest[0] = '!';
+    dest[0] = '-';
     dest += 1;
     dest_len -= 1;
   }

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -440,10 +440,10 @@ char *getValueOrSrcVarString(char *dest, size_t len, gvar_t value, gvar_t vmin,
     const char* s = getSourceString(v.value);
     strncpy(dest, s, len);
   } else {
-    value += offset;
+    v.value += offset;
     if (usePPMUnit && g_eeGeneral.ppmunit == PPM_US)
-      value = value * 128 / 25;
-    formatNumberAsString(dest, len, value, flags, 0, nullptr, suffix);
+      v.value = v.value * 128 / 25;
+    formatNumberAsString(dest, len, v.value, flags, 0, nullptr, suffix);
   }
   return dest;
 }

--- a/radio/src/strhelpers.h
+++ b/radio/src/strhelpers.h
@@ -98,6 +98,9 @@ char *getGVarString(int idx);
 char *getValueOrGVarString(char *dest, size_t len, gvar_t value, gvar_t vmin,
                            gvar_t vmax, LcdFlags flags = 0,
                            const char *suffix = nullptr, gvar_t offset = 0, bool usePPMUnit = false);
+char *getValueOrSrcVarString(char *dest, size_t len, gvar_t value, gvar_t vmin,
+                             gvar_t vmax, LcdFlags flags = 0,
+                             const char *suffix = nullptr, gvar_t offset = 0, bool usePPMUnit = false);
 const char *getSwitchWarnSymbol(uint8_t pos);
 const char *getSwitchPositionSymbol(uint8_t pos);
 char *getSwitchPositionName(char *dest, swsrc_t idx);

--- a/radio/src/tests/lua.cpp
+++ b/radio/src/tests/lua.cpp
@@ -134,7 +134,9 @@ TEST(Lua, testModelInputs)
   EXPECT_EQ(3, (int)g_model.expoData[0].chn);
   EXPECT_STRNEQ("test2", g_model.expoData[0].name);
   EXPECT_EQ(MIXSRC_FIRST_STICK, g_model.expoData[0].srcRaw);
-  EXPECT_EQ(-56, g_model.expoData[0].weight);
+  SourceNumVal v;
+  v.rawValue = g_model.expoData[0].weight;
+  EXPECT_EQ(-56, v.value);
   EXPECT_EQ(0, g_model.expoData[0].offset);
   EXPECT_EQ(0, g_model.expoData[0].swtch);
 
@@ -155,7 +157,8 @@ TEST(Lua, testModelInputs)
   EXPECT_EQ(3, (int)g_model.expoData[0].chn);
   EXPECT_STRNEQ("test2", g_model.expoData[0].name);
   EXPECT_EQ(MIXSRC_FIRST_STICK, g_model.expoData[0].srcRaw);
-  EXPECT_EQ(-56, g_model.expoData[0].weight);
+  v.rawValue = g_model.expoData[0].weight;
+  EXPECT_EQ(-56, v.value);
   EXPECT_EQ(0, g_model.expoData[0].offset);
   EXPECT_EQ(0, g_model.expoData[0].swtch);
 

--- a/radio/src/tests/mixer.cpp
+++ b/radio/src/tests/mixer.cpp
@@ -463,8 +463,8 @@ TEST_F(TrimsTest, MoveTrimsToOffsetsWithTrimIdle)
   // Trim idle only
   g_model.thrTrim = 1;
   anaSetFiltered(THR_STICK,  THR_STICK_MIN_THR_POS);  // Min stick
-  g_model.limitData[THR_CHAN].offset = makeSourceNumVal(0);
-  g_model.limitData[ELE_CHAN].offset = makeSourceNumVal(0);
+  g_model.limitData[THR_CHAN].offset = 0;
+  g_model.limitData[ELE_CHAN].offset = 0;
   setTrimValue(0, MIXSRC_TRIMTHR - MIXSRC_FIRST_TRIM, 100);
   setTrimValue(0, MIXSRC_TRIMELE - MIXSRC_FIRST_TRIM, -100);
   evalMixes(1);
@@ -497,8 +497,8 @@ TEST_F(TrimsTest, MoveTrimsToOffsetsWithCrossTrims)
   // No trim idle only
   // Cross trims
   g_model.thrTrim = 0;
-  g_model.limitData[THR_CHAN].offset = makeSourceNumVal(0);
-  g_model.limitData[ELE_CHAN].offset = makeSourceNumVal(0);
+  g_model.limitData[THR_CHAN].offset = 0;
+  g_model.limitData[ELE_CHAN].offset = 0;
   g_model.setThrottleStickTrimSource(MIXSRC_TRIMELE);
   ExpoData *expo = expoAddress(THR_CHAN);
   expo->trimSource = ELE_TRIM_SOURCE;
@@ -529,8 +529,8 @@ TEST_F(TrimsTest, MoveTrimsToOffsetsWithCrosstrimsAndTrimIdle)
 {
   // Trim idle only
   // Cross trims
-  g_model.limitData[THR_CHAN].offset = makeSourceNumVal(0);
-  g_model.limitData[ELE_CHAN].offset = makeSourceNumVal(0);
+  g_model.limitData[THR_CHAN].offset = 0;
+  g_model.limitData[ELE_CHAN].offset = 0;
   g_model.thrTrim = 1;
   g_model.thrTrimSw = ELE_THRTRIMSW;
   ExpoData *expo = expoAddress(THR_CHAN);

--- a/radio/src/tests/mixer.cpp
+++ b/radio/src/tests/mixer.cpp
@@ -279,7 +279,7 @@ TEST_F(TrimsTest, throttleTrimWithZeroWeightOnThrottle)
   g_model.thrTrim = 1;
   // the input already exists
   ExpoData *expo = expoAddress(THR_STICK);
-  expo->weight = 0;
+  expo->weight = makeSourceNumVal(0);
   // stick max + trim max
   anaSetFiltered(THR_STICK,  +1024);
   setTrimValue(0, THR_STICK, TRIM_MAX);
@@ -350,7 +350,7 @@ TEST_F(TrimsTest, invertedThrottlePlusthrottleTrimWithZeroWeightOnThrottle)
   g_model.thrTrim = 1;
   // the input already exists
   ExpoData *expo = expoAddress(THR_STICK);
-  expo->weight = 0;
+  expo->weight = makeSourceNumVal(0);
   // stick max + trim max
   anaSetFiltered(THR_STICK,  +1024);
   setTrimValue(0, THR_STICK, TRIM_MAX);
@@ -463,8 +463,8 @@ TEST_F(TrimsTest, MoveTrimsToOffsetsWithTrimIdle)
   // Trim idle only
   g_model.thrTrim = 1;
   anaSetFiltered(THR_STICK,  THR_STICK_MIN_THR_POS);  // Min stick
-  g_model.limitData[THR_CHAN].offset = 0;
-  g_model.limitData[ELE_CHAN].offset = 0;
+  g_model.limitData[THR_CHAN].offset = makeSourceNumVal(0);
+  g_model.limitData[ELE_CHAN].offset = makeSourceNumVal(0);
   setTrimValue(0, MIXSRC_TRIMTHR - MIXSRC_FIRST_TRIM, 100);
   setTrimValue(0, MIXSRC_TRIMELE - MIXSRC_FIRST_TRIM, -100);
   evalMixes(1);
@@ -497,8 +497,8 @@ TEST_F(TrimsTest, MoveTrimsToOffsetsWithCrossTrims)
   // No trim idle only
   // Cross trims
   g_model.thrTrim = 0;
-  g_model.limitData[THR_CHAN].offset = 0;
-  g_model.limitData[ELE_CHAN].offset = 0;
+  g_model.limitData[THR_CHAN].offset = makeSourceNumVal(0);
+  g_model.limitData[ELE_CHAN].offset = makeSourceNumVal(0);
   g_model.setThrottleStickTrimSource(MIXSRC_TRIMELE);
   ExpoData *expo = expoAddress(THR_CHAN);
   expo->trimSource = ELE_TRIM_SOURCE;
@@ -529,8 +529,8 @@ TEST_F(TrimsTest, MoveTrimsToOffsetsWithCrosstrimsAndTrimIdle)
 {
   // Trim idle only
   // Cross trims
-  g_model.limitData[THR_CHAN].offset = 0;
-  g_model.limitData[ELE_CHAN].offset = 0;
+  g_model.limitData[THR_CHAN].offset = makeSourceNumVal(0);
+  g_model.limitData[ELE_CHAN].offset = makeSourceNumVal(0);
   g_model.thrTrim = 1;
   g_model.thrTrimSw = ELE_THRTRIMSW;
   ExpoData *expo = expoAddress(THR_CHAN);
@@ -579,7 +579,7 @@ TEST_F(TrimsTest, InstantTrimNegativeCurve)
 {
   ExpoData *expo = expoAddress(AIL_STICK);
   expo->curve.type = CURVE_REF_CUSTOM;
-  expo->curve.value = 1;
+  expo->curve.value = makeSourceNumVal(1);
   g_model.points[0] = -100;
   g_model.points[1] = -75;
   g_model.points[2] = -50;
@@ -616,13 +616,13 @@ TEST_F(MixerTest, InfiniteRecursiveChannels)
 {
   g_model.mixData[0].destCh = 0;
   g_model.mixData[0].srcRaw = MIXSRC_FIRST_CH + 1;
-  g_model.mixData[0].weight = 100;
+  g_model.mixData[0].weight = makeSourceNumVal(100);
   g_model.mixData[1].destCh = 1;
   g_model.mixData[1].srcRaw = MIXSRC_FIRST_CH + 2;
-  g_model.mixData[1].weight = 100;
+  g_model.mixData[1].weight = makeSourceNumVal(100);
   g_model.mixData[2].destCh = 2;
   g_model.mixData[2].srcRaw = MIXSRC_FIRST_CH;
-  g_model.mixData[2].weight = 100;
+  g_model.mixData[2].weight = makeSourceNumVal(100);
   evalFlightModeMixes(e_perout_mode_normal, 0);
   EXPECT_EQ(chans[2], 0);
   EXPECT_EQ(chans[1], 0);
@@ -633,7 +633,7 @@ TEST_F(MixerTest, BlockingChannel)
 {
   g_model.mixData[0].destCh = 0;
   g_model.mixData[0].srcRaw = MIXSRC_FIRST_CH;
-  g_model.mixData[0].weight = 100;
+  g_model.mixData[0].weight = makeSourceNumVal(100);
   evalFlightModeMixes(e_perout_mode_normal, 0);
   EXPECT_EQ(chans[0], 0);
 }
@@ -643,14 +643,14 @@ TEST_F(MixerTest, RecursiveAddChannel)
   g_model.mixData[0].destCh = 0;
   g_model.mixData[0].mltpx = MLTPX_ADD;
   g_model.mixData[0].srcRaw = MIXSRC_MAX;
-  g_model.mixData[0].weight = 50;
+  g_model.mixData[0].weight = makeSourceNumVal(50);
   g_model.mixData[1].destCh = 0;
   g_model.mixData[1].mltpx = MLTPX_ADD;
   g_model.mixData[1].srcRaw = MIXSRC_FIRST_CH + 1;
-  g_model.mixData[1].weight = 100;
+  g_model.mixData[1].weight = makeSourceNumVal(100);
   g_model.mixData[2].destCh = 1;
   g_model.mixData[2].srcRaw = MIXSRC_FIRST_STICK;
-  g_model.mixData[2].weight = 100;
+  g_model.mixData[2].weight = makeSourceNumVal(100);
 
   anaSetFiltered(0, 0);
   evalFlightModeMixes(e_perout_mode_normal, 0);
@@ -665,15 +665,15 @@ TEST_F(MixerTest, RecursiveAddChannelAfterInactivePhase)
   g_model.mixData[0].mltpx = MLTPX_ADD;
   g_model.mixData[0].srcRaw = MIXSRC_FIRST_CH + 1;
   g_model.mixData[0].flightModes = 0b11110;
-  g_model.mixData[0].weight = 50;
+  g_model.mixData[0].weight = makeSourceNumVal(50);
   g_model.mixData[1].destCh = 0;
   g_model.mixData[1].mltpx = MLTPX_ADD;
   g_model.mixData[1].srcRaw = MIXSRC_MAX;
   g_model.mixData[1].flightModes = 0b11101;
-  g_model.mixData[1].weight = 50;
+  g_model.mixData[1].weight = makeSourceNumVal(50);
   g_model.mixData[2].destCh = 1;
   g_model.mixData[2].srcRaw = MIXSRC_MAX;
-  g_model.mixData[2].weight = 100;
+  g_model.mixData[2].weight = makeSourceNumVal(100);
   simuSetSwitch(3, -1);
   evalMixes(1);
   EXPECT_EQ(chans[0], CHANNEL_MAX/2);
@@ -691,7 +691,7 @@ TEST_F(MixerTest, SlowOnPhase)
   g_model.mixData[0].destCh = 0;
   g_model.mixData[0].mltpx = MLTPX_ADD;
   g_model.mixData[0].srcRaw = MIXSRC_MAX;
-  g_model.mixData[0].weight = 100;
+  g_model.mixData[0].weight = makeSourceNumVal(100);
   g_model.mixData[0].flightModes = 0x2 + 0x4 + 0x8 + 0x10 /*only enabled in phase 0*/;
   g_model.mixData[0].speedUp = 50;
   g_model.mixData[0].speedDown = 50;
@@ -714,7 +714,7 @@ TEST_F(MixerTest, SlowOnSwitchSource)
   g_eeGeneral.switchConfig = 0x03;
   g_model.mixData[0].srcRaw = MIXSRC_FIRST_SWITCH;
   int switchIndex = 0;
-  g_model.mixData[0].weight = 100;
+  g_model.mixData[0].weight = makeSourceNumVal(100);
   g_model.mixData[0].speedUp = 50;
   g_model.mixData[0].speedDown = 50;
 
@@ -734,7 +734,7 @@ TEST_F(MixerTest, SlowOnPhasePrec10ms)
   g_model.mixData[0].destCh = 0;
   g_model.mixData[0].mltpx = MLTPX_ADD;
   g_model.mixData[0].srcRaw = MIXSRC_MAX;
-  g_model.mixData[0].weight = 100;
+  g_model.mixData[0].weight = makeSourceNumVal(100);
   g_model.mixData[0].flightModes = 0x2 + 0x4 + 0x8 + 0x10 /*only enabled in phase 0*/;
   g_model.mixData[0].speedUp = 50;
   g_model.mixData[0].speedDown = 50;
@@ -758,7 +758,7 @@ TEST_F(MixerTest, SlowOnSwitchSourcePrec10ms)
   g_eeGeneral.switchConfig = 0x03;
   g_model.mixData[0].srcRaw = MIXSRC_FIRST_SWITCH;
   int switchIndex = 0;
-  g_model.mixData[0].weight = 100;
+  g_model.mixData[0].weight = makeSourceNumVal(100);
   g_model.mixData[0].speedUp = 50;
   g_model.mixData[0].speedDown = 50;
   g_model.mixData[0].speedPrec = 1;
@@ -778,7 +778,7 @@ TEST_F(MixerTest, SlowDisabledOnStartup)
   g_model.mixData[0].destCh = 0;
   g_model.mixData[0].mltpx = MLTPX_ADD;
   g_model.mixData[0].srcRaw = MIXSRC_MAX;
-  g_model.mixData[0].weight = 100;
+  g_model.mixData[0].weight = makeSourceNumVal(100);
   g_model.mixData[0].speedUp = 50;
   g_model.mixData[0].speedDown = 50;
 
@@ -791,7 +791,7 @@ TEST_F(MixerTest, DelayOnSwitch)
   g_model.mixData[0].destCh = 0;
   g_model.mixData[0].mltpx = MLTPX_ADD;
   g_model.mixData[0].srcRaw = MIXSRC_MAX;
-  g_model.mixData[0].weight = 100;
+  g_model.mixData[0].weight = makeSourceNumVal(100);
   g_model.mixData[0].swtch = SWSRC_FIRST_SWITCH + 2;
   g_model.mixData[0].delayUp = 50;
   g_model.mixData[0].delayDown = 50;
@@ -822,7 +822,7 @@ TEST_F(MixerTest, DelayOnSwitch2)
   g_model.mixData[0].destCh = 0;
   g_model.mixData[0].mltpx = MLTPX_ADD;
   g_model.mixData[0].srcRaw = MIXSRC_FIRST_SWITCH;
-  g_model.mixData[0].weight = 100;
+  g_model.mixData[0].weight = makeSourceNumVal(100);
   // g_model.mixData[0].swtch = SWSRC_ON;
   g_model.mixData[0].delayUp = 50;
   g_model.mixData[0].delayDown = 50;
@@ -851,11 +851,11 @@ TEST_F(MixerTest, SlowOnMultiply)
   g_model.mixData[0].destCh = 0;
   g_model.mixData[0].mltpx = MLTPX_ADD;
   g_model.mixData[0].srcRaw = MIXSRC_MAX;
-  g_model.mixData[0].weight = 100;
+  g_model.mixData[0].weight = makeSourceNumVal(100);
   g_model.mixData[1].destCh = 0;
   g_model.mixData[1].mltpx = MLTPX_MUL;
   g_model.mixData[1].srcRaw = MIXSRC_MAX;
-  g_model.mixData[1].weight = 100;
+  g_model.mixData[1].weight = makeSourceNumVal(100);
   g_model.mixData[1].swtch = SWSRC_FIRST_SWITCH;
   g_model.mixData[1].speedUp = 50;
   g_model.mixData[1].speedDown = 50;
@@ -877,11 +877,11 @@ TEST_F(MixerTest, SlowOnMultiplyPrec10ms)
   g_model.mixData[0].destCh = 0;
   g_model.mixData[0].mltpx = MLTPX_ADD;
   g_model.mixData[0].srcRaw = MIXSRC_MAX;
-  g_model.mixData[0].weight = 100;
+  g_model.mixData[0].weight = makeSourceNumVal(100);
   g_model.mixData[1].destCh = 0;
   g_model.mixData[1].mltpx = MLTPX_MUL;
   g_model.mixData[1].srcRaw = MIXSRC_MAX;
-  g_model.mixData[1].weight = 100;
+  g_model.mixData[1].weight = makeSourceNumVal(100);
   g_model.mixData[1].swtch = SWSRC_FIRST_SWITCH;
   g_model.mixData[1].speedUp = 50;
   g_model.mixData[1].speedDown = 50;
@@ -938,15 +938,15 @@ TEST(Heli, BasicTest)
   g_model.mixData[0].destCh = 0;
   g_model.mixData[0].mltpx = MLTPX_ADD;
   g_model.mixData[0].srcRaw = MIXSRC_CYC1;
-  g_model.mixData[0].weight = 100;
+  g_model.mixData[0].weight = makeSourceNumVal(100);
   g_model.mixData[1].destCh = 1;
   g_model.mixData[1].mltpx = MLTPX_ADD;
   g_model.mixData[1].srcRaw = MIXSRC_CYC2;
-  g_model.mixData[1].weight = 100;
+  g_model.mixData[1].weight = makeSourceNumVal(100);
   g_model.mixData[2].destCh = 2;
   g_model.mixData[2].mltpx = MLTPX_ADD;
   g_model.mixData[2].srcRaw = MIXSRC_CYC3;
-  g_model.mixData[2].weight = 100;
+  g_model.mixData[2].weight = makeSourceNumVal(100);
   anaSetFiltered(THR_STICK, 0);
   anaSetFiltered(ELE_STICK, 1024);
   anaSetFiltered(AIL_STICK, 0);
@@ -974,15 +974,15 @@ TEST(Heli, Mode2Test)
   g_model.mixData[0].destCh = 0;
   g_model.mixData[0].mltpx = MLTPX_ADD;
   g_model.mixData[0].srcRaw = MIXSRC_CYC1;
-  g_model.mixData[0].weight = 100;
+  g_model.mixData[0].weight = makeSourceNumVal(100);
   g_model.mixData[1].destCh = 1;
   g_model.mixData[1].mltpx = MLTPX_ADD;
   g_model.mixData[1].srcRaw = MIXSRC_CYC2;
-  g_model.mixData[1].weight = 100;
+  g_model.mixData[1].weight = makeSourceNumVal(100);
   g_model.mixData[2].destCh = 2;
   g_model.mixData[2].mltpx = MLTPX_ADD;
   g_model.mixData[2].srcRaw = MIXSRC_CYC3;
-  g_model.mixData[2].weight = 100;
+  g_model.mixData[2].weight = makeSourceNumVal(100);
   anaSetFiltered(THR_STICK, 0);
   anaSetFiltered(ELE_STICK, 1024);
   anaSetFiltered(AIL_STICK, 0);
@@ -1003,7 +1003,7 @@ TEST(Trainer, UnpluggedTest)
   g_model.mixData[0].destCh = 0;
   g_model.mixData[0].mltpx = MLTPX_ADD;
   g_model.mixData[0].srcRaw = MIXSRC_FIRST_TRAINER;
-  g_model.mixData[0].weight = 100;
+  g_model.mixData[0].weight = makeSourceNumVal(100);
   g_model.mixData[0].delayUp = 50;
   g_model.mixData[0].delayDown = 50;
   trainerSetTimer(0);
@@ -1026,12 +1026,12 @@ TEST_F(MixerTest, flightModeTransition)
   g_model.mixData[0].mltpx = MLTPX_REPL;
   g_model.mixData[0].srcRaw = MIXSRC_MAX;
   g_model.mixData[0].flightModes = 0b11110;
-  g_model.mixData[0].weight = 100;
+  g_model.mixData[0].weight = makeSourceNumVal(100);
   g_model.mixData[1].destCh = 0;
   g_model.mixData[1].mltpx = MLTPX_REPL;
   g_model.mixData[1].srcRaw = MIXSRC_MAX;
   g_model.mixData[1].flightModes = 0b11101;
-  g_model.mixData[1].weight = -10;
+  g_model.mixData[1].weight = makeSourceNumVal(-10);
   evalMixes(1);
   simuSetSwitch(0, 1);
   CHECK_FLIGHT_MODE_TRANSITION(0, 1000, 1024, -102);
@@ -1050,7 +1050,7 @@ TEST_F(MixerTest, flightModeOverflow)
   g_model.mixData[0].mltpx = MLTPX_REPL;
   g_model.mixData[0].srcRaw = MIXSRC_MAX;
   g_model.mixData[0].flightModes = 0;
-  g_model.mixData[0].weight = 250;
+  g_model.mixData[0].weight = makeSourceNumVal(250);
   evalMixes(1);
   simuSetSwitch(0, 1);
   CHECK_FLIGHT_MODE_TRANSITION(0, 1000, 1024, 1024);

--- a/radio/src/thirdparty/libopenui/src/choice.cpp
+++ b/radio/src/thirdparty/libopenui/src/choice.cpp
@@ -153,7 +153,8 @@ void Choice::setValue(int val)
 
 void Choice::onClicked()
 {
-  openMenu();
+  if (!deleted())
+    openMenu();
 }
 
 void Choice::fillMenu(Menu* menu, const FilterFct& filter)


### PR DESCRIPTION
Fixes #4452 

Time to continue with this change, now that source invert has been implemented.

Allows any source to be used in inputs and mixes for fields like weight, offset, expo, etc (not just GVars).

TODO

Radio:

- [x] Data structures
- [x] Save and load to YAML files
- [x] Mix calculations
- [x] Color UI
- [x] B&W UI
- [x] Fix tests

Companion:

- [x] Data structures
- [x] Save and load YAML files
- [x] UI for settings fields
- [x] Binary file conversion
- [x] Testing