### PR TITLE
chore(usb): remove obsolete MSC_BOT_Data

### DIFF
--- a/radio/src/edgetx.cpp
+++ b/radio/src/edgetx.cpp
@@ -96,10 +96,6 @@ safetych_t safetyCh[MAX_OUTPUT_CHANNELS];
 // __DMA for the MSC_BOT_Data member
 union ReusableBuffer reusableBuffer __DMA;
 
-#if !defined(SIMU)
-uint8_t* MSC_BOT_Data = reusableBuffer.MSC_BOT_Data;
-#endif
-
 #if defined(DEBUG_LATENCY)
 uint8_t latencyToggleSwitch = 0;
 #endif

--- a/radio/src/edgetx.h
+++ b/radio/src/edgetx.h
@@ -792,12 +792,6 @@ union ReusableBuffer
     ModuleInformation internalModule;
 #endif
   } viewMain;
-
-#if !defined(SIMU)
-  // Data for the USB mass storage driver. If USB mass storage
-  // runs no menu is not allowed to be displayed
-  uint8_t MSC_BOT_Data[MASS_STORAGE_BUFFER_SIZE];
-#endif
 };
 
 extern ReusableBuffer reusableBuffer;


### PR DESCRIPTION
The USB code uses `USBD_static_malloc`, which allocates a static buffer based on `sizeof(USBD_MSC_BOT_HandleTypeDef)`.