### PR TITLE
fix(x12s): only preset AUX2 to GPS if enabled

### DIFF
--- a/radio/src/storage/storage_common.cpp
+++ b/radio/src/storage/storage_common.cpp
@@ -93,7 +93,7 @@ void postRadioSettingsLoad()
     setDefaultOwnerId();
   }
 #endif
-#if defined(PCBX12S)
+#if defined(PCBX12S) && defined(INTERNAL_GPS)
   // AUX2 is hardwired to AUX2 on X12S
   serialSetMode(SP_AUX2, UART_MODE_GPS);
 #endif


### PR DESCRIPTION
Fixes #5826

While this does fix the issue, I do wonder if it would be better to instead set this as part of the one-shot `generalDefault()` that is run if there is no settings present, and thus not also override the user setting if they *don't* want to build custom firmware. 