### PR TITLE
fix(color): fullscreen dialog may appear over the main view UI

### DIFF
--- a/radio/src/gui/colorlcd/mainview/view_main_menu.cpp
+++ b/radio/src/gui/colorlcd/mainview/view_main_menu.cpp
@@ -59,7 +59,7 @@ static lv_obj_t* etx_modal_dialog_create(lv_obj_t* parent)
 }
 
 ViewMainMenu::ViewMainMenu(Window* parent, std::function<void()> closeHandler) :
-    Window(parent->getFullScreenWindow(), {0, 0, LCD_W, LCD_H}),
+    Window(parent, {0, 0, LCD_W, LCD_H}),
     closeHandler(std::move(closeHandler))
 {
   // Save focus


### PR DESCRIPTION
Steps to reproduce:
- load a model with failsafe not set
- before the 'Failsafe warning' dialog pops up, tap the screen to open the quick menu.

The failsafe warning page will show with the main view UI still visible underneath.
