### PR TITLE
fix(bw): fixes and improvements for model setup page

### DIFF
--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -603,6 +603,7 @@ bool checkCFSSwitchAvailable(int sw)
 void menuModelSetup(event_t event)
 {
   int8_t old_editMode = s_editMode;
+  bool CURSOR_ON_CELL = (menuHorizontalPosition >= 0);
 
 #if defined(PCBTARANIS)
   int8_t old_posHorz = menuHorizontalPosition;
@@ -627,10 +628,10 @@ void menuModelSetup(event_t event)
 
     0,   // Preflight section
       PREFLIGHT_ROW(0), // Checklist
-      PREFLIGHT_ROW(0), // Checklist interactive
+      PREFLIGHT_ROW(g_model.displayChecklist ? 0 : HIDDEN_ROW), // Checklist interactive
       PREFLIGHT_ROW(0), // Throttle warning
-      PREFLIGHT_ROW(0), // Custom position for throttle warning enable
-      PREFLIGHT_ROW(0), // Custom position for throttle warning value
+      PREFLIGHT_ROW(!g_model.disableThrottleWarning ? 0 : HIDDEN_ROW), // Custom position for throttle warning enable
+      PREFLIGHT_ROW(!g_model.disableThrottleWarning && g_model.enableCustomThrottleWarning ? 0 : HIDDEN_ROW), // Custom position for throttle warning value
       WARN_ROWS
 
     uint8_t(NAVIGATION_LINE_BY_LINE | (adcGetInputOffset(ADC_INPUT_FLEX + 1) - 1)), // Center beeps
@@ -1189,17 +1190,23 @@ void menuModelSetup(event_t event)
 
       case ITEM_MODEL_SETUP_BEEP_CENTER: {
         lcdDrawTextAlignedLeft(y, STR_BEEPCTR);
+        uint8_t pot_offset = adcGetInputOffset(ADC_INPUT_FLEX);
         uint8_t input_max = adcGetMaxInputs(ADC_INPUT_MAIN) + adcGetMaxInputs(ADC_INPUT_FLEX);
+        coord_t x = MODEL_SETUP_2ND_COLUMN;
         for (uint8_t i = 0; i < input_max; i++) {
-          coord_t x = MODEL_SETUP_2ND_COLUMN + i*FW;
+          if ( i >= pot_offset && (IS_POT_MULTIPOS(i - pot_offset) || !IS_POT_SLIDER_AVAILABLE(i - pot_offset)) ) {
+            if (attr && menuHorizontalPosition == i) repeatLastCursorMove(event);
+            continue;
+          }
           LcdFlags flags = 0;
           if ((menuHorizontalPosition == i) && attr)
             flags = BLINK | INVERS;
           else if (ANALOG_CENTER_BEEP(i) || (attr && CURSOR_ON_LINE()))
             flags = INVERS;
           lcdDrawText(x, y, getAnalogShortLabel(i), flags);
+          x = lcdNextPos;
         }
-        if (attr) {
+        if (attr && CURSOR_ON_CELL) {
           if (event == EVT_KEY_BREAK(KEY_ENTER)) {
             s_editMode = 0;
             g_model.beepANACenter ^= ((BeepANACenter)1<<menuHorizontalPosition);

--- a/radio/src/gui/212x64/model_setup.cpp
+++ b/radio/src/gui/212x64/model_setup.cpp
@@ -531,10 +531,10 @@ void menuModelSetup(event_t event)
 
     0,   // ITEM_MODEL_SETUP_PREFLIGHT_LABEL
       PREFLIGHT_ROW(0), // ITEM_MODEL_SETUP_CHECKLIST_DISPLAY
-      PREFLIGHT_ROW(0), // ITEM_MODEL_SETUP_CHECKLIST_INTERACTIVE
-      PREFLIGHT_ROW(0), // ITEM_MODEL_SETUP_THROTTLE_WARNING
-      PREFLIGHT_ROW(0), // ITEM_MODEL_SETUP_CUSTOM_THROTTLE_WARNING
-      PREFLIGHT_ROW(0), // ITEM_MODEL_SETUP_CUSTOM_THROTTLE_WARNING_VALUE
+      PREFLIGHT_ROW(g_model.displayChecklist ? 0 : HIDDEN_ROW), // Checklist interactive
+      PREFLIGHT_ROW(0), // Throttle warning
+      PREFLIGHT_ROW(!g_model.disableThrottleWarning ? 0 : HIDDEN_ROW), // Custom position for throttle warning enable
+      PREFLIGHT_ROW(!g_model.disableThrottleWarning && g_model.enableCustomThrottleWarning ? 0 : HIDDEN_ROW), // Custom position for throttle warning value
       SW_WARN_ROWS, // ITEM_MODEL_SETUP_SWITCHES_WARNING1
       POT_WARN_ROWS, // ITEM_MODEL_SETUP_POTS_WARNING
 
@@ -1011,7 +1011,7 @@ void menuModelSetup(event_t event)
         uint8_t max_inputs = adcGetMaxInputs(ADC_INPUT_MAIN) + adcGetMaxInputs(ADC_INPUT_FLEX);
         coord_t x = MODEL_SETUP_2ND_COLUMN;
         for (uint8_t i = 0; i < max_inputs; i++) {
-          if ( i >= pot_offset && IS_POT_MULTIPOS(i - pot_offset) ) {
+          if ( i >= pot_offset && (IS_POT_MULTIPOS(i - pot_offset) || !IS_POT_SLIDER_AVAILABLE(i - pot_offset)) ) {
             if (attr && menuHorizontalPosition == i) repeatLastCursorMove(event);
             continue;
           }


### PR DESCRIPTION
- Fix: when the ENTER key is pressed on the center beep warning list to enter edit mode, the first value is also toggled (128x64).
- Fix: 6POS switches are shown in center beep warning list (128x64).
- Fix: disabled pots/sliders are shown in the center beep warning list.
- Feat: hide the interactive checklist toggle if the checklist is disabled.
- Feat: hide the throttle custom position settings if the throttle warning is disabled.
- Feat: hide the throttle custom position value if the custom position check is disabled.

Potential candidate for 2.10.
