### PR TITLE
fix(color): display only GV name in mix/input overview when used for weight

### DIFF
--- a/radio/src/gui/colorlcd/controls/source_numberedit.h
+++ b/radio/src/gui/colorlcd/controls/source_numberedit.h
@@ -45,7 +45,7 @@ class SourceNumberEdit : public Window
 
   void update();
 
-  static LAYOUT_VAL(NUM_EDIT_W, 84, 74)
+  static LAYOUT_VAL(NUM_EDIT_W, 84, 84)
   static LAYOUT_VAL(SRC_BTN_W, 38, 38)
 
  protected:

--- a/radio/src/gui/colorlcd/model/mixer_edit.cpp
+++ b/radio/src/gui/colorlcd/model/mixer_edit.cpp
@@ -81,7 +81,7 @@ static const lv_coord_t col_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(2),
                                      LV_GRID_TEMPLATE_LAST};
 static const lv_coord_t row_dsc[] = {LV_GRID_CONTENT, LV_GRID_TEMPLATE_LAST};
 #else
-static const lv_coord_t col_dsc[] = {LV_GRID_FR(2), LV_GRID_FR(3),
+static const lv_coord_t col_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(2),
                                      LV_GRID_TEMPLATE_LAST};
 static const lv_coord_t row_dsc[] = {LV_GRID_CONTENT, LV_GRID_CONTENT,
                                      LV_GRID_TEMPLATE_LAST};

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -437,8 +437,12 @@ char *getValueOrSrcVarString(char *dest, size_t len, gvar_t value, gvar_t vmin,
   SourceNumVal v;
   v.rawValue = value;
   if (v.isSource) {
-    const char* s = getSourceString(v.value);
-    strncpy(dest, s, len);
+    if (v.value >= MIXSRC_FIRST_GVAR && v.value <= MIXSRC_LAST_GVAR) {
+      getGVarString(dest, v.value - MIXSRC_FIRST_GVAR);
+    } else {
+      const char* s = getSourceString(v.value);
+      strncpy(dest, s, len);
+    }
   } else {
     v.value += offset;
     if (usePPMUnit && g_eeGeneral.ppmunit == PPM_US)


### PR DESCRIPTION
If the Weight value for an input or mix line is set to a GV, and the GV has a name, then just display the name instead of trying to show GVX:NAM in the list view (as it was pre PR 5220).

Fix layout for EL18 mix edit (remove horizontal scroll on Curve line).
