### PR TITLE
fix(color): issues with main view UI

### DIFF
--- a/radio/src/gui/colorlcd/mainview/screen_setup.cpp
+++ b/radio/src/gui/colorlcd/mainview/screen_setup.cpp
@@ -338,7 +338,13 @@ void ScreenSetupPage::buildLayoutOptions()
     // Option value
     switch (option->type) {
       case ZoneOption::Bool:
-        new ToggleSwitch(line, rect_t{}, GET_SET_DEFAULT(value->boolValue));
+        new ToggleSwitch(line, rect_t{},
+                         GET_DEFAULT(value->boolValue),
+                         [=](int newValue) {
+                           value->boolValue = newValue;
+                           customScreens[customScreenIndex]->show();
+                           SET_DIRTY();
+                         });
         break;
 
       case ZoneOption::Color:

--- a/radio/src/gui/colorlcd/mainview/topbar_impl.cpp
+++ b/radio/src/gui/colorlcd/mainview/topbar_impl.cpp
@@ -85,6 +85,20 @@ void TopBar::setVisible(float visible) // 0.0 -> 1.0
   }
 }
 
+void TopBar::setEdgeTxButtonVisible(float visible) // 0.0 -> 1.0
+{
+  if (visible == 0.0) {
+    headerIcon->setTop(-(int)EdgeTxStyles::MENU_HEADER_HEIGHT);
+  }
+  else if (visible == 1.0) {
+    headerIcon->setTop(0);
+  }
+  else if (visible > 0.0 && visible < 1.0){
+    float top = - (float)EdgeTxStyles::MENU_HEADER_HEIGHT * (1.0 - visible);
+    headerIcon->setTop((coord_t)top);
+  }
+}
+
 coord_t TopBar::getVisibleHeight(float visible) const // 0.0 -> 1.0
 {
   if (visible == 0.0) {
@@ -96,16 +110,6 @@ coord_t TopBar::getVisibleHeight(float visible) const // 0.0 -> 1.0
 
   float h = (float)EdgeTxStyles::MENU_HEADER_HEIGHT * visible;
   return (coord_t)h;
-}
-
-void TopBar::showEdgeTxButton()
-{
-  headerIcon->show();
-}
-
-void TopBar::hideEdgeTxButton()
-{
-  headerIcon->hide();
 }
 
 void TopBar::checkEvents()

--- a/radio/src/gui/colorlcd/mainview/topbar_impl.h
+++ b/radio/src/gui/colorlcd/mainview/topbar_impl.h
@@ -50,9 +50,8 @@ class TopBar: public TopBarBase
     rect_t getZone(unsigned int index) const override;
 
     void setVisible(float visible);
+    void setEdgeTxButtonVisible(float visible);
     coord_t getVisibleHeight(float visible) const; // 0.0 -> 1.0
-    void showEdgeTxButton();
-    void hideEdgeTxButton();
   
     void checkEvents() override;
 

--- a/radio/src/gui/colorlcd/mainview/view_main.h
+++ b/radio/src/gui/colorlcd/mainview/view_main.h
@@ -80,7 +80,9 @@ class ViewMain : public NavWindow
   void hideTopBarEdgeTxButton();
 
   bool hasTopbar();
+  bool hasTopbar(unsigned view);
   bool isAppMode();
+  bool isAppMode(unsigned view);
 
   void runBackground();
   void refreshWidgetSelectTimer();
@@ -103,6 +105,7 @@ class ViewMain : public NavWindow
 
   // Set topbar visibility [0.0 -> 1.0]
   void setTopbarVisible(float visible);
+  void setEdgeTxButtonVisible(float visible);
 
   static void ws_timer(lv_timer_t* t);
 

--- a/radio/src/gui/colorlcd/mainview/widget.h
+++ b/radio/src/gui/colorlcd/mainview/widget.h
@@ -51,15 +51,6 @@ class Widget : public ButtonBase
     return &persistentData->options[index].value;
   }
 
-  //
-  // TODO: for some reason, this one crashes on the radio...
-  //
-  // inline void setOptionValue(unsigned int index, const ZoneOptionValue&
-  // value)
-  // {
-  //   persistentData->options[index].value = value;
-  // }
-
   PersistentData* getPersistentData() { return persistentData; }
 
 #if defined(DEBUG_WINDOWS)

--- a/radio/src/gui/colorlcd/mainview/widgets_container_impl.h
+++ b/radio/src/gui/colorlcd/mainview/widgets_container_impl.h
@@ -111,12 +111,6 @@ class WidgetsContainerImpl : public WidgetsContainer
     return &persistentData->options[index].value;
   }
 
-  inline void setOptionValue(unsigned int index, const ZoneOptionValue& value)
-  {
-    persistentData->options[index].value = value;
-    adjustLayout();
-  }
-
   unsigned int getZonesCount() const override = 0;
 
   rect_t getZone(unsigned int index) const override = 0;


### PR DESCRIPTION
Reported on discord.

Fixes a number of issues with the main view UI, introduced with the 'App Mode' layout changes.

1. EdgeTx button visibility not set correctly:
- Create a model with a single screen and top bar visible
- Add a second screen with top bar hidden
- Return to main view and scroll to second screen - EdgeTx button remains visible instead of being hidden
- Enter screen setup (TELE) while on second screen
- Return to main view, EdgeTX button is now hidden
- Scroll left to first screen - EdgeTx button remains hidden instead of being visible.

2. Trims, Sliders and Flight mode decorations may remain visible after being turned off:
- Enter screen setup and add a new screen
- Turn off topbar, trims, sliders and flight mode decorations
- Return to main view and scroll to newly added screen - Trims, Sliders and Flight mode remain visible.