### PR TITLE
fix(bw): prevent phantom 'Script error' message after trying to load a Lua 5.2 luac file

### DIFF
--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -561,10 +561,12 @@ int luaLoadScriptFileToState(lua_State * L, const char * filename, const char * 
   TRACE("luaLoadScriptFileToState(%s, %s): loading %s", filename, lmode, filenameFull);
 
   // we don't pass <mode> on to loadfilex() because we want lua to load whatever file we specify, regardless of content
+  int t = lua_gettop(L);
   lstatus = luaL_loadfilex(L, filenameFull, nullptr);
 #if defined(LUA_COMPILER)
   // Check for bytecode encoding problem, eg. compiled for x64. Unfortunately Lua doesn't provide a unique error code for this. See Lua/src/lundump.c.
   if (lstatus == LUA_ERRSYNTAX && loadFileType == 2 && frLuaS == FR_OK && strstr(lua_tostring(L, -1), "precompiled")) {
+    lua_settop(L, t); // reset stack to prevent phantom error
     loadFileType = 1;
     scriptNeedsCompile = true;
     strcpy(filenameFull + fnamelen, SCRIPT_EXT);

--- a/radio/src/lua/lua_api.h
+++ b/radio/src/lua/lua_api.h
@@ -37,7 +37,7 @@ extern "C" {
   // Can force loading of binary (.luac) or plain-text (.lua) versions of scripts specifically, and control
   //  compilation options. See interface.cpp:luaLoadScriptFileToState() <mode> parameter description for details.
   #if !defined(LUA_COMPILER) || defined(SIMU) || defined(DEBUG)
-    #define LUA_SCRIPT_LOAD_MODE    "T"   // prefer loading .lua source file for full debug info
+    #define LUA_SCRIPT_LOAD_MODE    "bt"   // prefer loading .lua source file for full debug info
   #else
     #define LUA_SCRIPT_LOAD_MODE    "bt"  // binary or text, whichever is newer
   #endif

--- a/radio/src/lua/lua_api.h
+++ b/radio/src/lua/lua_api.h
@@ -37,7 +37,7 @@ extern "C" {
   // Can force loading of binary (.luac) or plain-text (.lua) versions of scripts specifically, and control
   //  compilation options. See interface.cpp:luaLoadScriptFileToState() <mode> parameter description for details.
   #if !defined(LUA_COMPILER) || defined(SIMU) || defined(DEBUG)
-    #define LUA_SCRIPT_LOAD_MODE    "bt"   // prefer loading .lua source file for full debug info
+    #define LUA_SCRIPT_LOAD_MODE    "T"   // prefer loading .lua source file for full debug info
   #else
     #define LUA_SCRIPT_LOAD_MODE    "bt"  // binary or text, whichever is newer
   #endif


### PR DESCRIPTION
Prevent phantom 'Script error' message after trying to load a Lua 5.2 version file.

Radio shows a 'Script error' message after trying to run a tool where a Lua 5.2 version .luac file already exists.