### PR TITLE
feat(bw128): allow long press to open curve edit without entering edit mode

### DIFF
--- a/radio/src/gui/128x64/model_input_edit.cpp
+++ b/radio/src/gui/128x64/model_input_edit.cpp
@@ -131,7 +131,7 @@ void menuModelExpoOne(event_t event)
         break;
 
       case EXPO_FIELD_CURVE:
-        editCurveRef(EXPO_ONE_2ND_COLUMN, y, ed->curve, s_editMode > 0 ? event : 0, RIGHT | attr);
+        editCurveRef(EXPO_ONE_2ND_COLUMN, y, ed->curve, event, RIGHT | attr);
         break;
 
 #if defined(FLIGHT_MODES)

--- a/radio/src/gui/128x64/model_mix_edit.cpp
+++ b/radio/src/gui/128x64/model_mix_edit.cpp
@@ -162,7 +162,7 @@ void menuModelMixOne(event_t event)
         lcdDrawTextAlignedLeft(y, STR_CURVE);
         s_currSrcRaw = md2->srcRaw;
         s_currScale = 0;
-        editCurveRef(MIXES_2ND_COLUMN, y, md2->curve, s_editMode > 0 ? event : 0, attr);
+        editCurveRef(MIXES_2ND_COLUMN, y, md2->curve, event, attr);
         break;
 
 #if defined(FLIGHT_MODES)


### PR DESCRIPTION
On 128x64 B&W radios the long press of the enter key to open the curve edit page only works if the user is editing the custom curve value. 
On 212x64 radios the long press works whenever the custom curve value is selected.

Changes 128x64 B&W radio to match the 212x64 logic.
