### PR TITLE
chore: improve VBAT measurement

### DIFF
--- a/radio/src/hal/adc_driver.cpp
+++ b/radio/src/hal/adc_driver.cpp
@@ -314,7 +314,10 @@ uint16_t getBatteryVoltage()
   int32_t instant_vbat = anaIn(adcGetInputOffset(ADC_INPUT_VBAT));
 
   // TODO: remove BATT_SCALE / BATTERY_DIVIDER defines
-#if defined(BATT_SCALE)
+#if defined(VBAT_MOSFET_DROP)
+  // 1000 is used as multiplier for both numerator and denominator to allow to stay in integer domain
+  return (uint16_t)((instant_vbat * ADC_VREF_PREC2 * ((((1000 + g_eeGeneral.txVoltageCalibration)) * (VBAT_DIV_R2 + VBAT_DIV_R1)) / VBAT_DIV_R1)) / (2*RESX*1000)) + VBAT_MOSFET_DROP;
+#elif defined(BATT_SCALE)
   instant_vbat =
       (instant_vbat * BATT_SCALE * (128 + g_eeGeneral.txVoltageCalibration)) /
       BATTERY_DIVIDER;

--- a/radio/src/targets/simu/adc_driver.cpp
+++ b/radio/src/targets/simu/adc_driver.cpp
@@ -43,13 +43,13 @@ static bool simu_start_conversion()
 
   // set VBAT / RTC_BAT
   if (adcGetMaxInputs(ADC_INPUT_VBAT) > 0) {
-    uint32_t vbat = (BATTERY_MAX + BATTERY_MIN) * 5; // * 10 / 2
 #if defined(VBAT_MOSFET_DROP)
-    // 1000 is used as multiplier for both numerator and denominator to allow to stay in integer domain
-    return (uint16_t)((vbat * ADC_VREF_PREC2 * ((((1000 + g_eeGeneral.txVoltageCalibration)) * (VBAT_DIV_R2 + VBAT_DIV_R1)) / VBAT_DIV_R1)) / (2*1024*1000)) + VBAT_MOSFET_DROP;
+    uint32_t vbat = (2 * (BATTERY_MAX + BATTERY_MIN) * (VBAT_DIV_R2 + VBAT_DIV_R1)) / VBAT_DIV_R1;
 #elif defined(BATT_SCALE)
+    uint32_t vbat = (BATTERY_MAX + BATTERY_MIN) * 5; // * 10 / 2
     vbat = ((vbat - VOLTAGE_DROP) * BATTERY_DIVIDER) / (BATT_SCALE * 128);
 #else
+    uint32_t vbat = (BATTERY_MAX + BATTERY_MIN) * 5; // * 10 / 2
     vbat = (vbat * BATTERY_DIVIDER) / 1000;
 #endif
     setAnalogValue(adcGetInputOffset(ADC_INPUT_VBAT), vbat * 2);

--- a/radio/src/targets/simu/adc_driver.cpp
+++ b/radio/src/targets/simu/adc_driver.cpp
@@ -44,7 +44,10 @@ static bool simu_start_conversion()
   // set VBAT / RTC_BAT
   if (adcGetMaxInputs(ADC_INPUT_VBAT) > 0) {
     uint32_t vbat = (BATTERY_MAX + BATTERY_MIN) * 5; // * 10 / 2
-#if defined(BATT_SCALE)
+#if defined(VBAT_MOSFET_DROP)
+    // 1000 is used as multiplier for both numerator and denominator to allow to stay in integer domain
+    return (uint16_t)((vbat * ADC_VREF_PREC2 * ((((1000 + g_eeGeneral.txVoltageCalibration)) * (VBAT_DIV_R2 + VBAT_DIV_R1)) / VBAT_DIV_R1)) / (2*1024*1000)) + VBAT_MOSFET_DROP;
+#elif defined(BATT_SCALE)
     vbat = ((vbat - VOLTAGE_DROP) * BATTERY_DIVIDER) / (BATT_SCALE * 128);
 #else
     vbat = (vbat * BATTERY_DIVIDER) / 1000;

--- a/radio/src/targets/taranis/board.h
+++ b/radio/src/targets/taranis/board.h
@@ -408,14 +408,18 @@ void setTopBatteryValue(uint32_t volts);
 
 #define INTMODULE_FIFO_SIZE            128
 
-#if defined(MANUFACTURER_RADIOMASTER)
+#if defined(MANUFACTURER_RADIOMASTER) || defined(MANUFACTURER_JUMPER)
 // --- MOSFET ---- R2 --- MCU
 //                     |__ R1 --- GND
 //
 #define VBAT_DIV_R1       160 // kOhms
 #define VBAT_DIV_R2       499 // kOhms
-#define VBAT_MOSFET_DROP   20 // * 10mV
+#if defined(MANUFACTURER_JUMPER)
+#define VBAT_MOSFET_DROP   50 // * 10mV
 #else
+#define VBAT_MOSFET_DROP   20 // * 10mV
+#endif
+#else //--- MOSFET ---- R2 --- MCU
 #if defined (RADIO_T8) || defined(RADIO_COMMANDO8)
   #define BATTERY_DIVIDER 50000
 #elif defined (RADIO_LR3PRO)
@@ -423,12 +427,7 @@ void setTopBatteryValue(uint32_t volts);
 #else
   #define BATTERY_DIVIDER 26214
 #endif 
-
-#if defined(RADIO_TPROV2) || defined(RADIO_TPROS) || defined(RADIO_FAMILY_T20)
-  #define VOLTAGE_DROP 60
-#else
-  #define VOLTAGE_DROP 20
-#endif
+#define VOLTAGE_DROP 20
 #endif //--- MOSFET ---- R2 --- MCU
 
 #if defined(RADIO_FAMILY_T20)

--- a/radio/src/targets/taranis/board.h
+++ b/radio/src/targets/taranis/board.h
@@ -408,25 +408,28 @@ void setTopBatteryValue(uint32_t volts);
 
 #define INTMODULE_FIFO_SIZE            128
 
-#if defined (RADIO_TX12)
-  #define BATTERY_DIVIDER 22830
-#elif defined (RADIO_T8) || defined(RADIO_COMMANDO8)
+#if defined(MANUFACTURER_RADIOMASTER)
+// --- MOSFET ---- R2 --- MCU
+//                     |__ R1 --- GND
+//
+#define VBAT_DIV_R1       160 // kOhms
+#define VBAT_DIV_R2       499 // kOhms
+#define VBAT_MOSFET_DROP   20 // * 10mV
+#else
+#if defined (RADIO_T8) || defined(RADIO_COMMANDO8)
   #define BATTERY_DIVIDER 50000
-#elif defined (RADIO_ZORRO) || defined(RADIO_TX12MK2) || defined(RADIO_BOXER) || defined(RADIO_MT12) || defined(RADIO_POCKET)
-  #define BATTERY_DIVIDER 23711 // = 2047*128*BATT_SCALE/(100*(VREF*(160+499)/160))
 #elif defined (RADIO_LR3PRO)
   #define BATTERY_DIVIDER 39500
 #else
   #define BATTERY_DIVIDER 26214
 #endif 
 
-#if defined(RADIO_ZORRO) || defined(RADIO_TX12MK2) || defined(RADIO_BOXER) || defined(RADIO_MT12) || defined(RADIO_POCKET)
-  #define VOLTAGE_DROP 45
-#elif defined(RADIO_TPROV2) || defined(RADIO_TPROS) || defined(RADIO_FAMILY_T20)
+#if defined(RADIO_TPROV2) || defined(RADIO_TPROS) || defined(RADIO_FAMILY_T20)
   #define VOLTAGE_DROP 60
 #else
   #define VOLTAGE_DROP 20
 #endif
+#endif //--- MOSFET ---- R2 --- MCU
 
 #if defined(RADIO_FAMILY_T20)
 #define NUM_TRIMS                               8

--- a/radio/src/targets/taranis/board.h
+++ b/radio/src/targets/taranis/board.h
@@ -417,7 +417,7 @@ void setTopBatteryValue(uint32_t volts);
 #if defined(MANUFACTURER_JUMPER)
 #define VBAT_MOSFET_DROP   50 // * 10mV
 #else
-#define VBAT_MOSFET_DROP   20 // * 10mV
+#define VBAT_MOSFET_DROP   25 // * 10mV
 #endif
 #else //--- MOSFET ---- R2 --- MCU
 #if defined (RADIO_T8) || defined(RADIO_COMMANDO8)


### PR DESCRIPTION
Cleanup of VBAT measurement definition for Radiomaster and Jumper radio where we have exact drawings and resistors values. This will break existing calibration (likely not by a whole lot), but overall I think it is for the best. In most cases, default value should already be very accurate
