### PR TITLE
fix(bw212): timer display on telemetry screen, main view

### DIFF
--- a/radio/src/gui/212x64/lcd.cpp
+++ b/radio/src/gui/212x64/lcd.cpp
@@ -550,8 +550,8 @@ void drawTelemetryTopBar()
     else
       val = timersStates[0].val;
     LcdFlags att = (val < 0 ? BLINK : 0) | TIMEHOUR;
-    drawTimer(22*FW, 0, val, att, att);
-    lcdDrawText(22*FW, 0, "T1:", RIGHT);
+    drawTimer(18*FW, 0, val, att, att);
+    lcdDrawText(18*FW, 0, "T1:", RIGHT);
   }
   if (g_model.timers[1].mode) {
     TimerData *timer =  &g_model.timers[1];
@@ -561,8 +561,8 @@ void drawTelemetryTopBar()
     else
       val = timersStates[1].val;
     LcdFlags att = (val < 0 ? BLINK : 0) | TIMEHOUR;
-    drawTimer(31*FW, 0, val, att, att);
-    lcdDrawText(31*FW, 0, "T2:", RIGHT);
+    drawTimer(28*FW, 0, val, att, att);
+    lcdDrawText(28*FW, 0, "T2:", RIGHT);
   }
   lcdInvertLine(0);
 }

--- a/radio/src/gui/212x64/view_main.cpp
+++ b/radio/src/gui/212x64/view_main.cpp
@@ -369,7 +369,7 @@ void displayTimers()
         val = (int)timerData.start - (int)timerState.val;
       drawTimer(TIMERS_X, y, val, TIMEHOUR|MIDSIZE|LEFT, TIMEHOUR|MIDSIZE|LEFT);
       if (timerData.persistent) {
-        lcdDrawChar(TIMERS_R, y+1, 'P', SMLSIZE);
+        lcdDrawChar(TIMERS_R, y-7, 'P', SMLSIZE);
       }
       if (timerState.val < 0) {
         if (BLINK_ON_PHASE) {


### PR DESCRIPTION
Fixes #5369

Summary of changes:
- T2 timer offscreen on telemetry screen
- The 'P' indicator for persistance was overlapping timer display on main view timer.

Both of these would have been fine pre https://github.com/EdgeTX/edgetx/pull/3871. 