### PR TITLE
feat(tx16s): default calibration for 6POS

### DIFF
--- a/radio/src/edgetx.cpp
+++ b/radio/src/edgetx.cpp
@@ -420,7 +420,7 @@ void generalDefault()
 #endif
 
 #if defined(DEFAULT_6POS_CALIB)
-  uint8_t defaultCalib[] = DEFAULT_6POS_CALIB; ;
+  uint8_t defaultCalib[] = DEFAULT_6POS_CALIB;
   StepsCalibData* calib = (StepsCalibData*)&g_eeGeneral.calib[DEFAULT_6POS_IDX];
 
   for (int i = 0; i < 5; i++) {

--- a/radio/src/edgetx.cpp
+++ b/radio/src/edgetx.cpp
@@ -419,10 +419,9 @@ void generalDefault()
   g_eeGeneral.hatsMode = HATSMODE_SWITCHABLE;
 #endif
 
-#if defined(RADIO_TX16S)
-  // Pre calibrate 6POS on TX16S
-  constexpr uint8_t defaultCalib[]= {3, 12, 21, 30, 38};
-  StepsCalibData* calib = (StepsCalibData*)&g_eeGeneral.calib[5];
+#if defined(DEFAULT_6POS_CALIB)
+  uint8_t defaultCalib[] = DEFAULT_6POS_CALIB; ;
+  StepsCalibData* calib = (StepsCalibData*)&g_eeGeneral.calib[DEFAULT_6POS_IDX];
 
   for (int i = 0; i < 5; i++) {
     calib->steps[i] = defaultCalib[i];

--- a/radio/src/edgetx.cpp
+++ b/radio/src/edgetx.cpp
@@ -419,6 +419,16 @@ void generalDefault()
   g_eeGeneral.hatsMode = HATSMODE_SWITCHABLE;
 #endif
 
+#if defined(RADIO_TX16S)
+  // Pre calibrate 6POS on TX16S
+  constexpr uint8_t defaultCalib[]= {3, 12, 21, 30, 38};
+  StepsCalibData* calib = (StepsCalibData*)&g_eeGeneral.calib[5];
+
+  for (int i = 0; i < 5; i++) {
+    calib->steps[i] = defaultCalib[i];
+  }
+#endif
+
   g_eeGeneral.chkSum = 0xFFFF;
 }
 

--- a/radio/src/targets/horus/hal.h
+++ b/radio/src/targets/horus/hal.h
@@ -572,6 +572,11 @@
   #error "Missing ADC_DIRECTION array"
 #endif
 
+#if defined(RADIO_TX16S)
+  #define DEFAULT_6POS_CALIB          {3, 12, 21, 30, 38}
+  #define DEFAULT_6POS_IDX            5
+#endif
+
   
 // Power
 #if defined(RADIO_T18)

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -1832,6 +1832,11 @@
   #define ADC_DIRECTION {1,-1,-1,1,  -1,1,  1,  1}
 #endif
 
+#if defined(RADIO_BOXER)
+  #define DEFAULT_6POS_CALIB          {5, 13, 22, 31, 40}
+  #define DEFAULT_6POS_IDX            6
+#endif
+
 // PWR and LED driver
 
 #if defined(PCBX9LITE)

--- a/radio/util/hw_defs/legacy_names.py
+++ b/radio/util/hw_defs/legacy_names.py
@@ -335,11 +335,11 @@ LEGACY_NAMES = [
                 "description": "Potentiometer 2"
             },
             "P3": {
-                "yaml": "POT3",
-                "lua": "s3",
-                "label": "S3",
+                "yaml": "6POS",
+                "lua": "6P",
+                "label": "6P",
                 "short_label": "3",
-                "description": "6 pos"
+                "description": "Multipos Switch"
             }
         }
     },

--- a/radio/util/hw_defs/pot_config.py
+++ b/radio/util/hw_defs/pot_config.py
@@ -4,8 +4,7 @@ POT_CONFIG = {
     "boxer": {
         "P1": {"default": "POT_CENTER"},
         "P2": {"default": "POT_CENTER"},
-        "S1": {"default": "SLIDER"},
-        "S2": {"default": "SLIDER"}
+        "P3": {"default": "MULTIPOS"}
     },
     "gx12": {
         "P1": {"default": "POT_CENTER"},


### PR DESCRIPTION
This precalibrate 6POS on TX16S radio, so that if 6POS is not manually calibrated by user, it operates with default values that should be ok unless radio has been somehow modded.

Note: this precalibration is loaded on radio default creation, so will only affect new/reformated radio. It will stay in place no matter how many times calibration is run as long as users doesn't initiate a 6POS calibration