### PR TITLE
fix(crsf): send modelID after module reset

### DIFF
--- a/radio/src/pulses/crossfire.cpp
+++ b/radio/src/pulses/crossfire.cpp
@@ -42,6 +42,10 @@
 
 #define MIN_FRAME_LEN 3
 
+#define MODULE_ALIVE_TIMEOUT  50                      // if the module has sent a valid frame within 500ms it is declared alive
+static tmr10ms_t lastAlive[NUM_MODULES];              // last time stamp module sent CRSF frames
+static bool moduleAlive[NUM_MODULES];                 // module alive status
+
 uint8_t createCrossfireBindFrame(uint8_t moduleIdx, uint8_t * frame)
 {
   uint8_t * buf = frame;
@@ -125,6 +129,34 @@ static void setupPulsesCrossfire(uint8_t module, uint8_t*& p_buf,
   } else
 #endif
   {
+    //
+    // An ELRS module stores the RF parameters in a model specific way using the
+    // modelID as index. If the module resets after it was initally initialized the modelID 
+    // needs to be resent as otherwise the module assumes modelID 0 which leads to the
+    // module using the stored RF parameters for the model with modelID 0. This is not only
+    // annoying but also potentially dangerous as a receiver will no longer re-connect.
+    //
+    // Reasons for a module resetting might be:
+    // - power surge
+    // - internal non-recoverable error
+    // - after flashing in WiFi mode
+    // - putting the module in WiFi mode and exiting WiFi mode (LUA script)
+    // 
+    // This logic takes care of sending the modelID again after a module comes back to 
+    // live after a module reset
+    // 
+    if(moduleState[module].counter != CRSF_FRAME_MODELID ) {            // skip the reset check logic if first init
+      if((get_tmr10ms() - lastAlive[module]) > MODULE_ALIVE_TIMEOUT) {  // check if module has recently sent CRSF frames 
+        moduleAlive[module] = false;                                    // no, declare it as dead  
+      } else {
+        if(moduleAlive[module] == false) {                              // if the module was dead and came back to live, e.g. reset
+          moduleAlive[module] = true;                                   // declare the module as alive
+          moduleState[module].counter = CRSF_FRAME_MODELID;             // and send it the modelID again 
+          TRACE("[XF] sending ModelID after module reset");
+        }
+      }
+    }
+
     if (moduleState[module].counter == CRSF_FRAME_MODELID) {
       p_buf += createCrossfireModelIDFrame(module, p_buf);
       moduleState[module].counter = CRSF_FRAME_MODELID_SENT;
@@ -223,6 +255,7 @@ static uint8_t* _processFrames(void* ctx, uint8_t* buf, uint8_t& len)
 #endif
       auto mod_st = (etx_module_state_t*)ctx;
       auto module = modulePortGetModule(mod_st);
+      lastAlive[module] = get_tmr10ms();                              // valid frame received, note timestamp
       processCrossfireTelemetryFrame(module, p_buf, pkt_len);
     }
 


### PR DESCRIPTION
Problem:

ExpressLRS modules store the RF parameters in a model specific way using the modelID as index. EdgeTX sends the modelID once at first initialization of the module. If after that the module resets for any reason the module starts up and assumes modelID 0 for a lack of better information. This is not only annoying but also dangerous because a receiver will potentially not re-connect after the module comes back to live after the reset as the module is now using the RF parameters stored for the model with the modelID 0.

The effect is demonstrated in the attached video. The module is removed during normal operation with a receiver connected using a model with modelID 7 (100Hz in my case) to simulate a reset. After putting the module back in it starts up but uses modelID 0 RF parameters (250 Hz in my case) which prevents the receiver to re-connect. If you want to try this you can use a less brutal method that also works for internal modules. Prepare two models and set one to modelID 0, the other to modelID e.g. 7. Use the LUA script to set both models to different packet rates. Select the model with modelID 7 and connect to a receiver. Start the LUA Script, put the module into WiFi mode and exit WiFi mode again. Best to observe the LCD screen on an external module.

Reasons for a module resetting might be:
- power surge
- internal non-recoverable error
- after flashing in WiFi mode
- putting the module in WiFi mode and exiting WiFi mode (LUA script)

Solution:

This PR adds some logic to detect a module coming back to live after a reset and in this case sends the current modelID again to ensure the correct RF parameters are used.

Implementation:

A live ExpressLRS module will send CRSF packets even if no receiver is connected. If no packets are received within 500ms the module is declared not alive. If the module boots up again it'll start sending CRSF frames with a period of far less than 500ms again. The transition from not alive to alive triggers the sending of the modelID. The module receives the modelID and selects the correct RF parameter which allow the receiver to re-connect.


https://github.com/user-attachments/assets/45ac3270-be5d-460d-9626-2c6eb69d45dc

