### PR TITLE
chore: bump to macos-13

### DIFF
--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -32,7 +32,7 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: macos-12
+    runs-on: macos-13
 
     steps:
       - name: Select XCode version

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Select XCode version
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: '13.2.1'
+          xcode-version: '14.1.0'
 
       - name: Check out the repo
         uses: actions/checkout@v4


### PR DESCRIPTION
GitHub is ending macos-12 support in December 2024, and is already throttling the build duration for this target as of July. 

> The macOS 12 runner image will be removed by December 3rd, 2024. To raise awareness of the upcoming removal, jobs using macOS 12 will temporarily fail during scheduled time periods defined below:
> 
> November 4, 9:00 AM - 7:00 PM EST
> November 11, 9:00 AM - 7:00 PM EST
> November 18, 9:00 AM - 7:00 PM EST
> November 25, 9:00 AM - 7:00 PM EST
> 

ref: https://github.com/actions/runner-images/issues/10721