### PR TITLE
chore: remove ADC_DIRECTION diagnostic from build output

### DIFF
--- a/radio/util/hw_defs/hal_adc.py
+++ b/radio/util/hw_defs/hal_adc.py
@@ -126,7 +126,7 @@ class ADCInputParser:
         dirs = self.hw_defs.get('ADC_DIRECTION') or ''
         if dirs:
             dirs = dirs.strip('{} ').split(',')
-        eprint(dirs)
+        # eprint(dirs)
         for i in dirs:
             ret.append(int(i))
 


### PR DESCRIPTION
Comment out build diagnostic that outputs "['1', ' -1', ' 1', ' -1', ' 1', ' 1', ' 1']" string.
