### PR TITLE
feat: add support for USB HS

### DIFF
--- a/radio/src/targets/common/arm/stm32/usb_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/usb_driver.cpp
@@ -45,6 +45,12 @@ extern "C" {
 #include "hal.h"
 #include "debug.h"
 
+#if defined(USE_USB_HS)
+  #define DEVICE_ID DEVICE_HS
+#else
+  #define DEVICE_ID DEVICE_FS
+#endif
+
 static bool usbDriverStarted = false;
 #if defined(BOOT)
 static usbMode selectedUsbMode = USB_MASS_STORAGE_MODE;
@@ -52,7 +58,7 @@ static usbMode selectedUsbMode = USB_MASS_STORAGE_MODE;
 static usbMode selectedUsbMode = USB_UNSELECTED_MODE;
 #endif
 
-USBD_HandleTypeDef hUsbDeviceFS;
+USBD_HandleTypeDef hUsbDevice;
 
 int getSelectedUsbMode()
 {
@@ -74,8 +80,11 @@ int usbPlugged()
   static uint8_t debouncedState = 0;
   static uint8_t lastState = 0;
 
-  // uint8_t state = GPIO_ReadInputDataBit(USB_GPIO, USB_GPIO_PIN_VBUS);
+#if defined(USB_GPIO_VBUS_OPEN_DRAIN)
+  uint8_t state = gpio_read(USB_GPIO_VBUS) ? 0 : 1;
+#else
   uint8_t state = gpio_read(USB_GPIO_VBUS) ? 1 : 0;
+#endif
   if (state == lastState)
     debouncedState = state;
   else
@@ -85,13 +94,21 @@ int usbPlugged()
 }
 #endif
 
-extern PCD_HandleTypeDef hpcd_USB_OTG_FS;
+extern PCD_HandleTypeDef hpcd_USB_OTG;
 
+#if defined(USE_USB_HS)
+extern "C" void OTG_HS_IRQHandler()
+{
+  DEBUG_INTERRUPT(INT_OTG_FS);
+  HAL_PCD_IRQHandler(&hpcd_USB_OTG);
+}
+#else
 extern "C" void OTG_FS_IRQHandler()
 {
   DEBUG_INTERRUPT(INT_OTG_FS);
-  HAL_PCD_IRQHandler(&hpcd_USB_OTG_FS);
+  HAL_PCD_IRQHandler(&hpcd_USB_OTG);
 }
+#endif
 
 void usbInit()
 {
@@ -99,9 +116,16 @@ void usbInit()
   gpio_init_af(USB_GPIO_DP, USB_GPIO_AF, GPIO_PIN_SPEED_VERY_HIGH);
   
 #if defined(USB_GPIO_VBUS)
+#if defined(USB_GPIO_VBUS_OPEN_DRAIN)
+  gpio_init(USB_GPIO_VBUS, GPIO_IN_PU, GPIO_PIN_SPEED_LOW);
+#else
   gpio_init(USB_GPIO_VBUS, GPIO_IN, GPIO_PIN_SPEED_LOW);
 #endif
+#endif
 
+// TODO: seems this is only needed for USB wakeup,
+//       which we do not support.
+#if !defined(STM32H7RS)
 #if defined(LL_APB2_GRP1_PERIPH_SYSCFG)
   LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_SYSCFG);
 #elif defined(LL_APB4_GRP1_PERIPH_SYSCFG)
@@ -109,30 +133,19 @@ void usbInit()
 #else
   #error "Unable to enable SYSCFG peripheral clock"
 #endif
-
-#if defined(LL_AHB2_GRP1_PERIPH_OTGFS)
-  LL_AHB2_GRP1_EnableClock(LL_AHB2_GRP1_PERIPH_OTGFS);
-#elif defined(LL_AHB1_GRP1_PERIPH_USB2OTGHS)
-  LL_AHB1_GRP1_EnableClock(LL_AHB1_GRP1_PERIPH_USB2OTGHS);
-#else
-  #error "Unable to enable USB peripheral clock"
-#endif
-
-#if defined(STM32H7) || defined(STM32H7RS)
-  LL_PWR_EnableUSBVoltageDetector();
 #endif
 
   usbDriverStarted = false;
 }
 
 extern void usbInitLUNs();
-extern USBD_HandleTypeDef hUsbDeviceFS;
-extern "C" USBD_StorageTypeDef USBD_Storage_Interface_fops_FS;
-extern USBD_CDC_ItfTypeDef USBD_Interface_fops_FS;
+extern USBD_HandleTypeDef hUsbDevice;
+extern "C" USBD_StorageTypeDef USBD_Storage_Interface_fops;
+extern USBD_CDC_ItfTypeDef USBD_Interface_fops;
 
 void usbStart()
 {
-  USBD_Init(&hUsbDeviceFS, &FS_Desc, DEVICE_FS);
+  USBD_Init(&hUsbDevice, &FS_Desc, DEVICE_ID);
   switch (getSelectedUsbMode()) {
 #if !defined(BOOT)
     case USB_JOYSTICK_MODE:
@@ -140,17 +153,13 @@ void usbStart()
 #if defined(USBJ_EX)
       setupUSBJoystick();
 #endif
-      //USBD_Init(&hUsbDeviceFS, USB_OTG_FS_CORE_ID, &USR_desc, &USBD_HID_cb, &USR_cb);
-      //MX_USB_DEVICE_Init();
-      USBD_RegisterClass(&hUsbDeviceFS, &USBD_HID);
+      USBD_RegisterClass(&hUsbDevice, &USBD_HID);
       break;
 #if defined(USB_SERIAL)
     case USB_SERIAL_MODE:
       // initialize USB as CDC device (virtual serial port)
-      //USBD_Init(&hUsbDeviceFS, USB_OTG_FS_CORE_ID, &USR_desc, &USBD_CDC_cb, &USR_cb);
-      //MX_USB_DEVICE_Init();
-      USBD_RegisterClass(&hUsbDeviceFS, &USBD_CDC);
-      USBD_CDC_RegisterInterface(&hUsbDeviceFS, &USBD_Interface_fops_FS);
+      USBD_RegisterClass(&hUsbDevice, &USBD_CDC);
+      USBD_CDC_RegisterInterface(&hUsbDevice, &USBD_Interface_fops);
       break;
 #endif
 #endif
@@ -158,14 +167,12 @@ void usbStart()
     case USB_MASS_STORAGE_MODE:
       // initialize USB as MSC device
       usbInitLUNs();
-      //MX_USB_DEVICE_Init();
-      USBD_RegisterClass(&hUsbDeviceFS, &USBD_MSC);
-      USBD_MSC_RegisterStorage(&hUsbDeviceFS, &USBD_Storage_Interface_fops_FS);
-      //USBD_Init(&hUsbDeviceFS, USB_OTG_FS_CORE_ID, &USR_desc, &USBD_MSC_cb, &USR_cb);
+      USBD_RegisterClass(&hUsbDevice, &USBD_MSC);
+      USBD_MSC_RegisterStorage(&hUsbDevice, &USBD_Storage_Interface_fops);
       break;
   }
 
-  if (USBD_Start(&hUsbDeviceFS) == USBD_OK) {
+  if (USBD_Start(&hUsbDevice) == USBD_OK) {
     usbDriverStarted = true;
   }
 }
@@ -173,7 +180,7 @@ void usbStart()
 void usbStop()
 {
   usbDriverStarted = false;
-  USBD_DeInit(&hUsbDeviceFS);
+  USBD_DeInit(&hUsbDevice);
 }
 
 
@@ -190,11 +197,11 @@ void usbJoystickRestart()
 {
   if (!usbDriverStarted || getSelectedUsbMode() != USB_JOYSTICK_MODE) return;
 
-  USBD_DeInit(&hUsbDeviceFS);
+  USBD_DeInit(&hUsbDevice);
   delay_ms(100);
-  USBD_Init(&hUsbDeviceFS, &FS_Desc, DEVICE_FS);
-  USBD_RegisterClass(&hUsbDeviceFS, &USBD_HID);
-  USBD_Start(&hUsbDeviceFS);
+  USBD_Init(&hUsbDevice, &FS_Desc, DEVICE_ID);
+  USBD_RegisterClass(&hUsbDevice, &USBD_HID);
+  USBD_Start(&hUsbDevice);
 }
 #else
 // TODO: fix after HAL conversion is complete
@@ -235,19 +242,15 @@ void usbJoystickUpdate()
    }
 
    //analog values
-   //uint8_t * p = HID_Buffer + 1;
    for (int i = 0; i < 8; ++i) {
-
      int16_t value = limit<int16_t>(0, channelOutputs[i] + 1024, 2048);;
-
      HID_Buffer[i*2 +3] = static_cast<uint8_t>(value & 0xFF);
      HID_Buffer[i*2 +4] = static_cast<uint8_t>(value >> 8);
-
    }
-   USBD_HID_SendReport(&hUsbDeviceFS, HID_Buffer, HID_IN_PACKET);
+   USBD_HID_SendReport(&hUsbDevice, HID_Buffer, HID_IN_PACKET);
 #else
   usbReport_t ret = usbReport();
-  USBD_HID_SendReport(&hUsbDeviceFS, ret.ptr, ret.size);
+  USBD_HID_SendReport(&hUsbDevice, ret.ptr, ret.size);
 #endif
 }
 #endif

--- a/radio/src/targets/common/arm/stm32/usbd_cdc.cpp
+++ b/radio/src/targets/common/arm/stm32/usbd_cdc.cpp
@@ -63,7 +63,7 @@ volatile uint32_t APP_Tx_ptr_out = 0;
   * @{
   */
 
-extern USBD_HandleTypeDef hUsbDeviceFS;
+extern USBD_HandleTypeDef hUsbDevice;
 
 /* USER CODE BEGIN EXPORTED_VARIABLES */
 
@@ -93,7 +93,7 @@ static int8_t VCP_StartOfFrame_FS();
   * @}
   */
 
-USBD_CDC_ItfTypeDef USBD_Interface_fops_FS =
+USBD_CDC_ItfTypeDef USBD_Interface_fops =
 {
   VCP_Init_FS,
   VCP_DeInit_FS,
@@ -123,8 +123,8 @@ bool cdcConnected = false;
 static int8_t VCP_Init_FS(void)
 {
   cdcConnected = true;
-  USBD_CDC_SetTxBuffer(&hUsbDeviceFS, UserTxBufferFS, 0);
-  USBD_CDC_SetRxBuffer(&hUsbDeviceFS, UserRxBufferFS);
+  USBD_CDC_SetTxBuffer(&hUsbDevice, UserTxBufferFS, 0);
+  USBD_CDC_SetRxBuffer(&hUsbDevice, UserRxBufferFS);
   return USBD_OK;
 }
 
@@ -262,7 +262,7 @@ static int8_t VCP_StartOfFrame_FS()
     FrameCount = 0;
 
     /* Check the data to be sent through IN pipe */
-    USBD_CDC_HandleTypeDef *hcdc = (USBD_CDC_HandleTypeDef*)hUsbDeviceFS.pClassData;
+    USBD_CDC_HandleTypeDef *hcdc = (USBD_CDC_HandleTypeDef*)hUsbDevice.pClassData;
 
     if (hcdc->TxState != 0)
       return USBD_OK;
@@ -284,8 +284,8 @@ static int8_t VCP_StartOfFrame_FS()
       length = APP_Tx_ptr_in - APP_Tx_ptr_out;
     }
 
-    USBD_CDC_SetTxBuffer(&hUsbDeviceFS, &UserTxBufferFS[APP_Tx_ptr_out], length);
-    result = USBD_CDC_TransmitPacket(&hUsbDeviceFS);
+    USBD_CDC_SetTxBuffer(&hUsbDevice, &UserTxBufferFS[APP_Tx_ptr_out], length);
+    result = USBD_CDC_TransmitPacket(&hUsbDevice);
     if(result == USBD_OK)
       APP_Tx_ptr_out += length;
   }
@@ -360,8 +360,8 @@ static int8_t VCP_Receive_FS(uint8_t* Buf, uint32_t *Len)
 
   if (_rxCb) _rxCb(/*_ctx,*/ Buf, *Len);
 
-  USBD_CDC_SetRxBuffer(&hUsbDeviceFS, &Buf[0]);
-  USBD_CDC_ReceivePacket(&hUsbDeviceFS);
+  USBD_CDC_SetRxBuffer(&hUsbDevice, &Buf[0]);
+  USBD_CDC_ReceivePacket(&hUsbDevice);
   return USBD_OK;
 }
 

--- a/radio/src/targets/common/arm/stm32/usbd_conf.c
+++ b/radio/src/targets/common/arm/stm32/usbd_conf.c
@@ -44,7 +44,7 @@
 
 /* USER CODE END PV */
 
-PCD_HandleTypeDef hpcd_USB_OTG_FS;
+PCD_HandleTypeDef hpcd_USB_OTG;
 void Error_Handler(void){}
 
 /* External functions --------------------------------------------------------*/
@@ -73,46 +73,67 @@ USBD_StatusTypeDef USBD_Get_USB_Status(HAL_StatusTypeDef hal_status);
 
 void HAL_PCD_MspInit(PCD_HandleTypeDef* pcdHandle)
 {
+#if defined(USE_USB_HS)
+  if(pcdHandle->Instance==USB_OTG_HS)
+  {
+#if defined(STM32H7) || defined(STM32H7RS)
+    /* Enable USB Voltage detector & HS regulator */
+    HAL_PWREx_EnableUSBVoltageDetector();
+    HAL_PWREx_EnableUSBHSregulator();
+#endif
+
+    /* Peripheral clock enable */
+    __HAL_RCC_USB_OTG_HS_CLK_ENABLE();
+#if defined(STM32H7) || defined(STM32H7RS)
+    __HAL_RCC_USBPHYC_CLK_ENABLE();
+#endif
+
+    /* Peripheral interrupt init */
+    NVIC_SetPriority(OTG_HS_IRQn, 11);
+    NVIC_EnableIRQ(OTG_HS_IRQn);
+  }
+#else
   if(pcdHandle->Instance==USB_OTG_FS)
   {
-  /* USER CODE BEGIN USB_OTG_FS_MspInit 0 */
-
-  /* USER CODE END USB_OTG_FS_MspInit 0 */
-
+#if defined(STM32H7) || defined(STM32H7RS)
+    /* Enable USB Voltage detector */
+    HAL_PWREx_EnableUSBVoltageDetector();
+#endif
 
     /* Peripheral clock enable */
     __HAL_RCC_USB_OTG_FS_CLK_ENABLE();
 
     /* Peripheral interrupt init */
-    NVIC_SetPriority(OTG_FS_IRQn, 11); // Lower priority interrupt
+    NVIC_SetPriority(OTG_FS_IRQn, 11);
     NVIC_EnableIRQ(OTG_FS_IRQn);
-  /* USER CODE BEGIN USB_OTG_FS_MspInit 1 */
-
-  /* USER CODE END USB_OTG_FS_MspInit 1 */
   }
+#endif
 }
 
 void HAL_PCD_MspDeInit(PCD_HandleTypeDef* pcdHandle)
 {
+#if defined(USE_USB_HS)
+  if(pcdHandle->Instance==USB_OTG_HS)
+  {
+    /* Peripheral clock disable */
+    __HAL_RCC_USB_OTG_HS_CLK_DISABLE();
+#if defined(STM32H7) || defined(STM32H7RS)
+    __HAL_RCC_USBPHYC_CLK_DISABLE();
+#endif
+
+    /* Peripheral interrupt Deinit*/
+    NVIC_DisableIRQ(OTG_HS_IRQn);
+  }
+#else
   if(pcdHandle->Instance==USB_OTG_FS)
   {
-  /* USER CODE BEGIN USB_OTG_FS_MspDeInit 0 */
-
-  /* USER CODE END USB_OTG_FS_MspDeInit 0 */
     /* Peripheral clock disable */
     __HAL_RCC_USB_OTG_FS_CLK_DISABLE();
 
-    /**USB_OTG_FS GPIO Configuration
-    */
-  //  LLL_GPIO_DeInit(GPIOA, USB_GPIO_PIN_DM | USB_GPIO_PIN_DP);
-
     /* Peripheral interrupt Deinit*/
     NVIC_DisableIRQ(OTG_FS_IRQn);
-
-  /* USER CODE BEGIN USB_OTG_FS_MspDeInit 1 */
-
-  /* USER CODE END USB_OTG_FS_MspDeInit 1 */
   }
+#endif
 }
 
 /**
@@ -318,49 +339,59 @@ void HAL_PCD_DisconnectCallback(PCD_HandleTypeDef *hpcd)
 USBD_StatusTypeDef USBD_LL_Init(USBD_HandleTypeDef *pdev)
 {
   /* Init USB Ip. */
-  if (pdev->id == DEVICE_FS) {
-  /* Link the driver to the stack. */
-  hpcd_USB_OTG_FS.pData = pdev;
-  pdev->pData = &hpcd_USB_OTG_FS;
+#if defined(USE_USB_HS)
+  if (pdev->id == DEVICE_HS) {
+    /* Link the driver to the stack. */
+    hpcd_USB_OTG.pData = pdev;
+    pdev->pData = &hpcd_USB_OTG;
 
-  hpcd_USB_OTG_FS.Instance = USB_OTG_FS;
-  hpcd_USB_OTG_FS.Init.dev_endpoints = 4;
-  hpcd_USB_OTG_FS.Init.speed = PCD_SPEED_FULL;
-  hpcd_USB_OTG_FS.Init.dma_enable = DISABLE;
-  hpcd_USB_OTG_FS.Init.phy_itface = PCD_PHY_EMBEDDED;
-  hpcd_USB_OTG_FS.Init.Sof_enable = ENABLE;
-  hpcd_USB_OTG_FS.Init.low_power_enable = DISABLE;
-  hpcd_USB_OTG_FS.Init.lpm_enable = DISABLE;
-#if defined(VBUS_SENSING_ENABLED)
-  hpcd_USB_OTG_FS.Init.vbus_sensing_enable = ENABLE;
+    hpcd_USB_OTG.Instance = USB_OTG_HS;
+    hpcd_USB_OTG.Init.dev_endpoints = 9;
+    hpcd_USB_OTG.Init.speed = PCD_SPEED_HIGH;
+    hpcd_USB_OTG.Init.phy_itface = USB_OTG_HS_EMBEDDED_PHY;
+    hpcd_USB_OTG.Init.dma_enable = DISABLE;
+    hpcd_USB_OTG.Init.Sof_enable = DISABLE;
+    hpcd_USB_OTG.Init.low_power_enable = DISABLE;
+    hpcd_USB_OTG.Init.lpm_enable = DISABLE;
+    hpcd_USB_OTG.Init.use_dedicated_ep1 = DISABLE;
+    hpcd_USB_OTG.Init.vbus_sensing_enable = DISABLE;
+    if (HAL_PCD_Init(&hpcd_USB_OTG) != HAL_OK)
+    {
+      Error_Handler();
+    }
+    HAL_PCDEx_SetRxFiFo(&hpcd_USB_OTG, 0x200);
+    HAL_PCDEx_SetTxFiFo(&hpcd_USB_OTG, 0, 0x40);
+    HAL_PCDEx_SetTxFiFo(&hpcd_USB_OTG, 1, 0x100);
+  }
 #else
-  hpcd_USB_OTG_FS.Init.vbus_sensing_enable = DISABLE;
+  if (pdev->id == DEVICE_FS) {
+    /* Link the driver to the stack. */
+    hpcd_USB_OTG.pData = pdev;
+    pdev->pData = &hpcd_USB_OTG;
+
+    hpcd_USB_OTG.Instance = USB_OTG_FS;
+    hpcd_USB_OTG.Init.dev_endpoints = 4;
+    hpcd_USB_OTG.Init.speed = PCD_SPEED_FULL;
+    hpcd_USB_OTG.Init.dma_enable = DISABLE;
+    hpcd_USB_OTG.Init.phy_itface = PCD_PHY_EMBEDDED;
+    hpcd_USB_OTG.Init.Sof_enable = ENABLE;
+    hpcd_USB_OTG.Init.low_power_enable = DISABLE;
+    hpcd_USB_OTG.Init.lpm_enable = DISABLE;
+#if defined(VBUS_SENSING_ENABLED)
+    hpcd_USB_OTG.Init.vbus_sensing_enable = ENABLE;
+#else
+    hpcd_USB_OTG.Init.vbus_sensing_enable = DISABLE;
 #endif
-  hpcd_USB_OTG_FS.Init.use_dedicated_ep1 = DISABLE;
-  if (HAL_PCD_Init(&hpcd_USB_OTG_FS) != HAL_OK)
-  {
-    Error_Handler( );
+    hpcd_USB_OTG.Init.use_dedicated_ep1 = DISABLE;
+    if (HAL_PCD_Init(&hpcd_USB_OTG) != HAL_OK)
+    {
+      Error_Handler( );
+    }
+    HAL_PCDEx_SetRxFiFo(&hpcd_USB_OTG, 0x80);
+    HAL_PCDEx_SetTxFiFo(&hpcd_USB_OTG, 0, 0x40);
+    HAL_PCDEx_SetTxFiFo(&hpcd_USB_OTG, 1, 0x80);
   }
-
-#if (USE_HAL_PCD_REGISTER_CALLBACKS == 1U)
-  /* Register USB PCD CallBacks */
-  HAL_PCD_RegisterCallback(&hpcd_USB_OTG_FS, HAL_PCD_SOF_CB_ID, PCD_SOFCallback);
-  HAL_PCD_RegisterCallback(&hpcd_USB_OTG_FS, HAL_PCD_SETUPSTAGE_CB_ID, PCD_SetupStageCallback);
-  HAL_PCD_RegisterCallback(&hpcd_USB_OTG_FS, HAL_PCD_RESET_CB_ID, PCD_ResetCallback);
-  HAL_PCD_RegisterCallback(&hpcd_USB_OTG_FS, HAL_PCD_SUSPEND_CB_ID, PCD_SuspendCallback);
-  HAL_PCD_RegisterCallback(&hpcd_USB_OTG_FS, HAL_PCD_RESUME_CB_ID, PCD_ResumeCallback);
-  HAL_PCD_RegisterCallback(&hpcd_USB_OTG_FS, HAL_PCD_CONNECT_CB_ID, PCD_ConnectCallback);
-  HAL_PCD_RegisterCallback(&hpcd_USB_OTG_FS, HAL_PCD_DISCONNECT_CB_ID, PCD_DisconnectCallback);
-
-  HAL_PCD_RegisterDataOutStageCallback(&hpcd_USB_OTG_FS, PCD_DataOutStageCallback);
-  HAL_PCD_RegisterDataInStageCallback(&hpcd_USB_OTG_FS, PCD_DataInStageCallback);
-  HAL_PCD_RegisterIsoOutIncpltCallback(&hpcd_USB_OTG_FS, PCD_ISOOUTIncompleteCallback);
-  HAL_PCD_RegisterIsoInIncpltCallback(&hpcd_USB_OTG_FS, PCD_ISOINIncompleteCallback);
-#endif /* USE_HAL_PCD_REGISTER_CALLBACKS */
-  HAL_PCDEx_SetRxFiFo(&hpcd_USB_OTG_FS, 0x80);
-  HAL_PCDEx_SetTxFiFo(&hpcd_USB_OTG_FS, 0, 0x40);
-  HAL_PCDEx_SetTxFiFo(&hpcd_USB_OTG_FS, 1, 0x80);
-  }
+#endif
   return USBD_OK;
 }
 

--- a/radio/src/targets/common/arm/stm32/usbd_storage_msd.cpp
+++ b/radio/src/targets/common/arm/stm32/usbd_storage_msd.cpp
@@ -119,7 +119,7 @@ static int8_t STORAGE_GetMaxLun_FS(void);
 /* USER CODE BEGIN PRIVATE_FUNCTIONS_DECLARATION */
 
 
-USBD_StorageTypeDef USBD_Storage_Interface_fops_FS =
+USBD_StorageTypeDef USBD_Storage_Interface_fops =
 {
   STORAGE_Init_FS,
   STORAGE_GetCapacity_FS,

--- a/radio/src/targets/common/arm/stm32/usbd_storage_msd.h
+++ b/radio/src/targets/common/arm/stm32/usbd_storage_msd.h
@@ -88,7 +88,7 @@
   */
 
 /** STORAGE Interface callback. */
-extern USBD_StorageTypeDef USBD_Storage_Interface_fops_FS;
+extern USBD_StorageTypeDef USBD_Storage_Interface_fops;
 
 /* USER CODE BEGIN EXPORTED_VARIABLES */
 


### PR DESCRIPTION
At the moment, none of the supported targets have a USB HS PHY, however, some upcoming targets do (notably STM32H7RS). To add USB HS support on targets that have a USB HS PHY, `USE_USB_HS` must be defined. Additionally, support for open-drain VBUS sensing has been added (define `USB_GPIO_VBUS_OPEN_DRAIN` in `hal.h`).