### PR TITLE
fix(color): attempt to show units for value widget if height < 50

### DIFF
--- a/radio/src/gui/colorlcd/widgets/value.cpp
+++ b/radio/src/gui/colorlcd/widgets/value.cpp
@@ -197,7 +197,6 @@ class ValueWidget : public Widget
 
     // Get positions, alignment and value font size.
     if (height() < 50) {
-      valueFlags = NO_UNIT;
       if (width() >= 120) {
         lblAlign = ALIGN_LEFT;
         valAlign = ALIGN_RIGHT;


### PR DESCRIPTION
Summary of changes:
- don't drop value unit at all, just try to show it, even if it gets clipped

`main` version of #5811