### PR TITLE
fix(color): min/max highlight in output list swapped if inverted

### DIFF
--- a/radio/src/gui/colorlcd/model/model_outputs.cpp
+++ b/radio/src/gui/colorlcd/model/model_outputs.cpp
@@ -211,16 +211,15 @@ class OutputLineButton : public ListLineButton
     if (value != newValue) {
       value = newValue;
 
-      const LimitData* output = limitAddress(index);
-      int chanZero = output->ppmCenter;
+      int chanVal = calcRESXto100(ex_chans[index]);
 
-      if (value < chanZero - 5) {
+      if (chanVal < -DEADBAND) {
         lv_obj_add_state(min, ETX_STATE_MINMAX_BOLD);
       } else {
         lv_obj_clear_state(min, ETX_STATE_MINMAX_BOLD);
       }
 
-      if (value > chanZero + 5) {
+      if (chanVal > DEADBAND) {
         lv_obj_add_state(max, ETX_STATE_MINMAX_BOLD);
       } else {
         lv_obj_clear_state(max, ETX_STATE_MINMAX_BOLD);

--- a/radio/src/gui/colorlcd/model/output_edit.cpp
+++ b/radio/src/gui/colorlcd/model/output_edit.cpp
@@ -30,16 +30,6 @@
 
 #define ETX_STATE_MINMAX_HIGHLIGHT LV_STATE_USER_1
 
-// deadband in % for switching direction of Min/Max text and value field highlighting
-// 0 = no deadband
-// 1..100 = [-DEADBAND; DEADBAND]
-#define DEADBAND 0
-
-// deadband in % for switching direction of Min/Max text and value field highlighting
-// 0 = no deadband
-// 1..100 = [-DEADBAND; DEADBAND]
-#define DEADBAND 0
-
 class OutputEditStatusBar : public Window
 {
  public:

--- a/radio/src/gui/colorlcd/model/output_edit.h
+++ b/radio/src/gui/colorlcd/model/output_edit.h
@@ -24,6 +24,11 @@
 #include "page.h"
 #include "gvar_numberedit.h"
 
+// deadband in % for switching direction of Min/Max text and value field highlighting
+// 0 = no deadband
+// 1..100 = [-DEADBAND; DEADBAND]
+#define DEADBAND 0
+
 class OutputEditStatusBar;
 
 class OutputEditWindow : public Page


### PR DESCRIPTION
Fixes #1989 

Use code from output edit page to highlight min/max values on output list page.
Fixes issue when output is inverted.