### PR TITLE
fix(cpn): ADC switch type hardware definition

### DIFF
--- a/companion/src/firmwares/boardjson.cpp
+++ b/companion/src/firmwares/boardjson.cpp
@@ -51,6 +51,7 @@ static const StringTagMappingTable switchTypesLookupTable = {
     {std::to_string(Board::SWITCH_2POS),          "2POS"},
     {std::to_string(Board::SWITCH_3POS),          "3POS"},
     {std::to_string(Board::SWITCH_FUNC),          "FSWITCH"},
+    {std::to_string(Board::SWITCH_ADC),           "ADC"},
 };
 
 static const StringTagMappingTable stickNamesLookupTable = {
@@ -993,6 +994,17 @@ bool BoardJson::loadFile(Board::Type board, QString hwdefn, InputsTable * inputs
           const QJsonArray &d = obj.value("display").toArray();
           sw.display.x = (unsigned int)d.at(0).toInt(0);
           sw.display.y = (unsigned int)d.at(1).toInt(0);
+        }
+
+        // special handing for ADC
+        if (sw.type == Board::SWITCH_ADC) {
+          if (sw.dflt == Board::SWITCH_TOGGLE) {
+            // this could be 2 or 3 position toggle so play safe
+            // it therefore has an impact on configuring hardware, available switches, simulator widget, yaml encode and decode
+            sw.dflt = Board::SWITCH_3POS;
+          }
+          // make the same
+          sw.type = sw.dflt;
         }
 
         switches->insert(switches->end(), sw);

--- a/companion/src/firmwares/boards.h
+++ b/companion/src/firmwares/boards.h
@@ -119,6 +119,7 @@ namespace Board {
     SWITCH_2POS,
     SWITCH_3POS,
     SWITCH_FUNC,
+    SWITCH_ADC,
     SWITCH_TYPE_COUNT
   };
 


### PR DESCRIPTION
Summary of changes:
- handle ADC switch type
- ADC switch TOGGLE set to non-toggle 3 position switch as toggle could be 2 or 3 positions

Note: hardware setup, assignable switches, simulator and yaml read/write will use 3 position non-toggle logic.

PL18 in main

![Screenshot from 2025-01-27 21-18-43](https://github.com/user-attachments/assets/81372b9a-0308-4e8a-8f80-74afedee392b)

![Screenshot from 2025-01-27 21-22-30](https://github.com/user-attachments/assets/4115308d-2428-4094-9ded-db61bb1dccec)