### PR TITLE
fix(color): restore previous 'Fullscreen' functionality and add new 'App mode' layout

### DIFF
--- a/radio/src/gui/colorlcd/layouts/layout1x1AppMode.cpp
+++ b/radio/src/gui/colorlcd/layouts/layout1x1AppMode.cpp
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "layout.h"
+#include "layout_factory_impl.h"
+
+const ZoneOption OPTIONS_LAYOUT_APPMODE[] = {LAYOUT_OPTIONS_END};
+
+class LayoutAppMode : public Layout
+{
+ public:
+  LayoutAppMode(Window* parent, const LayoutFactory* factory,
+            Layout::PersistentData* persistentData, uint8_t zoneCount,
+            uint8_t* zoneMap) :
+      Layout(parent, factory, persistentData, zoneCount, zoneMap)
+  {
+  }
+
+  bool hasTopbar() const override { return false; }
+  bool hasFlightMode() const override { return false; }
+  bool hasSliders() const override { return false; }
+  bool hasTrims() const override { return false; }
+  bool isMirrored() const override { return false; }
+  bool isAppMode() const override { return true; }
+
+ protected:
+};
+
+static const uint8_t zmap[] = {
+    LAYOUT_MAP_0, LAYOUT_MAP_0, LAYOUT_MAP_FULL, LAYOUT_MAP_FULL,
+};
+
+BaseLayoutFactory<LayoutAppMode> layoutAppMode("Layout1x1AM", "App mode", OPTIONS_LAYOUT_APPMODE,
+                                       1, (uint8_t*)zmap);

--- a/radio/src/gui/colorlcd/layouts/layout_factory_impl.h
+++ b/radio/src/gui/colorlcd/layouts/layout_factory_impl.h
@@ -78,25 +78,27 @@ class Layout: public LayoutBase
       return factory;
     }
   
-    bool hasTopbar() const {
+    virtual bool hasTopbar() const {
       return ((uint8_t*)(&getOptionValue(LAYOUT_OPTION_TOPBAR)->boolValue))[0];
     }
 
-    bool hasFlightMode() const {
+    virtual bool hasFlightMode() const {
       return ((uint8_t*)(&getOptionValue(LAYOUT_OPTION_FM)->boolValue))[0];
     }
 
-    bool hasSliders() const {
+    virtual bool hasSliders() const {
       return ((uint8_t*)(&getOptionValue(LAYOUT_OPTION_SLIDERS)->boolValue))[0];
     }
 
-    bool hasTrims() const {
+    virtual bool hasTrims() const {
       return ((uint8_t*)(&getOptionValue(LAYOUT_OPTION_TRIMS)->boolValue))[0];
     }
 
-    bool isMirrored() const {
+    virtual bool isMirrored() const {
       return ((uint8_t*)(&getOptionValue(LAYOUT_OPTION_MIRRORED)->boolValue))[0];
     }
+
+    virtual bool isAppMode() const { return false; }
 
     // Set decoration visibility
     void setTrimsVisible(bool visible);
@@ -108,8 +110,6 @@ class Layout: public LayoutBase
     void show(bool visible = true) override;
 
     bool isLayout() override { return true; }
-
-    bool isAppMode() { return decorationSettings == DECORATION_NONE && zoneCount == 1; }
   
     static LAYOUT_VAL(MAIN_ZONE_BORDER, 10, 10)
 

--- a/radio/src/gui/colorlcd/view_main.cpp
+++ b/radio/src/gui/colorlcd/view_main.cpp
@@ -353,10 +353,11 @@ bool ViewMain::onLongPress()
 
 void ViewMain::show(bool visible)
 {
+  if (deleted()) return;
   isVisible = visible;
   int view = getCurrentMainView();
   setTopbarVisible(visible && ::hasTopbar(view));
-  if (visible)
+  if (visible && (::hasTopbar(view) || isAppMode()))
     topbar->showEdgeTxButton();
   else
     topbar->hideEdgeTxButton();

--- a/radio/src/storage/storage_common.cpp
+++ b/radio/src/storage/storage_common.cpp
@@ -25,6 +25,10 @@
 #include "mixes.h"
 #include "switches.h"
 
+#if defined(COLORLCD)
+#include "view_main.h"
+#endif
+
 #if defined(USBJ_EX)
 #include "usb_joystick.h"
 #endif
@@ -281,6 +285,7 @@ if(g_model.rssiSource) {
 
 #if defined(COLORLCD)
   LayoutFactory::loadCustomScreens();
+  ViewMain::instance()->show(true);
 #else
   LOAD_MODEL_BITMAP();
 #endif


### PR DESCRIPTION
Fixes #5246 

PR #4655 adds the requested 'App mode' functionality; but breaks existing 'Full screen' functionality for some widgets.

This PR restores the old functionality when the layout is set to 'Full screen'.
A new layout called 'App mode' implements the new app mode functionality.
The 'App mode' layout has a single widget and disables topbar, sliders, trims and flight modes.

![screenshot_tx16s_24-07-05_16-50-38](https://github.com/EdgeTX/edgetx/assets/9474356/749908a7-1478-4a2e-9eb5-9158f6742f14)

![screenshot_tx16s_24-07-05_16-34-39](https://github.com/EdgeTX/edgetx/assets/9474356/621b6e39-3b94-4809-8292-c87dee354155)
