### PR TITLE
fix: data width must be set before enabling SPI

### DIFF
--- a/radio/src/targets/common/arm/stm32/ads79xx.cpp
+++ b/radio/src/targets/common/arm/stm32/ads79xx.cpp
@@ -41,9 +41,8 @@ void ads79xx_init(const stm32_spi_adc_t* adc)
 {
   const auto* spi = &adc->spi;
 
-  stm32_spi_init(spi);
+  stm32_spi_init(spi, LL_SPI_DATAWIDTH_16BIT);
   stm32_spi_set_max_baudrate(spi, ADS79XX_MAX_FREQ);
-  LL_SPI_SetDataWidth(spi->SPIx, LL_SPI_DATAWIDTH_16BIT);
   
   stm32_spi_unselect(spi);
   delay_01us(1);

--- a/radio/src/targets/common/arm/stm32/sdcard_spi.cpp
+++ b/radio/src/targets/common/arm/stm32/sdcard_spi.cpp
@@ -247,7 +247,7 @@ static sd_init_fsm_state_t _init_sd_fsm_step(const stm32_spi_t* spi,
   switch (state) {
   case SD_INIT_START:
     TRACE("SD_INIT_START");
-    stm32_spi_init(spi);
+    stm32_spi_init(spi, LL_SPI_DATAWIDTH_8BIT);
     stm32_spi_set_max_baudrate(spi, SD_SPI_CLK_400K);
     return SD_INIT_SPI_POWER_SEQ;
 

--- a/radio/src/targets/common/arm/stm32/spi_flash.cpp
+++ b/radio/src/targets/common/arm/stm32/spi_flash.cpp
@@ -247,7 +247,7 @@ void flashSpiSync()
 
 bool flashSpiInit(void)
 {
-  stm32_spi_init(&_flash_spi);
+  stm32_spi_init(&_flash_spi, LL_SPI_DATAWIDTH_8BIT);
   delay_ms(1);
   flashSpiSync();
 

--- a/radio/src/targets/common/arm/stm32/stm32_spi.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_spi.cpp
@@ -164,7 +164,7 @@ static void _config_dma_streams(const stm32_spi_t* spi)
 }
 #endif
 
-void stm32_spi_init(const stm32_spi_t* spi)
+void stm32_spi_init(const stm32_spi_t* spi, uint32_t data_width)
 {
   _init_gpios(spi);
 
@@ -178,6 +178,7 @@ void stm32_spi_init(const stm32_spi_t* spi)
   spiInit.TransferDirection = LL_SPI_FULL_DUPLEX;
   spiInit.Mode = LL_SPI_MODE_MASTER;
   spiInit.NSS = LL_SPI_NSS_SOFT;
+  spiInit.DataWidth = data_width;
 
   LL_SPI_Init(SPIx, &spiInit);
   LL_SPI_Enable(SPIx);

--- a/radio/src/targets/common/arm/stm32/stm32_spi.h
+++ b/radio/src/targets/common/arm/stm32/stm32_spi.h
@@ -44,7 +44,7 @@ struct stm32_spi_t {
 
 void stm32_spi_enable_clock(SPI_TypeDef *SPIx);
 
-void stm32_spi_init(const stm32_spi_t* spi);
+void stm32_spi_init(const stm32_spi_t* spi, uint32_t data_width);
 void stm32_spi_deinit(const stm32_spi_t* spi);
 
 void stm32_spi_select(const stm32_spi_t* spi);

--- a/radio/src/targets/common/arm/stm32/vs1053b.cpp
+++ b/radio/src/targets/common/arm/stm32/vs1053b.cpp
@@ -114,7 +114,7 @@ void audioSpiInit(void)
   pinInit.Mode = LL_GPIO_MODE_INPUT;
   LL_GPIO_Init(AUDIO_DREQ_GPIO, &pinInit);
 
-  stm32_spi_init(&_audio_spi);
+  stm32_spi_init(&_audio_spi, LL_SPI_DATAWIDTH_8BIT);
 }
 
 void audioWaitReady()


### PR DESCRIPTION
According to the data sheets, SPI data width can only be set when the peripheral is not enabled (see RM0090; section 28.5.1):

<img width="699" alt="Screenshot 2024-07-10 at 13 52 37" src="https://github.com/EdgeTX/edgetx/assets/1050031/e78d9838-0ff3-4f76-9c6e-ce7dbb2d260d">
