### PR TITLE
feat: allow for compile time user override of power LED color

### DIFF
--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -62,6 +62,7 @@ if(PCB STREQUAL X9D+ AND PCBREV STREQUAL 2019)
 else()
   option(USBJ_EX "Enable USB Joystick Extension" ON)
 endif()
+option(POWER_LED_BLUE  "Override Power LED to be normally Blue" OFF)
 
 # since we reset all default CMAKE compiler flags for firmware builds, provide an alternate way for user to specify additional flags.
 set(FIRMWARE_C_FLAGS "" CACHE STRING "Additional flags for firmware target c compiler (note: all CMAKE_C_FLAGS[_*] are ignored for firmware/bootloader).")
@@ -432,6 +433,10 @@ if(USBJ_EX)
   set(SRC ${SRC}
     usb_joystick.cpp
   )
+endif()
+
+if(POWER_LED_BLUE)
+  add_definitions(-DPOWER_LED_BLUE)
 endif()
 
 foreach(FILE ${TARGET_SRC})

--- a/radio/src/edgetx.h
+++ b/radio/src/edgetx.h
@@ -598,10 +598,10 @@ constexpr uint8_t OPENTX_START_NO_CHECKS = 0x04;
 
 #if defined(STATUS_LEDS)
   #define LED_ERROR_BEGIN()            ledRed()
-// Green is preferred "ready to use" color for these radios
-#if defined(MANUFACTURER_RADIOMASTER) || defined(MANUFACTURER_JUMPER) || defined(RADIO_COMMANDO8)
-#define LED_ERROR_END() ledGreen()
-#define LED_BIND() ledBlue()
+  // Green is preferred "ready to use" color for these radios, unless overridden by user
+#if !defined(POWER_LED_BLUE) && (defined(MANUFACTURER_RADIOMASTER) || defined(MANUFACTURER_JUMPER) || defined(RADIO_COMMANDO8))
+  #define LED_ERROR_END() ledGreen()
+  #define LED_BIND() ledBlue()
 #else
 // Either green is not an option, or blue is preferred "ready to use" color
   #define LED_ERROR_END()              ledBlue()

--- a/radio/src/options.h
+++ b/radio/src/options.h
@@ -103,5 +103,8 @@ static const char * const options[] = {
 #if defined(ENABLE_SERIAL_PASSTHROUGH)
     "passthrough",
 #endif
+#if defined(POWER_LED_BLUE)
+    "power_led_blue",
+#endif
   nullptr //sentinel
 };

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -259,7 +259,12 @@ void boardInit()
   rtcInit(); // RTC must be initialized before rambackupRestore() is called
 #endif
 
+#if !defined(POWER_LED_BLUE)
   ledBlue();
+#else
+  ledGreen();
+#endif
+
 #if !defined(LCD_VERTICAL_INVERT)
   lcdSetInitalFrameBuffer(lcdFront->getData());
 #elif defined(RADIO_F16)

--- a/radio/src/targets/pl18/board.cpp
+++ b/radio/src/targets/pl18/board.cpp
@@ -288,7 +288,11 @@ void boardInit()
   rtcInit(); // RTC must be initialized before rambackupRestore() is called
 #endif
 #if defined(LED_STRIP_GPIO)
+#if !defined(POWER_LED_BLUE)
   ledBlue();
+#else
+  ledGreen();
+#endif
 #endif
 
   lcdSetInitalFrameBuffer(lcdFront->getData());

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -167,7 +167,7 @@ void boardInit()
 
 #if defined(STATUS_LEDS)
   ledInit();
-#if defined(MANUFACTURER_RADIOMASTER) || defined(MANUFACTURER_JUMPER) || defined(RADIO_COMMANDO8)
+#if !defined(POWER_LED_BLUE) && (defined(MANUFACTURER_RADIOMASTER) || defined(MANUFACTURER_JUMPER) || defined(RADIO_COMMANDO8))
   ledBlue();
 #else
   ledGreen();


### PR DESCRIPTION
Resolves #5010

Summary of changes:
- allows for user override of Power LED startup sequence from the mostly standardised RED (pre RTC init), BLUE (starting up), GREEN (ready to use) via compile time flag
- inverts the blue -> green sequence to be green -> blue, allowing for blue to be the "ready" color, and adds mention of this override to build opts listing. 

Tested on TX16S, Boxer and PL18EV