### PR TITLE
fix(radio): a Lua script GF/SF continues to run after function changed

### DIFF
--- a/radio/src/gui/128x64/model_special_functions.cpp
+++ b/radio/src/gui/128x64/model_special_functions.cpp
@@ -220,7 +220,11 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
           if (CFN_SWITCH(cfn)) {
             lcdDrawText(MODEL_SPECIAL_FUNC_2ND_COLUMN, y, funcGetLabel(func), attr);
             if (active) {
-              CFN_FUNC(cfn) = cfn_sorted[checkIncDec(event, getFuncSortIdx(CFN_FUNC(cfn)), 0, FUNC_MAX-1, eeFlags, isAssignableFunctionAvailableSorted)];
+              Functions newFunc = cfn_sorted[checkIncDec(event, getFuncSortIdx(CFN_FUNC(cfn)), 0, FUNC_MAX-1, eeFlags, isAssignableFunctionAvailableSorted)];
+              // If changing from Lua script then reload to remove old reference
+              if ((CFN_FUNC(cfn) == FUNC_PLAY_SCRIPT || CFN_FUNC(cfn) == FUNC_RGB_LED) && newFunc != FUNC_PLAY_SCRIPT && newFunc != FUNC_RGB_LED)
+                LUA_LOAD_MODEL_SCRIPTS();
+              CFN_FUNC(cfn) = newFunc;
               if (checkIncDec_Ret) CFN_RESET(cfn);
             }
           }

--- a/radio/src/gui/212x64/model_special_functions.cpp
+++ b/radio/src/gui/212x64/model_special_functions.cpp
@@ -212,7 +212,11 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
           if (CFN_SWITCH(cfn)) {
             lcdDrawText(MODEL_SPECIAL_FUNC_2ND_COLUMN, y, funcGetLabel(func), attr);
             if (active) {
-              func = CFN_FUNC(cfn) = cfn_sorted[checkIncDec(event, getFuncSortIdx(CFN_FUNC(cfn)), 0, FUNC_MAX-1, eeFlags, isAssignableFunctionAvailableSorted)];
+              Functions newFunc = cfn_sorted[checkIncDec(event, getFuncSortIdx(CFN_FUNC(cfn)), 0, FUNC_MAX-1, eeFlags, isAssignableFunctionAvailableSorted)];
+              // If changing from Lua script then reload to remove old reference
+              if ((CFN_FUNC(cfn) == FUNC_PLAY_SCRIPT || CFN_FUNC(cfn) == FUNC_RGB_LED) && newFunc != FUNC_PLAY_SCRIPT && newFunc != FUNC_RGB_LED)
+                LUA_LOAD_MODEL_SCRIPTS();
+              func = CFN_FUNC(cfn) = newFunc;
               if (checkIncDec_Ret) CFN_RESET(cfn);
             }
           }

--- a/radio/src/gui/colorlcd/model/special_functions.cpp
+++ b/radio/src/gui/colorlcd/model/special_functions.cpp
@@ -652,14 +652,18 @@ void FunctionEditPage::buildBody(Window *form)
   line = form->newLine(grid);
   new StaticText(line, rect_t{}, STR_FUNC);
   auto functionChoice =
-      new Choice(line, rect_t{}, 0, FUNC_MAX - 1, GET_DEFAULT(getFuncSortIdx(CFN_FUNC(cfn))));
+      new Choice(line, rect_t{}, 0, FUNC_MAX - 1, GET_DEFAULT(getFuncSortIdx(CFN_FUNC(cfn))),
+                  [=](int32_t newValue) {
+                    Functions newFunc = cfn_sorted[newValue];
+                    // If changing from Lua script then reload to remove old reference
+                    if ((CFN_FUNC(cfn) == FUNC_PLAY_SCRIPT || CFN_FUNC(cfn) == FUNC_RGB_LED) && newFunc != FUNC_PLAY_SCRIPT && newFunc != FUNC_RGB_LED)
+                      LUA_LOAD_MODEL_SCRIPTS();
+                    CFN_FUNC(cfn) = newFunc;
+                    CFN_RESET(cfn);
+                    SET_DIRTY();
+                    updateSpecialFunctionOneWindow();
+                  });
   functionChoice->setTextHandler([=](int val) { return funcGetLabel(cfn_sorted[val]); });
-  functionChoice->setSetValueHandler([=](int32_t newValue) {
-    CFN_FUNC(cfn) = cfn_sorted[newValue];
-    CFN_RESET(cfn);
-    SET_DIRTY();
-    updateSpecialFunctionOneWindow();
-  });
   functionChoice->setAvailableHandler(
       [=](int value) { return isAssignableFunctionAvailable(cfn_sorted[value]); });
 


### PR DESCRIPTION
Steps to reproduce:
- create a GF or SF which runs a Lua script (or RGB led script). Something that plays sound or flashes led is easiest to test.
- enable and test GF/SF.
- change GF/SF function to a non-script function and re-enable.
- trigger GF/SF - previous Lua script continues to run.
