### PR TITLE
chore: make firmware check fatal error by default

### DIFF
--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -480,9 +480,9 @@ if(NATIVE_BUILD)
   return()
 endif()
 
-if(NOT CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "14.2.1")
-  message(WARNING "Only Arm GNU Toolchain version 14.2.rel1 is supported")
+if(NOT USE_UNSUPPORTED_TOOLCHAIN AND NOT CMAKE_CXX_COMPILER_VERSION VERSION_EQUAL "14.2.1")
   message("CPP Compiler: ${CMAKE_CXX_COMPILER}, version ${CMAKE_CXX_COMPILER_VERSION}")
+  message(FATAL_ERROR "Only Arm GNU Toolchain version 14.2.rel1 is supported!!")
 endif()
 
 set(CMAKE_C_FLAGS "${FIRMWARE_C_FLAGS}")


### PR DESCRIPTION
Summary of changes:
- now that the version check is *not* breaking everything other firmware builds... the version check can be a fatal error unless `-DUSE_UNSUPPORTED_TOOLCHAIN=Y` is specified as a build option to force it to be skipped. 
