### PR TITLE
fix(bw): prevent autodetection of unavailable sources

### DIFF
--- a/radio/src/gui/navigation/navigation_9x.cpp
+++ b/radio/src/gui/navigation/navigation_9x.cpp
@@ -89,7 +89,9 @@ int checkIncDec(event_t event, int val, int i_min, int i_max, int srcMin, int sr
       }
     }
 
-    newval = checkMovedInput(newval, i_min, i_max, i_flags, isSource);
+    auto moved =  checkMovedInput(newval, i_min, i_max, i_flags, isSource);
+    if (isValueAvailable(moved))
+      newval = moved;
 
     if (invert) {
       newval = -newval;

--- a/radio/src/gui/navigation/navigation_x7.cpp
+++ b/radio/src/gui/navigation/navigation_x7.cpp
@@ -103,7 +103,9 @@ int checkIncDec(event_t event, int val, int i_min, int i_max, int srcMin, int sr
       }
     }
 
-    newval = checkMovedInput(newval, i_min, i_max, i_flags, isSource);
+    auto moved =  checkMovedInput(newval, i_min, i_max, i_flags, isSource);
+    if (isValueAvailable(moved))
+      newval = moved;
 
     if (invert) {
       newval = -newval;


### PR DESCRIPTION
As discovered as part of #5485 investigation, autoswitch feature allow users to select unproper value.

This fixes it.

Likely needed in 2.10 too