### PR TITLE
chore: remove hardcoded aux1 debug hack

### DIFF
--- a/radio/src/serial.cpp
+++ b/radio/src/serial.cpp
@@ -486,20 +486,10 @@ void serialInit(uint8_t port_nr, int mode)
 
 void initSerialPorts()
 {
-#if defined(DEBUG)
-  // AUX1 and serialPortStates was already initialized early in DEBUG config
-  for (uint8_t port_nr = 0; port_nr < MAX_AUX_SERIAL; port_nr++) {
-    if (port_nr != SP_AUX1) {
-      auto mode = getSerialPortMode(port_nr);
-      serialInit(port_nr, mode);
-    }
-  }
-#else
   for (uint8_t port_nr = 0; port_nr < MAX_AUX_SERIAL; port_nr++) {
     auto mode = getSerialPortMode(port_nr);
     serialInit(port_nr, mode);
   }
-#endif
 }
 
 int serialGetMode(uint8_t port_nr)

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -164,11 +164,6 @@ void boardInit()
 
   __enable_irq();
 
-#if defined(DEBUG) && defined(AUX_SERIAL)
-  serialSetMode(SP_AUX1, UART_MODE_DEBUG);                // indicate AUX1 is used
-  serialInit(SP_AUX1, UART_MODE_DEBUG);                   // early AUX1 init
-#endif
-
   TRACE("\nHorus board started :)");
   TRACE("RCC->CSR = %08x", RCC->CSR);
 

--- a/radio/src/targets/nv14/board.cpp
+++ b/radio/src/targets/nv14/board.cpp
@@ -111,11 +111,6 @@ void boardInit()
   // detect NV14 vs EL18
   hardwareOptions.pcbrev = boardGetPcbRev();
 
-#if defined(DEBUG) && defined(AUX_SERIAL)
-  serialSetMode(SP_AUX1, UART_MODE_DEBUG);                // indicate AUX1 is used
-  serialInit(SP_AUX1, UART_MODE_DEBUG);                   // early AUX1 init
-#endif
-
   TRACE("\n%s board started :)",
         hardwareOptions.pcbrev == PCBREV_NV14 ?
         "NV14" : "EL18");

--- a/radio/src/targets/pl18/board.cpp
+++ b/radio/src/targets/pl18/board.cpp
@@ -100,11 +100,6 @@ void boardInit()
   __enable_irq();
 #endif
 
-#if defined(DEBUG) && defined(AUX_SERIAL)
-  serialSetMode(SP_AUX1, UART_MODE_DEBUG);                // indicate AUX1 is used
-  serialInit(SP_AUX1, UART_MODE_DEBUG);                   // early AUX1 init
-#endif
-
   TRACE("\nPL18 board started :)");
   delay_ms(10);
   TRACE("RCC->CSR = %08x", RCC->CSR);

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -250,11 +250,6 @@ void boardInit()
   ws2812_update(&_led_timer);
 #endif
 
-#if defined(DEBUG) && defined(AUX_SERIAL)
-  serialSetMode(SP_AUX1, UART_MODE_DEBUG);                // indicate AUX1 is used
-  serialInit(SP_AUX1, UART_MODE_DEBUG);                   // early AUX1 init
-#endif
-
 #if defined(HAPTIC)
   hapticInit();
 #endif


### PR DESCRIPTION
Remove "hack" allowing hardcoded early traces of ETX start on serial port 1, since it was done for us (me mostly) and we are now using JLink.

Output debug traces on any aux (including aux1) is still supported, just happens a bit later in the boot process