### PR TITLE
feat(lua): add end coordinates to lcd.drawTextLines

### DIFF
--- a/radio/src/gui/colorlcd/libui/bitmapbuffer.h
+++ b/radio/src/gui/colorlcd/libui/bitmapbuffer.h
@@ -190,7 +190,7 @@ class BitmapBuffer
   coord_t drawNumber(coord_t x, coord_t y, int32_t val, LcdFlags flags = 0,
                      uint8_t len = 0, const char* prefix = nullptr,
                      const char* suffix = nullptr);
-  void drawTextLines(coord_t left, coord_t top, coord_t width, coord_t height,
+  point_t drawTextLines(coord_t left, coord_t top, coord_t width, coord_t height,
                      const char* str, LcdFlags flags);
   void drawTimer(coord_t x, coord_t y, int32_t tme, LcdFlags flags = 0);
   void drawSource(coord_t x, coord_t y, mixsrc_t idx, LcdFlags flags = 0);

--- a/radio/src/gui/colorlcd/libui/bitmapbuffer_draw_extra.cpp
+++ b/radio/src/gui/colorlcd/libui/bitmapbuffer_draw_extra.cpp
@@ -69,7 +69,7 @@ void BitmapBuffer::drawValueWithUnit(coord_t x, coord_t y, int val,
   }
 }
 
-void BitmapBuffer::drawTextLines(coord_t left, coord_t top, coord_t width,
+point_t BitmapBuffer::drawTextLines(coord_t left, coord_t top, coord_t width,
                                  coord_t height, const char *str,
                                  LcdFlags flags)
 {
@@ -78,6 +78,7 @@ void BitmapBuffer::drawTextLines(coord_t left, coord_t top, coord_t width,
   coord_t line = getFontHeightCondensed(flags & 0xFFFF);
   coord_t space = getTextWidth(" ", 1, flags);
   coord_t word;
+  point_t maxP={0,0};
   const char *nxt = str;
   flags &= ~(VCENTERED | CENTERED | RIGHT);
 
@@ -102,16 +103,22 @@ void BitmapBuffer::drawTextLines(coord_t left, coord_t top, coord_t width,
     if (x + word > left + width && x > left) {
       x = left;
       y += line;
+      maxP.y= y + line;
     }
-    if (y + line > top + height) return;
+    else
+    {
+      maxP.x = max( maxP.x, x+word);
+    }
+    if (y + line > top + height) return maxP;
     drawSizedText(x, y, str, nxt - str, flags);
     x += word;
     switch (nxt[0]) {
       case '\0':
-        return;
+        return maxP;
       case '\n':
         x = left;
         y += line;
+        maxP.y= y + line;
         nxt++;
         break;
       case ' ':

--- a/radio/src/lua/api_colorlcd.cpp
+++ b/radio/src/lua/api_colorlcd.cpp
@@ -310,7 +310,7 @@ Draw text inside rectangle (x,y,w,h) with line breaks
 
 @retval x,y (integers) point where text drawing ended
 
-@status current Introduced in 2.5.0
+@status current Introduced in 2.5.0, return x,y added in 2.11.0
 */
 static int luaLcdDrawTextLines(lua_State *L)
 {

--- a/radio/src/lua/api_colorlcd.cpp
+++ b/radio/src/lua/api_colorlcd.cpp
@@ -308,6 +308,8 @@ Draw text inside rectangle (x,y,w,h) with line breaks
 
 @param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html) for drawing flags and colors, and [Appendix](../../part_vii_-_appendix/fonts.md) for available characters in each font set. RIGHT, CENTER and VCENTER are not implemented.
 
+@retval x,y (integers) point where text drawing ended
+
 @status current Introduced in 2.5.0
 */
 static int luaLcdDrawTextLines(lua_State *L)
@@ -319,6 +321,7 @@ static int luaLcdDrawTextLines(lua_State *L)
   int y = luaL_checkinteger(L, 2);
   int w = luaL_checkinteger(L, 3);
   int h = luaL_checkinteger(L, 4);
+  point_t maxP = {0,0};
   const char * s = luaL_checkstring(L, 5);
   LcdFlags flags = luaL_optunsigned(L, 6, 0);
   
@@ -347,8 +350,14 @@ static int luaLcdDrawTextLines(lua_State *L)
     flags = (flags & 0xFFFF) | colorToRGB(flags);
   }
   
-  luaLcdBuffer->drawTextLines(x, y, w, h, s, flags);
-  return 0;
+  maxP = luaLcdBuffer->drawTextLines(x, y, w, h, s, flags);
+  if (!invers && flags & SHADOWED) {
+    maxP.x++;
+    maxP.y++;
+  }
+  lua_pushinteger(L, maxP.x);
+  lua_pushinteger(L, maxP.y);
+  return 2;
 }
 
 /*luadoc


### PR DESCRIPTION
adds text end coordinates to drawTextLines to enable stacking of draw textLines.

Fixes not knowing where prior multi-line drawTextLines calls have ended.

Summary of changes:
Adds new returns to lua.drawTextLines containing end bottom right corner of used text area.


I consider adding similar return to drawTimer, drawString, drawNumber