### PR TITLE
fix(color): built in widgets do not resize properly when view decorations turned on or off.

### DIFF
--- a/radio/src/gui/colorlcd/widget.h
+++ b/radio/src/gui/colorlcd/widget.h
@@ -83,7 +83,10 @@ class Widget : public ButtonBase
   virtual void background() {}
 
   // Update widget 'zone' data (for Lua widgets)
-  virtual void updateZoneRect(rect_t rect, bool updateUI = true) {}
+  virtual void updateZoneRect(rect_t rect, bool updateUI = true)
+  {
+    if (updateUI) update();
+  }
 
   void enableFocus(bool enable);
 

--- a/radio/src/gui/colorlcd/widgets/widgets_container_impl.h
+++ b/radio/src/gui/colorlcd/widgets/widgets_container_impl.h
@@ -132,6 +132,7 @@ class WidgetsContainerImpl : public WidgetsContainer
 
   void updateZones() override
   {
+    adjustLayout();
     for (int i = 0; i < N; i++) {
       if (widgets[i]) {
         auto zone = getZone(i);


### PR DESCRIPTION
In current main, the built in widgets are not being updated when the view decorations (trim, sliders, etc) are turned on or off.
