### PR TITLE
fix(color): setup dialog for pots on portrait LCD has overlapping text

### DIFF
--- a/radio/src/gui/colorlcd/radio/hw_inputs.cpp
+++ b/radio/src/gui/colorlcd/radio/hw_inputs.cpp
@@ -136,7 +136,7 @@ HWPots::HWPots(Window* parent) :
     pot->setAvailableHandler([=](int val) { return isPotTypeAvailable(val); });
 
     auto tgl = new ToggleSwitch(
-          this, rect_t{P_INV_X, P_Y(i) + P_OFST_Y + yo, P_INV_W, 0},
+          this, rect_t{P_INV_X, P_Y(i) + yo, P_INV_W, 0},
           [=]() -> uint8_t { return (uint8_t)getPotInversion(i); },
           [=](int8_t newValue) {
             setPotInversion(i, newValue);

--- a/radio/src/gui/colorlcd/radio/hw_inputs.h
+++ b/radio/src/gui/colorlcd/radio/hw_inputs.h
@@ -43,11 +43,11 @@ struct HWPots : public Window
   // in a flex layout
   static LAYOUT_VAL(P_LBL_X, 0, 0)
   static LAYOUT_VAL(P_LBL_W, (DIALOG_DEFAULT_WIDTH - 45) * 2 / 11, (DIALOG_DEFAULT_WIDTH - 18) * 13 / 21)
-  static constexpr coord_t P_NM_X = P_LBL_X + P_LBL_W + PAD_MEDIUM;
+  static LAYOUT_VAL(P_NM_X, P_LBL_X + P_LBL_W + PAD_MEDIUM, 100);
   static LAYOUT_VAL(P_NM_W, 70, 70)
-  static LAYOUT_VAL(P_TYP_X, P_NM_X + P_NM_W, 0)
+  static LAYOUT_VAL(P_TYP_X, P_NM_X + P_NM_W, 32)
   static LAYOUT_VAL(P_TYP_W, 160, P_LBL_W)
-  static constexpr coord_t P_INV_X = P_TYP_X + P_TYP_W + PAD_MEDIUM;
+  static LAYOUT_VAL(P_INV_X, P_TYP_X + P_TYP_W + PAD_MEDIUM, P_NM_X + P_NM_W + PAD_MEDIUM)
   static LAYOUT_VAL(P_INV_W, 52, 52)
   static LAYOUT_VAL(P_ROW_H, 36, 72)
   static LAYOUT_VAL(P_OFST_Y, 0, 36)


### PR DESCRIPTION
Before:
![screenshot_el18_25-01-24_20-54-41](https://github.com/user-attachments/assets/86bbcdcd-da7e-4e39-972f-e4b82aec81f3)

After:
![screenshot_el18_25-01-24_20-55-29](https://github.com/user-attachments/assets/2970e094-1ce9-49ab-80fb-dd421696eab7)
