### PR TITLE
fix(bw): incorrect X-Lite navigation selection

### DIFF
--- a/radio/src/gui/navigation/navigation.cpp
+++ b/radio/src/gui/navigation/navigation.cpp
@@ -26,7 +26,7 @@
 #elif defined(NAVIGATION_9X)
   #include "navigation_9x.cpp"
 #elif defined(NAVIGATION_XLITE)
-  #include "navigation_xlite"
+  #include "navigation_xlite.cpp"
 #elif defined(NAVIGATION_X7)
   #include "navigation_x7.cpp"
 #else

--- a/radio/src/opentx.h
+++ b/radio/src/opentx.h
@@ -106,10 +106,10 @@ enum RotaryEncoderMode {
 // Define navigation type based on available keys
 #if LCD_W == 212
   #define NAVIGATION_X9D
-#elif defined(KEYS_GPIO_REG_LEFT)
-  #define NAVIGATION_9X
 #elif defined(KEYS_GPIO_REG_SHIFT)
   #define NAVIGATION_XLITE
+#elif defined(KEYS_GPIO_REG_LEFT)
+  #define NAVIGATION_9X
 #elif defined(KEYS_GPIO_REG_PAGEUP) && defined(KEYS_GPIO_REG_TELE)
   #define NAVIGATION_X7
   #define NAVIGATION_X7_TX12


### PR DESCRIPTION
Current main selects NAVIGATION_9X for X-Lite instead of NAVIGATION_XLITE.

Broken in PR #4893 
