### PR TITLE
feat(color): use curve select button on outputs edit page to match inputs and mixes

### DIFF
--- a/radio/src/edgetx.h
+++ b/radio/src/edgetx.h
@@ -307,7 +307,6 @@ void perMain();
 getvalue_t getValue(mixsrc_t i, bool* valid = nullptr);
 
 int8_t getMovedSource(uint8_t min);
-#define GET_MOVED_SOURCE(min, max) getMovedSource(min)
 
 #if defined(FLIGHT_MODES)
   extern uint8_t getFlightMode();

--- a/radio/src/gui/colorlcd/controls/curve_param.cpp
+++ b/radio/src/gui/colorlcd/controls/curve_param.cpp
@@ -28,30 +28,22 @@
 
 #define SET_DIRTY() storageDirty(EE_MODEL)
 
-class CurveChoice : public Choice
-{
- public:
-  CurveChoice(Window* parent, std::function<int()> getRefValue, std::function<void(int32_t)> setRefValue, std::function<void(void)> refreshView) :
-    Choice(parent, rect_t{}, -MAX_CURVES, MAX_CURVES, getRefValue, setRefValue),
-    refreshView(std::move(refreshView))
-    {
-      setTextHandler([](int value) { return getCurveString(value); });
-    }
-
-  bool onLongPress() override
+CurveChoice::CurveChoice(Window* parent, std::function<int()> getRefValue, std::function<void(int32_t)> setRefValue, std::function<void(void)> refreshView) :
+  Choice(parent, rect_t{}, -MAX_CURVES, MAX_CURVES, getRefValue, setRefValue),
+  refreshView(std::move(refreshView))
   {
-    if (modelCurvesEnabled()) {
-      if (_getValue()) {
-        lv_obj_clear_state(lvobj, LV_STATE_PRESSED);
-        ModelCurvesPage::pushEditCurve(abs(_getValue()) - 1, refreshView);
-      }
-    }
-    return true;
+    setTextHandler([](int value) { return getCurveString(value); });
   }
 
- protected:
-  std::function<void(void)> refreshView;
-};
+bool CurveChoice::onLongPress()
+{
+  if (modelCurvesEnabled()) {
+    if (_getValue()) {
+      ModelCurvesPage::pushEditCurve(abs(_getValue()) - 1, refreshView);
+    }
+  }
+  return true;
+}
 
 CurveParam::CurveParam(Window* parent, const rect_t& rect, CurveRef* ref,
                        std::function<void(int32_t)> setRefValue, int16_t sourceMin,

--- a/radio/src/gui/colorlcd/controls/curve_param.cpp
+++ b/radio/src/gui/colorlcd/controls/curve_param.cpp
@@ -28,9 +28,10 @@
 
 #define SET_DIRTY() storageDirty(EE_MODEL)
 
-CurveChoice::CurveChoice(Window* parent, std::function<int()> getRefValue, std::function<void(int32_t)> setRefValue, std::function<void(void)> refreshView) :
+CurveChoice::CurveChoice(Window* parent, std::function<int()> getRefValue, 
+        std::function<void(int32_t)> setRefValue, std::function<void(void)> refreshView, mixsrc_t source) :
   Choice(parent, rect_t{}, -MAX_CURVES, MAX_CURVES, getRefValue, setRefValue),
-  refreshView(std::move(refreshView))
+  source(source), refreshView(std::move(refreshView))
   {
     setTextHandler([](int value) { return getCurveString(value); });
   }
@@ -39,14 +40,14 @@ bool CurveChoice::onLongPress()
 {
   if (modelCurvesEnabled()) {
     if (_getValue()) {
-      ModelCurvesPage::pushEditCurve(abs(_getValue()) - 1, refreshView);
+      ModelCurvesPage::pushEditCurve(abs(_getValue()) - 1, refreshView, source);
     }
   }
   return true;
 }
 
 CurveParam::CurveParam(Window* parent, const rect_t& rect, CurveRef* ref,
-                       std::function<void(int32_t)> setRefValue, int16_t sourceMin,
+                       std::function<void(int32_t)> setRefValue, int16_t sourceMin, mixsrc_t source,
                        std::function<void(void)> refreshView) :
     Window(parent, rect), ref(ref), refreshView(std::move(refreshView))
 {
@@ -95,7 +96,7 @@ CurveParam::CurveParam(Window* parent, const rect_t& rect, CurveRef* ref,
                                   v.isSource = false;
                                   v.value = newValue;
                                   setRefValue(v.rawValue);
-                                }, refreshView);
+                                }, refreshView, source);
 
   update();
 }

--- a/radio/src/gui/colorlcd/controls/curve_param.cpp
+++ b/radio/src/gui/colorlcd/controls/curve_param.cpp
@@ -40,6 +40,7 @@ bool CurveChoice::onLongPress()
 {
   if (modelCurvesEnabled()) {
     if (_getValue()) {
+      lv_obj_clear_state(lvobj, LV_STATE_PRESSED);
       ModelCurvesPage::pushEditCurve(abs(_getValue()) - 1, refreshView, source);
     }
   }

--- a/radio/src/gui/colorlcd/controls/curve_param.h
+++ b/radio/src/gui/colorlcd/controls/curve_param.h
@@ -31,11 +31,13 @@ class CurveChoice : public Choice
 {
  public:
   CurveChoice(Window* parent, std::function<int()> getRefValue,
-              std::function<void(int32_t)> setRefValue, std::function<void(void)> refreshView);
+              std::function<void(int32_t)> setRefValue, std::function<void(void)> refreshView,
+              mixsrc_t source);
 
   bool onLongPress() override;
 
  protected:
+  mixsrc_t source;
   std::function<void(void)> refreshView;
 };
 
@@ -44,7 +46,7 @@ class CurveParam : public Window
  public:
   CurveParam(Window* parent, const rect_t& rect, CurveRef* ref,
              std::function<void(int32_t)> setRefValue,
-             int16_t sourceMin,
+             int16_t sourceMin, mixsrc_t source,
              std::function<void(void)> refreshView = nullptr);
 
  protected:

--- a/radio/src/gui/colorlcd/controls/curve_param.h
+++ b/radio/src/gui/colorlcd/controls/curve_param.h
@@ -22,10 +22,22 @@
 #pragma once
 
 #include "window.h"
+#include "choice.h"
 
 struct CurveRef;
-class Choice;
 class SourceNumberEdit;
+
+class CurveChoice : public Choice
+{
+ public:
+  CurveChoice(Window* parent, std::function<int()> getRefValue,
+              std::function<void(int32_t)> setRefValue, std::function<void(void)> refreshView);
+
+  bool onLongPress() override;
+
+ protected:
+  std::function<void(void)> refreshView;
+};
 
 class CurveParam : public Window
 {

--- a/radio/src/gui/colorlcd/model/curveedit.cpp
+++ b/radio/src/gui/colorlcd/model/curveedit.cpp
@@ -84,15 +84,9 @@ class CurveEdit : public Window
   void checkEvents(void) override
   {
     if (!lockSource) {
-      int16_t val = getMovedSource(MIXSRC_FIRST_INPUT);
-      if (val > 0) {
-        // TODO: this code seems odd
-        if (val > MAX_STICKS + MAX_POTS)
-          currentSource = val + 1 - MIXSRC_FIRST_INPUT;
-        else {
-          currentSource = expoAddress(val - 1)->srcRaw;
-        }
-      }
+      int16_t val = getMovedSource(MIXSRC_FIRST_STICK);
+      if (val > 0)
+        currentSource = val;
     }
     Window::checkEvents();
   }

--- a/radio/src/gui/colorlcd/model/curveedit.cpp
+++ b/radio/src/gui/colorlcd/model/curveedit.cpp
@@ -32,6 +32,72 @@ static const lv_coord_t default_col_dsc[] = {LV_GRID_CONTENT,
 static const lv_coord_t default_row_dsc[] = {LV_GRID_CONTENT,
                                              LV_GRID_TEMPLATE_LAST};
 
+class CurveEdit : public Window
+{
+ public:
+  CurveEdit(Window* parent, const rect_t& rect, uint8_t index) :
+      Window(parent, rect),
+      preview(
+          this, {0, 0, width(), height()},
+          [=](int x) -> int { return applyCustomCurve(x, index); },
+          [=]() -> int { return getValue(currentSource); }),
+      index(index),
+      current(0)
+  {
+    setWindowFlag(NO_FOCUS);
+    updatePreview();
+  }
+
+  void setCurrentSource(mixsrc_t source)
+  {
+    currentSource = source;
+    if (source)
+      lockSource = true;
+    else
+      lockSource = false;
+  }
+
+  void updatePreview()
+  {
+    preview.clearPoints();
+    CurveHeader& curve = g_model.curves[index];
+    for (uint8_t i = 0; i < 5 + curve.points; i++) {
+      preview.addPoint(getPoint(index, i));
+    }
+  }
+
+ protected:
+  Curve preview;
+  uint8_t index;
+  uint8_t current;
+  mixsrc_t currentSource = 0;
+  bool lockSource = false;
+
+  void deleteLater(bool detach = true, bool trash = true) override
+  {
+    if (!_deleted) {
+      preview.deleteLater(true, false);
+      Window::deleteLater(detach, trash);
+    }
+  }
+
+  void checkEvents(void) override
+  {
+    if (!lockSource) {
+      int16_t val = getMovedSource(MIXSRC_FIRST_INPUT);
+      if (val > 0) {
+        // TODO: this code seems odd
+        if (val > MAX_STICKS + MAX_POTS)
+          currentSource = val + 1 - MIXSRC_FIRST_INPUT;
+        else {
+          currentSource = expoAddress(val - 1)->srcRaw;
+        }
+      }
+    }
+    Window::checkEvents();
+  }
+};
+
 class CurveDataEdit : public Window
 {
  public:
@@ -179,56 +245,6 @@ class CurveDataEdit : public Window
     }
   }
 };
-
-void CurveEdit::SetCurrentSource(mixsrc_t source)
-{
-  CurveEdit::currentSource = source;
-  if (source)
-    lockSource = true;
-  else
-    lockSource = false;
-}
-
-mixsrc_t CurveEdit::currentSource = 0;
-bool CurveEdit::lockSource = false;
-
-CurveEdit::CurveEdit(Window* parent, const rect_t& rect, uint8_t index) :
-    Window(parent, rect),
-    preview(
-        this, {0, 0, width(), height()},
-        [=](int x) -> int { return applyCustomCurve(x, index); },
-        [=]() -> int { return getValue(CurveEdit::currentSource); }),
-    index(index),
-    current(0)
-{
-  setWindowFlag(NO_FOCUS);
-  updatePreview();
-}
-
-void CurveEdit::updatePreview()
-{
-  preview.clearPoints();
-  CurveHeader& curve = g_model.curves[index];
-  for (uint8_t i = 0; i < 5 + curve.points; i++) {
-    preview.addPoint(getPoint(index, i));
-  }
-}
-
-void CurveEdit::checkEvents()
-{
-  if (!lockSource) {
-    int16_t val = getMovedSource(MIXSRC_FIRST_INPUT);
-    if (val > 0) {
-      // TODO: this code seems odd
-      if (val > MAX_STICKS + MAX_POTS)
-        CurveEdit::currentSource = val + 1 - MIXSRC_FIRST_INPUT;
-      else {
-        CurveEdit::currentSource = expoAddress(val - 1)->srcRaw;
-      }
-    }
-  }
-  Window::checkEvents();
-}
 
 CurveEditWindow::CurveEditWindow(uint8_t index,
                                  std::function<void(void)> refreshView) :
@@ -389,4 +405,9 @@ void CurveEditWindow::onCancel()
 {
   if (refreshView) refreshView();
   Page::onCancel();
+}
+
+void CurveEditWindow::setCurrentSource(mixsrc_t source)
+{
+  curveEdit->setCurrentSource(source);
 }

--- a/radio/src/gui/colorlcd/model/curveedit.h
+++ b/radio/src/gui/colorlcd/model/curveedit.h
@@ -26,40 +26,16 @@
 #include "window.h"
 
 class NumberEdit;
+class CurveEdit;
 class CurveDataEdit;
-
-class CurveEdit : public Window
-{
- public:
-  CurveEdit(Window* parent, const rect_t& rect, uint8_t index);
-  static void SetCurrentSource(mixsrc_t source);
-
-  void deleteLater(bool detach = true, bool trash = true) override
-  {
-    if (_deleted) return;
-
-    preview.deleteLater(true, false);
-
-    Window::deleteLater(detach, trash);
-  }
-
-  void updatePreview();
-
-  void checkEvents(void) override;
-
- protected:
-  Curve preview;
-  uint8_t index;
-  uint8_t current;
-  static mixsrc_t currentSource;
-  static bool lockSource;
-};
 
 class CurveEditWindow : public Page
 {
  public:
   CurveEditWindow(uint8_t index,
                   std::function<void(void)> refreshView = nullptr);
+
+  void setCurrentSource(mixsrc_t source);
 
   static LAYOUT_VAL(NUMEDT_W, 70, 70)
   static LAYOUT_VAL(CURVE_WIDTH, 215, 232)

--- a/radio/src/gui/colorlcd/model/input_edit.cpp
+++ b/radio/src/gui/colorlcd/model/input_edit.cpp
@@ -76,8 +76,6 @@ InputEditWindow::InputEditWindow(int8_t input, uint8_t index) :
         return anas[line->chn];
       },
       [=]() -> int { return getValue(expoAddress(index)->srcRaw); });
-
-  CurveEdit::SetCurrentSource(expoAddress(index)->srcRaw);
 }
 
 void InputEditWindow::setTitle()
@@ -159,7 +157,7 @@ void InputEditWindow::buildBody(Window* form)
           input->curve.value = newValue;
           updatePreview = true;
           SET_DIRTY();
-        }, MIXSRC_FIRST,
+        }, MIXSRC_FIRST, input->srcRaw,
         [=]() {
           updatePreview = true;
         });
@@ -174,14 +172,6 @@ void InputEditWindow::buildBody(Window* form)
         return 0;
       });
   lv_obj_set_width(btn->getLvObj(), lv_pct(100));
-}
-
-void InputEditWindow::deleteLater(bool detach, bool trash)
-{
-  if (!deleted()) {
-    CurveEdit::SetCurrentSource(0);
-    Page::deleteLater(detach, trash);
-  }
 }
 
 void InputEditWindow::checkEvents()

--- a/radio/src/gui/colorlcd/model/input_edit.h
+++ b/radio/src/gui/colorlcd/model/input_edit.h
@@ -50,5 +50,4 @@ class InputEditWindow : public Page
   void buildBody(Window *window);
 
   void checkEvents() override;
-  void deleteLater(bool detach = true, bool trash = true) override;
 };

--- a/radio/src/gui/colorlcd/model/mixer_edit.cpp
+++ b/radio/src/gui/colorlcd/model/mixer_edit.cpp
@@ -104,7 +104,6 @@ void MixEditWindow::buildBody(Window *form)
   new StaticText(line, rect_t{}, STR_SOURCE);
   new SourceChoice(line, rect_t{}, 0, MIXSRC_LAST,
                    GET_SET_DEFAULT(mix->srcRaw), true);
-  CurveEdit::SetCurrentSource(mix->srcRaw);
 
   // Weight
   line = form->newLine(grid);
@@ -127,7 +126,7 @@ void MixEditWindow::buildBody(Window *form)
 
   // Curve
   new StaticText(line, rect_t{}, STR_CURVE);
-  new CurveParam(line, rect_t{}, &mix->curve, SET_DEFAULT(mix->curve.value), MIXSRC_FIRST);
+  new CurveParam(line, rect_t{}, &mix->curve, SET_DEFAULT(mix->curve.value), MIXSRC_FIRST, mix->srcRaw);
 
   line = form->newLine(grid);
   line->padAll(PAD_LARGE);
@@ -137,12 +136,4 @@ void MixEditWindow::buildBody(Window *form)
         return 0;
       });
   lv_obj_set_width(btn->getLvObj(), lv_pct(100));
-}
-
-void MixEditWindow::deleteLater(bool detach, bool trash)
-{
-  if (!deleted()) {
-    CurveEdit::SetCurrentSource(0);
-    Page::deleteLater(detach, trash);
-  }
 }

--- a/radio/src/gui/colorlcd/model/mixer_edit.h
+++ b/radio/src/gui/colorlcd/model/mixer_edit.h
@@ -39,6 +39,4 @@ class MixEditWindow : public Page
 
   void buildHeader(Window *window);
   void buildBody(Window *window);
-
-  void deleteLater(bool detach = true, bool trash = true) override;
 };

--- a/radio/src/gui/colorlcd/model/model_curves.cpp
+++ b/radio/src/gui/colorlcd/model/model_curves.cpp
@@ -116,7 +116,7 @@ ModelCurvesPage::ModelCurvesPage() : PageTab(STR_MENUCURVES, ICON_MODEL_CURVES)
 
 // can be called from any other screen to edit a curve.
 // currently called from model_mixes.cpp on longpress.
-void ModelCurvesPage::pushEditCurve(int index, std::function<void(void)> refreshView)
+void ModelCurvesPage::pushEditCurve(int index, std::function<void(void)> refreshView, mixsrc_t source)
 {
   if (!isCurveUsed(index)) {
     CurveHeader &curve = g_model.curves[index];
@@ -124,7 +124,8 @@ void ModelCurvesPage::pushEditCurve(int index, std::function<void(void)> refresh
     initPoints(curve, points);
   }
 
-  new CurveEditWindow(index, refreshView);
+  auto cv = new CurveEditWindow(index, refreshView);
+  cv->setCurrentSource(source);
 }
 
 void ModelCurvesPage::rebuild(Window *window)

--- a/radio/src/gui/colorlcd/model/model_curves.h
+++ b/radio/src/gui/colorlcd/model/model_curves.h
@@ -28,7 +28,7 @@ class ModelCurvesPage : public PageTab
 {
  public:
   ModelCurvesPage();
-  static void pushEditCurve(int index, std::function<void(void)> refreshView = nullptr);
+  static void pushEditCurve(int index, std::function<void(void)> refreshView, mixsrc_t source);
 
   bool isVisible() const override { return modelCurvesEnabled(); }
 

--- a/radio/src/gui/colorlcd/model/output_edit.cpp
+++ b/radio/src/gui/colorlcd/model/output_edit.cpp
@@ -61,16 +61,6 @@ OutputEditWindow::OutputEditWindow(uint8_t channel) :
 
   buildHeader(header);
   buildBody(body);
-
-  CurveEdit::SetCurrentSource(channel + MIXSRC_FIRST_CH);
-}
-
-void OutputEditWindow::deleteLater(bool detach, bool trash)
-{
-  if (!deleted()) {
-    CurveEdit::SetCurrentSource(0);
-    Page::deleteLater(detach, trash);
-  }
 }
 
 void OutputEditWindow::checkEvents()
@@ -187,7 +177,7 @@ void OutputEditWindow::buildBody(Window *form)
 
   // Curve
   new StaticText(line, rect_t{}, TR_CURVE);
-  new CurveChoice(line, GET_SET_DEFAULT(output->curve), nullptr);
+  new CurveChoice(line, GET_SET_DEFAULT(output->curve), nullptr, channel + MIXSRC_FIRST_CH);
 
   // PPM center
   line = form->newLine(grid);

--- a/radio/src/gui/colorlcd/model/output_edit.cpp
+++ b/radio/src/gui/colorlcd/model/output_edit.cpp
@@ -22,6 +22,8 @@
 #include "output_edit.h"
 
 #include "channel_bar.h"
+#include "curveedit.h"
+#include "curve_param.h"
 #include "gvar_numberedit.h"
 #include "edgetx.h"
 #include "etx_lv_theme.h"
@@ -59,6 +61,16 @@ OutputEditWindow::OutputEditWindow(uint8_t channel) :
 
   buildHeader(header);
   buildBody(body);
+
+  CurveEdit::SetCurrentSource(channel + MIXSRC_FIRST_CH);
+}
+
+void OutputEditWindow::deleteLater(bool detach, bool trash)
+{
+  if (!deleted()) {
+    CurveEdit::SetCurrentSource(0);
+    Page::deleteLater(detach, trash);
+  }
 }
 
 void OutputEditWindow::checkEvents()
@@ -175,10 +187,7 @@ void OutputEditWindow::buildBody(Window *form)
 
   // Curve
   new StaticText(line, rect_t{}, TR_CURVE);
-  auto edit = new NumberEdit(line, rect_t{}, -MAX_CURVES, +MAX_CURVES,
-                             GET_SET_DEFAULT(output->curve));
-  edit->setDisplayHandler(
-      [](int32_t value) { return std::string(getCurveString(value)); });
+  new CurveChoice(line, GET_SET_DEFAULT(output->curve), nullptr);
 
   // PPM center
   line = form->newLine(grid);

--- a/radio/src/gui/colorlcd/model/output_edit.h
+++ b/radio/src/gui/colorlcd/model/output_edit.h
@@ -49,6 +49,7 @@ class OutputEditWindow : public Page
   OutputEditStatusBar *statusBar = nullptr;
 
   void checkEvents() override;
+  void deleteLater(bool detach = true, bool trash = true) override;
   void buildHeader(Window *window);
   void buildBody(Window *window);
 };

--- a/radio/src/gui/colorlcd/model/output_edit.h
+++ b/radio/src/gui/colorlcd/model/output_edit.h
@@ -49,7 +49,6 @@ class OutputEditWindow : public Page
   OutputEditStatusBar *statusBar = nullptr;
 
   void checkEvents() override;
-  void deleteLater(bool detach = true, bool trash = true) override;
   void buildHeader(Window *window);
   void buildBody(Window *window);
 };

--- a/radio/src/gui/navigation/navigation.cpp
+++ b/radio/src/gui/navigation/navigation.cpp
@@ -191,7 +191,7 @@ int checkMovedInput(int newval, int i_min, int i_max, unsigned int i_flags, bool
 
 #if defined(AUTOSOURCE)
     if (i_flags & (INCDEC_SOURCE|INCDEC_SOURCE_VALUE)) {
-      int source = GET_MOVED_SOURCE(i_min, i_max);
+      int source = getMovedSource(i_min);
       if (source) {
         if (i_flags & INCDEC_SOURCE_VALUE) {
           if (isSource) {


### PR DESCRIPTION
As discussed in #4914 

- Use popup menu to select curve.
- Allow long press on curve button to jump to curve edit page.

Fixes #5520