### PR TITLE
fix(color): refresh issues on Input edit page

### DIFF
--- a/radio/src/gui/colorlcd/libui/textedit.cpp
+++ b/radio/src/gui/colorlcd/libui/textedit.cpp
@@ -178,15 +178,18 @@ void TextEdit::preview(bool edited, char* text, uint8_t length)
 }
 
 ModelTextEdit::ModelTextEdit(Window* parent, const rect_t& rect, char* value,
-                             uint8_t length) :
+                             uint8_t length, std::function<void(void)> updateHandler) :
     TextEdit(parent, rect, value, length,
-                   []() { storageDirty(EE_MODEL); })
+             [=]() {
+               if (updateHandler) updateHandler();
+               storageDirty(EE_MODEL);
+             })
 {
 }
 
 RadioTextEdit::RadioTextEdit(Window* parent, const rect_t& rect, char* value,
                              uint8_t length) :
     TextEdit(parent, rect, value, length,
-                   []() { storageDirty(EE_GENERAL); })
+             []() { storageDirty(EE_GENERAL); })
 {
 }

--- a/radio/src/gui/colorlcd/libui/textedit.h
+++ b/radio/src/gui/colorlcd/libui/textedit.h
@@ -27,7 +27,7 @@ class TextEdit : public TextButton
 {
  public:
   TextEdit(Window* parent, const rect_t& rect, char* text, uint8_t length,
-                 std::function<void(void)> updateHandler = nullptr);
+           std::function<void(void)> updateHandler = nullptr);
 
 #if defined(DEBUG_WINDOWS)
   std::string getName() const override { return "TextEdit \"" + text + "\""; }
@@ -51,7 +51,7 @@ class ModelTextEdit : public TextEdit
 {
  public:
   ModelTextEdit(Window* parent, const rect_t& rect, char* value,
-                uint8_t length);
+                uint8_t length, std::function<void(void)> updateHandler = nullptr);
 };
 
 class RadioTextEdit : public TextEdit

--- a/radio/src/gui/colorlcd/model/input_edit.h
+++ b/radio/src/gui/colorlcd/model/input_edit.h
@@ -39,12 +39,18 @@ class InputEditWindow : public Page
   uint8_t input;
   uint8_t index;
   Curve* preview = nullptr;
+  bool updatePreview = false;
   getvalue_t lastWeightVal = 0;
   getvalue_t lastOffsetVal = 0;
   getvalue_t lastCurveVal = 0;
+  bool lastSwitchState = false;
+  bool active = false;
+  StaticText * headerSwitchName = nullptr;
 
+  void setTitle();
   void buildBody(Window *window);
 
+  bool isActive();
   void checkEvents() override;
   void deleteLater(bool detach = true, bool trash = true) override;
 };

--- a/radio/src/gui/colorlcd/model/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model/model_setup.cpp
@@ -58,21 +58,6 @@ ModelSetupPage::ModelSetupPage() :
 {
 }
 
-struct ModelNameEdit : public ModelTextEdit {
-  ModelNameEdit(Window *parent, const rect_t &rect) :
-      ModelTextEdit(parent, rect, g_model.header.name,
-                    sizeof(g_model.header.name))
-  {
-    setChangeHandler([=]() {
-                      auto model = modelslist.getCurrentModel();
-                      if (model) {
-                        model->setModelName(g_model.header.name);
-                      }
-                      SET_DIRTY();
-                    });
-  }
-};
-
 static void viewOption(Window* parent, coord_t x, coord_t y,
                 std::function<uint8_t()> getValue,
                 std::function<void(uint8_t)> setValue, bool globalState)
@@ -297,7 +282,15 @@ static SetupLineDef setupLines[] = {
     // Model name
     STR_MODELNAME,
     [](Window* parent, coord_t x, coord_t y) {
-      new ModelNameEdit(parent, {x, y, ModelSetupPage::NAM_W, 0});
+      new ModelTextEdit(parent, {x, y, ModelSetupPage::NAM_W, 0},
+                        g_model.header.name, sizeof(g_model.header.name),
+                        [=]() {
+                          auto model = modelslist.getCurrentModel();
+                          if (model) {
+                            model->setModelName(g_model.header.name);
+                          }
+                          SET_DIRTY();
+                        });
     }
   },
   {


### PR DESCRIPTION
For Input edit:
- Fix preview not updating when a switch is assigned to the input.
- Fix name not updating in header when name changed.
- Show name in bold & ACTIVE color in header when input line is active.

Also fixes an issue where the model name was not being updated on the model select page list after editing the model name.

