### PR TITLE
fix: RTC issue causing time reset and lag on colorlcd 

### DIFF
--- a/radio/src/targets/common/arm/stm32/rtc_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/rtc_driver.cpp
@@ -72,7 +72,7 @@ void rtcInit()
   // Enable LSE Oscillator
   RCC_OscInitTypeDef RCC_OscInitStruct;
   RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_LSE;
-  // RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE;
+  RCC_OscInitStruct.PLL.PLLState   = RCC_PLL_NONE;
   RCC_OscInitStruct.LSEState       = RCC_LSE_ON;
 
   if (HAL_RCC_OscConfig(&RCC_OscInitStruct) == HAL_OK) {


### PR DESCRIPTION
Fix RTC issue when RTC battery is removed.

I have a feeling it should fix 5782 too. If someone could test
