### PR TITLE
fix: supported internal module for monochrome radios w/ ISRM

### DIFF
--- a/radio/src/targets/taranis/CMakeLists.txt
+++ b/radio/src/targets/taranis/CMakeLists.txt
@@ -490,7 +490,7 @@ endif()
 
 if(INTERNAL_MODULE_SERIAL)
 
-  if("${PCBREV}" STREQUAL 2019 OR "${PCBREV}" STREQUAL ACCESS)
+  if(DEFAULT_INTERNAL_MODULE STREQUAL ISRM_PXX2)
     # defines existing internal modules
     set(INTERNAL_MODULES PXX2 CACHE STRING "Internal modules")
   else()


### PR DESCRIPTION
Fixes #5234
Fixes #5153

pfeerick: I am going to tentatively say this resolves #1942 also as this gem has been present since 2.6, so could have been responsible since it was a 2.7 issue. 

Summary of changes:
- use `DEFAULT_INTERNAL_MODULE == ISRM_PXX2` as a better heuristic to determine the supported modules.

Note: it seems X9lite and X9liteS are impacted as well.