### PR TITLE
fix(color): view refresh issues after opening telemetry sensor edit page

### DIFF
--- a/radio/src/gui/colorlcd/model/model_telemetry.cpp
+++ b/radio/src/gui/colorlcd/model/model_telemetry.cpp
@@ -403,6 +403,7 @@ class SensorEditWindow : public SubPage
   {
     buildHeader(header);
     buildBody(body);
+    enableRefresh();
   }
 
  protected:


### PR DESCRIPTION
Fixes #5400

Enable LVGL refresh after building sensor edit page.