### PR TITLE
feat(radio): add repeat option for 'RGB Led' SF

### DIFF
--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -332,8 +332,7 @@ int Boards::getCapability(Board::Type board, Board::Capability capability)
       return (IS_STM32(board) && !IS_TARANIS_X9(board));
 
     case HasLedStripGPIO:
-      // No current radio do support that feature
-      return false;
+      return IS_RADIOMASTER_MT12(board) || (board == BOARD_HELLORADIOSKY_V16);
 
     case HasSDCard:
       return IS_STM32(board);

--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -332,8 +332,8 @@ int Boards::getCapability(Board::Type board, Board::Capability capability)
       return (IS_STM32(board) && !IS_TARANIS_X9(board));
 
     case HasLedStripGPIO:
-      return IS_RADIOMASTER_MT12(board) || (board == BOARD_HELLORADIOSKY_V16) ||
-             IS_FLYSKY_PL18(board);
+      return (IS_RADIOMASTER_MT12(board) || IS_FLYSKY_PL18(board) ||
+              IS_HELLORADIOSKY_V16(board));
 
     case HasSDCard:
       return IS_STM32(board);

--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -332,7 +332,8 @@ int Boards::getCapability(Board::Type board, Board::Capability capability)
       return (IS_STM32(board) && !IS_TARANIS_X9(board));
 
     case HasLedStripGPIO:
-      return IS_RADIOMASTER_MT12(board) || (board == BOARD_HELLORADIOSKY_V16);
+      return IS_RADIOMASTER_MT12(board) || (board == BOARD_HELLORADIOSKY_V16) ||
+             IS_FLYSKY_PL18(board);
 
     case HasSDCard:
       return IS_STM32(board);

--- a/radio/src/gui/128x64/model_special_functions.cpp
+++ b/radio/src/gui/128x64/model_special_functions.cpp
@@ -343,7 +343,7 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
               x = x - 5 * FW;
             else if (func == FUNC_PLAY_TRACK)
               x = x - 3 * FW;
-            else if (func == FUNC_BACKGND_MUSIC)
+            else if (func == FUNC_BACKGND_MUSIC || func == FUNC_RGB_LED)
               x = x - 2 * FW;
             if (ZEXIST(cfn->play.name))
               lcdDrawSizedText(x, y, cfn->play.name, sizeof(cfn->play.name), attr);
@@ -487,7 +487,7 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
 
         case 4:
           if (HAS_REPEAT_PARAM(func)) {
-            if (func == FUNC_PLAY_SCRIPT) {
+            if (func == FUNC_PLAY_SCRIPT || func == FUNC_RGB_LED) {
               lcdDrawText(MODEL_SPECIAL_FUNC_4TH_COLUMN_ONOFF-3, y, (CFN_PLAY_REPEAT(cfn) == 0) ? "On" : "1x", attr);
               if (active) CFN_PLAY_REPEAT(cfn) = checkIncDec(event, CFN_PLAY_REPEAT(cfn), 0, 1, eeFlags);
             }

--- a/radio/src/gui/212x64/model_special_functions.cpp
+++ b/radio/src/gui/212x64/model_special_functions.cpp
@@ -436,7 +436,7 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
 
         case ITEM_CUSTOM_FUNCTIONS_REPEAT:
           if (HAS_REPEAT_PARAM(func)) {
-            if (func == FUNC_PLAY_SCRIPT) {
+            if (func == FUNC_PLAY_SCRIPT || func == FUNC_RGB_LED) {
               lcdDrawText(MODEL_SPECIAL_FUNC_4TH_COLUMN+2, y, (CFN_PLAY_REPEAT(cfn) == 0) ? "On" : "1x", attr);
               if (active) CFN_PLAY_REPEAT(cfn) = checkIncDec(event, CFN_PLAY_REPEAT(cfn), 0, 1, eeFlags);
             }

--- a/radio/src/gui/colorlcd/model/special_functions.cpp
+++ b/radio/src/gui/colorlcd/model/special_functions.cpp
@@ -264,7 +264,7 @@ void FunctionLineButton::refresh()
     lv_obj_clear_state(sfEnable, LV_STATE_CHECKED);
 
   if (HAS_REPEAT_PARAM(func)) {
-    if (func == FUNC_PLAY_SCRIPT) {
+    if (func == FUNC_PLAY_SCRIPT || func == FUNC_RGB_LED) {
       sprintf(s, "(%s)", (CFN_PLAY_REPEAT(cfn) == 0) ? "On" : "1x");
     } else {
       sprintf(
@@ -614,7 +614,7 @@ void FunctionEditPage::updateSpecialFunctionOneWindow()
   if (HAS_REPEAT_PARAM(func)) {  // !1x 1x 1s 2s 3s ...
     line = specialFunctionOneWindow->newLine(grid);
     new StaticText(line, rect_t{}, STR_REPEAT);
-    if (func == FUNC_PLAY_SCRIPT) {
+    if (func == FUNC_PLAY_SCRIPT || func == FUNC_RGB_LED) {
       auto repeat = new Choice(line, rect_t{}, 0, 1,
                                GET_DEFAULT((int8_t)CFN_PLAY_REPEAT(cfn)),
                                SET_DEFAULT(CFN_PLAY_REPEAT(cfn)));

--- a/radio/src/myeeprom.h
+++ b/radio/src/myeeprom.h
@@ -47,7 +47,7 @@
   #define IS_HAPTIC_FUNC(func)         (0)
 #endif
 
-#define HAS_REPEAT_PARAM(func)         (IS_PLAY_FUNC(func) || IS_HAPTIC_FUNC(func) || func == FUNC_PLAY_SCRIPT || func == FUNC_SET_SCREEN)
+#define HAS_REPEAT_PARAM(func)         (IS_PLAY_FUNC(func) || IS_HAPTIC_FUNC(func) || func == FUNC_PLAY_SCRIPT || func == FUNC_RGB_LED || func == FUNC_SET_SCREEN)
 
 #define CFN_EMPTY(p)                   (!(p)->swtch)
 #define CFN_SWITCH(p)                  ((p)->swtch)

--- a/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
@@ -1724,7 +1724,7 @@ static void r_customFn(void* user, uint8_t* data, uint32_t bitoffs,
   }
 
   if (HAS_REPEAT_PARAM(func)) {
-    if (func == FUNC_PLAY_SCRIPT) {
+    if (func == FUNC_PLAY_SCRIPT || func == FUNC_RGB_LED) {
       if (val_len == 2 && val[0] == '1' && val[1] == 'x')
         CFN_PLAY_REPEAT(cfn) = 1;
       else
@@ -1887,7 +1887,7 @@ static bool w_customFn(void* user, uint8_t* data, uint32_t bitoffs,
     // ","
     if (!wf(opaque,",",1)) return false;
 
-    if (func == FUNC_PLAY_SCRIPT) {
+    if (func == FUNC_PLAY_SCRIPT || func == FUNC_RGB_LED) {
       if (!wf(opaque,(CFN_PLAY_REPEAT(cfn) == 0) ? "On" : "1x",2)) return false;
     } else if (CFN_PLAY_REPEAT(cfn) == 0) {
       // "1x"


### PR DESCRIPTION
Currently RGB Led Lua scripts are run continuously. 

PR adds the repeat option to match the 'Play Script' SF - allows simple Led scripts that just set the color to be run once only.

Existing models will default to 'On' (run continuously) for all 'RGB Led' SF entries.
