### PR TITLE
fix: move firmware compiler version check down 

### DIFF
--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -115,9 +115,6 @@ endif()
 
 if(ARCH STREQUAL ARM)
   include(targets/common/arm/CMakeLists.txt)
-  if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "14.2.1")
-    message(WARNING "Only Arm GNU Toolchain version 14.2.rel1 is supported")
-  endif()
 endif()
 
 include_directories(targets/${TARGET_DIR} ${THIRDPARTY_DIR})
@@ -481,6 +478,11 @@ set(SRC ${SRC} ${FIRMWARE_SRC})
 if(NATIVE_BUILD)
   message(STATUS "firmware target disabled")
   return()
+endif()
+
+if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "14.2.1")
+  message(WARNING "Only Arm GNU Toolchain version 14.2.rel1 is supported")
+  message("CPP Compiler: ${CMAKE_CXX_COMPILER}, version ${CMAKE_CXX_COMPILER_VERSION}")
 endif()
 
 set(CMAKE_C_FLAGS "${FIRMWARE_C_FLAGS}")


### PR DESCRIPTION
Summary of changes:
- compiler version test that was included as part of #5263 was placed too high, and would false trigger when doing builds using the native compiler. This is now done later, when firmware target only configuration is done. 
