### PR TITLE
feat(cpn): add customisable switch colors to Companion YAML file handling

### DIFF
--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -405,6 +405,9 @@ int Boards::getCapability(Board::Type board, Board::Capability capability)
     case Surface:
       return IS_RADIOMASTER_MT12(board);
 
+    case FunctionSwitchColors:
+      return IS_RADIOMASTER_GX12(board);
+
     default:
       return getBoardJson(board)->getCapability(capability);
   }

--- a/companion/src/firmwares/boards.h
+++ b/companion/src/firmwares/boards.h
@@ -209,6 +209,7 @@ namespace Board {
     FlexInputs,
     FlexSwitches,
     FunctionSwitches,
+    FunctionSwitchColors,
     Gyros,
     GyroAxes,
     HasAudioMuteGPIO,

--- a/companion/src/firmwares/edgetx/yaml_modeldata.cpp
+++ b/companion/src/firmwares/edgetx/yaml_modeldata.cpp
@@ -1206,6 +1206,19 @@ Node convert<ModelData>::encode(const ModelData& rhs)
         node["switchNames"][std::to_string(i)]["val"] = rhs.functionSwitchNames[i];
       }
     }
+
+    if (Boards::getCapability(board, Board::FunctionSwitchColors)) {
+      for (int i = 0; i < CPN_MAX_SWITCHES_FUNCTION; i += 1) {
+        node["functionSwitchLedONColor"][std::to_string(i)]["r"] = rhs.functionSwitchLedONColor[i].r;
+        node["functionSwitchLedONColor"][std::to_string(i)]["g"] = rhs.functionSwitchLedONColor[i].g;
+        node["functionSwitchLedONColor"][std::to_string(i)]["b"] = rhs.functionSwitchLedONColor[i].b;
+      }
+      for (int i = 0; i < CPN_MAX_SWITCHES_FUNCTION; i += 1) {
+        node["functionSwitchLedOFFColor"][std::to_string(i)]["r"] = rhs.functionSwitchLedOFFColor[i].r;
+        node["functionSwitchLedOFFColor"][std::to_string(i)]["g"] = rhs.functionSwitchLedOFFColor[i].g;
+        node["functionSwitchLedOFFColor"][std::to_string(i)]["b"] = rhs.functionSwitchLedOFFColor[i].b;
+      }
+    }
   }
 
   // Custom USB joytsick mapping
@@ -1474,6 +1487,20 @@ bool convert<ModelData>::decode(const Node& node, ModelData& rhs)
   node["functionSwitchStartConfig"] >> rhs.functionSwitchStartConfig;
   node["functionSwitchLogicalState"] >> rhs.functionSwitchLogicalState;
   node["switchNames"] >> rhs.functionSwitchNames;
+  if (node["functionSwitchLedONColor"]) {
+    for (int i = 0; i < CPN_MAX_SWITCHES_FUNCTION; i += 1) {
+      node["functionSwitchLedONColor"][std::to_string(i)]["r"] >> rhs.functionSwitchLedONColor[i].r;
+      node["functionSwitchLedONColor"][std::to_string(i)]["g"] >> rhs.functionSwitchLedONColor[i].g;
+      node["functionSwitchLedONColor"][std::to_string(i)]["b"] >> rhs.functionSwitchLedONColor[i].b;
+    }
+  }
+  if (node["functionSwitchLedOFFColor"]) {
+    for (int i = 0; i < CPN_MAX_SWITCHES_FUNCTION; i += 1) {
+      node["functionSwitchLedOFFColor"][std::to_string(i)]["r"] >> rhs.functionSwitchLedOFFColor[i].r;
+      node["functionSwitchLedOFFColor"][std::to_string(i)]["g"] >> rhs.functionSwitchLedOFFColor[i].g;
+      node["functionSwitchLedOFFColor"][std::to_string(i)]["b"] >> rhs.functionSwitchLedOFFColor[i].b;
+    }
+  }
 
   // Custom USB joytsick mapping
   node["usbJoystickExtMode"] >> rhs.usbJoystickExtMode;

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -104,6 +104,15 @@ class USBJoystickChData {
     void clear() { memset(reinterpret_cast<void *>(this), 0, sizeof(USBJoystickChData)); }
 };
 
+class RGBLedColor {
+  public:
+    RGBLedColor() { clear(); }
+    int r;
+    int g;
+    int b;
+    void clear() { memset(reinterpret_cast<void *>(this), 0, sizeof(RGBLedColor)); }
+};
+
 class ModelData {
   Q_DECLARE_TR_FUNCTIONS(ModelData)
 
@@ -232,6 +241,8 @@ class ModelData {
     unsigned int functionSwitchStartConfig;
     unsigned int functionSwitchLogicalState;
     char functionSwitchNames[CPN_MAX_SWITCHES_FUNCTION][HARDWARE_NAME_LEN + 1];
+    RGBLedColor functionSwitchLedONColor[CPN_MAX_SWITCHES_FUNCTION];
+    RGBLedColor functionSwitchLedOFFColor[CPN_MAX_SWITCHES_FUNCTION];
 
     // Custom USB joytsick mapping
     unsigned int usbJoystickExtMode;


### PR DESCRIPTION
Currently Companion will lose the function switch colors when loading model data from the radio.

Note: the colors cannot be edited or viewed in Companion yet. This just ensures they survive being loaded from the radio.