### PR TITLE
fix(radio): CS values may be read incorrectly from yaml

### DIFF
--- a/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
@@ -1022,7 +1022,7 @@ static uint32_t r_swtchSrc(const YamlNode* node, const char* val, uint8_t val_le
 
       ival = switchLookupIdx(val, val_len - 1) * 3;
       if (ival < 0) return SWSRC_NONE;
-      ival += yaml_str2int(val + 3, val_len - 2);
+      ival += yaml_str2int(val + 3, val_len - 3);
       ival += SWSRC_FIRST_SWITCH;
       
     } else if (val_len > 2 && val[0] == 'S'


### PR DESCRIPTION
Fixes #5510 

Incorrect length passed when converting int value for CS position.
If additional character is a digit then bad index value is calculated.

Also needs to be applied to 2.10.5.
