### PR TITLE
fix: MPM disable telemetry user choice ignored

### DIFF
--- a/radio/src/pulses/multi.cpp
+++ b/radio/src/pulses/multi.cpp
@@ -137,7 +137,7 @@ static void setupPulsesMulti(uint8_t*& p_buf, uint8_t module)
   }
 
   // Invert telemetry if needed
-  uint8_t disableTelemetry = modulePortHasRx(module) ? 0 : 1;
+  uint8_t disableTelemetry = g_model.moduleData[module].multi.disableTelemetry || (modulePortHasRx(module) ? 0 : 1);
   if (invert[module] & 0x80 && !disableTelemetry) {
     if (getMultiModuleStatus(module).isValid()) {
       invert[module] &= 0x08;  // Telemetry received, stop searching


### PR DESCRIPTION
Fixes #5285

Summary of changes: overrides auto detection with user choice for MPM telemetry disabling
