### PR TITLE
fix(color): ensure script loaded when Lua Script SF enabled

### DIFF
--- a/radio/src/gui/colorlcd/model/special_functions.cpp
+++ b/radio/src/gui/colorlcd/model/special_functions.cpp
@@ -608,7 +608,13 @@ void FunctionEditPage::updateSpecialFunctionOneWindow()
 
   line = specialFunctionOneWindow->newLine(grid);
   new StaticText(line, rect_t{}, STR_ENABLE);
-  new ToggleSwitch(line, rect_t{}, GET_SET_DEFAULT(CFN_ACTIVE(cfn)));
+  new ToggleSwitch(line, rect_t{}, GET_DEFAULT(CFN_ACTIVE(cfn)),
+            [=](int newValue) {
+              CFN_ACTIVE(cfn) = newValue;
+              SET_DIRTY();
+              if (CFN_FUNC(cfn) == FUNC_PLAY_SCRIPT || CFN_FUNC(cfn) == FUNC_RGB_LED)
+                LUA_LOAD_MODEL_SCRIPTS();
+            });
 }
 
 void FunctionEditPage::buildBody(Window *form)


### PR DESCRIPTION
A special function that runs a Lua script may not work when:
- the SF is first created and the Enable toggle is set to on in the SF edit page
- the SF is disabled, then re-enabled in the SF edit page

Disabling then re-enabling on the SF list view page, or restarting, will activate the SF.
