### PR TITLE
fix(radio): fix GV calculation and menu navigation in weight/offset/expo fields.

### DIFF
--- a/radio/src/gui/navigation/common.cpp
+++ b/radio/src/gui/navigation/common.cpp
@@ -78,8 +78,7 @@ void onSourceLongEnterPress(const char * result)
   if (result == STR_MENU_INPUTS) {
     checkIncDecSelection =
         getFirstAvailable(MIXSRC_FIRST_INPUT, MIXSRC_LAST_INPUT,
-                          isInputAvailable) +
-        1;
+                          isInputAvailable);
   }
 #if defined(LUA_MODEL_SCRIPTS)
   else if (result == STR_MENU_LUA) {

--- a/radio/src/gui/navigation/navigation.cpp
+++ b/radio/src/gui/navigation/navigation.cpp
@@ -181,7 +181,7 @@ inline int showPopupMenus(event_t event, int newval, int i_min, int i_max,
   return newval;
 }
 
-int checkMovedInput(int newval, int i_min, int i_max, unsigned int i_flags, bool isSource)
+int checkMovedInput(int newval, unsigned int i_flags, bool isSource)
 {
 #if defined(AUTOSWITCH)
   if (i_flags & INCDEC_SWITCH) {
@@ -191,7 +191,7 @@ int checkMovedInput(int newval, int i_min, int i_max, unsigned int i_flags, bool
 
 #if defined(AUTOSOURCE)
     if (i_flags & (INCDEC_SOURCE|INCDEC_SOURCE_VALUE)) {
-      int source = getMovedSource(i_min);
+      int source = getMovedSource(MIXSRC_FIRST_STICK);
       if (source) {
         if (i_flags & INCDEC_SOURCE_VALUE) {
           if (isSource) {

--- a/radio/src/gui/navigation/navigation_9x.cpp
+++ b/radio/src/gui/navigation/navigation_9x.cpp
@@ -35,12 +35,11 @@ int checkIncDec(event_t event, int val, int i_min, int i_max, int srcMin, int sr
   int newval = val;
 
   bool isSource = false;
-  bool origIsSource = false;
   if (i_flags & INCDEC_SOURCE_VALUE) {
     SourceNumVal v;
     v.rawValue = val;
     // Save isSource flag;
-    origIsSource = isSource = v.isSource;
+    isSource = v.isSource;
     // Remove isSource flag;
     val = v.value;
     newval = v.value;
@@ -54,19 +53,22 @@ int checkIncDec(event_t event, int val, int i_min, int i_max, int srcMin, int sr
       val = -val;
     }
 
+    int vmin = isSource ? srcMin : i_min;
+    int vmax = isSource ? srcMax : i_max;
+
     if (event == EVT_KEY_FIRST(KEY_UP) || event == EVT_KEY_REPT(KEY_UP) ||
         event == EVT_KEY_FIRST(KEY_RIGHT) || event == EVT_KEY_REPT(KEY_RIGHT)) {
       do {
         if (IS_KEY_REPT(event) && (i_flags & INCDEC_REP10)) {
-          newval += min(10, i_max - val);
+          newval += min(10, vmax - val);
         }
         else {
           newval++;
         }
       } while (!(i_flags & INCDEC_SKIP_VAL_CHECK_FUNC) && isValueAvailable && !isValueAvailable(newval) &&
-               newval <= i_max);
+               newval <= vmax);
 
-      if (newval > i_max) {
+      if (newval > vmax) {
         newval = val;
         killEvents(event);
         AUDIO_KEY_ERROR();
@@ -75,21 +77,21 @@ int checkIncDec(event_t event, int val, int i_min, int i_max, int srcMin, int sr
                event == EVT_KEY_FIRST(KEY_LEFT) || event == EVT_KEY_REPT(KEY_LEFT)) {
       do {
         if (IS_KEY_REPT(event) && (i_flags & INCDEC_REP10)) {
-          newval -= min(10, val - i_min);
+          newval -= min(10, val - vmin);
         } else {
           newval--;
         }
       } while (!(i_flags & INCDEC_SKIP_VAL_CHECK_FUNC) && isValueAvailable && !isValueAvailable(newval) &&
-               newval >= i_min);
+               newval >= vmin);
 
-      if (newval < i_min) {
+      if (newval < vmin) {
         newval = val;
         killEvents(event);
         AUDIO_KEY_ERROR();
       }
     }
 
-    auto moved =  checkMovedInput(newval, i_min, i_max, i_flags, isSource);
+    auto moved = checkMovedInput(newval, i_flags, isSource);
     if (!isValueAvailable || isValueAvailable(moved))
       newval = moved;
 

--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -60,7 +60,7 @@ int32_t getSourceNumFieldValue(int16_t val, int16_t min, int16_t max)
   SourceNumVal v; v.rawValue = val;
   if (v.isSource) {
     result = getValue(v.value);
-    if (v.value >= MIXSRC_FIRST_GVAR && v.value <= MIXSRC_LAST_GVAR) {
+    if (abs(v.value) >= MIXSRC_FIRST_GVAR && v.value <= MIXSRC_LAST_GVAR) {
       // Mimic behviour of GET_GVAR_PREC1
       result = result * 10;
     } else {

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -437,8 +437,8 @@ char *getValueOrSrcVarString(char *dest, size_t len, gvar_t value, gvar_t vmin,
   SourceNumVal v;
   v.rawValue = value;
   if (v.isSource) {
-    if (v.value >= MIXSRC_FIRST_GVAR && v.value <= MIXSRC_LAST_GVAR) {
-      getGVarString(dest, v.value - MIXSRC_FIRST_GVAR);
+    if (abs(v.value) >= MIXSRC_FIRST_GVAR && v.value <= MIXSRC_LAST_GVAR) {
+      getGVarString(dest, (v.value < 0) ? v.value + MIXSRC_FIRST_GVAR - 1 : v.value - MIXSRC_FIRST_GVAR);
     } else {
       const char* s = getSourceString(v.value);
       strncpy(dest, s, len);


### PR DESCRIPTION
Fixes a number of issues from the changes that allow any source to be used for weight/offset/expo fields.
- Negative GV values are not calculated correctly (all radios).
- After changing field to a source value, the field reverts to a constant value (b&w only).
- Cannot change source value properly using roller, when an Input is selected for the field (b&w only).
- When selecting Inputs as the source type (using long press on the field), the second input is selected instead of the first (b&w only).
