### PR TITLE
fix: soft-serial polarity

### DIFF
--- a/radio/src/targets/common/arm/stm32/stm32_softserial_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_softserial_driver.cpp
@@ -196,7 +196,7 @@ void stm32_softserial_rx_timer_isr(const stm32_softserial_rx_port* port)
       rxByte >>= 1;
     }
 
-    if (!gpio_read(port->GPIO) == 0)
+    if (gpio_read(port->GPIO) == 0)
       rxByte |= 0x80;
 
     ++rxBitCount;


### PR DESCRIPTION
This was most visible when flashing an external MPM, which was broken.

This fixes #5348