### PR TITLE
feat(cpn): simulator allow manually setting transmitter battery voltage

### DIFF
--- a/companion/src/simulation/simulatorinterface.h
+++ b/companion/src/simulation/simulatorinterface.h
@@ -192,6 +192,7 @@ class SimulatorInterface : public QObject
     void auxSerialSetBaudrate(const quint8 port_num, const quint32 baudrate);
     void auxSerialStart(const quint8 port_num);
     void auxSerialStop(const quint8 port_num);
+    void txBatteryVoltageChanged(const int voltage);
 };
 
 class SimulatorFactory {

--- a/companion/src/simulation/simulatormainwindow.cpp
+++ b/companion/src/simulation/simulatormainwindow.cpp
@@ -579,11 +579,11 @@ void SimulatorMainWindow::openTxBatteryVoltageDialog()
   QDoubleSpinBox *sb = new QDoubleSpinBox();
   sb->setDecimals(1);
   // vBatWarn is voltage in 100mV, vBatMin is in 100mV but with -9V offset, vBatMax has a -12V offset
-  sb->setMinimum((float)((m_batMin + 90) / 10));
-  sb->setMaximum((float)((m_batMax + 120) / 10));
+  sb->setMinimum((float)((m_batMin + 90) / 10.0f));
+  sb->setMaximum((float)((m_batMax + 120) / 10.0f));
   sb->setSingleStep(0.1);
   sb->setSuffix(tr("V"));
-  sb->setValue(m_batVoltage);
+  sb->setValue((float)m_batVoltage / 10.0f);
 
   auto *btnBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
   connect(btnBox, &QDialogButtonBox::accepted, dlg, &QDialog::accept);

--- a/companion/src/simulation/simulatormainwindow.cpp
+++ b/companion/src/simulation/simulatormainwindow.cpp
@@ -589,5 +589,5 @@ void SimulatorMainWindow::openTxBatteryVoltageDialog()
   dlg->deleteLater();
 
   if(dlg->exec())
-    emit txBatteryVoltageChanged((int)(sb->value() * 10.0f));
+    emit txBatteryVoltageChanged((int)(sb->value() * 10.0f)); // float -> int
 }

--- a/companion/src/simulation/simulatormainwindow.cpp
+++ b/companion/src/simulation/simulatormainwindow.cpp
@@ -143,7 +143,7 @@ SimulatorMainWindow::SimulatorMainWindow(QWidget *parent, const QString & simula
   connect(ui->actionReloadRadioData, &QAction::triggered, this, &SimulatorMainWindow::simulatorRestart);
 
   connect(ui->actionReloadLua, &QAction::triggered, m_simulator, &SimulatorInterface::setLuaStateReloadPermanentScripts);
-  connect(ui->actionBatteryVoltage, &QAction::triggered, this, &SimulatorMainWindow::openBatteryVoltageDialog);
+  connect(ui->actionSetTxBatteryVoltage, &QAction::triggered, this, &SimulatorMainWindow::openTxBatteryVoltageDialog);
 
   if (m_outputsWidget) {
     connect(this, &SimulatorMainWindow::simulatorStart, m_outputsWidget, &RadioOutputsWidget::start);
@@ -557,7 +557,7 @@ void SimulatorMainWindow::showAbout(bool show)
   msgBox.exec();
 }
 
-void SimulatorMainWindow::openBatteryVoltageDialog()
+void SimulatorMainWindow::openTxBatteryVoltageDialog()
 {
   // vBatWarn is voltage in 100mV, vBatMin is in 100mV but with -9V offset, vBatMax has a -12V offset
   int vBatMin, vBatMax;
@@ -588,5 +588,5 @@ void SimulatorMainWindow::openBatteryVoltageDialog()
   dlg->deleteLater();
 
   if(dlg->exec())
-    emit batteryVoltageChanged((int)(sb->value() * 10.0f));
+    emit txBatteryVoltageChanged((int)(sb->value() * 10.0f));
 }

--- a/companion/src/simulation/simulatormainwindow.cpp
+++ b/companion/src/simulation/simulatormainwindow.cpp
@@ -559,7 +559,7 @@ void SimulatorMainWindow::showAbout(bool show)
 
 void SimulatorMainWindow::openTxBatteryVoltageDialog()
 {
-  // vBatWarn is voltage in 100mV, vBatMin is in 100mV but with -9V offset, vBatMax has a -12V offset
+  // TODO: use GeneralSettings
   int vBatMin, vBatMax;
   unsigned int vBatWarn;
   Boards::getBattRange(getCurrentBoard(), vBatMin, vBatMax, vBatWarn);
@@ -569,11 +569,12 @@ void SimulatorMainWindow::openTxBatteryVoltageDialog()
   QLabel *lbl = new QLabel(tr("Set voltage"));
   QDoubleSpinBox *sb = new QDoubleSpinBox();
   sb->setDecimals(1);
+  // vBatWarn is voltage in 100mV, vBatMin is in 100mV but with -9V offset, vBatMax has a -12V offset
   sb->setMinimum((float)((vBatMin + 90) / 10));
   sb->setMaximum((float)((vBatMax + 120) / 10));
   sb->setSingleStep(0.1);
   sb->setSuffix(tr("V"));
-  sb->setValue(vBatWarn + 20);
+  sb->setValue(vBatWarn + 5); // + 0.5V
 
   auto *btnBox = new QDialogButtonBox(QDialogButtonBox::Ok | QDialogButtonBox::Cancel, this);
   connect(btnBox, &QDialogButtonBox::accepted, dlg, &QDialog::accept);

--- a/companion/src/simulation/simulatormainwindow.cpp
+++ b/companion/src/simulation/simulatormainwindow.cpp
@@ -588,5 +588,5 @@ void SimulatorMainWindow::openBatteryVoltageDialog()
   dlg->deleteLater();
 
   if(dlg->exec())
-    emit batteryVoltageChanged((int)(sb->value() * 10));
+    emit batteryVoltageChanged((int)(sb->value() * 10.0f));
 }

--- a/companion/src/simulation/simulatormainwindow.cpp
+++ b/companion/src/simulation/simulatormainwindow.cpp
@@ -598,12 +598,13 @@ void SimulatorMainWindow::openTxBatteryVoltageDialog()
   dlg->deleteLater();
 
   if(dlg->exec()) {
-    m_batVoltage = (int)(sb->value() * 10.0f);
-    emit txBatteryVoltageChanged((int)(sb->value() * 10.0f));
+    unsigned int volts = (unsigned int)((float)sb->value() * 10.0f);
+    m_batVoltage = volts;
+    emit txBatteryVoltageChanged(volts);
   }
 }
 
-void SimulatorMainWindow::onTxBatteryVoltageChanged(const int voltage)
+void SimulatorMainWindow::onTxBatteryVoltageChanged(const unsigned int voltage)
 {
   m_batVoltage = voltage;
 }

--- a/companion/src/simulation/simulatormainwindow.cpp
+++ b/companion/src/simulation/simulatormainwindow.cpp
@@ -597,8 +597,10 @@ void SimulatorMainWindow::openTxBatteryVoltageDialog()
   dlg->setWindowTitle(tr("Battery"));
   dlg->deleteLater();
 
-  if(dlg->exec())
+  if(dlg->exec()) {
     m_batVoltage = (int)(sb->value() * 10.0f);
+    emit txBatteryVoltageChanged((int)(sb->value() * 10.0f));
+  }
 }
 
 void SimulatorMainWindow::onTxBatteryVoltageChanged(const int voltage)

--- a/companion/src/simulation/simulatormainwindow.h
+++ b/companion/src/simulation/simulatormainwindow.h
@@ -86,6 +86,8 @@ class SimulatorMainWindow : public QMainWindow
     void showHelp(bool show);
     void showAbout(bool show);
     void openTxBatteryVoltageDialog();
+    void onSettingsBatteryChanged(const int batMin, const int batMax, const unsigned int batWarn);
+    void onTxBatteryVoltageChanged(const int voltage);
 
   protected:
     void createDockWidgets();
@@ -116,6 +118,10 @@ class SimulatorMainWindow : public QMainWindow
     bool m_firstShow;
     bool m_showRadioDocked;
     bool m_showMenubar;
+    int m_batMin;
+    int m_batMax;
+    unsigned int m_batWarn;
+    unsigned int m_batVoltage;
 
     const static quint16 m_savedUiStateVersion;
 };

--- a/companion/src/simulation/simulatormainwindow.h
+++ b/companion/src/simulation/simulatormainwindow.h
@@ -71,6 +71,7 @@ class SimulatorMainWindow : public QMainWindow
   signals:
     void simulatorStart();
     void simulatorRestart();
+    void batteryVoltageChanged(qint16 volts);
 
   protected slots:
     virtual void closeEvent(QCloseEvent *);
@@ -84,6 +85,7 @@ class SimulatorMainWindow : public QMainWindow
     void openSerialPortsDialog(bool);
     void showHelp(bool show);
     void showAbout(bool show);
+    void openBatteryVoltageDialog();
 
   protected:
     void createDockWidgets();

--- a/companion/src/simulation/simulatormainwindow.h
+++ b/companion/src/simulation/simulatormainwindow.h
@@ -71,7 +71,7 @@ class SimulatorMainWindow : public QMainWindow
   signals:
     void simulatorStart();
     void simulatorRestart();
-    void txBatteryVoltageChanged(qint16 volts);
+    void txBatteryVoltageChanged(int volts); // this changed value
 
   protected slots:
     virtual void closeEvent(QCloseEvent *);
@@ -86,8 +86,9 @@ class SimulatorMainWindow : public QMainWindow
     void showHelp(bool show);
     void showAbout(bool show);
     void openTxBatteryVoltageDialog();
+    // TODO: detect if changed via ui as currently event only on GeneralSettings (re)load
     void onSettingsBatteryChanged(const int batMin, const int batMax, const unsigned int batWarn);
-    void onTxBatteryVoltageChanged(const int voltage);
+    void onTxBatteryVoltageChanged(const unsigned int voltage); // something else changed voltage
 
   protected:
     void createDockWidgets();

--- a/companion/src/simulation/simulatormainwindow.h
+++ b/companion/src/simulation/simulatormainwindow.h
@@ -71,7 +71,7 @@ class SimulatorMainWindow : public QMainWindow
   signals:
     void simulatorStart();
     void simulatorRestart();
-    void batteryVoltageChanged(qint16 volts);
+    void txBatteryVoltageChanged(qint16 volts);
 
   protected slots:
     virtual void closeEvent(QCloseEvent *);
@@ -85,7 +85,7 @@ class SimulatorMainWindow : public QMainWindow
     void openSerialPortsDialog(bool);
     void showHelp(bool show);
     void showAbout(bool show);
-    void openBatteryVoltageDialog();
+    void openTxBatteryVoltageDialog();
 
   protected:
     void createDockWidgets();

--- a/companion/src/simulation/simulatormainwindow.ui
+++ b/companion/src/simulation/simulatormainwindow.ui
@@ -69,6 +69,7 @@
     <property name="title">
      <string>Tools</string>
     </property>
+    <addaction name="actionBatteryVoltage"/>
     <addaction name="actionScreenshot"/>
     <addaction name="actionJoystickSettings"/>
     <addaction name="actionSerialPorts"/>
@@ -232,6 +233,14 @@
   <action name="actionAbout">
    <property name="text">
     <string>About</string>
+   </property>
+  </action>
+  <action name="actionBatteryVoltage">
+   <property name="text">
+    <string>Battery Voltage...</string>
+   </property>
+   <property name="toolTip">
+    <string>Open set battery voltage dialog</string>
    </property>
   </action>
  </widget>

--- a/companion/src/simulation/simulatormainwindow.ui
+++ b/companion/src/simulation/simulatormainwindow.ui
@@ -69,7 +69,7 @@
     <property name="title">
      <string>Tools</string>
     </property>
-    <addaction name="actionBatteryVoltage"/>
+    <addaction name="actionSetTxBatteryVoltage"/>
     <addaction name="actionScreenshot"/>
     <addaction name="actionJoystickSettings"/>
     <addaction name="actionSerialPorts"/>
@@ -235,12 +235,12 @@
     <string>About</string>
    </property>
   </action>
-  <action name="actionBatteryVoltage">
+  <action name="actionSetTxBatteryVoltage">
    <property name="text">
-    <string>Battery Voltage...</string>
+    <string>TX Battery Voltage...</string>
    </property>
    <property name="toolTip">
-    <string>Open set battery voltage dialog</string>
+    <string>Open set transmitter battery voltage dialog</string>
    </property>
   </action>
  </widget>

--- a/companion/src/simulation/simulatorwidget.cpp
+++ b/companion/src/simulation/simulatorwidget.cpp
@@ -107,7 +107,7 @@ SimulatorWidget::SimulatorWidget(QWidget * parent, SimulatorInterface * simulato
   connect(simulator, &SimulatorInterface::runtimeError, this, &SimulatorWidget::onSimulatorError);
   connect(simulator, &SimulatorInterface::phaseChanged, this, &SimulatorWidget::onPhaseChanged);
 
-  connect((SimulatorMainWindow *)parent, &SimulatorMainWindow::batteryVoltageChanged, this, &SimulatorWidget::onBatteryVoltageChanged);
+  connect((SimulatorMainWindow *)parent, &SimulatorMainWindow::txBatteryVoltageChanged, this, &SimulatorWidget::onTxBatteryVoltageChanged);
 
   m_timer.setInterval(SIMULATOR_INTERFACE_HEARTBEAT_PERIOD * 6);
   connect(&m_timer, &QTimer::timeout, this, &SimulatorWidget::onTimerEvent);
@@ -891,7 +891,7 @@ void SimulatorWidget::onjoystickButtonValueChanged(int button, bool state)
 #endif
 }
 
-void SimulatorWidget::onBatteryVoltageChanged(qint16 volts)
+void SimulatorWidget::onTxBatteryVoltageChanged(qint16 volts)
 {
   emit inputValueChange(SimulatorInterface::INPUT_SRC_TXVIN, 0, volts);
 }

--- a/companion/src/simulation/simulatorwidget.cpp
+++ b/companion/src/simulation/simulatorwidget.cpp
@@ -673,8 +673,7 @@ void SimulatorWidget::restoreRadioWidgetsState()
   // Set throttle stick down and locked, side depends on mode
   emit stickModeChange(radioSettings.stickMode);
 
-  // TODO : custom voltages
-  qint16 volts = radioSettings.vBatWarn + 20; // +2V
+  qint16 volts = radioSettings.vBatWarn + 5; // +0.5V
   emit inputValueChange(SimulatorInterface::INPUT_SRC_TXVIN, 0, volts);
 }
 
@@ -688,7 +687,6 @@ void SimulatorWidget::saveRadioWidgetsState(QList<QByteArray> & state)
     }
   }
 }
-
 
 /*
  * Event handlers/private slots

--- a/companion/src/simulation/simulatorwidget.cpp
+++ b/companion/src/simulation/simulatorwidget.cpp
@@ -157,6 +157,7 @@ void SimulatorWidget::setPaths(const QString & sdPath, const QString & dataPath)
 void SimulatorWidget::setRadioSettings(const GeneralSettings settings)
 {
   radioSettings = settings;
+  emit settingsBatteryChanged(settings.vBatMin, settings.vBatMax, settings.vBatWarn);
 }
 
 /*
@@ -231,7 +232,7 @@ bool SimulatorWidget::setStartupData(const QByteArray & dataSource, bool fromFil
     return false;
   }
 
-  radioSettings = simuData.generalSettings;
+  setRadioSettings(simuData.generalSettings);
   startupFromFile = fromFile;
 
   return true;
@@ -262,7 +263,7 @@ bool SimulatorWidget::setRadioData(RadioData * radioData)
   }
 
   if (ret)
-    radioSettings = radioData->generalSettings;
+    setRadioSettings(radioData->generalSettings);
 
   return ret;
 }

--- a/companion/src/simulation/simulatorwidget.cpp
+++ b/companion/src/simulation/simulatorwidget.cpp
@@ -38,6 +38,7 @@
 #include "joystickdialog.h"
 #endif
 #include "simulateduiwidgetGeneric.h"
+#include "simulatormainwindow.h"
 
 #include <AppDebugMessageHandler>
 #include <QFile>
@@ -105,6 +106,8 @@ SimulatorWidget::SimulatorWidget(QWidget * parent, SimulatorInterface * simulato
   connect(simulator, &SimulatorInterface::heartbeat, this, &SimulatorWidget::onSimulatorHeartbeat);
   connect(simulator, &SimulatorInterface::runtimeError, this, &SimulatorWidget::onSimulatorError);
   connect(simulator, &SimulatorInterface::phaseChanged, this, &SimulatorWidget::onPhaseChanged);
+
+  connect((SimulatorMainWindow *)parent, &SimulatorMainWindow::batteryVoltageChanged, this, &SimulatorWidget::onBatteryVoltageChanged);
 
   m_timer.setInterval(SIMULATOR_INTERFACE_HEARTBEAT_PERIOD * 6);
   connect(&m_timer, &QTimer::timeout, this, &SimulatorWidget::onTimerEvent);
@@ -671,7 +674,7 @@ void SimulatorWidget::restoreRadioWidgetsState()
   emit stickModeChange(radioSettings.stickMode);
 
   // TODO : custom voltages
-  qint16 volts = radioSettings.vBatWarn + 20; // 1V above min
+  qint16 volts = radioSettings.vBatWarn + 20; // +2V
   emit inputValueChange(SimulatorInterface::INPUT_SRC_TXVIN, 0, volts);
 }
 
@@ -888,4 +891,9 @@ void SimulatorWidget::onjoystickButtonValueChanged(int button, bool state)
     emit widgetValueAdjust(RadioWidget::RADIO_WIDGET_TRIM, swtch, offset, state);
   }
 #endif
+}
+
+void SimulatorWidget::onBatteryVoltageChanged(qint16 volts)
+{
+  emit inputValueChange(SimulatorInterface::INPUT_SRC_TXVIN, 0, volts);
 }

--- a/companion/src/simulation/simulatorwidget.h
+++ b/companion/src/simulation/simulatorwidget.h
@@ -114,6 +114,7 @@ class SimulatorWidget : public QWidget
     void onRadioWidgetValueChange(const RadioWidget::RadioWidgetType type, int index, int value);
     void onjoystickAxisValueChanged(int axis, int value);
     void onjoystickButtonValueChanged(int button, bool state);
+    void onBatteryVoltageChanged(qint16 volts);
 
     void setRadioProfileId(int value);
     void setupRadioWidgets();

--- a/companion/src/simulation/simulatorwidget.h
+++ b/companion/src/simulation/simulatorwidget.h
@@ -99,6 +99,7 @@ class SimulatorWidget : public QWidget
     void simulatorStop();
     void simulatorSdPathChange(const QString & sdPath, const QString & dataPath);
     void simulatorVolumeGainChange(const int gain);
+    void settingsBatteryChanged(const int batMin, const int batMax, const unsigned int batWarn);
 
   private slots:
     virtual void mousePressEvent(QMouseEvent *event);

--- a/companion/src/simulation/simulatorwidget.h
+++ b/companion/src/simulation/simulatorwidget.h
@@ -114,7 +114,7 @@ class SimulatorWidget : public QWidget
     void onRadioWidgetValueChange(const RadioWidget::RadioWidgetType type, int index, int value);
     void onjoystickAxisValueChanged(int axis, int value);
     void onjoystickButtonValueChanged(int button, bool state);
-    void onBatteryVoltageChanged(qint16 volts);
+    void onTxBatteryVoltageChanged(qint16 volts);
 
     void setRadioProfileId(int value);
     void setupRadioWidgets();

--- a/radio/src/hal/adc_driver.cpp
+++ b/radio/src/hal/adc_driver.cpp
@@ -309,19 +309,14 @@ tmr10ms_t jitterResetTime = 0;
 
 uint16_t getBatteryVoltage()
 {
-#if defined(SIMU)
-  // use the value managed by the sim so ensure the math mirrors OpenTxSimulator::voltageToAdc
-  return getAnalogValue(adcGetInputOffset(ADC_INPUT_VBAT)) * 1000 / BATTERY_DIVIDER;
-#else
-#if defined(CSD203_SENSOR)
+#if defined(CSD203_SENSOR) && !defined(SIMU)
   return getCSD203BatteryVoltage() / 10;
 #else
   // using filtered ADC value on purpose
   if (adcGetMaxInputs(ADC_INPUT_VBAT) < 1) return 0;
   int32_t instant_vbat = anaIn(adcGetInputOffset(ADC_INPUT_VBAT));
-#endif
 
-// TODO: remove BATT_SCALE / BATTERY_DIVIDER defines
+  // TODO: remove BATT_SCALE / BATTERY_DIVIDER defines
 #if defined(VBAT_MOSFET_DROP)
   // 1000 is used as multiplier for both numerator and denominator to allow to stay in integer domain
   return (uint16_t)((instant_vbat * ADC_VREF_PREC2 * ((((1000 + g_eeGeneral.txVoltageCalibration)) * (VBAT_DIV_R2 + VBAT_DIV_R1)) / VBAT_DIV_R1)) / (2*RESX*1000)) + VBAT_MOSFET_DROP;

--- a/radio/src/targets/simu/adc_driver.cpp
+++ b/radio/src/targets/simu/adc_driver.cpp
@@ -41,18 +41,25 @@ static bool simu_start_conversion()
     setAnalogValue(i, simu_get_analog(i));
   }
 
-  // set VBAT / RTC_BAT
+  // set batteries default voltage
   if (adcGetMaxInputs(ADC_INPUT_VBAT) > 0) {
+    // use default voltage on 1st call as it may have been overriden in user ui
+    int i = adcGetInputOffset(ADC_INPUT_VBAT);
+    if (simu_get_analog(i) < 1000) {
 #if defined(VBAT_MOSFET_DROP)
-    uint32_t vbat = (2 * (BATTERY_MAX + BATTERY_MIN) * (VBAT_DIV_R2 + VBAT_DIV_R1)) / VBAT_DIV_R1;
+      uint32_t vbat = (2 * (BATTERY_MAX + BATTERY_MIN) * (VBAT_DIV_R2 + VBAT_DIV_R1)) / VBAT_DIV_R1;
 #elif defined(BATT_SCALE)
-    uint32_t vbat = (BATTERY_MAX + BATTERY_MIN) * 5; // * 10 / 2
-    vbat = ((vbat - VOLTAGE_DROP) * BATTERY_DIVIDER) / (BATT_SCALE * 128);
+      uint32_t vbat = (BATTERY_MAX + BATTERY_MIN) * 5; // * 10 / 2
+      vbat = ((vbat - VOLTAGE_DROP) * BATTERY_DIVIDER) / (BATT_SCALE * 128);
 #else
-    uint32_t vbat = (BATTERY_MAX + BATTERY_MIN) * 5; // * 10 / 2
-    vbat = (vbat * BATTERY_DIVIDER) / 1000;
+      uint32_t vbat = (BATTERY_MAX + BATTERY_MIN) * 5; // * 10 / 2
+      vbat = (vbat * BATTERY_DIVIDER) / 1000;
 #endif
-    setAnalogValue(adcGetInputOffset(ADC_INPUT_VBAT), vbat * 2);
+      setAnalogValue(adcGetInputOffset(ADC_INPUT_VBAT), vbat);
+    }
+    else {
+      setAnalogValue(i, simu_get_analog(i));
+    }
   }
 
   if (adcGetMaxInputs(ADC_INPUT_RTC_BAT) > 0) {

--- a/radio/src/targets/simu/adc_driver.cpp
+++ b/radio/src/targets/simu/adc_driver.cpp
@@ -41,21 +41,27 @@ static bool simu_start_conversion()
     setAnalogValue(i, simu_get_analog(i));
   }
 
-  // set batteries default voltage
-  if (adcGetMaxInputs(ADC_INPUT_VBAT) > 0) {
-    int i = adcGetInputOffset(ADC_INPUT_VBAT);
+  // set batteries default voltages
+  int i = adcGetInputOffset(ADC_INPUT_VBAT);
+
+  if (i > 0) {
     // calculate default voltage on 1st call
-    if (simu_get_analog(i) < 100) {
+    TRACE("Old ana: %d", simu_get_analog(i));
+    if (simu_get_analog(i) <= 2048) {
 #if defined(VBAT_MOSFET_DROP)
+      TRACE("min: %d max: %d r1: %d r2: %d", BATTERY_MIN, BATTERY_MAX, VBAT_DIV_R1, VBAT_DIV_R2);
       uint32_t vbat = (2 * (BATTERY_MAX + BATTERY_MIN) * (VBAT_DIV_R2 + VBAT_DIV_R1)) / VBAT_DIV_R1;
 #elif defined(BATT_SCALE)
+      TRACE("min: %d max: %d div: %d drop: %d", BATTERY_MIN, BATTERY_MAX, BATTERY_DIVIDER, VOLTAGE_DROP);
       uint32_t vbat = (BATTERY_MAX + BATTERY_MIN) * 5; // * 10 / 2
       vbat = ((vbat - VOLTAGE_DROP) * BATTERY_DIVIDER) / (BATT_SCALE * 128);
 #else
+      TRACE("min: %d max: %d div: %d", BATTERY_MIN, BATTERY_MAX, BATTERY_DIVIDER);
       uint32_t vbat = (BATTERY_MAX + BATTERY_MIN) * 5; // * 10 / 2
       vbat = (vbat * BATTERY_DIVIDER) / 1000;
 #endif
-      setAnalogValue(adcGetInputOffset(ADC_INPUT_VBAT), vbat * 2);
+      TRACE("vbat: %d", vbat);
+      setAnalogValue(adcGetInputOffset(ADC_INPUT_VBAT), vbat);
     }
     else {
       // use last saved voltage as can be manually adjusted via ui

--- a/radio/src/targets/simu/adc_driver.cpp
+++ b/radio/src/targets/simu/adc_driver.cpp
@@ -45,7 +45,7 @@ static bool simu_start_conversion()
   if (adcGetMaxInputs(ADC_INPUT_VBAT) > 0) {
     // use default voltage on 1st call
     int i = adcGetInputOffset(ADC_INPUT_VBAT);
-    if (simu_get_analog(i) < 1000) {
+    if (simu_get_analog(i) < 100) {
 #if defined(VBAT_MOSFET_DROP)
       uint32_t vbat = (2 * (BATTERY_MAX + BATTERY_MIN) * (VBAT_DIV_R2 + VBAT_DIV_R1)) / VBAT_DIV_R1;
 #elif defined(BATT_SCALE)
@@ -55,7 +55,7 @@ static bool simu_start_conversion()
       uint32_t vbat = (BATTERY_MAX + BATTERY_MIN) * 5; // * 10 / 2
       vbat = (vbat * BATTERY_DIVIDER) / 1000;
 #endif
-      setAnalogValue(adcGetInputOffset(ADC_INPUT_VBAT), vbat);
+      setAnalogValue(adcGetInputOffset(ADC_INPUT_VBAT), vbat * 2);
     }
     else {
       // use last saved voltage

--- a/radio/src/targets/simu/adc_driver.cpp
+++ b/radio/src/targets/simu/adc_driver.cpp
@@ -43,7 +43,7 @@ static bool simu_start_conversion()
 
   // set batteries default voltage
   if (adcGetMaxInputs(ADC_INPUT_VBAT) > 0) {
-    // use default voltage on 1st call as it may have been overriden in user ui
+    // use default voltage on 1st call
     int i = adcGetInputOffset(ADC_INPUT_VBAT);
     if (simu_get_analog(i) < 1000) {
 #if defined(VBAT_MOSFET_DROP)
@@ -58,6 +58,7 @@ static bool simu_start_conversion()
       setAnalogValue(adcGetInputOffset(ADC_INPUT_VBAT), vbat);
     }
     else {
+      // use last saved voltage
       setAnalogValue(i, simu_get_analog(i));
     }
   }

--- a/radio/src/targets/simu/adc_driver.cpp
+++ b/radio/src/targets/simu/adc_driver.cpp
@@ -43,8 +43,8 @@ static bool simu_start_conversion()
 
   // set batteries default voltage
   if (adcGetMaxInputs(ADC_INPUT_VBAT) > 0) {
-    // use default voltage on 1st call
     int i = adcGetInputOffset(ADC_INPUT_VBAT);
+    // calculate default voltage on 1st call
     if (simu_get_analog(i) < 100) {
 #if defined(VBAT_MOSFET_DROP)
       uint32_t vbat = (2 * (BATTERY_MAX + BATTERY_MIN) * (VBAT_DIV_R2 + VBAT_DIV_R1)) / VBAT_DIV_R1;
@@ -58,7 +58,7 @@ static bool simu_start_conversion()
       setAnalogValue(adcGetInputOffset(ADC_INPUT_VBAT), vbat * 2);
     }
     else {
-      // use last saved voltage
+      // use last saved voltage as can be manually adjusted via ui
       setAnalogValue(i, simu_get_analog(i));
     }
   }

--- a/radio/src/targets/simu/adc_driver.cpp
+++ b/radio/src/targets/simu/adc_driver.cpp
@@ -27,6 +27,7 @@
 
 #include "hal_adc_inputs.inc"
 #include "board.h"
+#include "edgetx.h"
 
 void enableVBatBridge(){}
 void disableVBatBridge(){}
@@ -46,27 +47,30 @@ static bool simu_start_conversion()
 
   if (i > 0) {
     // calculate default voltage on 1st call
-    TRACE("Old ana: %d", simu_get_analog(i));
-    if (simu_get_analog(i) <= 2048) {
+    uint32_t adc = (simu_get_analog(i) - 2048) * 1000 / 2000;
+    // TRACE("raw ana: %d adj ana: %d", simu_get_analog(i), vbat);
+    // just in case the voltage has not been initialised in sim initialisation/startup
+    // these formulae must mirror OpenTxSimulator::voltageToAdc
+    if (adc == 0) {
+      uint32_t volts = (uint32_t)((g_eeGeneral.vBatWarn > 0 ? g_eeGeneral.vBatWarn : BATTERY_WARN) + 5) * 10; // +0.5V and prec2
 #if defined(VBAT_MOSFET_DROP)
-      TRACE("min: %d max: %d r1: %d r2: %d", BATTERY_MIN, BATTERY_MAX, VBAT_DIV_R1, VBAT_DIV_R2);
-      uint32_t vbat = (2 * (BATTERY_MAX + BATTERY_MIN) * (VBAT_DIV_R2 + VBAT_DIV_R1)) / VBAT_DIV_R1;
+      // TRACE("volts: %d r1: %d r2: %d drop: %d vref: %d calib: %d", volts, VBAT_DIV_R1, VBAT_DIV_R2, VBAT_MOSFET_DROP, ADC_VREF_PREC2, g_eeGeneral.txVoltageCalibration);
+      adc = (volts - VBAT_MOSFET_DROP) * (2 * RESX * 1000) / ADC_VREF_PREC2 / (((1000 + g_eeGeneral.txVoltageCalibration) * (VBAT_DIV_R2 + VBAT_DIV_R1)) / VBAT_DIV_R1);
 #elif defined(BATT_SCALE)
-      TRACE("min: %d max: %d div: %d drop: %d", BATTERY_MIN, BATTERY_MAX, BATTERY_DIVIDER, VOLTAGE_DROP);
-      uint32_t vbat = (BATTERY_MAX + BATTERY_MIN) * 5; // * 10 / 2
-      vbat = ((vbat - VOLTAGE_DROP) * BATTERY_DIVIDER) / (BATT_SCALE * 128);
+      // TRACE("volts: %d div: %d drop: %d scale: %d calib: %d", volts, BATTERY_DIVIDER, VOLTAGE_DROP, BATT_SCALE, g_eeGeneral.txVoltageCalibration);
+      adc = (volts - VOLTAGE_DROP) * BATTERY_DIVIDER / (128 + g_eeGeneral.txVoltageCalibration) / BATT_SCALE;
+#elif defined(VOLTAGE_DROP)
+      // TRACE("volts: %d div: %d drop: %d", volts, BATTERY_DIVIDER, VOLTAGE_DROP);
+      adc = (volts - VOLTAGE_DROP) * BATTERY_DIVIDER / (1000 + g_eeGeneral.txVoltageCalibration);
 #else
-      TRACE("min: %d max: %d div: %d", BATTERY_MIN, BATTERY_MAX, BATTERY_DIVIDER);
-      uint32_t vbat = (BATTERY_MAX + BATTERY_MIN) * 5; // * 10 / 2
-      vbat = (vbat * BATTERY_DIVIDER) / 1000;
+      // TRACE("volts: %d div: %d calib: %d", volts, BATTERY_DIVIDER, g_eeGeneral.txVoltageCalibration);
+      adc = volts * BATTERY_DIVIDER / (1000 + g_eeGeneral.txVoltageCalibration);
 #endif
-      TRACE("vbat: %d", vbat);
-      setAnalogValue(adcGetInputOffset(ADC_INPUT_VBAT), vbat);
+      // TRACE("calc adc: %d", adc);
+      adc = adc * 2; // div by 2 in firmware filtered adc calcs
     }
-    else {
-      // use last saved voltage as can be manually adjusted via ui
-      setAnalogValue(i, simu_get_analog(i));
-    }
+
+    setAnalogValue(i, adc);
   }
 
   if (adcGetMaxInputs(ADC_INPUT_RTC_BAT) > 0) {

--- a/radio/src/targets/simu/opentxsimulator.cpp
+++ b/radio/src/targets/simu/opentxsimulator.cpp
@@ -182,7 +182,7 @@ OpenTxSimulator::OpenTxSimulator() :
   tracebackDevices.clear();
   traceCallback = firmwareTraceCb;
 
-  // When we create the simulator, we change the UART driver 
+  // When we create the simulator, we change the UART driver
   for (int i = 0; i < MAX_AUX_SERIAL; i++) {
     etx_serial_port_t * port = serialPorts[i];
     if (port != nullptr) {
@@ -893,15 +893,10 @@ const char * OpenTxSimulator::getError()
 
 const int OpenTxSimulator::voltageToAdc(const int volts)
 {
-  int ret = 0;
-#if defined(PCBHORUS) || defined(PCBX7)
-  ret = (float)volts * 16.2f;
-#elif defined(PCBTARANIS)
-  ret = (float)volts * 13.3f;
-#else
-  ret = (float)volts * 14.15f;
-#endif
-  return ret;
+  // this math makes the result close to real calculation to minimise unexpected
+  // results when value is retieved by adc driver getBatteryVoltage and used
+  // * 10 precision 1 to 2
+  return volts * 10 * BATTERY_DIVIDER / 1000;
 }
 
 

--- a/radio/src/targets/simu/opentxsimulator.cpp
+++ b/radio/src/targets/simu/opentxsimulator.cpp
@@ -893,10 +893,13 @@ const char * OpenTxSimulator::getError()
 
 const int OpenTxSimulator::voltageToAdc(const int volts)
 {
-  // this math makes the result close to real calculation to minimise unexpected
-  // results when value is retieved by adc driver getBatteryVoltage and used
-  // * 10 precision 1 to 2
-  return volts * 10 * BATTERY_DIVIDER / 1000;
+#if defined(VBAT_MOSFET_DROP)
+  return (2 * volts) * (VBAT_DIV_R2 + VBAT_DIV_R1)) / VBAT_DIV_R1;
+#elif defined(BATT_SCALE)
+  return ((volts - VOLTAGE_DROP) * BATTERY_DIVIDER) / (BATT_SCALE * 128);
+#else
+  return (volts * BATTERY_DIVIDER) / 1000;
+#endif
 }
 
 

--- a/radio/src/targets/simu/opentxsimulator.cpp
+++ b/radio/src/targets/simu/opentxsimulator.cpp
@@ -24,6 +24,7 @@
 #include "simulcd.h"
 #include "switches.h"
 #include "serial.h"
+#include "myeeprom.h"
 
 #include "hal/adc_driver.h"
 #include "hal/rotary_encoder.h"
@@ -61,6 +62,8 @@ extern etx_serial_port_t * serialPorts[MAX_AUX_SERIAL];
 
 uint16_t simu_get_analog(uint8_t idx)
 {
+  // TODO: return raw values for ADC_INPUT_VBAT and ADC_INPUT_RTC_BAT
+
   // 6POS simu mechanism use a different scale, so needs specific offset
   if (IS_POT_MULTIPOS(idx - adcGetInputOffset(ADC_INPUT_FLEX))) {
     // Use radio calibration data to determine conversion factor
@@ -891,15 +894,26 @@ const char * OpenTxSimulator::getError()
   return main_thread_error;
 }
 
-const int OpenTxSimulator::voltageToAdc(const int volts)
+const int OpenTxSimulator::voltageToAdc(const int voltage)
 {
+  int volts = voltage * 10;  // prec2
+  int adc = 0;
+
 #if defined(VBAT_MOSFET_DROP)
-  return (2 * volts) * (VBAT_DIV_R2 + VBAT_DIV_R1) / VBAT_DIV_R1;
+  // TRACE("volts: %d r1: %d r2: %d drop: %d vref: %d calib: %d", volts, VBAT_DIV_R1, VBAT_DIV_R2, VBAT_MOSFET_DROP, ADC_VREF_PREC2, g_eeGeneral.txVoltageCalibration);
+  adc = (volts - VBAT_MOSFET_DROP) * (2 * RESX * 1000) / ADC_VREF_PREC2 / (((1000 + g_eeGeneral.txVoltageCalibration) * (VBAT_DIV_R2 + VBAT_DIV_R1)) / VBAT_DIV_R1);
 #elif defined(BATT_SCALE)
-  return ((volts - VOLTAGE_DROP) * BATTERY_DIVIDER) / (BATT_SCALE * 128);
+  // TRACE("volts: %d div: %d drop: %d scale: %d calib: %d", volts, BATTERY_DIVIDER, VOLTAGE_DROP, BATT_SCALE, g_eeGeneral.txVoltageCalibration);
+  adc = (volts - VOLTAGE_DROP) * BATTERY_DIVIDER / (128 + g_eeGeneral.txVoltageCalibration) / BATT_SCALE;
+#elif defined(VOLTAGE_DROP)
+  // TRACE("volts: %d div: %d drop: %d", volts, BATTERY_DIVIDER, VOLTAGE_DROP);
+  adc = (volts - VOLTAGE_DROP) * BATTERY_DIVIDER / (1000 + g_eeGeneral.txVoltageCalibration);
 #else
-  return (volts * BATTERY_DIVIDER) / 1000;
+  // TRACE("volts: %d div: %d calib: %d", volts, BATTERY_DIVIDER, g_eeGeneral.txVoltageCalibration);
+  adc = volts * BATTERY_DIVIDER / (1000 + g_eeGeneral.txVoltageCalibration);
 #endif
+  // TRACE("calc adc: %d", adc);
+  return adc * 2; // div by 2 in firmware filtered adc calcs
 }
 
 

--- a/radio/src/targets/simu/opentxsimulator.cpp
+++ b/radio/src/targets/simu/opentxsimulator.cpp
@@ -380,7 +380,7 @@ void OpenTxSimulator::setInputValue(int type, uint8_t index, int16_t value)
       if (adcGetMaxInputs(ADC_INPUT_VBAT) > 0) {
         auto idx = adcGetInputOffset(ADC_INPUT_VBAT);
         setAnalogValue(idx, voltageToAdc(value));
-        emit txBatteryVoltageChanged(value);
+        emit txBatteryVoltageChanged((unsigned int)value);
       }
       break;
     case INPUT_SRC_SWITCH :

--- a/radio/src/targets/simu/opentxsimulator.cpp
+++ b/radio/src/targets/simu/opentxsimulator.cpp
@@ -380,6 +380,7 @@ void OpenTxSimulator::setInputValue(int type, uint8_t index, int16_t value)
       if (adcGetMaxInputs(ADC_INPUT_VBAT) > 0) {
         auto idx = adcGetInputOffset(ADC_INPUT_VBAT);
         setAnalogValue(idx, voltageToAdc(value));
+        emit txBatteryVoltageChanged(value);
       }
       break;
     case INPUT_SRC_SWITCH :

--- a/radio/src/targets/simu/opentxsimulator.cpp
+++ b/radio/src/targets/simu/opentxsimulator.cpp
@@ -894,7 +894,7 @@ const char * OpenTxSimulator::getError()
 const int OpenTxSimulator::voltageToAdc(const int volts)
 {
 #if defined(VBAT_MOSFET_DROP)
-  return (2 * volts) * (VBAT_DIV_R2 + VBAT_DIV_R1)) / VBAT_DIV_R1;
+  return (2 * volts) * (VBAT_DIV_R2 + VBAT_DIV_R1) / VBAT_DIV_R1;
 #elif defined(BATT_SCALE)
   return ((volts - VOLTAGE_DROP) * BATTERY_DIVIDER) / (BATT_SCALE * 128);
 #else

--- a/radio/src/targets/simu/opentxsimulator.h
+++ b/radio/src/targets/simu/opentxsimulator.h
@@ -106,7 +106,7 @@ class DLLEXPORT OpenTxSimulator : public SimulatorInterface
     const char * getPhaseName(unsigned int phase);
     const QString getCurrentPhaseName();
     const char * getError();
-    const int voltageToAdc(const int volts);
+    const int voltageToAdc(const int voltage);
 
     QString simuSdDirectory;
     QString simuSettingsDirectory;


### PR DESCRIPTION
Fixes #5053

Summary of changes:
- add Battery Voltage option to Tools menu

Notes:
- the radio will not update to the new voltage instantly but over a number of adc read cycles as filtered adc averaging is used.
- there maybe instances of rounding variance as the radio uses integers
- the tx battery settings for min max and warn values are only read on sim load ie changes via radio ui will not be detected