### PR TITLE
chore(translation): change CRSF_ARMING_MODE German text

### DIFF
--- a/radio/src/translations/de.h
+++ b/radio/src/translations/de.h
@@ -709,7 +709,7 @@
 #define TR_TEMP_CALIB                  "Temp.  abgl."
 #define TR_TIME                        "Uhrzeit:"
 #define TR_BAUDRATE                    "Baudrate"
-#define TR_CRSF_ARMING_MODE            "Armen via"
+#define TR_CRSF_ARMING_MODE            "Arm via"
 #define TR_CRSF_ARMING_MODES           TR_CH"5", TR_SWITCH
 #define TR_MAXBAUDRATE                 "Max Baud"
 #define TR_SAMPLE_MODE                 "Abtastmodus"


### PR DESCRIPTION
The term "armen" is a mixture of english and german. Because there is no good direct translation of the verb "to arm" I would suggest to leave the english term even in the german translation (as in other similar situations too). 

The german translation "scharf schalten" is too long.