### PR TITLE
fix(radio): ensure customisable switch set as Toggle starts in the OFF state.

### DIFF
--- a/radio/src/gui/colorlcd/function_switches.cpp
+++ b/radio/src/gui/colorlcd/function_switches.cpp
@@ -69,6 +69,7 @@ class FunctionSwitch : public Window
           FSWITCH_SET_CONFIG(switchIndex, val);
           if (val == SWITCH_TOGGLE) {
             FSWITCH_SET_STARTUP(switchIndex, FS_START_PREVIOUS);
+            setFSLogicalState(switchIndex, 0);
             startChoice->setValue(startChoice->getIntValue());
           }
           SET_DIRTY();

--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -22,7 +22,9 @@
 #include "hal/switch_driver.h"
 #include "hal/adc_driver.h"
 
+#include "myeeprom.h"
 #include "opentx.h"
+#include "opentx_constants.h"
 #include "switches.h"
 #include "input_mapping.h"
 
@@ -90,6 +92,8 @@ void setFSStartupPosition()
 {
   for (uint8_t i = 0; i < NUM_FUNCTIONS_SWITCHES; i++) {
     uint8_t startPos = (g_model.functionSwitchStartConfig >> 2 * i) & 0x03;
+    if (FSWITCH_CONFIG(i) == SWITCH_TOGGLE)
+      startPos = FS_START_OFF;
     switch(startPos) {
       case FS_START_OFF:
         g_model.functionSwitchLogicalState &= ~(1 << i);   // clear state


### PR DESCRIPTION
Radios with customisable switches (i.e. T20V2, T15) can be set into an unexpected state when the switch type is set to Toggle.

To reproduce:
- Set switch type to 2POS, no group and startup to Last value.
- Press switch to turn it on.
- Change type to Toggle with switch turned on.

Toggle works backwards - with pressed state being switch UP and LED OFF.
Even on restart switch is backwards.

This PR ensures Toggle state is consistent when changed and on startup.