### PR TITLE
Add bluetooth option to Radiomaster MT12

### DIFF
--- a/radio/util/fwoptions.py
+++ b/radio/util/fwoptions.py
@@ -280,6 +280,7 @@ options_radiomaster_mt12 = {
     "nooverridech": ("OVERRIDE_CHANNEL_FUNCTION", "NO", "YES"),
     "flexr9m": ("MODULE_PROTOCOL_FLEX", "YES", None),
     "afhds3": ("AFHDS3", "YES", "NO"),
+    "bluetooth": ("BLUETOOTH", "YES", "NO"),
     "internalelrs": ("INTERNAL_MODULE_ELRS", "YES", "NO"),
 }
 


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #

Summary of changes: Enable the Bluetooth build flag for Radiomaster MT12


