### PR TITLE
fix(color): rotary encoder events not always working on some screens

### DIFF
--- a/radio/src/gui/colorlcd/libui/table.cpp
+++ b/radio/src/gui/colorlcd/libui/table.cpp
@@ -320,3 +320,13 @@ void TableField::setAutoEdit()
     lv_group_set_editing(g, true);
   }
 }
+
+void TableField::deleteLater(bool detach, bool trash)
+{
+  if (!deleted())
+    if (autoedit) {
+      lv_group_t* g = (lv_group_t*)lv_obj_get_group(lvobj);
+      lv_group_set_focus_cb(g, nullptr);
+      lv_group_set_editing(g, false);
+    }
+}

--- a/radio/src/gui/colorlcd/libui/table.h
+++ b/radio/src/gui/colorlcd/libui/table.h
@@ -64,5 +64,7 @@ class TableField : public Window
   void onEvent(event_t event) override;
   bool onLongPress() override;
 
+  void deleteLater(bool detach = true, bool trash = true) override;
+
   static void force_editing(lv_group_t* g) { lv_group_set_editing(g, true); }
 };


### PR DESCRIPTION
Fixes an issue introduced in PR #5663, where the rotary encoder may stop working on some setup screens.

To reproduce:
- Open the system menu Tools page, verify rotary encoder working
- Page to the SD Manager page, verify rotary encoder working
- Page to the Radio Setup page - rotary encoder stops working
