### PR TITLE
fix(color): show script name for 'RGB led' function in SF/GF list view

### DIFF
--- a/radio/src/gui/colorlcd/model/special_functions.cpp
+++ b/radio/src/gui/colorlcd/model/special_functions.cpp
@@ -190,6 +190,7 @@ void FunctionLineButton::refresh()
     case FUNC_PLAY_TRACK:
     case FUNC_BACKGND_MUSIC:
     case FUNC_PLAY_SCRIPT:
+    case FUNC_RGB_LED:
       if (ZEXIST(cfn->play.name)) {
         strAppend(s + strlen(s), cfn->play.name, LEN_FUNCTION_NAME);
       } else {


### PR DESCRIPTION
Show script name in list view.

![screen-2024-11-18-133816](https://github.com/user-attachments/assets/e81ad689-f593-4665-af18-a759c5479fd1)
