### PR TITLE
fix(cpn): sounds processing extra files and cancel update processes earlier

### DIFF
--- a/companion/src/progresswidget.cpp
+++ b/companion/src/progresswidget.cpp
@@ -212,3 +212,10 @@ void ProgressWidget::forceKeepOpen(bool value)
 {
   emit keepOpen(value);
 }
+
+void ProgressWidget::refresh()
+{
+  ui->info->update();
+  ui->progressBar->update();
+  ui->textEdit->update();
+}

--- a/companion/src/progresswidget.h
+++ b/companion/src/progresswidget.h
@@ -53,6 +53,7 @@ class ProgressWidget : public QWidget
     void stop();
     void clearDetails() const;
     void forceKeepOpen(bool value);
+    void refresh();
 
   signals:
     void detailsToggled();

--- a/companion/src/storage/minizinterface.cpp
+++ b/companion/src/storage/minizinterface.cpp
@@ -174,8 +174,10 @@ bool MinizInterface::addFileToArchive(const QString & path)
 
 bool MinizInterface::unzipArchiveToPath(const QString & archiveFile, const QString & destinationPath)
 {
+  QFileInfo file(archiveFile);
+
   if (progress)
-    progress->setInfo(tr("Decompressing %1").arg(archiveFile));
+    progress->setInfo(tr("Decompressing %1").arg(file.fileName()));
   else
     qDebug() << QString("Decompressing %1 to %2").arg(archiveFile, destinationPath);
 

--- a/companion/src/storage/minizinterface.h
+++ b/companion/src/storage/minizinterface.h
@@ -28,9 +28,9 @@
 
 class ProgressWidget;
 
-class MinizInterface
+class MinizInterface : public QObject
 {
-  Q_DECLARE_TR_FUNCTIONS(MinizInterface)
+  Q_OBJECT
 
   public:
     enum ProgressCalcMethod {
@@ -44,6 +44,9 @@ class MinizInterface
     bool zipPathToFile(const QString & sourcePath, const QString & archiveFile, bool append = true);
     bool unzipArchiveToPath(const QString & archiveFile, const QString & destinationPath);
 
+  public slots:
+    void stop();
+
   private:
     ProgressWidget *progress;
     ProgressCalcMethod progressMethod;
@@ -51,10 +54,12 @@ class MinizInterface
     int logLevel;
     QString path;
     QString archiveFile;
+    bool stopping;
 
     mz_zip_archive zip_archive;
 
     bool addFileToArchive(const QString & path);
     bool createDirectory(const QString & path);
     void reportProgress(const QString & text, const int & type = QtInfoMsg, bool richText = false);
+    bool isStopping() { return stopping; }
 };

--- a/companion/src/updates/repoassets.cpp
+++ b/companion/src/updates/repoassets.cpp
@@ -106,6 +106,15 @@ bool AssetsRawItemModel::setDownloadName(const int id, const QString name)
   return setValue(id, RIMR_DownloadName, QVariant(name));
 }
 
+bool AssetsRawItemModel::resetFlags()
+{
+  for (int i = 0; i < rowCount(); i++) {
+    item(i)->setData(0, RIMR_Flags);
+  }
+
+  return true;
+}
+
 /*
     AssetsFilteredItemModel
 */
@@ -319,4 +328,9 @@ bool RepoAssets::setDownloadUrl(const QString url)
 bool RepoAssets::setDownloadName(const QString name)
 {
   return m_rawItemModel->setDownloadName(id(), name);
+}
+
+bool RepoAssets::resetFlags()
+{
+  return m_rawItemModel->resetFlags();
 }

--- a/companion/src/updates/repoassets.h
+++ b/companion/src/updates/repoassets.h
@@ -39,6 +39,7 @@ class AssetsRawItemModel : public RepoRawItemModel
 
     bool setDownloadUrl(const int id, const QString url);
     bool setDownloadName(const int id, const QString name);
+    bool resetFlags();
 
   private:
     QObject *m_parentRepo;  // cannot use Repo class from repo.h as compile error due to cyclic headers
@@ -93,15 +94,21 @@ class RepoAssets : public QObject, public RepoMetaData
     bool getJson(const QString assetName, QJsonDocument * json);
     const QString name() const;
     const QString name(const int row);
+
     bool setCopyFilter(const QString filter);
+
     bool setSubDirectory(const QString path);
     const QString subDirectory() const;
+
     bool setDownloadUrl(const QString url);
     const QString downloadUrl() const;
     const QString downloadUrl(const int row);
+
     bool setDownloadName(const QString name);
     const QString downloadName() const;
     const QString downloadName(const int row);
+
+    bool resetFlags();
 
   signals:
     void idChanged(int id);

--- a/companion/src/updates/updatecloudbuild.h
+++ b/companion/src/updates/updatecloudbuild.h
@@ -31,6 +31,16 @@ class UpdateCloudBuild: public UpdateInterface
   Q_DECLARE_TR_FUNCTIONS(UpdateCloudBuild)
 
   public:
+    enum ProcessStatus {
+      STATUS_UNKNOWN,
+      STATUS_WAITING,
+      STATUS_IN_PROGRESS,
+      STATUS_SUCCESS,
+      STATUS_ERROR,
+      STATUS_TIMEOUT,
+      STATUS_CANCELLED
+    };
+    Q_ENUM(ProcessStatus)
 
     explicit UpdateCloudBuild(QWidget * parent);
     virtual ~UpdateCloudBuild();
@@ -53,7 +63,7 @@ class UpdateCloudBuild: public UpdateInterface
     QString m_logDir;
     QString m_buildFlags;
     QTime m_buildStartTime;
-    QString m_jobStatus;
+    int m_jobStatus;
     QStringList m_profileOpts;
     QString m_radio;
 
@@ -69,4 +79,6 @@ class UpdateCloudBuild: public UpdateInterface
     bool isStatusInProgress();
     bool setAssetDownload();
     void waitForBuildFinish();
+    static QString statusToString(const int status);
+    static int cloudStatusToInt(const QString status);
 };

--- a/companion/src/updates/updateinterface.h
+++ b/companion/src/updates/updateinterface.h
@@ -107,7 +107,7 @@ class UpdateInterface : public QWidget
     bool update(ProgressWidget * progress = nullptr);
 
   signals:
-    void stop();
+    void stopping();
     void finished();
 
   protected:
@@ -156,6 +156,7 @@ class UpdateInterface : public QWidget
 
   private slots:
     void onStatusCancelled();
+    void processEvents();
 
   private:
     const ComponentIdentity m_id;
@@ -169,6 +170,8 @@ class UpdateInterface : public QWidget
     QString m_updateDir;
     bool m_stopping;
     int m_result;
+    QEventLoop m_eventLoop;
+    QTimer m_timer;
 
     void appSettingsInit();
     bool checkCreateDirectory(const QString & dirSetting, const UpdateFlags flag);
@@ -177,7 +180,9 @@ class UpdateInterface : public QWidget
     bool setRunFolders();
     bool validateFolder(QString & fldr);
 
-    bool okToRun() { return m_result == PROC_RESULT_SUCCESS && m_stopping == false; }
+    bool isOkay() { return m_result == PROC_RESULT_SUCCESS && !m_stopping; }
+    const QString resultToString() const;
+
     void runAsyncInstall();
     void runBuild();
     void runCopyToDestination();

--- a/companion/src/updates/updatenetwork.h
+++ b/companion/src/updates/updatenetwork.h
@@ -72,7 +72,10 @@ class UpdateNetwork : public QObject
     static QString downloadDataTypeToString(const DownloadDataType val);
 
   private slots:
-    void onDownloadFinished(QNetworkReply * reply, DownloadDataType ddt);
+    void onGetFinished(QNetworkReply * reply, DownloadDataType ddt);
+    void onPostFinished();
+    void updateProgress();
+    void cancelDownload();
 
   private:
     UpdateStatus *m_status;
@@ -83,6 +86,11 @@ class UpdateNetwork : public QObject
     QFile *m_file;
     QUrl m_url;
     bool m_success;
+    QEventLoop m_eventLoop;
+    QTimer m_timer;
+    QString m_action;
 
     bool init(const QString & url);
+    void connectReplyCommon();
+    void cleanup();
 };

--- a/companion/src/updates/updates.cpp
+++ b/companion/src/updates/updates.cpp
@@ -28,6 +28,7 @@
 #include "helpers.h"
 
 #include <QMessageBox>
+#include <QApplication>
 
 Updates::Updates(QWidget * parent, UpdateFactories * updateFactories) :
   QWidget(parent),
@@ -127,6 +128,9 @@ void Updates::runUpdate()
   ok = factories->updateAll(progressDialog.progress());
   progressDialog.setProcessStopped();
   progressDialog.progress()->setInfo(tr("Finished %1").arg(ok ? tr("successfully") : tr("with errors")));
+  progressDialog.progress()->setValue(progressDialog.progress()->maximum());
+  progressDialog.progress()->refresh();
+  QApplication::processEvents();
   progressDialog.exec();
 
   if (ok)


### PR DESCRIPTION
Summary of changes:
- fix multiple runs of updating sounds re-running previous selections
- add ability to interrupt miniz decompress
- add lots more check points for cancel button press test to stop processes earlier
- improve status refresh
- chores clean up network class and fix signal/slot disconnects
