### PR TITLE
feat(vs1053b): use callbacks for RST & MUTE pins

### DIFF
--- a/radio/src/targets/common/arm/stm32/vs1053b.cpp
+++ b/radio/src/targets/common/arm/stm32/vs1053b.cpp
@@ -98,24 +98,23 @@ static inline uint32_t _read_dreq() { return gpio_read(_instance->DREQ); }
 
 static inline void _reset_high()
 {
-  if (_instance->RST != GPIO_UNDEF) {
-    gpio_set(_instance->RST);
+  if (_instance->set_rst_pin) {
+    _instance->set_rst_pin(true);
   }
 }
 
 static inline void _reset_low()
 {
-  if (_instance->RST != GPIO_UNDEF) {
-    gpio_clear(_instance->RST);
+  if (_instance->set_rst_pin) {
+    _instance->set_rst_pin(false);
   }
 }
 
 static inline void _set_mute_pin(bool muted)
 {
-  if (_instance->MUTE != GPIO_UNDEF) {
+  if (_instance->set_mute_pin) {
     _is_muted = muted;
-    bool inv = _instance->flags & VS1053B_MUTE_INVERTED;
-    gpio_write(_instance->MUTE, inv ? !muted : muted);
+    _instance->set_mute_pin(muted);
   }
 }
 
@@ -124,14 +123,7 @@ static void vs1053b_gpio_init(void)
   gpio_init(_instance->XDCS, GPIO_OUT, GPIO_PIN_SPEED_HIGH);
   gpio_init(_instance->DREQ, GPIO_IN, GPIO_PIN_SPEED_HIGH);
 
-  if (_instance->RST != GPIO_UNDEF) {
-    gpio_init(_instance->RST, GPIO_OUT, GPIO_PIN_SPEED_HIGH);
-  }
-
-  if (_instance->MUTE != GPIO_UNDEF) {
-    gpio_init(_instance->MUTE, GPIO_OUT, GPIO_PIN_SPEED_HIGH);
-    _set_mute_pin(true);
-  }
+  _set_mute_pin(true);
 
   stm32_spi_init(_instance->spi, LL_SPI_DATAWIDTH_8BIT);
 }

--- a/radio/src/targets/common/arm/stm32/vs1053b.h
+++ b/radio/src/targets/common/arm/stm32/vs1053b.h
@@ -24,17 +24,15 @@
 #include "hal/gpio.h"
 #include "stm32_spi.h"
 
-#define VS1053B_MUTE_INVERTED (1 << 0)
-
 typedef struct {
   stm32_spi_t* spi;
 
   gpio_t       XDCS;
   gpio_t       DREQ;
-  gpio_t       RST;
-  gpio_t       MUTE;
 
-  uint32_t     flags;
+  void (*set_rst_pin)(bool set);
+  void (*set_mute_pin)(bool set);
+
   uint32_t     mute_delay_ms;
   uint32_t     unmute_delay_ms;
 } vs1053b_t;

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -87,6 +87,11 @@ void boardBLEarlyInit()
 #include "edgetx.h"
 
 #if defined(PCBX12S)
+static void audio_set_rst_pin(bool set)
+{
+  gpio_write(AUDIO_RST_GPIO, set);
+}
+
 void audioInit()
 {
   static stm32_spi_t spi_dev = {
@@ -101,11 +106,13 @@ void audioInit()
       .spi = &spi_dev,
       .XDCS = AUDIO_XDCS_GPIO,
       .DREQ = AUDIO_DREQ_GPIO,
-      .RST = AUDIO_RST_GPIO,
+      .set_rst_pin = audio_set_rst_pin,
   };
 
+  gpio_init(AUDIO_RST_GPIO, GPIO_OUT, 0);
   gpio_init(AUDIO_SHUTDOWN_GPIO, GPIO_OUT, 0);
   gpio_set(AUDIO_SHUTDOWN_GPIO);
+
   vs1053b_init(&vs1053);
 }
 #endif


### PR DESCRIPTION
Summary of changes:
- allows for boards to define custom callbacks for RST and MUTE pins, instead of assuming regular GPIOs.
