### PR TITLE
fix(sim): initial state for customisable switches not set correctly

### DIFF
--- a/radio/src/edgetx.cpp
+++ b/radio/src/edgetx.cpp
@@ -161,6 +161,10 @@ void checkValidMCU(void)
 #endif
 }
 
+#if defined(SIMU)
+static bool evalFSok = false;
+#endif
+
 void timer_10ms()
 {
   DEBUG_TIMER_START(debugTimerPer10ms);
@@ -205,7 +209,12 @@ void timer_10ms()
   }
 
 #if defined(FUNCTION_SWITCHES)
+#if defined(SIMU)
+  if (evalFSok)
+    evalFunctionSwitches();
+#else
   evalFunctionSwitches();
+#endif
 #endif
 
 #if defined(ROTARY_ENCODER_NAVIGATION) && !defined(LIBOPENUI)
@@ -1517,9 +1526,10 @@ void edgeTxInit()
 #endif
 
 #if defined(FUNCTION_SWITCHES)
-    if (!UNEXPECTED_SHUTDOWN()) {
-      setFSStartupPosition();
-    }
+    setFSStartupPosition();
+#if defined(SIMU)
+    evalFSok = true;
+#endif
 #endif
 
 #if defined(GUI)


### PR DESCRIPTION
Fixes #5795 

Skip evalFunctionSwitches until fully initialised in simulator.

