### PR TITLE
fix(radio): multiplex setting is not valid for 1st line in a mix

### DIFF
--- a/companion/src/modeledit/mixerdialog.cpp
+++ b/companion/src/modeledit/mixerdialog.cpp
@@ -27,7 +27,7 @@
 #include "namevalidator.h"
 #include "sourcenumref.h"
 
-MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, GeneralSettings & generalSettings, Firmware * firmware,
+MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, int index, GeneralSettings & generalSettings, Firmware * firmware,
                          CompoundItemModelFactory * sharedItemModels) :
   QDialog(parent),
   ui(new Ui::MixerDialog),
@@ -92,6 +92,11 @@ MixerDialog::MixerDialog(QWidget *parent, ModelData & model, MixData * mixdata, 
   if (!firmware->getCapability(HasNoExpo)) {
     ui->MixDR_CB->hide();
     ui->label_MixDR->hide();
+  }
+
+  if (index == 0 || model.mixData[index - 1].destCh != mixdata->destCh) {
+    ui->mltpxCB->hide();
+    ui->mltpxLbl->hide();
   }
 
   if (!firmware->getCapability(VirtualInputs)) {

--- a/companion/src/modeledit/mixerdialog.h
+++ b/companion/src/modeledit/mixerdialog.h
@@ -37,7 +37,7 @@ namespace Ui {
 class MixerDialog : public QDialog {
     Q_OBJECT
   public:
-    MixerDialog(QWidget *parent, ModelData & model, MixData *mixdata, GeneralSettings & generalSettings, Firmware * firmware,
+    MixerDialog(QWidget *parent, ModelData & model, MixData *mixdata, int index, GeneralSettings & generalSettings, Firmware * firmware,
                 CompoundItemModelFactory * sharedItemModels);
     ~MixerDialog();
 

--- a/companion/src/modeledit/mixerdialog.ui
+++ b/companion/src/modeledit/mixerdialog.ui
@@ -165,7 +165,7 @@
       </widget>
      </item>
      <item row="10" column="0">
-      <widget class="QLabel" name="label_7">
+      <widget class="QLabel" name="mltpxLbl">
        <property name="text">
         <string>Multiplex</string>
        </property>

--- a/companion/src/modeledit/mixes.cpp
+++ b/companion/src/modeledit/mixes.cpp
@@ -184,7 +184,7 @@ void MixesPanel::gm_openMix(int index)
 
   MixData mixd(model->mixData[index]);
 
-  MixerDialog *dlg = new MixerDialog(this, *model, &mixd, generalSettings, firmware, sharedItemModels);
+  MixerDialog *dlg = new MixerDialog(this, *model, &mixd, index, generalSettings, firmware, sharedItemModels);
   if(dlg->exec()) {
     model->mixData[index] = mixd;
     emit modified();

--- a/companion/src/modelprinter.cpp
+++ b/companion/src/modelprinter.cpp
@@ -416,10 +416,7 @@ QString ModelPrinter::printMixerLine(const MixData & mix, bool showMultiplex, in
   }
   str += "&nbsp;" + source;
 
-  if (mix.mltpx == MLTPX_MUL && !showMultiplex)
-    str += " " + tr("MULT!").toHtmlEscaped();
-  else
-    str += " " + tr("Weight(%1)").arg(SourceNumRef(mix.weight).toString(&model, &generalSettings)).toHtmlEscaped();
+  str += " " + tr("Weight(%1)").arg(SourceNumRef(mix.weight).toString(&model, &generalSettings)).toHtmlEscaped();
 
   QString flightModesStr = printFlightModes(mix.flightModes);
   if (!flightModesStr.isEmpty())

--- a/radio/src/gui/128x64/model_mix_edit.cpp
+++ b/radio/src/gui/128x64/model_mix_edit.cpp
@@ -108,7 +108,10 @@ void menuModelMixOne(event_t event)
   uint8_t old_editMode = s_editMode;
   
   SUBMENU(STR_MIXES, MIX_FIELD_COUNT,
-          {0, 0, 0, 0, 0, 1, CASE_FLIGHT_MODES(FM_ROW((MAX_FLIGHT_MODES-1) | NAVIGATION_LINE_BY_LINE)) 0, 0 /*, ...*/});
+          {0, 0, 0, 0, 0, 1, CASE_FLIGHT_MODES(FM_ROW((MAX_FLIGHT_MODES-1) | NAVIGATION_LINE_BY_LINE)) 0, 0,
+           (uint8_t)((s_currIdx > 0 && mixAddress(s_currIdx - 1)->destCh == md2->destCh) ? 0 : HIDDEN_ROW),
+           0 /*, ...*/
+          });
   
   int8_t sub = menuVerticalPosition;
   int8_t editMode = s_editMode;

--- a/radio/src/gui/212x64/model_mix_edit.cpp
+++ b/radio/src/gui/212x64/model_mix_edit.cpp
@@ -104,7 +104,10 @@ void menuModelMixOne(event_t event)
   uint8_t old_editMode = s_editMode;
 
   SUBMENU(STR_MIXES, MIX_FIELD_COUNT,
-          {0, 0, 0, 0, 0, 1, CASE_FLIGHT_MODES(FM_ROW((MAX_FLIGHT_MODES-1) | NAVIGATION_LINE_BY_LINE)) 0, 0 /*, ...*/});
+          {0, 0, 0, 0, 0, 1, CASE_FLIGHT_MODES(FM_ROW((MAX_FLIGHT_MODES-1) | NAVIGATION_LINE_BY_LINE)) 0, 0,
+           (uint8_t)((s_currIdx > 0 && mixAddress(s_currIdx - 1)->destCh == md2->destCh) ? 0 : HIDDEN_ROW),
+           0 /*, ...*/
+          });
 
   int8_t sub = menuVerticalPosition;
   int8_t editMode = s_editMode;

--- a/radio/src/gui/colorlcd/model/mixer_edit_adv.cpp
+++ b/radio/src/gui/colorlcd/model/mixer_edit_adv.cpp
@@ -60,11 +60,14 @@ void MixEditAdvanced::buildBody(Window* form)
   MixData* mix = mixAddress(index);
 
   // Advanced...
+  FormLine* line;
 
   // Multiplex
-  auto line = form->newLine(grid);
-  new StaticText(line, rect_t{}, STR_MULTPX);
-  new Choice(line, rect_t{}, STR_VMLTPX, 0, 2, GET_SET_DEFAULT(mix->mltpx));
+  if (index > 0 && mixAddress(index - 1)->destCh == channel) {
+    line = form->newLine(grid);
+    new StaticText(line, rect_t{}, STR_MULTPX);
+    new Choice(line, rect_t{}, STR_VMLTPX, 0, 2, GET_SET_DEFAULT(mix->mltpx));
+  }
 
   // Flight modes
   if (modelFMEnabled()) {

--- a/radio/src/gui/common/stdlcd/model_mixes.cpp
+++ b/radio/src/gui/common/stdlcd/model_mixes.cpp
@@ -333,14 +333,9 @@ void menuModelMixAll(event_t event)
 
           drawSource(MIX_LINE_SRC_POS, y, md->srcRaw, 0);
 
-          if (mixCnt == 0 && md->mltpx == 1) {
-            lcdDrawText(MIX_LINE_WEIGHT_POS, y, "MULT!", RIGHT | ((isMixActive(i) ? BOLD : 0)));
-          }
-          else {
-            editSrcVarFieldValue(MIX_LINE_WEIGHT_POS, y, nullptr, md->weight, 
-                        MIX_WEIGHT_MIN, MIX_WEIGHT_MAX, RIGHT | ((isMixActive(i) ? BOLD : 0)),
-                        0, 0, MIXSRC_FIRST, INPUTSRC_LAST);
-          }
+          editSrcVarFieldValue(MIX_LINE_WEIGHT_POS, y, nullptr, md->weight, 
+                      MIX_WEIGHT_MIN, MIX_WEIGHT_MAX, RIGHT | ((isMixActive(i) ? BOLD : 0)),
+                      0, 0, MIXSRC_FIRST, INPUTSRC_LAST);
 
 #if LCD_W >= 212
           displayMixLine(y, md);


### PR DESCRIPTION
Fixes #47

For the first line in any mix:
- don't use the Multiplex setting in the mixer.
- don't display the Multiplex setting when editing the mix line (radio & Companion).
- remove 'MULT!' warning display (B&W radios and Companion).
