### PR TITLE
fix(bumblebee): customisable switches display issue, audio mute not working

### DIFF
--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -885,7 +885,11 @@ void menuModelSetup(event_t event)
       case ITEM_MODEL_SETUP_SW5:
       case ITEM_MODEL_SETUP_SW6:
       {
+#if defined(FUNCTION_SWITCHES_RGB_LEDS)
         int index = (k - ITEM_MODEL_SETUP_SW1) / 2;
+#else
+        int index = (k - ITEM_MODEL_SETUP_SW1);
+#endif
         lcdDrawSizedText(INDENT_WIDTH, y, STR_CHAR_SWITCH, 2, menuHorizontalPosition < 0 ? attr : 0);
 
         // TODO: restore following line when switchGetName(index+switchGetMaxSwitches()) doesn't crash anymore

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -2725,7 +2725,7 @@
   #define JACK_DETECT_GPIO              GPIO_PIN(GPIOC, 13) // PC.13
   #define AUDIO_SPEAKER_ENABLE_GPIO     GPIO_PIN(GPIOD, 14) // PD.14
   #define HEADPHONE_TRAINER_SWITCH_GPIO GPIO_PIN(GPIOD, 9)  // PD.09
-#elif defined(RADIO_FAMILY_T20)
+#elif defined(RADIO_FAMILY_T20) || defined(RADIO_BUMBLEBEE)
   #define AUDIO_MUTE_GPIO               GPIO_PIN(GPIOG, 4) // PG.04
   #define AUDIO_MUTE_DELAY              500  // ms
   #define AUDIO_UNMUTE_DELAY            150  // ms


### PR DESCRIPTION
Fixes:
- display issue in model setup screen
- sw6 was not working
- audio mute wasn't working (unless you pushed sw6, oh boy)