### PR TITLE
fix(lua): incorrect name for MIN source

### DIFF
--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -382,7 +382,7 @@ const LuaSingleField luaSingleFields[] = {
     {MIXSRC_SPACEMOUSE_F, "smf", "SpaceMouse F"},
 #endif
 
-    {MIXSRC_MAX, "min", "MIN"},
+    {MIXSRC_MIN, "min", "MIN"},
     {MIXSRC_MAX, "max", "MAX"},
 
     {MIXSRC_TX_VOLTAGE, "tx-voltage", "Transmitter battery voltage [volts]"},


### PR DESCRIPTION
Fixes #5292

Summary of changes:
Corrected the source constant to use for min,

Now it returns properly min or max.