### PR TITLE
fix(pl18): key diagnostic screen display trims in wrong mapping

### DIFF
--- a/radio/src/gui/colorlcd/radio_diagkeys.cpp
+++ b/radio/src/gui/colorlcd/radio_diagkeys.cpp
@@ -206,8 +206,8 @@ class RadioKeyDiagsWindow : public Window
     char s[10] = "0";
 
     for (uint8_t i = 0; i < keysGetMaxTrims() * 2; i++) {
-      s[0] = keysGetTrimState(i) + '0';
-      lv_label_set_text(trimValues[_trimMap[i]], s);
+      s[0] = keysGetTrimState(_trimMap[i]) + '0';
+      lv_label_set_text(trimValues[i], s);
     }
   }
 


### PR DESCRIPTION
The trims are not listed properly, the naming is wrong.

The code use different mapping interpretation as per v2.10

i.e. v2.10 do not have problem but 2.11 has problem
