### PR TITLE
fix(color): place UI for all three pots at bottom of main view for PL18/PL18EV

### DIFF
--- a/radio/src/gui/colorlcd/mainview/sliders.cpp
+++ b/radio/src/gui/colorlcd/mainview/sliders.cpp
@@ -162,7 +162,7 @@ MainViewVerticalSlider::MainViewVerticalSlider(Window* parent,
 }
 
 MainView6POS::MainView6POS(Window* parent, uint8_t idx) :
-    Window(parent, rect_t{0, 0, MULTIPOS_W, MULTIPOS_H}), idx(idx)
+    Window(parent, rect_t{0, 0, MULTIPOS_W, LayoutFactory::TRIM_SQUARE_SIZE}), idx(idx)
 {
   char num[] = " ";
   coord_t x = MULTIPOS_W_SPACING / 4 + LayoutFactory::TRIM_SQUARE_SIZE / 4;

--- a/radio/src/gui/colorlcd/mainview/sliders.cpp
+++ b/radio/src/gui/colorlcd/mainview/sliders.cpp
@@ -95,7 +95,7 @@ MainViewSlider::MainViewSlider(Window* parent, const rect_t& rect, uint8_t idx,
 
     lv_coord_t x = LayoutFactory::TRIM_SQUARE_SIZE / 2;
     for (uint8_t i = 0; i <= sliderTicksCount; i++) {
-      if (i == 0 || i == sliderTicksCount / 2 || i == SLIDER_TICKS_COUNT) {
+      if (i == 0 || i == sliderTicksCount / 2 || i == sliderTicksCount) {
         tickPoints[i * 2] = {x, PAD_TINY};
         tickPoints[i * 2 + 1] = {x, SL_SZ};
       } else {

--- a/radio/src/gui/colorlcd/mainview/sliders.h
+++ b/radio/src/gui/colorlcd/mainview/sliders.h
@@ -38,12 +38,17 @@ class MainViewSlider : public Window
   MainViewSlider(Window* parent, const rect_t& rect, uint8_t idx,
                  bool isVertical);
 
-  static LAYOUT_VAL(SLIDER_TICKS_COUNT, 40, 30)
   static LAYOUT_VAL(SLIDER_TICK_SPACING, 4, 4)
+  static LAYOUT_VAL(SLIDER_VTICKS_COUNT, 40, 30)
+#if defined(RADIO_PL18) || defined(RADIO_PL18EV)
+  static constexpr coord_t SLIDER_HTICKS_COUNT = 34;
+#else
+  static LAYOUT_VAL(SLIDER_HTICKS_COUNT, 40, 30)
+#endif
   static constexpr coord_t HORIZONTAL_SLIDERS_WIDTH =
-      SLIDER_TICKS_COUNT * SLIDER_TICK_SPACING + LayoutFactory::TRIM_SQUARE_SIZE;
+      SLIDER_HTICKS_COUNT * SLIDER_TICK_SPACING + LayoutFactory::TRIM_SQUARE_SIZE;
   static constexpr coord_t VERTICAL_SLIDERS_HEIGHT =
-      SLIDER_TICKS_COUNT * SLIDER_TICK_SPACING + LayoutFactory::TRIM_SQUARE_SIZE;
+      SLIDER_VTICKS_COUNT * SLIDER_TICK_SPACING + LayoutFactory::TRIM_SQUARE_SIZE;
 
   static LAYOUT_VAL(SL_SZ, 15, 15)
 

--- a/radio/src/gui/colorlcd/mainview/sliders.h
+++ b/radio/src/gui/colorlcd/mainview/sliders.h
@@ -85,11 +85,10 @@ class MainView6POS : public Window
 
   void checkEvents() override;
 
-  static LAYOUT_VAL(MULTIPOS_H, 18, 18)
   static LAYOUT_VAL(MULTIPOS_W_SPACING, 12, 12)
   static LAYOUT_VAL(MULTIPOS_SZ, 12, 12)
   static LAYOUT_VAL(MULTIPOS_XO, 3, 3)
-  static constexpr coord_t MULTIPOS_W = (6 + 1) * MULTIPOS_W_SPACING;
+  static constexpr coord_t MULTIPOS_W = (XPOTS_MULTIPOS_COUNT + 1) * MULTIPOS_W_SPACING;
 
  protected:
   uint8_t idx;

--- a/radio/src/gui/colorlcd/mainview/view_main_decoration.cpp
+++ b/radio/src/gui/colorlcd/mainview/view_main_decoration.cpp
@@ -121,11 +121,18 @@ void ViewMainDecoration::createSliders(Window* ml, Window* mr, Window* bl, Windo
 
   // Bottom center 6POS
   if (IS_POT_AVAILABLE(pot)) {
+#if defined(RADIO_PL18) || defined(RADIO_PL18EV)
+    if (IS_POT_AVAILABLE(pot)) {
+      sliders[pot] = new MainViewHorizontalSlider(bc, pot);
+    }
+    pot += 1;
+#else
     if (IS_POT_MULTIPOS(pot)) {
       // Has 6POS - place bottom center
       sliders[pot] = new MainView6POS(bc, pot);
       pot += 1;
     }
+#endif
   } else {
     pot += 1;
   }
@@ -141,13 +148,13 @@ void ViewMainDecoration::createSliders(Window* ml, Window* mr, Window* bl, Windo
     // create containers for the sliders, so that they are at the borders of the display
     // on top of each other, when there are two sliders to display per side
     auto leftPots = layoutBox(ml, LV_ALIGN_LEFT_MID, LV_FLEX_FLOW_COLUMN);
-    leftPots->setHeight(MainViewSlider::HORIZONTAL_SLIDERS_WIDTH);
+    leftPots->setHeight(MainViewSlider::VERTICAL_SLIDERS_HEIGHT);
 
     auto rightPots = layoutBox(mr, LV_ALIGN_RIGHT_MID, LV_FLEX_FLOW_COLUMN);
     rightPots->setHeight(MainViewSlider::VERTICAL_SLIDERS_HEIGHT);
 
-    coord_t lsh = (IS_POT_AVAILABLE(pot + 2)) ? MainViewSlider::HORIZONTAL_SLIDERS_WIDTH / 2 : MainViewSlider::HORIZONTAL_SLIDERS_WIDTH;
-    coord_t rsh = (IS_POT_AVAILABLE(pot + 3)) ? MainViewSlider::HORIZONTAL_SLIDERS_WIDTH / 2 : MainViewSlider::HORIZONTAL_SLIDERS_WIDTH;
+    coord_t lsh = (IS_POT_AVAILABLE(pot + 2)) ? MainViewSlider::VERTICAL_SLIDERS_HEIGHT / 2 : MainViewSlider::VERTICAL_SLIDERS_HEIGHT;
+    coord_t rsh = (IS_POT_AVAILABLE(pot + 3)) ? MainViewSlider::VERTICAL_SLIDERS_HEIGHT / 2 : MainViewSlider::VERTICAL_SLIDERS_HEIGHT;
 
     if (IS_POT_AVAILABLE(pot)) {
       sliders[pot] = new MainViewVerticalSlider(leftPots, rect_t{0, 0, LayoutFactory::TRIM_SQUARE_SIZE, lsh}, pot);

--- a/radio/src/gui/colorlcd/mainview/view_main_decoration.cpp
+++ b/radio/src/gui/colorlcd/mainview/view_main_decoration.cpp
@@ -122,9 +122,7 @@ void ViewMainDecoration::createSliders(Window* ml, Window* mr, Window* bl, Windo
   // Bottom center 6POS
   if (IS_POT_AVAILABLE(pot)) {
 #if defined(RADIO_PL18) || defined(RADIO_PL18EV)
-    if (IS_POT_AVAILABLE(pot)) {
-      sliders[pot] = new MainViewHorizontalSlider(bc, pot);
-    }
+    sliders[pot] = new MainViewHorizontalSlider(bc, pot);
     pot += 1;
 #else
     if (IS_POT_MULTIPOS(pot)) {


### PR DESCRIPTION
Clean up PL18 UI by having the three pots at the bottom and the two sliders on the sides.

Also repositions the 6POS display so that the selection box is aligned with the sliders.
