### PR TITLE
fix(color): MPM - wrong display of used RF protocol

### DIFF
--- a/radio/src/gui/colorlcd/module/mpm_settings.cpp
+++ b/radio/src/gui/colorlcd/module/mpm_settings.cpp
@@ -172,6 +172,7 @@ struct MPMSubtype : public FormLine {
     }
 
     choice->setValues(rfProto->subProtos);
+    choice->update();
     choice->setMax(rfProto->subProtos.size() - 1);
 
     show();


### PR DESCRIPTION
Display correct name for MPM RF Protocol.

Fixes #5812
