### PR TITLE
fix(sim): flight mode name incorrect in the simulator window title bar

### DIFF
--- a/radio/src/edgetx.h
+++ b/radio/src/edgetx.h
@@ -794,30 +794,6 @@ union ReusableBuffer
 
 extern ReusableBuffer reusableBuffer;
 
-uint8_t zlen(const char *str, uint8_t size);
-bool zexist(const char *str, uint8_t size);
-char * strcat_zchar(char *dest, const char *name, uint8_t size, const char spaceSym = 0, const char *defaultName=nullptr, uint8_t defaultNameSize=0, uint8_t defaultIdx=0);
-#define strcatFlightmodeName(dest, idx) strcat_zchar(dest, g_model.flightModeData[idx].name, LEN_FLIGHT_MODE_NAME, 0, STR_FM, PSIZE(TR_FM), idx+1)
-
-#if !defined(STORAGE_MODELSLIST)
-
-#define strcat_modelname(dest, idx, spaceSym)                                     \
-  strcat_zchar(dest, modelHeaders[idx].name, LEN_MODEL_NAME, spaceSym, STR_MODEL, \
-               PSIZE(TR_MODEL), idx + 1)
-
-#define strcat_currentmodelname(dest, spaceSym)      \
-  strcat_modelname(dest, g_eeGeneral.currModel, spaceSym)
-
-#else
-
-#define strcat_currentmodelname(dest, spaceSym)                         \
-  strcat_zchar(dest, g_model.header.name, LEN_MODEL_NAME, spaceSym)
-
-#endif
-
-#define ZLEN(s) zlen(s, sizeof(s))
-#define ZEXIST(s) zexist(s, sizeof(s))
-
 // Stick tolerance varies between transmitters, Higher is better
 #define STICK_TOLERANCE 64
 

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -48,61 +48,9 @@ const char* sanitizeForFilename(const char* name, int len)
   return _static_str_buffer;
 }
 
-char hex2zchar(uint8_t hex) { return (hex >= 10 ? hex - 9 : 27 + hex); }
-
 char hex2char(uint8_t hex) { return (hex >= 10 ? hex - 10 + 'A' : hex + '0'); }
 
-char zchar2char(int8_t idx)
-{
-  if (idx == 0) return ' ';
-  if (idx < 0) {
-    if (idx > -27) return 'a' - idx - 1;
-    idx = -idx;
-  }
-  if (idx < 27) return 'A' + idx - 1;
-  if (idx < 37) return '0' + idx - 27;
-  if (idx <= 40) return *(s_charTab + idx - 37);
-#if LEN_SPECIAL_CHARS > 0
-  if (idx <= (LEN_STD_CHARS + LEN_SPECIAL_CHARS)) return 'z' + 5 + idx - 40;
-#endif
-  return ' ';
-}
-
 char char2lower(char c) { return (c >= 'A' && c <= 'Z') ? c + 32 : c; }
-
-int8_t char2zchar(char c)
-{
-  if (c == '_') return 37;
-#if LEN_SPECIAL_CHARS > 0
-  if ((int8_t)c < 0 && c + 128 <= LEN_SPECIAL_CHARS) return 41 + (c + 128);
-#endif
-  if (c >= 'a') return 'a' - c - 1;
-  if (c >= 'A') return c - 'A' + 1;
-  if (c >= '0') return c - '0' + 27;
-  if (c == '-') return 38;
-  if (c == '.') return 39;
-  if (c == ',') return 40;
-  return 0;
-}
-
-void str2zchar(char *dest, const char *src, int size)
-{
-  memset(dest, 0, size);
-  for (int c = 0; c < size && src[c]; c++) {
-    dest[c] = char2zchar(src[c]);
-  }
-}
-
-int zchar2str(char *dest, const char *src, int size)
-{
-  for (int c = 0; c < size; c++) {
-    dest[c] = zchar2char(src[c]);
-  }
-  do {
-    dest[size--] = '\0';
-  } while (size >= 0 && dest[size] == ' ');
-  return size + 1;
-}
 
 int strnlen(const char *src, int max_size)
 {

--- a/radio/src/strhelpers.h
+++ b/radio/src/strhelpers.h
@@ -56,15 +56,35 @@ typedef union {
   TimerDisplayOptions displayOptions;
 } TimerOptions;
 
+uint8_t zlen(const char *str, uint8_t size);
+bool zexist(const char *str, uint8_t size);
+char * strcat_zchar(char *dest, const char *name, uint8_t size, const char spaceSym = 0, const char *defaultName=nullptr, uint8_t defaultNameSize=0, uint8_t defaultIdx=0);
+
+#define strcatFlightmodeName(dest, idx) strcat_zchar(dest, g_model.flightModeData[idx].name, LEN_FLIGHT_MODE_NAME, 0, STR_FM, PSIZE(TR_FM), idx+1)
+
+#if !defined(STORAGE_MODELSLIST)
+
+#define strcat_modelname(dest, idx, spaceSym)                                     \
+  strcat_zchar(dest, modelHeaders[idx].name, LEN_MODEL_NAME, spaceSym, STR_MODEL, \
+               PSIZE(TR_MODEL), idx + 1)
+
+#define strcat_currentmodelname(dest, spaceSym)      \
+  strcat_modelname(dest, g_eeGeneral.currModel, spaceSym)
+
+#else
+
+#define strcat_currentmodelname(dest, spaceSym)                         \
+  strcat_zchar(dest, g_model.header.name, LEN_MODEL_NAME, spaceSym)
+
+#endif
+
+#define ZLEN(s) zlen(s, sizeof(s))
+#define ZEXIST(s) zexist(s, sizeof(s))
+
 const char* sanitizeForFilename(const char* name, int len);
 
-char hex2zchar(uint8_t hex);
 char hex2char(uint8_t hex);
-char zchar2char(int8_t idx);
 char char2lower(char c);
-int8_t char2zchar(char c);
-void str2zchar(char *dest, const char *src, int size);
-int zchar2str(char *dest, const char *src, int size);
 int strnlen(const char *src, int max_size);
 unsigned int effectiveLen(const char *str, unsigned int size);
 

--- a/radio/src/targets/simu/opentxsimulator.cpp
+++ b/radio/src/targets/simu/opentxsimulator.cpp
@@ -876,8 +876,8 @@ uint8_t OpenTxSimulator::getStickMode()
 
 const char * OpenTxSimulator::getPhaseName(unsigned int phase)
 {
-  static char buff[sizeof(g_model.flightModeData[0].name)+1];
-  zchar2str(buff, g_model.flightModeData[phase].name, sizeof(g_model.flightModeData[0].name));
+  static char buff[LEN_FLIGHT_MODE_NAME+1];
+  strAppend(buff, g_model.flightModeData[phase].name, LEN_FLIGHT_MODE_NAME);
   return buff;
 }
 

--- a/radio/src/tests/gtests.cpp
+++ b/radio/src/tests/gtests.cpp
@@ -129,14 +129,6 @@ uint16_t simu_get_analog(uint8_t idx)
 }
 
 static char _stringResult[200];
-const char * zchar2string(const char * zstring, int size)
-{
-  if (size > (int)sizeof(_stringResult) ) {
-    return nullptr;
-  }
-  zchar2str(_stringResult, zstring, size);
-  return _stringResult;
-}
 
 const char * nchar2string(const char * string, int size)
 {


### PR DESCRIPTION
If the flight mode has a non-empty name it is not being displayed correctly in the simulator window title.

Also cleans up some unused code and moves string related definitions to strhelpers.h.
