### PR TITLE
fix(cpn): halt when multiple locations for read and write models and settings detected

### DIFF
--- a/companion/src/radiointerface.cpp
+++ b/companion/src/radiointerface.cpp
@@ -302,13 +302,12 @@ QString findMassstoragePath(const QString & filename, bool onlyPath, ProgressWid
   QString temppath;
   QString probefile;
   int found = 0;
-  const qint64 maxStorage = 64000000000; // screen out non-radio sD cards use 64GB but SD card recommendation 32GB or less
 
   QRegularExpression fstypeRe("^(v?fat|msdos|lifs)", QRegularExpression::CaseInsensitiveOption);  // Linux: "vfat"; macOS: "msdos" or "lifs"; Win: "FAT32"
 
   foreach(const QStorageInfo & si, QStorageInfo::mountedVolumes()) {
     //qDebug() << si.rootPath() << si.name() << si.device() << si.displayName() << si.fileSystemType() << si.isReady() << si.bytesTotal() << si.blockSize();
-    if (!si.isReady() || si.isReadOnly() || si.bytesTotal() > maxStorage || !QString(si.fileSystemType()).contains(fstypeRe))
+    if (!si.isReady() || si.isReadOnly() || !QString(si.fileSystemType()).contains(fstypeRe))
       continue;
     temppath = si.rootPath();
     probefile = temppath % "/" % filename;

--- a/companion/src/radiointerface.h
+++ b/companion/src/radiointerface.h
@@ -29,7 +29,7 @@ class ProgressWidget;
 
 QString getRadioInterfaceCmd();
 
-QString findMassstoragePath(const QString &filename, bool onlyPath = false);
+QString findMassstoragePath(const QString &filename, bool onlyPath = false, ProgressWidget *progress = nullptr);
 
 QStringList getSambaArgs(const QString &tcl);
 QStringList getDfuArgs(const QString &cmd, const QString &filename);


### PR DESCRIPTION
Quick and nasty. Revisit in binary clean up.