### PR TITLE
feat(radio): OS compatibility layer

### DIFF
--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -484,9 +484,16 @@ if(NATIVE_BUILD)
     ${RADIOLIB_NATIVE_SRC}
   )
 
-  # Add -DSIMU here PUBLIC, so it can be imported by other targets
+  # Add SIMU and POSIX_THREAD here PUBLIC, so it can be imported by other targets
   # via INTERFACE_COMPILE_OPTIONS
-  target_compile_options(radiolib_native PUBLIC -DSIMU)
+  target_compile_options(radiolib_native PUBLIC -DSIMU -DPOSIX_THREADS)
+  target_sources(radiolib_native PUBLIC
+    os/async_native.cpp
+    os/sleep_native.cpp
+    os/task_pthread.cpp
+    os/time_native.cpp
+    os/timer_pthread.cpp
+  )
   add_dependencies(radiolib_native ${RADIO_DEPENDENCIES})
   set_property(TARGET radiolib_native PROPERTY POSITION_INDEPENDENT_CODE ON)
 
@@ -554,12 +561,22 @@ if(BOOTLOADER)
   set(RADIO_DEPENDENCIES ${RADIO_DEPENDENCIES} bootloader)
 endif()
 
-add_definitions(-DFREE_RTOS)
-
 add_executable(firmware ${SRC})
 link_libraries(firmware -lstdc++)
 add_dependencies(firmware ${RADIO_DEPENDENCIES})
 set_target_properties(firmware PROPERTIES EXCLUDE_FROM_ALL TRUE)
+
+target_compile_definitions(board PUBLIC FREE_RTOS)
+target_compile_definitions(board_lib PUBLIC FREE_RTOS)
+target_compile_definitions(firmware PUBLIC FREE_RTOS)
+
+target_sources(firmware PUBLIC
+  os/async_freertos.cpp
+  os/sleep_freertos.cpp
+  os/task_freertos.cpp
+  os/time_freertos.cpp
+  os/timer_freertos.cpp
+)
 
 if(DEBUG)
   target_compile_definitions(board PRIVATE -DDEBUG)

--- a/radio/src/audio.h
+++ b/radio/src/audio.h
@@ -470,7 +470,6 @@ void codecsInit();
 void audioEvent(unsigned int index);
 void audioPlay(unsigned int index, uint8_t id=0);
 void audioStart();
-void audioTask(void * pdata);
 
 #if defined(AUDIO) && defined(BUZZER)
   #define AUDIO_BUZZER(a, b)  do { a; b; } while(0)

--- a/radio/src/bluetooth.cpp
+++ b/radio/src/bluetooth.cpp
@@ -23,6 +23,7 @@
 #include "edgetx.h"
 #include "io/frsky_firmware_update.h"
 #include "bluetooth_driver.h"
+#include "os/sleep.h"
 #include "trainer.h"
 
 #if defined(LIBOPENUI)
@@ -571,7 +572,7 @@ uint8_t Bluetooth::read(uint8_t * data, uint8_t size, uint32_t timeout)
       if (elapsed++ >= timeout) {
         return len;
       }
-      RTOS_WAIT_MS(1);
+      sleep_ms(1);
     }
     data[len++] = byte;
   }
@@ -829,11 +830,11 @@ const char * Bluetooth::flashFirmware(const char * filename, ProgressHandler pro
 
   bluetoothInit(BLUETOOTH_BOOTLOADER_BAUDRATE, true); // normal mode
   watchdogSuspend(500 /*5s*/);
-  RTOS_WAIT_MS(1000);
+  sleep_ms(1000);
 
   bluetoothInit(BLUETOOTH_BOOTLOADER_BAUDRATE, false); // bootloader mode
   watchdogSuspend(500 /*5s*/);
-  RTOS_WAIT_MS(1000);
+  sleep_ms(1000);
 
   const char * result = doFlashFirmware(filename, progressHandler);
 
@@ -851,7 +852,7 @@ const char * Bluetooth::flashFirmware(const char * filename, ProgressHandler pro
 
   /* wait 1s off */
   watchdogSuspend(500 /*5s*/);
-  RTOS_WAIT_MS(1000);
+  sleep_ms(1000);
 
   state = BLUETOOTH_STATE_OFF;
   pulsesStart();

--- a/radio/src/edgetx.cpp
+++ b/radio/src/edgetx.cpp
@@ -19,6 +19,7 @@
  * GNU General Public License for more details.
  */
 
+#include "os/sleep.h"
 #if !defined(SIMU)
 #include "stm32_ws2812.h"
 #include "boards/generic_stm32/rgb_leds.h"
@@ -45,6 +46,7 @@
 
 #include "tasks.h"
 #include "tasks/mixer_task.h"
+#include "os/async.h"
 
 #if defined(BLUETOOTH)
   #include "bluetooth_driver.h"
@@ -719,7 +721,7 @@ void checkAll(bool isBootCheck)
     showMessageBox(STR_KEYSTUCK);
     tmr10ms_t tgtime = get_tmr10ms() + 500;
     while (tgtime != get_tmr10ms()) {
-      RTOS_WAIT_MS(1);
+      sleep_ms(1);
       WDG_RESET();
     }
   }
@@ -837,8 +839,7 @@ void checkThrottleStick()
     checkBacklight();
 
     WDG_RESET();
-
-    RTOS_WAIT_MS(10);
+    sleep_ms(10);
   }
 
   LED_ERROR_END();
@@ -869,7 +870,7 @@ void alert(const char * title, const char * msg , uint8_t sound)
 #endif
 
   while (true) {
-    RTOS_WAIT_MS(10);
+    sleep_ms(10);
 
     if (getEvent())  // wait for key release
       break;
@@ -1093,10 +1094,10 @@ void edgeTxClose(uint8_t shutdown)
   storageCheck(true);
 
   while (IS_PLAYING(ID_PLAY_PROMPT_BASE + AU_BYE)) {
-    RTOS_WAIT_MS(10);
+    sleep_ms(10);
   }
 
-  RTOS_WAIT_MS(100);
+  sleep_ms(100);
 
 #if defined(COLORLCD)
   cancelShutdownAnimation();  // To prevent simulator crash
@@ -1849,7 +1850,7 @@ uint32_t pwrCheck()
       RAISE_ALERT(STR_MODEL, STR_MODEL_STILL_POWERED, STR_PRESS_ENTER_TO_CONFIRM, AU_MODEL_STILL_POWERED);
       while (TELEMETRY_STREAMING()) {
         resetForcePowerOffRequest();
-        RTOS_WAIT_MS(20);
+        sleep_ms(20);
         if (pwrPressed()) {
           return e_power_on;
         }

--- a/radio/src/gui/128x64/view_statistics.cpp
+++ b/radio/src/gui/128x64/view_statistics.cpp
@@ -21,7 +21,9 @@
 
 #include "edgetx.h"
 #include "tasks.h"
+
 #include "mixer_scheduler.h"
+#include "tasks/mixer_task.h"
 
 #include "hal/adc_driver.h"
 
@@ -169,12 +171,12 @@ void menuStatisticsDebug(event_t event)
   y += FH;
 
   lcdDrawTextAlignedLeft(y, STR_FREE_STACK);
-  lcdDrawNumber(MENU_DEBUG_COL1_OFS, y, menusStack.available(), LEFT);
+  lcdDrawNumber(MENU_DEBUG_COL1_OFS, y, task_get_stack_usage(&menusTaskId), LEFT);
   lcdDrawText(lcdLastRightPos, y, "/");
-  lcdDrawNumber(lcdLastRightPos, y, mixerStack.available(), LEFT);
+  lcdDrawNumber(lcdLastRightPos, y, task_get_stack_usage(&mixerTaskId), LEFT);
 #if defined(AUDIO)
   lcdDrawText(lcdLastRightPos, y, "/");
-  lcdDrawNumber(lcdLastRightPos, y, audioStack.available(), LEFT);
+  lcdDrawNumber(lcdLastRightPos, y, task_get_stack_usage(&audioTaskId), LEFT);
 #endif
   y += FH;
 

--- a/radio/src/gui/212x64/view_statistics.cpp
+++ b/radio/src/gui/212x64/view_statistics.cpp
@@ -21,7 +21,9 @@
 
 #include "hal/adc_driver.h"
 #include "edgetx.h"
+
 #include "tasks.h"
+#include "tasks/mixer_task.h"
 
 #define STATS_1ST_COLUMN               FW/2
 #define STATS_2ND_COLUMN               12*FW+FW/2
@@ -188,12 +190,12 @@ void menuStatisticsDebug(event_t event)
 
   lcdDrawTextAlignedLeft(y, STR_FREE_STACK);
   lcdDrawText(MENU_DEBUG_COL1_OFS, y+1, "[M]", SMLSIZE);
-  lcdDrawNumber(lcdLastRightPos, y, menusStack.available(), LEFT);
+  lcdDrawNumber(lcdLastRightPos, y, task_get_stack_usage(&menusTaskId), LEFT);
   lcdDrawText(lcdLastRightPos+2, y+1, "[X]", SMLSIZE);
-  lcdDrawNumber(lcdLastRightPos, y, mixerStack.available(), LEFT);
+  lcdDrawNumber(lcdLastRightPos, y, task_get_stack_usage(&mixerTaskId), LEFT);
 #if defined(AUDIO)
   lcdDrawText(lcdLastRightPos+2, y+1, "[A]", SMLSIZE);
-  lcdDrawNumber(lcdLastRightPos, y, audioStack.available(), LEFT);
+  lcdDrawNumber(lcdLastRightPos, y, task_get_stack_usage(&audioTaskId), LEFT);
 #endif
   lcdDrawText(lcdLastRightPos+2, y+1, "[I]", SMLSIZE);
   lcdDrawNumber(lcdLastRightPos, y, mainStackAvailable(), LEFT);

--- a/radio/src/gui/colorlcd/LvglWrapper.cpp
+++ b/radio/src/gui/colorlcd/LvglWrapper.cpp
@@ -21,6 +21,7 @@
 
 #include "edgetx.h"
 #include "hal/rotary_encoder.h"
+#include "os/time.h"
 
 #include "LvglWrapper.h"
 #include "etx_lv_theme.h"
@@ -359,9 +360,10 @@ LvglWrapper* LvglWrapper::instance()
 void LvglWrapper::run()
 {
 #if defined(SIMU)
-  tmr10ms_t tick = get_tmr10ms();
-  lv_tick_inc((tick - lastTick) * 10);
-  lastTick = tick;
+  static uint32_t last_tick = 0;
+  uint32_t tick = time_get_ms();
+  lv_tick_inc(tick - last_tick);
+  last_tick = tick;
 #endif
   lv_timer_handler();
 }

--- a/radio/src/gui/colorlcd/LvglWrapper.h
+++ b/radio/src/gui/colorlcd/LvglWrapper.h
@@ -33,9 +33,6 @@ class LvglWrapper
   static LvglWrapper *_instance;
   static void pollInputs();
 
-  tmr10ms_t lastTick = 0;
-  // TODO: add driver instances here
-
   LvglWrapper();
   ~LvglWrapper() {}
 

--- a/radio/src/gui/colorlcd/libui/fullscreen_dialog.cpp
+++ b/radio/src/gui/colorlcd/libui/fullscreen_dialog.cpp
@@ -26,6 +26,7 @@
 #include "mainwindow.h"
 #include "edgetx.h"
 #include "etx_lv_theme.h"
+#include "os/sleep.h"
 #include "view_main.h"
 #include "hal/watchdog_driver.h"
 
@@ -186,7 +187,7 @@ static void run_ui_manually()
   checkBacklight();
   WDG_RESET();
 
-  RTOS_WAIT_MS(10);
+  sleep_ms(10);
   LvglWrapper::runNested();
   MainWindow::instance()->run(false);
 }
@@ -211,7 +212,7 @@ void FullScreenDialog::runForever(bool checkPwr)
 #endif
       } else if (check == e_power_press) {
         WDG_RESET();
-        RTOS_WAIT_MS(1);
+        sleep_ms(1);
         continue;
       }
     }

--- a/radio/src/gui/colorlcd/libui/tabsgroup.cpp
+++ b/radio/src/gui/colorlcd/libui/tabsgroup.cpp
@@ -37,13 +37,13 @@ static bool timepg = false;
 static void on_draw_begin(lv_event_t* e)
 {
   if (timepg) {
-    dsms = RTOS_GET_MS();
+    dsms = lv_tick_get();
   }
 }
 static void on_draw_end(lv_event_t* e)
 {
   timepg = false;
-  dems = RTOS_GET_MS();
+  dems = lv_tick_get();
   TRACE("tab time: build %ld layout %ld draw %ld total %ld",
         end_ms - start_ms, dsms - end_ms, dems - dsms, dems - start_ms);
 }
@@ -301,7 +301,7 @@ void TabsGroup::setCurrentTab(unsigned index)
     currentTab = tab;
 
 #if defined(DEBUG)
-    start_ms = RTOS_GET_MS();
+    start_ms = lv_tick_get();
     timepg = true;
 #endif
 
@@ -321,7 +321,7 @@ void TabsGroup::setCurrentTab(unsigned index)
     lv_obj_refresh_style(body->getLvObj(), LV_PART_ANY, LV_STYLE_PROP_ANY);
 
 #if defined(DEBUG)
-    end_ms = RTOS_GET_MS();
+    end_ms = lv_tick_get();
 #endif
   }
 }

--- a/radio/src/gui/colorlcd/mainview/topbar_impl.cpp
+++ b/radio/src/gui/colorlcd/mainview/topbar_impl.cpp
@@ -114,7 +114,7 @@ coord_t TopBar::getVisibleHeight(float visible) const // 0.0 -> 1.0
 
 void TopBar::checkEvents()
 {
-  uint32_t now = RTOS_GET_MS();
+  uint32_t now = lv_tick_get();
   if (now - lastRefresh >= TOPBAR_REFRESH) {
     lastRefresh = now;
     TopBarBase::checkEvents();

--- a/radio/src/gui/colorlcd/mainview/view_statistics.cpp
+++ b/radio/src/gui/colorlcd/mainview/view_statistics.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "view_statistics.h"
+#include "os/task.h"
 
 #include "edgetx.h"
 #include "tasks.h"
@@ -333,14 +334,14 @@ void DebugViewPage::build(Window* window)
 #endif
   new DebugInfoNumber<uint32_t>(
       line, rect_t{0, 0, DBG_B_WIDTH, DBG_B_HEIGHT},
-      [] { return menusStack.available(); }, STR_STACK_MENU);
+      [] { return task_get_stack_usage(&menusTaskId); }, STR_STACK_MENU);
   new DebugInfoNumber<uint32_t>(
       line, rect_t{0, 0, DBG_B_WIDTH, DBG_B_HEIGHT},
-      [] { return mixerStack.available(); }, STR_STACK_MIX);
+      [] { return task_get_stack_usage(&mixerTaskId); }, STR_STACK_MIX);
 #if defined(AUDIO)
   new DebugInfoNumber<uint32_t>(
       line, rect_t{0, 0, DBG_B_WIDTH, DBG_B_HEIGHT},
-      [] { return audioStack.available(); }, STR_STACK_AUDIO);
+      [] { return task_get_stack_usage(&audioTaskId); }, STR_STACK_AUDIO);
 #endif
 
 #if defined(DEBUG_LATENCY)

--- a/radio/src/gui/colorlcd/model/model_telemetry.cpp
+++ b/radio/src/gui/colorlcd/model/model_telemetry.cpp
@@ -367,7 +367,7 @@ class SensorButton : public ListLineButton
     else
       lv_obj_add_flag(fresh, LV_OBJ_FLAG_HIDDEN);
 
-    uint32_t now = RTOS_GET_MS();
+    uint32_t now = lv_tick_get();
     TelemetryItem& telemetryItem = telemetryItems[index];
 
     // Update value
@@ -479,7 +479,7 @@ class SensorEditWindow : public SubPage
 
   void checkEvents() override
   {
-    uint32_t now = RTOS_GET_MS();
+    uint32_t now = lv_tick_get();
     TelemetryItem& telemetryItem = telemetryItems[index];
 
     if ((now - lastRefresh >= 200) || telemetryItem.isFresh()) {

--- a/radio/src/gui/colorlcd/module/module_setup.cpp
+++ b/radio/src/gui/colorlcd/module/module_setup.cpp
@@ -609,8 +609,8 @@ class ModuleSubTypeChoice : public Choice
       MultiModuleStatus& status = getMultiModuleStatus(moduleIdx);
       status.invalidate();
 
-      uint32_t startUpdate = RTOS_GET_MS();
-      while (!status.isValid() && (RTOS_GET_MS() - startUpdate < 250))
+      uint32_t startUpdate = lv_tick_get();
+      while (!status.isValid() && (lv_tick_elaps(startUpdate) < 250))
         ;
       SET_DIRTY();
 #endif

--- a/radio/src/gui/colorlcd/module/multi_rfprotos.cpp
+++ b/radio/src/gui/colorlcd/module/multi_rfprotos.cpp
@@ -44,9 +44,9 @@ void RfScanDialog::checkEvents()
 {
   if (!protos->isScanning()) {
     closeDialog();
-  } else if (RTOS_GET_MS() - lastUpdate >= 200) {
+  } else if (lv_tick_elaps(lastUpdate) >= 200) {
     showProgress();
-    lastUpdate = RTOS_GET_MS();
+    lastUpdate = lv_tick_get();
   }
   
   ProgressDialog::checkEvents();

--- a/radio/src/gui/colorlcd/radio/radio_ghost_module_config.cpp
+++ b/radio/src/gui/colorlcd/radio/radio_ghost_module_config.cpp
@@ -25,6 +25,7 @@
 #include "edgetx.h"
 #include "telemetry/ghost.h"
 #include "telemetry/ghost_menu.h"
+#include "os/sleep.h"
 
 class GhostModuleConfigWindow : public Window
 {
@@ -166,7 +167,7 @@ void RadioGhostModuleConfig::onLongPressRTN()
   reusableBuffer.ghostMenu.buttonAction = GHST_BTN_NONE;
   reusableBuffer.ghostMenu.menuAction = GHST_MENU_CTRL_CLOSE;
   moduleState[EXTERNAL_MODULE].counter = GHST_MENU_CONTROL;
-  RTOS_WAIT_MS(10);
+  sleep_ms(10);
 #if defined(TRIMS_EMULATE_BUTTONS)
   setHatsAsKeys(false);  // switch trims back to normal
 #endif
@@ -183,7 +184,7 @@ void RadioGhostModuleConfig::checkEvents()
     reusableBuffer.ghostMenu.menuAction = GHST_MENU_CTRL_OPEN;
     moduleState[EXTERNAL_MODULE].counter = GHST_MENU_CONTROL;
   } else if (reusableBuffer.ghostMenu.menuStatus == GHST_MENU_STATUS_CLOSING) {
-    RTOS_WAIT_MS(10);
+    sleep_ms(10);
     deleteLater();
 #if defined(TRIMS_EMULATE_BUTTONS)
     setHatsAsKeys(false);  // switch trims back to normal

--- a/radio/src/gui/colorlcd/startup_shutdown.cpp
+++ b/radio/src/gui/colorlcd/startup_shutdown.cpp
@@ -22,6 +22,7 @@
 #include "hal/abnormal_reboot.h"
 #include "inactivity_timer.h"
 #include "edgetx.h"
+#include "os/sleep.h"
 #include "stamp.h"
 #include "theme_manager.h"
 
@@ -123,7 +124,7 @@ void waitSplash()
   if (splashStartTime) {
 #if defined(SIMU)
     // Simulator - inputsMoved() returns true immediately without this!
-    RTOS_WAIT_TICKS(30);
+    sleep_ms(30);
 #endif  // defined(SIMU)
 
     splashStartTime += SPLASH_TIMEOUT;
@@ -133,7 +134,7 @@ void waitSplash()
       WDG_RESET();
       checkSpeakerVolume();
       checkBacklight();
-      RTOS_WAIT_TICKS(10);
+      sleep_ms(10);
       auto evt = getEvent();
       if (evt || inactivityCheckInputs()) {
         if (evt) killEvents(evt);

--- a/radio/src/gui/common/stdlcd/radio_ghost_menu.cpp
+++ b/radio/src/gui/common/stdlcd/radio_ghost_menu.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "edgetx.h"
+#include "os/sleep.h"
 
 #if defined(GHOST) && defined(HARDWARE_EXTERNAL_MODULE)
 
@@ -84,7 +85,7 @@ void menuGhostModuleConfig(event_t event)
       reusableBuffer.ghostMenu.buttonAction = GHST_BTN_NONE;
       reusableBuffer.ghostMenu.menuAction = GHST_MENU_CTRL_CLOSE;
       moduleState[EXTERNAL_MODULE].counter = GHST_MENU_CONTROL;
-      RTOS_WAIT_MS(10);
+      sleep_ms(10);
       popMenu();
       break;
   }

--- a/radio/src/gui/common/stdlcd/radio_power_meter.cpp
+++ b/radio/src/gui/common/stdlcd/radio_power_meter.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "edgetx.h"
+#include "os/sleep.h"
 #include "timers_driver.h"
 
 extern uint8_t g_moduleIdx;
@@ -52,7 +53,7 @@ void menuRadioPowerMeter(event_t event)
     moduleState[g_moduleIdx].readModuleInformation(&reusableBuffer.moduleSetup.pxx2.moduleInformation, PXX2_HW_INFO_TX_ID, PXX2_HW_INFO_TX_ID);
     /* wait 1s to resume normal operation before leaving */
     watchdogSuspend(500 /*5s*/);
-    RTOS_WAIT_MS(1000);
+    sleep_ms(1000);
     return;
   }
 

--- a/radio/src/gui/common/stdlcd/radio_spectrum_analyser.cpp
+++ b/radio/src/gui/common/stdlcd/radio_spectrum_analyser.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "edgetx.h"
+#include "os/sleep.h"
 #include "timers_driver.h"
 
 extern uint8_t g_moduleIdx;
@@ -49,7 +50,7 @@ void menuRadioSpectrumAnalyser(event_t event)
 #endif
     /* wait 1s to resume normal operation before leaving */
     watchdogSuspend(500 /*5s*/);
-    RTOS_WAIT_MS(1000);
+    sleep_ms(1000);
     return;
   }
 

--- a/radio/src/gui/common/stdlcd/splash.cpp
+++ b/radio/src/gui/common/stdlcd/splash.cpp
@@ -21,6 +21,7 @@
 
 #include "edgetx.h"
 #include "inactivity_timer.h"
+#include "os/sleep.h"
 
 static bool splashStarted = false;
 
@@ -53,7 +54,7 @@ void waitSplash()
     tmr10ms_t tgtime = get_tmr10ms() + SPLASH_TIMEOUT;
 
     while (tgtime > get_tmr10ms()) {
-      RTOS_WAIT_TICKS(1);
+      sleep_ms(1);
 
       getADC();
 

--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -27,6 +27,7 @@
 #include "edgetx.h"
 #include "switches.h"
 #include "mixes.h"
+#include "os/sleep.h"
 
 #undef CPN
 #include "MultiSubtypeDefs.h"
@@ -756,7 +757,7 @@ static void runAntennaSelectionMenu()
     WDG_RESET();
     MainWindow::instance()->run();
     LvglWrapper::runNested();
-    RTOS_WAIT_MS(20);
+    sleep_ms(20);
   }
 }
 #else
@@ -1229,7 +1230,7 @@ bool confirmModelChange()
   if (TELEMETRY_STREAMING()) {
     RAISE_ALERT(STR_MODEL, STR_MODEL_STILL_POWERED, STR_PRESS_ENTER_TO_CONFIRM, AU_MODEL_STILL_POWERED);
     while (TELEMETRY_STREAMING()) {
-      RTOS_WAIT_MS(20);
+      sleep_ms(20);
       if (readKeys() == (1 << KEY_ENTER)) {
         killEvents(KEY_ENTER);
         return true;

--- a/radio/src/hal/fatfs_diskio.cpp
+++ b/radio/src/hal/fatfs_diskio.cpp
@@ -23,7 +23,7 @@
 #include "FatFs/diskio.h"
 
 #if FF_FS_REENTRANT != 0
-#include "rtos.h"
+#include "os/task.h"
 #endif
 
 struct fatfs_drive_t {
@@ -31,7 +31,7 @@ struct fatfs_drive_t {
   uint8_t                lun;
   bool                   initialized;
 #if FF_FS_REENTRANT != 0
-  RTOS_MUTEX_HANDLE      mutex;
+  mutex_handle_t         mutex;
 #endif
 };
 
@@ -52,7 +52,7 @@ int fatfsRegisterDriver(const diskio_driver_t* drv, uint8_t lun)
 
 #if FF_FS_REENTRANT != 0
   // init IO mutex only once
-  RTOS_CREATE_MUTEX(drive.mutex);
+  mutex_create(&drive.mutex);
 #endif
 
   return 1;
@@ -100,10 +100,10 @@ int ff_mutex_create(int vol)
 
 int ff_mutex_take(int vol)
 {
-  return RTOS_LOCK_MUTEX(_fatfs_drives[vol].mutex);
+  return mutex_lock(&_fatfs_drives[vol].mutex);
 }
 
-void ff_mutex_give(int vol) { RTOS_UNLOCK_MUTEX(_fatfs_drives[vol].mutex); }
+void ff_mutex_give(int vol) { mutex_unlock(&_fatfs_drives[vol].mutex); }
 
 void ff_mutex_delete(int vol) { }
 

--- a/radio/src/io/bootloader_flash.cpp
+++ b/radio/src/io/bootloader_flash.cpp
@@ -27,6 +27,7 @@
 #include "flash_driver.h"
 
 #include "hal/watchdog_driver.h"
+#include "os/sleep.h"
 
 #if defined(LIBOPENUI)
   #include "libopenui.h"
@@ -104,9 +105,7 @@ void BootloaderFirmwareUpdate::flashFirmware(const char * filename, ProgressHand
     if (f_eof(&file)) break;
 
 #if defined(SIMU)
-    // add an artificial delay and check for simu quit
-    if (SIMU_SLEEP_OR_EXIT_MS(30))
-      break;
+    sleep_ms(30);
 #endif
   }
 

--- a/radio/src/io/frsky_firmware_update.cpp
+++ b/radio/src/io/frsky_firmware_update.cpp
@@ -23,6 +23,7 @@
 #include "edgetx.h"
 #include "frsky_firmware_update.h"
 #include "debug.h"
+#include "os/sleep.h"
 #include "timers_driver.h"
 #include "tasks/mixer_task.h"
 
@@ -118,11 +119,9 @@ bool FrskyDeviceFirmwareUpdate::readBuffer(uint8_t * buffer, uint8_t count, uint
   while (index < count && elapsed < timeout) {
     if (uart_drv->getByte(uart_ctx, &(buffer[index]))) {
       ++index;
-    }
-    else {
-      RTOS_WAIT_MS(1);
-      if (++elapsed == timeout)
-        return false;
+    } else {
+      sleep_ms(1);
+      if (++elapsed == timeout) return false;
     }
   }
 
@@ -131,7 +130,7 @@ bool FrskyDeviceFirmwareUpdate::readBuffer(uint8_t * buffer, uint8_t count, uint
 
 const uint8_t * FrskyDeviceFirmwareUpdate::readFrame(uint32_t timeout)
 {
-  RTOS_WAIT_MS(1);
+  sleep_ms(1);
 
   uint8_t len = 0;
   bool bytestuff = false;
@@ -142,7 +141,7 @@ const uint8_t * FrskyDeviceFirmwareUpdate::readFrame(uint32_t timeout)
     uint8_t byte = 0;
 
     while (uart_drv->getByte(uart_ctx, &byte) == 0) {
-      RTOS_WAIT_MS(1);
+      sleep_ms(1);
       if (elapsed++ >= timeout) {
         TRACE("timeout in frame (len=%d)",len);
         return nullptr;
@@ -178,7 +177,7 @@ bool FrskyDeviceFirmwareUpdate::waitState(State newState, uint32_t timeout)
   static uint8_t pass = 0;
   if (++pass == 10) {
     pass = 0;
-    RTOS_WAIT_MS(1);
+    sleep_ms(1);
   }
   return true;
 #else
@@ -226,7 +225,7 @@ const char * FrskyDeviceFirmwareUpdate::sendPowerOn()
 {
   state = SPORT_POWERUP_REQ;
 
-  RTOS_WAIT_MS(50);
+  sleep_ms(50);
   uart_drv->clearRxBuffer(uart_ctx);
 
   for (int i=0; i<10; i++) {
@@ -242,7 +241,7 @@ const char * FrskyDeviceFirmwareUpdate::sendPowerOn()
 
 const char * FrskyDeviceFirmwareUpdate::sendReqVersion()
 {
-  RTOS_WAIT_MS(20);
+  sleep_ms(20);
   uart_drv->clearRxBuffer(uart_ctx);
 
   state = SPORT_VERSION_REQ;
@@ -354,7 +353,7 @@ const char *FrskyDeviceFirmwareUpdate::doFlashFirmware(
   if (set_pwr) set_pwr(true);
 
   // wait a bit for PWR to settle
-  RTOS_WAIT_MS(1);
+  sleep_ms(1);
 
   // Special update method for X12S / X10 iXJT
   if (module == INTERNAL_MODULE && port == ETX_MOD_PORT_UART && set_bootcmd != nullptr) {
@@ -408,7 +407,7 @@ const char *FrskyDeviceFirmwareUpdate::uploadFileToHorusXJT(
 
     if (count == 0) {
       uart_drv->sendByte(uart_ctx, 0xA1);
-      RTOS_WAIT_MS(50);
+      sleep_ms(50);
       return nullptr;
     }
 
@@ -453,7 +452,7 @@ const char *FrskyDeviceFirmwareUpdate::uploadFileNormal(
   if (result)
     return result;
 
-  RTOS_WAIT_MS(200);
+  sleep_ms(200);
   uart_drv->clearRxBuffer(uart_ctx);
 
   state = SPORT_DATA_TRANSFER;
@@ -519,7 +518,7 @@ const char *FrskyDeviceFirmwareUpdate::flashFirmware(
 
   /* wait 2s off */
   watchdogSuspend(1000 /*10s*/);
-  RTOS_WAIT_MS(2000);
+  sleep_ms(2000);
 
   const char * result = doFlashFirmware(filename, progressHandler);
 

--- a/radio/src/io/multi_firmware_update.cpp
+++ b/radio/src/io/multi_firmware_update.cpp
@@ -19,6 +19,7 @@
  * GNU General Public License for more details.
  */
 
+#include "os/sleep.h"
 #if !defined(DISABLE_MULTI_UPDATE)
 
 #include "hal.h"
@@ -32,6 +33,7 @@
 
 #include "timers_driver.h"
 #include "hal/watchdog_driver.h"
+#include "os/time.h"
 
 #include <memory>
 
@@ -157,9 +159,9 @@ void MultiFirmwareUpdateDriver::deinit()
 
 bool MultiFirmwareUpdateDriver::getRxByte(uint8_t & byte) const
 {
-  uint32_t time = RTOS_GET_MS();
+  uint32_t time = time_get_ms();
   
-  while ((RTOS_GET_MS() - time) < 100) {              // 100ms
+  while ((time_get_ms() - time) < 100) {              // 100ms
     if (getByte(byte)) {
 #if defined(DEBUG_EXT_MODULE_FLASH)
       TRACE("[RX] 0x%X", byte);
@@ -220,7 +222,7 @@ const char * MultiFirmwareUpdateDriver::waitForInitialSync()
   // avoids sending STK_READ_SIGN with STK_OK
   // in case the receiver is too slow changing
   // to RX mode (half-duplex).
-  RTOS_WAIT_TICKS(1);
+  sleep_ms(1);
 
   return nullptr;
 }
@@ -258,7 +260,7 @@ const char * MultiFirmwareUpdateDriver::loadAddress(uint32_t offset) const
 
   // avoids sending next page back-to-back with STK_OK
   // in case the receiver is to slow changing to RX mode (half-duplex).
-  RTOS_WAIT_TICKS(1);
+  sleep_ms(1);
 
   return nullptr;
 }
@@ -310,8 +312,7 @@ const char* MultiFirmwareUpdateDriver::flashFirmware(
 #if defined(SIMU)
   for (uint16_t i = 0; i < 100; i++) {
     progressHandler(label, STR_WRITING, i, 100);
-    if (SIMU_SLEEP_OR_EXIT_MS(30))
-      break;
+    sleep_ms(30);
   }
   return nullptr;
 #endif
@@ -321,7 +322,7 @@ const char* MultiFirmwareUpdateDriver::flashFirmware(
 
   /* wait 500ms for power on */
   watchdogSuspend(500 /*5s*/);
-  RTOS_WAIT_MS(500);
+  sleep_ms(500);
 
   result = waitForInitialSync();
   if (result) {
@@ -553,7 +554,7 @@ bool MultiDeviceFirmwareUpdate::flashFirmware(const char * filename, ProgressHan
 
   /* wait 2s off */
   watchdogSuspend(500 /*5s*/);
-  RTOS_WAIT_MS(3000);
+  sleep_ms(3000);
 
   MultiFirmwareUpdateDriver driver(module, type);
   const char * result = driver.flashFirmware(&file, getBasename(filename), progressHandler);

--- a/radio/src/io/multi_protolist.cpp
+++ b/radio/src/io/multi_protolist.cpp
@@ -29,30 +29,20 @@
 #include "gui_common.h"
 
 #include "edgetx.h" // reusableBuffer
+#include "os/time.h"
 
 #include <algorithm>
 
-#if !defined(SIMU)
+static timer_handle_t _protoScanTimers[NUM_MODULES] = {TIMER_INITIALIZER};
 
-#include <FreeRTOS/include/FreeRTOS.h>
-#include <FreeRTOS/include/timers.h>
-
-struct ProtoScanTimer {
-  TimerHandle_t timer = nullptr;
-  StaticTimer_t timerBuffer;
-};
-
-static ProtoScanTimer _protoScanTimers[NUM_MODULES];
-
-void MultiRfProtocols::timerCb(TimerHandle_t xTimer)
+void MultiRfProtocols::timerCb(timer_handle_t* h)
 {
-  uint8_t moduleIdx = (uint8_t)(uintptr_t)pvTimerGetTimerID(xTimer);
+  uint8_t moduleIdx = (uint8_t)(h - _protoScanTimers);
   auto instance = MultiRfProtocols::instance(moduleIdx);
   if (instance->scanState == ScanBegin || instance->scanState == Scanning) {
     instance->fillBuiltinProtos();
   }
 }
-#endif
 
 MultiRfProtocols* MultiRfProtocols::_instance[MAX_MODULES] = {};
 
@@ -201,7 +191,7 @@ float MultiRfProtocols::getProgress() const
   
   if (scanState == ScanStop)  return 0.0;
   if (scanState == ScanBegin) {
-    float t = (float)(RTOS_GET_MS() - scanStart) / (float)MULTI_PROTOLIST_START_TIMEOUT;
+    float t = (float)(time_get_ms() - scanStart) / (float)MULTI_PROTOLIST_START_TIMEOUT;
     return t * WAIT_TIME_RATIO;
   }
 
@@ -225,29 +215,17 @@ bool MultiRfProtocols::triggerScan()
     scanState = ScanBegin;
     currentProto = MULTI_INVALID_PROTO;
     moduleState[moduleIdx].mode = MODULE_MODE_GET_HARDWARE_INFO;
-    scanStart = lastScan = RTOS_GET_MS();
+    scanStart = lastScan = time_get_ms();
 
-#if !defined(SIMU)
     auto scanTimer = &_protoScanTimers[moduleIdx];
-    if (!scanTimer->timer) {
-      scanTimer->timer = xTimerCreateStatic(
-          "MPM", MULTI_PROTOLIST_START_TIMEOUT / RTOS_MS_PER_TICK, pdTRUE,
-          (void*)moduleIdx, MultiRfProtocols::timerCb, &scanTimer->timerBuffer);
+    if (!timer_is_created(scanTimer)) {
+      timer_create(scanTimer, MultiRfProtocols::timerCb, "mpm",
+                   MULTI_PROTOLIST_START_TIMEOUT, false);
+      timer_start(scanTimer);
     } else {
-      if (xTimerChangePeriod(scanTimer->timer,
-          MULTI_PROTOLIST_START_TIMEOUT / RTOS_MS_PER_TICK,
-          0) != pdPASS) {
-          /* The timer period could not be reset. */
-      }
+      timer_set_period(scanTimer, MULTI_PROTOLIST_START_TIMEOUT);
     }
 
-    if (scanTimer->timer) {
-      if( xTimerStart( scanTimer->timer, 0 ) != pdPASS ) {
-        /* The timer could not be set into the Active state. */
-      }
-    }
-#endif
-    
     return true;
   }
 
@@ -291,32 +269,18 @@ bool MultiRfProtocols::scanReply(const uint8_t* packet, uint8_t len)
           }
 
           currentProto++;
-          lastScan = RTOS_GET_MS();
+          lastScan = time_get_ms();
 
-#if !defined(SIMU)
           auto scanTimer = &_protoScanTimers[moduleIdx];
-          if (scanTimer->timer) {
-            if (xTimerChangePeriod(scanTimer->timer,
-                                   MULTI_PROTOLIST_TIMEOUT / RTOS_MS_PER_TICK,
-                                   0) != pdPASS) {
-              /* The timer period could not be reset. */
-            }
-          }
-#endif
+          timer_set_period(scanTimer, MULTI_PROTOLIST_TIMEOUT);
+
           return true;
 
         } else {
           scanState = ScanEnd;
           setModuleMode(moduleIdx, MODULE_MODE_NORMAL);
-
-#if !defined(SIMU)
           auto scanTimer = &_protoScanTimers[moduleIdx];
-          if (scanTimer->timer) {
-            if (xTimerStop(scanTimer->timer, 0) != pdPASS) {
-              /* The timer period could not be stopped. */
-            }
-          }
-#endif
+          timer_stop(scanTimer);
           break;
         }
       } else {
@@ -328,7 +292,7 @@ bool MultiRfProtocols::scanReply(const uint8_t* packet, uint8_t len)
           timeout = MULTI_PROTOLIST_START_TIMEOUT;
         }
 
-        if (RTOS_GET_MS() - lastScan >= timeout) {
+        if (time_get_ms() - lastScan >= timeout) {
           TRACE("proto scan timeout!");
           scanState = ScanInvalid;
         }

--- a/radio/src/io/multi_protolist.h
+++ b/radio/src/io/multi_protolist.h
@@ -22,16 +22,12 @@
 #include "dataconstants.h"
 #include "edgetx_types.h"
 
+#include "os/timer.h"
+
 #include <functional>
 #include <string>
 #include <vector>
 #include <map>
-
-#if !defined(SIMU)
-// Forward declare FreeRTOS timer
-struct tmrTimerControl;
-typedef struct tmrTimerControl * TimerHandle_t;
-#endif
 
 class MultiRfProtocols
 {
@@ -51,9 +47,7 @@ class MultiRfProtocols
   MultiRfProtocols(unsigned int moduleIdx);
   void fillBuiltinProtos();
 
-#if !defined(SIMU)
-  static void timerCb(TimerHandle_t xTimer);
-#endif
+  static void timerCb(timer_handle_t* h);
   
  public:
 

--- a/radio/src/lua/lua_widget.cpp
+++ b/radio/src/lua/lua_widget.cpp
@@ -28,6 +28,7 @@
 
 #include "touch.h"
 #include "view_main.h"
+#include "os/time.h"
 
 #define MAX_INSTRUCTIONS (20000 / 100)
 
@@ -117,11 +118,11 @@ void LuaEventHandler::event_cb(lv_event_t* e)
       _startX = rel_pos.x;
       _startY = rel_pos.y;
 
-      downTime = RTOS_GET_MS();
+      downTime = time_get_ms();
     }
   } else if (code == LV_EVENT_RELEASED) {
     // tap count handling
-    uint32_t now = RTOS_GET_MS();
+    uint32_t now = time_get_ms();
     if (now - downTime <= LUA_TAP_TIME) {
       if (now - tapTime > LUA_TAP_TIME) {
         tapCount = 1;

--- a/radio/src/main.cpp
+++ b/radio/src/main.cpp
@@ -465,9 +465,8 @@ void guiMain(event_t evt)
 }
 #endif
 
-#if !defined(SIMU)
+// from logs.cpp
 void initLoggingTimer();
-#endif
 
 void perMain()
 {
@@ -477,12 +476,7 @@ void perMain()
 
   if (!usbPlugged() || (getSelectedUsbMode() == USB_UNSELECTED_MODE)) {
     checkStorageUpdate();
-
-#if !defined(SIMU)       // use FreeRTOS software timer if radio firmware
     initLoggingTimer();  // initialize software timer for logging
-#else
-    logsWrite();  // call logsWrite the old way for simu
-#endif
   }
 
   handleUsbConnection();

--- a/radio/src/mixer_scheduler.cpp
+++ b/radio/src/mixer_scheduler.cpp
@@ -19,10 +19,12 @@
  * GNU General Public License for more details.
  */
 
-#include "edgetx.h"
 #include "mixer_scheduler.h"
 #include "tasks/mixer_task.h"
 #include "hal/usb_driver.h"
+
+#include "dataconstants.h"
+#include <string.h>
 
 bool mixerSchedulerWaitForTrigger(uint8_t timeoutMs)
 {
@@ -111,10 +113,10 @@ void mixerSchedulerISRTrigger()
 
   /* At this point xTaskToNotify should not be NULL as
      a transmission was in progress. */
-  configASSERT( mixerTaskId.rtos_handle != NULL );
+  configASSERT( mixerTaskId._rtos_handle != NULL );
 
   /* Notify the task that the transmission is complete. */
-  vTaskNotifyGiveFromISR( mixerTaskId.rtos_handle,
+  vTaskNotifyGiveFromISR( mixerTaskId._rtos_handle,
                           &xHigherPriorityTaskWoken );
 
   /* If xHigherPriorityTaskWoken is now set to pdTRUE then a

--- a/radio/src/os/async.h
+++ b/radio/src/os/async.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+typedef void (*async_func_t)(void* param1, uint32_t param2);
+
+// schedule a function call for later
+// return true if the async call could be stacked, false otherwise
+bool async_call(async_func_t func, volatile bool* excl_flag, void* param1,
+                uint32_t param2);
+
+// schedule a function call for later (interrupt handler)
+bool async_call_isr(async_func_t func, volatile bool* excl_flag, void* param1,
+                    uint32_t param2);

--- a/radio/src/os/async_freertos.cpp
+++ b/radio/src/os/async_freertos.cpp
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "async.h"
+
+#include <FreeRTOS/include/FreeRTOS.h>
+#include <FreeRTOS/include/timers.h>
+
+bool async_call(async_func_t func, volatile bool* excl_flag, void* param1,
+                uint32_t param2)
+{
+  if (xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED) {
+
+    // check exclusive flag first
+    if (excl_flag && *excl_flag) return false;
+
+    BaseType_t xReturn = xTimerPendFunctionCall(func, param1, param2, 0);
+
+    // update exclusive flag if provided
+    if (excl_flag && (xReturn == pdPASS)) *excl_flag = true;
+
+    return xReturn == pdPASS;
+  }
+
+  func(param1, param2);
+  return true;
+}
+
+bool async_call_isr(async_func_t func, volatile bool* excl_flag, void* param1,
+                    uint32_t param2)
+{
+  BaseType_t xHigherPriorityTaskWoken = pdFALSE;
+  if (xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED) {
+
+    // check exclusive flag first
+    if (excl_flag && *excl_flag) return false;
+
+    BaseType_t xReturn = xTimerPendFunctionCallFromISR(
+        func, param1, param2, &xHigherPriorityTaskWoken);
+
+    // update exclusive flag if provided
+    if (excl_flag && (xReturn == pdPASS)) *excl_flag = true;
+
+    portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
+    return xReturn == pdPASS;
+  }
+
+  func(param1, param2);
+  return true;
+}

--- a/radio/src/os/async_native.cpp
+++ b/radio/src/os/async_native.cpp
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "async.h"
+#include "timer_pthread_impl.h"
+
+bool async_call(async_func_t func, volatile bool* excl_flag, void* param1,
+                uint32_t param2)
+{
+  if (excl_flag && *excl_flag) return false;
+  timer_queue::instance().pend_function(func, param1, param2);
+  if (excl_flag) *excl_flag = true;
+  return true;
+}
+
+bool async_call_isr(async_func_t func, volatile bool* excl_flag, void* param1,
+                    uint32_t param2)
+{
+  return async_call(func, excl_flag, param1, param2);
+}

--- a/radio/src/os/sleep.h
+++ b/radio/src/os/sleep.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include "time.h"
+
+void sleep_ms(uint32_t ms);
+void sleep_until(time_point_t* tp, uint32_t ts_ms);

--- a/radio/src/os/sleep_freertos.cpp
+++ b/radio/src/os/sleep_freertos.cpp
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "sleep.h"
+
+#include <FreeRTOS/include/FreeRTOS.h>
+#include <FreeRTOS/include/task.h>
+    
+void sleep_ms(uint32_t ms)
+{
+  if (!ms) return;
+
+  ms /= portTICK_PERIOD_MS;
+  if (!ms) ms = 1;
+
+  vTaskDelay(ms);
+}
+
+void sleep_until(time_point_t* tp, uint32_t inc)
+{
+  inc /= portTICK_PERIOD_MS;
+  vTaskDelayUntil(tp, inc);
+}

--- a/radio/src/os/sleep_native.cpp
+++ b/radio/src/os/sleep_native.cpp
@@ -1,0 +1,37 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "sleep.h"
+
+#include <thread>
+
+extern uint8_t simuSleep(uint32_t ms);
+
+void sleep_ms(uint32_t ms)
+{
+  simuSleep(ms);
+}
+
+void sleep_until(time_point_t* tp, uint32_t inc)
+{
+  *tp += std::chrono::duration<uint32_t, std::milli>{inc};
+  std::this_thread::sleep_until(*tp);
+}

--- a/radio/src/os/sleep_nortos.cpp
+++ b/radio/src/os/sleep_nortos.cpp
@@ -19,19 +19,23 @@
  * GNU General Public License for more details.
  */
 
-#pragma once
+#include "sleep.h"
 
-#include <stdint.h>
+#include "timers_driver.h"
+    
+void sleep_ms(uint32_t ms)
+{
+  if (!ms) return;
 
-// OS specific implementation
-#if defined(POSIX_THREADS)
-  #include "time_native.h"
-#elif defined(FREE_RTOS)
-  #include "time_freertos.h"
-#else
-  #include "time_nortos.h"
-#endif
+  uint32_t timeout = timersGetMsTick();
+  while (timersGetMsTick() - timeout < ms) {}
+}
 
-uint32_t time_get_ms();
+void sleep_until(time_point_t* tp, uint32_t inc)
+{
+  uint32_t start = *tp;
+  *tp = start + inc;
 
-time_point_t time_point_now();
+  while (timersGetMsTick() - start < inc) {}
+}
+

--- a/radio/src/os/task.h
+++ b/radio/src/os/task.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+// OS specific implementation
+#if defined(POSIX_THREADS)
+  #include "task_pthread.h"
+#elif defined(FREE_RTOS)
+  #include "task_freertos.h"
+#endif
+
+typedef void (*task_func_t)();
+
+void task_create(task_handle_t* h, task_func_t func, const char* name,
+                 void* stack, unsigned stack_size, unsigned priority);
+
+unsigned task_get_stack_usage(task_handle_t* h);
+unsigned task_get_stack_size(task_handle_t* h);
+
+void mutex_create(mutex_handle_t* h);
+bool mutex_lock(mutex_handle_t* h);
+void mutex_unlock(mutex_handle_t* h);
+bool mutex_trylock(mutex_handle_t* h);
+

--- a/radio/src/os/task_freertos.cpp
+++ b/radio/src/os/task_freertos.cpp
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "task.h"
+
+static void _task_stub(void* p)
+{
+  task_func_t func = (task_func_t)p;
+  func();
+}
+
+void task_create(task_handle_t* h, task_func_t func, const char* name,
+                 void* stack, unsigned stack_size, unsigned priority)
+{
+  h->_stack_size = stack_size;
+  h->_rtos_handle =
+      xTaskCreateStatic(_task_stub, name, stack_size, (void*)func, priority,
+                        (StackType_t*)stack, &h->_task_struct);
+}
+
+unsigned task_get_stack_usage(task_handle_t* h)
+{
+  return uxTaskGetStackHighWaterMark(h->_rtos_handle);
+}
+
+unsigned task_get_stack_size(task_handle_t* h)
+{
+  return h->_stack_size * sizeof(StackType_t);
+}
+
+void mutex_create(mutex_handle_t* h)
+{
+  h->_rtos_handle = xSemaphoreCreateMutexStatic(&h->_mutex_struct);
+  mutex_unlock(h);
+}
+
+static inline bool _lock_mutex(mutex_handle_t* h, TickType_t xTickToWait)
+{
+  return xSemaphoreTake(h->_rtos_handle, xTickToWait) == pdTRUE;
+}
+
+bool mutex_lock(mutex_handle_t* h) { return _lock_mutex(h, portMAX_DELAY); }
+bool mutex_trylock(mutex_handle_t* h) { return _lock_mutex(h, (TickType_t)0); }
+void mutex_unlock(mutex_handle_t* h) { xSemaphoreGive(h->_rtos_handle); }

--- a/radio/src/os/task_freertos.h
+++ b/radio/src/os/task_freertos.h
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include <FreeRTOS/include/FreeRTOS.h>
+#include <FreeRTOS/include/task.h>
+#include <FreeRTOS/include/semphr.h>
+
+#include "definitions.h"
+
+#define TASK_DEFINE_STACK(name, size) StackType_t __ALIGNED(8) name[size] __CCMRAM
+
+struct task_handle_t {
+  TaskHandle_t _rtos_handle;
+  StaticTask_t _task_struct;
+  uint32_t     _stack_size;
+};
+
+struct mutex_handle_t {
+  SemaphoreHandle_t _rtos_handle;
+  StaticSemaphore_t _mutex_struct;
+};

--- a/radio/src/os/task_pthread.cpp
+++ b/radio/src/os/task_pthread.cpp
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "task.h"
+
+static void* _task_stub(void* p)
+{
+  task_func_t func = (task_func_t)p;
+  func();
+  return nullptr;
+}
+
+void task_create(task_handle_t* h, task_func_t func, const char* name,
+                 void* stack, unsigned stack_size, unsigned priority)
+{
+  h->_stack_size = stack_size;
+  pthread_create(&h->_thread_handle, nullptr, _task_stub, (void*)func);
+}
+
+unsigned task_get_stack_usage(task_handle_t* h)
+{
+  // fake...
+  return 0;
+}
+
+unsigned task_get_stack_size(task_handle_t* h)
+{
+  return h->_stack_size * 4;
+}
+
+void mutex_create(mutex_handle_t* h)
+{
+  *h = PTHREAD_MUTEX_INITIALIZER;
+}
+
+bool mutex_lock(mutex_handle_t* h)
+{
+  return pthread_mutex_lock(h) == 0;
+}
+
+void mutex_unlock(mutex_handle_t* h)
+{
+  pthread_mutex_unlock(h);
+}
+
+bool mutex_trylock(mutex_handle_t* h)
+{
+  return pthread_mutex_trylock(h) == 0;
+}
+
+

--- a/radio/src/os/task_pthread.h
+++ b/radio/src/os/task_pthread.h
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include <pthread.h>
+#include <semaphore.h>
+
+#include "definitions.h"
+
+#define TASK_DEFINE_STACK(name, size) void* name
+
+struct task_handle_t {
+  pthread_t _thread_handle;
+  uint32_t  _stack_size;
+};
+
+typedef pthread_mutex_t mutex_handle_t;

--- a/radio/src/os/time.h
+++ b/radio/src/os/time.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include <stdint.h>
+
+// OS specific implementation
+#if defined(POSIX_THREADS)
+  #include "time_native.h"
+#elif defined(FREE_RTOS)
+  #include "time_freertos.h"
+#endif
+
+uint32_t time_get_ms();
+
+time_point_t time_point_now();

--- a/radio/src/os/time_freertos.cpp
+++ b/radio/src/os/time_freertos.cpp
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "time.h"
+
+#include <FreeRTOS/include/FreeRTOS.h>
+#include <FreeRTOS/include/task.h>
+
+uint32_t time_get_ms()
+{
+  return xTaskGetTickCount() / portTICK_PERIOD_MS;
+}
+
+time_point_t time_point_now()
+{
+  return xTaskGetTickCount();
+}

--- a/radio/src/os/time_freertos.h
+++ b/radio/src/os/time_freertos.h
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include <FreeRTOS/include/FreeRTOS.h>
+
+typedef TickType_t time_point_t;

--- a/radio/src/os/time_native.cpp
+++ b/radio/src/os/time_native.cpp
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "time.h"
+
+#include <chrono>
+
+extern uint64_t simuTimerMicros(void);
+
+uint32_t time_get_ms()
+{
+  return simuTimerMicros() / 1000;
+}
+
+time_point_t time_point_now()
+{
+  return std::chrono::steady_clock::now();
+}

--- a/radio/src/os/time_native.h
+++ b/radio/src/os/time_native.h
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include <chrono>
+
+typedef std::chrono::time_point<std::chrono::steady_clock> time_point_t;
+

--- a/radio/src/os/time_nortos.cpp
+++ b/radio/src/os/time_nortos.cpp
@@ -19,19 +19,17 @@
  * GNU General Public License for more details.
  */
 
-#pragma once
+#include "time.h"
 
-#include <stdint.h>
+#include "timers_driver.h"
 
-// OS specific implementation
-#if defined(POSIX_THREADS)
-  #include "time_native.h"
-#elif defined(FREE_RTOS)
-  #include "time_freertos.h"
-#else
-  #include "time_nortos.h"
-#endif
+uint32_t time_get_ms()
+{
+  return timersGetMsTick();
+}
 
-uint32_t time_get_ms();
+time_point_t time_point_now()
+{
+  return time_get_ms();
+}
 
-time_point_t time_point_now();

--- a/radio/src/os/time_nortos.h
+++ b/radio/src/os/time_nortos.h
@@ -23,15 +23,5 @@
 
 #include <stdint.h>
 
-// OS specific implementation
-#if defined(POSIX_THREADS)
-  #include "time_native.h"
-#elif defined(FREE_RTOS)
-  #include "time_freertos.h"
-#else
-  #include "time_nortos.h"
-#endif
+typedef uint32_t time_point_t;
 
-uint32_t time_get_ms();
-
-time_point_t time_point_now();

--- a/radio/src/os/timer.h
+++ b/radio/src/os/timer.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include <stdint.h>
+#include <stdbool.h>
+
+// OS specific implementation
+#if defined(POSIX_THREADS)
+  #include "timer_pthread.h"
+#elif defined(FREE_RTOS)
+  #include "timer_freertos.h"
+#endif
+
+typedef void (*timer_func_t)(timer_handle_t*);
+
+int timer_create(timer_handle_t* h, timer_func_t func, const char* name,
+                 unsigned period, bool repeat);
+
+bool timer_is_created(timer_handle_t* h);
+bool timer_is_active(timer_handle_t* h);
+
+int timer_start(timer_handle_t* h);
+int timer_stop(timer_handle_t* h);
+
+int timer_set_period(timer_handle_t* h, unsigned period);

--- a/radio/src/os/timer_freertos.cpp
+++ b/radio/src/os/timer_freertos.cpp
@@ -1,0 +1,70 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "timer.h"
+
+static void _timer_cb(TimerHandle_t xTimer)
+{
+  timer_handle_t* h = (timer_handle_t*)pvTimerGetTimerID(xTimer);
+  if (h->_func) h->_func(h);
+}
+
+int timer_create(timer_handle_t* h, timer_func_t func, const char* name,
+                  unsigned period, bool repeat)
+{
+  if (h->_rtos_handle) return -1;
+  h->_rtos_handle = xTimerCreateStatic(name, period / portTICK_PERIOD_MS,
+                                       repeat ? pdTRUE : pdFALSE, (void*)h,
+                                       _timer_cb, &h->_timer_struct);
+  h->_func = func;
+  return 0;
+}
+
+bool timer_is_created(timer_handle_t* h)
+{
+  return h->_rtos_handle != nullptr;  
+}
+
+bool timer_is_active(timer_handle_t* h)
+{
+  return (h->_rtos_handle != nullptr) && (xTimerIsTimerActive(h->_rtos_handle));
+}
+
+int timer_start(timer_handle_t* h)
+{
+  if (!h->_rtos_handle) return -1;
+  return xTimerStart(h->_rtos_handle, 0) == pdPASS ? 0 : -1;
+}
+
+int timer_stop(timer_handle_t* h)
+{
+  if (!h->_rtos_handle) return -1;
+  return xTimerStop(h->_rtos_handle, 0) == pdPASS ? 0 : -1;
+}
+
+int timer_set_period(timer_handle_t* h, unsigned period)
+{
+  if (!h->_rtos_handle) return -1;
+  return xTimerChangePeriod(h->_rtos_handle, period / portTICK_PERIOD_MS, 0) ==
+                 pdPASS
+             ? 0
+             : -1;
+}

--- a/radio/src/os/timer_freertos.h
+++ b/radio/src/os/timer_freertos.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include <FreeRTOS/include/FreeRTOS.h>
+#include <FreeRTOS/include/timers.h>
+
+struct timer_handle_t;
+
+struct timer_handle_t {
+  TimerHandle_t _rtos_handle;
+  StaticTimer_t _timer_struct;
+  void (*_func)(timer_handle_t*);
+};
+
+#define TIMER_INITIALIZER { ._rtos_handle = nullptr }

--- a/radio/src/os/timer_pthread.cpp
+++ b/radio/src/os/timer_pthread.cpp
@@ -1,0 +1,215 @@
+#include "timer.h"
+#include "timer_pthread_impl.h"
+
+#include <algorithm>
+
+bool _timer_cmp(timer_handle_t *lh, timer_handle_t *rh) {
+  return lh->next_trigger < rh->next_trigger;
+}
+
+timer_queue::timer_queue() {}
+
+void timer_queue::update_current_time() {
+  _current_time = std::chrono::steady_clock::now();
+}
+
+void timer_queue::sort_timers() {
+  std::sort(_timers.begin(), _timers.end(), _timer_cmp);
+}
+
+timer_queue& timer_queue::instance()
+{
+  static timer_queue _instance;
+  return _instance;
+}
+
+void timer_queue::start()
+{
+  std::lock_guard<std::mutex> lock(_cmds_mutex);
+  if (!_running) {
+    _running = true;
+    _thread = std::make_unique<std::thread>([&]() { main_loop(); });
+  }
+}
+
+void timer_queue::stop() {
+  bool stopping = false;
+
+  std::unique_lock<std::mutex> lock(_cmds_mutex);
+  std::unique_lock<std::mutex> slock(_stop_mutex);
+
+  if (_running) {
+    stopping = true;
+    _running = false;
+    lock.unlock();
+    _cmds_condition.notify_one();
+    _stop_condition.wait(slock);
+    slock.unlock();
+  }
+  _thread->join();
+}
+
+void timer_queue::create_timer(timer_handle_t *timer, timer_func_t func, const char *name,
+                            unsigned period, bool repeat) {
+  timer->func = func;
+  timer->name = name;
+  timer->period = period;
+  timer->repeat = repeat;
+  timer->next_trigger = time_point_t{};
+}
+
+void timer_queue::send_cmd(timer_req_t&& req)
+{
+  {
+    std::lock_guard lock(_cmds_mutex);
+    _cmds.emplace_back(req);
+  }
+  _cmds_condition.notify_one();
+}
+
+void timer_queue::start_timer(timer_handle_t *timer) {
+  send_cmd(timer_req_t{.cmd = timer_req_t::cmd_start, .timer = timer});
+}
+
+void timer_queue::stop_timer(timer_handle_t *timer) {
+  send_cmd(timer_req_t{.cmd = timer_req_t::cmd_stop, .timer = timer});
+}
+
+void timer_queue::pend_function(timer_async_func_t func, void *param1,
+                                uint32_t param2) {
+  send_cmd(timer_req_t{
+      .cmd = timer_req_t::cmd_pend_func,
+      .func_call = {.func = func, .param1 = param1, .param2 = param2}});
+}
+
+void timer_queue::main_loop() {
+
+  while (true) {
+    {
+      std::unique_lock lock(_cmds_mutex);
+      time_point_t until;
+      
+      update_current_time();
+      process_cmds();
+
+      if (_timers.size() > 0) {
+        timer_handle_t* t = _timers[0];
+        until = t->next_trigger;
+      } else {
+        until = _current_time + std::chrono::milliseconds(1000);
+      }
+
+      std::cv_status result = _cmds_condition.wait_until(lock, until);
+      if (!_running) break;
+    }
+
+    async_calls();
+    trigger_timers();
+  }
+
+  _stop_condition.notify_one();
+}
+
+void timer_queue::process_cmds()
+{
+  while (!_cmds.empty()) {
+    timer_req_t req = _cmds.back();
+    _cmds.pop_back();
+
+    if (req.cmd == timer_req_t::cmd_pend_func) {
+      if (req.func_call.func) {
+        _funcs.emplace_back(std::move(req.func_call));
+      }
+    } else {
+      timer_handle_t *t = req.timer;
+      auto pos = std::find(_timers.begin(), _timers.end(), t);
+      switch (req.cmd) {
+      case timer_req_t::cmd_start:
+        t->next_trigger = _current_time + std::chrono::milliseconds(t->period);
+        t->active = true;
+        if (pos == _timers.end()) {
+          _timers.emplace_back(t);
+        }
+        break;
+
+      case timer_req_t::cmd_stop:
+        if (pos != _timers.end()) {
+          _timers.erase(pos);
+        }
+        break;
+
+      default:
+        break;
+      }
+    }
+  }
+}
+
+void timer_queue::trigger_timers() {
+  int triggered = 0;
+  for (auto t : _timers) {
+    if (t->next_trigger <= _current_time) {
+      if (t->repeat) {
+        t->next_trigger += std::chrono::milliseconds(t->period);
+      } else {
+        t->active = false;
+        stop_timer(t);
+      }
+      t->func(t);
+      triggered++;
+    } else {
+      break;
+    }
+  }
+
+  if (triggered) {
+    sort_timers();
+  }
+}
+
+void timer_queue::async_calls() {
+  for (auto f : _funcs) {
+    f.func(f.param1, f.param2);
+  }
+  _funcs.clear();
+}
+
+int timer_create(timer_handle_t* h, timer_func_t func, const char* name,
+                 unsigned period, bool repeat)
+{
+  if (!h || !func) return -1;
+  timer_queue::create_timer(h, func, name, period, repeat);
+  return 0;
+}
+
+bool timer_is_created(timer_handle_t* h)
+{
+  return h && h->func;
+}
+
+bool timer_is_active(timer_handle_t* h)
+{
+  return h && h->active;
+}
+
+int timer_start(timer_handle_t* h)
+{
+  if (!timer_is_created(h)) return -1;
+  timer_queue::instance().start_timer(h);
+  return 0;
+}
+
+int timer_stop(timer_handle_t* h)
+{
+  if (!timer_is_created(h)) return -1;
+  timer_queue::instance().stop_timer(h);
+  return 0; 
+}
+
+int timer_set_period(timer_handle_t *h, unsigned period)
+{
+  if (!timer_is_created(h)) return -1;
+  h->period = period;
+  timer_queue::instance().start_timer(h);
+  return 0;
+}

--- a/radio/src/os/timer_pthread.h
+++ b/radio/src/os/timer_pthread.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include "time.h"
+
+#include <atomic>
+
+struct timer_handle_t;
+typedef void (*timer_func_t)(timer_handle_t*);
+typedef void (*timer_async_func_t)(void*, uint32_t);
+
+using time_point = std::chrono::time_point<std::chrono::steady_clock>;
+
+struct timer_handle_t {
+  timer_func_t func;
+  const char*  name;
+  unsigned     period;
+  bool         repeat;
+
+  time_point_t next_trigger;
+  std::atomic_bool active;
+};
+
+#define TIMER_INITIALIZER {}
+

--- a/radio/src/os/timer_pthread_impl.h
+++ b/radio/src/os/timer_pthread_impl.h
@@ -1,0 +1,74 @@
+#include "timer_pthread.h"
+
+#include <condition_variable>
+#include <deque>
+#include <memory>
+#include <mutex>
+#include <thread>
+#include <vector>
+
+struct timer_async_call_t {
+  timer_async_func_t func;
+  void *param1;
+  uint32_t param2;
+};
+
+struct timer_req_t {
+  enum type {
+    cmd_start,
+    cmd_stop,
+    cmd_pend_func,
+  };
+
+  type cmd;
+
+  union {
+    timer_handle_t *timer;
+    timer_async_call_t func_call;
+  };
+};
+
+class timer_queue {
+
+  std::unique_ptr<std::thread> _thread;
+  bool _running;
+
+  std::deque<timer_req_t> _cmds;
+  std::mutex _cmds_mutex;
+  std::condition_variable _cmds_condition;
+
+  std::mutex _stop_mutex;
+  std::condition_variable _stop_condition;
+
+  std::vector<timer_handle_t*> _timers;
+  std::vector<timer_async_call_t> _funcs;
+
+  time_point_t _current_time;
+  
+  timer_queue();
+
+  void update_current_time();
+  void sort_timers();
+  void main_loop();
+  void trigger_timers();
+  void async_calls();
+  void process_cmds();
+  void send_cmd(timer_req_t&& req);
+
+public:
+  timer_queue(timer_queue const &) = delete;
+  void operator=(timer_queue const &) = delete;
+
+  static timer_queue &instance();
+
+  static void create_timer(timer_handle_t *timer, timer_func_t func, const char *name,
+                           unsigned period, bool repeat);
+
+  void start();
+  void stop();
+
+  void start_timer(timer_handle_t *timer);
+  void stop_timer(timer_handle_t *timer);
+
+  void pend_function(timer_async_func_t func, void* param1, uint32_t param2);
+};

--- a/radio/src/pulses/pxx2_ota.cpp
+++ b/radio/src/pulses/pxx2_ota.cpp
@@ -21,6 +21,7 @@
 
 #include "edgetx.h"
 #include "io/frsky_firmware_update.h"
+#include "os/sleep.h"
 #include "tasks/mixer_task.h"
 
 #include "pxx2_ota.h"
@@ -37,7 +38,7 @@ bool Pxx2OtaUpdate::waitStep(uint8_t step, uint8_t timeout)
     if (elapsed++ > timeout) {
       return false;
     }
-    RTOS_WAIT_MS(1);
+    sleep_ms(1);
     telemetryWakeup();
   }
 
@@ -135,7 +136,7 @@ void Pxx2OtaUpdate::flashFirmware(const char * filename, ProgressHandler progres
   mixerTaskStop();
 
   watchdogSuspend(100 /*1s*/);
-  RTOS_WAIT_MS(100);
+  sleep_ms(100);
 
   moduleState[module].mode = MODULE_MODE_OTA_UPDATE;
   const char * result = doFlashFirmware(filename, progressHandler);
@@ -152,7 +153,7 @@ void Pxx2OtaUpdate::flashFirmware(const char * filename, ProgressHandler progres
   }
 
   watchdogSuspend(100);
-  RTOS_WAIT_MS(100);
+  sleep_ms(100);
 
   mixerTaskStart();
 }

--- a/radio/src/rtos.h
+++ b/radio/src/rtos.h
@@ -32,199 +32,24 @@ extern "C++" {
   #include <pthread.h>
   #include <semaphore.h>
 
-  #define SIMU_SLEEP_OR_EXIT_MS(x)       simuSleep(x)
-  #define RTOS_MS_PER_TICK  1
-
-  typedef pthread_t RTOS_TASK_HANDLE;
-  typedef pthread_mutex_t RTOS_MUTEX_HANDLE;
-
-  typedef uint32_t RTOS_FLAG_HANDLE;
-
-  typedef sem_t * RTOS_EVENT_HANDLE;
-
-  extern uint64_t simuTimerMicros(void);
-  extern uint8_t simuSleep(uint32_t ms);
-
   static inline void RTOS_START()
   {
   }
 
-  static inline void RTOS_WAIT_MS(uint32_t x)
-  {
-    simuSleep(x);
-  }
-
-  static inline void RTOS_WAIT_TICKS(uint32_t x)
-  {
-    RTOS_WAIT_MS(x * RTOS_MS_PER_TICK);
-  }
-
-#ifdef __cplusplus
-  static inline void RTOS_CREATE_MUTEX(pthread_mutex_t &mutex)
-  {
-    mutex = PTHREAD_MUTEX_INITIALIZER;
-  }
-
-  static inline bool RTOS_LOCK_MUTEX(pthread_mutex_t &mutex)
-  {
-      return pthread_mutex_lock(&mutex) == 0;
-  }
-
-  static inline bool RTOS_TRYLOCK_MUTEX(pthread_mutex_t &mutex)
-  {
-      return pthread_mutex_trylock(&mutex) == 0;
-  }
-
-  static inline void RTOS_UNLOCK_MUTEX(pthread_mutex_t &mutex)
-  {
-      pthread_mutex_unlock(&mutex);
-  }
-
-  template<int SIZE>
-  class TaskStack
-  {
-    public:
-      TaskStack()
-      {
-      }
-
-      void paint()
-      {
-      }
-
-      uint32_t size()
-      {
-        return SIZE;
-      }
-
-      uint32_t available()
-      {
-        return SIZE / 2;
-      }
-  };
-  #define RTOS_DEFINE_STACK(taskHandle, name, size) TaskStack<size> name
-
-  #define TASK_FUNCTION(task)           void* task(void *)
-
-  inline void RTOS_CREATE_TASK(pthread_t &taskId, void * (*task)(void *), const char * name)
-  {
-    pthread_create(&taskId, nullptr, task, nullptr);
-#ifdef __linux__
-    pthread_setname_np(taskId, name);
-#endif
-  }
-
-  template <int SIZE>
-  inline void RTOS_CREATE_TASK(pthread_t &taskId, void *(*task)(void *),
-                               const char *name, TaskStack<SIZE> &,
-                               unsigned size = 0, unsigned priority = 0)
-  {
-    (void)size;
-    (void)priority;
-    RTOS_CREATE_TASK(taskId, task, name);
-  }
-
-#define TASK_RETURN()                 return nullptr
-
-  constexpr uint32_t mainStackAvailable()
+  static inline uint32_t mainStackAvailable()
   {
     return 500;
   }
-#endif  // __cplusplus
-
-  // return 2ms resolution to match CoOS settings
-  static inline uint32_t RTOS_GET_TIME(void)
-  {
-    return (uint32_t)(simuTimerMicros() / 2000);
-  }
-
-  static inline uint32_t RTOS_GET_MS(void)
-  {
-    return (uint32_t)(simuTimerMicros() / 1000);
-  }
 
 #elif defined(FREE_RTOS)
-#ifdef __cplusplus
-  extern "C" {
-#endif
-    #include <FreeRTOS/include/FreeRTOS.h>
-    #include <FreeRTOS/include/task.h>
-    #include <FreeRTOS/include/semphr.h>
-#ifdef __cplusplus
-  }
-#endif
 
-  #define RTOS_MS_PER_TICK portTICK_PERIOD_MS
-
-  typedef struct {
-    TaskHandle_t rtos_handle;
-    StaticTask_t task_struct;
-  } RTOS_TASK_HANDLE;
-
-  typedef struct {
-    SemaphoreHandle_t rtos_handle;
-    StaticSemaphore_t mutex_struct;
-  } RTOS_MUTEX_HANDLE;
-  
-  typedef RTOS_MUTEX_HANDLE RTOS_FLAG_HANDLE;
+  #include <FreeRTOS/include/FreeRTOS.h>
+  #include <FreeRTOS/include/task.h>
   
   static inline void RTOS_START()
   {
     vTaskStartScheduler();
   }
-
-  static inline void RTOS_WAIT_MS(uint32_t x)
-  {
-    if (!x)
-      return;
-    if ((x = x / RTOS_MS_PER_TICK) < 1)
-      x = 1;
-
-    vTaskDelay(x);
-  }
-
-  static inline void RTOS_WAIT_TICKS(uint32_t x)
-  {
-    vTaskDelay(x);
-  }
-
-  static inline void _RTOS_CREATE_TASK(RTOS_TASK_HANDLE *h,
-                                       TaskFunction_t pxTaskCode,
-                                       const char *name,
-                                       StackType_t *const puxStackBuffer,
-                                       const uint32_t ulStackDepth,
-                                       UBaseType_t uxPriority)
-  {
-    h->rtos_handle = xTaskCreateStatic(
-        pxTaskCode, name, ulStackDepth, NULL, uxPriority,
-        puxStackBuffer, &h->task_struct);
-  }
-
-  #define RTOS_CREATE_TASK(h,task,name,stackStruct,stackSize,prio) \
-    _RTOS_CREATE_TASK(&h,task,name,stackStruct.stack,stackSize,prio)
-  
-  static inline void _RTOS_CREATE_MUTEX(RTOS_MUTEX_HANDLE* h)
-  {
-    h->rtos_handle = xSemaphoreCreateMutexStatic(&h->mutex_struct);
-    xSemaphoreGive(h->rtos_handle);
-  }
-
-  #define RTOS_CREATE_MUTEX(handle) _RTOS_CREATE_MUTEX(&handle)
-
-  static inline bool _RTOS_LOCK_MUTEX(RTOS_MUTEX_HANDLE* h, TickType_t xTickToWait)
-  {
-    return xSemaphoreTake(h->rtos_handle, xTickToWait) == pdTRUE;
-  }
-
-  #define RTOS_LOCK_MUTEX(handle) _RTOS_LOCK_MUTEX(&handle, portMAX_DELAY)
-  #define RTOS_TRYLOCK_MUTEX(handle) _RTOS_LOCK_MUTEX(&handle, (TickType_t)0)
-
-  static inline void _RTOS_UNLOCK_MUTEX(RTOS_MUTEX_HANDLE* h)
-  {
-    xSemaphoreGive(h->rtos_handle);
-  }
-
-  #define RTOS_UNLOCK_MUTEX(handle) _RTOS_UNLOCK_MUTEX(&handle)
 
   static inline uint32_t getStackAvailable(void * address, uint32_t size)
   {
@@ -247,77 +72,6 @@ extern "C++" {
   {
     return getStackAvailable(&_main_stack_start, stackSize());
   }
-
-  //#define RTOS_CREATE_FLAG(flag)        flag = CoCreateFlag(false, false)
-  //#define RTOS_SET_FLAG(flag)           (void)CoSetFlag(flag)
-  //#define RTOS_CLEAR_FLAG(flag)         (void)CoClearFlag(flag)
-
-  // returns true if timeout
-  static inline bool _RTOS_WAIT_FLAG(RTOS_FLAG_HANDLE* flag, uint32_t timeout)
-  {
-    return xSemaphoreTake(flag->rtos_handle, timeout * RTOS_MS_PER_TICK)
-      == pdFALSE;
-  }
-
-  #define RTOS_WAIT_FLAG(flag,timeout) _RTOS_WAIT_FLAG(&flag,timeout)
-
-  static inline void _RTOS_ISR_SET_FLAG(RTOS_FLAG_HANDLE* flag)
-  {
-    BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-
-    // Give semaphore back from ISR to trigger a task waiting for it
-    xSemaphoreGiveFromISR( flag->rtos_handle, &xHigherPriorityTaskWoken );
-
-    // If xHigherPriorityTaskWoken was set to true we should yield
-    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
-  }
-
-  #define RTOS_ISR_SET_FLAG(flag) _RTOS_ISR_SET_FLAG(&flag)
-
-#ifdef __cplusplus
-  template<int SIZE>
-  class TaskStack
-  {
-    public:
-      TaskStack(RTOS_TASK_HANDLE *h) {
-        this->h = h;
-      }
-
-      uint32_t size()
-      {
-        return SIZE * 4;
-      }
-
-      uint32_t available()
-      {
-        return uxTaskGetStackHighWaterMark(h->rtos_handle);
-      }
-
-      StackType_t stack[SIZE];
-    protected:
-      RTOS_TASK_HANDLE *h;
-  };
-#endif // __cplusplus
-
-  static inline TickType_t RTOS_GET_TIME(void)
-  {
-    return xTaskGetTickCount();
-  }
-
-  static inline uint32_t RTOS_GET_MS(void)
-  {
-    return (RTOS_GET_TIME() * RTOS_MS_PER_TICK);
-  }
-
-  // stack must be aligned to 8 bytes otherwise printf for %f does not work!
-  #define RTOS_DEFINE_STACK(taskHandle, name, size) TaskStack<size> __ALIGNED(8) name __CCMRAM (&taskHandle) 
-
-  #define TASK_FUNCTION(task)           void task(void *)
-  #define TASK_RETURN()                 vTaskDelete(nullptr)
-
-#else // no RTOS
-
-  #error "No RTOS implementation defined"
 
 #endif  // RTOS type
 

--- a/radio/src/simu.cpp
+++ b/radio/src/simu.cpp
@@ -37,6 +37,8 @@
 #include "hal/adc_driver.h"
 #include "hal/rotary_encoder.h"
 
+#include "os/time.h"
+
 #if LCD_W > 212
   #define LCD_ZOOM 1
 #else
@@ -166,7 +168,6 @@ OpenTxSim::~OpenTxSim()
   TRACE("OpenTxSim::~OpenTxSim()");
 
   simuStop();
-  stopAudioThread();
 
   delete bmp;
   delete sliders[0];
@@ -492,7 +493,7 @@ long OpenTxSim::onTimeout(FXObject*, FXSelector, void*)
 
     static uint32_t last_tick = 0;
     if (rotencAction) {
-      uint32_t now = RTOS_GET_MS();
+      uint32_t now = time_get_ms();
       uint32_t dt = now - last_tick;
       rotencDt += dt;
       last_tick = now;
@@ -500,12 +501,11 @@ long OpenTxSim::onTimeout(FXObject*, FXSelector, void*)
 #endif
   }
 
-#if !defined(SIMU_BOOTLOADER)
-  per10ms();
-#else
+#if defined(SIMU_BOOTLOADER)
   void interrupt10ms();
   interrupt10ms();
 #endif
+
   refreshDisplay();
   getApp()->addTimeout(this, 2, 10);
   return 0;
@@ -644,8 +644,9 @@ int main(int argc, char ** argv)
   printf("Model size = %d\n", (int)sizeof(g_model));
 
 #if !defined(SIMU_BOOTLOADER)
-  startAudioThread();
+  startAudio();
 #endif
+
   simuStart(true/*false*/, argc >= 3 ? argv[2] : 0, argc >= 4 ? argv[3] : 0);
 
   return application.run();

--- a/radio/src/storage/modelslist.cpp
+++ b/radio/src/storage/modelslist.cpp
@@ -31,6 +31,7 @@ using std::list;
 #include "yaml/yaml_labelslist.h"
 #include "yaml/yaml_modelslist.h"
 #include "yaml/yaml_parser.h"
+#include "os/sleep.h"
 
 #if defined(USBJ_EX)
 #include "usb_joystick.h"
@@ -727,7 +728,7 @@ bool ModelMap::renameLabel(const std::string &from, std::string to,
                              (uint8_t *)modeldata, 0) != NULL);
     }
 #if defined(SIMU)
-    if (SIMU_SLEEP_OR_EXIT_MS(100)) break;
+    sleep_ms(100);
 #endif
   }
 

--- a/radio/src/storage/storage_common.cpp
+++ b/radio/src/storage/storage_common.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "edgetx.h"
+#include "os/sleep.h"
 #include "timers_driver.h"
 #include "tasks/mixer_task.h"
 #include "mixes.h"
@@ -76,8 +77,9 @@ void preModelLoad()
   LayoutFactory::deleteCustomScreens(true);
 #endif
 
-  if (needDelay)
-    RTOS_WAIT_MS(200);
+  if (needDelay) {
+    sleep_ms(200);
+  }
 }
 
 void postRadioSettingsLoad()

--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -26,6 +26,7 @@
 #include "myeeprom.h"
 #include "edgetx.h"
 #include "edgetx_constants.h"
+#include "os/sleep.h"
 #include "switches.h"
 #include "input_mapping.h"
 #include "inactivity_timer.h"
@@ -1051,8 +1052,7 @@ void checkSwitches()
     checkBacklight();
 
     WDG_RESET();
-
-    RTOS_WAIT_MS(10);
+    sleep_ms(10);
   }
 
   LED_ERROR_END();

--- a/radio/src/targets/common/arm/stm32/audio_dac_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/audio_dac_driver.cpp
@@ -22,6 +22,7 @@
 #include "hal/gpio.h"
 #include "hal/audio_driver.h"
 
+#include "os/sleep.h"
 #include "stm32_gpio.h"
 #include "stm32_timer.h"
 #include "stm32_dma.h"
@@ -162,7 +163,7 @@ void audioUnmute()
   if (get_mute_pin()) {
     // ..un-mute
     set_mute_pin(false);
-    RTOS_WAIT_MS(AUDIO_UNMUTE_DELAY);
+    sleep_ms(AUDIO_UNMUTE_DELAY);
   }
   // reset the mute delay
   audioQueue.lastAudioPlayTime = 0;

--- a/radio/src/targets/common/arm/stm32/bootloader/CMakeLists.txt
+++ b/radio/src/targets/common/arm/stm32/bootloader/CMakeLists.txt
@@ -6,6 +6,8 @@ AddHWGenTarget(${HW_DESC_JSON} hal_keys hal_keys.inc)
 
 set(BOOTLOADER_SRC ${BOOTLOADER_SRC}
   ${CMAKE_CURRENT_BINARY_DIR}/hal_keys.inc
+  ${RADIO_SRC_DIR}/os/time_nortos.cpp
+  ${RADIO_SRC_DIR}/os/sleep_nortos.cpp
   ${RADIO_SRC_DIR}/keys.cpp
   ${RADIO_SRC_DIR}/strhelpers.cpp
   ${RADIO_SRC_DIR}/stamp.cpp

--- a/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
+++ b/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
@@ -135,6 +135,9 @@ void bootloaderInitApp()
   boardBLInit();
 }
 
+// make linker happy
+void per5ms() {}
+
 int main()
 #else // SIMU
 void bootloaderInitApp() {}

--- a/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
+++ b/radio/src/targets/common/arm/stm32/bootloader/boot.cpp
@@ -135,8 +135,10 @@ void bootloaderInitApp()
   boardBLInit();
 }
 
+#if defined(FIRMWARE_FORMAT_UF2)
 // make linker happy
 void per5ms() {}
+#endif
 
 int main()
 #else // SIMU

--- a/radio/src/targets/common/arm/stm32/bootloader/boot_dfu.cpp
+++ b/radio/src/targets/common/arm/stm32/bootloader/boot_dfu.cpp
@@ -2,9 +2,11 @@
 
 #include "boot.h"
 #include "hal/usb_driver.h"
+#include "os/time.h"
+
 #include "lcd.h"
 
-extern volatile uint8_t tenms;
+#define FRAME_INTERVAL_MS 20
 
 void bootloaderDFU()
 {
@@ -13,8 +15,11 @@ void bootloaderDFU()
 
   bootloaderDrawDFUScreen();
 
+  uint32_t next_frame = time_get_ms();
   for (;;) {
-    if (tenms) {
+    if (time_get_ms() - next_frame >= FRAME_INTERVAL_MS) {
+      next_frame += FRAME_INTERVAL_MS;
+
       if (!usbPlugged()) break;
       bootloaderDrawDFUScreen();
       lcdRefresh();

--- a/radio/src/targets/common/arm/stm32/bootloader/boot_menu.cpp
+++ b/radio/src/targets/common/arm/stm32/bootloader/boot_menu.cpp
@@ -7,7 +7,7 @@
 
 #include "lcd.h"
 
-#define FRAME_INTERVAL_MS 10
+#define FRAME_INTERVAL_MS 20
 
 #if defined(SPI_FLASH)
   #define MAIN_MENU_LEN 3
@@ -35,6 +35,13 @@ void pollInputs()
     pushEvent(scrollRE < 0 ? EVT_ROTARY_LEFT : EVT_ROTARY_RIGHT);
   }
 #endif
+}
+
+// poll inputs every 10ms
+void per5ms()
+{
+  static uint32_t cnt = 0;
+  if (++cnt & 1) { pollInputs(); }
 }
 
 FlashCheckRes valid;
@@ -75,7 +82,6 @@ void bootloaderMenu()
 
     if (time_get_ms() - next_frame >= FRAME_INTERVAL_MS) {
       next_frame += FRAME_INTERVAL_MS;
-      pollInputs();
 
       if (state != ST_USB && state != ST_FLASHING
           && state != ST_FLASH_DONE && state != ST_RADIO_MENU) {

--- a/radio/src/targets/common/arm/stm32/rotary_encoder_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/rotary_encoder_driver.cpp
@@ -137,7 +137,7 @@ void rotaryEncoderCheck()
   rotenc_t diff = (value - last_value);
 
   if (diff != 0) {
-    uint32_t now = RTOS_GET_MS();
+    uint32_t now = timersGetMsTick();
     uint32_t dt = now - last_tick;
     // pre-compute accumulated dt (dx/dt is done later in LVGL driver)
     rotencDt += dt;

--- a/radio/src/targets/common/arm/stm32/timers_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/timers_driver.cpp
@@ -100,8 +100,6 @@ static inline void _interrupt_1ms()
       watchdogTimeout -= 1;
       WDG_RESET();  // Retrigger hardware watchdog
     }
-
-    per10ms();
   }
 }
 

--- a/radio/src/targets/common/arm/stm32/vs1053b.cpp
+++ b/radio/src/targets/common/arm/stm32/vs1053b.cpp
@@ -21,6 +21,7 @@
 
 #include "vs1053b.h"
 
+#include "os/sleep.h"
 #include "stm32_hal_ll.h"
 #include "stm32_gpio_driver.h"
 #include "stm32_gpio.h"
@@ -327,7 +328,7 @@ static void vs1053b_unmute()
     if (_is_muted) {
       // ..un-mute
       _set_mute_pin(false);
-      RTOS_WAIT_MS(_instance->unmute_delay_ms);
+      sleep_ms(_instance->unmute_delay_ms);
     }
     // reset the mute delay
     _last_play_ts = 0;

--- a/radio/src/targets/horus/cst8xx_driver.cpp
+++ b/radio/src/targets/horus/cst8xx_driver.cpp
@@ -42,8 +42,8 @@ volatile static bool touchEventOccured;
 
 static tc_handle_TypeDef tc_handle = {0, 0};
 
-tmr10ms_t downTime = 0;
-tmr10ms_t tapTime = 0;
+uint32_t downTime = 0;
+uint32_t tapTime = 0;
 short tapCount = 0;
 #define TAP_TIME 250  // ms
 
@@ -251,7 +251,7 @@ TouchState touchPanelRead()
 
   touchEventOccured = false;
 
-  tmr10ms_t now = RTOS_GET_MS();
+  uint32_t now = timersGetMsTick();
   internalTouchState.tapCount = 0;
 
   if (cst836u_TS_DetectTouch()) {

--- a/radio/src/targets/horus/tp_gt911.cpp
+++ b/radio/src/targets/horus/tp_gt911.cpp
@@ -29,10 +29,11 @@
 #include "stm32_exti_driver.h"
 
 #include "hal.h"
+#include "timers_driver.h"
 #include "tp_gt911.h"
 #include "delays_driver.h"
 
-#include "rtos.h"
+#include "os/sleep.h"
 #include "edgetx_types.h"
 #include "debug.h"
 
@@ -651,7 +652,7 @@ struct TouchState touchPanelRead()
 
   touchEventOccured = false;
 
-  uint32_t startReadStatus = RTOS_GET_MS();
+  uint32_t startReadStatus = timersGetMsTick();
   do {
     if (!I2C_GT911_ReadRegister(GT911_READ_XY_REG, &state, 1)) {
       // ledRed();
@@ -665,15 +666,15 @@ struct TouchState touchPanelRead()
       // ready
       break;
     }
-    RTOS_WAIT_MS(1);
-  } while (RTOS_GET_MS() - startReadStatus < GT911_TIMEOUT);
+    sleep_ms(1);
+  } while (timersGetMsTick() - startReadStatus < GT911_TIMEOUT);
 
   internalTouchState.deltaX = 0;
   internalTouchState.deltaY = 0;
   TRACE("touch state = 0x%x", state);
   if (state & 0x80u) {
     uint8_t pointsCount = (state & 0x0Fu);
-    uint32_t now = RTOS_GET_MS();
+    uint32_t now = timersGetMsTick();
     internalTouchState.tapCount = 0;
 
     if (pointsCount > 0 && pointsCount <= GT911_MAX_TP) {

--- a/radio/src/targets/simu/CMakeLists.txt
+++ b/radio/src/targets/simu/CMakeLists.txt
@@ -7,7 +7,6 @@ endif()
 
 set(SIMU_DRIVERS
   simpgmspace.cpp
-  simueeprom.cpp
   simufatfs.cpp
   simudisk.cpp
   simulcd.cpp
@@ -186,7 +185,7 @@ if(FOX_FOUND)
 
   target_include_directories(simu PUBLIC ${FOX_INCLUDE_DIR} )
   target_link_libraries(simu ${FOX_LIBRARY} pthread ${SDL2_LIBRARIES})
-  target_compile_options(simu PRIVATE -DSIMU)
+  target_compile_options(simu PRIVATE ${SIMU_SRC_OPTIONS})
 endif()
 
 if(APPLE)

--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -34,6 +34,9 @@
 #include "hal/usb_driver.h"
 #include "hal/audio_driver.h"
 
+#include "os/task.h"
+#include "os/timer_pthread_impl.h"
+
 #include <errno.h>
 #include <stdarg.h>
 #include <string>
@@ -211,6 +214,7 @@ void simuStart(bool tests, const char * sdPath, const char * settingsPath)
   lcdInit();
 
 #if !defined(SIMU_BOOTLOADER)
+  timer_queue::instance().start();
   simuMain();
 #else
   pthread_attr_t attr;
@@ -232,8 +236,8 @@ void simuStart(bool tests, const char * sdPath, const char * settingsPath)
 #endif
 }
 
-extern RTOS_TASK_HANDLE mixerTaskId;
-extern RTOS_TASK_HANDLE menusTaskId;
+extern task_handle_t mixerTaskId;
+extern task_handle_t menusTaskId;
 
 void simuStop()
 {
@@ -242,8 +246,12 @@ void simuStop()
 
   simu_shutdown = true;
 
-  pthread_join(mixerTaskId, nullptr);
-  pthread_join(menusTaskId, nullptr);
+  pthread_join(mixerTaskId._thread_handle, nullptr);
+  pthread_join(menusTaskId._thread_handle, nullptr);
+
+#if defined(SIMU_AUDIO)
+  stopAudio();
+#endif
 
   simu_running = false;
 }
@@ -253,8 +261,6 @@ struct SimulatorAudio {
   int currentVolume;
   int16_t leftoverData[AUDIO_BUFFER_SIZE];
   int leftoverLen;
-  bool threadRunning;
-  pthread_t threadPid;
 } simuAudio;
 
 bool simuIsRunning()
@@ -264,10 +270,9 @@ bool simuIsRunning()
 
 uint8_t simuSleep(uint32_t ms)
 {
-  for (uint32_t i = 0; i < ms; ++i){
-    if (simu_shutdown || !simu_running)
-      return 1;
-    sleep(1);
+  for (uint32_t i = 0; i < ms; i++) {
+    if (simu_shutdown || !simu_running) return 1;
+    usleep(1);
   }
   return 0;
 }
@@ -336,77 +341,44 @@ void fillAudioBuffer(void *udata, Uint8 *stream, int len)
     }
   }
 
-  //fill the rest of buffer with silence
+  // fill the rest of buffer with silence
   if (len > 0) {
     SDL_memset(stream, 0x8000, len);  // make sure this is silence.
-    // putchar('.');
   }
 }
 
-void * audioThread(void *)
+int startAudio(int volumeGain)
 {
-  /*
-    Checking here if SDL audio was initialized is wrong, because
-    the SDL_CloseAudio() de-initializes it.
+  simuAudio = {
+    .volumeGain = volumeGain,
+    .leftoverLen = 0,
+  };
 
-    if ( !SDL_WasInit(SDL_INIT_AUDIO) ) {
-      fprintf(stderr, "ERROR: couldn't initialize SDL audio support\n");
-      return 0;
-    }
-  */
-
-  SDL_AudioSpec wanted, have;
-
-  /* Set the audio format */
-  wanted.freq = AUDIO_SAMPLE_RATE;
-  wanted.format = AUDIO_S16SYS;
-  wanted.channels = 1;    /* 1 = mono, 2 = stereo */
-  wanted.samples =
-      AUDIO_BUFFER_SIZE * 2; /* Good low-latency value for callback */
-  wanted.callback = fillAudioBuffer;
-  wanted.userdata = nullptr;
-
-  /*
-    SDL_OpenAudio() internally calls SDL_InitSubSystem(SDL_INIT_AUDIO),
-    which initializes SDL Audio subsystem if necessary
-  */
-  if ( SDL_OpenAudio(&wanted, &have) < 0 ) {
-    fprintf(stderr, "Couldn't open audio: %s\n", SDL_GetError());
-    return nullptr;
-  }
-  SDL_PauseAudio(0);
-
-  while (simuAudio.threadRunning) {
-    audioQueue.wakeup();
-    sleep(1);
-  }
-  SDL_CloseAudio();
-  return nullptr;
-}
-
-void startAudioThread(int volumeGain)
-{
-  simuAudio.leftoverLen = 0;
-  simuAudio.threadRunning = true;
-  simuAudio.volumeGain = volumeGain;
-  TRACE_SIMPGMSPACE("startAudioThread(%d)", volumeGain);
+  TRACE("startAudioThread(%d)", volumeGain);
   audioSetVolume(VOLUME_LEVEL_DEF);
 
-  pthread_attr_t attr;
-  pthread_attr_init(&attr);
-  struct sched_param sp;
-  sp.sched_priority = SCHED_RR;
-  pthread_attr_setschedparam(&attr, &sp);
-  pthread_create(&simuAudio.threadPid, &attr, &audioThread, nullptr);
-#ifdef __linux__
-  pthread_setname_np(simuAudio.threadPid, "audio");
-#endif
+  /* Set the audio format */
+  SDL_AudioSpec desired = {
+    .freq = AUDIO_SAMPLE_RATE,
+    .format = AUDIO_S16SYS,
+    .channels = 1,
+    .samples = AUDIO_BUFFER_SIZE * 2,
+    .callback = fillAudioBuffer,
+    .userdata = nullptr,
+  };
+
+  SDL_AudioSpec obtained;
+  if ( SDL_OpenAudio(&desired, &obtained) < 0 ) {
+    fprintf(stderr, "Couldn't open audio: %s\n", SDL_GetError());
+    return -1;
+  }
+  SDL_PauseAudio(0);
+  return 0;
 }
 
-void stopAudioThread()
+void stopAudio()
 {
-  simuAudio.threadRunning = false;
-  pthread_join(simuAudio.threadPid, nullptr);
+  SDL_CloseAudio();
 }
 #endif // #if defined(SIMU_AUDIO)
 
@@ -675,6 +647,3 @@ struct TouchState getInternalTouchState()
   return simTouchState;
 }
 #endif
-
-void telemetryStart() {}
-void telemetryStop() {}

--- a/radio/src/targets/simu/simpgmspace.h
+++ b/radio/src/targets/simu/simpgmspace.h
@@ -30,16 +30,10 @@
 #include <stddef.h>
 #include <errno.h>
 
-// #undef min
-// #undef max
-
-extern uint8_t * eeprom;
-
 #define __disable_irq()
 #define __enable_irq()
 
 extern char * main_thread_error;
-
 
 uint64_t simuTimerMicros(void);
 uint8_t simuSleep(uint32_t ms);  // returns true if thread shutdown requested
@@ -57,20 +51,15 @@ void startEepromThread(const char * filename = "eeprom.bin");
 void stopEepromThread();
 
 #if defined(SIMU_AUDIO)
-  void startAudioThread(int volumeGain = 10);
-  void stopAudioThread(void);
+  int startAudio(int volumeGain = 10);
+  void stopAudio();
 #else
-  #define startAudioThread(dummy)
-  #define stopAudioThread()
+  #define startAudio(dummy) (-1)
+  #define stopAudio()
 #endif
 #endif
 
 void simuMain();
-
-
-// inline void delay_01us(uint32_t dummy) { }
-
-#define configure_pins(...)
 
 #if !defined(SKIP_FATFS_DECLARATION) && !defined(SIMU_DISKIO)
   #define SIMU_USE_SDCARD

--- a/radio/src/targets/stm32h7s78-dk/tp_gt911.cpp
+++ b/radio/src/targets/stm32h7s78-dk/tp_gt911.cpp
@@ -19,6 +19,7 @@
  * GNU General Public License for more details.
  */
 
+#include "os/sleep.h"
 #include "stm32_hal_ll.h"
 #include "stm32_hal.h"
 #include "stm32_i2c_driver.h"
@@ -32,6 +33,7 @@
 #include "hal.h"
 
 #include "stm32h7rsxx_hal_gpio.h"
+#include "timers_driver.h"
 #include "tp_gt911.h"
 #include "delays_driver.h"
 
@@ -215,7 +217,7 @@ struct TouchState touchPanelRead()
 
   touchEventOccured = false;
 
-  uint32_t startReadStatus = RTOS_GET_MS();
+  uint32_t startReadStatus = timersGetMsTick();
   do {
     if (!I2C_GT911_ReadRegister(GT911_READ_XY_REG, &state, 1)) {
       // ledRed();
@@ -229,15 +231,15 @@ struct TouchState touchPanelRead()
       // ready
       break;
     }
-    RTOS_WAIT_MS(1);
-  } while (RTOS_GET_MS() - startReadStatus < GT911_TIMEOUT);
+    sleep_ms(1);
+  } while (timersGetMsTick() - startReadStatus < GT911_TIMEOUT);
 
   internalTouchState.deltaX = 0;
   internalTouchState.deltaY = 0;
   TRACE("touch state = 0x%x", state);
   if (state & 0x80u) {
     uint8_t pointsCount = (state & 0x0Fu);
-    uint32_t now = RTOS_GET_MS();
+    uint32_t now = timersGetMsTick();
     internalTouchState.tapCount = 0;
 
     if (pointsCount > 0 && pointsCount <= GT911_MAX_TP) {

--- a/radio/src/tasks.cpp
+++ b/radio/src/tasks.cpp
@@ -19,7 +19,12 @@
  * GNU General Public License for more details.
  */
 
+#include "debug.h"
 #include "edgetx.h"
+#include "os/sleep.h"
+#include "os/task.h"
+#include "os/time.h"
+#include "os/timer.h"
 #include "timers_driver.h"
 #include "hal/abnormal_reboot.h"
 #include "hal/watchdog_driver.h"
@@ -32,23 +37,23 @@
 #include "startup_shutdown.h"
 #endif
 
-RTOS_TASK_HANDLE menusTaskId;
-RTOS_DEFINE_STACK(menusTaskId, menusStack, MENUS_STACK_SIZE);
+task_handle_t menusTaskId;
+TASK_DEFINE_STACK(menusStack, MENUS_STACK_SIZE);
 
 #if defined(AUDIO)
-RTOS_TASK_HANDLE audioTaskId;
-RTOS_DEFINE_STACK(audioTaskId, audioStack, AUDIO_STACK_SIZE);
+task_handle_t audioTaskId;
+TASK_DEFINE_STACK(audioStack, AUDIO_STACK_SIZE);
 #endif
 
-RTOS_MUTEX_HANDLE audioMutex;
+mutex_handle_t audioMutex;
 
-#define MENU_TASK_PERIOD_TICKS         (50 / RTOS_MS_PER_TICK)    // 50ms
+#define MENU_TASK_PERIOD (50)  // 50ms
 
 #if defined(COLORLCD) && defined(CLI)
 bool perMainEnabled = true;
 #endif
 
-TASK_FUNCTION(menusTask)
+static void menusTask()
 {
 #if defined(LIBOPENUI)
   LvglWrapper::instance();
@@ -63,15 +68,14 @@ TASK_FUNCTION(menusTask)
     uint32_t pwr_check = pwrCheck();
     if (pwr_check == e_power_off) {
       break;
-    }
-    else if (pwr_check == e_power_press) {
-      RTOS_WAIT_TICKS(MENU_TASK_PERIOD_TICKS);
+    } else if (pwr_check == e_power_press) {
+      sleep_ms(MENU_TASK_PERIOD);
       continue;
     }
 #else
   while (pwrCheck() != e_power_off) {
 #endif
-    uint32_t start = (uint32_t)RTOS_GET_TIME();
+    time_point_t next_tick = time_point_now();
     DEBUG_TIMER_START(debugTimerPerMain);
 #if defined(COLORLCD) && defined(CLI)
     if (perMainEnabled) {
@@ -81,14 +85,8 @@ TASK_FUNCTION(menusTask)
     perMain();
 #endif
     DEBUG_TIMER_STOP(debugTimerPerMain);
-    // TODO remove completely massstorage from sky9x firmware
-    uint32_t runtime = ((uint32_t)RTOS_GET_TIME() - start);
-    // deduct the thread run-time from the wait, if run-time was more than
-    // desired period, then skip the wait all together
-    if (runtime < MENU_TASK_PERIOD_TICKS) {
-      RTOS_WAIT_TICKS(MENU_TASK_PERIOD_TICKS - runtime);
-    }
 
+    sleep_until(&next_tick, MENU_TASK_PERIOD);
     resetForcePowerOffRequest();
   }
 
@@ -99,58 +97,61 @@ TASK_FUNCTION(menusTask)
   drawSleepBitmap();
   edgeTxClose();
   boardOff();
-
-  TASK_RETURN();
 }
 
-#if !defined(SIMU)
-// Handle 10ms timer asynchronously
-#include <FreeRTOS/include/FreeRTOS.h>
-#include <FreeRTOS/include/timers.h>
-
-static TimerHandle_t _timer10ms = nullptr;
-static StaticTimer_t _timer10msBuffer;
-
-static void _timer_10ms_cb(TimerHandle_t xTimer)
+static void audioTask()
 {
-  (void)xTimer;
+  while (!audioQueue.started()) {
+    sleep_ms(1);
+  }
+
+#if defined(PCBX12S) || defined(RADIO_TX16S) || defined(RADIO_F16) || defined(RADIO_V16)
+  // The audio amp needs ~2s to start
+  sleep_ms(1000); // 1s
+#endif
+
+  time_point_t next_tick = time_point_now();
+  while (true) {
+    DEBUG_TIMER_SAMPLE(debugTimerAudioIterval);
+    DEBUG_TIMER_START(debugTimerAudioDuration);
+    audioQueue.wakeup();
+    DEBUG_TIMER_STOP(debugTimerAudioDuration);
+    sleep_until(&next_tick, 4);
+  }
+}
+
+static timer_handle_t _timer10ms = TIMER_INITIALIZER;
+
+static void _timer_10ms_cb(timer_handle_t* h)
+{
   per10ms();
 }
 
 void timer10msStart()
 {
-  if (!_timer10ms) {
-    _timer10ms =
-        xTimerCreateStatic("10ms", 10 / RTOS_MS_PER_TICK, pdTRUE, (void*)0,
-                           _timer_10ms_cb, &_timer10msBuffer);
+  if (!timer_is_created(&_timer10ms)) {
+    timer_create(&_timer10ms, _timer_10ms_cb, "10ms", 10, true);
   }
 
-  if (_timer10ms) {
-    if( xTimerStart( _timer10ms, 0 ) != pdPASS ) {
-      /* The timer could not be set into the Active state. */
-    }
-  }
+  timer_start(&_timer10ms);
 }
-#endif
 
 void tasksStart()
 {
-  RTOS_CREATE_MUTEX(audioMutex);
+  mutex_create(&audioMutex);
 
 #if defined(CLI) && !defined(SIMU)
   cliStart();
 #endif
 
-#if !defined(SIMU)
   timer10msStart();
-#endif
 
-  RTOS_CREATE_TASK(menusTaskId, menusTask, "menus", menusStack,
-                   MENUS_STACK_SIZE, MENUS_TASK_PRIO);
+  task_create(&menusTaskId, menusTask, "menus", menusStack, MENUS_STACK_SIZE,
+              MENUS_TASK_PRIO);
 
-#if !defined(SIMU) && defined(AUDIO)
-  RTOS_CREATE_TASK(audioTaskId, audioTask, "audio", audioStack,
-                   AUDIO_STACK_SIZE, AUDIO_TASK_PRIO);
+#if defined(AUDIO)
+  task_create(&audioTaskId, audioTask, "audio", audioStack, AUDIO_STACK_SIZE,
+              AUDIO_TASK_PRIO);
 #endif
 
   RTOS_START();

--- a/radio/src/tasks.h
+++ b/radio/src/tasks.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#include "rtos.h"
+#include "os/task.h"
 
 // stack sizes should be in multiples of 8 for better alignment
 #if defined (COLORLCD)
@@ -53,15 +53,14 @@
 #endif
 
 
-extern TaskStack<MENUS_STACK_SIZE> menusStack;
-extern TaskStack<MIXER_STACK_SIZE> mixerStack;
+extern task_handle_t menusTaskId;
 
 #if defined(AUDIO)
-extern TaskStack<AUDIO_STACK_SIZE> audioStack;
+extern task_handle_t audioTaskId;
 #endif
 
 #if defined(CLI)
-extern TaskStack<CLI_STACK_SIZE> cliStack;
+extern task_handle_t cliTaskId;
 #endif
 
 void tasksStart();

--- a/radio/src/tasks/mixer_task.h
+++ b/radio/src/tasks/mixer_task.h
@@ -19,13 +19,13 @@
  * GNU General Public License for more details.
  */
 
-#include "rtos.h"
+#include "os/task.h"
 
 // needed by the mixer scheduler
-extern RTOS_TASK_HANDLE mixerTaskId;
+extern task_handle_t mixerTaskId;
 
 // function running the mixer task
-TASK_FUNCTION(mixerTask);
+void mixerTask();
 
 // init, create and start the OS task itself
 void mixerTaskInit();

--- a/radio/src/telemetry/hitec.cpp
+++ b/radio/src/telemetry/hitec.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "edgetx.h"
+#include "os/time.h"
 
 /* Full telemetry 
 packet[0] = TX RSSI value
@@ -354,7 +355,7 @@ void processHitecPacket(const uint8_t * packet)
       alt = (int16_t) ((packet[3] << 8) | packet[4]);
       sensor = getHitecSensor(HITEC_ID_ALT);
       setTelemetryValue(PROTOCOL_TELEMETRY_HITEC, HITEC_ID_ALT, 0, 0, alt, sensor->unit, sensor->precision);
-      current_ms = RTOS_GET_MS();
+      current_ms = time_get_ms();
       sensor = getHitecSensor(HITEC_ID_VARIO);
       value = (alt - last_alt) * 100;
       if ((current_ms - last_ms) < 1000)

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -21,6 +21,8 @@
 
 #include "edgetx.h"
 #include "multi.h"
+#include "os/async.h"
+#include "os/timer.h"
 #include "pulses/afhds3.h"
 #include "pulses/flysky.h"
 #include "mixer_scheduler.h"
@@ -168,14 +170,10 @@ void telemetryMirrorSend(uint8_t data)
   }
 }
 
-#if !defined(SIMU)
-static TimerHandle_t telemetryTimer = nullptr;
-static StaticTimer_t telemetryTimerBuffer;
+static timer_handle_t telemetryTimer = TIMER_INITIALIZER;
 
-static void telemetryTimerCb(TimerHandle_t xTimer)
+static void telemetryTimerCb(timer_handle_t* h)
 {
-  (void)xTimer;
-
   DEBUG_TIMER_START(debugTimerTelemetryWakeup);
   telemetryWakeup();
   DEBUG_TIMER_STOP(debugTimerTelemetryWakeup);
@@ -183,25 +181,17 @@ static void telemetryTimerCb(TimerHandle_t xTimer)
 
 void telemetryStart()
 {
-  if (!telemetryTimer) {
-    telemetryTimer =
-        xTimerCreateStatic("Telem", 2 / RTOS_MS_PER_TICK, pdTRUE, (void*)0,
-                           telemetryTimerCb, &telemetryTimerBuffer);
+  if (!timer_is_created(&telemetryTimer)) {
+    timer_create(&telemetryTimer, telemetryTimerCb, "Telem", 2, true);
   }
 
-  if (telemetryTimer) {
-    if( xTimerStart( telemetryTimer, 0 ) != pdPASS ) {
-      /* The timer could not be set into the Active state. */
-    }
-  }
+  timer_start(&telemetryTimer);
 }
 
 void telemetryStop()
 {
-  if (telemetryTimer) {
-    if( xTimerStop( telemetryTimer, 5 / RTOS_MS_PER_TICK ) != pdPASS ) {
-      /* The timer could not be stopped. */
-    }
+  if (!timer_is_created(&telemetryTimer)) {
+    timer_stop(&telemetryTimer);
   }
 }
 
@@ -248,21 +238,8 @@ static void _poll_frame(void *pvParameter1, uint32_t ulParameter2)
 
 void telemetryFrameTrigger_ISR(uint8_t module, const etx_proto_driver_t* drv)
 {
-  BaseType_t xHigherPriorityTaskWoken = pdFALSE;
-  BaseType_t xReturn = pdFALSE;
-
-  if (!_poll_frame_queued[module] && xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED) {
-    xReturn = xTimerPendFunctionCallFromISR(_poll_frame, (void*)drv, module, &xHigherPriorityTaskWoken);
-
-    if (xReturn == pdPASS) {
-      _poll_frame_queued[module] = true;
-    } else {
-      TRACE("xTimerPendFunctionCallFromISR() queue full");
-    }
-    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
-  }
+  async_call_isr(_poll_frame, &_poll_frame_queued[module], (void*)drv, module);
 }
-#endif
 
 inline bool isBadAntennaDetected()
 {


### PR DESCRIPTION
This PR is aimed at providing a cleaner way to deal with differences btw. simulator and firmware.

Tasks and mutex were already kind of provided by `rtos.h`, but we lacked support for timers and async calls, which were provided exclusively by FreeRTOS timers. Now there is an implementation of timers for native platform, which is used as well for async calls, the same way it is done with FreeRTOS.

Supported features:
- time
- timers
- asynchronous calls
- tasks and mutex