### PR TITLE
fix(lua): stick "side" missing from model.getInput

### DIFF
--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -595,10 +595,10 @@ Return input data for given input and line number
  * `curveValue` (number) curve index
  * `carryTrim` deprecated, please use trimSource instead. WARNING: carryTrim was getting negative values (carryTrim = - trimSource)
  * 'trimSource' (number) a positive number representing trim source
- * 'mode' (number) input side (positive, negative or all)
+ * 'side' (number) input side (positive, negative or all)
  * 'flightModes' (number) bit-mask of active flight modes
 
-@status current Introduced in 2.0.0, curveType/curveValue/carryTrim added in 2.3, inputName added 2.3.10, flighmode reworked in 2.3.11, broken carryTrim replaced by trimSource in 2.8.1, scale added in 2.10, mode added in 2.11
+@status current Introduced in 2.0.0, curveType/curveValue/carryTrim added in 2.3, inputName added 2.3.10, flighmode reworked in 2.3.11, broken carryTrim replaced by trimSource in 2.8.1, scale added in 2.10, side added in 2.11
 */
 static int luaModelGetInput(lua_State *L)
 {
@@ -619,7 +619,7 @@ static int luaModelGetInput(lua_State *L)
     lua_pushtableinteger(L, "curveType", expo->curve.type);
     lua_pushtableinteger(L, "curveValue", expo->curve.value);
     lua_pushtableinteger(L, "trimSource", - expo->trimSource);
-    lua_pushtableinteger(L, "mode", expo->mode);
+    lua_pushtableinteger(L, "side", expo->mode);
     lua_pushtableinteger(L, "flightModes", expo->flightModes);
   }
   else {
@@ -676,7 +676,7 @@ static int luaModelInsertInput(lua_State *L)
       else if (!strcmp(key, "scale")) {
         expo->scale = luaL_checkinteger(L, -1);
       }
-      else if (!strcmp(key, "mode")) {
+      else if (!strcmp(key, "side")) {
         expo->mode = luaL_checkinteger(L, -1);
       }
       else if (!strcmp(key, "weight")) {

--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -595,6 +595,7 @@ Return input data for given input and line number
  * `curveValue` (number) curve index
  * `carryTrim` deprecated, please use trimSource instead. WARNING: carryTrim was getting negative values (carryTrim = - trimSource)
  * 'trimSource' (number) a positive number representing trim source
+ * 'mode' (number) input side (positive, negative or all)
  * 'flightModes' (number) bit-mask of active flight modes
 
 @status current Introduced in 2.0.0, curveType/curveValue/carryTrim added in 2.3, inputName added 2.3.10, flighmode reworked in 2.3.11, broken carryTrim replaced by trimSource in 2.8.1, scale added in 2.10
@@ -618,6 +619,7 @@ static int luaModelGetInput(lua_State *L)
     lua_pushtableinteger(L, "curveType", expo->curve.type);
     lua_pushtableinteger(L, "curveValue", expo->curve.value);
     lua_pushtableinteger(L, "trimSource", - expo->trimSource);
+    lua_pushtableinteger(L, "mode", expo->mode);
     lua_pushtableinteger(L, "flightModes", expo->flightModes);
   }
   else {
@@ -673,6 +675,9 @@ static int luaModelInsertInput(lua_State *L)
       }
       else if (!strcmp(key, "scale")) {
         expo->scale = luaL_checkinteger(L, -1);
+      }
+      else if (!strcmp(key, "mode")) {
+        expo->mode = luaL_checkinteger(L, -1);
       }
       else if (!strcmp(key, "weight")) {
         int val = luaL_checkinteger(L, -1);

--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -598,7 +598,7 @@ Return input data for given input and line number
  * 'mode' (number) input side (positive, negative or all)
  * 'flightModes' (number) bit-mask of active flight modes
 
-@status current Introduced in 2.0.0, curveType/curveValue/carryTrim added in 2.3, inputName added 2.3.10, flighmode reworked in 2.3.11, broken carryTrim replaced by trimSource in 2.8.1, scale added in 2.10
+@status current Introduced in 2.0.0, curveType/curveValue/carryTrim added in 2.3, inputName added 2.3.10, flighmode reworked in 2.3.11, broken carryTrim replaced by trimSource in 2.8.1, scale added in 2.10, mode added in 2.11
 */
 static int luaModelGetInput(lua_State *L)
 {


### PR DESCRIPTION
Model > Input -> Side is missing from the Lua API.

This PR puts it back in.

NOTE: I think this is correct, I've been able to compile firmware, but currently I am unable to get the simulator to compile on a Ubuntu22 VM. It dies with the following error and my C++ skills are not going to be sufficient to move forward.

```
In file included from /home/user/edgetx/edgetx_main/companion/src/firmwares/eeprominterface.h:27,
                 from /home/user/edgetx/edgetx_main/companion/src/storage/eepe.cpp:24:
/home/user/edgetx/edgetx_main/build-output/native/../../radio/src/definitions.h:28:10: fatal error: memory_sections.h: No such file or directory
   28 | #include "memory_sections.h"
      |          ^~~~~~~~~~~~~~~~~~~
compilation terminated.
```