### PR TITLE
fix(color): attempt to show units for value widget if height < 50  - 2.10

### DIFF
--- a/radio/src/gui/colorlcd/widgets/value.cpp
+++ b/radio/src/gui/colorlcd/widgets/value.cpp
@@ -85,7 +85,7 @@ class ValueWidget: public Widget
         yValue = -2;
         xLabel = NUMBERS_PADDING;
         yLabel = +2;
-        attrValue = RIGHT | NO_UNIT | FONT(L);
+        attrValue = RIGHT | FONT(L);
       }
       else {
         switch (label_alignment) {


### PR DESCRIPTION
Fixes the issue were the value widget wouldn't display units in any of the four row screen layouts.

![image](https://github.com/user-attachments/assets/ed002106-f691-4ac4-8f4d-e5f6963965bc)

![image](https://github.com/user-attachments/assets/42d848ad-fbd9-4be9-a8c8-b0a94a3e9965)
