### PR TITLE
Add crsf-telemetry filtered queues

### DIFF
--- a/radio/src/.gitignore
+++ b/radio/src/.gitignore
@@ -29,3 +29,5 @@
 /lua_fields*
 .directory
 
+
+.codegpt

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -73,7 +73,7 @@
 // getSourceString() for this parametrization
 static constexpr uint8_t maxSourceNameLength{16};
 
-#ifdef CROSSFIRE
+#if defined(CROSSFIRE) && defined(COLORLCD)
 luaTelemetryQueueManager_t luaTelemetryQueueMgr;
 #endif
 
@@ -1135,6 +1135,7 @@ static int luaAccessTelemetryPush(lua_State * L)
 #endif
 
 #if defined(CROSSFIRE)
+#if defined(COLORLCD)
 static int luaCrossfireTelemetryRemovePrivateQueue(lua_State * const L) 
 {
   const int id = luaL_checkinteger(L, 1);
@@ -1209,6 +1210,7 @@ static int luaCrossfireTelemetryPopPrivate(lua_State * const L)
     }
   });
 }
+#endif
 
 /*luadoc
 @function crossfireTelemetryPop()
@@ -3061,9 +3063,11 @@ LROT_BEGIN(etxlib, NULL, 0)
 #if defined(CROSSFIRE)
   LROT_FUNCENTRY( crossfireTelemetryPop, luaCrossfireTelemetryPop )
   LROT_FUNCENTRY( crossfireTelemetryPush, luaCrossfireTelemetryPush )
+  #if defined(COLORLCD)
   LROT_FUNCENTRY( crossfireTelemetryCreatePrivateQueue, luaCrossfireTelemetryCreatePrivateQueue )
   LROT_FUNCENTRY( crossfireTelemetryPopPrivate, luaCrossfireTelemetryPopPrivate )
   LROT_FUNCENTRY( crossfireTelemetryRemovePrivateQueue, luaCrossfireTelemetryRemovePrivateQueue )
+  #endif
 #endif
 #if defined(GHOST)
   LROT_FUNCENTRY( ghostTelemetryPop, luaGhostTelemetryPop )

--- a/radio/src/lua/lua_api.h
+++ b/radio/src/lua/lua_api.h
@@ -244,6 +244,10 @@ void * tracer_alloc(void * ud, void * ptr, size_t osize, size_t nsize);
 void l_pushtableint(lua_State* ls, const char * key, int value);
 void l_pushtablebool(lua_State* ls, const char * key, bool value);
 
+#if defined(CROSSFIRE)
+void crossfireTelemetryRemovePrivateQueue(int widgetId); 
+#endif
+
 #else  // defined(LUA)
 
 #define luaInit()

--- a/radio/src/lua/lua_widget.cpp
+++ b/radio/src/lua/lua_widget.cpp
@@ -249,7 +249,7 @@ LuaWidget::~LuaWidget()
   TRACE("LuaWidget remove: %d", optionsDataRef);
   luaTelemetryQueueMgr.remove(optionsDataRef); // remove the filter (if any)
   #endif
-  luaL_unref(lsWidgets, LUA_REGISTRYINDEX, luaWidgetDataRef);
+  luaL_unref(lsWidgets, LUA_REGISTRYINDEX, luaScriptContextRef);
   luaL_unref(lsWidgets, LUA_REGISTRYINDEX, zoneRectDataRef);
   free(errorMessage);
 }

--- a/radio/src/lua/lua_widget_factory.cpp
+++ b/radio/src/lua/lua_widget_factory.cpp
@@ -102,7 +102,13 @@ Widget* LuaWidgetFactory::create(Window* parent, const rect_t& rect,
   // Push stored options for 'create' call
   lua_rawgeti(lsWidgets, LUA_REGISTRYINDEX, optionsDataRef);
 
+#if defined(CROSSFIRE)
+  lua_pushinteger(lsWidgets, optionsDataRef); // optionsDataRef serves as a widget-id (last argument to create() LUA function)
+  bool err = lua_pcall(lsWidgets, 3, 1, 0);
+#else
   bool err = lua_pcall(lsWidgets, 2, 1, 0);
+#endif
+
   int widgetData = err ? LUA_NOREF : luaL_ref(lsWidgets, LUA_REGISTRYINDEX);
   LuaWidget* lw = new LuaWidget(this, parent, rect, persistentData, widgetData, zoneRectDataRef, optionsDataRef);
   if (err) lw->setErrorMessage("create()");

--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -280,7 +280,7 @@ void telemetryPortInvertedInit(uint32_t baudrate);
 
 // Aux serial port driver
 #if defined(RADIO_TX16S) || defined(RADIO_F16)
-  #define DEBUG_BAUDRATE                  460800
+  #define DEBUG_BAUDRATE                  400000
   #define LUA_DEFAULT_BAUDRATE            115200
 #else
   #define DEBUG_BAUDRATE                  115200

--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -280,7 +280,7 @@ void telemetryPortInvertedInit(uint32_t baudrate);
 
 // Aux serial port driver
 #if defined(RADIO_TX16S) || defined(RADIO_F16)
-  #define DEBUG_BAUDRATE                  400000
+  #define DEBUG_BAUDRATE                  460800
   #define LUA_DEFAULT_BAUDRATE            115200
 #else
   #define DEBUG_BAUDRATE                  115200

--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -313,7 +313,11 @@ void processCrossfireTelemetryFrame(uint8_t module, uint8_t* rxBuffer,
         crossfireModuleStatus[module].queryCompleted = true;
       }
 
+#if defined(COLORLCD)
       const bool consumed = luaTelemetryQueueMgr.push(etx::span<const uint8_t>{&rxBuffer[1], rxBufferCount - 2}); // adds complete/valid frame
+#else
+      const bool consumed = false;
+#endif
       if (!consumed) {
         TRACE("[XF] not consumed: %d", rxBufferCount);
         if (luaInputTelemetryFifo && luaInputTelemetryFifo->hasSpace(rxBufferCount - 2)) {

--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -314,7 +314,7 @@ void processCrossfireTelemetryFrame(uint8_t module, uint8_t* rxBuffer,
       }
 
 #if defined(COLORLCD)
-      const bool consumed = luaTelemetryQueueMgr.push(etx::span<const uint8_t>{&rxBuffer[1], rxBufferCount - 2}); // adds complete/valid frame
+      const bool consumed = luaTelemetryQueueMgr.push(etx::span<const uint8_t>{&rxBuffer[1], (size_t)(rxBufferCount - 2)}); // adds complete/valid frame (rxCount > 2)
 #else
       const bool consumed = false;
 #endif

--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -69,6 +69,8 @@ const CrossfireSensor crossfireSensors[] = {
 
 CrossfireModuleStatus crossfireModuleStatus[2] = {0};
 
+extern LuaTelemetryQueueManager<8> luaTelemetryQueueMgr;
+
 const CrossfireSensor & getCrossfireSensor(uint8_t id, uint8_t subId)
 {
   if (id == LINK_ID)
@@ -311,11 +313,18 @@ void processCrossfireTelemetryFrame(uint8_t module, uint8_t* rxBuffer,
         crossfireModuleStatus[module].queryCompleted = true;
       }
 
-      if (luaInputTelemetryFifo && luaInputTelemetryFifo->hasSpace(rxBufferCount - 2)) {
-        for (uint8_t i = 1; i < rxBufferCount - 1; i++) {
-          // destination address and CRC are skipped
-          luaInputTelemetryFifo->push(rxBuffer[i]);
+      const bool consumed = luaTelemetryQueueMgr.push(etx::span<const uint8_t>{&rxBuffer[1], rxBufferCount - 2}); // adds complete/valid frame
+      if (!consumed) {
+        TRACE("[XF] not consumed: %d", rxBufferCount);
+        if (luaInputTelemetryFifo && luaInputTelemetryFifo->hasSpace(rxBufferCount - 2)) {
+          for (uint8_t i = 1; i < rxBufferCount - 1; i++) {
+            // start byte and CRC are skipped
+            luaInputTelemetryFifo->push(rxBuffer[i]);
+          }
         }
+      }
+      else {
+        TRACE("[XF] consumed: %d", rxBufferCount);
       }
       break;
 #endif


### PR DESCRIPTION
This PR tries to implement https://github.com/EdgeTX/edgetx/discussions/5757

It introduces the following new lua functions:

* `crossfireTelemetryCreatePrivateQueue()`
* `crossfireTelemetryPopPrivate()`
* `crossfireTelemetryRemovePrivateQueue()`

and it changes (non-breaking) the interface of 

* `create()`

of lua widgets.

For lua widgets that use `crossfireTelemetryPop()` nothing changes.

The `create(zone, options)` function gets a third parameter `create(zone, options, widget_id)`. The `widget_id` is a unique widget-identifier, that will be used in the other three new lua functions.

* `crossfireTelemetryCreatePrivateQueue(widget_id, filter_table)`

inserts a new filter for the widget with the id `widget_id`. `filter_table` can contain up to 8 bytes that are compared against the first 8 bytes (startung with the `length` byt eof the frame) of an incoming `crsf` packet. `0` values serve as wild-cards. If a `crsf`-packet matches it is sorted out into the according private queue. 

This function returns error codes: 
* `-1` if an equivalent filter already exists,
* `-2` if no more private filter queues are possible (up to 8 filter queues are possible)

* `crossfireTelemetryPopPrivate(widget_id)`

extract a `crsf` message out of the private `crsf` message queue for widget with `widget_id`. Return values are the same as for `crossfireTelemetryPop()`.

* `crossfireTelemetryRemovePrivateQueue(widget_id)`

removes a private `crsf` message queue (this also happens automatically if the widget is terminated).

