### PR TITLE
feat(color): only use red background for alert screens

### DIFF
--- a/radio/src/gui/colorlcd/libui/fullscreen_dialog.cpp
+++ b/radio/src/gui/colorlcd/libui/fullscreen_dialog.cpp
@@ -40,7 +40,7 @@ FullScreenDialog::FullScreenDialog(
     confirmHandler(confirmHandler)
 {
   setWindowFlag(OPAQUE);
-  etx_solid_bg(lvobj, COLOR_THEME_WARNING_INDEX);
+  etx_solid_bg(lvobj, (type == WARNING_TYPE_ALERT) ? COLOR_THEME_WARNING_INDEX : COLOR_THEME_SECONDARY1_INDEX);
 
   // In case alert raised while splash screen is showing.
   cancelSplash();


### PR DESCRIPTION
PR #5712 changed the fullscreen dialogs to have a solid background color.

This PR uses a less alarming color for non-alert fullscreen dialogs (e.g. flashing bootloader).
