### PR TITLE
feat(color): add FILE type for widget options

### DIFF
--- a/companion/src/firmwares/customisation_data.cpp
+++ b/companion/src/firmwares/customisation_data.cpp
@@ -71,6 +71,7 @@ inline ZoneOptionValueEnum zoneValueEnumFromType(ZoneOption::Type type)
 {
   switch(type) {
   case ZoneOption::String:
+  case ZoneOption::File:
     return ZOV_String;
 
   case ZoneOption::Integer:

--- a/companion/src/firmwares/customisation_data.h
+++ b/companion/src/firmwares/customisation_data.h
@@ -97,6 +97,7 @@ struct ZoneOption
     Align,
     Slider,
     Choice,
+    File,
   };
 
   const char * name;

--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -72,11 +72,11 @@ static inline void check_struct()
   CHKSIZE(LimitData, 13);
   CHKSIZE(TimerData, 17);
   CHKSIZE(ModelHeader, 131);
-  CHKSIZE(CustomScreenData, 1452);
+  CHKSIZE(CustomScreenData, 1892);
   #if defined(PCBNV14)
-    CHKTYPE(TopBarPersistentData, 540);
+    CHKTYPE(TopBarPersistentData, 704);
   #else
-    CHKTYPE(TopBarPersistentData, 804);
+    CHKTYPE(TopBarPersistentData, 1048);
   #endif
 #else
   #error CHKSIZE not set up
@@ -103,13 +103,13 @@ static inline void check_struct()
 #elif defined(PCBX7) || defined(PCBXLITE) || defined(PCBX9LITE)
   CHKSIZE(ModelData, 6329);
 #elif defined(PCBNV14)
-  CHKSIZE(ModelData, 21899);
+  CHKSIZE(ModelData, 26463);
 #elif defined(PCBPL18)
-  CHKSIZE(ModelData, 22201);
+  CHKSIZE(ModelData, 26845);
 #elif defined(RADIO_T15)
-  CHKSIZE(ModelData, 22190);
+  CHKSIZE(ModelData, 26834);
 #elif defined(PCBHORUS)
-  CHKSIZE(ModelData, 22165);
+  CHKSIZE(ModelData, 26809);
 #else
   #error CHKSIZE not set up
 #endif

--- a/radio/src/gui/colorlcd/libui/filechoice.h
+++ b/radio/src/gui/colorlcd/libui/filechoice.h
@@ -29,7 +29,7 @@ public:
              std::function<std::string()> getValue,
              std::function<void(std::string)> setValue,
              bool stripExtension = false,
-             const char* title = nullptr);
+             const char* title = "");
 
 #if defined(DEBUG_WINDOWS)
   std::string getName() const override { return "FileChoice"; }

--- a/radio/src/gui/colorlcd/mainview/widget_settings.cpp
+++ b/radio/src/gui/colorlcd/mainview/widget_settings.cpp
@@ -27,6 +27,7 @@
 #include "sourcechoice.h"
 #include "switchchoice.h"
 #include "view_main.h"
+#include "filechoice.h"
 
 #define SET_DIRTY() storageDirty(EE_MODEL)
 
@@ -190,6 +191,20 @@ WidgetSettings::WidgetSettings(Widget* w) :
               optVal->unsignedValue = newValue + 1;
               SET_DIRTY();
             });
+        break;
+
+      case ZoneOption::File:
+        new FileChoice(line, rect_t{}, opt->fileSelectPath, nullptr, LEN_ZONE_OPTION_STRING,
+                        [=]() {
+                          char s[LEN_ZONE_OPTION_STRING + 1];
+                          strncpy(s, optVal->stringValue, LEN_ZONE_OPTION_STRING);
+                          s[LEN_ZONE_OPTION_STRING] = 0;
+                          return std::string(s);
+                        },
+                        [=](std::string s) {
+                          strncpy(optVal->stringValue, s.c_str(), LEN_ZONE_OPTION_STRING);
+                          SET_DIRTY();
+                        });
         break;
     }
 

--- a/radio/src/gui/colorlcd/mainview/zone.h
+++ b/radio/src/gui/colorlcd/mainview/zone.h
@@ -25,7 +25,7 @@
 #include "storage/yaml/yaml_defs.h"
 #include <vector>
 
-#define LEN_ZONE_OPTION_STRING         8
+#define LEN_ZONE_OPTION_STRING 12
 
 #if defined(_MSC_VER)
   #define OPTION_VALUE_UNSIGNED(x)    { uint32_t(x) }
@@ -74,6 +74,7 @@ struct ZoneOption
     Align,
     Slider,
     Choice,
+    File,
   };
 
   const char * name;
@@ -82,6 +83,7 @@ struct ZoneOption
   ZoneOptionValue min;
   ZoneOptionValue max;
   const char * displayName;
+  std::string fileSelectPath;
   std::vector<std::string> choiceValues;
 };
 
@@ -105,6 +107,7 @@ inline ZoneOptionValueEnum zoneValueEnumFromType(ZoneOption::Type type)
 {
   switch(type) {
   case ZoneOption::String:
+  case ZoneOption::File:
     return ZOV_String;
 
   case ZoneOption::Integer:

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -3118,6 +3118,7 @@ LROT_BEGIN(etxcst, NULL, 0)
   LROT_NUMENTRY( SWITCH, ZoneOption::Switch )
   LROT_NUMENTRY( SLIDER, ZoneOption::Slider )
   LROT_NUMENTRY( CHOICE, ZoneOption::Choice )
+  LROT_NUMENTRY( FILE, ZoneOption::File )
   LROT_NUMENTRY( MENU_HEADER_HEIGHT, COLOR2FLAGS(EdgeTxStyles::MENU_HEADER_HEIGHT) )
 
   // Colors gui/colorlcd/colors.h

--- a/radio/src/lua/lua_widget.cpp
+++ b/radio/src/lua/lua_widget.cpp
@@ -323,6 +323,7 @@ void LuaWidget::update()
     auto optVal = getOptionValue(i);
     switch (option->type) {
       case ZoneOption::String:
+      case ZoneOption::File:
         {
           char str[LEN_ZONE_OPTION_STRING + 1] = {0};
           strncpy(str, optVal->stringValue, LEN_ZONE_OPTION_STRING);

--- a/radio/src/lua/lua_widget_factory.cpp
+++ b/radio/src/lua/lua_widget_factory.cpp
@@ -81,7 +81,7 @@ Widget* LuaWidgetFactory::create(Window* parent, const rect_t& rect,
   lua_newtable(lsWidgets);
   int i = 0;
   for (const ZoneOption* option = options; option->name; option++, i++) {
-    if (option->type == ZoneOption::String) {
+    if (option->type == ZoneOption::String || option->type == ZoneOption::File) {
       lua_pushstring(lsWidgets, option->name);
       // Zero-terminated string for Lua
       char str[LEN_ZONE_OPTION_STRING + 1] = {0};

--- a/radio/src/lua/widgets.cpp
+++ b/radio/src/lua/widgets.cpp
@@ -134,21 +134,18 @@ ZoneOption *createOptionsArray(int reference, uint8_t maxOptions)
         luaL_checktype(lsWidgets, -2, LUA_TNUMBER);  // key is number
         switch (field) {
           case 0:
-            luaL_checktype(lsWidgets, -1, LUA_TSTRING);  // value is string
-            option->name = lua_tostring(lsWidgets, -1);
+            option->name = luaL_checkstring(lsWidgets, -1);
             option->displayName = nullptr;
             // TRACE("name = %s", option->name);
             break;
           case 1:
-            luaL_checktype(lsWidgets, -1, LUA_TNUMBER);  // value is number
-            option->type = (ZoneOption::Type)lua_tointeger(lsWidgets, -1);
+            option->type = (ZoneOption::Type)luaL_checkinteger(lsWidgets, -1);
             option->deflt.unsignedValue = 0;
+            // set some sensible defaults
             if (option->type == ZoneOption::Integer) {
-              // set some sensible defaults
               option->min.signedValue = -100;
               option->max.signedValue = 100;
             } else if (option->type == ZoneOption::Switch) {
-              // set some sensible defaults
               option->min.signedValue = SWSRC_FIRST;
               option->max.signedValue = SWSRC_LAST;
             } else if (option->type == ZoneOption::Timer) {
@@ -157,7 +154,7 @@ ZoneOption *createOptionsArray(int reference, uint8_t maxOptions)
             } else if (option->type == ZoneOption::TextSize) {
               option->min.unsignedValue = FONT_STD_INDEX;
               option->max.unsignedValue = FONTS_COUNT - 1;
-            } else if (option->type == ZoneOption::String) {
+            } else if (option->type == ZoneOption::String || option->type == ZoneOption::File) {
               option->deflt.stringValue[0] = 0;
             } else if (option->type == ZoneOption::Slider) {
               option->min.unsignedValue = 0;
@@ -166,34 +163,31 @@ ZoneOption *createOptionsArray(int reference, uint8_t maxOptions)
             break;
           case 2:
             if (option->type == ZoneOption::Integer || option->type == ZoneOption::Switch) {
-              luaL_checktype(lsWidgets, -1, LUA_TNUMBER);  // value is number
-              option->deflt.signedValue = lua_tointeger(lsWidgets, -1);
+              option->deflt.signedValue = luaL_checkinteger(lsWidgets, -1);
             } else if (option->type == ZoneOption::Bool) {
-              luaL_checktype(lsWidgets, -1, LUA_TNUMBER);  // value is number
-              option->deflt.boolValue = (lua_tounsigned(lsWidgets, -1) != 0);
-            } else if (option->type == ZoneOption::String) {
-              strncpy(option->deflt.stringValue, lua_tostring(lsWidgets, -1),
+              option->deflt.boolValue = (luaL_checkunsigned(lsWidgets, -1) != 0);
+            } else if (option->type == ZoneOption::String || option->type == ZoneOption::File) {
+              strncpy(option->deflt.stringValue, luaL_checkstring(lsWidgets, -1),
                       LEN_ZONE_OPTION_STRING);
             } else {
-              luaL_checktype(lsWidgets, -1, LUA_TNUMBER);  // value is number
-              option->deflt.unsignedValue = lua_tounsigned(lsWidgets, -1);
+              option->deflt.unsignedValue = luaL_checkunsigned(lsWidgets, -1);
             }
             break;
           case 3:
             if (option->type == ZoneOption::Integer || option->type == ZoneOption::Switch || option->type == ZoneOption::Slider) {
-              luaL_checktype(lsWidgets, -1, LUA_TNUMBER);  // value is number
-              option->min.signedValue = lua_tointeger(lsWidgets, -1);
+              option->min.signedValue = luaL_checkinteger(lsWidgets, -1);
             } else if (option->type == ZoneOption::Choice) {
               luaL_checktype(lsWidgets, -1, LUA_TTABLE); // value is a table
               for (lua_pushnil(lsWidgets); lua_next(lsWidgets, -2); lua_pop(lsWidgets, 1)) {
-                option->choiceValues.push_back(lua_tostring(lsWidgets, -1));
+                option->choiceValues.push_back(luaL_checkstring(lsWidgets, -1));
               }
+            } else if (option->type == ZoneOption::File) {
+              option->fileSelectPath = luaL_checkstring(lsWidgets, -1);
             }
             break;
           case 4:
             if (option->type == ZoneOption::Integer || option->type == ZoneOption::Switch || option->type == ZoneOption::Slider) {
-              luaL_checktype(lsWidgets, -1, LUA_TNUMBER);  // value is number
-              option->max.signedValue = lua_tointeger(lsWidgets, -1);
+              option->max.signedValue = luaL_checkinteger(lsWidgets, -1);
             }
             break;
         }

--- a/radio/src/storage/yaml/yaml_datastructs_f16.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_f16.cpp
@@ -767,7 +767,7 @@ static const struct YamlNode union_ZoneOptionValue_elmts[] = {
   YAML_UNSIGNED( "unsignedValue", 32 ),
   YAML_SIGNED( "signedValue", 32 ),
   YAML_UNSIGNED( "boolValue", 32 ),
-  YAML_STRING("stringValue", 8),
+  YAML_STRING("stringValue", 12),
   YAML_CUSTOM("source",r_zov_source,w_zov_source),
   YAML_CUSTOM("color",r_zov_color,w_zov_color),
   YAML_END
@@ -775,33 +775,33 @@ static const struct YamlNode union_ZoneOptionValue_elmts[] = {
 static const struct YamlNode struct_ZoneOptionValueTyped[] = {
   YAML_IDX,
   YAML_ENUM("type", 32, enum_ZoneOptionValueEnum),
-  YAML_UNION("value", 64, union_ZoneOptionValue_elmts, select_zov),
+  YAML_UNION("value", 96, union_ZoneOptionValue_elmts, select_zov),
   YAML_END
 };
 static const struct YamlNode struct_WidgetPersistentData[] = {
-  YAML_ARRAY("options", 96, 10, struct_ZoneOptionValueTyped, NULL),
+  YAML_ARRAY("options", 128, 10, struct_ZoneOptionValueTyped, NULL),
   YAML_END
 };
 static const struct YamlNode struct_ZonePersistentData[] = {
   YAML_IDX,
   YAML_STRING("widgetName", 12),
-  YAML_STRUCT("widgetData", 960, struct_WidgetPersistentData, NULL),
+  YAML_STRUCT("widgetData", 1280, struct_WidgetPersistentData, NULL),
   YAML_END
 };
 static const struct YamlNode struct_LayoutPersistentData[] = {
-  YAML_ARRAY("zones", 1056, 10, struct_ZonePersistentData, NULL),
-  YAML_ARRAY("options", 96, 10, struct_ZoneOptionValueTyped, NULL),
+  YAML_ARRAY("zones", 1376, 10, struct_ZonePersistentData, NULL),
+  YAML_ARRAY("options", 128, 10, struct_ZoneOptionValueTyped, NULL),
   YAML_END
 };
 static const struct YamlNode struct_CustomScreenData[] = {
   YAML_IDX,
   YAML_STRING("LayoutId", 12),
-  YAML_STRUCT("layoutData", 11520, struct_LayoutPersistentData, NULL),
+  YAML_STRUCT("layoutData", 15040, struct_LayoutPersistentData, NULL),
   YAML_END
 };
 static const struct YamlNode struct_TopBarPersistentData[] = {
-  YAML_ARRAY("zones", 1056, 6, struct_ZonePersistentData, NULL),
-  YAML_ARRAY("options", 96, 1, struct_ZoneOptionValueTyped, NULL),
+  YAML_ARRAY("zones", 1376, 6, struct_ZonePersistentData, NULL),
+  YAML_ARRAY("options", 128, 1, struct_ZoneOptionValueTyped, NULL),
   YAML_END
 };
 static const struct YamlNode struct_USBJoystickChData[] = {
@@ -865,8 +865,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "potsWarnEnabled", 16 ),
   YAML_ARRAY("potsWarnPosition", 8, 16, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 60, struct_TelemetrySensor, NULL),
-  YAML_ARRAY("screenData", 11616, 10, struct_CustomScreenData, NULL),
-  YAML_STRUCT("topbarData", 6432, struct_TopBarPersistentData, NULL),
+  YAML_ARRAY("screenData", 15136, 10, struct_CustomScreenData, NULL),
+  YAML_STRUCT("topbarData", 8384, struct_TopBarPersistentData, NULL),
   YAML_ARRAY("topbarWidgetWidth", 8, 6, struct_unsigned_8, NULL),
   YAML_UNSIGNED( "view", 8 ),
   YAML_STRING("modelRegistrationID", 8),

--- a/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
@@ -764,7 +764,7 @@ static const struct YamlNode union_ZoneOptionValue_elmts[] = {
   YAML_UNSIGNED( "unsignedValue", 32 ),
   YAML_SIGNED( "signedValue", 32 ),
   YAML_UNSIGNED( "boolValue", 32 ),
-  YAML_STRING("stringValue", 8),
+  YAML_STRING("stringValue", 12),
   YAML_CUSTOM("source",r_zov_source,w_zov_source),
   YAML_CUSTOM("color",r_zov_color,w_zov_color),
   YAML_END
@@ -772,33 +772,33 @@ static const struct YamlNode union_ZoneOptionValue_elmts[] = {
 static const struct YamlNode struct_ZoneOptionValueTyped[] = {
   YAML_IDX,
   YAML_ENUM("type", 32, enum_ZoneOptionValueEnum),
-  YAML_UNION("value", 64, union_ZoneOptionValue_elmts, select_zov),
+  YAML_UNION("value", 96, union_ZoneOptionValue_elmts, select_zov),
   YAML_END
 };
 static const struct YamlNode struct_WidgetPersistentData[] = {
-  YAML_ARRAY("options", 96, 10, struct_ZoneOptionValueTyped, NULL),
+  YAML_ARRAY("options", 128, 10, struct_ZoneOptionValueTyped, NULL),
   YAML_END
 };
 static const struct YamlNode struct_ZonePersistentData[] = {
   YAML_IDX,
   YAML_STRING("widgetName", 12),
-  YAML_STRUCT("widgetData", 960, struct_WidgetPersistentData, NULL),
+  YAML_STRUCT("widgetData", 1280, struct_WidgetPersistentData, NULL),
   YAML_END
 };
 static const struct YamlNode struct_LayoutPersistentData[] = {
-  YAML_ARRAY("zones", 1056, 10, struct_ZonePersistentData, NULL),
-  YAML_ARRAY("options", 96, 10, struct_ZoneOptionValueTyped, NULL),
+  YAML_ARRAY("zones", 1376, 10, struct_ZonePersistentData, NULL),
+  YAML_ARRAY("options", 128, 10, struct_ZoneOptionValueTyped, NULL),
   YAML_END
 };
 static const struct YamlNode struct_CustomScreenData[] = {
   YAML_IDX,
   YAML_STRING("LayoutId", 12),
-  YAML_STRUCT("layoutData", 11520, struct_LayoutPersistentData, NULL),
+  YAML_STRUCT("layoutData", 15040, struct_LayoutPersistentData, NULL),
   YAML_END
 };
 static const struct YamlNode struct_TopBarPersistentData[] = {
-  YAML_ARRAY("zones", 1056, 4, struct_ZonePersistentData, NULL),
-  YAML_ARRAY("options", 96, 1, struct_ZoneOptionValueTyped, NULL),
+  YAML_ARRAY("zones", 1376, 4, struct_ZonePersistentData, NULL),
+  YAML_ARRAY("options", 128, 1, struct_ZoneOptionValueTyped, NULL),
   YAML_END
 };
 static const struct YamlNode struct_USBJoystickChData[] = {
@@ -863,8 +863,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "potsWarnEnabled", 16 ),
   YAML_ARRAY("potsWarnPosition", 8, 16, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 60, struct_TelemetrySensor, NULL),
-  YAML_ARRAY("screenData", 11616, 10, struct_CustomScreenData, NULL),
-  YAML_STRUCT("topbarData", 4320, struct_TopBarPersistentData, NULL),
+  YAML_ARRAY("screenData", 15136, 10, struct_CustomScreenData, NULL),
+  YAML_STRUCT("topbarData", 5632, struct_TopBarPersistentData, NULL),
   YAML_ARRAY("topbarWidgetWidth", 8, 4, struct_unsigned_8, NULL),
   YAML_UNSIGNED( "view", 8 ),
   YAML_STRING("modelRegistrationID", 8),

--- a/radio/src/storage/yaml/yaml_datastructs_pl18.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_pl18.cpp
@@ -764,7 +764,7 @@ static const struct YamlNode union_ZoneOptionValue_elmts[] = {
   YAML_UNSIGNED( "unsignedValue", 32 ),
   YAML_SIGNED( "signedValue", 32 ),
   YAML_UNSIGNED( "boolValue", 32 ),
-  YAML_STRING("stringValue", 8),
+  YAML_STRING("stringValue", 12),
   YAML_CUSTOM("source",r_zov_source,w_zov_source),
   YAML_CUSTOM("color",r_zov_color,w_zov_color),
   YAML_END
@@ -772,33 +772,33 @@ static const struct YamlNode union_ZoneOptionValue_elmts[] = {
 static const struct YamlNode struct_ZoneOptionValueTyped[] = {
   YAML_IDX,
   YAML_ENUM("type", 32, enum_ZoneOptionValueEnum),
-  YAML_UNION("value", 64, union_ZoneOptionValue_elmts, select_zov),
+  YAML_UNION("value", 96, union_ZoneOptionValue_elmts, select_zov),
   YAML_END
 };
 static const struct YamlNode struct_WidgetPersistentData[] = {
-  YAML_ARRAY("options", 96, 10, struct_ZoneOptionValueTyped, NULL),
+  YAML_ARRAY("options", 128, 10, struct_ZoneOptionValueTyped, NULL),
   YAML_END
 };
 static const struct YamlNode struct_ZonePersistentData[] = {
   YAML_IDX,
   YAML_STRING("widgetName", 12),
-  YAML_STRUCT("widgetData", 960, struct_WidgetPersistentData, NULL),
+  YAML_STRUCT("widgetData", 1280, struct_WidgetPersistentData, NULL),
   YAML_END
 };
 static const struct YamlNode struct_LayoutPersistentData[] = {
-  YAML_ARRAY("zones", 1056, 10, struct_ZonePersistentData, NULL),
-  YAML_ARRAY("options", 96, 10, struct_ZoneOptionValueTyped, NULL),
+  YAML_ARRAY("zones", 1376, 10, struct_ZonePersistentData, NULL),
+  YAML_ARRAY("options", 128, 10, struct_ZoneOptionValueTyped, NULL),
   YAML_END
 };
 static const struct YamlNode struct_CustomScreenData[] = {
   YAML_IDX,
   YAML_STRING("LayoutId", 12),
-  YAML_STRUCT("layoutData", 11520, struct_LayoutPersistentData, NULL),
+  YAML_STRUCT("layoutData", 15040, struct_LayoutPersistentData, NULL),
   YAML_END
 };
 static const struct YamlNode struct_TopBarPersistentData[] = {
-  YAML_ARRAY("zones", 1056, 6, struct_ZonePersistentData, NULL),
-  YAML_ARRAY("options", 96, 1, struct_ZoneOptionValueTyped, NULL),
+  YAML_ARRAY("zones", 1376, 6, struct_ZonePersistentData, NULL),
+  YAML_ARRAY("options", 128, 1, struct_ZoneOptionValueTyped, NULL),
   YAML_END
 };
 static const struct YamlNode struct_USBJoystickChData[] = {
@@ -863,8 +863,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "potsWarnEnabled", 16 ),
   YAML_ARRAY("potsWarnPosition", 8, 16, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 60, struct_TelemetrySensor, NULL),
-  YAML_ARRAY("screenData", 11616, 10, struct_CustomScreenData, NULL),
-  YAML_STRUCT("topbarData", 6432, struct_TopBarPersistentData, NULL),
+  YAML_ARRAY("screenData", 15136, 10, struct_CustomScreenData, NULL),
+  YAML_STRUCT("topbarData", 8384, struct_TopBarPersistentData, NULL),
   YAML_ARRAY("topbarWidgetWidth", 8, 6, struct_unsigned_8, NULL),
   YAML_UNSIGNED( "view", 8 ),
   YAML_STRING("modelRegistrationID", 8),

--- a/radio/src/storage/yaml/yaml_datastructs_t15.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t15.cpp
@@ -767,7 +767,7 @@ static const struct YamlNode union_ZoneOptionValue_elmts[] = {
   YAML_UNSIGNED( "unsignedValue", 32 ),
   YAML_SIGNED( "signedValue", 32 ),
   YAML_UNSIGNED( "boolValue", 32 ),
-  YAML_STRING("stringValue", 8),
+  YAML_STRING("stringValue", 12),
   YAML_CUSTOM("source",r_zov_source,w_zov_source),
   YAML_CUSTOM("color",r_zov_color,w_zov_color),
   YAML_END
@@ -775,33 +775,33 @@ static const struct YamlNode union_ZoneOptionValue_elmts[] = {
 static const struct YamlNode struct_ZoneOptionValueTyped[] = {
   YAML_IDX,
   YAML_ENUM("type", 32, enum_ZoneOptionValueEnum),
-  YAML_UNION("value", 64, union_ZoneOptionValue_elmts, select_zov),
+  YAML_UNION("value", 96, union_ZoneOptionValue_elmts, select_zov),
   YAML_END
 };
 static const struct YamlNode struct_WidgetPersistentData[] = {
-  YAML_ARRAY("options", 96, 10, struct_ZoneOptionValueTyped, NULL),
+  YAML_ARRAY("options", 128, 10, struct_ZoneOptionValueTyped, NULL),
   YAML_END
 };
 static const struct YamlNode struct_ZonePersistentData[] = {
   YAML_IDX,
   YAML_STRING("widgetName", 12),
-  YAML_STRUCT("widgetData", 960, struct_WidgetPersistentData, NULL),
+  YAML_STRUCT("widgetData", 1280, struct_WidgetPersistentData, NULL),
   YAML_END
 };
 static const struct YamlNode struct_LayoutPersistentData[] = {
-  YAML_ARRAY("zones", 1056, 10, struct_ZonePersistentData, NULL),
-  YAML_ARRAY("options", 96, 10, struct_ZoneOptionValueTyped, NULL),
+  YAML_ARRAY("zones", 1376, 10, struct_ZonePersistentData, NULL),
+  YAML_ARRAY("options", 128, 10, struct_ZoneOptionValueTyped, NULL),
   YAML_END
 };
 static const struct YamlNode struct_CustomScreenData[] = {
   YAML_IDX,
   YAML_STRING("LayoutId", 12),
-  YAML_STRUCT("layoutData", 11520, struct_LayoutPersistentData, NULL),
+  YAML_STRUCT("layoutData", 15040, struct_LayoutPersistentData, NULL),
   YAML_END
 };
 static const struct YamlNode struct_TopBarPersistentData[] = {
-  YAML_ARRAY("zones", 1056, 6, struct_ZonePersistentData, NULL),
-  YAML_ARRAY("options", 96, 1, struct_ZoneOptionValueTyped, NULL),
+  YAML_ARRAY("zones", 1376, 6, struct_ZonePersistentData, NULL),
+  YAML_ARRAY("options", 128, 1, struct_ZoneOptionValueTyped, NULL),
   YAML_END
 };
 static const struct YamlNode struct_string_24[] = {
@@ -870,8 +870,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "potsWarnEnabled", 16 ),
   YAML_ARRAY("potsWarnPosition", 8, 16, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 60, struct_TelemetrySensor, NULL),
-  YAML_ARRAY("screenData", 11616, 10, struct_CustomScreenData, NULL),
-  YAML_STRUCT("topbarData", 6432, struct_TopBarPersistentData, NULL),
+  YAML_ARRAY("screenData", 15136, 10, struct_CustomScreenData, NULL),
+  YAML_STRUCT("topbarData", 8384, struct_TopBarPersistentData, NULL),
   YAML_ARRAY("topbarWidgetWidth", 8, 6, struct_unsigned_8, NULL),
   YAML_UNSIGNED( "view", 8 ),
   YAML_STRING("modelRegistrationID", 8),

--- a/radio/src/storage/yaml/yaml_datastructs_x10.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x10.cpp
@@ -766,7 +766,7 @@ static const struct YamlNode union_ZoneOptionValue_elmts[] = {
   YAML_UNSIGNED( "unsignedValue", 32 ),
   YAML_SIGNED( "signedValue", 32 ),
   YAML_UNSIGNED( "boolValue", 32 ),
-  YAML_STRING("stringValue", 8),
+  YAML_STRING("stringValue", 12),
   YAML_CUSTOM("source",r_zov_source,w_zov_source),
   YAML_CUSTOM("color",r_zov_color,w_zov_color),
   YAML_END
@@ -774,33 +774,33 @@ static const struct YamlNode union_ZoneOptionValue_elmts[] = {
 static const struct YamlNode struct_ZoneOptionValueTyped[] = {
   YAML_IDX,
   YAML_ENUM("type", 32, enum_ZoneOptionValueEnum),
-  YAML_UNION("value", 64, union_ZoneOptionValue_elmts, select_zov),
+  YAML_UNION("value", 96, union_ZoneOptionValue_elmts, select_zov),
   YAML_END
 };
 static const struct YamlNode struct_WidgetPersistentData[] = {
-  YAML_ARRAY("options", 96, 10, struct_ZoneOptionValueTyped, NULL),
+  YAML_ARRAY("options", 128, 10, struct_ZoneOptionValueTyped, NULL),
   YAML_END
 };
 static const struct YamlNode struct_ZonePersistentData[] = {
   YAML_IDX,
   YAML_STRING("widgetName", 12),
-  YAML_STRUCT("widgetData", 960, struct_WidgetPersistentData, NULL),
+  YAML_STRUCT("widgetData", 1280, struct_WidgetPersistentData, NULL),
   YAML_END
 };
 static const struct YamlNode struct_LayoutPersistentData[] = {
-  YAML_ARRAY("zones", 1056, 10, struct_ZonePersistentData, NULL),
-  YAML_ARRAY("options", 96, 10, struct_ZoneOptionValueTyped, NULL),
+  YAML_ARRAY("zones", 1376, 10, struct_ZonePersistentData, NULL),
+  YAML_ARRAY("options", 128, 10, struct_ZoneOptionValueTyped, NULL),
   YAML_END
 };
 static const struct YamlNode struct_CustomScreenData[] = {
   YAML_IDX,
   YAML_STRING("LayoutId", 12),
-  YAML_STRUCT("layoutData", 11520, struct_LayoutPersistentData, NULL),
+  YAML_STRUCT("layoutData", 15040, struct_LayoutPersistentData, NULL),
   YAML_END
 };
 static const struct YamlNode struct_TopBarPersistentData[] = {
-  YAML_ARRAY("zones", 1056, 6, struct_ZonePersistentData, NULL),
-  YAML_ARRAY("options", 96, 1, struct_ZoneOptionValueTyped, NULL),
+  YAML_ARRAY("zones", 1376, 6, struct_ZonePersistentData, NULL),
+  YAML_ARRAY("options", 128, 1, struct_ZoneOptionValueTyped, NULL),
   YAML_END
 };
 static const struct YamlNode struct_USBJoystickChData[] = {
@@ -864,8 +864,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "potsWarnEnabled", 16 ),
   YAML_ARRAY("potsWarnPosition", 8, 16, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 60, struct_TelemetrySensor, NULL),
-  YAML_ARRAY("screenData", 11616, 10, struct_CustomScreenData, NULL),
-  YAML_STRUCT("topbarData", 6432, struct_TopBarPersistentData, NULL),
+  YAML_ARRAY("screenData", 15136, 10, struct_CustomScreenData, NULL),
+  YAML_STRUCT("topbarData", 8384, struct_TopBarPersistentData, NULL),
   YAML_ARRAY("topbarWidgetWidth", 8, 6, struct_unsigned_8, NULL),
   YAML_UNSIGNED( "view", 8 ),
   YAML_STRING("modelRegistrationID", 8),


### PR DESCRIPTION
Resolves #5573 

Parameters:
- Option name
- FILE
- default value
- Folder to open to select file

Only the filename is returned for the option, excluding the path.
Filenames are limited to 12 characters maximum length.

> [!NOTE]
String widget option is increased from 8 characters to 12 characters

Example:
```C
  { "File", FILE, "testimg.png", "/IMAGES"},
```
