### PR TITLE
fix(lua): missing speedPrec for getMix/insertMix

### DIFF
--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -842,10 +842,11 @@ Get configuration for specified Mix
  * `mixWarn` (number) warning (0 = off, 1 = 1 beep, .. 3 = 3 beeps)
  * `delayUp` (number) delay up (time in 1/10 s)
  * `delayDown` (number) delay down
+ * `speedPrec` precision of speed up/down (1 or 10)
  * `speedUp` (number) speed up
  * `speedDown` (number) speed down
 
-@status current Introduced in 2.0.0, parameters below `multiplex` added in 2.0.13
+@status current Introduced in 2.0.0, parameters below `multiplex` added in 2.0.13, `speedPrec` added in 2.10
 */
 static int luaModelGetMix(lua_State *L)
 {
@@ -869,6 +870,7 @@ static int luaModelGetMix(lua_State *L)
     lua_pushtableinteger(L, "mixWarn", mix->mixWarn);
     lua_pushtableinteger(L, "delayUp", mix->delayUp);
     lua_pushtableinteger(L, "delayDown", mix->delayDown);
+    lua_pushtableinteger(L, "speedPrec", mix->speedPrec);
     lua_pushtableinteger(L, "speedUp", mix->speedUp);
     lua_pushtableinteger(L, "speedDown", mix->speedDown);
   }
@@ -958,6 +960,9 @@ static int luaModelInsertMix(lua_State *L)
       }
       else if (!strcmp(key, "delayDown")) {
         mix->delayDown = luaL_checkinteger(L, -1);
+      }
+      else if (!strcmp(key, "speedPrec")) {
+        mix->speedPrec = luaL_checkinteger(L, -1);
       }
       else if (!strcmp(key, "speedUp")) {
         mix->speedUp = luaL_checkinteger(L, -1);


### PR DESCRIPTION
Fixes #5873 

Summary of changes:
- add missing `speedPrec` to Lua getMix() and insertMix() functions

Tested on GX12 with two mixer lines on CH20, lua function script run via SF will create the third. It beeps when it runs ;)

```lua
local tab

local function init()
  -- Called once when the script is loaded
end

local function run(event, touchState)
  -- Called periodically while the Special Function switch is on
  tab = model.getMix(19, 1) -- copy the first mixer line into the Table  "tab"
  model.insertMix(19, 2, tab) -- Insert the mixer line ("tab") in the second line of the channel
  playTone(2550, 160, 20, 3, -10)    -- play tone, use radio settings Beep volume
end

local function background()
  -- Called periodically while the Special Function switch is off
end

return { run=run, background=background, init=init }
```