### PR TITLE
fix(color): incorrect method called to free a widget options array

### DIFF
--- a/radio/src/lua/widgets.cpp
+++ b/radio/src/lua/widgets.cpp
@@ -205,7 +205,7 @@ ZoneOption *createOptionsArray(int reference, uint8_t maxOptions)
   else
   {
     TRACE("error in theme/widget options");
-    free(options);
+    delete[] options;
     return NULL;
   }
   UNPROTECT_LUA();


### PR DESCRIPTION
The options array for a widget is allocated with new[]; but was being de-allocated with free() instead of delete[].

Potential crash if there are errors when loading the options for a widget.
