### PR TITLE
fix(color): wrong selection order of model buttons on manage models page

### DIFF
--- a/radio/src/gui/colorlcd/model/model_select.cpp
+++ b/radio/src/gui/colorlcd/model/model_select.cpp
@@ -208,8 +208,10 @@ class ModelsPageBody : public Window
 
   void update()
   {
-    for (auto b : modelButtons)
+    for (auto b : modelButtons) {
       b->hide();
+      lv_group_remove_obj(b->getLvObj());
+    }
 
     ModelsVector models;
     if (selectedLabels.size()) {
@@ -245,7 +247,7 @@ class ModelsPageBody : public Window
       if (button) {
         button->setPos(x, y);
         button->show();
-        lv_obj_move_foreground(button->getLvObj());
+        lv_group_add_obj(lv_group_get_default(), button->getLvObj());
       } else {
         button = new ModelButton(
             this, {x, y, w, h}, model, [=]() { focusedModel = model; },


### PR DESCRIPTION
In some cases the model buttons may not be selected in order from top to bottom, left to right, when using the roller to change model.

To reproduce:
- Set labels select mode to single select
- Create a label that selects a subset of the available models (select from the middle of the model list)
- Enter the manage models page with the above label selected
- Uncheck the label to show all models

When using the roller to change model the selection order is not correct.