### PR TITLE
chore: remove discrepancy in x10/x7 naming

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -107,7 +107,7 @@ jobs:
           - f16
           - x10;x10express
           - x12s
-          - x7;x7-access
+          - x7;x7access
           - x9d;x9dp;x9dp2019
           - x9e;x9e-hall
           - x9lite;x9lites

--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -105,7 +105,7 @@ jobs:
           - tx12;tx12mk2;boxer
           - tx16s
           - f16
-          - x10;x10-access
+          - x10;x10express
           - x12s
           - x7;x7-access
           - x9d;x9dp;x9dp2019

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,7 +28,7 @@ jobs:
           - f16
           - x10;x10express
           - x12s
-          - x7;x7-access
+          - x7;x7access
           - x9d;x9dp;x9dp2019
           - x9e;x9e-hall
           - x9lite;x9lites

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -26,7 +26,7 @@ jobs:
           - tx12;tx12mk2;boxer
           - tx16s
           - f16
-          - x10;x10-access
+          - x10;x10express
           - x12s
           - x7;x7-access
           - x9d;x9dp;x9dp2019

--- a/companion/src/firmwares/opentx/opentxinterface.cpp
+++ b/companion/src/firmwares/opentx/opentxinterface.cpp
@@ -1326,7 +1326,7 @@ void registerOpenTxFirmwares()
   addOpenTxRfOptions(firmware, EU + FLEX);
 
   /* FrSky Taranis X7 Access board */
-  firmware = new OpenTxFirmware(FIRMWAREID("x7access"), Firmware::tr("FrSky Taranis X7 / X7S Access"), BOARD_TARANIS_X7_ACCESS, "x7-access");
+  firmware = new OpenTxFirmware(FIRMWAREID("x7access"), Firmware::tr("FrSky Taranis X7 / X7S Access"), BOARD_TARANIS_X7_ACCESS, "x7access");
   addOpenTxTaranisOptions(firmware);
   registerOpenTxFirmware(firmware);
   addOpenTxRfOptions(firmware, FLEX);

--- a/companion/src/firmwares/opentx/opentxinterface.cpp
+++ b/companion/src/firmwares/opentx/opentxinterface.cpp
@@ -1306,7 +1306,7 @@ void registerOpenTxFirmwares()
   addOpenTxRfOptions(firmware, EU + FLEX);
 
   /* FrSky Horus X10 Express board */
-  firmware = new OpenTxFirmware(FIRMWAREID("x10express"), Firmware::tr("FrSky Horus X10 Express / X10S Express"), BOARD_X10_EXPRESS, "x10-access");
+  firmware = new OpenTxFirmware(FIRMWAREID("x10express"), Firmware::tr("FrSky Horus X10 Express / X10S Express"), BOARD_X10_EXPRESS, "x10express");
   addOpenTxFrskyOptions(firmware);
   registerOpenTxFirmware(firmware);
   addOpenTxRfOptions(firmware, FLEX);

--- a/fw.json
+++ b/fw.json
@@ -7,7 +7,7 @@
         ["Flysky PL18", "pl18-"],
         ["Flysky PL18EV", "pl18ev-"],
         ["FrSky Horus X10", "x10-"],
-        ["FrSky Horus X10 Access", "x10-access-"],
+        ["FrSky Horus X10 Access", "x10express-"],
         ["FrSky Horus X12s", "x12s-"],
         ["FrSky QX7", "x7-"],
         ["FrSky QX7 Access", "x7-access-"],

--- a/fw.json
+++ b/fw.json
@@ -10,7 +10,7 @@
         ["FrSky Horus X10 Express", "x10express-"],
         ["FrSky Horus X12s", "x12s-"],
         ["FrSky QX7", "x7-"],
-        ["FrSky QX7 Access", "x7-access-"],
+        ["FrSky QX7 Access", "x7access-"],
         ["FrSky X9D", "x9d-"],
         ["FrSky X9D Plus", "x9dp-"],
         ["FrSky X9D Plus 2019", "x9dp2019-"],

--- a/fw.json
+++ b/fw.json
@@ -7,7 +7,7 @@
         ["Flysky PL18", "pl18-"],
         ["Flysky PL18EV", "pl18ev-"],
         ["FrSky Horus X10", "x10-"],
-        ["FrSky Horus X10 Access", "x10express-"],
+        ["FrSky Horus X10 Express", "x10express-"],
         ["FrSky Horus X12s", "x12s-"],
         ["FrSky QX7", "x7-"],
         ["FrSky QX7 Access", "x7-access-"],

--- a/tools/build-companion.sh
+++ b/tools/build-companion.sh
@@ -64,7 +64,7 @@ mkdir build
 cd build
 
 declare -a simulator_plugins=(x9lite x9lites
-                              x7 x7-access
+                              x7 x7access
                               t8 t12 tx12 tx12mk2
                               zorro commando8 boxer pocket
                               tlite tpro tprov2 lr3pro t14
@@ -89,7 +89,7 @@ do
         x7)
             BUILD_OPTIONS+="-DPCB=X7"
             ;;
-        x7-access)
+        x7access)
             BUILD_OPTIONS+="-DPCB=X7 -DPCBREV=ACCESS -DPXX1=YES"
             ;;
         t12)

--- a/tools/build-companion.sh
+++ b/tools/build-companion.sh
@@ -71,7 +71,7 @@ declare -a simulator_plugins=(x9lite x9lites
                               x9d x9dp x9dp2019 x9e
                               xlite xlites
                               nv14 el18 pl18 pl18ev
-                              x10 x10-access x12s
+                              x10 x10express x12s
                               t15 t16 t18 t20 t20v2 tx16s f16)
 
 for plugin in "${simulator_plugins[@]}"
@@ -158,7 +158,7 @@ do
         x10)
             BUILD_OPTIONS+="-DPCB=X10"
             ;;
-        x10-access)
+        x10express)
             BUILD_OPTIONS+="-DPCB=X10 -DPCBREV=EXPRESS -DPXX1=YES"
             ;;
         x12s)

--- a/tools/build-gh.sh
+++ b/tools/build-gh.sh
@@ -101,7 +101,7 @@ do
         x7)
             BUILD_OPTIONS+="-DPCB=X7"
             ;;
-        x7-access)
+        x7access)
             BUILD_OPTIONS+="-DPCB=X7 -DPCBREV=ACCESS -DPXX1=YES"
             ;;
         t12)

--- a/tools/build-gh.sh
+++ b/tools/build-gh.sh
@@ -176,7 +176,7 @@ do
         x10)
             BUILD_OPTIONS+="-DPCB=X10"
             ;;
-        x10-access)
+        x10express)
             BUILD_OPTIONS+="-DPCB=X10 -DPCBREV=EXPRESS -DPXX1=YES"
             ;;
         x12s)

--- a/tools/commit-tests.sh
+++ b/tools/commit-tests.sh
@@ -136,8 +136,8 @@ do
         x10)
             BUILD_OPTIONS+="-DPCB=X10"
             ;;
-        x10-access)
-            BUILD_OPTIONS+="-DPCB=X10 -DPCBREV=ACCESS -DPXX1=YES"
+        x10express)
+            BUILD_OPTIONS+="-DPCB=X10 -DPCBREV=EXPRESS -DPXX1=YES"
             ;;
         x12s)
             BUILD_OPTIONS+="-DPCB=X12S"

--- a/tools/commit-tests.sh
+++ b/tools/commit-tests.sh
@@ -79,7 +79,7 @@ do
         x7)
             BUILD_OPTIONS+="-DPCB=X7"
             ;;
-        x7-access)
+        x7access)
             BUILD_OPTIONS+="-DPCB=X7 -DPCBREV=ACCESS -DPXX1=YES"
             ;;
         t12)

--- a/tools/generate-hw-defs.sh
+++ b/tools/generate-hw-defs.sh
@@ -6,7 +6,7 @@ set -e
 
 : "${SRCDIR:=$(dirname "$(pwd)/$0")/..}"
 
-: ${FLAVOR:="nv14;t12;t15;t16;t18;t8;zorro;pocket;commando8;tlite;tpro;tprov2;t20;t20v2;t14;lr3pro;mt12;tx12;tx12mk2;boxer;tx16s;x10;x10express;x12s;x7;x7-access;x9d;x9dp;x9dp2019;x9e;x9lite;x9lites;xlite;xlites"}
+: ${FLAVOR:="nv14;t12;t15;t16;t18;t8;zorro;pocket;commando8;tlite;tpro;tprov2;t20;t20v2;t14;lr3pro;mt12;tx12;tx12mk2;boxer;tx16s;x10;x10express;x12s;x7;x7access;x9d;x9dp;x9dp2019;x9e;x9lite;x9lites;xlite;xlites"}
 : ${COMMON_OPTIONS:="-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_RULE_MESSAGES=OFF -Wno-dev -DCMAKE_MESSAGE_LOG_LEVEL=WARNING"}
 
 # wipe build directory clean
@@ -33,7 +33,7 @@ do
         x7)
             BUILD_OPTIONS+="-DPCB=X7"
             ;;
-        x7-access)
+        x7access)
             BUILD_OPTIONS+="-DPCB=X7 -DPCBREV=ACCESS -DPXX1=YES"
             ;;
         t12)

--- a/tools/generate-hw-defs.sh
+++ b/tools/generate-hw-defs.sh
@@ -6,7 +6,7 @@ set -e
 
 : "${SRCDIR:=$(dirname "$(pwd)/$0")/..}"
 
-: ${FLAVOR:="nv14;t12;t15;t16;t18;t8;zorro;pocket;commando8;tlite;tpro;tprov2;t20;t20v2;t14;lr3pro;mt12;tx12;tx12mk2;boxer;tx16s;x10;x10-access;x12s;x7;x7-access;x9d;x9dp;x9dp2019;x9e;x9lite;x9lites;xlite;xlites"}
+: ${FLAVOR:="nv14;t12;t15;t16;t18;t8;zorro;pocket;commando8;tlite;tpro;tprov2;t20;t20v2;t14;lr3pro;mt12;tx12;tx12mk2;boxer;tx16s;x10;x10express;x12s;x7;x7-access;x9d;x9dp;x9dp2019;x9e;x9lite;x9lites;xlite;xlites"}
 : ${COMMON_OPTIONS:="-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_RULE_MESSAGES=OFF -Wno-dev -DCMAKE_MESSAGE_LOG_LEVEL=WARNING"}
 
 # wipe build directory clean
@@ -102,7 +102,7 @@ do
         x10)
             BUILD_OPTIONS+="-DPCB=X10"
             ;;
-        x10-access)
+        x10express)
             BUILD_OPTIONS+="-DPCB=X10 -DPCBREV=EXPRESS -DPXX1=YES"
             ;;
         x12s)

--- a/tools/generate-yaml.sh
+++ b/tools/generate-yaml.sh
@@ -35,7 +35,7 @@ do
         x7)
             BUILD_OPTIONS+="-DPCB=X7"
             ;;
-        x7-access)
+        x7access)
             BUILD_OPTIONS+="-DPCB=X7 -DPCBREV=ACCESS -DPXX1=YES"
             ;;
         t12)

--- a/tools/generate-yaml.sh
+++ b/tools/generate-yaml.sh
@@ -101,7 +101,7 @@ do
         x10)
             BUILD_OPTIONS+="-DPCB=X10"
             ;;
-        x10-access)
+        x10express)
             BUILD_OPTIONS+="-DPCB=X10 -DPCBREV=EXPRESS -DPXX1=YES"
             ;;
         x12s)

--- a/tools/msys2_fetch_and_build_all.sh
+++ b/tools/msys2_fetch_and_build_all.sh
@@ -9,7 +9,7 @@
 
 # -----------------------------------------------------------------------------
 export BRANCH_NAME="main"  # main|2.9|...
-export RADIO_TYPE="tx16s"  # tx16s|x10|x10express|x12s|x9d|x9dp|x9lite|x9lites|x7|x7-access|t12|tx12|tx12mk2|mt12|boxer|t8|zorro|pocket|tlite|tpro|t20|t20v2|t14|lr3pro|xlite|xlites|x9dp2019|x9e|x9e-hall|t15|t16|t18|nv14|commando8
+export RADIO_TYPE="tx16s"  # tx16s|x10|x10express|x12s|x9d|x9dp|x9lite|x9lites|x7|x7access|t12|tx12|tx12mk2|mt12|boxer|t8|zorro|pocket|tlite|tpro|t20|t20v2|t14|lr3pro|xlite|xlites|x9dp2019|x9e|x9e-hall|t15|t16|t18|nv14|commando8
 
 export BUILD_OPTIONS="-DDEFAULT_MODE=2 -DGVARS=YES"
 
@@ -24,7 +24,7 @@ case $RADIO_TYPE in
     x7)
         BUILD_OPTIONS+=" -DPCB=X7"
         ;;
-    x7-access)
+    x7access)
         BUILD_OPTIONS+=" -DPCB=X7 -DPCBREV=ACCESS -DPXX1=YES"
         ;;
     t12)

--- a/tools/msys2_fetch_and_build_all.sh
+++ b/tools/msys2_fetch_and_build_all.sh
@@ -9,7 +9,7 @@
 
 # -----------------------------------------------------------------------------
 export BRANCH_NAME="main"  # main|2.9|...
-export RADIO_TYPE="tx16s"  # tx16s|x10|x10-access|x12s|x9d|x9dp|x9lite|x9lites|x7|x7-access|t12|tx12|tx12mk2|mt12|boxer|t8|zorro|pocket|tlite|tpro|t20|t20v2|t14|lr3pro|xlite|xlites|x9dp2019|x9e|x9e-hall|t15|t16|t18|nv14|commando8
+export RADIO_TYPE="tx16s"  # tx16s|x10|x10express|x12s|x9d|x9dp|x9lite|x9lites|x7|x7-access|t12|tx12|tx12mk2|mt12|boxer|t8|zorro|pocket|tlite|tpro|t20|t20v2|t14|lr3pro|xlite|xlites|x9dp2019|x9e|x9e-hall|t15|t16|t18|nv14|commando8
 
 export BUILD_OPTIONS="-DDEFAULT_MODE=2 -DGVARS=YES"
 
@@ -93,7 +93,7 @@ case $RADIO_TYPE in
     x10)
         BUILD_OPTIONS+=" -DPCB=X10"
         ;;
-    x10-access)
+    x10express)
         BUILD_OPTIONS+=" -DPCB=X10 -DPCBREV=EXPRESS -DPXX1=YES"
         ;;
     x12s)


### PR DESCRIPTION
Replace x10-access by x10express, which is flavor naming.

This also fixes commit-tests not run for x10 express because wrong PCBREV was used

This matches FrSky official naming
![image](https://github.com/EdgeTX/edgetx/assets/5167938/da439415-8373-4248-ae08-32fc314d5cc0)


For the same reason x7-access is renamed to x7access (the later already used for FLAVOUR)
