### PR TITLE
fix: I2C support for H7

### DIFF
--- a/radio/src/boards/generic_stm32/i2c_bus.cpp
+++ b/radio/src/boards/generic_stm32/i2c_bus.cpp
@@ -75,6 +75,23 @@ int i2c_init(etx_i2c_bus_t bus)
   return -1;
 }
 
+int i2c_deinit(etx_i2c_bus_t bus)
+{
+#if defined(I2C_B1)
+  if (bus == I2C_Bus_1) {
+    return stm32_i2c_deinit(I2C_Bus_1);
+  }
+#endif
+
+#if defined(I2C_B2)
+  if (bus == I2C_Bus_2) {
+    return stm32_i2c_deinit(I2C_Bus_2);
+  }
+#endif
+
+  return -1;
+}
+
 int i2c_dev_ready(etx_i2c_bus_t bus, uint16_t addr)
 {
   return stm32_i2c_is_dev_ready(bus, addr, I2C_DEFAULT_RETRIES,

--- a/radio/src/hal/i2c_driver.h
+++ b/radio/src/hal/i2c_driver.h
@@ -26,6 +26,7 @@
 typedef uint8_t etx_i2c_bus_t;
 
 int i2c_init(etx_i2c_bus_t bus);
+int i2c_deinit(etx_i2c_bus_t bus);
 
 int i2c_dev_ready(etx_i2c_bus_t bus, uint16_t addr);
 

--- a/radio/src/targets/common/arm/stm32/stm32_i2c_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_i2c_driver.cpp
@@ -162,6 +162,7 @@ static uint32_t I2C_GetTiming(uint32_t clock_src_freq, uint32_t i2c_freq)
       if ((i2c_freq >= I2C_Charac[speed].freq_min) &&
           (i2c_freq <= I2C_Charac[speed].freq_max))
       {
+        I2c_valid_timing_nbr = 0;
         I2C_Compute_PRESC_SCLDEL_SDADEL(clock_src_freq, speed);
         idx = I2C_Compute_SCLL_SCLH(clock_src_freq, speed);
 
@@ -400,11 +401,13 @@ static int i2c_disable_clock(I2C_TypeDef* instance)
 
 static int i2c_gpio_init(const stm32_i2c_hw_def_t* hw_def)
 {
+  gpio_set(hw_def->SCL_GPIO);
   gpio_init(hw_def->SCL_GPIO, GPIO_OD_PU, GPIO_PIN_SPEED_MEDIUM);
-  gpio_init_af(hw_def->SCL_GPIO, hw_def->GPIO_AF, GPIO_PIN_SPEED_MEDIUM);
+  gpio_set_af(hw_def->SCL_GPIO, hw_def->GPIO_AF);
 
+  gpio_set(hw_def->SDA_GPIO);
   gpio_init(hw_def->SDA_GPIO, GPIO_OD_PU, GPIO_PIN_SPEED_MEDIUM);
-  gpio_init_af(hw_def->SDA_GPIO, hw_def->GPIO_AF, GPIO_PIN_SPEED_MEDIUM);
+  gpio_set_af(hw_def->SDA_GPIO, hw_def->GPIO_AF);
 
   if (hw_def->set_pwr) {
     hw_def->set_pwr(true);


### PR DESCRIPTION
Summary of changes:
- fix I2C timing calculations for H7
- add `i2c_deinit`
