### PR TITLE
fix(color): view screen layout may not update correctly after changing screen setup.

### DIFF
--- a/radio/src/gui/colorlcd/mainview/layout.cpp
+++ b/radio/src/gui/colorlcd/mainview/layout.cpp
@@ -58,7 +58,7 @@ WidgetsContainer* LayoutFactory::loadLayout(
 //
 // Detaches and deletes all custom screens
 //
-void LayoutFactory::deleteCustomScreens()
+void LayoutFactory::deleteCustomScreens(bool clearTopBar)
 {
   for (auto& screen : customScreens) {
     if (screen) {
@@ -67,7 +67,8 @@ void LayoutFactory::deleteCustomScreens()
     }
   }
 
-  ViewMain::instance()->getTopbar()->removeAllWidgets();
+  if (clearTopBar)
+    ViewMain::instance()->getTopbar()->removeAllWidgets();
 }
 
 void LayoutFactory::loadDefaultLayout()

--- a/radio/src/gui/colorlcd/mainview/layout.h
+++ b/radio/src/gui/colorlcd/mainview/layout.h
@@ -64,7 +64,7 @@ class LayoutFactory
   static void disposeCustomScreen(unsigned idx);
 
   // delete all custom screens from memory
-  static void deleteCustomScreens();
+  static void deleteCustomScreens(bool clearTopBar = false);
 
   // intended for existing models
   static void loadCustomScreens();

--- a/radio/src/gui/colorlcd/mainview/layout_factory_impl.cpp
+++ b/radio/src/gui/colorlcd/mainview/layout_factory_impl.cpp
@@ -34,7 +34,6 @@ Layout::Layout(Window* parent, const LayoutFactory* factory,
     zoneCount(zoneCount),
     zoneMap(zoneMap)
 {
-  adjustLayout();
 }
 
 void Layout::setTrimsVisible(bool visible)
@@ -50,24 +49,6 @@ void Layout::setSlidersVisible(bool visible)
 void Layout::setFlightModeVisible(bool visible)
 {
   decoration->setFlightModeVisible(visible);
-}
-
-void Layout::adjustLayout()
-{
-  // Check if deco setting are still up-to-date
-  uint8_t checkSettings = (hasTopbar() ? DECORATION_TOPBAR : 0) |
-                          (hasSliders() ? DECORATION_SLIDERS : 0) |
-                          (hasTrims() ? DECORATION_TRIMS : 0) |
-                          (hasFlightMode() ? DECORATION_FLIGHTMODE : 0) |
-                          (isMirrored() ? DECORATION_MIRRORED : 0);
-
-  if (checkSettings == decorationSettings) {
-    // everything ok, exit!
-    return;
-  }
-
-  // Save settings
-  decorationSettings = checkSettings;
 }
 
 void Layout::show(bool visible)
@@ -86,8 +67,7 @@ void Layout::show(bool visible)
 rect_t Layout::getMainZone() const
 {
   rect_t zone = decoration->getMainZone();
-  if (decorationSettings &
-      (DECORATION_SLIDERS | DECORATION_TRIMS | DECORATION_FLIGHTMODE)) {
+  if (hasSliders() || hasTrims() || hasFlightMode()) {
     // some decoration activated
     zone.x += MAIN_ZONE_BORDER;
     zone.y += MAIN_ZONE_BORDER;

--- a/radio/src/gui/colorlcd/mainview/layout_factory_impl.h
+++ b/radio/src/gui/colorlcd/mainview/layout_factory_impl.h
@@ -106,7 +106,6 @@ class Layout: public LayoutBase
     void setFlightModeVisible(bool visible);
 
     // Updates settings for trims, sliders, pots, etc...
-    void adjustLayout() override;
     void show(bool visible = true) override;
 
     bool isLayout() override { return true; }
@@ -118,19 +117,6 @@ class Layout: public LayoutBase
     std::unique_ptr<ViewMainDecoration> decoration;
     uint8_t zoneCount;
     uint8_t* zoneMap = nullptr;
-
-    enum DecorationSettings {
-        DECORATION_NONE       = 0x00,
-        DECORATION_TOPBAR     = 0x01,
-        DECORATION_SLIDERS    = 0x02,
-        DECORATION_TRIMS      = 0x04,
-        DECORATION_FLIGHTMODE = 0x08,
-        DECORATION_MIRRORED   = 0x10,
-        DECORATION_UNKNOWN    = 0xFF
-    };
-
-    // Decoration settings bitmask to detect updates
-    uint8_t  decorationSettings = DECORATION_UNKNOWN;
 
     // Last time we refreshed the window
     uint32_t lastRefresh = 0;

--- a/radio/src/gui/colorlcd/mainview/screen_setup.cpp
+++ b/radio/src/gui/colorlcd/mainview/screen_setup.cpp
@@ -342,7 +342,6 @@ void ScreenSetupPage::buildLayoutOptions()
                          GET_DEFAULT(value->boolValue),
                          [=](int newValue) {
                            value->boolValue = newValue;
-                           customScreens[customScreenIndex]->show();
                            SET_DIRTY();
                          });
         break;

--- a/radio/src/gui/colorlcd/mainview/view_main.cpp
+++ b/radio/src/gui/colorlcd/mainview/view_main.cpp
@@ -111,7 +111,6 @@ void ViewMain::addMainView(WidgetsContainer* view, uint32_t viewId)
   lv_obj_add_event_cb(tile, tile_view_deleted_cb, LV_EVENT_CHILD_DELETED,
                       user_data);
 
-  view->adjustLayout();
   view->show();  
 }
 
@@ -193,7 +192,6 @@ void ViewMain::updateTopbarVisibility()
     int view = scrollPos / pageWidth;
     setTopbarVisible(hasTopbar(view));
     setEdgeTxButtonVisible(hasTopbar(view) || isAppMode(view));
-    if (customScreens[view]) customScreens[view]->adjustLayout();
   } else {
     int leftIdx = scrollPos / pageWidth;
     bool leftTopbar = hasTopbar(leftIdx);
@@ -233,9 +231,6 @@ void ViewMain::updateTopbarVisibility()
     }
 
     setEdgeTxButtonVisible(ratio);
-
-    customScreens[leftIdx]->adjustLayout();
-    customScreens[leftIdx + 1]->adjustLayout();
   }
 }
 
@@ -377,9 +372,11 @@ void ViewMain::show(bool visible)
   int view = getCurrentMainView();
   setTopbarVisible(visible && hasTopbar(view));
   setEdgeTxButtonVisible(visible && (hasTopbar(view) || isAppMode()));
-  if (customScreens[view]) {
-    customScreens[view]->show(visible);
-    customScreens[view]->showWidgets(visible);
+  for (int i = 0; i < MAX_CUSTOM_SCREENS; i += 1) {
+    if (customScreens[i]) {
+      customScreens[i]->show(visible);
+      customScreens[i]->showWidgets(visible);
+    }
   }
 }
 

--- a/radio/src/gui/colorlcd/mainview/widgets_container.h
+++ b/radio/src/gui/colorlcd/mainview/widgets_container.h
@@ -79,7 +79,6 @@ class WidgetsContainer: public Window
     virtual Widget * createWidget(unsigned int index, const WidgetFactory * factory) = 0;
     virtual Widget * getWidget(unsigned int index) = 0;
     virtual void removeWidget(unsigned int index) = 0;
-    virtual void adjustLayout() = 0;
     virtual void updateZones() = 0;
     virtual void showWidgets(bool visible = true) = 0;
     virtual void hideWidgets() { showWidgets(false); }

--- a/radio/src/gui/colorlcd/mainview/widgets_container_impl.h
+++ b/radio/src/gui/colorlcd/mainview/widgets_container_impl.h
@@ -132,7 +132,6 @@ class WidgetsContainerImpl : public WidgetsContainer
 
   void updateZones() override
   {
-    adjustLayout();
     for (int i = 0; i < N; i++) {
       if (widgets[i]) {
         auto zone = getZone(i);
@@ -150,8 +149,6 @@ class WidgetsContainerImpl : public WidgetsContainer
       }
     }
   }
-
-  void adjustLayout() override {}
 
   void runBackground() override
   {

--- a/radio/src/storage/sdcard_common.cpp
+++ b/radio/src/storage/sdcard_common.cpp
@@ -132,7 +132,7 @@ const char * createModel()
     storageCheck(true);
 #if defined(COLORLCD)
     // Default layout loaded when setting model defaults - neeed to remove it.
-    LayoutFactory::deleteCustomScreens();
+    LayoutFactory::deleteCustomScreens(true);
 #endif
   }
   postModelLoad(false);

--- a/radio/src/storage/storage_common.cpp
+++ b/radio/src/storage/storage_common.cpp
@@ -73,7 +73,7 @@ void preModelLoad()
 
   stopTrainer();
 #if defined(COLORLCD)
-  LayoutFactory::deleteCustomScreens();
+  LayoutFactory::deleteCustomScreens(true);
 #endif
 
   if (needDelay)


### PR DESCRIPTION
Fixes #5909 

Ensure all view screens are correctly updated.

To reproduce, create a model with multiple view screens. Enter screen setup and change to a view other than the current visible one. Change settings (topbar, trims, sliders, etc). Exit screen setup and scroll to the changed screen.
