### PR TITLE
fix: Commando8 does not need the startup animation

### DIFF
--- a/radio/src/opentx.cpp
+++ b/radio/src/opentx.cpp
@@ -1354,7 +1354,7 @@ void edgeTxInit()
 
   switchInit();
 
-#if defined(STARTUP_ANIMATION)
+#if defined(GUI) && !defined(COLORLCD)
   lcdRefreshWait();
   lcdClear();
   lcdRefresh();

--- a/radio/src/targets/taranis/board.h
+++ b/radio/src/targets/taranis/board.h
@@ -187,16 +187,16 @@ extern "C" {
 
 // Power driver
 #define SOFT_PWR_CTRL
+#if defined(PWR_BUTTON_PRESS) && !defined(RADIO_COMMANDO8)
+#  define STARTUP_ANIMATION
+#endif
+
 void pwrInit();
 uint32_t pwrCheck();
 void pwrOn();
 void pwrOff();
 bool pwrPressed();
 bool pwrOffPressed();
-#if defined(PWR_BUTTON_PRESS)
-#define STARTUP_ANIMATION
-uint32_t pwrPressedDuration();
-#endif
 void pwrResetHandler();
 #define pwrForcePressed()   false
 


### PR DESCRIPTION
Fixes #4798 since startup animation pwrOff() was responsible for shutting down radio
Fixes #4995 since screen was not being cleared on power up for radios with power switches