### PR TITLE
fix(bw): change char selection order when editing names

### DIFF
--- a/companion/src/shared/namevalidator.h
+++ b/companion/src/shared/namevalidator.h
@@ -25,7 +25,7 @@
 #include "textvalidator.h"
 
 // characters supportd by B&W radio firmware gui editor
-constexpr char NAME_VALID_PATTERN_BW[]    {"[ A-Za-z0-9\\-\\,\\.]*"};
+constexpr char NAME_VALID_PATTERN_BW[]    {"[ A-Za-z0-9\\_\\-\\,\\.]*"};
 // characters supported by color radio firmware keyboard widget
 constexpr char NAME_VALID_PATTERN_COLOR[] {"[ A-Za-z0-9\\-\\_\\,\\.\"\\+\\/\\*\\=\\%\\!\\?\\#\\<\\>\\@\\$\\(\\)\\{\\}\\[\\]\\;\\:\\']*"};
 

--- a/companion/src/shared/namevalidator.h
+++ b/companion/src/shared/namevalidator.h
@@ -25,7 +25,7 @@
 #include "textvalidator.h"
 
 // characters supportd by B&W radio firmware gui editor
-constexpr char NAME_VALID_PATTERN_BW[]    {"[ A-Za-z0-9\\-]*"};
+constexpr char NAME_VALID_PATTERN_BW[]    {"[ A-Za-z0-9\\-\\,\\.]*"};
 // characters supported by color radio firmware keyboard widget
 constexpr char NAME_VALID_PATTERN_COLOR[] {"[ A-Za-z0-9\\-\\_\\,\\.\"\\+\\/\\*\\=\\%\\!\\?\\#\\<\\>\\@\\$\\(\\)\\{\\}\\[\\]\\;\\:\\']*"};
 

--- a/radio/src/gui/common/stdlcd/draw_functions.cpp
+++ b/radio/src/gui/common/stdlcd/draw_functions.cpp
@@ -159,26 +159,17 @@ char getPreviousChar(char c, uint8_t position)
   return c - 1;
 }
 
-static bool isNameCharset(int v)
+static const char nameChars[] = " abcdefghijklmnopqrstuvwxyz0123456789-,.";
+
+static int nameCharIdx(char v)
 {
-  char c = (char)v;
-
-  if (c == ' ')
-    return true;
-
-  if (c == '-')
-    return true;
-
-  if (c >= '0' && c <= '9')
-    return true;
-
-  if (c >= 'A' && c <= 'Z')
-    return true;
-
-  if (c >= 'a' && c <= 'z')
-    return true;
-
-  return false;
+  if (islower(v)) return v - 'a' + 1;
+  if (isupper(v)) return v - 'A' + 1;
+  if (isdigit(v)) return v - '0' + 27;
+  if (v == '-') return 37;
+  if (v == ',') return 38;
+  if (v == '.') return 39;
+  return 0;
 }
 
 void editName(coord_t x, coord_t y, char* name, uint8_t size, event_t event,
@@ -202,7 +193,9 @@ void editName(coord_t x, coord_t y, char* name, uint8_t size, event_t event,
       int8_t v = c ? c : ' ';
 
       if (IS_NEXT_EVENT(event) || IS_PREVIOUS_EVENT(event)) {
-        v = checkIncDec(event, abs(v), ' ', 'z', 0, isNameCharset);
+        bool caps = isupper(v);
+        v = nameChars[checkIncDec(event, nameCharIdx(v), 0, DIM(nameChars)-2)];
+        if (caps && islower(v)) v = toupper(v);
       }
 
       switch (event) {

--- a/radio/src/gui/common/stdlcd/draw_functions.cpp
+++ b/radio/src/gui/common/stdlcd/draw_functions.cpp
@@ -159,16 +159,17 @@ char getPreviousChar(char c, uint8_t position)
   return c - 1;
 }
 
-static const char nameChars[] = " abcdefghijklmnopqrstuvwxyz0123456789-,.";
+static const char nameChars[] = " abcdefghijklmnopqrstuvwxyz0123456789_-,.";
 
 static int nameCharIdx(char v)
 {
   if (islower(v)) return v - 'a' + 1;
   if (isupper(v)) return v - 'A' + 1;
   if (isdigit(v)) return v - '0' + 27;
-  if (v == '-') return 37;
-  if (v == ',') return 38;
-  if (v == '.') return 39;
+  if (v == '_') return 37;
+  if (v == '-') return 38;
+  if (v == ',') return 39;
+  if (v == '.') return 40;
   return 0;
 }
 


### PR DESCRIPTION
Fixes #1858 and fixes #4618 

Change the order of character selection to:
```C
        " abcdefghijklmnopqrstuvwxyz0123456789-,."
```

Use long press to change case.
