### PR TITLE
fix: initial wait delay in SPI LCD.

### DIFF
--- a/radio/src/targets/taranis/lcd_driver_aspi.cpp
+++ b/radio/src/targets/taranis/lcd_driver_aspi.cpp
@@ -24,7 +24,9 @@
 
 #include "board.h"
 #include "lcd.h"
+
 #include "hal/abnormal_reboot.h"
+#include "timers_driver.h"
 
 #if !defined(BOOT)
 #include "myeeprom.h"
@@ -274,11 +276,8 @@ void lcdInitFinish()
   */
 
   if (!WAS_RESET_BY_WATCHDOG_OR_SOFTWARE()) {
-#if !defined(BOOT)
-    while (g_tmr10ms < (RESET_WAIT_DELAY_MS/10)); // Wait measured from the power-on
-#else
-    delay_ms(RESET_WAIT_DELAY_MS);
-#endif
+    // wait measured from the power-on
+    while (timersGetMsTick() < RESET_WAIT_DELAY_MS);
   }
   
   lcdStart();

--- a/radio/src/targets/taranis/lcd_driver_spi.cpp
+++ b/radio/src/targets/taranis/lcd_driver_spi.cpp
@@ -29,6 +29,7 @@
 #include "lcd.h"
 
 #include "hal/abnormal_reboot.h"
+#include "timers_driver.h"
 
 #if !defined(BOOT)
   #include "edgetx.h"
@@ -388,11 +389,8 @@ void lcdInitFinish()
   */
 
   if (LCD_DELAY_NEEDED()) {
-#if !defined(BOOT)
-    while (g_tmr10ms < (RESET_WAIT_DELAY_MS / 10)); // wait measured from the power-on
-#else
-    delay_ms(RESET_WAIT_DELAY_MS);
-#endif
+    // wait measured from the power-on
+    while (timersGetMsTick() < RESET_WAIT_DELAY_MS);
   }
 
   lcdStart();


### PR DESCRIPTION
The classical 10ms timer will be started later and should not be relied upon at this stage.
This fixes the issue introduced with #5424 (see https://github.com/EdgeTX/edgetx/pull/5424#issuecomment-2288548638).