### PR TITLE
feat: allow an 'input' as the source for weight, offset and curve in input line

### DIFF
--- a/companion/src/modeledit/expodialog.cpp
+++ b/companion/src/modeledit/expodialog.cpp
@@ -52,7 +52,7 @@ ExpoDialog::ExpoDialog(QWidget *parent, ModelData & model, ExpoData *expoData, G
   setWindowTitle(tr("Edit %1").arg(RawSource(srcType, ed->chn).toString(&model, &generalSettings)));
 
   int imId = dialogFilteredItemModels->registerItemModel(new FilteredItemModel(sharedItemModels->getItemModel(AbstractItemModel::IMID_RawSource),
-                                (RawSource::AllSourceGroups & ~RawSource::NoneGroup & ~RawSource::ScriptsGroup & ~RawSource::InputsGroup)),
+                                (RawSource::AllSourceGroups & ~RawSource::NoneGroup & ~RawSource::ScriptsGroup)),
                                 "EditorSource");
 
   FilteredItemModel *esMdl = dialogFilteredItemModels->getItemModel(imId);

--- a/radio/src/gui/128x64/model_input_edit.cpp
+++ b/radio/src/gui/128x64/model_input_edit.cpp
@@ -117,12 +117,12 @@ void menuModelExpoOne(event_t event)
 
       case EXPO_FIELD_WEIGHT:
         ed->weight = editSrcVarFieldValue(EXPO_ONE_2ND_COLUMN, y, STR_WEIGHT, ed->weight,
-                        -100, 100, attr, event, isSourceAvailableInInputs, INPUTSRC_FIRST, INPUTSRC_LAST);
+                        -100, 100, attr, event, isSourceAvailable, MIXSRC_FIRST, INPUTSRC_LAST);
         break;
 
       case EXPO_FIELD_OFFSET:
         ed->offset = editSrcVarFieldValue(EXPO_ONE_2ND_COLUMN, y, STR_OFFSET, ed->offset,
-                        -100, 100, attr, event, isSourceAvailableInInputs, INPUTSRC_FIRST, INPUTSRC_LAST);
+                        -100, 100, attr, event, isSourceAvailable, MIXSRC_FIRST, INPUTSRC_LAST);
         break;
 
       case EXPO_FIELD_CURVE_LABEL:
@@ -130,7 +130,7 @@ void menuModelExpoOne(event_t event)
         break;
 
       case EXPO_FIELD_CURVE:
-        editCurveRef(FW + 1, y, ed->curve, event, attr, isSourceAvailableInInputs, INPUTSRC_FIRST, INPUTSRC_LAST);
+        editCurveRef(FW + 1, y, ed->curve, event, attr, isSourceAvailable, MIXSRC_FIRST, INPUTSRC_LAST);
         break;
 
 #if defined(FLIGHT_MODES)

--- a/radio/src/gui/212x64/model_input_edit.cpp
+++ b/radio/src/gui/212x64/model_input_edit.cpp
@@ -120,17 +120,17 @@ void menuModelExpoOne(event_t event)
 
       case EXPO_FIELD_WEIGHT:
         ed->weight = editSrcVarFieldValue(EXPO_ONE_2ND_COLUMN, y, STR_WEIGHT, ed->weight,
-                        -100, 100, attr, event, isSourceAvailableInInputs, INPUTSRC_FIRST, INPUTSRC_LAST);
+                        -100, 100, attr, event, isSourceAvailable, MIXSRC_FIRST, INPUTSRC_LAST);
         break;
 
       case EXPO_FIELD_OFFSET:
         ed->offset = editSrcVarFieldValue(EXPO_ONE_2ND_COLUMN, y, STR_OFFSET, ed->offset,
-                        -100, 100, attr, event, isSourceAvailableInInputs, INPUTSRC_FIRST, INPUTSRC_LAST);
+                        -100, 100, attr, event, isSourceAvailable, MIXSRC_FIRST, INPUTSRC_LAST);
         break;
 
       case EXPO_FIELD_CURVE:
         lcdDrawTextAlignedLeft(y, STR_CURVE);
-        editCurveRef(EXPO_ONE_2ND_COLUMN, y, ed->curve, event, attr, isSourceAvailableInInputs, INPUTSRC_FIRST, INPUTSRC_LAST);
+        editCurveRef(EXPO_ONE_2ND_COLUMN, y, ed->curve, event, attr, isSourceAvailable, MIXSRC_FIRST, INPUTSRC_LAST);
         break;
 
 #if defined(FLIGHT_MODES)

--- a/radio/src/gui/colorlcd/model/input_edit.cpp
+++ b/radio/src/gui/colorlcd/model/input_edit.cpp
@@ -112,7 +112,7 @@ void InputEditWindow::buildBody(Window* form)
                              input->weight = newValue;
                              preview->update();
                              SET_DIRTY();
-                           }, INPUTSRC_FIRST);
+                           }, MIXSRC_FIRST);
   gvar->setSuffix("%");
 
   // Offset
@@ -123,7 +123,7 @@ void InputEditWindow::buildBody(Window* form)
                                 input->offset = newValue;
                                 preview->update();
                                 SET_DIRTY();
-                              }, INPUTSRC_FIRST);
+                              }, MIXSRC_FIRST);
   gvar->setSuffix("%");
 
   // Switch
@@ -142,7 +142,7 @@ void InputEditWindow::buildBody(Window* form)
           if (preview)
             preview->update();
           SET_DIRTY();
-        }, INPUTSRC_FIRST,
+        }, MIXSRC_FIRST,
         [=]() {
           if (preview)
             preview->update();

--- a/radio/src/gui/colorlcd/model/mixer_edit.cpp
+++ b/radio/src/gui/colorlcd/model/mixer_edit.cpp
@@ -110,13 +110,13 @@ void MixEditWindow::buildBody(Window *form)
   line = form->newLine(grid);
   new StaticText(line, rect_t{}, STR_WEIGHT);
   auto svar = new SourceNumberEdit(line, MIX_WEIGHT_MIN, MIX_WEIGHT_MAX,
-                                   GET_SET_DEFAULT(mix->weight), 0);
+                                   GET_SET_DEFAULT(mix->weight), MIXSRC_FIRST);
   svar->setSuffix("%");
 
   // Offset
   new StaticText(line, rect_t{}, STR_OFFSET);
   auto gvar = new SourceNumberEdit(line, MIX_OFFSET_MIN, MIX_OFFSET_MAX,
-                                   GET_SET_DEFAULT(mix->offset), 0);
+                                   GET_SET_DEFAULT(mix->offset), MIXSRC_FIRST);
   gvar->setSuffix("%");
 
   // Switch
@@ -127,7 +127,7 @@ void MixEditWindow::buildBody(Window *form)
 
   // Curve
   new StaticText(line, rect_t{}, STR_CURVE);
-  new CurveParam(line, rect_t{}, &mix->curve, SET_DEFAULT(mix->curve.value), 0);
+  new CurveParam(line, rect_t{}, &mix->curve, SET_DEFAULT(mix->curve.value), MIXSRC_FIRST);
 
   line = form->newLine(grid);
   line->padAll(PAD_LARGE);


### PR DESCRIPTION
Extending the changes from PR #5220 this change allows the source for weight, offset and curve in an Input line to be another Input.

Reasoning behind this is I want to use a slider to fine tune the expo for a control.
I create an input for the slider and use weight and offset to control the range of values.

Currently to use this 'expo' input to control Expo on a stick input I need to add a mix line and then use the output channel - which over complicates things.

TODO:

- [x] Companion support
