### PR TITLE
fix(lua): io.open(filename, “a”) overwriting instead of appending

### DIFF
--- a/radio/src/thirdparty/Lua/src/liolib.c
+++ b/radio/src/thirdparty/Lua/src/liolib.c
@@ -266,7 +266,7 @@ static inline BYTE fatfs_open_mode(const char *mode)
     return FA_WRITE | FA_CREATE_ALWAYS;
   } else if (mode[0] == 'a') {
     /* always open file (create it if necessary) */
-    return FA_WRITE | FA_OPEN_ALWAYS;
+    return FA_WRITE | FA_OPEN_APPEND;
   } else {
     return FA_READ;
   }


### PR DESCRIPTION
Fixes #5927 
