### PR TITLE
fix(el18): uart auto oversampling calculation

### DIFF
--- a/radio/src/hal/module_port.cpp
+++ b/radio/src/hal/module_port.cpp
@@ -69,10 +69,6 @@ static bool _init_serial_driver(etx_module_driver_t* d, const etx_module_port_t*
 
   // S.PORT specific HW settings
   if (port->port == ETX_MOD_PORT_SPORT && params->baudrate >= 400000) {
-
-    // enable over-sampling by 8
-    if (drv->setHWOption) drv->setHWOption(d->ctx, ETX_HWOption_OVER8);
-
     // one-bit
     if (g_eeGeneral.uartSampleMode == UART_SAMPLE_MODE_ONEBIT) {
       if (drv->setHWOption) drv->setHWOption(d->ctx, ETX_HWOption_ONEBIT);

--- a/radio/src/hal/serial_driver.h
+++ b/radio/src/hal/serial_driver.h
@@ -61,7 +61,6 @@ struct etx_serial_callbacks_t {
 };
 
 enum SerialHWOption {
-  ETX_HWOption_OVER8,  // oversampling by 8
   ETX_HWOption_ONEBIT, // one-bit sampling
 };
 

--- a/radio/src/targets/common/arm/stm32/stm32_usart_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_usart_driver.cpp
@@ -244,7 +244,7 @@ static uint32_t _get_usart_periph_clock(USART_TypeDef* USARTx)
 static uint32_t _calc_best_oversampling(USART_TypeDef* USARTx, uint32_t baudrate)
 {
   auto periphclk = _get_usart_periph_clock(USARTx);
-  return periphclk / baudrate < 16 ? LL_USART_OVERSAMPLING_8 : LL_USART_OVERSAMPLING_16;
+  return (periphclk < (baudrate << 4)) ? LL_USART_OVERSAMPLING_8 : LL_USART_OVERSAMPLING_16;
 }
 
 void stm32_usart_init_rx_dma(const stm32_usart_t* usart, const void* buffer, uint32_t length)

--- a/radio/src/targets/common/arm/stm32/stm32_usart_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_usart_driver.cpp
@@ -570,12 +570,12 @@ void stm32_usart_set_baudrate(const stm32_usart_t* usart, uint32_t baudrate)
 {
   auto periphclk = _get_usart_periph_clock(usart->USARTx);
   auto oversampling = LL_USART_GetOverSampling(usart->USARTx);
-#if defined(LL_USART_PRESCALER_DIV1)
-  LL_USART_SetBaudRate(usart->USARTx, periphclk, LL_USART_PRESCALER_DIV1, oversampling, baudrate);
-#else
   auto bestOversampling = _calc_best_oversampling(usart->USARTx, baudrate);
   if (bestOversampling != oversampling)
     LL_USART_SetOverSampling(usart->USARTx, bestOversampling);    
+#if defined(LL_USART_PRESCALER_DIV1)
+  LL_USART_SetBaudRate(usart->USARTx, periphclk, LL_USART_PRESCALER_DIV1, bestOversampling, baudrate);
+#else
   LL_USART_SetBaudRate(usart->USARTx, periphclk, bestOversampling, baudrate);
 #endif
 }


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #5318

Summary of changes:

Implemented auto oversampling calculation.

Formula in STM document RM0090 (F429):

For 16 bit oversampling:
baud = pclk / 16 * USARTDIV

For 8 bit oversampling:
baud = pclk / 8 * USARTDIV

Minimum USARTDIV = 1, therefore when pclk / baud < 16, 8 bit oversampling should be used

@raphaelcoeffic ~~I think more cleanup is required, if oversampling is chosen automatically, then no need for code that choose to use 8-bit oversampling.~~  Already did the clean up
