### PR TITLE
fix(color): curve button remaining in pressed state when editing input or mix

### DIFF
--- a/radio/src/gui/colorlcd/controls/curve_param.cpp
+++ b/radio/src/gui/colorlcd/controls/curve_param.cpp
@@ -28,16 +28,6 @@
 
 #define SET_DIRTY() storageDirty(EE_MODEL)
 
-void CurveParam::LongPressHandler(void* data)
-{
-  if (modelCurvesEnabled()) {
-    int8_t* value = (int8_t*)data;
-    if (*value != 0) {
-      ModelCurvesPage::pushEditCurve(abs(*value) - 1);
-    }
-  }
-}
-
 class CurveChoice : public Choice
 {
  public:
@@ -52,6 +42,7 @@ class CurveChoice : public Choice
   {
     if (modelCurvesEnabled()) {
       if (_getValue()) {
+        lv_obj_clear_state(lvobj, LV_STATE_PRESSED);
         ModelCurvesPage::pushEditCurve(abs(_getValue()) - 1, refreshView);
       }
     }

--- a/radio/src/gui/colorlcd/controls/curve_param.h
+++ b/radio/src/gui/colorlcd/controls/curve_param.h
@@ -48,6 +48,4 @@ class CurveParam : public Window
   std::function<void(void)> refreshView;
 
   void update();
-
-  static void LongPressHandler(void* data);
 };


### PR DESCRIPTION
To reproduce:
- Assign a custom curve to an input or mix.
- Set focus to the curve button and long press the ENTER key to open the curve editor.
- Press RTN to exit the curve editor - the curve button remains in the pressed state.

Also removes some unused code.
