### PR TITLE
feat(color): scroll menu bar so selected tab icon is always visible

### DIFF
--- a/radio/src/gui/colorlcd/libui/tabsgroup.cpp
+++ b/radio/src/gui/colorlcd/libui/tabsgroup.cpp
@@ -169,7 +169,14 @@ class TabsGroupHeader : public Window
       buttons[currentIndex]->check(false);
       currentIndex = index;
       buttons[currentIndex]->check(true);
-      selectedIcon->setPos(getX(currentIndex), 0);
+      coord_t x = getX(currentIndex);
+      selectedIcon->setPos(x, 0);
+      coord_t sx = lv_obj_get_scroll_x(carousel->getLvObj());
+      if (x + MENU_HEADER_BUTTON_WIDTH - sx > carousel->width()) {
+        lv_obj_scroll_to(carousel->getLvObj(), x + MENU_HEADER_BUTTON_WIDTH - carousel->width(), 0, LV_ANIM_OFF);
+      } else if (x < sx) {
+        lv_obj_scroll_to(carousel->getLvObj(), x, 0, LV_ANIM_OFF);
+      }
     }
   }
 


### PR DESCRIPTION
Scroll the menu bar in the Radio, Model and Screen setup pages to keep the selected tab icon visible.

Fixes issue on NV14/EL18, where selected tab icon goes off screen, when use hat trims as keys and paging left/right to select tabs.

Resolves #4133