### PR TITLE
fix(lua): radio tries to run 'nil' script if SF disabled

### DIFF
--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -1132,7 +1132,7 @@ static bool resumeLua(bool init, bool allowLcdUsage)
               if (sid.background == LUA_NOREF) continue;
               lua_rawgeti(lsScripts, LUA_REGISTRYINDEX, sid.background);
             }
-          }
+          } else continue;
         }
 #if defined(PCBTARANIS)
         else if (ref <= SCRIPT_TELEMETRY_LAST) {


### PR DESCRIPTION
Fixes #5456

Don't try and run script if SF disabled.
