### PR TITLE
fix(cpn): log viewer highlight selected data item

### DIFF
--- a/companion/src/logsdialog.cpp
+++ b/companion/src/logsdialog.cpp
@@ -243,7 +243,7 @@ void LogsDialog::selectionChanged()
     if (item == NULL) item = rightLegend->itemWithPlottable(graph);
     if (item->selected() || graph->selected()) {
       item->setSelected(true);
-      graph->setSelection(QCPDataSelection(QCPDataRange()));
+      graph->setSelection(QCPDataSelection(graph->data()->dataRange()));
     }
   }
 }
@@ -891,7 +891,7 @@ void LogsDialog::plotLogs()
           .toTime_t();
       }
       plotCoords.x.push_back(time);
-  
+
       if(plots.min_x == INVALID_MIN)
         plots.min_x = time;
       else


### PR DESCRIPTION
Fixes #5298

Summary of changes:
Broken by upgrade to QCustomPlot 2.1.1 and change to functionality