### PR TITLE
fix: do not init the watchdog in flash driver

### DIFF
--- a/radio/src/io/bootloader_flash.cpp
+++ b/radio/src/io/bootloader_flash.cpp
@@ -94,7 +94,9 @@ void BootloaderFirmwareUpdate::flashFirmware(const char * filename, ProgressHand
       break;
     }
     for (UINT j = 0; j < count; j += FLASH_PAGESIZE) {
+      WDG_ENABLE(3000);
       flashWrite(CONVERT_UINT_PTR(FIRMWARE_ADDRESS + i + j), CONVERT_UINT_PTR(buffer + j));
+      WDG_ENABLE(WDG_DURATION);
     }
     progressHandler("Bootloader", STR_WRITING, i, flash_size);
 

--- a/radio/src/targets/common/arm/stm32/bootloader/CMakeLists.txt
+++ b/radio/src/targets/common/arm/stm32/bootloader/CMakeLists.txt
@@ -27,7 +27,6 @@ remove_definitions(-DLUA)
 remove_definitions(-DCLI)
 remove_definitions(-DSEMIHOSTING)
 remove_definitions(-DUSB_SERIAL)
-remove_definitions(-DUSE_WATCHDOG)
 
 if(NOT NO_LTO)
   message("-- Use LTO to compile bootloader")

--- a/radio/src/targets/common/arm/stm32/flash_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/flash_driver.cpp
@@ -79,8 +79,6 @@ void lockFlash()
 
 void eraseSector(uint32_t sector)
 {
-  WDG_ENABLE(3000); // some sectors may take > 1s to erase
-
   waitFlashIdle();
 
 #if defined(FLASH_CR_PSIZE)
@@ -97,8 +95,6 @@ void eraseSector(uint32_t sector)
   /* if the erase operation is completed, disable the SER Bit */
   FLASH_CR &= (~FLASH_CR_SER);
   FLASH_CR &= SECTOR_MASK;
-
-  WDG_ENABLE(WDG_DURATION);
 }
 
 void flashWrite(uint32_t * address, const uint32_t * buffer) // page size is 256 bytes


### PR DESCRIPTION
Fix issue introduced in #5232 and reported by @philmoz on Discord

https://discord.com/channels/839849772864503828/909552654328406056/1265246121484226661