### PR TITLE
fix(bw): build fails for some radios when using GCC 13 or later

### DIFF
--- a/radio/src/bin_allocator.cpp
+++ b/radio/src/bin_allocator.cpp
@@ -96,11 +96,11 @@ typedef BinAllocator<40,300> BinAllocator_slots1;
 typedef BinAllocator<80,100> BinAllocator_slots2;
 #elif defined(CCMRAM)
 #if defined(DEBUG)
-typedef BinAllocator<28,400> BinAllocator_slots1;
-typedef BinAllocator<92,90> BinAllocator_slots2;
+typedef BinAllocator<28,380> BinAllocator_slots1;
+typedef BinAllocator<92,84> BinAllocator_slots2;
 #else
 typedef BinAllocator<28,415> BinAllocator_slots1;
-typedef BinAllocator<92,100> BinAllocator_slots2;
+typedef BinAllocator<92,98> BinAllocator_slots2;
 #endif
 #else
 typedef BinAllocator<28,200> BinAllocator_slots1;

--- a/radio/src/syscalls.c
+++ b/radio/src/syscalls.c
@@ -134,3 +134,11 @@ extern void _kill(int pid, int sig)
 {
   return;
 }
+
+extern void __assert_func (const char *p1, int p2, const char *p3, const char *p4)
+{
+  asm("BKPT");
+#if defined(DEBUG)
+  while(1);
+#endif
+}


### PR DESCRIPTION
The extra buffer added in #5716 plus the additional RAM used by #5717 overflows for some radios.

This PR reduces the 'bin_allocator' memory used to fit.
