### PR TITLE
fix(color): automatic switch and source selection in popup menus not working

### DIFF
--- a/radio/src/gui/colorlcd/libui/modal_window.cpp
+++ b/radio/src/gui/colorlcd/libui/modal_window.cpp
@@ -50,6 +50,7 @@ ModalWindow::ModalWindow(bool closeWhenClickOutside) :
     Window(MainWindow::instance(), {0, 0, LCD_W, LCD_H}, modal_create),
     closeWhenClickOutside(closeWhenClickOutside)
 {
+  setWindowFlag(OPAQUE);
   Layer::push(this);
 }
 


### PR DESCRIPTION
When setting the switch or source for an input, mix, etc, the automatic selection of any moved switch, axis or pot on the radio does not work.

Broken in #5558 