### PR TITLE
fix(color): long ENTER on main view not allowing widget selection

### DIFF
--- a/radio/src/gui/colorlcd/mainview/view_main.cpp
+++ b/radio/src/gui/colorlcd/mainview/view_main.cpp
@@ -364,6 +364,7 @@ bool ViewMain::onLongPress()
   } else {
     enableWidgetSelect(true);
   }
+  killEvents(KEY_ENTER);
   lv_indev_wait_release(lv_indev_get_act());
   return false;
 }


### PR DESCRIPTION
Restore 2.10 functionality.

Long press of ENTER enables widget selection mode, the popup menu should not open immediately so the user can select the widget to operate on with the rotary encoder.
