### PR TITLE
chore(cpn): remove unused binary general settings fields

### DIFF
--- a/companion/src/firmwares/generalsettings.h
+++ b/companion/src/firmwares/generalsettings.h
@@ -339,31 +339,6 @@ class GeneralSettings {
 
     bool invertLCD;
 
-    // v 2.10 ADC refactor
-    // earlier version data is read into legacy structs to maintain older version compatibility
-    // post reading the legacy structs are manipulated into the new structs
-    // An opportunity was taken group related structs
-    // Companion gui only references the new structs
-
-    // pre v2.10 legacy
-    // TODO remove when importing and conversion no longer neceesary
-    int calibMid[CPN_MAX_ANALOGS];
-    int calibSpanNeg[CPN_MAX_ANALOGS];
-    int calibSpanPos[CPN_MAX_ANALOGS];
-    char swtchName[CPN_MAX_SWITCHES][HARDWARE_NAME_LEN + 1];
-    unsigned int swtchConfig[CPN_MAX_SWITCHES];
-    char stickName[CPN_MAX_STICKS][HARDWARE_NAME_LEN + 1];
-    char potName[CPN_MAX_POTS][HARDWARE_NAME_LEN + 1];
-    unsigned int potConfig[CPN_MAX_POTS];
-    char sliderName[CPN_MAX_SLIDERS][HARDWARE_NAME_LEN + 1];
-    unsigned int sliderConfig[CPN_MAX_SLIDERS];
-
-    // ===================================================================================
-    // IMPORTANT: starting v2.10 this function MUST be called after importing non-yaml formats
-    //            yaml conversion is performed on the fly
-    bool convertLegacyConfiguration(Board::Type board);
-    // ===================================================================================
-
     // default values are retrieved from the radio json file
 
     struct InputCalib {


### PR DESCRIPTION
Summary of changes:
- remove legacy binary GeneralSettings fields
- fix function GeneralSettings::fix6POSCalibration to point to current fields - this was missed when the new fields were added