### PR TITLE
fix(cpn): inputs and mixes must have source

### DIFF
--- a/companion/src/companion.qrc
+++ b/companion/src/companion.qrc
@@ -10,6 +10,9 @@
     <file>images/track.png</file>
     <file>images/track0.png</file>
     <file>images/taranison.png</file>
+    <file>images/svg/circle-green.svg</file>
+    <file>images/svg/circle-orange.svg</file>
+    <file>images/svg/circle-red.svg</file>
     <file>images/simulator/icons/svg/arrow_click.svg</file>
     <file>images/simulator/icons/svg/camera.svg</file>
     <file>images/simulator/icons/svg/camera-active.svg</file>

--- a/companion/src/firmwares/edgetx/yaml_modeldata.cpp
+++ b/companion/src/firmwares/edgetx/yaml_modeldata.cpp
@@ -1014,7 +1014,7 @@ Node convert<ModelData>::encode(const ModelData& rhs)
 
   for (int i = 0; i < CPN_MAX_MIXERS; i++) {
     const MixData& mix = rhs.mixData[i];
-    if (!mix.isEmpty()) {
+    if (!mix.isEmpty() && mix.srcRaw != SOURCE_TYPE_NONE) {
       node["mixData"].push_back(Node(mix));
     }
   }
@@ -1029,7 +1029,7 @@ Node convert<ModelData>::encode(const ModelData& rhs)
   std::set<int> inputs;
   for (int i = 0; i < CPN_MAX_EXPOS; i++) {
     const ExpoData& expo = rhs.expoData[i];
-    if (!expo.isEmpty()) {
+    if (!expo.isEmpty() && expo.srcRaw != SOURCE_TYPE_NONE) {
       Node expoNode;
       expoNode = expo;
       node["expoData"].push_back(expoNode);

--- a/companion/src/firmwares/edgetx/yaml_modeldata.cpp
+++ b/companion/src/firmwares/edgetx/yaml_modeldata.cpp
@@ -1014,7 +1014,7 @@ Node convert<ModelData>::encode(const ModelData& rhs)
 
   for (int i = 0; i < CPN_MAX_MIXERS; i++) {
     const MixData& mix = rhs.mixData[i];
-    if (!mix.isEmpty() && mix.srcRaw != SOURCE_TYPE_NONE) {
+    if (!mix.isEmpty()) {
       node["mixData"].push_back(Node(mix));
     }
   }
@@ -1029,7 +1029,7 @@ Node convert<ModelData>::encode(const ModelData& rhs)
   std::set<int> inputs;
   for (int i = 0; i < CPN_MAX_EXPOS; i++) {
     const ExpoData& expo = rhs.expoData[i];
-    if (!expo.isEmpty() && expo.srcRaw != SOURCE_TYPE_NONE) {
+    if (!expo.isEmpty()) {
       Node expoNode;
       expoNode = expo;
       node["expoData"].push_back(expoNode);

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -29,6 +29,8 @@
 #include "adjustmentreference.h"
 #include "compounditemmodels.h"
 
+#include <QMessageBox>
+
 ModelData::ModelData()
 {
   clear();
@@ -1923,4 +1925,49 @@ int ModelData::getCustomScreensCount() const
   }
 
   return cnt;
+}
+
+bool ModelData::isValid(QWidget * parent)
+{
+  int inputerrors = 0;
+  for (int i = 0; i < CPN_MAX_INPUTS; i++) {
+    if (!expoData[i].isEmpty() && expoData[i].srcRaw == SOURCE_TYPE_NONE)
+      inputerrors++;
+  }
+
+  int mixerrors = 0;
+  for (int i = 0; i < CPN_MAX_MIXERS; i++) {
+    if (!mixData[i].isEmpty() && mixData[i].srcRaw == SOURCE_TYPE_NONE)
+      mixerrors++;
+  }
+
+  if (inputerrors > 0 || mixerrors > 0) {
+    QString msg = tr("Model %1 has the following errors:").arg(name) % "\n\n";
+    if (inputerrors > 0)
+      msg.append(tr("- %1 inputs with no source").arg(inputerrors) % "\n");
+    if (mixerrors > 0)
+      msg.append(tr("- %1 mixes with no source").arg(mixerrors));
+
+    QMessageBox::information(parent, CPN_STR_APP_NAME, msg);
+    return false;
+  }
+
+  return true;
+}
+
+void ModelData::fixErrors()
+{
+  for (int i = 0; i < CPN_MAX_INPUTS; i++) {
+    if (!expoData[i].isEmpty() && expoData[i].srcRaw == SOURCE_TYPE_NONE) {
+      //  delete input line and fix up anything else then update refs
+      //updateAllReferences(ModelData::REF_UPD_TYPE_INPUT, REF_UPD_ACT_CLEAR, i);
+    }
+  }
+
+  for (int i = 0; i < CPN_MAX_MIXERS; i++) {
+    if (!mixData[i].isEmpty() && mixData[i].srcRaw == SOURCE_TYPE_NONE) {
+      //  delete mixer line and fix up anything like numbering??
+    }
+  }
+
 }

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -1946,20 +1946,41 @@ void ModelData::validate()
   }
 }
 
-QList<QString> ModelData::errorsList()
+QStringList ModelData::errorsList()
 {
-  QList<QString> list;
+  QStringList list;
 
   for (int i = 0; i < CPN_MAX_INPUTS; i++) {
     if (!expoData[i].isEmpty() && expoData[i].srcRaw == SOURCE_TYPE_NONE)
-      list.append(tr("Input: %1 Error: %2").arg(i + 1).arg(tr("has no source")));
+      list.append(tr("Error - Input: %1 Line: %2 %3").arg(i + 1).arg(getInputLine(i)).arg(tr("has no source")));
   }
 
   for (int i = 0; i < CPN_MAX_MIXERS; i++) {
     // fix line # wrong !!!!!!
     if (!mixData[i].isEmpty() && mixData[i].srcRaw == SOURCE_TYPE_NONE)
-      list.append(tr("Mix: %1 Line: %2 Error: %3").arg(mixData[i].destCh).arg(i + 1).arg(tr("has no source")));
+      list.append(tr("Error - Mix: %1 Line: %2 %3").arg(mixData[i].destCh).arg(getMixLine(i)).arg(tr("has no source")));
   }
 
   return list;
+}
+
+int ModelData::getMixLine(int index) const
+{
+  int cnt = 1;
+
+  for (int i = index - 1; i >= 0 && mixData[i].destCh == mixData[index].destCh; i--)
+    cnt++;
+
+  return cnt;
+}
+
+int ModelData::getInputLine(int index) const
+{
+  int cnt = 1;
+
+  for (int i = 0; i < index; i++)
+    if (expoData[i].chn == expoData[index].chn)
+      cnt++;
+
+  return cnt;
 }

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -1956,7 +1956,6 @@ QStringList ModelData::errorsList()
   }
 
   for (int i = 0; i < CPN_MAX_MIXERS; i++) {
-    // fix line # wrong !!!!!!
     if (!mixData[i].isEmpty() && mixData[i].srcRaw == SOURCE_TYPE_NONE)
       list.append(tr("Error - Mix: %1 Line: %2 %3").arg(mixData[i].destCh).arg(getMixLine(i)).arg(tr("has no source")));
   }
@@ -1978,9 +1977,10 @@ int ModelData::getInputLine(int index) const
 {
   int cnt = 1;
 
-  for (int i = 0; i < index; i++)
+  for (int i = 0; i < index; i++) {
     if (expoData[i].chn == expoData[index].chn)
       cnt++;
+  }
 
   return cnt;
 }

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -1927,36 +1927,29 @@ int ModelData::getCustomScreensCount() const
   return cnt;
 }
 
-bool ModelData::isValid(QWidget * parent)
+void ModelData::validate()
 {
-  int inputerrors = 0;
+  modelErrors = false;
+
   for (int i = 0; i < CPN_MAX_INPUTS; i++) {
     if (!expoData[i].isEmpty() && expoData[i].srcRaw == SOURCE_TYPE_NONE)
-      inputerrors++;
+      modelErrors = true;
+      return;
   }
 
   int mixerrors = 0;
   for (int i = 0; i < CPN_MAX_MIXERS; i++) {
     if (!mixData[i].isEmpty() && mixData[i].srcRaw == SOURCE_TYPE_NONE)
-      mixerrors++;
+      modelErrors = true;
+      return;
   }
-
-  if (inputerrors > 0 || mixerrors > 0) {
-    QString msg = tr("Model %1 has the following errors:").arg(name) % "\n\n";
-    if (inputerrors > 0)
-      msg.append(tr("- %1 inputs with no source").arg(inputerrors) % "\n");
-    if (mixerrors > 0)
-      msg.append(tr("- %1 mixes with no source").arg(mixerrors));
-
-    QMessageBox::information(parent, CPN_STR_APP_NAME, msg);
-    return false;
-  }
-
-  return true;
 }
 
 void ModelData::fixErrors()
 {
+  if (!modelErrors)
+    return;
+
   for (int i = 0; i < CPN_MAX_INPUTS; i++) {
     if (!expoData[i].isEmpty() && expoData[i].srcRaw == SOURCE_TYPE_NONE) {
       //  delete input line and fix up anything else then update refs
@@ -1969,5 +1962,4 @@ void ModelData::fixErrors()
       //  delete mixer line and fix up anything like numbering??
     }
   }
-
 }

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -1952,7 +1952,7 @@ QStringList ModelData::errorsList()
 
   for (int i = 0; i < CPN_MAX_INPUTS; i++) {
     if (!expoData[i].isEmpty() && expoData[i].srcRaw == SOURCE_TYPE_NONE)
-      list.append(tr("Error - Input: %1 Line: %2 %3").arg(i + 1).arg(getInputLine(i)).arg(tr("has no source")));
+      list.append(tr("Error - Input: %1 Line: %2 %3").arg(expoData[i].chn + 1).arg(getInputLine(i)).arg(tr("has no source")));
   }
 
   for (int i = 0; i < CPN_MAX_MIXERS; i++) {

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -1932,34 +1932,34 @@ void ModelData::validate()
   modelErrors = false;
 
   for (int i = 0; i < CPN_MAX_INPUTS; i++) {
-    if (!expoData[i].isEmpty() && expoData[i].srcRaw == SOURCE_TYPE_NONE)
-      modelErrors = true;
-      return;
-  }
-
-  int mixerrors = 0;
-  for (int i = 0; i < CPN_MAX_MIXERS; i++) {
-    if (!mixData[i].isEmpty() && mixData[i].srcRaw == SOURCE_TYPE_NONE)
-      modelErrors = true;
-      return;
-  }
-}
-
-void ModelData::fixErrors()
-{
-  if (!modelErrors)
-    return;
-
-  for (int i = 0; i < CPN_MAX_INPUTS; i++) {
     if (!expoData[i].isEmpty() && expoData[i].srcRaw == SOURCE_TYPE_NONE) {
-      //  delete input line and fix up anything else then update refs
-      //updateAllReferences(ModelData::REF_UPD_TYPE_INPUT, REF_UPD_ACT_CLEAR, i);
+      modelErrors = true;
+      return;
     }
   }
 
   for (int i = 0; i < CPN_MAX_MIXERS; i++) {
     if (!mixData[i].isEmpty() && mixData[i].srcRaw == SOURCE_TYPE_NONE) {
-      //  delete mixer line and fix up anything like numbering??
+      modelErrors = true;
+      return;
     }
   }
+}
+
+QList<QString> ModelData::errorsList()
+{
+  QList<QString> list;
+
+  for (int i = 0; i < CPN_MAX_INPUTS; i++) {
+    if (!expoData[i].isEmpty() && expoData[i].srcRaw == SOURCE_TYPE_NONE)
+      list.append(tr("Input: %1 Error: %2").arg(i + 1).arg(tr("has no source")));
+  }
+
+  for (int i = 0; i < CPN_MAX_MIXERS; i++) {
+    // fix line # wrong !!!!!!
+    if (!mixData[i].isEmpty() && mixData[i].srcRaw == SOURCE_TYPE_NONE)
+      list.append(tr("Mix: %1 Line: %2 Error: %3").arg(mixData[i].destCh).arg(i + 1).arg(tr("has no source")));
+  }
+
+  return list;
 }

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -1952,12 +1952,12 @@ QStringList ModelData::errorsList()
 
   for (int i = 0; i < CPN_MAX_INPUTS; i++) {
     if (!expoData[i].isEmpty() && expoData[i].srcRaw == SOURCE_TYPE_NONE)
-      list.append(tr("Error - Input: %1 Line: %2 %3").arg(expoData[i].chn + 1).arg(getInputLine(i)).arg(tr("has no source")));
+      list.append(tr("Error - Input %1 Line %2 %3").arg(expoData[i].chn + 1).arg(getInputLine(i)).arg(tr("has no source")));
   }
 
   for (int i = 0; i < CPN_MAX_MIXERS; i++) {
     if (!mixData[i].isEmpty() && mixData[i].srcRaw == SOURCE_TYPE_NONE)
-      list.append(tr("Error - Mix: %1 Line: %2 %3").arg(mixData[i].destCh).arg(getMixLine(i)).arg(tr("has no source")));
+      list.append(tr("Error - Mix %1 Line %2 %3").arg(mixData[i].destCh).arg(getMixLine(i)).arg(tr("has no source")));
   }
 
   return list;

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -376,6 +376,9 @@ class ModelData {
     void removeGlobalVar(int & var);
 
   private:
+    int getMixLine(int index) const;
+    int getInputLine(int index) const;
+
     QVector<UpdateReferenceParams> *updRefList = nullptr;
 
     struct UpdateReferenceInfo
@@ -426,6 +429,4 @@ class ModelData {
         value = swtch.toValue();
     }
     void updateResetParam(CustomFunctionData * cfd);
-    int getMixLine(int index) const;
-    int getInputLine(int index) const;
 };

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -366,6 +366,8 @@ class ModelData {
     static AbstractStaticItemModel * funcSwitchStartItemModel();
 
     int getCustomScreensCount() const;
+    bool isValid(QWidget * parent = nullptr);
+    void fixErrors();
 
   protected:
     void removeGlobalVar(int & var);

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -367,10 +367,10 @@ class ModelData {
     static AbstractStaticItemModel * funcSwitchStartItemModel();
 
     int getCustomScreensCount() const;
-    void fixErrors();
     bool hasErrors() { return modelErrors; }
     bool isValid() { return !hasErrors(); }
     void validate();
+    QList<QString> errorsList();
 
   protected:
     void removeGlobalVar(int & var);

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -140,6 +140,7 @@ class ModelData {
     char      labels[100];
     int       modelIndex;      // Companion only, temporary index position managed by data model.
     bool      modelUpdated;    // Companion only, used to highlight if changed in models list
+    bool      modelErrors;     // Companion only, used to highlight if data errors in models list
 
     TimerData timers[CPN_MAX_TIMERS];
     bool      noGlobalFunctions;
@@ -366,8 +367,10 @@ class ModelData {
     static AbstractStaticItemModel * funcSwitchStartItemModel();
 
     int getCustomScreensCount() const;
-    bool isValid(QWidget * parent = nullptr);
     void fixErrors();
+    bool hasErrors() { return modelErrors; }
+    bool isValid() { return !hasErrors(); }
+    void validate();
 
   protected:
     void removeGlobalVar(int & var);

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -370,7 +370,7 @@ class ModelData {
     bool hasErrors() { return modelErrors; }
     bool isValid() { return !hasErrors(); }
     void validate();
-    QList<QString> errorsList();
+    QStringList errorsList();
 
   protected:
     void removeGlobalVar(int & var);
@@ -426,4 +426,6 @@ class ModelData {
         value = swtch.toValue();
     }
     void updateResetParam(CustomFunctionData * cfd);
+    int getMixLine(int index) const;
+    int getInputLine(int index) const;
 };

--- a/companion/src/firmwares/radiodata.cpp
+++ b/companion/src/firmwares/radiodata.cpp
@@ -359,9 +359,3 @@ int RadioData::invalidModels()
 
   return cnt;
 }
-
-void RadioData::fixInvalidModels()
-{
-  for(auto &model: models)
-    model.fixErrors();
-}

--- a/companion/src/firmwares/radiodata.cpp
+++ b/companion/src/firmwares/radiodata.cpp
@@ -343,3 +343,19 @@ AbstractStaticItemModel * RadioData::modelSortOrderItemModel()
   mdl->loadItemList();
   return mdl;
 }
+
+int RadioData::invalidModels(QWidget * parent)
+{
+  int cnt = 0;
+
+  for(auto &model: models)
+    cnt += model.isValid(parent) ? 0 : 1;
+
+  return cnt;
+}
+
+void RadioData::fixInvalidModels()
+{
+  for(auto &model: models)
+    model.fixErrors();
+}

--- a/companion/src/firmwares/radiodata.cpp
+++ b/companion/src/firmwares/radiodata.cpp
@@ -344,12 +344,18 @@ AbstractStaticItemModel * RadioData::modelSortOrderItemModel()
   return mdl;
 }
 
-int RadioData::invalidModels(QWidget * parent)
+void RadioData::validateModels()
+{
+  for(auto &model: models)
+    model.validate();
+}
+
+int RadioData::invalidModels()
 {
   int cnt = 0;
 
   for(auto &model: models)
-    cnt += model.isValid(parent) ? 0 : 1;
+    cnt += model.isValid() ? 0 : 1;
 
   return cnt;
 }

--- a/companion/src/firmwares/radiodata.h
+++ b/companion/src/firmwares/radiodata.h
@@ -66,7 +66,8 @@ class RadioData {
     void setCurrentModel(unsigned int index);
     void fixModelFilenames();
     QString getNextModelFilename();
-    int invalidModels(QWidget * parent = nullptr);
+    void validateModels();
+    int invalidModels();
     void fixInvalidModels();
 
     static QString modelSortOrderToString(int value);

--- a/companion/src/firmwares/radiodata.h
+++ b/companion/src/firmwares/radiodata.h
@@ -68,7 +68,6 @@ class RadioData {
     QString getNextModelFilename();
     void validateModels();
     int invalidModels();
-    void fixInvalidModels();
 
     static QString modelSortOrderToString(int value);
     static AbstractStaticItemModel * modelSortOrderItemModel();

--- a/companion/src/firmwares/radiodata.h
+++ b/companion/src/firmwares/radiodata.h
@@ -66,6 +66,8 @@ class RadioData {
     void setCurrentModel(unsigned int index);
     void fixModelFilenames();
     QString getNextModelFilename();
+    int invalidModels(QWidget * parent = nullptr);
+    void fixInvalidModels();
 
     static QString modelSortOrderToString(int value);
     static AbstractStaticItemModel * modelSortOrderItemModel();

--- a/companion/src/images/originals/circle-green.svg
+++ b/companion/src/images/originals/circle-green.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="48mm"
+   height="48mm"
+   viewBox="0 0 48 48"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   sodipodi:docname="circle-green.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="1.5197952"
+     inkscape:cx="153.96812"
+     inkscape:cy="139.82147"
+     inkscape:window-width="1920"
+     inkscape:window-height="1055"
+     inkscape:window-x="-7"
+     inkscape:window-y="-7"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <circle
+       style="fill:#14ff14;stroke:#ffffff;stroke-width:0.204744;stroke-linejoin:round;stroke-opacity:0.99572"
+       id="path1"
+       cx="24"
+       cy="24"
+       r="21.897629" />
+  </g>
+</svg>

--- a/companion/src/images/originals/circle-orange.svg
+++ b/companion/src/images/originals/circle-orange.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="48mm"
+   height="48mm"
+   viewBox="0 0 48 48"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   sodipodi:docname="circle-orange.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="1.5197952"
+     inkscape:cx="153.96812"
+     inkscape:cy="139.82147"
+     inkscape:window-width="1920"
+     inkscape:window-height="1055"
+     inkscape:window-x="-7"
+     inkscape:window-y="-7"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <circle
+       style="fill:#ff8000;stroke:#ffffff;stroke-width:0.204744;stroke-linejoin:round;stroke-opacity:0.99572;fill-opacity:1"
+       id="path1"
+       cx="24"
+       cy="24"
+       r="21.897629" />
+  </g>
+</svg>

--- a/companion/src/images/originals/circle-red.svg
+++ b/companion/src/images/originals/circle-red.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="48mm"
+   height="48mm"
+   viewBox="0 0 48 48"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   sodipodi:docname="circle-red.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="1.5197952"
+     inkscape:cx="153.96812"
+     inkscape:cy="139.82147"
+     inkscape:window-width="1920"
+     inkscape:window-height="1055"
+     inkscape:window-x="-7"
+     inkscape:window-y="-7"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <circle
+       style="fill:#ff0000;stroke:#ffffff;stroke-width:0.204744;stroke-linejoin:round;stroke-opacity:0.99572;fill-opacity:1"
+       id="path1"
+       cx="24"
+       cy="24"
+       r="21.897629" />
+  </g>
+</svg>

--- a/companion/src/images/svg/circle-green.svg
+++ b/companion/src/images/svg/circle-green.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="48mm"
+   height="48mm"
+   viewBox="0 0 48 48"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   sodipodi:docname="circle-green.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="1.5197952"
+     inkscape:cx="153.96812"
+     inkscape:cy="139.82147"
+     inkscape:window-width="1920"
+     inkscape:window-height="1055"
+     inkscape:window-x="-7"
+     inkscape:window-y="-7"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <circle
+       style="fill:#14ff14;stroke:#ffffff;stroke-width:0.204744;stroke-linejoin:round;stroke-opacity:0.99572"
+       id="path1"
+       cx="24"
+       cy="24"
+       r="21.897629" />
+  </g>
+</svg>

--- a/companion/src/images/svg/circle-orange.svg
+++ b/companion/src/images/svg/circle-orange.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="48mm"
+   height="48mm"
+   viewBox="0 0 48 48"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   sodipodi:docname="circle-orange.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="1.5197952"
+     inkscape:cx="153.96812"
+     inkscape:cy="139.82147"
+     inkscape:window-width="1920"
+     inkscape:window-height="1055"
+     inkscape:window-x="-7"
+     inkscape:window-y="-7"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <circle
+       style="fill:#ff8000;stroke:#ffffff;stroke-width:0.204744;stroke-linejoin:round;stroke-opacity:0.99572;fill-opacity:1"
+       id="path1"
+       cx="24"
+       cy="24"
+       r="21.897629" />
+  </g>
+</svg>

--- a/companion/src/images/svg/circle-red.svg
+++ b/companion/src/images/svg/circle-red.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   width="48mm"
+   height="48mm"
+   viewBox="0 0 48 48"
+   version="1.1"
+   id="svg1"
+   inkscape:version="1.4 (86a8ad7, 2024-10-11)"
+   sodipodi:docname="circle-red.svg"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <sodipodi:namedview
+     id="namedview1"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:showpageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     inkscape:deskcolor="#d1d1d1"
+     inkscape:document-units="mm"
+     inkscape:zoom="1.5197952"
+     inkscape:cx="153.96812"
+     inkscape:cy="139.82147"
+     inkscape:window-width="1920"
+     inkscape:window-height="1055"
+     inkscape:window-x="-7"
+     inkscape:window-y="-7"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="layer1" />
+  <defs
+     id="defs1" />
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1">
+    <circle
+       style="fill:#ff0000;stroke:#ffffff;stroke-width:0.204744;stroke-linejoin:round;stroke-opacity:0.99572;fill-opacity:1"
+       id="path1"
+       cx="24"
+       cy="24"
+       r="21.897629" />
+  </g>
+</svg>

--- a/companion/src/mainwindow.cpp
+++ b/companion/src/mainwindow.cpp
@@ -676,9 +676,9 @@ void MainWindow::updateMenus()
   saveAsAct->setEnabled(activeChild);
   closeAct->setEnabled(activeChild);
   compareAct->setEnabled(activeChild);
-  writeSettingsAct->setEnabled(activeChild);
+  writeSettingsAct->setEnabled(activeChild && !activeMdiChild()->invalidModels());
   readSettingsAct->setEnabled(true);
-  writeSettingsSDPathAct->setEnabled(activeChild && isSDPathValid());
+  writeSettingsSDPathAct->setEnabled(activeChild && isSDPathValid() && !activeMdiChild()->invalidModels());
   readSettingsSDPathAct->setEnabled(isSDPathValid());
   writeBUToRadioAct->setEnabled(false);
   readBUToFileAct->setEnabled(false);

--- a/companion/src/mainwindow.cpp
+++ b/companion/src/mainwindow.cpp
@@ -889,10 +889,8 @@ void MainWindow::createActions()
   // assigned menus in createMenus()
   recentFilesAct =         addAct("recentdocument.png");
   closeAct =               addAct("clear.png",              SLOT(closeFile())        /*, QKeySequence::Close*/); // setting/showing this shortcut interferes with the system one (Ctrl+W/Ctrl-F4)
-  // TODO change to more appropriate icon sets and uncomment toolbar actions
   writeSettingsSDPathAct = addAct("folder-tree-write.png",  SLOT(writeSettingsSDPath()));
   readSettingsSDPathAct =  addAct("folder-tree-read.png",   SLOT(readSettingsSDPath()));
-  // end TODO
   exitAct =                addAct("exit.png",               SLOT(closeAllWindows()),  QKeySequence::Quit, qApp);
 
   editAppSettingsAct =     addAct("apppreferences.png",     SLOT(editAppSettings()),         QKeySequence::Preferences);

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1336,19 +1336,6 @@ bool MdiChild::saveAs(bool isNew)
 
 bool MdiChild::saveFile(const QString & filename, bool setCurrent)
 {
-  //  do not check for etx files as we accept errors
-  int cnt = radioData.invalidModels();
-  if (cnt) {
-    if (askQuestion(tr("%1 models have errors. Repair?").arg(cnt), QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel) == QMessageBox::Yes) {
-      radioData.fixInvalidModels();
-      // NOW NEED TO REFRESH GUI if Model Edit open !!!!!!!
-      // refresh inputs and mixes lists
-      // update any data models
-    }
-    else
-      return false;
-  }
-
   radioData.fixModelFilenames();
   Storage storage(filename);
   bool result = storage.write(radioData);

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1896,6 +1896,8 @@ void MdiChild::setupStatusBar()
 {
   statusBar = new QStatusBar();
   ui->statusBarLayout->addWidget(statusBar);
+  QLabel *lbl = new QLabel(tr("Models status"));
+  statusBar->addPermanentWidget(lbl);
   statusBarIcon = new QLabel();
   statusBar->addPermanentWidget(statusBarIcon);
   statusBarCount = new QLabel();
@@ -1909,9 +1911,11 @@ void MdiChild::updateStatusBar()
   int invalid = radioData.invalidModels();
 
   if (!invalidModels()) {
+    statusBarIcon->setToolTip(tr("No errors"));
     p.load(":/images/svg/circle-green.svg");
   }
   else {
+    statusBarIcon->setToolTip(tr("Errors"));
     p.load(":/images/svg/circle-red.svg");
     cnt.setText(QString::number(invalid));
   }

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -227,11 +227,12 @@ void MdiChild::setupNavigation()
   addAct(ACT_MDL_SIM, "simulate.png",     SLOT(modelSimulate()),  tr("Alt+S"));
   addAct(ACT_MDL_DUP, "duplicate.png",    SLOT(modelDuplicate()), QKeySequence::Underline);
 
-  addAct(ACT_MDL_CUT, "cut.png",   SLOT(cut()),           QKeySequence::Cut);
-  addAct(ACT_MDL_CPY, "copy.png",  SLOT(copy()),          QKeySequence::Copy);
-  addAct(ACT_MDL_PST, "paste.png", SLOT(paste()),         QKeySequence::Paste);
-  addAct(ACT_MDL_INS, "list.png",  SLOT(insert()),        QKeySequence::Italic);
-  addAct(ACT_MDL_EXP, "save.png",  SLOT(modelExport()),   tr("Ctrl+Alt+S"));
+  addAct(ACT_MDL_CUT, "cut.png",         SLOT(cut()),             QKeySequence::Cut);
+  addAct(ACT_MDL_CPY, "copy.png",        SLOT(copy()),            QKeySequence::Copy);
+  addAct(ACT_MDL_PST, "paste.png",       SLOT(paste()),           QKeySequence::Paste);
+  addAct(ACT_MDL_INS, "list.png",        SLOT(insert()),          QKeySequence::Italic);
+  addAct(ACT_MDL_EXP, "save.png",        SLOT(modelExport()),     tr("Ctrl+Alt+S"));
+  addAct(ACT_MDL_ERR, "information.png", SLOT(modelShowErrors()), tr("Ctrl+Alt+E"));
 
   addAct(ACT_MDL_MOV, "arrow-right.png");
   QMenu * catsMenu = new QMenu(this);
@@ -371,6 +372,7 @@ void MdiChild::updateNavigation()
   action[ACT_MDL_DFT]->setEnabled(singleModelSelected && getCurrentModel() != (int)radioData.generalSettings.currModelIndex);
   action[ACT_MDL_PRT]->setEnabled(singleModelSelected);
   action[ACT_MDL_SIM]->setEnabled(singleModelSelected && !invalidModels());
+  action[ACT_MDL_ERR]->setEnabled(singleModelSelected && radioData.models[getCurrentModel()].modelErrors);
 }
 
 void MdiChild::retranslateUi()
@@ -400,6 +402,7 @@ void MdiChild::retranslateUi()
   action[ACT_MDL_PRT]->setText(tr("Print Model"));
   action[ACT_MDL_SIM]->setText(tr("Simulate Model"));
   action[ACT_MDL_DUP]->setText(tr("Duplicate Model"));
+  action[ACT_MDL_ERR]->setText(tr("Show Model Errors"));
 
   radioToolbar->setWindowTitle(tr("Show Radio Actions Toolbar"));
   modelsToolbar->setWindowTitle(tr("Show Model Actions Toolbar"));
@@ -445,6 +448,7 @@ QList<QAction *> MdiChild::getModelActions()
   //actGrp.append(getAction(ACT_MDL_RTR));
   actGrp.append(getAction(ACT_MDL_PRT));
   actGrp.append(getAction(ACT_MDL_SIM));
+  actGrp.append(getAction(ACT_MDL_ERR));
   return actGrp;
 }
 
@@ -1870,4 +1874,10 @@ QAction * MdiChild::actionsSeparator()
 bool MdiChild::invalidModels()
 {
   return (bool)radioData.invalidModels();
+}
+
+void MdiChild::modelShowErrors()
+{
+  ModelData &mdl = radioData.models[getCurrentModel()];
+  QMessageBox::information(this, tr("Model: %1 Information").arg(mdl.name), mdl.errorsList().join("\n"));
 }

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -63,6 +63,7 @@ MdiChild::MdiChild(QWidget * parent, QWidget * parentWin, Qt::WindowFlags f):
   if (parentWindow)
     parentWindow->setWindowIcon(windowIcon());
 
+  setupStatusBar();
   setupNavigation();
   initModelsList();
 
@@ -608,6 +609,7 @@ void MdiChild::refresh()
   }
   updateNavigation();
   updateTitle();
+  updateStatusBar();
 }
 
 void MdiChild::onItemActivated(const QModelIndex index)
@@ -1305,6 +1307,7 @@ bool MdiChild::loadFile(const QString & filename, bool resetCurrentFile)
   }
 
   radioData.validateModels();
+  updateStatusBar();
 
   return true;
 }
@@ -1887,4 +1890,32 @@ void MdiChild::onModelEditClosed(int id)
 {
   radioData.models[id].validate();
   refresh();
+}
+
+void MdiChild::setupStatusBar()
+{
+  statusBar = new QStatusBar();
+  ui->statusBarLayout->addWidget(statusBar);
+  statusBarIcon = new QLabel();
+  statusBar->addPermanentWidget(statusBarIcon);
+  statusBarCount = new QLabel();
+  statusBar->addPermanentWidget(statusBarCount);
+}
+
+void MdiChild::updateStatusBar()
+{
+  QPixmap p;
+  QLabel cnt;
+  int invalid = radioData.invalidModels();
+
+  if (!invalidModels()) {
+    p.load(":/images/svg/circle-green.svg");
+  }
+  else {
+    p.load(":/images/svg/circle-red.svg");
+    cnt.setText(QString::number(invalid));
+  }
+
+  statusBarIcon->setPixmap(p.scaled(QSize(16, 16)));
+  statusBarCount->setText(cnt.text());
 }

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1334,6 +1334,35 @@ bool MdiChild::saveAs(bool isNew)
 
 bool MdiChild::saveFile(const QString & filename, bool setCurrent)
 {
+  int cnt = 0;
+
+  for (int i = 0; i < (int)radioData.models.size(); i++) {
+    if (!radioData.models[i].isEmpty()) {
+      for (int j = 0; j < CPN_MAX_INPUTS; j++) {
+        if (!radioData.models[i].expoData[j].isEmpty() && radioData.models[i].expoData[j].srcRaw == SOURCE_TYPE_NONE)
+          cnt++;
+      }
+
+      if (cnt > 0) {
+        if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Model %1 has %2 inputs with no source and these inputs will not be saved. Continue?").arg(radioData.models[i].name).arg(cnt),
+                                  QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::No)
+          return false;
+      }
+
+      cnt = 0;
+      for (int j = 0; j < CPN_MAX_MIXERS; j++) {
+        if (!radioData.models[i].mixData[j].isEmpty() && radioData.models[i].mixData[j].srcRaw == SOURCE_TYPE_NONE)
+          cnt++;
+      }
+
+      if (cnt > 0) {
+        if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Model %1 has %2 mixes with no source and these mixes will not be saved. Continue?").arg(radioData.models[i].name).arg(cnt),
+                                  QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::No)
+          return false;
+      }
+    }
+  }
+
   radioData.fixModelFilenames();
   Storage storage(filename);
   bool result = storage.write(radioData);

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1298,6 +1298,8 @@ bool MdiChild::loadFile(const QString & filename, bool resetCurrentFile)
     refresh();
   }
 
+  radioData.validateModels();
+
   return true;
 }
 
@@ -1334,7 +1336,8 @@ bool MdiChild::saveAs(bool isNew)
 
 bool MdiChild::saveFile(const QString & filename, bool setCurrent)
 {
-  int cnt = radioData.invalidModels(this);
+  //  do not check for etx files as we accept errors
+  int cnt = radioData.invalidModels();
   if (cnt) {
     if (askQuestion(tr("%1 models have errors. Repair?").arg(cnt), QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel) == QMessageBox::Yes) {
       radioData.fixInvalidModels();
@@ -1356,8 +1359,10 @@ bool MdiChild::saveFile(const QString & filename, bool setCurrent)
   g.eepromDir(QFileInfo(filename).dir().absolutePath());
 
   for (int i = 0; i < (int)radioData.models.size(); i++) {
-    if (!radioData.models[i].isEmpty())
+    if (!radioData.models[i].isEmpty()) {
       radioData.models[i].modelUpdated = false;
+      radioData.models[i].validate();
+    }
   }
 
   refresh();

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -349,6 +349,7 @@ void MdiChild::updateNavigation()
     cboModelSortOrder->setCurrentIndex(radioData.sortOrder);
     cboModelSortOrder->blockSignals(false);
   }
+  action[ACT_GEN_SIM]->setEnabled(!invalidModels());
   action[ACT_GEN_SRT]->setVisible(hasLabels);
 
   action[ACT_MDL_DEL]->setEnabled(modelsSelected);
@@ -369,7 +370,7 @@ void MdiChild::updateNavigation()
   action[ACT_MDL_WIZ]->setEnabled(singleModelSelected);
   action[ACT_MDL_DFT]->setEnabled(singleModelSelected && getCurrentModel() != (int)radioData.generalSettings.currModelIndex);
   action[ACT_MDL_PRT]->setEnabled(singleModelSelected);
-  action[ACT_MDL_SIM]->setEnabled(singleModelSelected);
+  action[ACT_MDL_SIM]->setEnabled(singleModelSelected && !invalidModels());
 }
 
 void MdiChild::retranslateUi()
@@ -1490,6 +1491,13 @@ int MdiChild::askQuestion(const QString & msg, QMessageBox::StandardButtons butt
 
 void MdiChild::writeSettings(StatusDialog * status, bool toRadio)  // write to Tx
 {
+  //  safeguard as the menu actions should be disabled
+  int cnt = radioData.invalidModels();
+  if (cnt) {
+    QMessageBox::critical(this, tr("Write Models and Settings"), tr("Operation aborted as %1 models have significant errors that may affect model operation.").arg(cnt));
+    return;
+  }
+
   if (g.confirmWriteModelsAndSettings()) {
     QMessageBox msgbox;
     msgbox.setText(tr("You are about to overwrite ALL models."));
@@ -1857,4 +1865,9 @@ QAction * MdiChild::actionsSeparator()
   QAction * act = new QAction(this);
   act->setSeparator(true);
   return act;
+}
+
+bool MdiChild::invalidModels()
+{
+  return (bool)radioData.invalidModels();
 }

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1334,33 +1334,16 @@ bool MdiChild::saveAs(bool isNew)
 
 bool MdiChild::saveFile(const QString & filename, bool setCurrent)
 {
-  for (int i = 0; i < (int)radioData.models.size(); i++) {
-    int cnt = 0;
-
-    if (!radioData.models[i].isEmpty()) {
-      for (int j = 0; j < CPN_MAX_INPUTS; j++) {
-        if (!radioData.models[i].expoData[j].isEmpty() && radioData.models[i].expoData[j].srcRaw == SOURCE_TYPE_NONE)
-          cnt++;
-      }
-
-      if (cnt > 0) {
-        if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Model %1 has %2 inputs with no source and these inputs will not be saved. Continue?").arg(radioData.models[i].name).arg(cnt),
-                                  QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::No)
-          return false;
-      }
-
-      cnt = 0;
-      for (int j = 0; j < CPN_MAX_MIXERS; j++) {
-        if (!radioData.models[i].mixData[j].isEmpty() && radioData.models[i].mixData[j].srcRaw == SOURCE_TYPE_NONE)
-          cnt++;
-      }
-
-      if (cnt > 0) {
-        if (QMessageBox::question(this, CPN_STR_APP_NAME, tr("Model %1 has %2 mixes with no source and these mixes will not be saved. Continue?").arg(radioData.models[i].name).arg(cnt),
-                                  QMessageBox::Yes | QMessageBox::No, QMessageBox::No) == QMessageBox::No)
-          return false;
-      }
+  int cnt = radioData.invalidModels(this);
+  if (cnt) {
+    if (askQuestion(tr("%1 models have errors. Repair?").arg(cnt), QMessageBox::Yes | QMessageBox::Cancel, QMessageBox::Cancel) == QMessageBox::Yes) {
+      radioData.fixInvalidModels();
+      // NOW NEED TO REFRESH GUI if Model Edit open !!!!!!!
+      // refresh inputs and mixes lists
+      // update any data models
     }
+    else
+      return false;
   }
 
   radioData.fixModelFilenames();

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1209,6 +1209,7 @@ void MdiChild::openModelEditWindow(int row)
   gStopwatch.report("ModelEdit created");
   t->setWindowTitle(tr("Editing model %1: ").arg(row+1) + QString(model.name) + QString("   (%1)").arg(userFriendlyCurrentFile()));
   connect(t, &ModelEdit::modified, this, &MdiChild::setCurrentModelModified);
+  connect(t, &ModelEdit::closed, this, &MdiChild::onModelEditClosed);
   gStopwatch.report("STARTING MODEL EDIT");
   t->show();
   QApplication::restoreOverrideCursor();
@@ -1880,4 +1881,10 @@ void MdiChild::modelShowErrors()
 {
   ModelData &mdl = radioData.models[getCurrentModel()];
   QMessageBox::critical(this, QString("%1").arg(mdl.name), mdl.errorsList().join("\n"));
+}
+
+void MdiChild::onModelEditClosed(int id)
+{
+  radioData.models[id].validate();
+  refresh();
 }

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1879,5 +1879,5 @@ bool MdiChild::invalidModels()
 void MdiChild::modelShowErrors()
 {
   ModelData &mdl = radioData.models[getCurrentModel()];
-  QMessageBox::information(this, tr("Model: %1 Information").arg(mdl.name), mdl.errorsList().join("\n"));
+  QMessageBox::critical(this, QString("%1").arg(mdl.name), mdl.errorsList().join("\n"));
 }

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1334,9 +1334,9 @@ bool MdiChild::saveAs(bool isNew)
 
 bool MdiChild::saveFile(const QString & filename, bool setCurrent)
 {
-  int cnt = 0;
-
   for (int i = 0; i < (int)radioData.models.size(); i++) {
+    int cnt = 0;
+
     if (!radioData.models[i].isEmpty()) {
       for (int j = 0; j < CPN_MAX_INPUTS; j++) {
         if (!radioData.models[i].expoData[j].isEmpty() && radioData.models[i].expoData[j].srcRaw == SOURCE_TYPE_NONE)

--- a/companion/src/mdichild.h
+++ b/companion/src/mdichild.h
@@ -19,8 +19,7 @@
  * GNU General Public License for more details.
  */
 
-#ifndef _MDICHILD_H_
-#define _MDICHILD_H_
+#pragma once
 
 #include "eeprominterface.h"
 #include "modelslist.h"
@@ -201,6 +200,7 @@ class MdiChild : public QWidget
     bool convertStorage(Board::Type from, Board::Type to, bool newFile = false);
     void showWarning(const QString & msg);
     int askQuestion(const QString & msg, QMessageBox::StandardButtons buttons = (QMessageBox::Yes | QMessageBox::No), QMessageBox::StandardButton defaultButton = QMessageBox::No);
+
     QDialog * getChildDialog(QRegularExpression & regexp);
     QDialog * getModelEditDialog(int row);
     QList<QDialog *> * getChildrenDialogsList(QRegularExpression & regexp);
@@ -262,5 +262,3 @@ class ItemViewProxyStyle: public QProxyStyle
       }
     }
 };
-
-#endif // _MDICHILD_H_

--- a/companion/src/mdichild.h
+++ b/companion/src/mdichild.h
@@ -131,6 +131,7 @@ class MdiChild : public QWidget
     void onCurrentItemChanged(const QModelIndex &, const QModelIndex &);
     void onDataChanged(const QModelIndex & index);
     void onInternalModuleChanged();
+    void onModelEditClosed(int id);
 
     void generalEdit();
     void copyGeneralSettings();

--- a/companion/src/mdichild.h
+++ b/companion/src/mdichild.h
@@ -88,6 +88,7 @@ class MdiChild : public QWidget
     QList<QAction *> getModelActions();
     QList<QAction *> getLabelsActions();
     QAction * getAction(const Actions type);
+    bool invalidModels();
 
   public slots:
     void newFile(bool createDefaults = true);

--- a/companion/src/mdichild.h
+++ b/companion/src/mdichild.h
@@ -69,6 +69,7 @@ class MdiChild : public QWidget
       ACT_MDL_DFT,  // set as DeFaulT
       ACT_MDL_PRT,  // print
       ACT_MDL_SIM,
+      ACT_MDL_ERR,
       ACT_LBL_ADD,  // label actions..
       ACT_LBL_DEL,
       ACT_LBL_MVU,  // Move up
@@ -153,6 +154,7 @@ class MdiChild : public QWidget
     void labelsFault(QString msg);
     void wizardEdit();
     void modelDuplicate();
+    void modelShowErrors();
 
     void openModelWizard(int row = -1);
     void openModelEditWindow(int row = -1);

--- a/companion/src/mdichild.h
+++ b/companion/src/mdichild.h
@@ -32,6 +32,7 @@
 #include <QWidget>
 #include <QStyledItemDelegate>
 #include <QListWidget>
+#include <QStatusBar>
 
 class QToolBar;
 class StatusDialog;
@@ -223,6 +224,9 @@ class MdiChild : public QWidget
     QToolBar * modelsToolbar;
     QToolBar * labelsToolbar;
     QLabel *lblLabels;
+    QStatusBar *statusBar;
+    QLabel *statusBarIcon;
+    QLabel *statusBarCount;
 
     Firmware * firmware;
     RadioData radioData;
@@ -236,6 +240,8 @@ class MdiChild : public QWidget
     QComboBox* cboModelSortOrder;
     void setModelModified(const int modelIndex, bool cascade = true);
     QAction * actionsSeparator();
+    void setupStatusBar();
+    void updateStatusBar();
 };
 
 // This will draw the drop indicator across all columns of a model View (vs. in just one column), and lets us make the indicator more obvious.

--- a/companion/src/mdichild.ui
+++ b/companion/src/mdichild.ui
@@ -51,6 +51,9 @@
      </property>
     </widget>
    </item>
+   <item>
+    <layout class="QVBoxLayout" name="statusBarLayout"/>
+   </item>
   </layout>
  </widget>
  <resources/>

--- a/companion/src/modeledit/modeledit.cpp
+++ b/companion/src/modeledit/modeledit.cpp
@@ -140,7 +140,8 @@ ModelEdit::~ModelEdit()
 
 void ModelEdit::closeEvent(QCloseEvent *event)
 {
-  g.modelEditGeo( saveGeometry() );
+  g.modelEditGeo(saveGeometry());
+  emit closed(modelId);
 }
 
 void ModelEdit::addTab(GenericPanel *panel, QString text)

--- a/companion/src/modeledit/modeledit.h
+++ b/companion/src/modeledit/modeledit.h
@@ -19,8 +19,7 @@
  * GNU General Public License for more details.
  */
 
-#ifndef _MODELEDIT_H_
-#define _MODELEDIT_H_
+#pragma once
 
 #include <QtWidgets>
 #include "genericpanel.h"
@@ -56,6 +55,7 @@ class ModelEdit : public QDialog
 
   signals:
     void modified();
+    void closed(int id);
 
   private slots:
     void onTabIndexChanged(int index);
@@ -72,5 +72,3 @@ class ModelEdit : public QDialog
     void launchSimulation();
 
 };
-
-#endif // _MODELEDIT_H_

--- a/companion/src/modelslist.cpp
+++ b/companion/src/modelslist.cpp
@@ -186,6 +186,12 @@ QVariant ModelsListModel::data(const QModelIndex & index, int role) const
   }
 
   if (role == Qt::ForegroundRole && item->isModel()) {
+    if (index.column() == (hasLabels ? 0 : 1) && radioData->models[item->getModelIndex()].modelErrors) {
+      QBrush brush;
+      brush.setColor(Qt::red);
+      return brush;
+    }
+
     int col = item->columnCount() - 1;
     if(hasLabels)
         col --;


### PR DESCRIPTION
Fixes #5793

Summary of changes:
- check every model's inputs and mixes for source
- new traffic light status for each models and settings file, green if no errors
- if no source(s):
  - only allow saving to etx format
  - disable writing to radio or sd path as no source causes unexpected behaviours
  - disable simulate model and radio for the same reasons
  - new dialog to display errors
  - change status to red and display the number of models with errors
