### PR TITLE
feat: telemetry buffer for all internal modules

### DIFF
--- a/radio/src/targets/common/arm/CMakeLists.txt
+++ b/radio/src/targets/common/arm/CMakeLists.txt
@@ -50,13 +50,11 @@ endif()
 if(INTERNAL_MODULE_MULTI)
   add_definitions(-DHARDWARE_INTERNAL_MODULE)
   add_definitions(-DINTERNAL_MODULE_MULTI)
-  add_definitions(-DINTERNAL_MODULE_SERIAL_TELEMETRY)
 endif()
 
 if(INTERNAL_MODULE_CRSF)
   add_definitions(-DHARDWARE_INTERNAL_MODULE)
   add_definitions(-DINTERNAL_MODULE_CRSF)
-  add_definitions(-DINTERNAL_MODULE_SERIAL_TELEMETRY)
 endif()
 
 if(INTERNAL_MODULE_AFHDS2A)

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -60,37 +60,27 @@
   #include "flysky_ibus.h"
 #endif
 
-uint8_t telemetryStreaming = 0;
-uint8_t telemetryRxBuffer[TELEMETRY_RX_PACKET_SIZE];
-uint8_t telemetryRxBufferCount = 0;
+struct telemetry_buffer {
+  uint8_t buffer[TELEMETRY_RX_PACKET_SIZE];
+  uint8_t length;
+};
 
+uint8_t telemetryStreaming = 0;
 uint8_t telemetryState = TELEMETRY_INIT;
 
 TelemetryData telemetryData;
-
-#if defined(INTERNAL_MODULE_SERIAL_TELEMETRY)
-static uint8_t intTelemetryRxBuffer[TELEMETRY_RX_PACKET_SIZE];
-static uint8_t intTelemetryRxBufferCount;
-#endif
-
 static rxStatStruct rxStat;
 
-uint8_t * getTelemetryRxBuffer(uint8_t moduleIdx)
+telemetry_buffer _telemetry_rx_buffer[NUM_MODULES];
+
+uint8_t* getTelemetryRxBuffer(uint8_t moduleIdx)
 {
-#if defined(INTERNAL_MODULE_SERIAL_TELEMETRY)
-  if (moduleIdx == INTERNAL_MODULE)
-    return intTelemetryRxBuffer;
-#endif
-  return telemetryRxBuffer;
+  return _telemetry_rx_buffer[moduleIdx].buffer;
 }
 
 uint8_t &getTelemetryRxBufferCount(uint8_t moduleIdx)
 {
-#if defined(INTERNAL_MODULE_SERIAL_TELEMETRY)
-  if (moduleIdx == INTERNAL_MODULE)
-    return intTelemetryRxBufferCount;
-#endif
-  return telemetryRxBufferCount;
+  return _telemetry_rx_buffer[moduleIdx].length;
 }
 
 rxStatStruct *getRxStatLabels() {


### PR DESCRIPTION
Targets which did not have support for CRSF or MULTI internal module (ex: X9D+ 2019, X7 ACCESS, NV14) would use a single telemetry buffer for internal and external module, thus causing clashes when 2 modules are used in parallel. This would for instance prevent using an external MPM as trainer module.

Please note that this will slightly increases memory usage for the targets mentioned above (up to 128 bytes).

Summary of changes:
- enable telemetry buffer for targets without CRSF or MULTI internal module support compiled into the firmware.
