### PR TITLE
feat: indicate in diag ana if serial gimbals are used

### DIFF
--- a/radio/src/boards/generic_stm32/analog_inputs.cpp
+++ b/radio/src/boards/generic_stm32/analog_inputs.cpp
@@ -81,11 +81,13 @@ static void adc_wait_completion()
 }
 
 const etx_hal_adc_driver_t _adc_driver = {
-  _hal_inputs,
-  _pot_default_config,
-  adc_init,
-  adc_start_read,
-  adc_wait_completion
+  .inputs = _hal_inputs,
+  .default_pots_cfg = _pot_default_config,
+  .init = adc_init,
+  .start_conversion = adc_start_read,
+  .wait_completion = adc_wait_completion,
+  .set_input_mask = stm32_hal_set_inputs_mask,
+  .get_input_mask = stm32_hal_get_inputs_mask,
 };
 
 #if defined(PWM_STICKS)

--- a/radio/src/gui/128x64/radio_diaganas.cpp
+++ b/radio/src/gui/128x64/radio_diaganas.cpp
@@ -86,10 +86,13 @@ void menuRadioDiagAnalogs(event_t event)
       x = INDENT_WIDTH;
       y += FH;
     }
-    if (((adcGetInputMask() & (1 << i)) != 0) && i < adcGetMaxInputs(ADC_INPUT_MAIN))
-      drawStringWithIndex(x, y, "D", i + 1);
-    else
-      drawStringWithIndex(x, y, "A", i + 1);
+    if (((adcGetInputMask() & (1 << i)) != 0) && i < adcGetMaxInputs(ADC_INPUT_MAIN)) {
+      lcdDrawText(x, y, "D");
+      lcdDrawNumber(lcdNextPos, y, i + 1);
+    }
+    else {
+      lcdDrawNumber(x, y, i+1, LEADING0|LEFT, 2);
+    }
     lcdDrawChar(lcdNextPos, y, ':');
     switch (viewpage) {
       case (ANAVIEW_RAWLOWFPS):

--- a/radio/src/gui/128x64/radio_diaganas.cpp
+++ b/radio/src/gui/128x64/radio_diaganas.cpp
@@ -21,6 +21,7 @@
 
 #include "edgetx.h"
 #include "hal/adc_driver.h"
+#include "stm32_adc.h"
 
 #define HOLDANAVALUEFRAMES 4 /* 4* 50ms = 200 ms update rate */
 
@@ -86,7 +87,10 @@ void menuRadioDiagAnalogs(event_t event)
       x = INDENT_WIDTH;
       y += FH;
     }
-    drawStringWithIndex(x, y, "A", i + 1);
+    if ((stm32_hal_get_inputs_mask() & 0xF) == 0xF && i < adcGetMaxInputs(ADC_INPUT_MAIN))
+      drawStringWithIndex(x, y, "D", i + 1);
+    else
+      drawStringWithIndex(x, y, "A", i + 1);
     lcdDrawChar(lcdNextPos, y, ':');
     switch (viewpage) {
       case (ANAVIEW_RAWLOWFPS):

--- a/radio/src/gui/128x64/radio_diaganas.cpp
+++ b/radio/src/gui/128x64/radio_diaganas.cpp
@@ -21,7 +21,6 @@
 
 #include "edgetx.h"
 #include "hal/adc_driver.h"
-#include "stm32_adc.h"
 
 #define HOLDANAVALUEFRAMES 4 /* 4* 50ms = 200 ms update rate */
 
@@ -87,7 +86,7 @@ void menuRadioDiagAnalogs(event_t event)
       x = INDENT_WIDTH;
       y += FH;
     }
-    if ((stm32_hal_get_inputs_mask() & 0xF) == 0xF && i < adcGetMaxInputs(ADC_INPUT_MAIN))
+    if (((adcGetInputMask() & (1 << i)) != 0) && i < adcGetMaxInputs(ADC_INPUT_MAIN))
       drawStringWithIndex(x, y, "D", i + 1);
     else
       drawStringWithIndex(x, y, "A", i + 1);

--- a/radio/src/gui/212x64/radio_diaganas.cpp
+++ b/radio/src/gui/212x64/radio_diaganas.cpp
@@ -21,7 +21,6 @@
 
 #include "edgetx.h"
 #include "../../hal/adc_driver.h"
-#include "stm32_adc.h"
 
 #define HOLDANAVALUEFRAMES 4 /* 4* 50ms = 200 ms update rate */
 
@@ -57,7 +56,7 @@ void menuRadioDiagAnalogs(event_t event)
   for (uint8_t i = 0; i < MAX_ANALOG_INPUTS; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + (i/2)*FH;
     uint8_t x = i&1 ? LCD_W/2 + FW : 0;
-    if ((stm32_hal_get_inputs_mask() & 0xF) == 0xF && i < adcGetMaxInputs(ADC_INPUT_MAIN)) {
+    if (((adcGetInputMask() & (1 << i)) != 0) && i < adcGetMaxInputs(ADC_INPUT_MAIN)) {
       lcdDrawText(x, y, "D");
       lcdDrawNumber(lcdNextPos, y, i + 1);
     }

--- a/radio/src/gui/212x64/radio_diaganas.cpp
+++ b/radio/src/gui/212x64/radio_diaganas.cpp
@@ -60,8 +60,9 @@ void menuRadioDiagAnalogs(event_t event)
       lcdDrawText(x, y, "D");
       lcdDrawNumber(lcdNextPos, y, i + 1);
     }
-    else
-      lcdDrawNumber(x, y, i+1, LEADING0|LEFT, 2);
+    else {
+      lcdDrawNumber(x, y, i + 1, LEADING0 | LEFT, 2);
+    }
     lcdDrawChar(x+2*FW-2, y, ':');
     
     switch (viewpage)

--- a/radio/src/gui/212x64/radio_diaganas.cpp
+++ b/radio/src/gui/212x64/radio_diaganas.cpp
@@ -21,6 +21,7 @@
 
 #include "edgetx.h"
 #include "../../hal/adc_driver.h"
+#include "stm32_adc.h"
 
 #define HOLDANAVALUEFRAMES 4 /* 4* 50ms = 200 ms update rate */
 
@@ -56,7 +57,12 @@ void menuRadioDiagAnalogs(event_t event)
   for (uint8_t i = 0; i < MAX_ANALOG_INPUTS; i++) {
     coord_t y = MENU_HEADER_HEIGHT + 1 + (i/2)*FH;
     uint8_t x = i&1 ? LCD_W/2 + FW : 0;
-    lcdDrawNumber(x, y, i+1, LEADING0|LEFT, 2);
+    if ((stm32_hal_get_inputs_mask() & 0xF) == 0xF && i < adcGetMaxInputs(ADC_INPUT_MAIN)) {
+      lcdDrawText(x, y, "D");
+      lcdDrawNumber(lcdNextPos, y, i + 1);
+    }
+    else
+      lcdDrawNumber(x, y, i+1, LEADING0|LEFT, 2);
     lcdDrawChar(x+2*FW-2, y, ':');
     
     switch (viewpage)

--- a/radio/src/gui/colorlcd/radio/radio_diaganas.cpp
+++ b/radio/src/gui/colorlcd/radio/radio_diaganas.cpp
@@ -25,7 +25,6 @@
 #include "libopenui.h"
 #include "edgetx.h"
 #include "etx_lv_theme.h"
-#include "stm32_adc.h"
 
 // #if defined(IMU_LSM6DS33)
 // #include "imu_lsm6ds33.h"
@@ -85,7 +84,7 @@ class AnaViewWindow : public Window
 #endif
 
       lv_obj_set_style_pad_column(line->getLvObj(), 8, 0);
-      if ((stm32_hal_get_inputs_mask() & 0xF) == 0xF && i < adcGetMaxInputs(ADC_INPUT_MAIN))
+      if (((adcGetInputMask() & (1 << i)) != 0) && i < adcGetMaxInputs(ADC_INPUT_MAIN))
         sprintf(s, "D%d :", i + 1);
       else
         sprintf(s, "%02d :", i + 1);

--- a/radio/src/gui/colorlcd/radio/radio_diaganas.cpp
+++ b/radio/src/gui/colorlcd/radio/radio_diaganas.cpp
@@ -25,6 +25,7 @@
 #include "libopenui.h"
 #include "edgetx.h"
 #include "etx_lv_theme.h"
+#include "stm32_adc.h"
 
 // #if defined(IMU_LSM6DS33)
 // #include "imu_lsm6ds33.h"
@@ -84,8 +85,11 @@ class AnaViewWindow : public Window
 #endif
 
       lv_obj_set_style_pad_column(line->getLvObj(), 8, 0);
+      if ((stm32_hal_get_inputs_mask() & 0xF) == 0xF && i < adcGetMaxInputs(ADC_INPUT_MAIN))
+        sprintf(s, "D%d :", i + 1);
+      else
+        sprintf(s, "%02d :", i + 1);
 
-      sprintf(s, "%02d :", i + 1);
       new StaticText(line, rect_t{}, s);
 
       auto lbl = new DynamicText(

--- a/radio/src/hal/adc_driver.cpp
+++ b/radio/src/hal/adc_driver.cpp
@@ -582,10 +582,14 @@ const char* adcGetInputShortLabel(uint8_t type, uint8_t idx)
 
 void adcSetInputMask(uint32_t mask)
 {
-  _hal_adc_driver->set_input_mask(mask);
+  if (_hal_adc_driver && _hal_adc_driver->set_input_mask) {
+    _hal_adc_driver->set_input_mask(mask);
+  }
 }
 
 uint32_t adcGetInputMask()
 {
-  return _hal_adc_driver->get_input_mask();
+  return _hal_adc_driver && _hal_adc_driver->get_input_mask
+             ? _hal_adc_driver->get_input_mask()
+             : 0;
 }

--- a/radio/src/hal/adc_driver.cpp
+++ b/radio/src/hal/adc_driver.cpp
@@ -579,3 +579,13 @@ const char* adcGetInputShortLabel(uint8_t type, uint8_t idx)
 
   return _hal_adc_inputs[type].inputs[idx].short_label;
 }
+
+void adcSetInputMask(uint32_t mask)
+{
+  _hal_adc_driver->set_input_mask(mask);
+}
+
+uint32_t adcGetInputMask()
+{
+  return _hal_adc_driver->get_input_mask();
+}

--- a/radio/src/hal/adc_driver.h
+++ b/radio/src/hal/adc_driver.h
@@ -77,6 +77,9 @@ struct etx_hal_adc_driver_t {
   bool (*init)();
   bool (*start_conversion)();
   void (*wait_completion)();
+
+  void (*set_input_mask)(uint32_t);
+  uint32_t (*get_input_mask)();
 };
 
 bool adcInit(const etx_hal_adc_driver_t* driver);
@@ -136,6 +139,9 @@ int adcGetInputIdx(const char* input, uint8_t len);
 
 const char* adcGetInputLabel(uint8_t type, uint8_t idx);
 const char* adcGetInputShortLabel(uint8_t type, uint8_t idx);
+
+void adcSetInputMask(uint32_t mask);
+uint32_t adcGetInputMask();
 
 // To be implemented by the target driver
 // int8_t adcGetVRTC();

--- a/radio/src/targets/common/arm/stm32/flysky_gimbal_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/flysky_gimbal_driver.cpp
@@ -173,7 +173,7 @@ bool flysky_gimbal_init()
     delay_ms(1);
     if (_fs_gimbal_detected) {
       // Mask the first 4 inputs (sticks)
-      stm32_hal_mask_inputs(0xF);
+      stm32_hal_set_inputs_mask(0xF);
       return true;
     }
   }

--- a/radio/src/targets/common/arm/stm32/stm32_adc.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_adc.cpp
@@ -77,9 +77,14 @@ static uint8_t _adc_run;
 static uint8_t _adc_oversampling_disabled;
 static uint16_t _adc_oversampling[MAX_ADC_INPUTS];
 
-void stm32_hal_mask_inputs(uint32_t inputs)
+void stm32_hal_set_inputs_mask(uint32_t inputs)
 {
   _adc_input_inhibt_mask |= inputs;
+}
+
+uint32_t stm32_hal_get_inputs_mask()
+{
+  return _adc_input_inhibt_mask;
 }
 
 // STM32 uses a 25K+25K voltage divider bridge to measure the battery voltage

--- a/radio/src/targets/common/arm/stm32/stm32_adc.h
+++ b/radio/src/targets/common/arm/stm32/stm32_adc.h
@@ -67,4 +67,5 @@ void stm32_hal_adc_disable_oversampling();
 void stm32_hal_adc_dma_isr(const stm32_adc_t* adc);
 void stm32_hal_adc_isr(const stm32_adc_t* adc);
 
-void stm32_hal_mask_inputs(uint32_t inputs);
+void stm32_hal_set_inputs_mask(uint32_t inputs);
+uint32_t stm32_hal_get_inputs_mask();

--- a/radio/src/thirdparty/STM32F4xx_HAL_Driver/Inc/stm32f4xx_hal_def.h
+++ b/radio/src/thirdparty/STM32F4xx_HAL_Driver/Inc/stm32f4xx_hal_def.h
@@ -55,7 +55,9 @@ typedef enum
 
 /* Exported macro ------------------------------------------------------------*/
 
+#if !defined(UNUSED)
 #define UNUSED(X) (void)X      /* To avoid gcc/g++ warnings */
+#endif
 
 #define HAL_MAX_DELAY      0xFFFFFFFFU
 


### PR DESCRIPTION
Allow users (or devs :D) to know if serial gimbal are been used on their radio.

When serial gimbal are use, a 'D' is displayed instead of leading 0

![image](https://github.com/user-attachments/assets/8b2d719a-6875-4ad6-a325-ee2a3c5b0a45)

Despite being tiny, requires #5443 to fit on some targets

Some housekeeping while at it