### PR TITLE
fix(color): use LVGL canvas for drawing standalone script UI

### DIFF
--- a/radio/src/gui/colorlcd/standalone_lua.h
+++ b/radio/src/gui/colorlcd/standalone_lua.h
@@ -83,7 +83,5 @@ protected:
   void checkEvents() override;
   void onClicked() override;
   void onCancel() override;
-
-  static void redraw_cb(lv_event_t *e);
 };
 #endif


### PR DESCRIPTION
Fixes #5507 

Let LVGL manage display of script UI instead of DMA copying buffer directly to screen.
