### PR TITLE
fix(color): top bar widgets may not get removed when switching models.

### DIFF
--- a/radio/src/gui/colorlcd/mainview/layout.cpp
+++ b/radio/src/gui/colorlcd/mainview/layout.cpp
@@ -66,6 +66,8 @@ void LayoutFactory::deleteCustomScreens()
       screen = nullptr;
     }
   }
+
+  ViewMain::instance()->getTopbar()->removeAllWidgets();
 }
 
 void LayoutFactory::loadDefaultLayout()

--- a/radio/src/gui/colorlcd/mainview/widgets_container_impl.h
+++ b/radio/src/gui/colorlcd/mainview/widgets_container_impl.h
@@ -83,6 +83,12 @@ class WidgetsContainerImpl : public WidgetsContainer
 
   virtual void create() { memset(persistentData, 0, sizeof(PersistentData)); }
 
+  void removeAllWidgets()
+  {
+    for (unsigned int i = 0; i < N; i++)
+      removeWidget(i);
+  }
+
   virtual void load()
   {
     unsigned int count = getZonesCount();


### PR DESCRIPTION
Ensure all old top bar widgets are removed when changing models.

Can happen when switching from a model that has less top bar widget slots (using the size settings), to one with more slots.
