### PR TITLE
fix(bw): customisable switch LED color text sometimes incorrect on GX12

### DIFF
--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -643,6 +643,13 @@ bool checkCFSSwitchAvailable(int sw)
 }
 #endif
 
+#if defined(FUNCTION_SWITCHES_RGB_LEDS)
+bool checkCFSColorAvailable(int col)
+{
+  return col > 0;
+}
+#endif
+
 void menuModelSetup(event_t event)
 {
   int8_t old_editMode = s_editMode;
@@ -963,18 +970,18 @@ void menuModelSetup(event_t event)
         // ON
         selectedColor = getRGBColorIndex(g_model.functionSwitchLedONColor[index].getColor());
         selectedColor = editChoice(INDENT_WIDTH + getTextWidth(STR_FS_ON_COLOR) + 2, y, STR_FS_ON_COLOR, \
-          STR_FS_COLOR_LIST, selectedColor, 0, (sizeof(colorTable) / sizeof(colorTable[0])) - 1, menuHorizontalPosition == 0 ? attr : 0, event, INDENT_WIDTH);
+          STR_FS_COLOR_LIST, selectedColor, 0, DIM(colorTable), menuHorizontalPosition == 0 ? attr : 0, event, INDENT_WIDTH, checkCFSColorAvailable);
         if (attr && menuHorizontalPosition == 0 && checkIncDec_Ret) {
-          g_model.functionSwitchLedONColor[index].setColor(colorTable[selectedColor]);
+          g_model.functionSwitchLedONColor[index].setColor(colorTable[selectedColor - 1]);
           storageDirty(EE_MODEL);
         }
 
         // OFF
         selectedColor = getRGBColorIndex(g_model.functionSwitchLedOFFColor[index].getColor());
         selectedColor = editChoice((30 + 5*FW) + getTextWidth(STR_FS_OFF_COLOR) + 2, y, STR_FS_OFF_COLOR, \
-          STR_FS_COLOR_LIST, selectedColor, 0, (sizeof(colorTable) / sizeof(colorTable[0])) - 1, menuHorizontalPosition == 1 ? attr : 0, event, 30 + 5*FW);
+          STR_FS_COLOR_LIST, selectedColor, 0, DIM(colorTable), menuHorizontalPosition == 1 ? attr : 0, event, 30 + 5*FW, checkCFSColorAvailable);
         if (attr && menuHorizontalPosition == 1 && checkIncDec_Ret) {
-          g_model.functionSwitchLedOFFColor[index].setColor(colorTable[selectedColor]);
+          g_model.functionSwitchLedOFFColor[index].setColor(colorTable[selectedColor - 1]);
           storageDirty(EE_MODEL);
         }
 

--- a/radio/src/hal/rgbleds.h
+++ b/radio/src/hal/rgbleds.h
@@ -22,8 +22,11 @@
 #pragma once
 
 #include <stdint.h>
-// MUST match TR_FS_COLOR_LIST (  "White",  "Red",    "Green",   "Yellow", "Orange", "Blue",  "Pink",    "Off",    Custom gets display when none previous match
-constexpr uint32_t colorTable[] = {0xF8F8F8, 0xF80000, 0x00F800, 0xF8F800, 0xF84000, 0x0000F8, 0xF800F8, 0x000000};
+// MUST match TR_FS_COLOR_LIST (except 'Custom') -  Custom gets display when none previous match
+//                                    "Off",  "White",    "Red",  "Green", "Yellow", "Orange",   "Blue",   "Pink"
+constexpr uint32_t colorTable[] = {0x000000, 0xFFFFFF, 0xFF0000, 0x00FF00, 0xFFFF00, 0xFF4000, 0x0000FF, 0xFF00FF};
+// Alternate table for matching original RGB 565 converted values
+constexpr uint32_t colorTabl2[] = {0x000000, 0xF8F8F8, 0xF80000, 0x00F800, 0xF8F800, 0xF84000, 0x0000F8, 0xF800F8};
 
 void setFSLedOFF(uint8_t index);
 void setFSLedON(uint8_t index);

--- a/radio/src/targets/simu/led_driver.cpp
+++ b/radio/src/targets/simu/led_driver.cpp
@@ -36,11 +36,15 @@ void rgbLedColorApply() {}
 
 uint8_t getRGBColorIndex(uint32_t color)
 {
-  for (uint8_t i = 0; i < (sizeof(colorTable) / sizeof(colorTable[0])); i++) {
+  for (uint8_t i = 0; i < DIM(colorTable); i++) {
     if (color == colorTable[i])
-      return(i);
+      return(i + 1);
   }
-  return 5; // Custom value set with Companion
+  for (uint8_t i = 0; i < DIM(colorTabl2); i++) {
+    if (color == colorTabl2[i])
+      return(i + 1);
+  }
+  return 0; // Custom value set with Companion
 }
 
 // RGB

--- a/radio/src/targets/simu/led_driver.cpp
+++ b/radio/src/targets/simu/led_driver.cpp
@@ -21,6 +21,7 @@
 
 #include <stdint.h>
 #include "hal/rgbleds.h"
+#include "definitions.h"
 
 bool usbChargerLed() { return true; }
 void ledRed() {}

--- a/radio/src/targets/taranis/led_driver.cpp
+++ b/radio/src/targets/taranis/led_driver.cpp
@@ -71,11 +71,15 @@ void fsLedRGB(uint8_t index, uint32_t color)
 
 uint8_t getRGBColorIndex(uint32_t color)
 {
-  for (uint8_t i = 0; i < (sizeof(colorTable) / sizeof(colorTable[0])); i++) {
+  for (uint8_t i = 0; i < DIM(colorTable); i++) {
     if (color == colorTable[i])
-      return(i);
+      return(i + 1);
   }
-  return 5; // Custom value set with Companion
+  for (uint8_t i = 0; i < DIM(colorTabl2); i++) {
+    if (color == colorTabl2[i])
+      return(i + 1);
+  }
+  return 0; // Custom value set with Companion
 }
 #elif defined(FUNCTION_SWITCHES)
 void fsLedOff(uint8_t index)

--- a/radio/src/translations/cn.h
+++ b/radio/src/translations/cn.h
@@ -285,7 +285,7 @@
 #define TR_MS                          "ms"
 #define TR_SWITCH                      "开关"
 #define TR_FUNCTION_SWITCHES           "可自定义开关"
-#define TR_FS_COLOR_LIST               "White","Red","Green","Yellow","Orange","Blue","Pink","Off","Custom"
+#define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
 #define TR_GROUPS                      "Always on groups"

--- a/radio/src/translations/cz.h
+++ b/radio/src/translations/cz.h
@@ -299,7 +299,7 @@
 #define TR_MS                          "ms"
 #define TR_SWITCH                      "Spínač"
 #define TR_FUNCTION_SWITCHES           "Nastavitelné přepínače"
-#define TR_FS_COLOR_LIST               "White","Red","Green","Yellow","Orange","Blue","Pink","Off","Custom"
+#define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
 #define TR_GROUPS                      "Always on groups"

--- a/radio/src/translations/da.h
+++ b/radio/src/translations/da.h
@@ -292,7 +292,7 @@
 #define TR_MS                          "ms"
 #define TR_SWITCH                      "Kontakt"
 #define TR_FUNCTION_SWITCHES           "Kontakter der kan tilpasses"
-#define TR_FS_COLOR_LIST               "White","Red","Green","Yellow","Orange","Blue","Pink","Off","Custom"
+#define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
 #define TR_GROUPS                      "Always on groups"

--- a/radio/src/translations/de.h
+++ b/radio/src/translations/de.h
@@ -290,7 +290,7 @@
 #define TR_MS                 		     "ms"
 #define TR_SWITCH                      TR("Schalt.", "Schalter")
 #define TR_FUNCTION_SWITCHES           "Anpassbare Schalter"
-#define TR_FS_COLOR_LIST               "White","Red","Green","Yellow","Orange","Blue","Pink","Off","Custom"
+#define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
 #define TR_FS_ON_COLOR                 TR("ON:","ON Color")

--- a/radio/src/translations/en.h
+++ b/radio/src/translations/en.h
@@ -289,7 +289,7 @@
 #define TR_MS                          "ms"
 #define TR_SWITCH                      "Switch"
 #define TR_FUNCTION_SWITCHES           "Customizable Switches"
-#define TR_FS_COLOR_LIST               "White","Red","Green","Yellow","Orange","Blue","Pink","Off","Custom"
+#define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
 #define TR_FS_ON_COLOR                 TR("ON:","ON Color")

--- a/radio/src/translations/es.h
+++ b/radio/src/translations/es.h
@@ -287,7 +287,7 @@
 #define TR_MS                  "ms"
 #define TR_SWITCH              TR("Interr.", "Interruptor")
 #define TR_FUNCTION_SWITCHES           "Customizable switches"
-#define TR_FS_COLOR_LIST               "White","Red","Green","Yellow","Orange","Blue","Pink","Off","Custom"
+#define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
 #define TR_GROUPS                      "Always on groups"

--- a/radio/src/translations/fi.h
+++ b/radio/src/translations/fi.h
@@ -300,7 +300,7 @@
 #define TR_MS                          "ms"
 #define TR_SWITCH                      "Switch"
 #define TR_FUNCTION_SWITCHES           "Customizable switches"
-#define TR_FS_COLOR_LIST               "White","Red","Green","Yellow","Orange","Blue","Pink","Off","Custom"
+#define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
 #define TR_GROUPS                      "Always on groups"

--- a/radio/src/translations/fr.h
+++ b/radio/src/translations/fr.h
@@ -295,7 +295,7 @@
 #define TR_MS                          "ms"
 #define TR_SWITCH                      TR("Inter", "Interrupteur")
 #define TR_FUNCTION_SWITCHES           "Inters paramétrables"
-#define TR_FS_COLOR_LIST               "White","Red","Green","Yellow","Orange","Blue","Pink","Off","Custom"
+#define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
 #define TR_GROUPS                      "Always on groups"

--- a/radio/src/translations/he.h
+++ b/radio/src/translations/he.h
@@ -293,7 +293,7 @@
 #define TR_MS                          "ms"
 #define TR_SWITCH                      "מתג"
 #define TR_FUNCTION_SWITCHES           "מפסקים בהתאמה אישית"
-#define TR_FS_COLOR_LIST               "White","Red","Green","Yellow","Orange","Blue","Pink","Off","Custom"
+#define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
 #define TR_GROUPS                      "Always on groups"

--- a/radio/src/translations/it.h
+++ b/radio/src/translations/it.h
@@ -289,7 +289,7 @@
 #define TR_MS                           "ms"
 #define TR_SWITCH                       "Inter."
 #define TR_FUNCTION_SWITCHES            "Interruttori personalizzabili"
-#define TR_FS_COLOR_LIST               "White","Red","Green","Yellow","Orange","Blue","Pink","Off","Custom"
+#define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
 #define TR_GROUPS                      "Always on groups"

--- a/radio/src/translations/jp.h
+++ b/radio/src/translations/jp.h
@@ -288,7 +288,7 @@
 #define TR_MS                          "ms"
 #define TR_SWITCH                      "スイッチ"
 #define TR_FUNCTION_SWITCHES           "カスタマイズ スイッチ"
-#define TR_FS_COLOR_LIST               "White","Red","Green","Yellow","Orange","Blue","Pink","Off","Custom"
+#define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
 #define TR_GROUPS                      "Always on groups"

--- a/radio/src/translations/nl.h
+++ b/radio/src/translations/nl.h
@@ -286,7 +286,7 @@
 #define TR_MS                  "ms"
 #define TR_SWITCH              TR("Schak.", "Schakelaar")
 #define TR_FUNCTION_SWITCHES           "Customizable switches"
-#define TR_FS_COLOR_LIST               "White","Red","Green","Yellow","Orange","Blue","Pink","Off","Custom"
+#define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
 #define TR_GROUPS                      "Always on groups"

--- a/radio/src/translations/pl.h
+++ b/radio/src/translations/pl.h
@@ -286,7 +286,7 @@
 #define TR_MS                  "ms"
 #define TR_SWITCH              "Przełą"
 #define TR_FUNCTION_SWITCHES   "Ustawiane przełączniki"
-#define TR_FS_COLOR_LIST               "White","Red","Green","Yellow","Orange","Blue","Pink","Off","Custom"
+#define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP_ALWAYS_ON             "Always on"
 #define TR_GROUPS                      "Always on groups"
 #define TR_LAST                        "Last"

--- a/radio/src/translations/pt.h
+++ b/radio/src/translations/pt.h
@@ -292,7 +292,7 @@
 #define TR_MS                          "ms"
 #define TR_SWITCH                      "Chave"
 #define TR_FUNCTION_SWITCHES           "Chaves customizáveis"
-#define TR_FS_COLOR_LIST               "White","Red","Green","Yellow","Orange","Blue","Pink","Off","Custom"
+#define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
 #define TR_GROUPS                      "Always on groups"

--- a/radio/src/translations/ru.h
+++ b/radio/src/translations/ru.h
@@ -291,7 +291,7 @@
 #define TR_MS                          "ms"
 #define TR_SWITCH                      "Тумблер"
 #define TR_FUNCTION_SWITCHES           "Настр тумблеры"
-#define TR_FS_COLOR_LIST               "White","Red","Green","Yellow","Orange","Blue","Pink","Off","Custom"
+#define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
 #define TR_GROUPS                      "Always on groups"

--- a/radio/src/translations/se.h
+++ b/radio/src/translations/se.h
@@ -301,7 +301,7 @@
 #define TR_MS                           "ms"
 #define TR_SWITCH                       "Brytare"
 #define TR_FUNCTION_SWITCHES            "Anpassningsbara brytare"
-#define TR_FS_COLOR_LIST               "White","Red","Green","Yellow","Orange","Blue","Pink","Off","Custom"
+#define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                        "Grupp"
 #define TR_GROUP_ALWAYS_ON              "Alltid på"
 #define TR_GROUPS                       "Always on groups"

--- a/radio/src/translations/tw.h
+++ b/radio/src/translations/tw.h
@@ -290,7 +290,7 @@
 #define TR_MS                          "ms"
 #define TR_SWITCH                      "開關"
 #define TR_FUNCTION_SWITCHES           "可自定義開關"
-#define TR_FS_COLOR_LIST               "White","Red","Green","Yellow","Orange","Blue","Pink","Off","Custom"
+#define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
 #define TR_GROUPS                      "Always on groups"

--- a/radio/src/translations/ua.h
+++ b/radio/src/translations/ua.h
@@ -291,7 +291,7 @@
 #define TR_MS                          "ms"
 #define TR_SWITCH                      "Перемикач"
 #define TR_FUNCTION_SWITCHES           "Користувацькі перемикачі"
-#define TR_FS_COLOR_LIST               "White","Red","Green","Yellow","Orange","Blue","Pink","Off","Custom"
+#define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
 #define TR_GROUPS                      "Always on groups"


### PR DESCRIPTION
Fixes a number of issues with the way the colors are handled for the custom switches on the GX12:
- Default ON color is 'white'; but shows as 'blue' when viewed in model settings.
- If a custom value is set manually in the model file the color is shown as 'blue' instead of 'custom' in model settings.
