### PR TITLE
fix: only display PPM multiplier when PPM is used

### DIFF
--- a/radio/src/gui/colorlcd/radio/radio_trainer.cpp
+++ b/radio/src/gui/colorlcd/radio/radio_trainer.cpp
@@ -97,23 +97,25 @@ void RadioTrainerPage::build(Window* form)
 #endif
 
     // Trainer multiplier
-    auto lbl = new StaticText(line, rect_t{}, STR_MULTIPLIER);
-    lbl->padRight(PAD_SMALL);
-    lv_obj_set_grid_cell(lbl->getLvObj(), LV_GRID_ALIGN_END, 0, 2,
-                         LV_GRID_ALIGN_CENTER, 0, 1);
+    if (g_model.trainerData.mode == TRAINER_MODE_MASTER_TRAINER_JACK) {
+      auto lbl = new StaticText(line, rect_t{}, STR_MULTIPLIER);
+      lbl->padRight(PAD_SMALL);
+      lv_obj_set_grid_cell(lbl->getLvObj(), LV_GRID_ALIGN_END, 0, 2,
+                           LV_GRID_ALIGN_CENTER, 0, 1);
 
-    auto multiplier =
-        new NumberEdit(line, rect_t{0, 0, NUM_EDIT_W, 0}, -10, 40,
-                       GET_SET_DEFAULT(g_eeGeneral.PPM_Multiplier));
-    multiplier->setDisplayHandler(
-        [](int32_t value) { return formatNumberAsString(value + 10, PREC1); });
-    lv_obj_set_grid_cell(multiplier->getLvObj(), LV_GRID_ALIGN_START, 2, 1,
-                         LV_GRID_ALIGN_CENTER, 0, 1);
+      auto multiplier =
+              new NumberEdit(line, rect_t{0, 0, NUM_EDIT_W, 0}, -10, 40,
+                             GET_SET_DEFAULT(g_eeGeneral.PPM_Multiplier));
+      multiplier->setDisplayHandler(
+              [](int32_t value) { return formatNumberAsString(value + 10, PREC1); });
+      lv_obj_set_grid_cell(multiplier->getLvObj(), LV_GRID_ALIGN_START, 2, 1,
+                           LV_GRID_ALIGN_CENTER, 0, 1);
 
 #if PORTRAIT_LCD
-    line = form->newLine(grid);
-    line->padTop(10);
+      line = form->newLine(grid);
+      line->padTop(10);
 #endif
+    }
 
     // Trainer calibration
     auto btn = new TextButton(line, rect_t{}, std::string(STR_CALIBRATION),

--- a/radio/src/gui/common/stdlcd/radio_trainer.cpp
+++ b/radio/src/gui/common/stdlcd/radio_trainer.cpp
@@ -97,9 +97,11 @@ void menuRadioTrainer(event_t event)
   }
 
   attr = (menuVerticalPosition==HEADER_LINE+4) ? blink : 0;
-  lcdDrawTextAlignedLeft(y, STR_MULTIPLIER);
-  lcdDrawNumber(LEN_MULTIPLIER*FW+3*FW, y, g_eeGeneral.PPM_Multiplier+10, attr|PREC1|RIGHT);
-  if (attr) CHECK_INCDEC_GENVAR(event, g_eeGeneral.PPM_Multiplier, -10, 40);
+  if (g_model.trainerData.mode == TRAINER_MODE_MASTER_TRAINER_JACK) {
+      lcdDrawTextAlignedLeft(y, STR_MULTIPLIER);
+      lcdDrawNumber(LEN_MULTIPLIER * FW + 3 * FW, y, g_eeGeneral.PPM_Multiplier + 10, attr | PREC1 | RIGHT);
+      if (attr) CHECK_INCDEC_GENVAR(event, g_eeGeneral.PPM_Multiplier, -10, 40);
+  }
   y += FH;
 
   attr = (menuVerticalPosition==HEADER_LINE+5) ? INVERS : 0;


### PR DESCRIPTION
PPM multiplier is used only on trainer jack input (for history reason when PPM was hardly standardized), but is displayed in all mode. With this change, it is displayed only in master/jack mode

Fixes #5639
