### PR TITLE
fix(color): full screen widget may not exit cleanly after calling lcd.exitFullScreen()

### DIFF
--- a/radio/src/gui/colorlcd/mainview/widget.h
+++ b/radio/src/gui/colorlcd/mainview/widget.h
@@ -75,6 +75,7 @@ class Widget : public ButtonBase
 
   // Set/unset fullscreen mode
   void setFullscreen(bool enable);
+  void closeFullscreen() { closeFS = true; }
 
   // Called when the widget options have changed
   virtual void update();
@@ -95,6 +96,7 @@ class Widget : public ButtonBase
   PersistentData* persistentData;
   bool fullscreen = false;
   bool fsAllowed = true;
+  bool closeFS = false;
   lv_obj_t* focusBorder = nullptr;
   lv_style_t borderStyle;
   lv_point_t borderPts[5];

--- a/radio/src/lua/api_colorlcd.cpp
+++ b/radio/src/lua/api_colorlcd.cpp
@@ -1410,11 +1410,8 @@ Exit full screen widget mode.
 */
 static int luaLcdExitFullScreen(lua_State *L)
 {
-  if (runningFS) {
-    auto rfs = runningFS;
-    runningFS = nullptr;
-    rfs->setFullscreen(false);
-  }
+  if (runningFS)
+    runningFS->closeFullscreen();
   return 0;
 }
 

--- a/radio/src/lua/lua_widget.cpp
+++ b/radio/src/lua/lua_widget.cpp
@@ -260,6 +260,11 @@ void LuaWidget::checkEvents()
 {
   Widget::checkEvents();
 
+  if (closeFS) {
+    closeFS = false;
+    setFullscreen(false);
+  }
+
   // Call update once after widget first created
   if (!created) {
     created = true;


### PR DESCRIPTION
Fixes #5540 

Should also be applied to 2.10.5
