### PR TITLE
chore(cpn): delay loading libsims

### DIFF
--- a/companion/src/simulation/simulatorinterface.h
+++ b/companion/src/simulation/simulatorinterface.h
@@ -217,5 +217,5 @@ class SimulatorLoader
     typedef SimulatorFactory * (*RegisterSimulator)();
 
     static int registerSimulators(const QDir & dir);
-    static QMap<QString, QLibrary *> registeredSimulators;
+    static QMap<QString, QPair<QString, QLibrary *>> registeredSimulators;
 };


### PR DESCRIPTION
With ~40 libsims currently available, the application load time and resource consumption is a worsening issue. The current loading method was developed when there were < 10 libsims.

Summary of changes:
- do not load, validate and unload all libsims during Companion start-up to reduce start-up time.
- load libsims on demand to reduce total memory reserved (varies per OS)

Note: based on a comment in Qt QLibrary documentation, MacOS does not unload shared resources until the application is terminated therefore the current unload is ineffective.