### PR TITLE
fix(v16): 6pos logic stuck at 6 when switched on

### DIFF
--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -85,29 +85,36 @@ void boardBLInit()
 #if defined(SIXPOS_SWITCH_INDEX)
 uint8_t lastADCState = 0;
 uint8_t sixPosState = 0;
-bool dirty = true;
+bool sixPosInit = false;
+bool sixPosDirty = true;
 uint16_t getSixPosAnalogValue(uint16_t adcValue)
 {
-  uint8_t currentADCState = 0;
-  if (adcValue > 3800)
-    currentADCState = 6;
-  else if (adcValue > 3100)
-    currentADCState = 5;
-  else if (adcValue > 2300)
-    currentADCState = 4;
-  else if (adcValue > 1500)
-    currentADCState = 3;
-  else if (adcValue > 1000)
-    currentADCState = 2;
-  else if (adcValue > 400)
-    currentADCState = 1;
-  if (lastADCState != currentADCState) {
-    lastADCState = currentADCState;
-  } else if (lastADCState != 0 && lastADCState - 1 != sixPosState) {
-    sixPosState = lastADCState - 1;
-    dirty = true;
+  if (sixPosInit) {
+    uint8_t currentADCState = 0;
+    if (adcValue > 3800)
+      currentADCState = 6;
+    else if (adcValue > 3100)
+      currentADCState = 5;
+    else if (adcValue > 2300)
+      currentADCState = 4;
+    else if (adcValue > 1500)
+      currentADCState = 3;
+    else if (adcValue > 1000)
+      currentADCState = 2;
+    else if (adcValue > 400)
+      currentADCState = 1;
+    if (lastADCState != currentADCState) {
+      lastADCState = currentADCState;
+    } else if (lastADCState != 0 && lastADCState - 1 != sixPosState) {
+      sixPosState = lastADCState - 1;
+      sixPosDirty = true;
+    }
+  } else if (adcValue < 300) {
+    // Wait for nothing is pressed to start sampling, otherwise may goes into unknown state
+    sixPosInit = true;
   }
-  if (dirty) {
+
+  if (sixPosDirty) {
     for (uint8_t i = 0; i < 6; i++) {
       if (i == sixPosState)
         ws2812_set_color(i, SIXPOS_LED_RED, SIXPOS_LED_GREEN, SIXPOS_LED_BLUE);
@@ -115,7 +122,9 @@ uint16_t getSixPosAnalogValue(uint16_t adcValue)
         ws2812_set_color(i, 0, 0, 0);
     }
     ws2812_update(&_led_timer);
+    sixPosDirty = false;
   }
+
   return (4096/5)*(sixPosState);
 }
 #endif


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Summary of changes:
- Six pos logic stuck at 6 when switched on because the adc did not start sampling yet.