### PR TITLE
feat: dramatically reduce SDcard access while in Tools screen 

### DIFF
--- a/radio/src/edgetx.h
+++ b/radio/src/edgetx.h
@@ -712,6 +712,7 @@ union ReusableBuffer
   struct {
 #if defined(NUM_BODY_LINES)
     scriptInfo script[NUM_BODY_LINES];
+    uint8_t oldOffset;
 #endif
 #if defined(PXX2)
     ModuleInformation modules[NUM_MODULES];

--- a/radio/src/edgetx.h
+++ b/radio/src/edgetx.h
@@ -702,6 +702,9 @@ union ReusableBuffer
 #endif
 
   struct {
+#if defined(NUM_BODY_LINES)
+    char scriptName[NUM_BODY_LINES][(LCD_W / FW) + 1];
+#endif
 #if defined(PXX2)
     ModuleInformation modules[NUM_MODULES];
 #endif

--- a/radio/src/edgetx.h
+++ b/radio/src/edgetx.h
@@ -701,6 +701,7 @@ union ReusableBuffer
   PXX2HardwareAndSettings hardwareAndSettings; // radio_version
 #endif
 
+#if defined(NUM_BODY_LINES)
   struct scriptInfo{
       uint8_t index;
       char label[(LCD_W / FW) + 1];
@@ -708,6 +709,7 @@ union ReusableBuffer
       void (* tool)(event_t);
       char path[LEN_FILE_PATH_MAX+10+1];
   };
+#endif
 
   struct {
 #if defined(NUM_BODY_LINES)

--- a/radio/src/edgetx.h
+++ b/radio/src/edgetx.h
@@ -701,9 +701,17 @@ union ReusableBuffer
   PXX2HardwareAndSettings hardwareAndSettings; // radio_version
 #endif
 
+  struct scriptInfo{
+      uint8_t index;
+      char label[(LCD_W / FW) + 1];
+      uint8_t module;
+      void (* tool)(event_t);
+      char path[LEN_FILE_PATH_MAX+10+1];
+  };
+
   struct {
 #if defined(NUM_BODY_LINES)
-    char scriptName[NUM_BODY_LINES][(LCD_W / FW) + 1];
+    scriptInfo script[NUM_BODY_LINES];
 #endif
 #if defined(PXX2)
     ModuleInformation modules[NUM_MODULES];

--- a/radio/src/gui/common/stdlcd/radio_tools.cpp
+++ b/radio/src/gui/common/stdlcd/radio_tools.cpp
@@ -178,6 +178,7 @@ void menuRadioTools(event_t event)
 
   if (event == EVT_ENTRY  || event == EVT_ENTRY_UP) {
     memclear(&reusableBuffer.radioTools, sizeof(reusableBuffer.radioTools));
+    oldPosition = 0xFF;
 #if defined(PXX2)
     for (uint8_t module = 0; module < NUM_MODULES; module++) {
       if (isModulePXX2(module) && (module == INTERNAL_MODULE ? modulePortPowered(INTERNAL_MODULE) : modulePortPowered(EXTERNAL_MODULE))) {

--- a/radio/src/gui/common/stdlcd/radio_tools.cpp
+++ b/radio/src/gui/common/stdlcd/radio_tools.cpp
@@ -56,11 +56,9 @@ void displayRadioTool(uint8_t index)
         }
         else if (reusableBuffer.radioTools.script[index].path != nullptr) {
           char toolName[RADIO_TOOL_NAME_MAXLEN + 1];
-
           if (!readToolName(toolName, reusableBuffer.radioTools.script[index].path)) {
             strAppendFilename(toolName, getBasename(reusableBuffer.radioTools.script[index].path), RADIO_TOOL_NAME_MAXLEN);
           }
-
           char toolPath[FF_MAX_LFN];
           strcpy(toolPath, reusableBuffer.radioTools.script[index].path);
           *((char *)getBasename(toolPath)-1) = '\0';
@@ -192,7 +190,7 @@ void menuRadioTools(event_t event)
 
   uint8_t index = 0;
 
-  if (oldPosition == menuVerticalPosition) {
+  if (oldPosition == menuVerticalOffset) {
     for(uint8_t line =0; line < reusableBuffer.radioTools.linesCount; line++) {
       displayRadioTool(line);
     }
@@ -283,5 +281,5 @@ void menuRadioTools(event_t event)
   }
 
   reusableBuffer.radioTools.linesCount = index;
-  oldPosition = menuVerticalPosition;
+  oldPosition = menuVerticalOffset;
 }

--- a/radio/src/gui/common/stdlcd/radio_tools.cpp
+++ b/radio/src/gui/common/stdlcd/radio_tools.cpp
@@ -42,6 +42,7 @@ bool addRadioTool(uint8_t index, const char * label)
   if (index >= menuVerticalOffset) {
     uint8_t lineIndex = index - menuVerticalOffset;
     if (lineIndex < NUM_BODY_LINES) {
+      strncpy(reusableBuffer.radioTools.scriptName[index], label, sizeof(reusableBuffer.radioTools.scriptName[0]));
       int8_t sub = menuVerticalPosition - HEADER_LINE;
       LcdFlags attr = (sub == index ? INVERS : 0);
       coord_t y = MENU_HEADER_HEIGHT + lineIndex * FH;
@@ -101,6 +102,9 @@ void addRadioScriptTool(uint8_t index, const char * path)
 
 void menuRadioTools(event_t event)
 {
+
+  static uint8_t oldPosition = 0xFF;
+
   if (event == EVT_ENTRY  || event == EVT_ENTRY_UP) {
     memclear(&reusableBuffer.radioTools, sizeof(reusableBuffer.radioTools));
 #if defined(PXX2)
@@ -115,6 +119,13 @@ void menuRadioTools(event_t event)
   SIMPLE_MENU(STR_MENUTOOLS, menuTabGeneral, MENU_RADIO_TOOLS, HEADER_LINE + reusableBuffer.radioTools.linesCount);
 
   uint8_t index = 0;
+
+  if (oldPosition == menuVerticalPosition) {
+    for(uint8_t line =0; line < reusableBuffer.radioTools.linesCount; line++) {
+      addRadioTool(line, reusableBuffer.radioTools.scriptName[line]);
+    }
+    return;
+  }
 
 #if defined(LUA)
   FILINFO fno;
@@ -200,4 +211,5 @@ void menuRadioTools(event_t event)
   }
 
   reusableBuffer.radioTools.linesCount = index;
+  oldPosition = menuVerticalPosition;
 }

--- a/radio/src/gui/common/stdlcd/radio_tools.cpp
+++ b/radio/src/gui/common/stdlcd/radio_tools.cpp
@@ -171,12 +171,9 @@ void addRadioScriptToolHandler(uint8_t index, const char * path)
 
 void menuRadioTools(event_t event)
 {
-
-  static uint8_t oldPosition = 0xFF;
-
   if (event == EVT_ENTRY  || event == EVT_ENTRY_UP) {
     memclear(&reusableBuffer.radioTools, sizeof(reusableBuffer.radioTools));
-    oldPosition = 0xFF;
+    reusableBuffer.radioTools.oldOffset = 0xFF;
 #if defined(PXX2)
     for (uint8_t module = 0; module < NUM_MODULES; module++) {
       if (isModulePXX2(module) && (module == INTERNAL_MODULE ? modulePortPowered(INTERNAL_MODULE) : modulePortPowered(EXTERNAL_MODULE))) {
@@ -190,7 +187,7 @@ void menuRadioTools(event_t event)
 
   uint8_t index = 0;
 
-  if (oldPosition == menuVerticalOffset) {
+  if (reusableBuffer.radioTools.oldOffset == menuVerticalOffset) {
     for(uint8_t line =0; line < reusableBuffer.radioTools.linesCount; line++) {
       displayRadioTool(line);
     }
@@ -281,5 +278,5 @@ void menuRadioTools(event_t event)
   }
 
   reusableBuffer.radioTools.linesCount = index;
-  oldPosition = menuVerticalOffset;
+  reusableBuffer.radioTools.oldOffset = menuVerticalOffset;
 }


### PR DESCRIPTION
Current implementation of tools menu on BW hammers badly SDcard by continually read the directory and lua scripts.

With this change, all informations is stored in the reusable buffer (so NO extra ram is used at all), and SDcard is read once at load, and then once again when out of page scrolling does happen

For a typical access to the tools menu where you would spend 10sec and launch a script, that's around 100 times less sdcard access (hence the dramatically)