### PR TITLE
chore: remove PCB specific defines in preference to COLORLCD

### DIFF
--- a/radio/src/dataconstants.h
+++ b/radio/src/dataconstants.h
@@ -38,7 +38,7 @@
 #define LABELS_LENGTH 100 // Maximum length of the label string
 #define LABEL_LENGTH 16
 
-#if defined(PCBHORUS) || defined(PCBNV14) || defined(PCBPL18) || defined(STM32H747xx)
+#if defined(COLORLCD) || defined(STM32H747xx)
   #define MAX_MODELS                   60
   #define MAX_OUTPUT_CHANNELS          32 // number of real output channels CH1-CH32
   #define MAX_FLIGHT_MODES             9

--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -68,7 +68,7 @@ static inline void check_struct()
   CHKSIZE(FrSkyLineData, 6);
   CHKTYPE(TelemetryScreenData, 24);
   CHKSIZE(ModelHeader, 24);
-#elif defined(PCBHORUS) || defined(PCBNV14) || defined(PCBPL18)
+#elif defined(COLORLCD)
   CHKSIZE(LimitData, 13);
   CHKSIZE(TimerData, 17);
   CHKSIZE(ModelHeader, 131);


### PR DESCRIPTION
Spotted while reviewing #5228 where someone
had done half of what I was thinking of doing a
few days ago :rofl: 

After this PR, there are no more of these 
`#if defined(PCBHORUS) || defined(PCBNV14) || defined(PCBPL18)` 
conditionals in the entire code base :relieved: 
