### PR TITLE
fix: gx12 not entering BL

### DIFF
--- a/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
+++ b/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
@@ -91,7 +91,7 @@ void bootloaderInitApp()
 
     // wait a bit for the inputs to stabilize...
     if (!WAS_RESET_BY_WATCHDOG_OR_SOFTWARE()) {
-      delay_us(200);
+      delay_ms(10);
     }
 
     start_firmware = !boardBLStartCondition(); 


### PR DESCRIPTION
This fixes an issue where since #5738, gx12 (and possibly others) would not enter BL on first cold try.

Also happened to help user [CarlosPC on Discord](https://discord.com/channels/839849772864503828/839895574244229152/1331620399154466846).

This only affect cold start, and not at all EM handling (that isn't coming from cold state, so doesn't need stabilisation time)