### PR TITLE
fix: remove redundant touchPanelInit

### DIFF
--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -207,10 +207,6 @@ void boardInit()
   switchInit();
   rotaryEncoderInit();
 
-#if defined(HARDWARE_TOUCH)
-  touchPanelInit();
-#endif
-
 #if defined(PWM_STICKS)
   sticksPwmDetect();
 #endif


### PR DESCRIPTION
Appears the (unintentional, as it is already done in board.cpp a few lines further down?) double init introduced in #5284 locks up T16 hard on boot if no TP present. Tested TX16S w/ TP, still working fine. 

Fixes #5328
