### PR TITLE
fix(bw): bluetooth discovery popup menu lockup

### DIFF
--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -430,8 +430,7 @@ void onBluetoothConnectMenu(const char * result)
     uint8_t index = (result - reusableBuffer.moduleSetup.bt.devices[0]) / sizeof(reusableBuffer.moduleSetup.bt.devices[0]);
     strncpy(bluetooth.distantAddr, reusableBuffer.moduleSetup.bt.devices[index], LEN_BLUETOOTH_ADDR);
     bluetooth.state = BLUETOOTH_STATE_BIND_REQUESTED;
-  }
-  else {
+  } else {
     reusableBuffer.moduleSetup.bt.devicesCount = 0;
     bluetooth.state = BLUETOOTH_STATE_DISCOVER_END;
   }

--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -1724,10 +1724,8 @@ void menuModelSetup(event_t event)
               for (uint8_t i=0; i<popupMenuItemsCount; i++) {
                 popupMenuItems[i] = reusableBuffer.moduleSetup.bt.devices[i];
               }
-              if (popupMenuHandler != onBluetoothConnectMenu) {
-                POPUP_MENU_TITLE(STR_BT_SELECT_DEVICE);
-                POPUP_MENU_START(onBluetoothConnectMenu);
-              }
+              POPUP_MENU_TITLE(STR_BT_SELECT_DEVICE);
+              POPUP_MENU_START(onBluetoothConnectMenu);
             }
           }
         }

--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -1724,8 +1724,10 @@ void menuModelSetup(event_t event)
               for (uint8_t i=0; i<popupMenuItemsCount; i++) {
                 popupMenuItems[i] = reusableBuffer.moduleSetup.bt.devices[i];
               }
-              POPUP_MENU_TITLE(STR_BT_SELECT_DEVICE);
-              POPUP_MENU_START(onBluetoothConnectMenu);
+              if (popupMenuHandler != onBluetoothConnectMenu) {
+                POPUP_MENU_TITLE(STR_BT_SELECT_DEVICE);
+                POPUP_MENU_START(onBluetoothConnectMenu);
+              }
             }
           }
         }

--- a/radio/src/gui/common/stdlcd/popups.cpp
+++ b/radio/src/gui/common/stdlcd/popups.cpp
@@ -337,8 +337,8 @@ void POPUP_MENU_TITLE(const char * s)
 
 void POPUP_MENU_START(PopupMenuHandler handler)
 {
-  killAllEvents();
   if (handler != popupMenuHandler) {
+    killAllEvents();
     AUDIO_KEY_PRESS();
     popupMenuHandler = handler;
   }

--- a/radio/src/gui/common/stdlcd/popups.cpp
+++ b/radio/src/gui/common/stdlcd/popups.cpp
@@ -337,7 +337,7 @@ void POPUP_MENU_TITLE(const char * s)
 
 void POPUP_MENU_START(PopupMenuHandler handler)
 {
-  // killAllEvents();
+  killAllEvents();
   if (handler != popupMenuHandler) {
     AUDIO_KEY_PRESS();
     popupMenuHandler = handler;

--- a/radio/src/gui/common/stdlcd/popups.cpp
+++ b/radio/src/gui/common/stdlcd/popups.cpp
@@ -337,7 +337,7 @@ void POPUP_MENU_TITLE(const char * s)
 
 void POPUP_MENU_START(PopupMenuHandler handler)
 {
-  killAllEvents();
+  // killAllEvents();
   if (handler != popupMenuHandler) {
     AUDIO_KEY_PRESS();
     popupMenuHandler = handler;


### PR DESCRIPTION
Fixes #5895

Summary of changes:
- ensures `killAllEvents()` is only run on `POPUP_MENU_START()` starting a new menu