### PR TITLE
feat(color): show widget name in settings popups

### DIFF
--- a/radio/src/gui/colorlcd/mainview/widget.cpp
+++ b/radio/src/gui/colorlcd/mainview/widget.cpp
@@ -63,6 +63,7 @@ void Widget::openMenu()
     // covers the main view menu
     Window* w = parent->getFullScreenWindow()->getParent();
     Menu* menu = new Menu(w ? w : this);
+    menu->setTitle(getFactory()->getDisplayName());
     if (fsAllowed) {
       menu->addLine(STR_WIDGET_FULLSCREEN, [&]() { setFullscreen(true); });
     }

--- a/radio/src/gui/colorlcd/mainview/widget_settings.cpp
+++ b/radio/src/gui/colorlcd/mainview/widget_settings.cpp
@@ -43,7 +43,7 @@ static const lv_coord_t line_row_dsc[] = {LV_GRID_CONTENT,
                                           LV_GRID_TEMPLATE_LAST};
 
 WidgetSettings::WidgetSettings(Window* parent, Widget* w) :
-    BaseDialog(ViewMain::instance(), STR_WIDGET_SETTINGS, true), widget(w)
+    BaseDialog(ViewMain::instance(), w->getFactory()->getDisplayName(), true), widget(w)
 {
   FlexGridLayout grid(line_col_dsc, line_row_dsc);
   form->padAll(PAD_SMALL);

--- a/radio/src/gui/colorlcd/mainview/widgets_setup.cpp
+++ b/radio/src/gui/colorlcd/mainview/widgets_setup.cpp
@@ -91,8 +91,14 @@ void SetupWidgetsPageSlot::setFocusState()
 void SetupWidgetsPageSlot::addNewWidget(WidgetsContainer* container,
                                         uint8_t slotIndex)
 {
+  const char* cur = nullptr;
+  auto w = container->getWidget((slotIndex));
+  if (w) cur = w->getFactory()->getDisplayName();
+
   Menu* menu = new Menu(parent);
   menu->setTitle(STR_SELECT_WIDGET);
+  int selected = -1;
+  int index = 0;
   for (auto factory : WidgetFactory::getRegisteredWidgets()) {
     menu->addLine(factory->getDisplayName(), [=]() {
       container->createWidget(slotIndex, factory);
@@ -100,7 +106,13 @@ void SetupWidgetsPageSlot::addNewWidget(WidgetsContainer* container,
       if (widget->getOptions() && widget->getOptions()->name)
         new WidgetSettings(parent, widget);
     });
+    if (cur && strcmp(cur, factory->getDisplayName()) == 0)
+      selected = index;
+    index += 1;
   }
+
+  if (selected >= 0)
+    menu->select(selected);
 }
 
 SetupWidgetsPage::SetupWidgetsPage(uint8_t customScreenIdx) :


### PR DESCRIPTION
Fixes #4183 

- Show widget name in popup menu title on long press
- Show widget name in widget settings dialog title
- When 'Select widget' option is chosen on an existing widget, set selected item in menu to the current widget name

![screenshot_tx16s_24-08-04_09-15-40](https://github.com/user-attachments/assets/3a215d4e-dbe9-492a-9acc-52284a368fee)

![screenshot_tx16s_24-08-04_09-15-45](https://github.com/user-attachments/assets/f897dfa1-b348-42ed-b29a-b09ff4215b3e)
