### PR TITLE
fix(bw): prevent script from re-opening itself

### DIFF
--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -1207,6 +1207,7 @@ static bool resumeLua(bool init, bool allowLcdUsage)
           lua_pop(lsScripts, 1);  /* pop returned value */
          
           if (scriptResult != 0) {
+            killAllEvents();
             TRACE("Script finished with status %d", scriptResult);
             luaState = INTERPRETER_RELOAD_PERMANENT_SCRIPTS;
           }


### PR DESCRIPTION
Kill events when script closes itself to prevent the script running again.
