### PR TITLE
fix(bw): wait time in lcd init

### DIFF
--- a/radio/src/targets/taranis/lcd_driver_aspi.cpp
+++ b/radio/src/targets/taranis/lcd_driver_aspi.cpp
@@ -276,8 +276,8 @@ void lcdInitFinish()
   */
 
   if (!WAS_RESET_BY_WATCHDOG_OR_SOFTWARE()) {
-    // wait measured from the power-on
-    while (timersGetMsTick() < RESET_WAIT_DELAY_MS);
+    uint32_t end = timersGetMsTick() + RESET_WAIT_DELAY_MS;
+    while (timersGetMsTick() < end);
   }
   
   lcdStart();

--- a/radio/src/targets/taranis/lcd_driver_spi.cpp
+++ b/radio/src/targets/taranis/lcd_driver_spi.cpp
@@ -389,8 +389,8 @@ void lcdInitFinish()
   */
 
   if (LCD_DELAY_NEEDED()) {
-    // wait measured from the power-on
-    while (timersGetMsTick() < RESET_WAIT_DELAY_MS);
+    uint32_t end = timersGetMsTick() + RESET_WAIT_DELAY_MS;
+    while (timersGetMsTick() < end);
   }
 
   lcdStart();


### PR DESCRIPTION
Fixes an issue spotted by @philmoz when in certain conditions (ie T12Max bootloader), lcd init might not be successful
