### PR TITLE
fix(lua): io.read always reading 256 bytes rather than specified value

### DIFF
--- a/radio/src/thirdparty/Lua/src/liolib.c
+++ b/radio/src/thirdparty/Lua/src/liolib.c
@@ -425,7 +425,7 @@ static int read_chars (lua_State *L, FIL *f, size_t n) {
   luaL_Buffer b;
   luaL_buffinit(L, &b);
   p = luaL_prepbuffsize(&b, n);  /* prepare buffer to read whole block */
-  if (f_read(f, p, LUAL_BUFFERSIZE, &nr) != FR_OK) nr = 0; /* try to read 'n' chars */
+  if (f_read(f, p, n, &nr) != FR_OK) nr = 0; /* try to read 'n' chars */
   luaL_addsize(&b, nr);
   luaL_pushresult(&b);  /* close buffer */
   return (nr > 0);  /* true iff read something */


### PR DESCRIPTION
Fixes #5832

Summary of changes:
Use parameter "n" instead of the fix LUAL_BUFFERSIZE

![image](https://github.com/user-attachments/assets/b610d1ba-b486-446e-92a8-db28eb6dafb4)


