### PR TITLE
feat(radio): Logical Switch list display UI

### DIFF
--- a/radio/src/gui/128x64/model_logical_switches.cpp
+++ b/radio/src/gui/128x64/model_logical_switches.cpp
@@ -297,11 +297,14 @@ void menuModelLogicalSwitches(event_t event)
     drawSwitch(0, y, sw, (sub==k ? INVERS : 0) | (getSwitch(sw) ? BOLD : 0));
 
     if (cs->func > 0) {
-      // CSW func
-      lcdDrawTextAtIndex(CSW_1ST_COLUMN, y, STR_VCSWFUNC, cs->func, 0);
-
       // CSW params
       uint8_t cstate = lswFamily(cs->func);
+
+      // CSW func
+      LcdFlags flags = 0;
+      if (cstate == LS_FAMILY_STICKY && getLSStickyState(k))
+        flags = BOLD;
+      lcdDrawTextAtIndex(CSW_1ST_COLUMN, y, STR_VCSWFUNC, cs->func, flags);
 
       if (cstate == LS_FAMILY_BOOL || cstate == LS_FAMILY_STICKY) {
         drawSwitch(CSW_2ND_COLUMN, y, cs->v1, 0);

--- a/radio/src/gui/212x64/model_logical_switches.cpp
+++ b/radio/src/gui/212x64/model_logical_switches.cpp
@@ -110,15 +110,18 @@ void menuModelLogicalSwitches(event_t event)
     unsigned int sw = SWSRC_FIRST_LOGICAL_SWITCH+k;
     drawSwitch(0, y, sw, (getSwitch(sw) ? BOLD : 0) | ((sub==k && CURSOR_ON_LINE()) ? INVERS : 0));
 
-    // CSW func
-    lcdDrawTextAtIndex(CSW_1ST_COLUMN, y, STR_VCSWFUNC, cs->func, horz==0 ? attr : 0);
-
     // CSW params
     unsigned int cstate = lswFamily(cs->func);
     mixsrc_t v1_val = cs->v1;
     int16_t v1_min = 0, v1_max = MIXSRC_LAST_TELEM;
     int16_t v2_min = 0, v2_max = MIXSRC_LAST_TELEM;
     int16_t v3_min =-1, v3_max = 100;
+
+    // CSW func
+    LcdFlags flags = 0;
+    if (cstate == LS_FAMILY_STICKY && getLSStickyState(k))
+      flags = BOLD;
+    lcdDrawTextAtIndex(CSW_1ST_COLUMN, y, STR_VCSWFUNC, cs->func, (horz==0 ? attr : 0) | flags);
 
     if (cstate == LS_FAMILY_BOOL || cstate == LS_FAMILY_STICKY) {
       drawSwitch(CSW_2ND_COLUMN, y, cs->v1, attr1);

--- a/radio/src/gui/colorlcd/model_logical_switches.cpp
+++ b/radio/src/gui/colorlcd/model_logical_switches.cpp
@@ -342,22 +342,26 @@ class LogicalSwitchButton : public ListLineButton
     etx_obj_add_style(lsFunc, styles->text_align_left, LV_PART_MAIN);
     lv_obj_set_pos(lsFunc, FN_X, FN_Y);
     lv_obj_set_size(lsFunc, FN_W, FN_H);
+    lv_obj_set_style_text_font(lsFunc, getFont(FONT(BOLD)), LV_STATE_USER_1);
 
     lsV1 = lv_label_create(lvobj);
     etx_obj_add_style(lsV1, styles->text_align_center, LV_PART_MAIN);
     etx_font(lsV1, FONT_XS_INDEX, ETX_STATE_V1_SMALL_FONT);
     lv_obj_set_pos(lsV1, V1_X, V1_Y);
     lv_obj_set_size(lsV1, V1_W, V1_H);
+    lv_obj_set_style_text_font(lsV1, getFont(FONT(BOLD)), LV_STATE_USER_1);
 
     lsV2 = lv_label_create(lvobj);
     etx_obj_add_style(lsV2, styles->text_align_center, LV_PART_MAIN);
     lv_obj_set_pos(lsV2, V2_X, V2_Y);
     lv_obj_set_size(lsV2, V2_W, V2_H);
+    lv_obj_set_style_text_font(lsV2, getFont(FONT(BOLD)), LV_STATE_USER_1);
 
     lsAnd = lv_label_create(lvobj);
     etx_obj_add_style(lsAnd, styles->text_align_center, LV_PART_MAIN);
     lv_obj_set_pos(lsAnd, AND_X, AND_Y);
     lv_obj_set_size(lsAnd, AND_W, AND_H);
+    lv_obj_set_style_text_font(lsAnd, getFont(FONT(BOLD)), LV_STATE_USER_1);
 
     lsDuration = lv_label_create(lvobj);
     etx_obj_add_style(lsDuration, styles->text_align_center, LV_PART_MAIN);
@@ -378,6 +382,35 @@ class LogicalSwitchButton : public ListLineButton
   bool isActive() const override
   {
     return getSwitch(SWSRC_FIRST_LOGICAL_SWITCH + index);
+  }
+
+  void checkEvents() override
+  {
+    ListLineButton::checkEvents();
+    check(isActive());
+
+    LogicalSwitchData* ls = lswAddress(index);
+    uint8_t lsFamily = lswFamily(ls->func);
+
+    if (lsFamily == LS_FAMILY_STICKY && getLSStickyState(index))
+      lv_obj_add_state(lsFunc, LV_STATE_USER_1);
+    else
+      lv_obj_clear_state(lsFunc, LV_STATE_USER_1);
+
+    if ((lsFamily == LS_FAMILY_BOOL || lsFamily == LS_FAMILY_EDGE || lsFamily == LS_FAMILY_STICKY) && getSwitch(ls->v1))
+      lv_obj_add_state(lsV1, LV_STATE_USER_1);
+    else
+      lv_obj_clear_state(lsV1, LV_STATE_USER_1);
+
+    if ((lsFamily == LS_FAMILY_BOOL || lsFamily == LS_FAMILY_STICKY) && getSwitch(ls->v2))
+      lv_obj_add_state(lsV2, LV_STATE_USER_1);
+    else
+      lv_obj_clear_state(lsV2, LV_STATE_USER_1);
+
+    if (getSwitch(ls->andsw))
+      lv_obj_add_state(lsAnd, LV_STATE_USER_1);
+    else
+      lv_obj_clear_state(lsAnd, LV_STATE_USER_1);
   }
 
   void refresh() override

--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -490,6 +490,11 @@ PACK(typedef struct {
   uint16_t duration:15;
 }) ls_stay_struct;
 
+bool getLSStickyState(uint8_t idx)
+{
+  return lswFm[mixerCurrentFlightMode].lsw[idx].lastValue & 1;
+}
+
 void logicalSwitchesInit(bool force)
 {
   for (unsigned int idx=0; idx<MAX_LOGICAL_SWITCHES; idx++) {

--- a/radio/src/switches.h
+++ b/radio/src/switches.h
@@ -41,6 +41,7 @@ typedef int16_t delayval_t;
 uint8_t lswFamily(uint8_t func);
 int16_t lswTimerValue(delayval_t val);
 
+bool getLSStickyState(uint8_t idx);
 void evalLogicalSwitches(bool isCurrentFlightmode=true);
 void logicalSwitchesCopyState(uint8_t src, uint8_t dst);
 void logicalSwitchesReset();


### PR DESCRIPTION
Changes:
- Change color UI to show V1, V2 and AND switches in bold when they are on (to match B&W UI).
- Show 'Stcky' label for sticky switches in bold when the switch sticky state is ON.

Sticky LS with an AND switch can be off; yet still have the 'sticky' state set to on.
This can make setting up a LS somewhat confusing.
This change aims to show the 'sticky' state in addition to the LS switch state.

![screenshot_tx16s_24-08-01_09-08-09](https://github.com/user-attachments/assets/7bec66c8-5200-4385-a1a8-795d7f872431)
![screenshot_tx16s_24-08-01_09-08-19](https://github.com/user-attachments/assets/8640e0c4-805f-45d6-b35f-dd4f0e999678)

