### PR TITLE
fix(sim): workaround for settings being retained when restarting the simulator.

### DIFF
--- a/radio/src/analogs.cpp
+++ b/radio/src/analogs.cpp
@@ -20,20 +20,17 @@
  */
 
 #include "analogs.h"
-#include "dataconstants.h"
-#include "edgetx_helpers.h"
+#include "edgetx.h"
 
 #include "hal/adc_driver.h"
-
-static char _custom_names[MAX_ANALOG_INPUTS][LEN_ANA_NAME + 1] = { 0 };
 
 void analogSetCustomLabel(uint8_t type, uint8_t idx, const char* str, size_t len)
 {
   if (idx >= adcGetMaxInputs(type)) return;
   idx += adcGetInputOffset(type);
 
-  strncpy(_custom_names[idx], str, min<size_t>(LEN_ANA_NAME, len));
-  _custom_names[idx][LEN_ANA_NAME] = '\0';
+  strncpy(g_eeGeneral.analogNames[idx], str, min<size_t>(LEN_ANA_NAME, len));
+  g_eeGeneral.analogNames[idx][LEN_ANA_NAME] = '\0';
 }
 
 const char* analogGetCustomLabel(uint8_t type, uint8_t idx)
@@ -41,7 +38,7 @@ const char* analogGetCustomLabel(uint8_t type, uint8_t idx)
   if (idx >= adcGetMaxInputs(type)) return "";
   idx += adcGetInputOffset(type);
 
-  return _custom_names[idx];
+  return g_eeGeneral.analogNames[idx];
 }
 
 bool analogHasCustomLabel(uint8_t type, uint8_t idx)

--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -83,11 +83,11 @@ static inline void check_struct()
 #endif
 
 #if defined(PCBXLITES)
-  CHKSIZE(RadioData, 872);
+  CHKSIZE(RadioData, 1008);
 #elif defined(COLORLCD)
-  CHKSIZE(RadioData, 966);
+  CHKSIZE(RadioData, 1134);
 #else
-  CHKSIZE(RadioData, 870);
+  CHKSIZE(RadioData, 1006);
 #endif
 
 #if defined(RADIO_TPRO) || defined(RADIO_TPROV2) || defined(RADIO_BUMBLEBEE)

--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -1026,6 +1026,9 @@ PACK(struct RadioData {
 
   NOBACKUP(uint8_t pwrOffIfInactive);
 
+  NOBACKUP(char switchNames[MAX_SWITCHES][LEN_SWITCH_NAME + 1] SKIP);
+  NOBACKUP(char analogNames[MAX_ANALOG_INPUTS][LEN_ANA_NAME + 1] SKIP);
+
   NOBACKUP(uint8_t getBrightness() const
   {
 #if defined(OLED_SCREEN)

--- a/radio/src/edgetx.cpp
+++ b/radio/src/edgetx.cpp
@@ -1116,6 +1116,7 @@ void edgeTxClose(uint8_t shutdown)
 #if defined(HAPTIC)
     hapticOff();
 #endif
+    mixerTaskExit();
   }
 
   logsClose();

--- a/radio/src/storage/yaml/yaml_datastructs_128x64.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_128x64.cpp
@@ -262,6 +262,11 @@ static const struct YamlNode struct_CustomFunctionData[] = {
   YAML_PADDING( 7 ),
   YAML_END
 };
+static const struct YamlNode struct_string_32[] = {
+  YAML_IDX,
+  YAML_STRING("val", 4),
+  YAML_END
+};
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
@@ -363,6 +368,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "invertLCD", 1 ),
   YAML_PADDING( 3 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
+  YAML_PADDING( 640 ),
+  YAML_PADDING( 448 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_f16.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_f16.cpp
@@ -281,6 +281,11 @@ static const struct YamlNode struct_CustomFunctionData[] = {
   YAML_PADDING( 7 ),
   YAML_END
 };
+static const struct YamlNode struct_string_32[] = {
+  YAML_IDX,
+  YAML_STRING("val", 4),
+  YAML_END
+};
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
@@ -389,6 +394,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_PADDING( 6 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
+  YAML_PADDING( 640 ),
+  YAML_PADDING( 704 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {
@@ -690,11 +697,6 @@ static const struct YamlNode struct_ScriptData[] = {
   YAML_STRING("file", 6),
   YAML_STRING("name", 6),
   YAML_ARRAY("inputs", 16, 6, union_ScriptDataInput, NULL),
-  YAML_END
-};
-static const struct YamlNode struct_string_32[] = {
-  YAML_IDX,
-  YAML_STRING("val", 4),
   YAML_END
 };
 static const struct YamlNode union_anonymous_14_elmts[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_gx12.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_gx12.cpp
@@ -263,6 +263,11 @@ static const struct YamlNode struct_CustomFunctionData[] = {
   YAML_PADDING( 7 ),
   YAML_END
 };
+static const struct YamlNode struct_string_32[] = {
+  YAML_IDX,
+  YAML_STRING("val", 4),
+  YAML_END
+};
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
@@ -364,6 +369,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "invertLCD", 1 ),
   YAML_PADDING( 3 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
+  YAML_PADDING( 640 ),
+  YAML_PADDING( 448 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_nb4p.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_nb4p.cpp
@@ -272,6 +272,11 @@ static const struct YamlNode struct_CustomFunctionData[] = {
   YAML_PADDING( 7 ),
   YAML_END
 };
+static const struct YamlNode struct_string_32[] = {
+  YAML_IDX,
+  YAML_STRING("val", 4),
+  YAML_END
+};
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
@@ -380,6 +385,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_PADDING( 6 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
+  YAML_PADDING( 640 ),
+  YAML_PADDING( 704 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {
@@ -681,11 +688,6 @@ static const struct YamlNode struct_ScriptData[] = {
   YAML_STRING("file", 6),
   YAML_STRING("name", 6),
   YAML_ARRAY("inputs", 16, 6, union_ScriptDataInput, NULL),
-  YAML_END
-};
-static const struct YamlNode struct_string_32[] = {
-  YAML_IDX,
-  YAML_STRING("val", 4),
   YAML_END
 };
 static const struct YamlNode union_anonymous_14_elmts[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_nv14_family.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_nv14_family.cpp
@@ -279,6 +279,11 @@ static const struct YamlNode struct_CustomFunctionData[] = {
   YAML_PADDING( 7 ),
   YAML_END
 };
+static const struct YamlNode struct_string_32[] = {
+  YAML_IDX,
+  YAML_STRING("val", 4),
+  YAML_END
+};
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
@@ -387,6 +392,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_PADDING( 6 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
+  YAML_PADDING( 640 ),
+  YAML_PADDING( 704 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {
@@ -688,11 +695,6 @@ static const struct YamlNode struct_ScriptData[] = {
   YAML_STRING("file", 6),
   YAML_STRING("name", 6),
   YAML_ARRAY("inputs", 16, 6, union_ScriptDataInput, NULL),
-  YAML_END
-};
-static const struct YamlNode struct_string_32[] = {
-  YAML_IDX,
-  YAML_STRING("val", 4),
   YAML_END
 };
 static const struct YamlNode union_anonymous_14_elmts[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_t15.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t15.cpp
@@ -281,6 +281,11 @@ static const struct YamlNode struct_CustomFunctionData[] = {
   YAML_PADDING( 7 ),
   YAML_END
 };
+static const struct YamlNode struct_string_32[] = {
+  YAML_IDX,
+  YAML_STRING("val", 4),
+  YAML_END
+};
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
@@ -389,6 +394,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_PADDING( 6 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
+  YAML_PADDING( 640 ),
+  YAML_PADDING( 704 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {
@@ -690,11 +697,6 @@ static const struct YamlNode struct_ScriptData[] = {
   YAML_STRING("file", 6),
   YAML_STRING("name", 6),
   YAML_ARRAY("inputs", 16, 6, union_ScriptDataInput, NULL),
-  YAML_END
-};
-static const struct YamlNode struct_string_32[] = {
-  YAML_IDX,
-  YAML_STRING("val", 4),
   YAML_END
 };
 static const struct YamlNode union_anonymous_14_elmts[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_t20.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t20.cpp
@@ -263,6 +263,11 @@ static const struct YamlNode struct_CustomFunctionData[] = {
   YAML_PADDING( 7 ),
   YAML_END
 };
+static const struct YamlNode struct_string_32[] = {
+  YAML_IDX,
+  YAML_STRING("val", 4),
+  YAML_END
+};
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
@@ -364,6 +369,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "invertLCD", 1 ),
   YAML_PADDING( 3 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
+  YAML_PADDING( 640 ),
+  YAML_PADDING( 448 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_tpro.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tpro.cpp
@@ -263,6 +263,11 @@ static const struct YamlNode struct_CustomFunctionData[] = {
   YAML_PADDING( 7 ),
   YAML_END
 };
+static const struct YamlNode struct_string_32[] = {
+  YAML_IDX,
+  YAML_STRING("val", 4),
+  YAML_END
+};
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
@@ -364,6 +369,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "invertLCD", 1 ),
   YAML_PADDING( 3 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
+  YAML_PADDING( 640 ),
+  YAML_PADDING( 448 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_x10.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x10.cpp
@@ -280,6 +280,11 @@ static const struct YamlNode struct_CustomFunctionData[] = {
   YAML_PADDING( 7 ),
   YAML_END
 };
+static const struct YamlNode struct_string_32[] = {
+  YAML_IDX,
+  YAML_STRING("val", 4),
+  YAML_END
+};
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
@@ -388,6 +393,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_PADDING( 6 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
+  YAML_PADDING( 640 ),
+  YAML_PADDING( 704 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {
@@ -689,11 +696,6 @@ static const struct YamlNode struct_ScriptData[] = {
   YAML_STRING("file", 6),
   YAML_STRING("name", 6),
   YAML_ARRAY("inputs", 16, 6, union_ScriptDataInput, NULL),
-  YAML_END
-};
-static const struct YamlNode struct_string_32[] = {
-  YAML_IDX,
-  YAML_STRING("val", 4),
   YAML_END
 };
 static const struct YamlNode union_anonymous_14_elmts[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
@@ -262,6 +262,11 @@ static const struct YamlNode struct_CustomFunctionData[] = {
   YAML_PADDING( 7 ),
   YAML_END
 };
+static const struct YamlNode struct_string_32[] = {
+  YAML_IDX,
+  YAML_STRING("val", 4),
+  YAML_END
+};
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
@@ -362,6 +367,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_PADDING( 4 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
+  YAML_PADDING( 640 ),
+  YAML_PADDING( 448 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {
@@ -662,11 +669,6 @@ static const struct YamlNode struct_ScriptData[] = {
   YAML_STRING("file", 6),
   YAML_STRING("name", 6),
   YAML_ARRAY("inputs", 16, 6, union_ScriptDataInput, NULL),
-  YAML_END
-};
-static const struct YamlNode struct_string_32[] = {
-  YAML_IDX,
-  YAML_STRING("val", 4),
   YAML_END
 };
 static const struct YamlNode union_anonymous_14_elmts[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_x9dp2019.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9dp2019.cpp
@@ -262,6 +262,11 @@ static const struct YamlNode struct_CustomFunctionData[] = {
   YAML_PADDING( 7 ),
   YAML_END
 };
+static const struct YamlNode struct_string_32[] = {
+  YAML_IDX,
+  YAML_STRING("val", 4),
+  YAML_END
+};
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
@@ -362,6 +367,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_PADDING( 4 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
+  YAML_PADDING( 640 ),
+  YAML_PADDING( 448 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {
@@ -662,11 +669,6 @@ static const struct YamlNode struct_ScriptData[] = {
   YAML_STRING("file", 6),
   YAML_STRING("name", 6),
   YAML_ARRAY("inputs", 16, 6, union_ScriptDataInput, NULL),
-  YAML_END
-};
-static const struct YamlNode struct_string_32[] = {
-  YAML_IDX,
-  YAML_STRING("val", 4),
   YAML_END
 };
 static const struct YamlNode union_anonymous_14_elmts[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
@@ -262,6 +262,11 @@ static const struct YamlNode struct_CustomFunctionData[] = {
   YAML_PADDING( 7 ),
   YAML_END
 };
+static const struct YamlNode struct_string_32[] = {
+  YAML_IDX,
+  YAML_STRING("val", 4),
+  YAML_END
+};
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
@@ -362,6 +367,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "disablePwrOnOffHaptic", 1 ),
   YAML_PADDING( 4 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
+  YAML_PADDING( 640 ),
+  YAML_PADDING( 448 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {
@@ -662,11 +669,6 @@ static const struct YamlNode struct_ScriptData[] = {
   YAML_STRING("file", 6),
   YAML_STRING("name", 6),
   YAML_ARRAY("inputs", 16, 6, union_ScriptDataInput, NULL),
-  YAML_END
-};
-static const struct YamlNode struct_string_32[] = {
-  YAML_IDX,
-  YAML_STRING("val", 4),
   YAML_END
 };
 static const struct YamlNode union_anonymous_14_elmts[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_xlite.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_xlite.cpp
@@ -262,6 +262,11 @@ static const struct YamlNode struct_CustomFunctionData[] = {
   YAML_PADDING( 7 ),
   YAML_END
 };
+static const struct YamlNode struct_string_32[] = {
+  YAML_IDX,
+  YAML_STRING("val", 4),
+  YAML_END
+};
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
@@ -363,6 +368,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "invertLCD", 1 ),
   YAML_PADDING( 3 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
+  YAML_PADDING( 640 ),
+  YAML_PADDING( 448 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
@@ -264,6 +264,11 @@ static const struct YamlNode struct_CustomFunctionData[] = {
   YAML_PADDING( 7 ),
   YAML_END
 };
+static const struct YamlNode struct_string_32[] = {
+  YAML_IDX,
+  YAML_STRING("val", 4),
+  YAML_END
+};
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
@@ -367,6 +372,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "invertLCD", 1 ),
   YAML_PADDING( 3 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
+  YAML_PADDING( 640 ),
+  YAML_PADDING( 448 ),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -319,12 +319,10 @@ char switchGetLetter(uint8_t idx)
   return name[c];
 }
 
-static char _switchNames[MAX_SWITCHES][LEN_SWITCH_NAME + 1] = { 0 };
-
 void switchSetCustomName(uint8_t idx, const char* str, size_t len)
 {
-  strncpy(_switchNames[idx], str, min<size_t>(LEN_SWITCH_NAME, len));
-  _switchNames[idx][LEN_SWITCH_NAME] = '\0';  
+  strncpy(g_eeGeneral.switchNames[idx], str, min<size_t>(LEN_SWITCH_NAME, len));
+  g_eeGeneral.switchNames[idx][LEN_SWITCH_NAME] = '\0';  
 }
 
 const char* switchGetCustomName(uint8_t idx)
@@ -334,7 +332,7 @@ const char* switchGetCustomName(uint8_t idx)
     return g_model.switchNames[idx - switchGetMaxSwitches()];
   else
 #endif
-    return _switchNames[idx];
+    return g_eeGeneral.switchNames[idx];
 }
 
 bool switchHasCustomName(uint8_t idx)

--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -211,6 +211,8 @@ void simuStart(bool tests, const char * sdPath, const char * settingsPath)
   lcdInit();
 
 #if !defined(SIMU_BOOTLOADER)
+  memset(&g_eeGeneral, 0, sizeof(g_eeGeneral));
+  memset(&g_model, 0, sizeof(g_model));
   simuMain();
 #else
   pthread_attr_t attr;

--- a/radio/src/tasks/mixer_task.cpp
+++ b/radio/src/tasks/mixer_task.cpp
@@ -172,12 +172,7 @@ TASK_FUNCTION(mixerTask)
     // re-enable trigger
     mixerSchedulerEnableTrigger();
 
-#if defined(SIMU)
-    // TODO: should be using mixerTaskExit() instead...
-    if (pwrCheck() == e_power_off) {
-      TASK_RETURN();
-    }
-#else
+#if !defined(SIMU)
     // Emergency power OFF: in case the UI is not functional anymore
     // or maybe locked, this will effectively shutdown and cut power.
     if (isForcePowerOffRequested()) {


### PR DESCRIPTION
Workaround for #5919 

Underlying reason is still to be determined; but this workaround resolves the issue for now.

