### PR TITLE
fix(tx16s): turn on aux2 power when used for BT

### DIFF
--- a/radio/src/bluetooth.cpp
+++ b/radio/src/bluetooth.cpp
@@ -413,6 +413,15 @@ void Bluetooth::wakeup()
     return;
   }
 
+#if defined(BT_PWR_GPIO)
+  if (g_eeGeneral.bluetoothMode == BLUETOOTH_OFF) {
+    bluetoothDisable();
+    state = BLUETOOTH_STATE_OFF;
+    wakeupTime = now + 10; /* 100ms */
+    return;
+  }
+#endif
+
   if (g_eeGeneral.bluetoothMode == BLUETOOTH_OFF ||
       (g_eeGeneral.bluetoothMode == BLUETOOTH_TRAINER &&
        !IS_BLUETOOTH_TRAINER())) {

--- a/radio/src/targets/common/arm/stm32/bluetooth_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/bluetooth_driver.cpp
@@ -63,6 +63,9 @@ void bluetoothInit(uint32_t baudrate, bool enable)
 #if defined(BT_EN_GPIO)
   gpio_init(BT_EN_GPIO, GPIO_OUT, GPIO_PIN_SPEED_LOW);
 #endif
+#if defined(BT_PWR_GPIO)
+  gpio_init(BT_PWR_GPIO, GPIO_OUT, GPIO_PIN_SPEED_LOW);
+#endif
 
 #if !defined(BOOT)
   etx_serial_init cfg = {
@@ -83,6 +86,9 @@ void bluetoothInit(uint32_t baudrate, bool enable)
 #if defined(BT_EN_GPIO)
   gpio_write(BT_EN_GPIO, !enable);
 #endif
+#if defined(BT_PWR_GPIO)
+  gpio_set(BT_PWR_GPIO);
+#endif
 }
 
 #if !defined(BOOT)
@@ -91,6 +97,9 @@ void bluetoothDisable()
 #if defined(BT_EN_GPIO)
   // close bluetooth (recent modules will go to bootloader mode)
   gpio_set(BT_EN_GPIO);
+#endif
+#if defined(BT_PWR_GPIO)
+  gpio_clear(BT_PWR_GPIO);
 #endif
   if (_bt_usart_ctx) {
     STM32SerialDriver.deinit(_bt_usart_ctx);

--- a/radio/src/targets/horus/hal.h
+++ b/radio/src/targets/horus/hal.h
@@ -1057,6 +1057,9 @@
   #define BT_USART_GPIO                 GPIOG
   #define BT_TX_GPIO                    GPIO_PIN(GPIOG, 14) // PG.14
   #define BT_RX_GPIO                    GPIO_PIN(GPIOG, 9)  // PG.09
+#if defined(RADIO_TX16S)
+  #define BT_PWR_GPIO                   GPIO_PIN(GPIOB, 0) // PB.00
+#endif
 #endif
 
 #if defined(PCBX12S)


### PR DESCRIPTION
Enable/disable BT power on radio that remap AUX2 with power pin (introduced with stdperif removal)

Fixes #5352

