### PR TITLE
fix(color): touch events may not work correctly in the SD manager file browser.

### DIFF
--- a/radio/src/gui/colorlcd/libui/file_browser.cpp
+++ b/radio/src/gui/colorlcd/libui/file_browser.cpp
@@ -269,6 +269,7 @@ void FileBrowser::onSelected(const char* name, bool is_dir)
 {
   if (is_dir) {
     if (fileSelected) fileSelected(nullptr, nullptr, nullptr, is_dir);
+    selected = nullptr;
     return;
   }
 
@@ -285,6 +286,7 @@ void FileBrowser::onPress(const char* name, bool is_dir)
   if (is_dir) {
     f_chdir(fullpath);
     if (fileSelected) fileSelected(nullptr, nullptr, nullptr, is_dir);
+    selected = nullptr;
     refresh();
     return;
   }

--- a/radio/src/gui/colorlcd/libui/file_browser.h
+++ b/radio/src/gui/colorlcd/libui/file_browser.h
@@ -46,6 +46,7 @@ class FileBrowser : public TableField
   void onSelected(uint16_t row, uint16_t col) override;
   void onPress(uint16_t row, uint16_t col) override;
   bool onPressLong(uint16_t row, uint16_t col) override;
+  bool onLongPress() override { return false; }
 
  protected:
   void onSelected(const char* name, bool is_dir);


### PR DESCRIPTION
Issues:
- Two taps may be required to close the popup menu for a file or folder.
- The popup menu for a file may open as soon as the file is selected using the touch screen. The popup menu should only open on long press or on the second tap on the file name.

The first issue (two taps to close the popup) happens when a long press of the ENTER key, or a long touch on the file name is used to open the popup.

The second issue happens when:
- Tap on a folder name.
- Tap on a file name; but do not open the popup menu.
- Tap on the '..' parent directory.
- Tap on the same folder name.
- Tap on the same file name. The popup opens immediately.
