### PR TITLE
fix(color): preview not removed in SD manager after image file deleted

### DIFF
--- a/radio/src/gui/colorlcd/radio/radio_sdmanager.cpp
+++ b/radio/src/gui/colorlcd/radio/radio_sdmanager.cpp
@@ -529,6 +529,9 @@ void RadioSdManagerPage::fileAction(const char* path, const char* name,
   menu->addLine(STR_DELETE_FILE, [=]() {
     f_unlink(fullpath);
     browser->refresh();
+    loadPreview = 0;
+    preview->setFile(nullptr);
+    loading->hide();
   });
 }
 


### PR DESCRIPTION
Preview remains visible after file deletion.