### PR TITLE
fix(bw): unable to select GV as source for weight/offset/curve in input/mix

### DIFF
--- a/radio/src/dataconstants.h
+++ b/radio/src/dataconstants.h
@@ -545,7 +545,7 @@ enum MixSources {
 };
 
 
-#define MIXSRC_LAST                 MIXSRC_LAST_CH
+#define MIXSRC_LAST                 MIXSRC_LAST_GVAR
 #define INPUTSRC_FIRST              MIXSRC_FIRST_STICK
 #define INPUTSRC_LAST               MIXSRC_LAST_TELEM
 

--- a/radio/src/gui/128x64/gui.h
+++ b/radio/src/gui/128x64/gui.h
@@ -82,7 +82,7 @@ swsrc_t editSwitch(coord_t x, coord_t y, swsrc_t value, LcdFlags attr,
 
 uint16_t editSrcVarFieldValue(coord_t x, coord_t y, const char* title, uint16_t value,
                               int16_t min, int16_t max, LcdFlags attr, event_t event,
-                              IsValueAvailable isValueAvailable, int16_t sourceMin);
+                              IsValueAvailable isValueAvailable, int16_t sourceMin, int16_t sourceMax);
 
 #if defined(GVARS)
 
@@ -201,7 +201,7 @@ void showAlertBox(const char * title, const char * text, const char * action , u
 #define IS_OTHER_VIEW_DISPLAYED()      menuHandlers[0] == menuChannelsView
 
 void editCurveRef(coord_t x, coord_t y, CurveRef & curve, event_t event, LcdFlags flags,
-                  IsValueAvailable isValueAvailable, int16_t sourceMin);
+                  IsValueAvailable isValueAvailable, int16_t sourceMin, int16_t sourceMax);
 
 #if defined(FLIGHT_MODES)
 void displayFlightModes(coord_t x, coord_t y, FlightModesType value);

--- a/radio/src/gui/128x64/model_input_edit.cpp
+++ b/radio/src/gui/128x64/model_input_edit.cpp
@@ -117,12 +117,12 @@ void menuModelExpoOne(event_t event)
 
       case EXPO_FIELD_WEIGHT:
         ed->weight = editSrcVarFieldValue(EXPO_ONE_2ND_COLUMN, y, STR_WEIGHT, ed->weight,
-                        -100, 100, attr, event, isSourceAvailableInInputs, INPUTSRC_FIRST);
+                        -100, 100, attr, event, isSourceAvailableInInputs, INPUTSRC_FIRST, INPUTSRC_LAST);
         break;
 
       case EXPO_FIELD_OFFSET:
         ed->offset = editSrcVarFieldValue(EXPO_ONE_2ND_COLUMN, y, STR_OFFSET, ed->offset,
-                        -100, 100, attr, event, isSourceAvailableInInputs, INPUTSRC_FIRST);
+                        -100, 100, attr, event, isSourceAvailableInInputs, INPUTSRC_FIRST, INPUTSRC_LAST);
         break;
 
       case EXPO_FIELD_CURVE_LABEL:
@@ -130,7 +130,7 @@ void menuModelExpoOne(event_t event)
         break;
 
       case EXPO_FIELD_CURVE:
-        editCurveRef(FW + 1, y, ed->curve, event, attr, isSourceAvailableInInputs, INPUTSRC_FIRST);
+        editCurveRef(FW + 1, y, ed->curve, event, attr, isSourceAvailableInInputs, INPUTSRC_FIRST, INPUTSRC_LAST);
         break;
 
 #if defined(FLIGHT_MODES)

--- a/radio/src/gui/128x64/model_mix_edit.cpp
+++ b/radio/src/gui/128x64/model_mix_edit.cpp
@@ -140,12 +140,12 @@ void menuModelMixOne(event_t event)
 
       case MIX_FIELD_WEIGHT:
         md2->weight = editSrcVarFieldValue(MIXES_2ND_COLUMN, y, STR_WEIGHT, md2->weight, 
-                        MIX_WEIGHT_MIN, MIX_WEIGHT_MAX, attr, event, isSourceAvailable, 1);
+                        MIX_WEIGHT_MIN, MIX_WEIGHT_MAX, attr, event, isSourceAvailable, 1, MIXSRC_LAST);
         break;
 
       case MIX_FIELD_OFFSET:
         md2->offset = editSrcVarFieldValue(MIXES_2ND_COLUMN, y, STR_OFFSET, md2->offset,
-                        MIX_OFFSET_MIN, MIX_OFFSET_MAX, attr, event, isSourceAvailable, 1);
+                        MIX_OFFSET_MIN, MIX_OFFSET_MAX, attr, event, isSourceAvailable, 1, MIXSRC_LAST);
         drawOffsetBar(LCD_W - 33, y, md2);
         break;
 
@@ -159,7 +159,7 @@ void menuModelMixOne(event_t event)
         lcdDrawTextAlignedLeft(y, STR_CURVE);
         s_currSrcRaw = md2->srcRaw;
         s_currScale = 0;
-        editCurveRef(MIXES_2ND_COLUMN, y, md2->curve, event, attr, isSourceAvailable, 1);
+        editCurveRef(MIXES_2ND_COLUMN, y, md2->curve, event, attr, isSourceAvailable, 1, MIXSRC_LAST);
         break;
 
 #if defined(FLIGHT_MODES)

--- a/radio/src/gui/128x64/widgets.cpp
+++ b/radio/src/gui/128x64/widgets.cpp
@@ -164,7 +164,7 @@ void drawSlider(coord_t x, coord_t y, uint8_t value, uint8_t max, uint8_t attr)
 
 uint16_t editSrcVarFieldValue(coord_t x, coord_t y, const char* title, uint16_t value,
                               int16_t min, int16_t max, LcdFlags attr, event_t event,
-                              IsValueAvailable isValueAvailable, int16_t sourceMin)
+                              IsValueAvailable isValueAvailable, int16_t sourceMin, int16_t sourceMax)
 {
   if (title)
     lcdDrawTextAlignedLeft(y, title);
@@ -173,14 +173,15 @@ uint16_t editSrcVarFieldValue(coord_t x, coord_t y, const char* title, uint16_t 
   if (v.isSource) {
     drawSource(x, y, v.value, attr);
     if (attr & (~RIGHT)) {
-      value = checkIncDec(event, value, sourceMin, MIXSRC_LAST,
+      value = checkIncDec(event, value, sourceMin, sourceMax,
                 EE_MODEL|INCDEC_SOURCE|INCDEC_SOURCE_VALUE|INCDEC_SOURCE_INVERT|NO_INCDEC_MARKS, isValueAvailable);
     }
   } else {
     lcdDrawNumber(x, y, v.value, attr);
     if (attr & (~RIGHT)) {
-      value = checkIncDec(event, value, min, max,
-                EE_MODEL|INCDEC_SOURCE_VALUE|NO_INCDEC_MARKS|(sourceMin == INPUTSRC_FIRST ? INCDEC_SOURCE_NOINPUTS : 0));
+      value = checkIncDec(event, value, min, max, sourceMin, sourceMax,
+                EE_MODEL|INCDEC_SOURCE_VALUE|NO_INCDEC_MARKS,
+                isValueAvailable);
     }
   }
   return value;

--- a/radio/src/gui/212x64/gui.h
+++ b/radio/src/gui/212x64/gui.h
@@ -92,7 +92,7 @@ swsrc_t editSwitch(coord_t x, coord_t y, swsrc_t value, LcdFlags attr,
 
 uint16_t editSrcVarFieldValue(coord_t x, coord_t y, const char* title, uint16_t value,
                               int16_t min, int16_t max, LcdFlags attr, event_t event,
-                              IsValueAvailable isValueAvailable, int16_t sourceMin);
+                              IsValueAvailable isValueAvailable, int16_t sourceMin, int16_t sourceMax);
 
 #if defined(GVARS)
 void drawGVarValue(coord_t x, coord_t y, uint8_t gvar, gvar_t value,
@@ -121,7 +121,7 @@ int16_t editGVarFieldValue(coord_t x, coord_t y, int16_t value, int16_t min,
 #endif
 
 void editCurveRef(coord_t x, coord_t y, CurveRef & curve, event_t event, LcdFlags flags,
-                  IsValueAvailable isValueAvailable, int16_t sourceMin);
+                  IsValueAvailable isValueAvailable, int16_t sourceMin, int16_t sourceMax);
 
 extern uint8_t editNameCursorPos;
 

--- a/radio/src/gui/212x64/model_input_edit.cpp
+++ b/radio/src/gui/212x64/model_input_edit.cpp
@@ -120,17 +120,17 @@ void menuModelExpoOne(event_t event)
 
       case EXPO_FIELD_WEIGHT:
         ed->weight = editSrcVarFieldValue(EXPO_ONE_2ND_COLUMN, y, STR_WEIGHT, ed->weight,
-                        -100, 100, attr, event, isSourceAvailableInInputs, INPUTSRC_FIRST);
+                        -100, 100, attr, event, isSourceAvailableInInputs, INPUTSRC_FIRST, INPUTSRC_LAST);
         break;
 
       case EXPO_FIELD_OFFSET:
         ed->offset = editSrcVarFieldValue(EXPO_ONE_2ND_COLUMN, y, STR_OFFSET, ed->offset,
-                        -100, 100, attr, event, isSourceAvailableInInputs, INPUTSRC_FIRST);
+                        -100, 100, attr, event, isSourceAvailableInInputs, INPUTSRC_FIRST, INPUTSRC_LAST);
         break;
 
       case EXPO_FIELD_CURVE:
         lcdDrawTextAlignedLeft(y, STR_CURVE);
-        editCurveRef(EXPO_ONE_2ND_COLUMN, y, ed->curve, event, attr, isSourceAvailableInInputs, INPUTSRC_FIRST);
+        editCurveRef(EXPO_ONE_2ND_COLUMN, y, ed->curve, event, attr, isSourceAvailableInInputs, INPUTSRC_FIRST, INPUTSRC_LAST);
         break;
 
 #if defined(FLIGHT_MODES)

--- a/radio/src/gui/212x64/model_mix_edit.cpp
+++ b/radio/src/gui/212x64/model_mix_edit.cpp
@@ -134,12 +134,12 @@ void menuModelMixOne(event_t event)
 
       case MIX_FIELD_WEIGHT:
         md2->weight = editSrcVarFieldValue(MIXES_2ND_COLUMN, y, STR_WEIGHT, md2->weight, 
-                        MIX_WEIGHT_MIN, MIX_WEIGHT_MAX, attr, event, isSourceAvailable, 1);
+                        MIX_WEIGHT_MIN, MIX_WEIGHT_MAX, attr, event, isSourceAvailable, 1, MIXSRC_LAST);
         break;
 
       case MIX_FIELD_OFFSET:
         md2->offset = editSrcVarFieldValue(MIXES_2ND_COLUMN, y, STR_OFFSET, md2->offset,
-                        MIX_OFFSET_MIN, MIX_OFFSET_MAX, attr, event, isSourceAvailable, 1);
+                        MIX_OFFSET_MIN, MIX_OFFSET_MAX, attr, event, isSourceAvailable, 1, MIXSRC_LAST);
         drawOffsetBar(MIXES_2ND_COLUMN+35, y, md2);
         break;
 
@@ -155,7 +155,7 @@ void menuModelMixOne(event_t event)
         lcdDrawTextAlignedLeft(y, STR_CURVE);
         s_currSrcRaw = md2->srcRaw;
         s_currScale = 0;
-        editCurveRef(MIXES_2ND_COLUMN, y, md2->curve, event, attr, isSourceAvailable, 1);
+        editCurveRef(MIXES_2ND_COLUMN, y, md2->curve, event, attr, isSourceAvailable, 1, MIXSRC_LAST);
         break;
 
 #if defined(FLIGHT_MODES)

--- a/radio/src/gui/212x64/widgets.cpp
+++ b/radio/src/gui/212x64/widgets.cpp
@@ -122,7 +122,7 @@ void drawSlider(coord_t x, coord_t y, uint8_t value, uint8_t max, uint8_t attr)
 
 uint16_t editSrcVarFieldValue(coord_t x, coord_t y, const char* title, uint16_t value,
                               int16_t min, int16_t max, LcdFlags attr, event_t event,
-                              IsValueAvailable isValueAvailable, int16_t sourceMin)
+                              IsValueAvailable isValueAvailable, int16_t sourceMin, int16_t sourceMax)
 {
   if (title)
     lcdDrawTextAlignedLeft(y, title);
@@ -131,14 +131,15 @@ uint16_t editSrcVarFieldValue(coord_t x, coord_t y, const char* title, uint16_t 
   if (v.isSource) {
     drawSource(x, y, v.value, attr);
     if (attr & (~RIGHT)) {
-      value = checkIncDec(event, value, sourceMin,
-                MIXSRC_LAST, EE_MODEL|INCDEC_SOURCE|INCDEC_SOURCE_VALUE|INCDEC_SOURCE_INVERT|NO_INCDEC_MARKS, isValueAvailable);
+      value = checkIncDec(event, value, sourceMin, sourceMax,
+                EE_MODEL|INCDEC_SOURCE|INCDEC_SOURCE_VALUE|INCDEC_SOURCE_INVERT|NO_INCDEC_MARKS, isValueAvailable);
     }
   } else {
     lcdDrawNumber(x, y, v.value, attr);
     if (attr & (~RIGHT)) {
-      value = checkIncDec(event, value, min, max,
-                EE_MODEL|INCDEC_SOURCE_VALUE|NO_INCDEC_MARKS|(sourceMin == INPUTSRC_FIRST ? INCDEC_SOURCE_NOINPUTS : 0));
+      value = checkIncDec(event, value, min, max, sourceMin, sourceMax,
+                EE_MODEL|INCDEC_SOURCE_VALUE|NO_INCDEC_MARKS,
+                isValueAvailable);
     }
   }
   return value;

--- a/radio/src/gui/common/stdlcd/draw_functions.cpp
+++ b/radio/src/gui/common/stdlcd/draw_functions.cpp
@@ -398,12 +398,12 @@ void drawCurveRef(coord_t x, coord_t y, CurveRef & curve, LcdFlags att)
     switch (curve.type) {
       case CURVE_REF_DIFF:
         lcdDrawText(x, y, "D", att);
-        editSrcVarFieldValue(lcdNextPos, y, nullptr, curve.value, -100, 100, LEFT|att, 0, 0, 0);
+        editSrcVarFieldValue(lcdNextPos, y, nullptr, curve.value, -100, 100, LEFT|att, 0, 0, MIXSRC_FIRST, INPUTSRC_LAST);
         break;
 
       case CURVE_REF_EXPO:
         lcdDrawText(x, y, "E", att);
-        editSrcVarFieldValue(lcdNextPos, y, nullptr, curve.value, -100, 100, LEFT|att, 0, 0, 0);
+        editSrcVarFieldValue(lcdNextPos, y, nullptr, curve.value, -100, 100, LEFT|att, 0, 0, MIXSRC_FIRST, INPUTSRC_LAST);
         break;
 
       case CURVE_REF_FUNC:

--- a/radio/src/gui/common/stdlcd/model_curves.cpp
+++ b/radio/src/gui/common/stdlcd/model_curves.cpp
@@ -97,7 +97,7 @@ void menuModelCurvesAll(event_t event)
 }
 
 void editCurveRef(coord_t x, coord_t y, CurveRef & curve, event_t event, LcdFlags flags,
-                  IsValueAvailable isValueAvailable, int16_t sourceMin)
+                  IsValueAvailable isValueAvailable, int16_t sourceMin, int16_t sourceMax)
 {
   coord_t x1 = x;
   LcdFlags flags1 = flags;
@@ -127,7 +127,7 @@ void editCurveRef(coord_t x, coord_t y, CurveRef & curve, event_t event, LcdFlag
   switch (curve.type) {
     case CURVE_REF_DIFF:
     case CURVE_REF_EXPO:
-      curve.value = editSrcVarFieldValue(x, y, nullptr, curve.value, -100, 100, flags, event, isValueAvailable, sourceMin);
+      curve.value = editSrcVarFieldValue(x, y, nullptr, curve.value, -100, 100, flags, event, isValueAvailable, sourceMin, sourceMax);
       break;
     case CURVE_REF_FUNC:
     {

--- a/radio/src/gui/common/stdlcd/model_inputs.cpp
+++ b/radio/src/gui/common/stdlcd/model_inputs.cpp
@@ -415,7 +415,7 @@ void menuModelExposAll(event_t event)
         if (cur-menuVerticalOffset >= 0 && cur-menuVerticalOffset < NUM_BODY_LINES) {
           editSrcVarFieldValue(EXPO_LINE_WEIGHT_POS, y, nullptr, ed->weight,
                         -100, 100, RIGHT | (isExpoActive(i) ? BOLD : 0),
-                        0, 0, 0);
+                        0, 0, MIXSRC_FIRST, INPUTSRC_LAST);
           displayExpoLine(y, ed, 0);
           
           if (s_copyMode) {

--- a/radio/src/gui/common/stdlcd/model_mixes.cpp
+++ b/radio/src/gui/common/stdlcd/model_mixes.cpp
@@ -339,7 +339,7 @@ void menuModelMixAll(event_t event)
           else {
             editSrcVarFieldValue(MIX_LINE_WEIGHT_POS, y, nullptr, md->weight, 
                         MIX_WEIGHT_MIN, MIX_WEIGHT_MAX, RIGHT | ((isMixActive(i) ? BOLD : 0)),
-                        0, 0, 0);
+                        0, 0, MIXSRC_FIRST, INPUTSRC_LAST);
           }
 
 #if LCD_W >= 212

--- a/radio/src/gui/navigation/navigation.cpp
+++ b/radio/src/gui/navigation/navigation.cpp
@@ -86,6 +86,13 @@ uint8_t menuIdx(const MenuHandler * menuTab, uint8_t curr)
   return menuSize(menuTab, curr + 1) - 1;
 }
 
+void addPopupItem(int i_min, int i_max, int rangeMin, int rangeMax, IsValueAvailable isValueAvailable, const char* menuItem)
+{
+  if (i_min <= rangeMin && i_max >= rangeMin && getFirstAvailable(rangeMin, rangeMax, isValueAvailable) != MIXSRC_NONE) {
+    POPUP_MENU_ADD_ITEM(menuItem);
+  }
+}
+
 inline int showPopupMenus(event_t event, int newval, int i_min, int i_max,
                           unsigned int i_flags, IsValueAvailable isValueAvailable,
                           bool& isSource)
@@ -98,19 +105,9 @@ inline int showPopupMenus(event_t event, int newval, int i_min, int i_max,
         POPUP_MENU_ADD_ITEM(STR_CONSTANT);
       }
 
-      if (i_min <= MIXSRC_FIRST_INPUT && i_max >= MIXSRC_FIRST_INPUT) {
-        if (getFirstAvailable(MIXSRC_FIRST_INPUT, MIXSRC_LAST_INPUT, isInputAvailable) != MIXSRC_NONE &&
-            (i_flags & INCDEC_SOURCE_NOINPUTS) == 0) {
-          POPUP_MENU_ADD_ITEM(STR_MENU_INPUTS);
-        }
-      }
+      addPopupItem(i_min, i_max, MIXSRC_FIRST_INPUT, MIXSRC_LAST_INPUT, isValueAvailable, STR_MENU_INPUTS);
 #if defined(LUA_MODEL_SCRIPTS)
-      if (i_min <= MIXSRC_FIRST_LUA && i_max >= MIXSRC_FIRST_LUA) {
-        if (getFirstAvailable(MIXSRC_FIRST_LUA, MIXSRC_LAST_LUA, isSourceAvailable) != MIXSRC_NONE &&
-            (i_flags & INCDEC_SOURCE_NOINPUTS) == 0) {
-          POPUP_MENU_ADD_ITEM(STR_MENU_LUA);
-        }
-      }
+      addPopupItem(i_min, i_max, MIXSRC_FIRST_LUA, MIXSRC_LAST_LUA, isValueAvailable, STR_MENU_LUA);
 #endif
       if (i_min <= MIXSRC_FIRST_STICK && i_max >= MIXSRC_FIRST_STICK)      POPUP_MENU_ADD_ITEM(STR_MENU_STICKS);
       if (i_min <= MIXSRC_FIRST_POT && i_max >= MIXSRC_FIRST_POT)          POPUP_MENU_ADD_ITEM(STR_MENU_POTS);
@@ -118,16 +115,13 @@ inline int showPopupMenus(event_t event, int newval, int i_min, int i_max,
       if (i_min <= MIXSRC_MAX && i_max >= MIXSRC_MAX)                      POPUP_MENU_ADD_ITEM(STR_MENU_MAX);
 #if defined(HELI)
       if (modelHeliEnabled())
-        if (i_min <= MIXSRC_FIRST_HELI && i_max >= MIXSRC_FIRST_HELI && isValueAvailable && isValueAvailable(MIXSRC_FIRST_HELI))
-          POPUP_MENU_ADD_ITEM(STR_MENU_HELI);
+        addPopupItem(i_min, i_max, MIXSRC_FIRST_HELI, MIXSRC_LAST_HELI, isValueAvailable, STR_MENU_HELI);
 #endif
       if (i_min <= MIXSRC_FIRST_TRIM && i_max >= MIXSRC_FIRST_TRIM)        POPUP_MENU_ADD_ITEM(STR_MENU_TRIMS);
       if (i_min <= MIXSRC_FIRST_SWITCH && i_max >= MIXSRC_FIRST_SWITCH)    POPUP_MENU_ADD_ITEM(STR_MENU_SWITCHES);
-      if (i_min <= MIXSRC_FIRST_TRAINER && i_max >= MIXSRC_FIRST_TRAINER)  POPUP_MENU_ADD_ITEM(STR_MENU_TRAINER);
+      addPopupItem(i_min, i_max, MIXSRC_FIRST_TRAINER, MIXSRC_LAST_TRAINER, isValueAvailable, STR_MENU_TRAINER);
       if (i_min <= MIXSRC_FIRST_CH && i_max >= MIXSRC_FIRST_CH)            POPUP_MENU_ADD_ITEM(STR_MENU_CHANNELS);
-      if (i_min <= MIXSRC_FIRST_GVAR && i_max >= MIXSRC_FIRST_GVAR && isValueAvailable && isValueAvailable(MIXSRC_FIRST_GVAR)) {
-        POPUP_MENU_ADD_ITEM(STR_MENU_GVARS);
-      }
+      addPopupItem(i_min, i_max, MIXSRC_FIRST_GVAR, MIXSRC_LAST_GVAR, isValueAvailable, STR_MENU_GVARS);
 
       if (modelTelemetryEnabled() && i_min <= MIXSRC_FIRST_TELEM && i_max >= MIXSRC_FIRST_TELEM) {
         for (int i = 0; i < MAX_TELEMETRY_SENSORS; i++) {

--- a/radio/src/gui/navigation/navigation.h
+++ b/radio/src/gui/navigation/navigation.h
@@ -75,9 +75,12 @@ extern int8_t s_editMode; // global editmode
 #define NO_DBLKEYS                     0x80
 #define INCDEC_SOURCE_INVERT           0x100
 #define INCDEC_SOURCE_VALUE            0x200  // Field can be source or value
-#define INCDEC_SOURCE_NOINPUTS         0x400  // Do not allow Inputs in source selection
 
 int checkIncDec(event_t event, int val, int i_min, int i_max,
+                unsigned int i_flags = 0, IsValueAvailable isValueAvailable = nullptr,
+                const CheckIncDecStops &stops = stops100);
+
+int checkIncDec(event_t event, int val, int i_min, int i_max, int srcMin, int srcMax,
                 unsigned int i_flags = 0, IsValueAvailable isValueAvailable = nullptr,
                 const CheckIncDecStops &stops = stops100);
 

--- a/radio/src/gui/navigation/navigation_9x.cpp
+++ b/radio/src/gui/navigation/navigation_9x.cpp
@@ -25,6 +25,13 @@ int checkIncDec(event_t event, int val, int i_min, int i_max,
                 unsigned int i_flags, IsValueAvailable isValueAvailable,
                 const CheckIncDecStops &stops)
 {
+  return checkIncDec(event, val, i_min, i_max, i_min, i_max, i_flags, isValueAvailable, stops);
+}
+
+int checkIncDec(event_t event, int val, int i_min, int i_max, int srcMin, int srcMax,
+                unsigned int i_flags, IsValueAvailable isValueAvailable,
+                const CheckIncDecStops &stops)
+{
   int newval = val;
 
   bool isSource = false;
@@ -92,7 +99,7 @@ int checkIncDec(event_t event, int val, int i_min, int i_max,
 
   newval = checkBoolean(event, i_min, i_max, newval, val);
 
-  newval = showPopupMenus(event, newval, i_min, i_max, i_flags, isValueAvailable, isSource);
+  newval = showPopupMenus(event, newval, srcMin, srcMax, i_flags, isValueAvailable, isSource);
 
   finishCheckIncDec(event, i_min, i_max, i_flags, newval, val, stops);
 

--- a/radio/src/gui/navigation/navigation_x7.cpp
+++ b/radio/src/gui/navigation/navigation_x7.cpp
@@ -33,6 +33,13 @@ int checkIncDec(event_t event, int val, int i_min, int i_max,
                 unsigned int i_flags, IsValueAvailable isValueAvailable,
                 const CheckIncDecStops &stops)
 {
+  return checkIncDec(event, val, i_min, i_max, i_min, i_max, i_flags, isValueAvailable, stops);
+}
+
+int checkIncDec(event_t event, int val, int i_min, int i_max, int srcMin, int srcMax,
+                unsigned int i_flags, IsValueAvailable isValueAvailable,
+                const CheckIncDecStops &stops)
+{
   int newval = val;
   event_t evt_rot_inc = EVT_ROTARY_RIGHT;
   event_t evt_rot_dec = EVT_ROTARY_LEFT;
@@ -109,7 +116,7 @@ int checkIncDec(event_t event, int val, int i_min, int i_max,
 
   newval = checkBoolean(event, i_min, i_max, newval, val);
 
-  newval = showPopupMenus(event, newval, i_min, i_max, i_flags, isValueAvailable, isSource);
+  newval = showPopupMenus(event, newval, srcMin, srcMax, i_flags, isValueAvailable, isSource);
 
   finishCheckIncDec(event, i_min, i_max, i_flags, newval, val, stops);
 


### PR DESCRIPTION
Fixes for B&W radios from PR #5220:
- Fix source selection for weight/offset/curve to allow GV selection.
- Allow GV as source for mixer lines.
- Filter empty categories from source select popup.

Fixes https://github.com/EdgeTX/edgetx/issues/4007