### PR TITLE
Change the DEBUG_BAUDRATE to a standard baudrate (460800) for TX16S and F16

### DIFF
--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -293,7 +293,7 @@ void telemetryPortInvertedInit(uint32_t baudrate);
 
 // Aux serial port driver
 #if defined(RADIO_TX16S) || defined(RADIO_F16)
-  #define DEBUG_BAUDRATE                  400000
+  #define DEBUG_BAUDRATE                  460800
   #define LUA_DEFAULT_BAUDRATE            115200
 #else
   #define DEBUG_BAUDRATE                  115200


### PR DESCRIPTION
Using 400kB as baudrate for debugging via serial seems a bit strange because this is not a "standard baudrate" and some cheap USB/serial converter like the popular `CP210x` do not support these non-standard baudrates (at least with `picocom`). 