### PR TITLE
fix(color): cannot change 'Invert' state on radios with no touch screen

### DIFF
--- a/radio/src/gui/colorlcd/controls/sourcechoice.cpp
+++ b/radio/src/gui/colorlcd/controls/sourcechoice.cpp
@@ -104,7 +104,6 @@ class SourceChoiceMenuToolbar : public MenuToolbar
         choice->isValueAvailable(0))
       addButton(STR_SELECT_MENU_CLR, 0, 0, nullptr, nullptr, true);
 
-#if defined(HARDWARE_TOUCH)
     if (choice->canInvert) {
       invertBtn = new MenuToolbarButton(this, {0, 0, LV_PCT(100), 0},
                                         STR_SELECT_MENU_INV);
@@ -117,7 +116,6 @@ class SourceChoiceMenuToolbar : public MenuToolbar
         return choice->inverted;
       });
     }
-#endif
   }
 
   void invertChoice()
@@ -128,9 +126,7 @@ class SourceChoiceMenuToolbar : public MenuToolbar
       auto idx = menu->selection();
       sourceChoice->fillMenu(menu, filter);
       menu->select(idx);
-#if defined(HARDWARE_TOUCH)
       invertBtn->check(sourceChoice->inverted);
-#endif
     }
   }
 
@@ -145,9 +141,7 @@ class SourceChoiceMenuToolbar : public MenuToolbar
   static LAYOUT_VAL(FILTER_COLUMNS, 3, 2)
 
  protected:
-#if defined(HARDWARE_TOUCH)
   MenuToolbarButton* invertBtn = nullptr;
-#endif
 };
 
 bool SourceChoice::onLongPress()
@@ -191,6 +185,9 @@ void SourceChoice::openMenu()
 
   auto tb = new SourceChoiceMenuToolbar(this, menu);
   menu->setToolbar(tb);
+
+  if (canInvert)
+    menu->setLongPressHandler([=]() { tb->invertChoice(); });
 
 #if defined(AUTOSOURCE)
   menu->setWaitHandler([=]() {

--- a/radio/src/gui/colorlcd/controls/switchchoice.cpp
+++ b/radio/src/gui/colorlcd/controls/switchchoice.cpp
@@ -63,7 +63,6 @@ class SwitchChoiceMenuToolbar : public MenuToolbar
         choice->isValueAvailable(0))
       addButton(STR_SELECT_MENU_CLR, 0, 0, nullptr, nullptr, true);
 
-#if defined(HARDWARE_TOUCH)
     invertBtn = new MenuToolbarButton(this, {0, 0, LV_PCT(100), 0},
                                       STR_SELECT_MENU_INV);
     invertBtn->check(choice->inverted);
@@ -74,7 +73,6 @@ class SwitchChoiceMenuToolbar : public MenuToolbar
       invertChoice();
       return choice->inverted;
     });
-#endif
   }
 
   void invertChoice()
@@ -84,9 +82,7 @@ class SwitchChoiceMenuToolbar : public MenuToolbar
     auto idx = menu->selection();
     switchChoice->fillMenu(menu, filter);
     menu->select(idx);
-#if defined(HARDWARE_TOUCH)
     invertBtn->check(switchChoice->inverted);
-#endif
   }
 
   void longPress()
@@ -98,9 +94,7 @@ class SwitchChoiceMenuToolbar : public MenuToolbar
   }
 
  protected:
-#if defined(HARDWARE_TOUCH)
   MenuToolbarButton* invertBtn = nullptr;
-#endif
 };
 
 bool SwitchChoice::onLongPress()
@@ -139,6 +133,8 @@ void SwitchChoice::openMenu()
 
   auto tb = new SwitchChoiceMenuToolbar(this, menu);
   menu->setToolbar(tb);
+
+  menu->setLongPressHandler([=]() { tb->invertChoice(); });
 
 #if defined(AUTOSWITCH)
   menu->setWaitHandler([=]() {

--- a/radio/src/gui/colorlcd/libui/file_browser.h
+++ b/radio/src/gui/colorlcd/libui/file_browser.h
@@ -45,8 +45,6 @@ class FileBrowser : public TableField
   // TableField methods
   void onSelected(uint16_t row, uint16_t col) override;
   void onPress(uint16_t row, uint16_t col) override;
-  bool onPressLong(uint16_t row, uint16_t col) override;
-  bool onLongPress() override { return false; }
 
  protected:
   void onSelected(const char* name, bool is_dir);

--- a/radio/src/gui/colorlcd/libui/listbox.cpp
+++ b/radio/src/gui/colorlcd/libui/listbox.cpp
@@ -20,53 +20,16 @@
  */
 
 #include "listbox.h"
-
 #include "libopenui.h"
-
-void ListBox::event_cb(lv_event_t* e)
-{
-  static bool _nested = false;
-  if (_nested) return;
-
-  lv_event_code_t code = lv_event_get_code(e);
-  lv_obj_t* obj = lv_event_get_target(e);
-  if (!obj) return;
-
-  ListBox* lb = (ListBox*)lv_event_get_user_data(e);
-  if (!lb) return;
-
-  if (code == LV_EVENT_FOCUSED && lb->autoEdit) {
-    lv_group_set_editing((lv_group_t*)lv_obj_get_group(obj), true);
-  } else if (code == LV_EVENT_DEFOCUSED) {
-    // Hack to get rid of 'FOCUSED' event sent
-    // when calling 'lv_group_set_editing()'
-    _nested = true;
-    lv_group_set_editing((lv_group_t*)lv_obj_get_group(obj), false);
-    _nested = false;
-  }
-}
 
 ListBox::ListBox(Window* parent, const rect_t& rect,
                  const std::vector<std::string>& names, uint8_t lineHeight) :
     TableField(parent, rect)
 {
-  lv_obj_add_event_cb(lvobj, ListBox::event_cb, LV_EVENT_ALL, this);
-
   setColumnWidth(0, rect.w);
 
   setLineHeight(lineHeight);
   setNames(names);
-}
-
-void ListBox::setAutoEdit(bool enable)
-{
-  if (autoEdit == enable) return;
-
-  autoEdit = enable;
-  if (autoEdit && hasFocus()) {
-    lv_group_t* g = (lv_group_t*)lv_obj_get_group(lvobj);
-    if (g) lv_group_set_editing(g, true);
-  }
 }
 
 void ListBox::setName(uint16_t idx, const std::string& name)
@@ -105,16 +68,6 @@ void ListBox::setSelected(std::set<uint32_t> selected)
     else
       lv_table_clear_cell_ctrl(lvobj, i, 0, LV_TABLE_CELL_CTRL_CUSTOM_1);
   }
-}
-
-int ListBox::getSelected() const
-{
-  uint16_t row, col;
-  lv_table_get_selected_cell(lvobj, &row, &col);
-  if (row != LV_TABLE_CELL_NONE) {
-    return row;
-  }
-  return -1;
 }
 
 bool ListBox::isRowSelected(uint16_t row)
@@ -168,33 +121,15 @@ void ListBox::onPress(uint16_t row, uint16_t col)
   }
 }
 
-bool ListBox::onLongPress()
-{
-  TRACE("LONG_PRESS");
-  if (longPressHandler) {
-    longPressHandler();
-    lv_indev_wait_release(lv_indev_get_act());
-    return false;
-  }
-  return true;
-}
-
-// TODO: !auto-edit
 void ListBox::onClicked()
 {
-  if (!autoEdit) {
-    lv_group_set_editing((lv_group_t*)lv_obj_get_group(lvobj), true);
-
-  } else {
-    TableField::onClicked();
-  }
+  lv_group_set_editing((lv_group_t*)lv_obj_get_group(lvobj), true);
 }
 
 void ListBox::onCancel()
 {
-  lv_group_t* g = (lv_group_t*)lv_obj_get_group(lvobj);
-  if (!autoEdit && lv_group_get_editing(g)) {
-    lv_group_set_editing(g, false);
+  if (!isAutoEdit() && lv_group_get_editing((lv_group_t*)lv_obj_get_group(lvobj))) {
+    lv_group_set_editing((lv_group_t*)lv_obj_get_group(lvobj), false);
   } else {
     TableField::onCancel();
   }

--- a/radio/src/gui/colorlcd/libui/listbox.h
+++ b/radio/src/gui/colorlcd/libui/listbox.h
@@ -29,19 +29,15 @@
 // Class for lists of elements with names
 class ListBox : public TableField
 {
-  std::function<void()> longPressHandler = nullptr;
   std::function<void()> pressHandler = nullptr;
   std::function<void(std::set<uint32_t>, std::set<uint32_t>)>
       _multiSelectHandler = nullptr;
   std::function<const char*(uint16_t row)> getSelectedSymbol = nullptr;
-  bool autoEdit = false;
 
  public:
   ListBox(Window* parent, const rect_t& rect,
           const std::vector<std::string>& names,
           uint8_t lineHeight = MENUS_LINE_HEIGHT);
-
-  void setAutoEdit(bool enable);
 
   void setName(uint16_t idx, const std::string& name);
   void setNames(const std::vector<std::string>& names);
@@ -50,7 +46,6 @@ class ListBox : public TableField
   virtual void setSelected(int selected, bool force = false);
   virtual void setSelected(std::set<uint32_t> selected);
 
-  int getSelected() const;
   bool isRowSelected(uint16_t row);
   std::set<uint32_t> getSelection();
 
@@ -68,11 +63,6 @@ class ListBox : public TableField
   void setGetSelectedSymbol(std::function<const char*(uint16_t)> handler)
   {
     getSelectedSymbol = std::move(handler);
-  }
-
-  void setLongPressHandler(std::function<void()> handler)
-  {
-    longPressHandler = std::move(handler);
   }
 
   void setPressHandler(std::function<void()> handler)
@@ -95,7 +85,6 @@ class ListBox : public TableField
   bool smallSelectMarker = false;
 
   void onPress(uint16_t row, uint16_t col) override;
-  bool onLongPress() override;
 
   void onClicked() override;
   void onCancel() override;

--- a/radio/src/gui/colorlcd/libui/menu.cpp
+++ b/radio/src/gui/colorlcd/libui/menu.cpp
@@ -74,17 +74,11 @@ class MenuBody : public TableField
 
     setColumnWidth(0, rect.w);
 
-    lv_group_t* g = (lv_group_t*)lv_obj_get_group(lvobj);
-    if (g) {
-      setFocusHandler([=](bool focus) {
-        if (focus) {
-          lv_group_set_focus_cb(g, MenuBody::force_editing);
-        } else {
-          lv_group_set_focus_cb(g, nullptr);
-        }
-      });
-      lv_group_set_editing(g, true);
-    }
+    setAutoEdit();
+
+    setLongPressHandler([=]() {
+      getParentMenu()->handleLongPress();
+    });
   }
 
   ~MenuBody()
@@ -273,24 +267,11 @@ class MenuBody : public TableField
 
   void onSelected(uint16_t row, uint16_t col) override { selectedIndex = row; }
 
-  bool onPressLong(uint16_t row, uint16_t col) override
-  {
-    return true;
-  }
-
-  bool onLongPress() override
-  {
-    getParentMenu()->handleLongPress();
-    return false;
-  }
-
  protected:
   std::vector<MenuLine*> lines;
   int selectedIndex = 0;
 
   Menu* getParentMenu() { return static_cast<Menu*>(getParent()->getParent()); }
-
-  static void force_editing(lv_group_t* g) { lv_group_set_editing(g, true); }
 };
 
 //-----------------------------------------------------------------------------

--- a/radio/src/gui/colorlcd/libui/menu.h
+++ b/radio/src/gui/colorlcd/libui/menu.h
@@ -37,6 +37,7 @@ class Menu : public ModalWindow
 
   void setCancelHandler(std::function<void()> handler);
   void setWaitHandler(std::function<void()> handler);
+  void setLongPressHandler(std::function<void()> handler);
 
   void setToolbar(MenuToolbar *window);
 
@@ -83,12 +84,15 @@ class Menu : public ModalWindow
     }
   }
 
+  void handleLongPress();
+
  protected:
   bool multiple;
   MenuWindowContent *content;
   MenuToolbar *toolbar = nullptr;
   std::function<void()> waitHandler;
   std::function<void()> cancelHandler;
+  std::function<void()> longPressHandler;
 
   void updatePosition();
 };

--- a/radio/src/gui/colorlcd/libui/table.h
+++ b/radio/src/gui/colorlcd/libui/table.h
@@ -45,10 +45,24 @@ class TableField : public Window
   void adjustScroll();
   void selectNext(int16_t dir);
 
+  void setAutoEdit();
+  bool isAutoEdit() const { return autoedit; }
+
+  int getSelected() const;
+
+  void setLongPressHandler(std::function<void()> handler)
+  {
+    longPressHandler = std::move(handler);
+  }
+
   static void table_event(const lv_obj_class_t* class_p, lv_event_t* e);
 
  protected:
-  bool isLongPress = false;
+  bool autoedit = false;
+  std::function<void()> longPressHandler = nullptr;
 
   void onEvent(event_t event) override;
+  bool onLongPress() override;
+
+  static void force_editing(lv_group_t* g) { lv_group_set_editing(g, true); }
 };

--- a/radio/src/gui/colorlcd/radio/radio_theme.cpp
+++ b/radio/src/gui/colorlcd/radio/radio_theme.cpp
@@ -595,7 +595,7 @@ void ThemeSetupPage::setupListbox(Window *window, rect_t r,
 {
   listBox = new ListBox(window, r, tp->getNames());
   etx_scrollbar(listBox->getLvObj());
-  listBox->setAutoEdit(true);
+  listBox->setAutoEdit();
   listBox->setSelected(currentTheme);
   listBox->setActiveItem(tp->getThemeIndex());
   listBox->setLongPressHandler([=]() {


### PR DESCRIPTION
Allow long press of ENTER to change 'Invert' state in switch and source popup menus when menu is open.

Fixes #5640
