### PR TITLE
chore(bw): cleanup and consolidate navigation code

### DIFF
--- a/radio/src/edgetx.h
+++ b/radio/src/edgetx.h
@@ -103,20 +103,6 @@ enum RotaryEncoderMode {
 #include "myeeprom.h"
 #include "curves.h"
 
-// Define navigation type based on available keys
-#if LCD_W == 212
-  #define NAVIGATION_X9D
-#elif defined(KEYS_GPIO_REG_SHIFT)
-  #define NAVIGATION_XLITE
-#elif defined(KEYS_GPIO_REG_LEFT)
-  #define NAVIGATION_9X
-#elif defined(KEYS_GPIO_REG_PAGEUP) && defined(KEYS_GPIO_REG_TELE)
-  #define NAVIGATION_X7
-  #define NAVIGATION_X7_TX12
-#else
-  #define NAVIGATION_X7
-#endif
-
 void memswap(void * a, void * b, uint8_t size);
 
 // TODO: move these config check macros somewhere else

--- a/radio/src/gui/128x64/gui.h
+++ b/radio/src/gui/128x64/gui.h
@@ -30,14 +30,6 @@
 
 #define MENUS_SCROLLBAR_WIDTH          0
 
-#if defined(NAVIGATION_X7)
-  #define HEADER_LINE                  0
-  #define HEADER_LINE_COLUMNS
-#else
-  #define HEADER_LINE                  1
-  #define HEADER_LINE_COLUMNS          0,
-#endif
-
 #define NUM_BODY_LINES                 (LCD_LINES-1)
 #define TEXT_VIEWER_LINES              NUM_BODY_LINES
 #define MENU_HEADER_HEIGHT             FH

--- a/radio/src/gui/128x64/model_curve_edit.cpp
+++ b/radio/src/gui/128x64/model_curve_edit.cpp
@@ -147,26 +147,12 @@ void menuModelCurveOne(event_t event)
   drawCheckBox(7 * FW, 7 * FH + 1, crv.smooth, menuVerticalPosition == 3 ? INVERS : 0);
   if (menuVerticalPosition==3) crv.smooth = checkIncDecModel(event, crv.smooth, 0, 1);
 
-  switch (event) {
-    case EVT_ENTRY:
-      break;
-
-    case EVT_KEY_LONG(KEY_ENTER):
-      if (menuVerticalPosition > 1) {
-        POPUP_MENU_START(onCurveOneMenu, 3, STR_CURVE_PRESET, STR_MIRROR, STR_CLEAR);
-      }
-      break;
-
-#if defined(NAVIGATION_XLITE)
-    case EVT_KEY_FIRST(KEY_ENTER):
-      if (!keysGetState(KEY_SHIFT))
-        break;
-#else
-    case EVT_KEY_BREAK(KEY_MODEL):
-    case EVT_KEY_BREAK(KEY_MENU):
-#endif
-      pushMenu(menuChannelsView);
-      break;
+  if (event == EVT_KEY_LONG(KEY_ENTER)) {
+    if (menuVerticalPosition > 1) {
+      POPUP_MENU_START(onCurveOneMenu, 3, STR_CURVE_PRESET, STR_MIRROR, STR_CLEAR);
+    }
+  } else if (EVT_KEY_OPEN_CHAN_VIEW(event)) {
+    pushMenu(menuChannelsView);
   }
 
   drawCurve();

--- a/radio/src/gui/128x64/model_input_edit.cpp
+++ b/radio/src/gui/128x64/model_input_edit.cpp
@@ -57,15 +57,10 @@ uint8_t FM_ROW(uint8_t value)
 
 void menuModelExpoOne(event_t event)
 {
-#if defined(NAVIGATION_XLITE)
-  if (event == EVT_KEY_FIRST(KEY_ENTER) && keysGetState(KEY_SHIFT)) {
+  if (EVT_KEY_OPEN_CHAN_VIEW(event)) {
     pushMenu(menuChannelsView);
   }
-#else
-  if (event == EVT_KEY_BREAK(KEY_MODEL) || event == EVT_KEY_BREAK(KEY_MENU)) {
-    pushMenu(menuChannelsView);
-  }
-#endif
+
   ExpoData * ed = expoAddress(s_currIdx);
   drawSource(PSIZE(TR_MENUINPUTS)*FW+FW, 0, MIXSRC_FIRST_INPUT+ed->chn, 0);
 

--- a/radio/src/gui/128x64/model_mix_edit.cpp
+++ b/radio/src/gui/128x64/model_mix_edit.cpp
@@ -93,15 +93,10 @@ void drawOffsetBar(uint8_t x, uint8_t y, MixData * md)
 
 void menuModelMixOne(event_t event)
 {
-#if defined(NAVIGATION_XLITE)
-  if (event == EVT_KEY_FIRST(KEY_ENTER) && keysGetState(KEY_SHIFT)) {
+  if (EVT_KEY_OPEN_CHAN_VIEW(event)) {
     pushMenu(menuChannelsView);
   }
-#else
-  if (event == EVT_KEY_BREAK(KEY_MODEL) || event == EVT_KEY_BREAK(KEY_MENU)) {
-    pushMenu(menuChannelsView);
-  }
-#endif
+
   MixData * md2 = mixAddress(s_currIdx) ;
   putsChn(PSIZE(TR_MIXES)*FW+FW, 0, md2->destCh+1,0);
 

--- a/radio/src/gui/128x64/view_channels.cpp
+++ b/radio/src/gui/128x64/view_channels.cpp
@@ -25,33 +25,6 @@ constexpr coord_t CHANNEL_NAME_OFFSET = 0;
 constexpr coord_t CHANNEL_VALUE_OFFSET = CHANNEL_NAME_OFFSET + 41;
 constexpr coord_t CHANNEL_BAR_WIDTH = 70;
 
-#if defined(RADIO_T8) || defined(RADIO_COMMANDO8)
-#define EVT_KEY_PREVIOUS_VIEW          EVT_KEY_BREAK(KEY_PAGEUP)
-#define EVT_KEY_NEXT_VIEW              EVT_KEY_BREAK(KEY_PAGEDN)
-#define EVT_KEY_NEXT_PAGE              EVT_KEY_BREAK(KEY_PLUS)
-#define EVT_KEY_PREVIOUS_PAGE          EVT_KEY_BREAK(KEY_MINUS)
-#elif defined(NAVIGATION_X7_TX12)
-#define EVT_KEY_PREVIOUS_VIEW          EVT_KEY_BREAK(KEY_PAGEUP)
-#define EVT_KEY_NEXT_VIEW              EVT_KEY_BREAK(KEY_PAGEDN)
-#define EVT_KEY_NEXT_PAGE              EVT_ROTARY_RIGHT
-#define EVT_KEY_PREVIOUS_PAGE          EVT_ROTARY_LEFT
-#elif defined(NAVIGATION_X7)
-#define EVT_KEY_PREVIOUS_VIEW          EVT_KEY_BREAK(KEY_PAGEUP)
-#define EVT_KEY_NEXT_VIEW              EVT_KEY_BREAK(KEY_PAGEDN)
-#define EVT_KEY_NEXT_PAGE              EVT_ROTARY_RIGHT
-#define EVT_KEY_PREVIOUS_PAGE          EVT_ROTARY_LEFT
-#elif defined(NAVIGATION_XLITE)
-#define EVT_KEY_PREVIOUS_VIEW          EVT_KEY_BREAK(KEY_UP)
-#define EVT_KEY_NEXT_VIEW              EVT_KEY_BREAK(KEY_DOWN)
-#define EVT_KEY_NEXT_PAGE              EVT_KEY_BREAK(KEY_RIGHT)
-#define EVT_KEY_PREVIOUS_PAGE          EVT_KEY_BREAK(KEY_LEFT)
-#else
-#define EVT_KEY_PREVIOUS_VIEW          EVT_KEY_BREAK(KEY_UP)
-#define EVT_KEY_NEXT_VIEW              EVT_KEY_BREAK(KEY_DOWN)
-#define EVT_KEY_NEXT_PAGE              EVT_KEY_BREAK(KEY_RIGHT)
-#define EVT_KEY_PREVIOUS_PAGE          EVT_KEY_BREAK(KEY_LEFT)
-#endif
-
 static bool mixersView = false;
 
 void menuChannelsViewCommon(event_t event)

--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -301,42 +301,6 @@ void displayBattVoltage()
 
 #define displayVoltageOrAlarm() displayBattVoltage()
 
-#define EVT_KEY_CONTEXT_MENU           EVT_KEY_LONG(KEY_ENTER)
-
-#if defined(RADIO_T8) || defined(RADIO_COMMANDO8)
-#define EVT_KEY_PREVIOUS_VIEW          EVT_KEY_BREAK(KEY_PAGEUP)
-#define EVT_KEY_NEXT_VIEW              EVT_KEY_BREAK(KEY_PAGEDN)
-#define EVT_KEY_NEXT_PAGE              EVT_KEY_BREAK(KEY_PLUS)
-#define EVT_KEY_PREVIOUS_PAGE          EVT_KEY_BREAK(KEY_MINUS)
-#define EVT_KEY_MODEL_MENU             EVT_KEY_BREAK(KEY_MODEL)
-#define EVT_KEY_GENERAL_MENU           EVT_KEY_BREAK(KEY_SYS)
-#define EVT_KEY_TELEMETRY              EVT_KEY_LONG(KEY_PAGEUP)
-#elif defined(NAVIGATION_X7_TX12)
-#define EVT_KEY_PREVIOUS_VIEW          EVT_KEY_BREAK(KEY_PAGEUP)
-#define EVT_KEY_NEXT_VIEW              EVT_KEY_BREAK(KEY_PAGEDN)
-#define EVT_KEY_NEXT_PAGE              EVT_ROTARY_RIGHT
-#define EVT_KEY_PREVIOUS_PAGE          EVT_ROTARY_LEFT
-#define EVT_KEY_MODEL_MENU             EVT_KEY_BREAK(KEY_MODEL)
-#define EVT_KEY_GENERAL_MENU           EVT_KEY_BREAK(KEY_SYS)
-#define EVT_KEY_TELEMETRY              EVT_KEY_BREAK(KEY_TELE)
-#elif defined(NAVIGATION_X7) || defined(NAVIGATION_TBS)
-#define EVT_KEY_NEXT_VIEW              EVT_KEY_BREAK(KEY_PAGEDN)
-#define EVT_KEY_NEXT_PAGE              EVT_ROTARY_RIGHT
-#define EVT_KEY_PREVIOUS_PAGE          EVT_ROTARY_LEFT
-#define EVT_KEY_MODEL_MENU             EVT_KEY_BREAK(KEY_MENU)
-#define EVT_KEY_GENERAL_MENU           EVT_KEY_LONG(KEY_MENU)
-#define EVT_KEY_TELEMETRY              EVT_KEY_BREAK(KEY_PAGEUP)
-#else
-#define EVT_KEY_PREVIOUS_VIEW          EVT_KEY_BREAK(KEY_UP)
-#define EVT_KEY_NEXT_VIEW              EVT_KEY_BREAK(KEY_DOWN)
-#define EVT_KEY_NEXT_PAGE              EVT_KEY_BREAK(KEY_RIGHT)
-#define EVT_KEY_PREVIOUS_PAGE          EVT_KEY_BREAK(KEY_LEFT)
-#define EVT_KEY_MODEL_MENU             EVT_KEY_LONG(KEY_RIGHT)
-#define EVT_KEY_GENERAL_MENU           EVT_KEY_LONG(KEY_LEFT)
-#define EVT_KEY_TELEMETRY              EVT_KEY_LONG(KEY_DOWN)
-#define EVT_KEY_STATISTICS             EVT_KEY_LONG(KEY_UP)
-#endif
-
 void onMainViewMenu(const char * result)
 {
   if (result == STR_RESET_TIMER1) {
@@ -668,14 +632,3 @@ void menuMainView(event_t event)
 #endif
 #endif
 }
-
-#undef EVT_KEY_CONTEXT_MENU
-#undef EVT_KEY_PREVIOUS_VIEW
-#undef EVT_KEY_NEXT_VIEW
-#undef EVT_KEY_NEXT_PAGE
-#undef EVT_KEY_PREVIOUS_PAGE
-#undef EVT_KEY_MODEL_MENU
-#undef EVT_KEY_GENERAL_MENU
-#undef EVT_KEY_LAST_MENU
-#undef EVT_KEY_TELEMETRY
-#undef EVT_KEY_STATISTICS

--- a/radio/src/gui/212x64/gui.h
+++ b/radio/src/gui/212x64/gui.h
@@ -29,9 +29,6 @@
 #include "navigation/navigation.h"
 #include "common/stdlcd/draw_functions.h"
 
-#define HEADER_LINE                    0
-#define HEADER_LINE_COLUMNS
-
 #define NUM_BODY_LINES                 (LCD_LINES-1)
 #define TEXT_VIEWER_LINES              NUM_BODY_LINES
 #define MENU_HEADER_HEIGHT             FH

--- a/radio/src/gui/212x64/view_main.cpp
+++ b/radio/src/gui/212x64/view_main.cpp
@@ -471,22 +471,22 @@ void menuMainView(event_t event)
       LOAD_MODEL_BITMAP();
       break;
 
-    case EVT_KEY_LONG(KEY_ENTER):
+    case EVT_KEY_CONTEXT_MENU:
       if (modelHasNotes()) {
         POPUP_MENU_ADD_ITEM(STR_VIEW_NOTES);
       }
       POPUP_MENU_START(onMainViewMenu, 3, STR_RESET_SUBMENU, STR_STATISTICS, STR_ABOUT_US);
       break;
 
-    case EVT_KEY_BREAK(KEY_MENU):
+    case EVT_KEY_MODEL_MENU:
       pushMenu(menuModelSelect);
       break;
 
-    case EVT_KEY_LONG(KEY_MENU):
+    case EVT_KEY_GENERAL_MENU:
       pushMenu(menuTabGeneral[0].menuFunc);
       break;
 
-    case EVT_KEY_BREAK(KEY_PAGEDN):
+    case EVT_KEY_NEXT_VIEW:
       storageDirty(EE_MODEL);
       g_model.view += 1;
       if (g_model.view >= VIEW_COUNT) {
@@ -495,7 +495,7 @@ void menuMainView(event_t event)
       }
       break;
 
-    case EVT_KEY_BREAK(KEY_PAGEUP):
+    case EVT_KEY_TELEMETRY:
       chainMenu(menuViewTelemetry);
       break;
 

--- a/radio/src/gui/common/stdlcd/draw_functions.cpp
+++ b/radio/src/gui/common/stdlcd/draw_functions.cpp
@@ -211,7 +211,7 @@ void editName(coord_t x, coord_t y, char* name, uint8_t size, event_t event,
             s_editMode = 0;
           break;
 
-#if defined(NAVIGATION_XLITE) || defined(NAVIGATION_9X)
+#if defined(HAS_LEFT_RIGHT_NAV_KEYS)
         case EVT_KEY_BREAK(KEY_LEFT):
           if (cur > 0)
             cur--;
@@ -223,33 +223,21 @@ void editName(coord_t x, coord_t y, char* name, uint8_t size, event_t event,
           break;
 #endif
 
-#if defined(NAVIGATION_XLITE)
         case EVT_KEY_BREAK(KEY_SHIFT):
-#elif defined(NAVIGATION_9X)
         case EVT_KEY_LONG(KEY_LEFT):
         case EVT_KEY_LONG(KEY_RIGHT):
-#else
         case EVT_KEY_LONG(KEY_ENTER):
-#endif
           killEvents(event);
 
-#if !defined(NAVIGATION_XLITE)
-          if (v == ' ') {
+          if ((event != EVT_KEY_BREAK(KEY_SHIFT)) && v == ' ') {
             s_editMode = 0;
             break;
-          }
-          else
-#endif
-          if (v >= 'A' && v <= 'Z') {
-            v = 'a' + v - 'A'; // toggle case
-          }
-          else if (v >= 'a' && v <= 'z') {
-            v = 'A' + v - 'a'; // toggle case
+          } else if (isupper(v)) {
+            v = tolower(v); // toggle case
+          } else if (islower(v)) {
+            v = toupper(v); // toggle case
           }
 
-#if defined(NAVIGATION_9X)
-          if (event==EVT_KEY_LONG(KEY_LEFT))
-#endif
           break;
       }
 

--- a/radio/src/gui/common/stdlcd/model_usbjoystick.cpp
+++ b/radio/src/gui/common/stdlcd/model_usbjoystick.cpp
@@ -50,15 +50,10 @@ enum USBJFields {
 
 void menuModelUSBJoystickOne(event_t event)
 {
-#if defined(NAVIGATION_XLITE)
-  if (event == EVT_KEY_FIRST(KEY_ENTER) && keysGetState(KEY_SHIFT)) {
+  if (EVT_KEY_OPEN_CHAN_VIEW(event)) {
     pushMenu(menuChannelsView);
   }
-#else
-  if (event == EVT_KEY_BREAK(KEY_MODEL) || event == EVT_KEY_BREAK(KEY_MENU)) {
-    pushMenu(menuChannelsView);
-  }
-#endif
+
   USBJoystickChData * cch = usbJChAddress(s_currIdx);
   putsChn(12*FW, 0, s_currIdx+1, 0);
   lcdDrawNumber(20*FW, 0, channelOutputs[s_currIdx], RIGHT);

--- a/radio/src/gui/common/stdlcd/radio_sdmanager.cpp
+++ b/radio/src/gui/common/stdlcd/radio_sdmanager.cpp
@@ -273,13 +273,13 @@ void onUpdateReceiverSelection(const char * result)
 
 void menuRadioSdManager(event_t _event)
 {
-#if defined(NAVIGATION_X9D)
+#if LCD_DEPTH > 1
   int lastPos = menuVerticalPosition;
 #endif
 
   if (_event == EVT_ENTRY) {
     f_chdir(ROOT_PATH);
-#if defined(NAVIGATION_X9D)
+#if LCD_DEPTH > 1
     lastPos = -1;
 #endif
   }

--- a/radio/src/gui/common/stdlcd/view_telemetry.cpp
+++ b/radio/src/gui/common/stdlcd/view_telemetry.cpp
@@ -32,23 +32,6 @@ enum NavigationDirection {
 #define decrTelemetryScreen() direction = NAVIGATION_DIRECTION_UP
 #define incrTelemetryScreen() direction = NAVIGATION_DIRECTION_DOWN
 
-#if defined(NAVIGATION_XLITE)
-  #define EVT_KEY_PREVIOUS_VIEW(evt)         (evt == EVT_KEY_LONG(KEY_LEFT) && keysGetState(KEY_SHIFT))
-  #define EVT_KEY_NEXT_VIEW(evt)             (evt == EVT_KEY_LONG(KEY_RIGHT) && keysGetState(KEY_SHIFT))
-#elif defined(KEYS_GPIO_REG_PAGEDN)
-  #define EVT_KEY_PREVIOUS_VIEW(evt)         (evt == EVT_KEY_FIRST(KEY_PAGEUP))
-  #define EVT_KEY_NEXT_VIEW(evt)             (evt == EVT_KEY_FIRST(KEY_PAGEDN))
-#elif defined(NAVIGATION_X7) || defined(NAVIGATION_X9D)
-  #define EVT_KEY_PREVIOUS_VIEW(evt)         (evt == EVT_KEY_BREAK(KEY_PAGEUP))
-  #define EVT_KEY_NEXT_VIEW(evt)             (evt == EVT_KEY_BREAK(KEY_PAGEDN))
-#elif defined(NAVIGATION_9X)
-  #define EVT_KEY_PREVIOUS_VIEW(evt)         (evt == EVT_KEY_LONG(KEY_UP))
-  #define EVT_KEY_NEXT_VIEW(evt)             (evt == EVT_KEY_LONG(KEY_DOWN))
-#else
-  #define EVT_KEY_PREVIOUS_VIEW(evt)         (evt == EVT_KEY_FIRST(KEY_UP))
-  #define EVT_KEY_NEXT_VIEW(evt)             (evt == EVT_KEY_FIRST(KEY_DOWN))
-#endif
-
 void menuViewTelemetry(event_t event)
 {
   enum NavigationDirection direction = NAVIGATION_DIRECTION_NONE;
@@ -61,11 +44,11 @@ void menuViewTelemetry(event_t event)
     chainMenu(menuMainView);
   }
 #endif
-  else if (EVT_KEY_PREVIOUS_VIEW(event)) {
+  else if (EVT_KEY_PREVIOUS_TELEM_VIEW(event)) {
     killEvents(event);
     decrTelemetryScreen();
   }
-  else if (EVT_KEY_NEXT_VIEW(event)) {
+  else if (EVT_KEY_NEXT_TELEM_VIEW(event)) {
     killEvents(event);
     incrTelemetryScreen();
   }
@@ -109,6 +92,3 @@ void showTelemScreen(uint8_t index)
     }
   }
 }
-
-#undef EVT_KEY_PREVIOUS_VIEW
-#undef EVT_KEY_NEXT_VIEW

--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -1359,21 +1359,6 @@ void setPotType(int index, int value)
   g_eeGeneral.potsConfig = bfSet<potconfig_t>(g_eeGeneral.potsConfig, value, (POT_CFG_BITS * index), POT_CFG_TYPE_BITS);
 }
 
-#if defined(NAVIGATION_X7) || defined(NAVIGATION_X9D)
-uint8_t MENU_FIRST_LINE_EDIT(const uint8_t * horTab, uint8_t horTabMax)
-{
-  if (horTab) {
-    uint8_t result = 0;
-    while (result < horTabMax && horTab[result] >= HIDDEN_ROW)
-      ++result;
-    return result;
-  }
-  else {
-    return 0;
-  }
-}
-#endif
-
 uint8_t MODULE_BIND_ROWS(int moduleIdx)
 {
   if (isModuleELRS(moduleIdx) && CRSF_ELRS_MIN_VER(moduleIdx, 3, 4)) 

--- a/radio/src/gui/gui_common.h
+++ b/radio/src/gui/gui_common.h
@@ -37,10 +37,6 @@
   #define CASE_ROTARY_ENCODER(x)
 #endif
 
-#if defined(NAVIGATION_X7) || defined(NAVIGATION_X9D)
-extern uint8_t MENU_FIRST_LINE_EDIT(const uint8_t * horTab, uint8_t horTabMax);
-#endif
-
 #if defined(LIBOPENUI)
 typedef std::function<bool(int)> IsValueAvailable;
 #else

--- a/radio/src/gui/navigation/navigation.h
+++ b/radio/src/gui/navigation/navigation.h
@@ -21,6 +21,96 @@
 
 #pragma once
 
+// Define navigation type based on available keys
+#if LCD_W == 212
+  #define NAVIGATION_X9D
+#elif defined(KEYS_GPIO_REG_SHIFT)
+  #define NAVIGATION_XLITE
+#elif defined(KEYS_GPIO_REG_LEFT)
+  #define NAVIGATION_9X
+#elif defined(KEYS_GPIO_REG_PAGEUP) && defined(KEYS_GPIO_REG_TELE)
+  #define NAVIGATION_X7
+  #define NAVIGATION_X7_TX12
+#else
+  #define NAVIGATION_X7
+#endif
+
+#if defined(NAVIGATION_X7) || defined(NAVIGATION_X9D)
+  #define HEADER_LINE                  0
+  #define HEADER_LINE_COLUMNS
+#else
+  #define HEADER_LINE                  1
+  #define HEADER_LINE_COLUMNS          0,
+#endif
+
+// Main View and Channel Monitor view navigation mapping
+
+#define EVT_KEY_CONTEXT_MENU           EVT_KEY_LONG(KEY_ENTER)
+
+#if defined(RADIO_T8) || defined(RADIO_COMMANDO8)
+#define EVT_KEY_PREVIOUS_VIEW          EVT_KEY_BREAK(KEY_PAGEUP)
+#define EVT_KEY_NEXT_VIEW              EVT_KEY_BREAK(KEY_PAGEDN)
+#define EVT_KEY_NEXT_PAGE              EVT_KEY_BREAK(KEY_PLUS)
+#define EVT_KEY_PREVIOUS_PAGE          EVT_KEY_BREAK(KEY_MINUS)
+#define EVT_KEY_MODEL_MENU             EVT_KEY_BREAK(KEY_MODEL)
+#define EVT_KEY_GENERAL_MENU           EVT_KEY_BREAK(KEY_SYS)
+#define EVT_KEY_TELEMETRY              EVT_KEY_LONG(KEY_PAGEUP)
+#elif defined(NAVIGATION_X7_TX12)
+#define EVT_KEY_PREVIOUS_VIEW          EVT_KEY_BREAK(KEY_PAGEUP)
+#define EVT_KEY_NEXT_VIEW              EVT_KEY_BREAK(KEY_PAGEDN)
+#define EVT_KEY_NEXT_PAGE              EVT_ROTARY_RIGHT
+#define EVT_KEY_PREVIOUS_PAGE          EVT_ROTARY_LEFT
+#define EVT_KEY_MODEL_MENU             EVT_KEY_BREAK(KEY_MODEL)
+#define EVT_KEY_GENERAL_MENU           EVT_KEY_BREAK(KEY_SYS)
+#define EVT_KEY_TELEMETRY              EVT_KEY_BREAK(KEY_TELE)
+#elif defined(NAVIGATION_X7) || defined(NAVIGATION_X9D)
+#define EVT_KEY_NEXT_VIEW              EVT_KEY_BREAK(KEY_PAGEDN)
+#define EVT_KEY_NEXT_PAGE              EVT_ROTARY_RIGHT
+#define EVT_KEY_PREVIOUS_PAGE          EVT_ROTARY_LEFT
+#define EVT_KEY_MODEL_MENU             EVT_KEY_BREAK(KEY_MENU)
+#define EVT_KEY_GENERAL_MENU           EVT_KEY_LONG(KEY_MENU)
+#define EVT_KEY_TELEMETRY              EVT_KEY_BREAK(KEY_PAGEUP)
+#else
+#define EVT_KEY_PREVIOUS_VIEW          EVT_KEY_BREAK(KEY_UP)
+#define EVT_KEY_NEXT_VIEW              EVT_KEY_BREAK(KEY_DOWN)
+#define EVT_KEY_NEXT_PAGE              EVT_KEY_BREAK(KEY_RIGHT)
+#define EVT_KEY_PREVIOUS_PAGE          EVT_KEY_BREAK(KEY_LEFT)
+#define EVT_KEY_MODEL_MENU             EVT_KEY_LONG(KEY_RIGHT)
+#define EVT_KEY_GENERAL_MENU           EVT_KEY_LONG(KEY_LEFT)
+#define EVT_KEY_TELEMETRY              EVT_KEY_LONG(KEY_DOWN)
+#define EVT_KEY_STATISTICS             EVT_KEY_LONG(KEY_UP)
+#endif
+
+// Telemtry view navigation mapping
+
+#if defined(NAVIGATION_XLITE)
+  #define EVT_KEY_PREVIOUS_TELEM_VIEW(evt)  (evt == EVT_KEY_LONG(KEY_LEFT) && keysGetState(KEY_SHIFT))
+  #define EVT_KEY_NEXT_TELEM_VIEW(evt)      (evt == EVT_KEY_LONG(KEY_RIGHT) && keysGetState(KEY_SHIFT))
+#elif defined(KEYS_GPIO_REG_PAGEDN)
+  #define EVT_KEY_PREVIOUS_TELEM_VIEW(evt)  (evt == EVT_KEY_FIRST(KEY_PAGEUP))
+  #define EVT_KEY_NEXT_TELEM_VIEW(evt)      (evt == EVT_KEY_FIRST(KEY_PAGEDN))
+#elif defined(NAVIGATION_X7) || defined(NAVIGATION_X9D)
+  #define EVT_KEY_PREVIOUS_TELEM_VIEW(evt)  (evt == EVT_KEY_BREAK(KEY_PAGEUP))
+  #define EVT_KEY_NEXT_TELEM_VIEW(evt)      (evt == EVT_KEY_BREAK(KEY_PAGEDN))
+#elif defined(NAVIGATION_9X)
+  #define EVT_KEY_PREVIOUS_TELEM_VIEW(evt)  (evt == EVT_KEY_LONG(KEY_UP))
+  #define EVT_KEY_NEXT_TELEM_VIEW(evt)      (evt == EVT_KEY_LONG(KEY_DOWN))
+#else
+  #define EVT_KEY_PREVIOUS_TELEM_VIEW(evt)  (evt == EVT_KEY_FIRST(KEY_UP))
+  #define EVT_KEY_NEXT_TELEM_VIEW(evt)      (evt == EVT_KEY_FIRST(KEY_DOWN))
+#endif
+
+// Open Channel view
+#if defined(NAVIGATION_XLITE)
+  #define EVT_KEY_OPEN_CHAN_VIEW(evt)       (evt == EVT_KEY_FIRST(KEY_ENTER) && keysGetState(KEY_SHIFT))
+#else
+  #define EVT_KEY_OPEN_CHAN_VIEW(evt)       (evt == EVT_KEY_BREAK(KEY_MODEL) || evt == EVT_KEY_BREAK(KEY_MENU))
+#endif
+
+#if defined(NAVIGATION_XLITE) || defined(NAVIGATION_9X)
+  #define HAS_LEFT_RIGHT_NAV_KEYS
+#endif
+
 struct CheckIncDecStops
 {
   const int count;

--- a/radio/src/gui/navigation/navigation_x7.cpp
+++ b/radio/src/gui/navigation/navigation_x7.cpp
@@ -29,6 +29,19 @@
 coord_t scrollbar_X = DEFAULT_SCROLLBAR_X;
 #endif
 
+static uint8_t MENU_FIRST_LINE_EDIT(const uint8_t * horTab, uint8_t horTabMax)
+{
+  if (horTab) {
+    uint8_t result = 0;
+    while (result < horTabMax && horTab[result] >= HIDDEN_ROW)
+      ++result;
+    return result;
+  }
+  else {
+    return 0;
+  }
+}
+
 int checkIncDec(event_t event, int val, int i_min, int i_max,
                 unsigned int i_flags, IsValueAvailable isValueAvailable,
                 const CheckIncDecStops &stops)

--- a/radio/src/keys.cpp
+++ b/radio/src/keys.cpp
@@ -311,7 +311,7 @@ bool trimDown(uint8_t idx)
   return READ_TRIMS() & (1 << idx);
 }
 
-uint8_t keysGetState(uint8_t key)
+bool keysGetState(uint8_t key)
 {
   if (key >= MAX_KEYS) return 0;
   return keys[key].pressed();

--- a/radio/src/keys.h
+++ b/radio/src/keys.h
@@ -190,7 +190,7 @@ event_t getTrimEvent();
 void pauseTrimEvents(event_t event);
 void killTrimEvents(event_t event);
 
-uint8_t keysGetState(uint8_t key);
+bool keysGetState(uint8_t key);
 uint8_t keysGetTrimState(uint8_t trim);
 
 bool keysPollingCycle();


### PR DESCRIPTION
Move most of the configuration for the different B&W navigation types into the navigation code files.

This PR focuses on the KEY navigation variations, to hopefully make future changes easier to manage.

There are a few other places where NAVIGATION_X7 is being used to control how the UI is displayed.
These may be able to be cleaned up in future.

Not sure if this will be needed for 2.11 or can wait for 3.0.