### PR TITLE
fix(nv14): AFHDS3 missing for FRM303 external module

### DIFF
--- a/radio/src/targets/nv14/CMakeLists.txt
+++ b/radio/src/targets/nv14/CMakeLists.txt
@@ -44,7 +44,6 @@ if (PCBREV STREQUAL EL18)
     # defines existing internal modules
     set(INTERNAL_MODULES AFHDS3;CRSF CACHE STRING "Internal modules")
     set(DEFAULT_INTERNAL_MODULE FLYSKY_AFHDS3 CACHE STRING "Default internal module")
-    set(AFHDS3 ON)
 else()
     set(FLAVOUR nv14)
     # defines existing internal modules
@@ -63,6 +62,7 @@ set(RADIO_DEPENDENCIES ${RADIO_DEPENDENCIES} ${BITMAPS_TARGET})
 
 set(HARDWARE_TOUCH ON)
 set(FLYSKY_GIMBAL ON)
+set(AFHDS3 ON)
 
 add_definitions(
   -DSTM32F429_439xx -DSTM32F429xx


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #5750

Summary of changes:
