### PR TITLE
feat(bw): do not show time on main view when RTC not set

### DIFF
--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -674,13 +674,13 @@ void menuMainView(event_t event)
     lcdDrawText(15 * FW, 0, "BIND", 0);
   }
 #if defined(RTCLOCK)
-  else if (view_base != VIEW_CHAN_MONITOR && isRtcValid()) {
+  else if (view_base != VIEW_CHAN_MONITOR && rtcIsValid()) {
     drawRtcTime(CLOCK_X, CLOCK_Y, LEFT|TIMEBLINK);
   }
 #endif
 #else
 #if defined(RTCLOCK)
-  if (view_base != VIEW_CHAN_MONITOR && isRtcValid()) {
+  if (view_base != VIEW_CHAN_MONITOR && rtcIsValid()) {
     drawRtcTime(CLOCK_X, CLOCK_Y, LEFT|TIMEBLINK);
   }
 #endif

--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -674,13 +674,13 @@ void menuMainView(event_t event)
     lcdDrawText(15 * FW, 0, "BIND", 0);
   }
 #if defined(RTCLOCK)
-  else if (view_base != VIEW_CHAN_MONITOR) {
+  else if (view_base != VIEW_CHAN_MONITOR && isRtcValid()) {
     drawRtcTime(CLOCK_X, CLOCK_Y, LEFT|TIMEBLINK);
   }
 #endif
 #else
 #if defined(RTCLOCK)
-  if (view_base != VIEW_CHAN_MONITOR) {
+  if (view_base != VIEW_CHAN_MONITOR && isRtcValid()) {
     drawRtcTime(CLOCK_X, CLOCK_Y, LEFT|TIMEBLINK);
   }
 #endif

--- a/radio/src/gui/212x64/view_main.cpp
+++ b/radio/src/gui/212x64/view_main.cpp
@@ -335,7 +335,7 @@ void displayTopBar()
     LCD_ICON(BAR_VOLUME_X, BAR_Y, ICON_SPEAKER3);
 
   /* RTC time */
-  drawRtcTime(BAR_TIME_X, BAR_Y+1, LEFT|TIMEBLINK);
+  if (rtcIsValid()) drawRtcTime(BAR_TIME_X, BAR_Y+1, LEFT|TIMEBLINK);
 
   /* The background */
   lcdDrawFilledRect(BAR_X, BAR_Y, BAR_W, BAR_H, SOLID, FILL_WHITE|GREY(12)|ROUND);

--- a/radio/src/rtc.cpp
+++ b/radio/src/rtc.cpp
@@ -493,3 +493,16 @@ uint8_t rtcAdjust(uint16_t year, uint8_t mon, uint8_t day, uint8_t hour, uint8_t
   }
   return 0;
 }
+
+bool isRtcValid()
+{
+  struct gtm t;
+  gettime(&t);
+
+  // If year is 2000, rtc circuit aren't working
+  // No RTC battery or other issue
+  if (t.tm_year <= 100)
+    return false;
+
+  return true;
+}

--- a/radio/src/rtc.cpp
+++ b/radio/src/rtc.cpp
@@ -494,7 +494,7 @@ uint8_t rtcAdjust(uint16_t year, uint8_t mon, uint8_t day, uint8_t hour, uint8_t
   return 0;
 }
 
-bool isRtcValid()
+bool rtcIsValid()
 {
   struct gtm t;
   gettime(&t);

--- a/radio/src/rtc.h
+++ b/radio/src/rtc.h
@@ -50,6 +50,7 @@ struct gtm
 extern gtime_t g_rtcTime;
 extern uint8_t g_ms100; // global to allow time set function to reset to zero
 
+bool isRtcValid();
 void rtcInit();
 void rtcSetTime(const struct gtm * tm);
 gtime_t gmktime (struct gtm *tm);

--- a/radio/src/rtc.h
+++ b/radio/src/rtc.h
@@ -50,7 +50,7 @@ struct gtm
 extern gtime_t g_rtcTime;
 extern uint8_t g_ms100; // global to allow time set function to reset to zero
 
-bool isRtcValid();
+bool rtcIsValid();
 void rtcInit();
 void rtcSetTime(const struct gtm * tm);
 gtime_t gmktime (struct gtm *tm);


### PR DESCRIPTION
Inspired by discussion on RCG where users either have difficulties with RTC resets or simply don't care and do not put a battery.

In such case, time is not displayed anymore on main view
