### PR TITLE
feat(flysky): Flysky Gimbal 2.0 Sync Sampling Support

### DIFF
--- a/radio/src/boards/generic_stm32/analog_inputs.cpp
+++ b/radio/src/boards/generic_stm32/analog_inputs.cpp
@@ -31,10 +31,6 @@
   #include "ads79xx.h"
 #endif
 
-#if defined(FLYSKY_GIMBAL)
-  #include "flysky_gimbal_driver.h"
-#endif
-
 #include "definitions.h"
 
 #include "myeeprom.h"

--- a/radio/src/boards/generic_stm32/analog_inputs.cpp
+++ b/radio/src/boards/generic_stm32/analog_inputs.cpp
@@ -72,9 +72,6 @@ static bool adc_start_read()
     success = success && ads79xx_adc_start_read(&_ADC_spi[0], _ADC_inputs);
   }
 #endif
-#if defined(FLYSKY_GIMBAL)
-  flysky_gimbal_start_read();
-#endif
   return success;
 }
 
@@ -86,9 +83,6 @@ static void adc_wait_completion()
   if (n_ADC_spi > 0) ads79xx_adc_wait_completion(&_ADC_spi[0], _ADC_inputs);
 #endif
   stm32_hal_adc_wait_completion(_ADC_adc, n_ADC, _ADC_inputs, n_inputs);
-#if defined(FLYSKY_GIMBAL)
-  flysky_gimbal_wait_completion();
-#endif
 }
 
 const etx_hal_adc_driver_t _adc_driver = {

--- a/radio/src/boards/generic_stm32/analog_inputs.cpp
+++ b/radio/src/boards/generic_stm32/analog_inputs.cpp
@@ -31,6 +31,10 @@
   #include "ads79xx.h"
 #endif
 
+#if defined(FLYSKY_GIMBAL)
+  #include "flysky_gimbal_driver.h"
+#endif
+
 #include "definitions.h"
 
 #include "myeeprom.h"
@@ -68,6 +72,9 @@ static bool adc_start_read()
     success = success && ads79xx_adc_start_read(&_ADC_spi[0], _ADC_inputs);
   }
 #endif
+#if defined(FLYSKY_GIMBAL)
+  flysky_gimbal_start_read();
+#endif
   return success;
 }
 
@@ -79,6 +86,9 @@ static void adc_wait_completion()
   if (n_ADC_spi > 0) ads79xx_adc_wait_completion(&_ADC_spi[0], _ADC_inputs);
 #endif
   stm32_hal_adc_wait_completion(_ADC_adc, n_ADC, _ADC_inputs, n_inputs);
+#if defined(FLYSKY_GIMBAL)
+  flysky_gimbal_wait_completion();
+#endif
 }
 
 const etx_hal_adc_driver_t _adc_driver = {

--- a/radio/src/hal/adc_driver.cpp
+++ b/radio/src/hal/adc_driver.cpp
@@ -21,6 +21,9 @@
 
 #include "adc_driver.h"
 #include "board.h"
+#if defined(FLYSKY_GIMBAL)
+  #include "flysky_gimbal_driver.h"
+#endif
 
 #include "edgetx.h"
 
@@ -57,6 +60,12 @@ static bool adcSingleRead()
   if (_hal_adc_driver->wait_completion)
     _hal_adc_driver->wait_completion();
 
+  // Need to put all in a group to ensure DMA transfer will not affect ADC sampling
+#if defined(FLYSKY_GIMBAL) && !defined(SIMU)
+  flysky_gimbal_start_read();
+  flysky_gimbal_wait_completion();
+#endif  
+  
   return true;
 }
 

--- a/radio/src/targets/common/arm/stm32/flysky_gimbal_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/flysky_gimbal_driver.cpp
@@ -55,7 +55,7 @@ static const stm32_usart_t fsUSART = {
   .rxDMA_Channel = FLYSKY_HALL_DMA_Channel,
 };
 
-DEFINE_STM32_SERIAL_PORT(FSGimbal, fsUSART, HALLSTICK_BUFF_SIZE, 0);
+DEFINE_STM32_SERIAL_PORT(FSGimbal, fsUSART, HALLSTICK_BUFF_SIZE, HALLSTICK_CMD_BUFF_SIZE);
 
 static const etx_serial_port_t _fs_gimbal_serial_port = {
   .name = "gimbals",
@@ -65,8 +65,6 @@ static const etx_serial_port_t _fs_gimbal_serial_port = {
 };
 
 static STRUCT_HALL HallProtocol = { 0 };
-
-static uint8_t _fs_hall_command[8] __DMA;
 
 static void* _fs_usart_ctx = nullptr;
 
@@ -156,18 +154,18 @@ void _fs_send_cmd(uint8_t id, uint8_t payload)
     return;
   }
 
-  _fs_hall_command[0] = FLYSKY_HALL_PROTOLO_HEAD;
-  _fs_hall_command[1] = id;
-  _fs_hall_command[2] = 0x01;
-  _fs_hall_command[3] = payload;
+  FSGimbal_TXBuffer[0] = FLYSKY_HALL_PROTOLO_HEAD;
+  FSGimbal_TXBuffer[1] = id;
+  FSGimbal_TXBuffer[2] = 0x01;
+  FSGimbal_TXBuffer[3] = payload;
 
-  unsigned short crc = crc16(CRC_1021, _fs_hall_command, 4, 0xffff);
+  unsigned short crc = crc16(CRC_1021, FSGimbal_TXBuffer, 4, 0xffff);
 
-  _fs_hall_command[4] = crc & 0xff;
-  _fs_hall_command[5] = crc >>8 & 0xff ;
+  FSGimbal_TXBuffer[4] = crc & 0xff;
+  FSGimbal_TXBuffer[5] = crc >>8 & 0xff ;
 
   _fs_gimbal_cmd_finished = false;
-  STM32SerialDriver.sendBuffer(_fs_usart_ctx, _fs_hall_command, 6);
+  STM32SerialDriver.sendBuffer(_fs_usart_ctx, FSGimbal_TXBuffer, 6);
 //  TRACE("Flysky Gimbal: Sent command, id = %d, payload = %d", id, payload);
 }
 

--- a/radio/src/targets/common/arm/stm32/flysky_gimbal_driver.h
+++ b/radio/src/targets/common/arm/stm32/flysky_gimbal_driver.h
@@ -38,6 +38,7 @@
 #define FLYSKY_OFFSET_VALUE             ( 1 << 12 )
 
 #define FLYSKY_HALL_PROTOLO_HEAD        0x55
+#define FLYSKY_PACKET_MODE_ID           0x04
 #define FLYSKY_PACKET_VERSION_ID        0x0b
 #define FLYSKY_PACKET_CHANNEL_ID        0x0c
 
@@ -125,9 +126,15 @@ enum TRANSFER_DIR_E {
   TRANSFER_DIR_RFMODULE,
 };
 
-enum FLYSKY_GIMBAL_VERSION {
+enum GIMBAL_VERSION {
   GIMBAL_V1,
   GIMBAL_V2
+};
+
+enum V2_GIMBAL_MODE {
+  V1_MODE = 0,
+  SYNC_400Hz = 1,
+  SYNC_1000Hz = 2
 };
 
 extern signed short hall_raw_values[FLYSKY_HALL_CHANNEL_COUNT];
@@ -139,6 +146,8 @@ bool flysky_gimbal_init();
 void flysky_gimbal_force_init();
 
 void flysky_gimbal_deinit();
-bool is_flysky_gimbal_sync_supported();
+
+void flysky_gimbal_start_read();
+void flysky_gimbal_wait_completion();
 
 const etx_serial_port_t* flysky_gimbal_get_port();

--- a/radio/src/targets/common/arm/stm32/flysky_gimbal_driver.h
+++ b/radio/src/targets/common/arm/stm32/flysky_gimbal_driver.h
@@ -133,8 +133,8 @@ enum GIMBAL_VERSION {
 
 enum V2_GIMBAL_MODE {
   V1_MODE = 0,
-  SYNC_400Hz = 1,
-  SYNC_1000Hz = 2
+  SYNC_SAMPLING = 1,   // Can serve sampling frequency < 400Hz
+  SYNC_RESAMPLING = 2  // Can serve sampling frequency up to 1000Hz
 };
 
 extern signed short hall_raw_values[FLYSKY_HALL_CHANNEL_COUNT];

--- a/radio/src/targets/common/arm/stm32/flysky_gimbal_driver.h
+++ b/radio/src/targets/common/arm/stm32/flysky_gimbal_driver.h
@@ -26,6 +26,7 @@
 // Max packet size = 1 byte header + 1 byte ID + 1 byte length + 25 bytes payload + 2 bytes CRC = 30 bytes
 // using 32 bytes is more than enough
 #define HALLSTICK_BUFF_SIZE             ( 32 )
+#define HALLSTICK_CMD_BUFF_SIZE         ( 8 )
 #define FLYSKY_HALL_BAUDRATE            ( 921600 )
 #define FLYSKY_HALL_CHANNEL_COUNT       ( 4 )
 

--- a/radio/src/targets/common/arm/stm32/flysky_gimbal_driver.h
+++ b/radio/src/targets/common/arm/stm32/flysky_gimbal_driver.h
@@ -38,7 +38,8 @@
 #define FLYSKY_OFFSET_VALUE             ( 1 << 12 )
 
 #define FLYSKY_HALL_PROTOLO_HEAD        0x55
-#define FLYSKY_HALL_RESP_TYPE_VALUES    0x0c
+#define FLYSKY_PACKET_VERSION_ID        0x0b
+#define FLYSKY_PACKET_CHANNEL_ID        0x0c
 
 typedef  struct
 {
@@ -124,6 +125,11 @@ enum TRANSFER_DIR_E {
   TRANSFER_DIR_RFMODULE,
 };
 
+enum FLYSKY_GIMBAL_VERSION {
+  GIMBAL_V1,
+  GIMBAL_V2
+};
+
 extern signed short hall_raw_values[FLYSKY_HALL_CHANNEL_COUNT];
 extern unsigned short hall_adc_values[FLYSKY_HALL_CHANNEL_COUNT];
 
@@ -133,4 +139,6 @@ bool flysky_gimbal_init();
 void flysky_gimbal_force_init();
 
 void flysky_gimbal_deinit();
+bool is_flysky_gimbal_sync_supported();
+
 const etx_serial_port_t* flysky_gimbal_get_port();

--- a/radio/src/targets/horus/hal.h
+++ b/radio/src/targets/horus/hal.h
@@ -1017,7 +1017,7 @@
   #define FLYSKY_HALL_SERIAL_USART_IRQn            UART4_IRQn
   #define FLYSKY_HALL_SERIAL_DMA                   DMA1
   #define FLYSKY_HALL_DMA_Stream_RX                LL_DMA_STREAM_2
-  // #define FLYSKY_HALL_DMA_Stream_TX                LL_DMA_STREAM_4
+  #define FLYSKY_HALL_DMA_Stream_TX                LL_DMA_STREAM_4
 #endif
 
 #if defined(RADIO_V16)

--- a/radio/src/targets/st16/hal.h
+++ b/radio/src/targets/st16/hal.h
@@ -378,6 +378,7 @@
 
 #define FLYSKY_HALL_SERIAL_DMA                   DMA1
 #define FLYSKY_HALL_DMA_Stream_RX                LL_DMA_STREAM_2
+#define FLYSKY_HALL_DMA_Stream_TX                LL_DMA_STREAM_4
 #define FLYSKY_HALL_DMA_Channel                  LL_DMAMUX1_REQ_USART2_RX
 
 // LED Strip

--- a/radio/src/tasks/mixer_task.cpp
+++ b/radio/src/tasks/mixer_task.cpp
@@ -36,6 +36,10 @@
 #include "hal/gpio.h"
 #endif
 
+#if defined(FLYSKY_GIMBAL)
+  #include "flysky_gimbal_driver.h"
+#endif
+
 task_handle_t mixerTaskId;
 TASK_DEFINE_STACK(mixerStack, MIXER_STACK_SIZE);
 
@@ -235,6 +239,14 @@ void doMixerCalculations()
   DEBUG_TIMER_START(debugTimerGetAdc);
   getADC();
   DEBUG_TIMER_STOP(debugTimerGetAdc);
+
+ // Need to put all in a group to ensure DMA transfer will not affect ADC sampling
+#if defined(FLYSKY_GIMBAL)
+  flysky_gimbal_start_read();
+#endif
+#if defined(FLYSKY_GIMBAL)
+  flysky_gimbal_wait_completion();
+#endif
 
   DEBUG_TIMER_START(debugTimerGetSwitches);
   getSwitchesPosition(!s_mixer_first_run_done);

--- a/radio/src/tasks/mixer_task.cpp
+++ b/radio/src/tasks/mixer_task.cpp
@@ -241,10 +241,10 @@ void doMixerCalculations()
   DEBUG_TIMER_STOP(debugTimerGetAdc);
 
  // Need to put all in a group to ensure DMA transfer will not affect ADC sampling
-#if defined(FLYSKY_GIMBAL)
+#if defined(FLYSKY_GIMBAL) && !defined(SIMU)
   flysky_gimbal_start_read();
 #endif
-#if defined(FLYSKY_GIMBAL)
+#if defined(FLYSKY_GIMBAL) && !defined(SIMU)
   flysky_gimbal_wait_completion();
 #endif
 

--- a/radio/src/tasks/mixer_task.cpp
+++ b/radio/src/tasks/mixer_task.cpp
@@ -240,14 +240,6 @@ void doMixerCalculations()
   getADC();
   DEBUG_TIMER_STOP(debugTimerGetAdc);
 
- // Need to put all in a group to ensure DMA transfer will not affect ADC sampling
-#if defined(FLYSKY_GIMBAL) && !defined(SIMU)
-  flysky_gimbal_start_read();
-#endif
-#if defined(FLYSKY_GIMBAL) && !defined(SIMU)
-  flysky_gimbal_wait_completion();
-#endif
-
   DEBUG_TIMER_START(debugTimerGetSwitches);
   getSwitchesPosition(!s_mixer_first_run_done);
   DEBUG_TIMER_STOP(debugTimerGetSwitches);


### PR DESCRIPTION
Flysky works out a new version of firmware that can support sync sampling:

1. Upon init the gimbal will operate in backward compatible mode (i.e. old EdgeTX will works after the gimbal firmware is upgraded)
2. New firmware will check the version of the firmware to see if sync mode is supported
3. New driver will send command to the gimbal for sync sampling

The gimbal driver changes:
1. It will automatic obtain the version of the gimbal to check if sync sampling is available
2. The default operation mode is backward compatible mode, will switch to sync modes only when new version of gimbal firmware is detected
3. Based on sampling frequency, the driver will automatically switch to sync sampling mode (<= 400Hz - switching threshold) or sync resampling mode (> 400Hz)

Testing:
1. Not breaking the operation of existing old gimbals including the gimbal of GX12
2. Flysky firmware seems to have some problems now, trying to verifying with them.
