### PR TITLE
fix(color): crash if radio shut down on some menu pages

### DIFF
--- a/radio/src/gui/colorlcd/libui/tabsgroup.cpp
+++ b/radio/src/gui/colorlcd/libui/tabsgroup.cpp
@@ -277,6 +277,8 @@ uint8_t TabsGroup::tabCount() const { return header->tabCount(); }
 
 void TabsGroup::setCurrentTab(unsigned index)
 {
+  if (deleted()) return;
+
   header->setCurrentIndex(index);
 
   PageTab* tab = header->pageTab(index);


### PR DESCRIPTION
Check deleted state to prevent crash when shutting down.
