### PR TITLE
feat(color): telemetry queues for Lua, enhance default widget options

### DIFF
--- a/radio/src/gui/colorlcd/libui/list_line_button.cpp
+++ b/radio/src/gui/colorlcd/libui/list_line_button.cpp
@@ -109,7 +109,7 @@ void InputMixButtonBase::setSource(mixsrc_t idx)
   else
     lv_obj_clear_state(source, LV_STATE_USER_1);
 
-    lv_label_set_text(source, s);
+  lv_label_set_text(source, s);
 }
 
 void InputMixButtonBase::setOpts(const char* s)

--- a/radio/src/gui/colorlcd/mainview/layout.h
+++ b/radio/src/gui/colorlcd/mainview/layout.h
@@ -49,7 +49,7 @@ class LayoutFactory
 
   virtual const uint8_t* getBitmap() const = 0;
 
-  virtual const ZoneOption* getOptions() const = 0;
+  virtual const ZoneOption* getLayoutOptions() const = 0;
 
   virtual WidgetsContainer* create(
       Window* parent, LayoutPersistentData* persistentData) const = 0;

--- a/radio/src/gui/colorlcd/mainview/layout_factory_impl.h
+++ b/radio/src/gui/colorlcd/mainview/layout_factory_impl.h
@@ -182,7 +182,7 @@ class BaseLayoutFactory: public LayoutFactory
 
     const uint8_t* getBitmap() const override { return bitmap; }
 
-    const ZoneOption * getOptions() const override
+    const ZoneOption * getLayoutOptions() const override
     {
       return options;
     }

--- a/radio/src/gui/colorlcd/mainview/layout_factory_impl.h
+++ b/radio/src/gui/colorlcd/mainview/layout_factory_impl.h
@@ -98,8 +98,6 @@ class Layout: public LayoutBase
       return getOptionValue(LAYOUT_OPTION_MIRRORED)->boolValue;
     }
 
-    virtual bool isAppMode() const { return false; }
-
     // Set decoration visibility
     void setTrimsVisible(bool visible);
     void setSlidersVisible(bool visible);

--- a/radio/src/gui/colorlcd/mainview/screen_setup.cpp
+++ b/radio/src/gui/colorlcd/mainview/screen_setup.cpp
@@ -327,7 +327,7 @@ void ScreenSetupPage::buildLayoutOptions()
   if (!factory) return;
 
   int index = 0;
-  for (auto* option = factory->getOptions(); option->name; option++, index++) {
+  for (auto* option = factory->getLayoutOptions(); option->name; option++, index++) {
     auto layoutData = &g_model.screenData[customScreenIndex].layoutData;
     ZoneOptionValue* value = &layoutData->options[index].value;
 

--- a/radio/src/gui/colorlcd/mainview/widget.cpp
+++ b/radio/src/gui/colorlcd/mainview/widget.cpp
@@ -57,13 +57,13 @@ void Widget::openMenu()
     return;
   }
 
-  if (getOptions() || fsAllowed) {
+  if (hasOptions() || fsAllowed) {
     Menu* menu = new Menu();
     menu->setTitle(getFactory()->getDisplayName());
     if (fsAllowed) {
       menu->addLine(STR_WIDGET_FULLSCREEN, [&]() { setFullscreen(true); });
     }
-    if (getOptions() && getOptions()->name) {
+    if (hasOptions()) {
       menu->addLine(STR_WIDGET_SETTINGS,
                     [=]() { new WidgetSettings(this); });
     }
@@ -146,9 +146,9 @@ bool Widget::onLongPress()
   return true;
 }
 
-const ZoneOption* Widget::getOptions() const
+const ZoneOption* Widget::getOptionDefinitions() const
 {
-  return getFactory()->getOptions();
+  return getFactory()->getDefaultOptions();
 }
 
 void Widget::enableFocus(bool enable)
@@ -253,6 +253,7 @@ void WidgetFactory::initPersistentData(Widget::PersistentData* persistentData,
 {
   if (setDefault) {
     memset(persistentData, 0, sizeof(Widget::PersistentData));
+    parseOptionDefaults();
   }
   if (options) {
     int i = 0;

--- a/radio/src/gui/colorlcd/mainview/widget.h
+++ b/radio/src/gui/colorlcd/mainview/widget.h
@@ -42,7 +42,8 @@ class Widget : public ButtonBase
 
   const WidgetFactory* getFactory() const { return factory; }
 
-  const ZoneOption* getOptions() const;
+  const ZoneOption* getOptionDefinitions() const;
+  bool hasOptions() const { return getOptionDefinitions() && getOptionDefinitions()->name; }
 
   virtual const char* getErrorMessage() const { return nullptr; }
 
@@ -117,7 +118,8 @@ class WidgetFactory
 
   const char* getName() const { return name; }
 
-  const ZoneOption* getOptions() const { return options; }
+  const ZoneOption* getDefaultOptions() const { return options; }
+  virtual const void parseOptionDefaults() const {}
 
   const char* getDisplayName() const
   {

--- a/radio/src/gui/colorlcd/mainview/widget_settings.cpp
+++ b/radio/src/gui/colorlcd/mainview/widget_settings.cpp
@@ -49,7 +49,8 @@ WidgetSettings::WidgetSettings(Widget* w) :
   FlexGridLayout grid(line_col_dsc, line_row_dsc, PAD_TINY);
 
   uint8_t optIdx = 0;
-  auto opt = widget->getOptions();
+  auto opt = widget->getOptionDefinitions();
+
   while (opt && opt->name != nullptr) {
     auto line = form->newLine(grid);
 

--- a/radio/src/gui/colorlcd/mainview/widgets_container.h
+++ b/radio/src/gui/colorlcd/mainview/widgets_container.h
@@ -85,5 +85,6 @@ class WidgetsContainer: public Window
     virtual void runBackground() = 0;
 
     virtual bool isLayout() { return false; }
+    virtual bool isAppMode() const { return false; }
     bool isWidgetsContainer() override { return true; }
 };

--- a/radio/src/gui/colorlcd/mainview/widgets_setup.cpp
+++ b/radio/src/gui/colorlcd/mainview/widgets_setup.cpp
@@ -41,7 +41,7 @@ SetupWidgetsPageSlot::SetupWidgetsPageSlot(Window* parent, const rect_t& rect,
       menu->addLine(STR_SELECT_WIDGET,
                     [=]() { addNewWidget(container, slotIndex); });
       auto widget = container->getWidget(slotIndex);
-      if (widget->getOptions() && widget->getOptions()->name)
+      if (widget->hasOptions())
         menu->addLine(STR_WIDGET_SETTINGS,
                       [=]() { new WidgetSettings(widget); });
       menu->addLine(STR_REMOVE_WIDGET,
@@ -103,7 +103,7 @@ void SetupWidgetsPageSlot::addNewWidget(WidgetsContainer* container,
     menu->addLine(factory->getDisplayName(), [=]() {
       container->createWidget(slotIndex, factory);
       auto widget = container->getWidget(slotIndex);
-      if (widget->getOptions() && widget->getOptions()->name)
+      if (widget->hasOptions())
         new WidgetSettings(widget);
     });
     if (cur && strcmp(cur, factory->getDisplayName()) == 0)

--- a/radio/src/gui/colorlcd/standalone_lua.cpp
+++ b/radio/src/gui/colorlcd/standalone_lua.cpp
@@ -133,6 +133,8 @@ StandaloneLuaWindow::StandaloneLuaWindow(bool useLvgl, int initFn, int runFn) :
 
   etx_solid_bg(lvobj);
 
+  luaScriptManager = this;
+
   if (useLvglLayout()) {
     padAll(PAD_ZERO);
     etx_scrollbar(lvobj);
@@ -146,8 +148,6 @@ StandaloneLuaWindow::StandaloneLuaWindow(bool useLvgl, int initFn, int runFn) :
     lv_obj_set_style_text_align(lbl, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
     lv_obj_set_style_pad_top(lbl, (LCD_H - EdgeTxStyles::PAGE_LINE_HEIGHT) / 2, LV_PART_MAIN);
     lv_label_set_text(lbl, STR_LOADING);
-
-    luaLvglManager = this;
   } else {
     lcdBuffer = new BitmapBuffer(BMP_RGB565, LCD_W, LCD_H);
 
@@ -218,7 +218,7 @@ void StandaloneLuaWindow::deleteLater(bool detach, bool trash)
   if (lcdBuffer) delete lcdBuffer;
   lcdBuffer = nullptr;
 
-  luaLvglManager = nullptr;
+  luaScriptManager = nullptr;
 
   Layer::pop(this);
   Layer::back()->show();
@@ -320,13 +320,13 @@ void StandaloneLuaWindow::checkEvents()
   luaLcdAllowed = false;
 }
 
-void StandaloneLuaWindow::onClicked() { Keyboard::hide(false); LuaEventHandler::onClicked(); }
+void StandaloneLuaWindow::onClicked() { Keyboard::hide(false); LuaScriptManager::onClickedEvent(); }
 
-void StandaloneLuaWindow::onCancel() { LuaEventHandler::onCancel(); }
+void StandaloneLuaWindow::onCancel() { LuaScriptManager::onCancelEvent(); }
 
 void StandaloneLuaWindow::onEvent(event_t evt)
 {
-  LuaEventHandler::onLuaEvent(evt);
+  LuaScriptManager::onLuaEvent(evt);
 }
 
 void StandaloneLuaWindow::popupPaint(BitmapBuffer* dc, coord_t x, coord_t y, coord_t w, coord_t h,

--- a/radio/src/gui/colorlcd/standalone_lua.h
+++ b/radio/src/gui/colorlcd/standalone_lua.h
@@ -28,7 +28,7 @@
 
 extern void luaExecStandalone(const char * filename);
 
-class StandaloneLuaWindow : public Window, public LuaEventHandler, public LuaLvglManager
+class StandaloneLuaWindow : public Window, public LuaScriptManager
 {
   static StandaloneLuaWindow* _instance;
 

--- a/radio/src/lua/api_colorlcd.cpp
+++ b/radio/src/lua/api_colorlcd.cpp
@@ -36,7 +36,6 @@
 #define BITMAP_METATABLE "BITMAP*"
 
 BitmapBuffer* luaLcdBuffer  = nullptr;
-LuaWidget *runningFS = nullptr;
 
 /*luadoc
 @function lcd.refresh()
@@ -1386,8 +1385,8 @@ Exit full screen widget mode.
 */
 static int luaLcdExitFullScreen(lua_State *L)
 {
-  if (runningFS)
-    runningFS->closeFullscreen();
+  if (luaScriptManager)
+    luaScriptManager->exitFullscreen();
   return 0;
 }
 

--- a/radio/src/lua/api_colorlcd_lvgl.cpp
+++ b/radio/src/lua/api_colorlcd_lvgl.cpp
@@ -351,7 +351,7 @@ LROT_BEGIN(lvgllib, NULL, 0)
   LROT_FUNCENTRY(source, [](lua_State* L) { return luaLvglObjEx(L, []() { return new LvglWidgetSourcePicker(); }, true); })
   // Containers
   LROT_FUNCENTRY(box, [](lua_State* L) { return luaLvglObj(L, []() { return new LvglWidgetBox(); }, true); })
-  LROT_FUNCENTRY(setting, [](lua_State* L) { return luaLvglObj(L, []() { return new LvglWidgetSetting(); }, true); })
+  LROT_FUNCENTRY(setting, [](lua_State* L) { return luaLvglObjEx(L, []() { return new LvglWidgetSetting(); }, true); })
   LROT_FUNCENTRY(page, [](lua_State* L) { return luaLvglObj(L, []() { return new LvglWidgetPage(); }, true); })
   LROT_FUNCENTRY(dialog, [](lua_State* L) { return luaLvglObjEx(L, []() { return new LvglWidgetDialog(); }, true); })
   // Dialogs
@@ -436,6 +436,9 @@ LROT_BEGIN(lvgl_mt, NULL, LROT_MASK_GC_INDEX)
   LROT_FUNCENTRY(timer, [](lua_State* L) { return luaLvglObjEx(L, []() { return new LvglWidgetTimerPicker(); }, true); })
   LROT_FUNCENTRY(switch, [](lua_State* L) { return luaLvglObjEx(L, []() { return new LvglWidgetSwitchPicker(); }, true); })
   LROT_FUNCENTRY(source, [](lua_State* L) { return luaLvglObjEx(L, []() { return new LvglWidgetSourcePicker(); }, true); })
+  // Containers
+  LROT_FUNCENTRY(box, [](lua_State* L) { return luaLvglObj(L, []() { return new LvglWidgetBox(); }, true); })
+  LROT_FUNCENTRY(setting, [](lua_State* L) { return luaLvglObjEx(L, []() { return new LvglWidgetSetting(); }, true); })
   // Object manipulation functions
   LROT_FUNCENTRY(set, luaLvglSet)
   LROT_FUNCENTRY(show, luaLvglShow)

--- a/radio/src/lua/api_colorlcd_lvgl.cpp
+++ b/radio/src/lua/api_colorlcd_lvgl.cpp
@@ -32,8 +32,7 @@ static int luaLvglObj(lua_State *L, std::function<LvglWidgetObject*()> create, b
 {
   if (luaScriptManager && (!fullscreenOnly || luaScriptManager->isFullscreen())) {
     auto obj = create();
-    obj->getParams(L, 1);
-    obj->build(L);
+    obj->create(L, 1);
     obj->push(L);
   } else {
     lua_pushnil(L);
@@ -56,8 +55,7 @@ static int luaLvglObjEx(lua_State *L, std::function<LvglWidgetObjectBase*()> cre
     }
 
     auto obj = create();
-    obj->getParams(L, -1);
-    obj->build(L);
+    obj->create(L, -1);
     obj->push(L);
 
     if (p)
@@ -72,8 +70,7 @@ static int luaLvglObjEx(lua_State *L, std::function<LvglWidgetObjectBase*()> cre
 static int luaLvglPopup(lua_State *L, std::function<LvglWidgetObjectBase*()> create)
 {
   auto obj = create();
-  obj->getParams(L, 1);
-  obj->build(L);
+  obj->create(L, 1);
   return 0;
 }
 
@@ -234,8 +231,7 @@ static void buildLvgl(lua_State *L, int srcIndex, int refIndex)
         obj = new LvglWidgetSetting();
     }
     if (obj) {
-      obj->getParams(L, -1);
-      obj->build(L);
+      obj->create(L, -1);
       auto ref = obj->getRef(L);
       if (p.name) {
         lua_pushstring(L, p.name);

--- a/radio/src/lua/api_colorlcd_lvgl.cpp
+++ b/radio/src/lua/api_colorlcd_lvgl.cpp
@@ -145,6 +145,15 @@ static int luaLvglDisable(lua_State *L)
   return 0;
 }
 
+static int luaLvglClose(lua_State *L)
+{
+  auto p = LvglWidgetObjectBase::checkLvgl(L, 1);
+  if (p) {
+    p->close();
+  }
+  return 0;
+}
+
 class LvglWidgetParams
 {
  public:
@@ -363,6 +372,7 @@ LROT_BEGIN(lvgllib, NULL, 0)
   LROT_FUNCENTRY(hide, luaLvglHide)
   LROT_FUNCENTRY(enable, luaLvglEnable)
   LROT_FUNCENTRY(disable, luaLvglDisable)
+  LROT_FUNCENTRY(close, luaLvglClose)
   LROT_NUMENTRY(FLOW_ROW, LV_FLEX_FLOW_ROW)
   LROT_NUMENTRY(FLOW_COLUMN, LV_FLEX_FLOW_COLUMN)
   LROT_NUMENTRY(PAD_TINY, PAD_TINY)
@@ -445,6 +455,7 @@ LROT_BEGIN(lvgl_mt, NULL, LROT_MASK_GC_INDEX)
   LROT_FUNCENTRY(hide, luaLvglHide)
   LROT_FUNCENTRY(enable, luaLvglEnable)
   LROT_FUNCENTRY(disable, luaLvglDisable)
+  LROT_FUNCENTRY(close, luaLvglClose)
 LROT_END(lvgl_mt, NULL, LROT_MASK_GC_INDEX)
 
 extern "C" {

--- a/radio/src/lua/api_colorlcd_lvgl.cpp
+++ b/radio/src/lua/api_colorlcd_lvgl.cpp
@@ -172,6 +172,7 @@ static void buildLvgl(lua_State *L, int srcIndex, int refIndex)
 {
   luaL_checktype(L, srcIndex, LUA_TTABLE);
   for (lua_pushnil(L); lua_next(L, srcIndex - 1); lua_pop(L, 1)) {
+    auto t = lua_gettop(L);
     LvglWidgetParams p(L, -1);
     LvglWidgetObjectBase *obj = nullptr;
     if (strcasecmp(p.type, "label") == 0)
@@ -247,6 +248,7 @@ static void buildLvgl(lua_State *L, int srcIndex, int refIndex)
         luaScriptManager->setTempParent(prevParent);
       }
     }
+    lua_settop(L, t); // In case of errors in build functions
   }
 }
 

--- a/radio/src/lua/api_colorlcd_lvgl.cpp
+++ b/radio/src/lua/api_colorlcd_lvgl.cpp
@@ -359,7 +359,7 @@ LROT_BEGIN(lvgllib, NULL, 0)
   LROT_FUNCENTRY(switch, [](lua_State* L) { return luaLvglObjEx(L, []() { return new LvglWidgetSwitchPicker(); }, true); })
   LROT_FUNCENTRY(source, [](lua_State* L) { return luaLvglObjEx(L, []() { return new LvglWidgetSourcePicker(); }, true); })
   // Containers
-  LROT_FUNCENTRY(box, [](lua_State* L) { return luaLvglObj(L, []() { return new LvglWidgetBox(); }, true); })
+  LROT_FUNCENTRY(box, [](lua_State* L) { return luaLvglObjEx(L, []() { return new LvglWidgetBox(); }); })
   LROT_FUNCENTRY(setting, [](lua_State* L) { return luaLvglObjEx(L, []() { return new LvglWidgetSetting(); }, true); })
   LROT_FUNCENTRY(page, [](lua_State* L) { return luaLvglObj(L, []() { return new LvglWidgetPage(); }, true); })
   LROT_FUNCENTRY(dialog, [](lua_State* L) { return luaLvglObjEx(L, []() { return new LvglWidgetDialog(); }, true); })
@@ -447,7 +447,7 @@ LROT_BEGIN(lvgl_mt, NULL, LROT_MASK_GC_INDEX)
   LROT_FUNCENTRY(switch, [](lua_State* L) { return luaLvglObjEx(L, []() { return new LvglWidgetSwitchPicker(); }, true); })
   LROT_FUNCENTRY(source, [](lua_State* L) { return luaLvglObjEx(L, []() { return new LvglWidgetSourcePicker(); }, true); })
   // Containers
-  LROT_FUNCENTRY(box, [](lua_State* L) { return luaLvglObj(L, []() { return new LvglWidgetBox(); }, true); })
+  LROT_FUNCENTRY(box, [](lua_State* L) { return luaLvglObjEx(L, []() { return new LvglWidgetBox(); }); })
   LROT_FUNCENTRY(setting, [](lua_State* L) { return luaLvglObjEx(L, []() { return new LvglWidgetSetting(); }, true); })
   // Object manipulation functions
   LROT_FUNCENTRY(set, luaLvglSet)

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -2193,8 +2193,8 @@ Get percent of already used Lua instructions in current script execution cycle.
 static int luaGetUsage(lua_State * L)
 {
 #if defined(COLORLCD)
-  if (luaLvglManager && luaLvglManager->useLvglLayout()) {
-    lua_pushinteger(L, luaLvglManager->refreshInstructionsPercent);
+  if (luaScriptManager && luaScriptManager->useLvglLayout()) {
+    lua_pushinteger(L, luaScriptManager->refreshInstructionsPercent);
   } else {
     lua_pushinteger(L, instructionsPercent);
   }
@@ -2592,30 +2592,10 @@ to the fields in the table returned by `model.getLogicalSwitch(switch)` identify
 static int luaGetSwitchIndex(lua_State * L)
 {
   const char * name = luaL_checkstring(L, 1);
-  bool negate = false;
-  bool found = false;
-  swsrc_t idx;
+  swsrc_t idx = getSwitchIndex(name, true);
 
-  if (name[0] == '!') {
-    name++;
-    negate = true;
-  }
-
-  for (idx = SWSRC_NONE; idx < SWSRC_COUNT; idx++) {
-    if (isSwitchAvailable(idx, ModelCustomFunctionsContext)) {
-      char* s = getSwitchPositionName(idx);
-      if (!strncasecmp(s, name, 31)) {
-        found = true;
-        break;
-      }
-    }
-  }
-
-  if (found) {
-    if (negate)
-      idx = -idx;
+  if (idx != SWSRC_INVERT)
     lua_pushinteger(L, idx);
-  }
   else
     lua_pushnil(L);
 
@@ -2715,8 +2695,7 @@ static int luaSwitches(lua_State * L)
   } else
     last = SWSRC_LAST;
 
-  lua_pushcfunction(L, luaNextSwitch);
-  lua_pushinteger(L, last);
+  lua_pushcfunction(L, luaNextSwitch);  lua_pushinteger(L, last);
   lua_pushinteger(L, first);
   return 3;
 }
@@ -2737,21 +2716,9 @@ This function is rather time consuming, and should not be used repeatedly in a s
 static int luaGetSourceIndex(lua_State* const L)
 {
   const char* const name = luaL_checkstring(L, 1);
-  bool found = false;
-  mixsrc_t idx;
+  mixsrc_t idx = getSourceIndex(name, true);
 
-  for (idx = MIXSRC_NONE; idx <= MIXSRC_LAST_TELEM; idx++) {
-    if (isSourceAvailable(idx)) {
-      char srcName[maxSourceNameLength];
-      getSourceString(srcName, idx);
-      if (!strncasecmp(srcName, name)) {
-        found = true;
-        break;
-      }
-    }
-  }
-
-  if (found)
+  if (idx >= 0)
     lua_pushinteger(L, idx);
   else
     lua_pushnil(L);

--- a/radio/src/lua/lua_api.h
+++ b/radio/src/lua/lua_api.h
@@ -61,12 +61,6 @@ extern bool luaLcdAllowed;
 class BitmapBuffer;
 extern BitmapBuffer* luaLcdBuffer;
 
-class LuaWidget;
-extern LuaWidget* runningFS;
-
-class LuaLvglManager;
-extern LuaLvglManager* luaLvglManager;
-
 extern uint32_t luaExtraMemoryUsage;
 void luaInitThemesAndWidgets();
 #endif

--- a/radio/src/lua/lua_lvgl_widget.cpp
+++ b/radio/src/lua/lua_lvgl_widget.cpp
@@ -83,7 +83,7 @@ LvglWidgetObjectBase *LvglWidgetObjectBase::checkLvgl(lua_State *L, int index)
 
 LvglWidgetObjectBase::LvglWidgetObjectBase(const char* meta) :
     metatable(meta),
-    lvglManager(luaLvglManager)
+    lvglManager(luaScriptManager)
 {
 }
 
@@ -126,12 +126,12 @@ void LvglWidgetObjectBase::pcallSimpleFunc(lua_State *L, int funcRef)
   if (funcRef != LUA_REFNIL) {
     PROTECT_LUA()
     {
-      auto save = luaLvglManager;
-      luaLvglManager = lvglManager;
+      auto save = luaScriptManager;
+      luaScriptManager = lvglManager;
       if (!pcallFunc(L, funcRef, 0)) {
         lvglManager->luaShowError();
       }
-      luaLvglManager = save;
+      luaScriptManager = save;
     }
     UNPROTECT_LUA();
   }
@@ -142,8 +142,8 @@ bool LvglWidgetObjectBase::pcallUpdateBool(lua_State *L, int getFuncRef,
 {
   bool res = true;
   if (getFuncRef != LUA_REFNIL) {
-    auto save = luaLvglManager;
-    luaLvglManager = lvglManager;
+    auto save = luaScriptManager;
+    luaScriptManager = lvglManager;
     int t = lua_gettop(L);
     if (pcallFunc(L, getFuncRef, 1)) {
       bool val = false;
@@ -166,8 +166,8 @@ bool LvglWidgetObjectBase::pcallUpdate1Int(lua_State *L, int getFuncRef,
 {
   bool res = true;
   if (getFuncRef != LUA_REFNIL) {
-    auto save = luaLvglManager;
-    luaLvglManager = lvglManager;
+    auto save = luaScriptManager;
+    luaScriptManager = lvglManager;
     int t = lua_gettop(L);
     if (pcallFunc(L, getFuncRef, 1)) {
       int val = luaL_checkunsigned(L, -1);
@@ -186,8 +186,8 @@ bool LvglWidgetObjectBase::pcallUpdate2Int(lua_State *L, int getFuncRef,
 {
   bool res = true;
   if (getFuncRef != LUA_REFNIL) {
-    auto save = luaLvglManager;
-    luaLvglManager = lvglManager;
+    auto save = luaScriptManager;
+    luaScriptManager = lvglManager;
     int t = lua_gettop(L);
     if (pcallFunc(L, getFuncRef, 2)) {
       int v1 = luaL_checkunsigned(L, -2);
@@ -206,8 +206,8 @@ int LvglWidgetObjectBase::pcallGetIntVal(lua_State *L, int getFuncRef)
 {
   int val = 0;
   if (getFuncRef != LUA_REFNIL) {
-    auto save = luaLvglManager;
-    luaLvglManager = lvglManager;
+    auto save = luaScriptManager;
+    luaScriptManager = lvglManager;
     int t = lua_gettop(L);
     PROTECT_LUA()
     {
@@ -235,8 +235,8 @@ int LvglWidgetObjectBase::pcallGetOptIntVal(lua_State *L, int getFuncRef, int de
 {
   int val = 0;
   if (getFuncRef != LUA_REFNIL) {
-    auto save = luaLvglManager;
-    luaLvglManager = lvglManager;
+    auto save = luaScriptManager;
+    luaScriptManager = lvglManager;
     int t = lua_gettop(L);
     PROTECT_LUA()
     {
@@ -263,8 +263,8 @@ int LvglWidgetObjectBase::pcallGetOptIntVal(lua_State *L, int getFuncRef, int de
 void LvglWidgetObjectBase::pcallSetIntVal(lua_State *L, int setFuncRef, int val)
 {
   if (setFuncRef != LUA_REFNIL) {
-    auto save = luaLvglManager;
-    luaLvglManager = lvglManager;
+    auto save = luaScriptManager;
+    luaScriptManager = lvglManager;
     int t = lua_gettop(L);
     PROTECT_LUA()
     {
@@ -1051,7 +1051,7 @@ void LvglWidgetBox::build(lua_State* L)
   window =
       new Window(lvglManager->getCurrentParent(), {x, y, w, h}, lv_obj_create);
   lv_obj_add_flag(window->getLvObj(), LV_OBJ_FLAG_EVENT_BUBBLE);
-  if (luaLvglManager->isWidget()) {
+  if (luaScriptManager->isWidget()) {
     lv_obj_clear_flag(window->getLvObj(), LV_OBJ_FLAG_CLICKABLE);
   } else {
     etx_scrollbar(window->getLvObj());
@@ -1129,7 +1129,7 @@ void LvglWidgetBorderedObject::build(lua_State *L)
   window =
       new Window(lvglManager->getCurrentParent(), {x, y, w, h}, lv_obj_create);
   lv_obj_add_flag(window->getLvObj(), LV_OBJ_FLAG_EVENT_BUBBLE);
-  if (luaLvglManager->isWidget()) {
+  if (luaScriptManager->isWidget()) {
     lv_obj_clear_flag(window->getLvObj(), LV_OBJ_FLAG_CLICKABLE);
   } else {
     etx_scrollbar(window->getLvObj());
@@ -1729,7 +1729,7 @@ class WidgetPage : public NavWindow, public LuaEventHandler
 
   bool bubbleEvents() override { return true; }
 
-  void onClicked() override { Keyboard::hide(false); LuaEventHandler::onClicked(); }
+  void onClicked() override { Keyboard::hide(false); LuaEventHandler::onClickedEvent(); }
 
   void onCancel() override { backAction(); }
 

--- a/radio/src/lua/lua_lvgl_widget.cpp
+++ b/radio/src/lua/lua_lvgl_widget.cpp
@@ -1896,14 +1896,14 @@ class LvglDialog : public BaseDialog
 
   Window *getBody() { return form; }
 
- protected:
-  std::function<void()> onClose;
-
   void onCancel() override
   {
     onClose();
     BaseDialog::onCancel();
   }
+
+ protected:
+  std::function<void()> onClose;
 };
 
 void LvglWidgetDialog::parseParam(lua_State *L, const char *key)
@@ -1929,9 +1929,16 @@ void LvglWidgetDialog::build(lua_State *L)
   if (h == LV_SIZE_CONTENT) h = DIALOG_DEFAULT_HEIGHT;
   auto dlg = new LvglDialog(title, w, h,
       [=]() { pcallSimpleFunc(L, closeFunction); });
+  dialog = dlg;
   window = dlg->getBody();
   window->setWidth(w);
   setFlex();
+}
+
+void LvglWidgetDialog::close()
+{
+  dialog->onCancel();
+  clear();
 }
 
 //-----------------------------------------------------------------------------

--- a/radio/src/lua/lua_lvgl_widget.h
+++ b/radio/src/lua/lua_lvgl_widget.h
@@ -207,18 +207,25 @@ class LvglWidgetVLine : public LvglWidgetLineBase
 class LvglWidgetLine : public LvglSimpleWidgetObject
 {
  public:
-  LvglWidgetLine() : LvglSimpleWidgetObject() {}
+  LvglWidgetLine();
+  ~LvglWidgetLine();
 
   void setColor(LcdFlags newColor) override;
   void setOpacity(uint8_t newOpa) override;
   void setPos(coord_t x, coord_t y) override;
   void setSize(coord_t w, coord_t h) override;
 
+  bool callRefs(lua_State *L) override;
+  void clearRefs(lua_State *L) override;
+
  protected:
   coord_t thickness = 1;
   bool rounded = false;
   size_t ptCnt = 0;
   lv_point_t* pts = nullptr;
+  uint32_t ptsHash = -1;
+  lv_obj_t* parent = nullptr;
+  int getPointsFunction = LUA_REFNIL;
 
   void setLine();
 
@@ -244,7 +251,7 @@ class LvglWidgetTriangle : public LvglSimpleWidgetObject
 
  protected:
   lv_point_t pts[3] = {0};
-  lv_point_t last[3] = {-1};
+  uint32_t ptsHash = -1;
   MaskBitmap* mask = nullptr;
   lv_obj_t* parent = nullptr;
   int getPointsFunction = LUA_REFNIL;

--- a/radio/src/lua/lua_lvgl_widget.h
+++ b/radio/src/lua/lua_lvgl_widget.h
@@ -24,6 +24,8 @@
 #define LVGL_METATABLE "LVGL*"
 #define LVGL_SIMPLEMETATABLE "LVGLSIMPLE*"
 
+class LuaScriptManager;
+
 //-----------------------------------------------------------------------------
 
 class LvglWidgetObjectBase
@@ -66,7 +68,7 @@ class LvglWidgetObjectBase
   std::vector<int> lvglObjectRefs;
   const char* metatable = nullptr;
   bool clearRequest = false;
-  LuaLvglManager *lvglManager = nullptr;
+  LuaScriptManager *lvglManager = nullptr;
   coord_t x = 0, y = 0, w = LV_SIZE_CONTENT, h = LV_SIZE_CONTENT;
   LcdFlags color = COLOR2FLAGS(COLOR_THEME_SECONDARY1_INDEX);
   LcdFlags currentColor = -1;

--- a/radio/src/lua/lua_lvgl_widget.h
+++ b/radio/src/lua/lua_lvgl_widget.h
@@ -25,6 +25,7 @@
 #define LVGL_SIMPLEMETATABLE "LVGLSIMPLE*"
 
 class LuaScriptManager;
+class LvglDialog;
 
 //-----------------------------------------------------------------------------
 
@@ -46,6 +47,7 @@ class LvglWidgetObjectBase
   virtual void hide() = 0;
   virtual void enable() {};
   virtual void disable() {};
+  virtual void close() {};
 
   virtual void setColor(LcdFlags newColor) {}
   virtual void setOpacity(uint8_t newOpa) {}
@@ -654,9 +656,11 @@ class LvglWidgetDialog : public LvglWidgetObject
   LvglWidgetDialog() : LvglWidgetObject() {}
 
   void clearRefs(lua_State *L) override;
+  void close() override;
 
  protected:
   const char *title = nullptr;
+  LvglDialog* dialog = nullptr;
 
   int closeFunction = LUA_REFNIL;
 

--- a/radio/src/lua/lua_widget.cpp
+++ b/radio/src/lua/lua_widget.cpp
@@ -584,3 +584,20 @@ bool LuaScriptManager::callRefs(lua_State *L)
   }
   return true;
 }
+
+void LuaScriptManager::createTelemetryQueue()
+{
+  if (luaInputTelemetryFifo == nullptr) {
+    luaInputTelemetryFifo = new TelemetryQueue();
+    registerTelemetryQueue(luaInputTelemetryFifo);
+  }
+}
+
+LuaScriptManager::~LuaScriptManager()
+{
+  if (luaInputTelemetryFifo == nullptr) {
+    deregisterTelemetryQueue(luaInputTelemetryFifo);
+    delete luaInputTelemetryFifo;
+    luaInputTelemetryFifo = nullptr;
+  }
+}

--- a/radio/src/lua/lua_widget.cpp
+++ b/radio/src/lua/lua_widget.cpp
@@ -552,7 +552,7 @@ bool LuaWidget::useLvglLayout() const { return luaFactory()->useLvglLayout(); }
 
 bool LuaWidget::isAppMode() const
 {
-  return fullscreen && ViewMain::instance()->isAppMode();
+  return ViewMain::instance()->isAppMode();
 }
 
 void LuaScriptManager::saveLvglObjectRef(int ref)

--- a/radio/src/lua/lua_widget.h
+++ b/radio/src/lua/lua_widget.h
@@ -108,8 +108,8 @@ class LuaWidget : public Widget, public LuaScriptManager
 
  public:
   LuaWidget(const WidgetFactory* factory, Window* parent, const rect_t& rect,
-            WidgetPersistentData* persistentData, int luaScriptContextRef, int zoneRectDataRef,
-            int optionsDataRef);
+            WidgetPersistentData* persistentData, int zoneRectDataRef,
+            int optionsDataRef, int createFunctionRef, std::string path);
   ~LuaWidget() override;
 
 #if defined(DEBUG_WINDOWS)

--- a/radio/src/lua/lua_widget.h
+++ b/radio/src/lua/lua_widget.h
@@ -28,6 +28,7 @@
 #include "lua_states.h"
 #include "lua_api.h"
 #include "lua_lvgl_widget.h"
+#include "telemetry/telemetry.h"
 
 #include "edgetx_types.h"
 
@@ -65,6 +66,7 @@ class LuaScriptManager : public LuaEventHandler
 {
  public:
   LuaScriptManager() = default;
+  ~LuaScriptManager();
 
   std::vector<int> getLvglObjectRefs() const { return lvglObjectRefs; }
   void saveLvglObjectRef(int ref);
@@ -88,10 +90,16 @@ class LuaScriptManager : public LuaEventHandler
 
   uint8_t refreshInstructionsPercent;
 
+  void createTelemetryQueue();
+  TelemetryQueue* telemetryQueue() { return luaInputTelemetryFifo; }
+
  protected:
   int luaScriptContextRef = 0;
   std::vector<int> lvglObjectRefs;
   LvglWidgetObjectBase* tempParent = nullptr;
+#if defined(LUA)
+  TelemetryQueue* luaInputTelemetryFifo = nullptr;
+#endif
 };
 
 class LuaWidget : public Widget, public LuaScriptManager

--- a/radio/src/lua/lua_widget.h
+++ b/radio/src/lua/lua_widget.h
@@ -35,10 +35,36 @@
 
 class LuaWidgetFactory;
 
-class LuaLvglManager
+class LuaEventHandler
+{
+public:
+  LuaEventHandler() = default;
+  void setupHandler(Window* w);
+  void removeHandler(Window* w);
+
+protected:
+#if defined(HARDWARE_TOUCH)
+  // "tap" handling
+  static uint32_t downTime;
+  static uint32_t tapTime;
+  static uint32_t tapCount;
+  // "swipe" / "slide" handling
+  static tmr10ms_t swipeTimeOut;
+  static bool _sliding;
+  static coord_t _startX;
+  static coord_t _startY;
+#endif
+  static void event_cb(lv_event_t* e);
+
+  void onClickedEvent();
+  void onCancelEvent();
+  void onLuaEvent(event_t event);
+};
+
+class LuaScriptManager : public LuaEventHandler
 {
  public:
-  LuaLvglManager() = default;
+  LuaScriptManager() = default;
 
   std::vector<int> getLvglObjectRefs() const { return lvglObjectRefs; }
   void saveLvglObjectRef(int ref);
@@ -68,33 +94,7 @@ class LuaLvglManager
   LvglWidgetObjectBase* tempParent = nullptr;
 };
 
-class LuaEventHandler
-{
-public:
-  LuaEventHandler() = default;
-  void setupHandler(Window* w);
-  void removeHandler(Window* w);
-
-protected:
-#if defined(HARDWARE_TOUCH)
-  // "tap" handling
-  static uint32_t downTime;
-  static uint32_t tapTime;
-  static uint32_t tapCount;
-  // "swipe" / "slide" handling
-  static tmr10ms_t swipeTimeOut;
-  static bool _sliding;
-  static coord_t _startX;
-  static coord_t _startY;
-#endif
-  static void event_cb(lv_event_t* e);
-
-  void onClicked();
-  void onCancel();
-  void onLuaEvent(event_t event);
-};
-
-class LuaWidget : public Widget, public LuaEventHandler, public LuaLvglManager
+class LuaWidget : public Widget, public LuaScriptManager
 {
   friend class LuaWidgetFactory;
 
@@ -160,3 +160,5 @@ class LuaWidget : public Widget, public LuaEventHandler, public LuaLvglManager
 
   static void redraw_cb(lv_event_t *e);
 };
+
+extern LuaScriptManager* luaScriptManager;

--- a/radio/src/lua/lua_widget_factory.cpp
+++ b/radio/src/lua/lua_widget_factory.cpp
@@ -70,7 +70,6 @@ Widget* LuaWidgetFactory::create(Window* parent, const rect_t& rect,
   initPersistentData(persistentData, init);
 
   luaSetInstructionsLimit(lsWidgets, MAX_INSTRUCTIONS);
-  lua_rawgeti(lsWidgets, LUA_REGISTRYINDEX, createFunction);
 
   // Make 'zone' table for 'create' call
   lua_newtable(lsWidgets);
@@ -83,8 +82,6 @@ Widget* LuaWidgetFactory::create(Window* parent, const rect_t& rect,
 
   // Store the zone data in registry for later updates
   int zoneRectDataRef = luaL_ref(lsWidgets, LUA_REGISTRYINDEX);
-  // Push stored zone for 'create' call
-  lua_rawgeti(lsWidgets, LUA_REGISTRYINDEX, zoneRectDataRef);
 
   // Create options table
   lua_newtable(lsWidgets);
@@ -107,16 +104,8 @@ Widget* LuaWidgetFactory::create(Window* parent, const rect_t& rect,
 
   // Store the options data in registry for later updates
   int optionsDataRef = luaL_ref(lsWidgets, LUA_REGISTRYINDEX);
-  // Push stored options for 'create' call
-  lua_rawgeti(lsWidgets, LUA_REGISTRYINDEX, optionsDataRef);
 
-  lua_pushstring(lsWidgets, path.c_str());
-
-  bool err = lua_pcall(lsWidgets, 3, 1, 0);
-  int widgetData = err ? LUA_NOREF : luaL_ref(lsWidgets, LUA_REGISTRYINDEX);
-  LuaWidget* lw = new LuaWidget(this, parent, rect, persistentData, widgetData, zoneRectDataRef, optionsDataRef);
-  if (err) lw->setErrorMessage("create()");
-  return lw;
+  return new LuaWidget(this, parent, rect, persistentData, zoneRectDataRef, optionsDataRef, createFunction, path);
 }
 
 void LuaWidgetFactory::translateOptions(ZoneOption * options)

--- a/radio/src/lua/lua_widget_factory.cpp
+++ b/radio/src/lua/lua_widget_factory.cpp
@@ -157,25 +157,39 @@ void LuaWidgetFactory::translateOptions(ZoneOption * options)
 
 static int switchValue()
 {
-  int v;
-  if (lua_type(lsWidgets, -1) == LUA_TSTRING) {
+  int v = SWSRC_INVERT;
+  if (lua_istable(lsWidgets, -1)) {
+    // Find first available
+    int t = lua_gettop(lsWidgets);
+    for (lua_pushnil(lsWidgets); v == SWSRC_INVERT && lua_next(lsWidgets, -2); lua_pop(lsWidgets, 1)) {
+      v = getSwitchIndex(luaL_checkstring(lsWidgets, -1), false);
+    }
+    lua_settop(lsWidgets, t);
+  } else if (lua_type(lsWidgets, -1) == LUA_TSTRING) {
     v = getSwitchIndex(lua_tostring(lsWidgets, -1), true);
-    if (v == SWSRC_INVERT) v = SWSRC_NONE;
   } else {
     v = luaL_checkinteger(lsWidgets, -1);
   }
+  if (v == SWSRC_INVERT) v = SWSRC_NONE;
   return v;
 }
 
 static int sourceValue()
 {
-  int v;
-  if (lua_type(lsWidgets, -1) == LUA_TSTRING) {
+  int v = -1;
+  if (lua_istable(lsWidgets, -1)) {
+    // Find first available
+    int t = lua_gettop(lsWidgets);
+    for (lua_pushnil(lsWidgets); v < 0 && lua_next(lsWidgets, -2); lua_pop(lsWidgets, 1)) {
+      v = getSourceIndex(luaL_checkstring(lsWidgets, -1), false);
+    }
+    lua_settop(lsWidgets, t);
+  } else if (lua_type(lsWidgets, -1) == LUA_TSTRING) {
     v = getSourceIndex(lua_tostring(lsWidgets, -1), true);
-    if (v == -1) v = MIXSRC_NONE;
   } else {
     v = luaL_checkunsigned(lsWidgets, -1);
   }
+  if (v == -1) v = MIXSRC_NONE;
   return v;
 }
 

--- a/radio/src/lua/lua_widget_factory.h
+++ b/radio/src/lua/lua_widget_factory.h
@@ -25,12 +25,13 @@
 
 class LuaWidgetFactory : public WidgetFactory
 {
-  friend void luaLoadWidgetCallback();
   friend class LuaWidget;
 
  public:
-  LuaWidgetFactory(const char* name, ZoneOption* widgetOptions,
-                   int createFunction);
+  LuaWidgetFactory(const char* name, ZoneOption* widgetOptions, int optionDefinitionsReference,
+                   int createFunction, int updateFunction, int refreshFunction,
+                   int backgroundFunction, int translateFunction, bool lvgllayout,
+                   const char* filename);
   ~LuaWidgetFactory();
 
   Widget* create(Window* parent, const rect_t& rect,
@@ -41,14 +42,18 @@ class LuaWidgetFactory : public WidgetFactory
 
   bool useLvglLayout() const { return lvglLayout; }
 
+  static ZoneOption* parseOptionDefinitions(int reference);
+  const void parseOptionDefaults() const override;
+
  protected:
   void translateOptions(ZoneOption * options);
 
+  int optionDefinitionsReference;
   int createFunction;
   int updateFunction;
   int refreshFunction;
   int backgroundFunction;
   int translateFunction;
-  int settingsFunction;
   bool lvglLayout;
+  std::string path;
 };

--- a/radio/src/lua/widgets.cpp
+++ b/radio/src/lua/widgets.cpp
@@ -98,123 +98,12 @@ void luaSetInstructionsLimit(lua_State * L, int count)
 #endif
 }
 
-ZoneOption *createOptionsArray(int reference, uint8_t maxOptions)
-{
-  if (reference == 0) {
-    // TRACE("createOptionsArray() no options");
-    return NULL;
-  }
-
-  int count = 0;
-  lua_rawgeti(lsWidgets, LUA_REGISTRYINDEX, reference);
-  for (lua_pushnil(lsWidgets); lua_next(lsWidgets, -2); lua_pop(lsWidgets, 1)) {
-    count++;
-  }
-
-  // TRACE("we have %d options", count);
-  if (count > maxOptions) {
-    count = maxOptions;
-    // TRACE("limited to %d options", count);
-  }
-
-  ZoneOption *options = new ZoneOption[count + 1];
-  if (!options) {
-    return NULL;
-  }
-
-  PROTECT_LUA()
-  {
-    lua_rawgeti(lsWidgets, LUA_REGISTRYINDEX, reference);
-    ZoneOption *option = options;
-    for (lua_pushnil(lsWidgets); lua_next(lsWidgets, -2), count-- > 0;
-         lua_pop(lsWidgets, 1)) {
-      // TRACE("parsing option %d", count);
-      luaL_checktype(lsWidgets, -2, LUA_TNUMBER);  // key is number
-      luaL_checktype(lsWidgets, -1, LUA_TTABLE);   // value is table
-      uint8_t field = 0;
-      for (lua_pushnil(lsWidgets); lua_next(lsWidgets, -2) && field < 5;
-           lua_pop(lsWidgets, 1), field++) {
-        luaL_checktype(lsWidgets, -2, LUA_TNUMBER);  // key is number
-        switch (field) {
-          case 0:
-            option->name = luaL_checkstring(lsWidgets, -1);
-            option->displayName = nullptr;
-            // TRACE("name = %s", option->name);
-            break;
-          case 1:
-            option->type = (ZoneOption::Type)luaL_checkinteger(lsWidgets, -1);
-            option->deflt.unsignedValue = 0;
-            // set some sensible defaults
-            if (option->type == ZoneOption::Integer) {
-              option->min.signedValue = -100;
-              option->max.signedValue = 100;
-            } else if (option->type == ZoneOption::Switch) {
-              option->min.signedValue = SWSRC_FIRST;
-              option->max.signedValue = SWSRC_LAST;
-            } else if (option->type == ZoneOption::Timer) {
-              option->min.unsignedValue = 0;
-              option->max.unsignedValue = MAX_TIMERS - 1;
-            } else if (option->type == ZoneOption::TextSize) {
-              option->min.unsignedValue = FONT_STD_INDEX;
-              option->max.unsignedValue = FONTS_COUNT - 1;
-            } else if (option->type == ZoneOption::String || option->type == ZoneOption::File) {
-              option->deflt.stringValue[0] = 0;
-            } else if (option->type == ZoneOption::Slider) {
-              option->min.unsignedValue = 0;
-              option->max.unsignedValue = 9;
-            }
-            break;
-          case 2:
-            if (option->type == ZoneOption::Integer || option->type == ZoneOption::Switch) {
-              option->deflt.signedValue = luaL_checkinteger(lsWidgets, -1);
-            } else if (option->type == ZoneOption::Bool) {
-              option->deflt.boolValue = (luaL_checkunsigned(lsWidgets, -1) != 0);
-            } else if (option->type == ZoneOption::String || option->type == ZoneOption::File) {
-              strncpy(option->deflt.stringValue, luaL_checkstring(lsWidgets, -1),
-                      LEN_ZONE_OPTION_STRING);
-            } else {
-              option->deflt.unsignedValue = luaL_checkunsigned(lsWidgets, -1);
-            }
-            break;
-          case 3:
-            if (option->type == ZoneOption::Integer || option->type == ZoneOption::Switch || option->type == ZoneOption::Slider) {
-              option->min.signedValue = luaL_checkinteger(lsWidgets, -1);
-            } else if (option->type == ZoneOption::Choice) {
-              luaL_checktype(lsWidgets, -1, LUA_TTABLE); // value is a table
-              for (lua_pushnil(lsWidgets); lua_next(lsWidgets, -2); lua_pop(lsWidgets, 1)) {
-                option->choiceValues.push_back(luaL_checkstring(lsWidgets, -1));
-              }
-            } else if (option->type == ZoneOption::File) {
-              option->fileSelectPath = luaL_checkstring(lsWidgets, -1);
-            }
-            break;
-          case 4:
-            if (option->type == ZoneOption::Integer || option->type == ZoneOption::Switch || option->type == ZoneOption::Slider) {
-              option->max.signedValue = luaL_checkinteger(lsWidgets, -1);
-            }
-            break;
-        }
-      }
-      option++;
-    }
-    option->name = NULL;  // sentinel
-  }
-  else
-  {
-    TRACE("error in theme/widget options");
-    delete[] options;
-    return NULL;
-  }
-  UNPROTECT_LUA();
-  return options;
-}
-
-void luaLoadWidgetCallback()
+void luaLoadWidgetCallback(const char* filename)
 {
   TRACE("luaLoadWidgetCallback()");
   const char * name=NULL;
 
-  int widgetOptions = 0, createFunction = 0, updateFunction = 0, settingsFunction = 0,
+  int optionDefinitionsReference = LUA_REFNIL, createFunction = 0, updateFunction = 0,
       refreshFunction = 0, backgroundFunction = 0, translateFunction = 0;
   bool lvglLayout = false;
 
@@ -226,7 +115,7 @@ void luaLoadWidgetCallback()
       name = luaL_checkstring(lsWidgets, -1);
     }
     else if (!strcmp(key, "options")) {
-      widgetOptions = luaL_ref(lsWidgets, LUA_REGISTRYINDEX);
+      optionDefinitionsReference = luaL_ref(lsWidgets, LUA_REGISTRYINDEX);
       lua_pushnil(lsWidgets);
     }
     else if (!strcmp(key, "create")) {
@@ -249,34 +138,25 @@ void luaLoadWidgetCallback()
       translateFunction = luaL_ref(lsWidgets, LUA_REGISTRYINDEX);
       lua_pushnil(lsWidgets);
     }
-    else if (!strcmp(key, "settings")) {
-      settingsFunction = luaL_ref(lsWidgets, LUA_REGISTRYINDEX);
-      lua_pushnil(lsWidgets);
-    }
     else if (!strcasecmp(key, "useLvgl")) {
       lvglLayout = lua_toboolean(lsWidgets, -1);
     }
   }
 
   if (name && createFunction) {
-    ZoneOption * options = createOptionsArray(widgetOptions, MAX_WIDGET_OPTIONS);
+    ZoneOption * options = LuaWidgetFactory::parseOptionDefinitions(optionDefinitionsReference);
     if (options) {
-      LuaWidgetFactory * factory = new LuaWidgetFactory(name, options, createFunction);
-      factory->updateFunction = updateFunction;
-      factory->refreshFunction = refreshFunction;
-      factory->backgroundFunction = backgroundFunction;
-      factory->translateFunction = translateFunction;
-      factory->settingsFunction = settingsFunction;
-      factory->translateOptions(options);
-      factory->lvglLayout = lvglLayout;
+      new LuaWidgetFactory(name, options, optionDefinitionsReference,
+              createFunction, updateFunction, refreshFunction, backgroundFunction,
+              translateFunction, lvglLayout, filename);
       TRACE("Loaded Lua widget %s", name);
     }
   }
 }
 
-void luaLoadFile(const char * filename, void (*callback)())
+static void luaLoadFile(const char * filename, std::function<void()> callback)
 {
-  if (lsWidgets == NULL || callback == NULL)
+  if (lsWidgets == NULL)
     return;
 
   TRACE("luaLoadFile(%s)", filename);
@@ -286,7 +166,7 @@ void luaLoadFile(const char * filename, void (*callback)())
   PROTECT_LUA() {
     if (luaLoadScriptFileToState(lsWidgets, filename, LUA_SCRIPT_LOAD_MODE) == SCRIPT_OK) {
       if (lua_pcall(lsWidgets, 0, 1, 0) == LUA_OK && lua_istable(lsWidgets, -1)) {
-        (*callback)();
+        callback();
       }
       else {
         TRACE("luaLoadFile(%s): Error parsing script: %s", filename, lua_tostring(lsWidgets, -1));
@@ -301,7 +181,7 @@ void luaLoadFile(const char * filename, void (*callback)())
   UNPROTECT_LUA();
 }
 
-void luaLoadFiles(const char * directory, void (*callback)())
+static void luaLoadFiles(const char * directory)
 {
   char path[LUA_FULLPATH_MAXLEN+1];
   FILINFO fno;
@@ -324,7 +204,7 @@ void luaLoadFiles(const char * directory, void (*callback)())
         strcpy(&path[pathlen], fno.fname);
         strcat(&path[pathlen], LUA_WIDGET_FILENAME);
         if (isFileAvailable(path)) {
-          luaLoadFile(path, callback);
+          luaLoadFile(path, [=]() { luaLoadWidgetCallback(path); });
         }
       }
     }
@@ -374,7 +254,7 @@ void luaInitThemesAndWidgets()
     }
     UNPROTECT_LUA();
     TRACE("lsWidgets %p", lsWidgets);
-    luaLoadFiles(WIDGETS_PATH, luaLoadWidgetCallback);
+    luaLoadFiles(WIDGETS_PATH);
     luaDoGc(lsWidgets, true);
   }
 }

--- a/radio/src/strhelpers.h
+++ b/radio/src/strhelpers.h
@@ -110,9 +110,11 @@ char *strAppendStringWithIndex(char *dest, const char *s, int idx);
 #define LEN_TIMER_STRING 10  // "-00:00:00"
 char *getTimerString(char *dest, int32_t tme,
                      TimerOptions timerOptions = {.options = 0});
+char *getTimerString(int32_t tme, TimerOptions timerOptions = {.options = 0});
 char *getFormattedTimerString(char *dest, int32_t tme,
                               TimerOptions timerOptions);
 char *getCurveString(char *dest, int idx);
+char *getCurveString(int idx);
 char *getGVarString(char *dest, int idx);
 char *getGVarString(int idx);
 char *getValueOrGVarString(char *dest, size_t len, gvar_t value, gvar_t vmin,
@@ -123,33 +125,33 @@ char *getValueOrSrcVarString(char *dest, size_t len, gvar_t value, gvar_t vmin,
                              const char *suffix = nullptr, gvar_t offset = 0, bool usePPMUnit = false);
 const char *getSwitchWarnSymbol(uint8_t pos);
 const char *getSwitchPositionSymbol(uint8_t pos);
-char *getSwitchPositionName(char *dest, swsrc_t idx);
-char *getSwitchName(char *dest, uint8_t idx);
+char *getSwitchPositionName(char *dest, swsrc_t idx, bool defaultOnly = false);
+char *getSwitchPositionName(swsrc_t idx, bool defaultOnly = false);
+char *getSwitchName(char *dest, uint8_t idx, bool defaultOnly = false);
+int getSwitchIndex(const char* name, bool all);
+int getSourceIndex(const char* name, bool all);
 
-const char *getAnalogLabel(uint8_t type, uint8_t idx);
+const char *getAnalogLabel(uint8_t type, uint8_t idx, bool defaultOnly = false);
 const char *getAnalogShortLabel(uint8_t idx);
-const char *getMainControlLabel(uint8_t idx);
-const char *getTrimLabel(uint8_t idx);
+const char *getMainControlLabel(uint8_t idx, bool defaultOnly = false);
+const char *getTrimLabel(uint8_t idx, bool defaultOnly = false);
 const char *getTrimSourceLabel(uint16_t src_raw, int8_t trim_src);
-const char *getPotLabel(uint8_t idx);
+const char *getPotLabel(uint8_t idx, bool defaultOnly = false);
 char *getCustomSwitchesGroupName(char *dest, uint8_t idx);
 
 template <size_t L>
-char *getSourceString(char (&dest)[L], mixsrc_t idx);
+char *getSourceString(char (&dest)[L], mixsrc_t idx, bool defaultOnly = false);
+char *getSourceString(mixsrc_t idx, bool defaultOnly = false);
 
 template <size_t L>
 char *getSourceCustomValueString(char (&dest)[L], mixsrc_t source, int32_t val,
                                  LcdFlags flags);
-
-#endif
+char *getSourceCustomValueString(mixsrc_t source, int32_t val, LcdFlags flags);
 
 char *getFlightModeString(char *dest, int8_t idx);
 
-char *getSourceString(mixsrc_t idx);
-char *getSourceCustomValueString(mixsrc_t source, int32_t val, LcdFlags flags);
-char *getSwitchPositionName(swsrc_t idx);
-char *getCurveString(int idx);
-char *getTimerString(int32_t tme, TimerOptions timerOptions = {.options = 0});
+#endif
+
 void splitTimer(char *s0, char *s1, char *s2, char *s3, int tme,
                 bool bLowercase = true);
 

--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -311,12 +311,8 @@ void processCrossfireTelemetryFrame(uint8_t module, uint8_t* rxBuffer,
         crossfireModuleStatus[module].queryCompleted = true;
       }
 
-      if (luaInputTelemetryFifo && luaInputTelemetryFifo->hasSpace(rxBufferCount - 2)) {
-        for (uint8_t i = 1; i < rxBufferCount - 1; i++) {
-          // destination address and CRC are skipped
-          luaInputTelemetryFifo->push(rxBuffer[i]);
-        }
-      }
+      // destination address and CRC are skipped
+      pushTelemetryDataToQueues(rxBuffer + 1, rxBufferCount - 2);
       break;
 #endif
   }

--- a/radio/src/telemetry/frsky_sport.cpp
+++ b/radio/src/telemetry/frsky_sport.cpp
@@ -391,18 +391,12 @@ void sportProcessTelemetryPacketWithoutCrc(uint8_t module, uint8_t origin, const
         }
         else if (dataId >= DIY_STREAM_FIRST_ID && dataId <= DIY_STREAM_LAST_ID) {
 #if defined(LUA)
-          if (luaInputTelemetryFifo &&
-              luaInputTelemetryFifo->hasSpace(sizeof(SportTelemetryPacket))) {
-
-            SportTelemetryPacket luaPacket;
-            luaPacket.physicalId = physicalId;
-            luaPacket.primId = primId;
-            luaPacket.dataId = dataId;
-            luaPacket.value = data;
-            for (uint8_t i=0; i<sizeof(SportTelemetryPacket); i++) {
-              luaInputTelemetryFifo->push(luaPacket.raw[i]);
-            }
-          }
+          SportTelemetryPacket luaPacket;
+          luaPacket.physicalId = physicalId;
+          luaPacket.primId = primId;
+          luaPacket.dataId = dataId;
+          luaPacket.value = data;
+          pushTelemetryDataToQueues(luaPacket.raw, sizeof(SportTelemetryPacket));
 #endif
         }
         else if (dataId >= RB3040_CH1_2_FIRST_ID && dataId <= RB3040_CH7_8_LAST_ID) {
@@ -433,16 +427,12 @@ void sportProcessTelemetryPacketWithoutCrc(uint8_t module, uint8_t origin, const
   }
 #if defined(LUA)
   else if (primId == 0x32) {
-    if (luaInputTelemetryFifo && luaInputTelemetryFifo->hasSpace(sizeof(SportTelemetryPacket))) {
-      SportTelemetryPacket luaPacket;
-      luaPacket.physicalId = physicalId;
-      luaPacket.primId = primId;
-      luaPacket.dataId = dataId;
-      luaPacket.value = data;
-      for (uint8_t i=0; i<sizeof(SportTelemetryPacket); i++) {
-        luaInputTelemetryFifo->push(luaPacket.raw[i]);
-      }
-    }
+    SportTelemetryPacket luaPacket;
+    luaPacket.physicalId = physicalId;
+    luaPacket.primId = primId;
+    luaPacket.dataId = dataId;
+    luaPacket.value = data;
+    pushTelemetryDataToQueues(luaPacket.raw, sizeof(SportTelemetryPacket));
   }
 #endif
 }

--- a/radio/src/telemetry/ghost.cpp
+++ b/radio/src/telemetry/ghost.cpp
@@ -315,11 +315,7 @@ void processGhostTelemetryFrame(uint8_t module, uint8_t* buffer, uint32_t length
 #if defined(LUA)
     default:
       // destination address and CRC are skipped
-      if (luaInputTelemetryFifo && luaInputTelemetryFifo->hasSpace(length - 2) ) {
-        for (uint8_t i = 1; i < length - 1; i++) {
-          luaInputTelemetryFifo->push(buffer[i]);
-        }
-      }
+      pushTelemetryDataToQueues(buffer + 1, length - 2);
       break;
 #endif
   }

--- a/radio/src/telemetry/telemetry.h
+++ b/radio/src/telemetry/telemetry.h
@@ -236,7 +236,11 @@ extern OutputTelemetryBuffer outputTelemetryBuffer __DMA_NO_CACHE;
 #if defined(LUA)
 #include "fifo.h"
 #define LUA_TELEMETRY_INPUT_FIFO_SIZE  256
-extern Fifo<uint8_t, LUA_TELEMETRY_INPUT_FIFO_SIZE> * luaInputTelemetryFifo;
+typedef Fifo<uint8_t, LUA_TELEMETRY_INPUT_FIFO_SIZE> TelemetryQueue;
+extern TelemetryQueue* luaInputTelemetryFifo;
+void registerTelemetryQueue(TelemetryQueue*);
+void deregisterTelemetryQueue(TelemetryQueue*);
+void pushTelemetryDataToQueues(uint8_t* data, int length);
 #endif
 
 void processPXX2Frame(uint8_t idx, const uint8_t* frame,

--- a/radio/src/tests/crossfire.cpp
+++ b/radio/src/tests/crossfire.cpp
@@ -61,8 +61,7 @@ struct crsf_frame_test {
   {
     ctx = CrossfireDriver.init(EXTERNAL_MODULE);
     if (!luaInputTelemetryFifo) {
-      luaInputTelemetryFifo =
-          new Fifo<uint8_t, LUA_TELEMETRY_INPUT_FIFO_SIZE>();
+      luaInputTelemetryFifo = new TelemetryQueue();
       assert(luaInputTelemetryFifo != nullptr);
     } else {
       luaInputTelemetryFifo->clear();


### PR DESCRIPTION
Summary:
- Make current Lua script owner visible to API functions (for PR #5773).
- Add telemetry queue per widget (for PR #5773).
- Send path name of widget folder to script 'create()' function (requested by @offer-shmuely).
- Enhancements for widgets option default values, getSwitchIndex() and getSourceIndex() Lua function (for Issue #5917).

Details:
This PR allow the Lua API functions to access the widget or stand alone script that called the function. In addition this adds the telemetry queue per widget required for #5773.

The code now sends the path of the widget being loaded to the script 'create()' function (as the 3rd parameter).

The following changes have been made to the getSwitchIndex() and getSourceIndex() API functions:
- Both functions check the name value against the default names for switches and sources as well as the user defined custom names (previously only custom names were checked if set by the user).
- Both functions will always return the switch or source index, previously they would only return a value if the requested item was available, so could not be used on startup when the widgets are loaded.
- The getSourceIndex() function will match names with or without the symbol string prefix. E.G. getSourceIndex(CHAR_SWITCH.."SF") and getSourceIndex("SF") will both work.

For the widget 'options' table, entries of type SWITCH and SOURCE, can set their default, min and max values from a string. This is a shortcut to using getSwitchIndex() or getSourceIndex() in the option table.
E.G. these two lines are equivalent:
```Lua
  { "Switch", SWITCH, "SF"..CHAR_DOWN },
  { "Switch", SWITCH, getSwitchIndex("SF"..CHAR_DOWN) },
```
