### PR TITLE
refactor(radio): async call handling to prevent GX12 switch lockups

### DIFF
--- a/radio/src/edgetx.cpp
+++ b/radio/src/edgetx.cpp
@@ -250,7 +250,7 @@ void timer_10ms()
 #include <FreeRTOS/include/FreeRTOS.h>
 #include <FreeRTOS/include/timers.h>
 
-static bool _timer_10ms_cb_in_queue = false;
+static volatile bool _timer_10ms_cb_in_queue = false;
 
 static void _timer_10ms_cb(void *pvParameter1, uint32_t ulParameter2)
 {

--- a/radio/src/edgetx.cpp
+++ b/radio/src/edgetx.cpp
@@ -268,12 +268,13 @@ void per10ms()
     BaseType_t xReturn = pdFALSE;
 
     xReturn = xTimerPendFunctionCallFromISR(_timer_10ms_cb, nullptr, 0, &xHigherPriorityTaskWoken);
-    portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
+
     if (xReturn == pdPASS) {
       _timer_10ms_cb_in_queue = true;
     } else {
       TRACE("xTimerPendFunctionCallFromISR() queue full");
     }
+    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
   }
 }
 

--- a/radio/src/edgetx.cpp
+++ b/radio/src/edgetx.cpp
@@ -250,16 +250,18 @@ void timer_10ms()
 #include <FreeRTOS/include/FreeRTOS.h>
 #include <FreeRTOS/include/timers.h>
 
+static bool _timer_10ms_cb_in_queue = false;
+
 static void _timer_10ms_cb(void *pvParameter1, uint32_t ulParameter2)
 {
   (void)pvParameter1;
   (void)ulParameter2;
+  _timer_10ms_cb_in_queue = false;
   timer_10ms();
 }
 
 void per10ms()
 {
-  static bool _timer_10ms_cb_in_queue = false;
 
   if (!_timer_10ms_cb_in_queue && xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED) {
     BaseType_t xHigherPriorityTaskWoken = pdFALSE;

--- a/radio/src/targets/taranis/gx12/bsp_io.cpp
+++ b/radio/src/targets/taranis/gx12/bsp_io.cpp
@@ -76,7 +76,7 @@ static void _io_int_handler()
                                   &xHigherPriorityTaskWoken);
     portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 
-	if (xReturn == pdPASS) {
+    if (xReturn == pdPASS) {
       _poll_switches_in_queue = true;
     } else {
        TRACE("xTimerPendFunctionCallFromISR() queue full");

--- a/radio/src/targets/taranis/gx12/bsp_io.cpp
+++ b/radio/src/targets/taranis/gx12/bsp_io.cpp
@@ -74,13 +74,13 @@ static void _io_int_handler()
   if (!_poll_switches_in_queue && xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED) {
     xReturn = xTimerPendFunctionCallFromISR(_poll_switches, nullptr, 0,
                                   &xHigherPriorityTaskWoken);
-    portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
 
     if (xReturn == pdPASS) {
       _poll_switches_in_queue = true;
     } else {
        TRACE("xTimerPendFunctionCallFromISR() queue full");
     }
+    portYIELD_FROM_ISR(xHigherPriorityTaskWoken);
   }
 }
 

--- a/radio/src/targets/taranis/gx12/bsp_io.cpp
+++ b/radio/src/targets/taranis/gx12/bsp_io.cpp
@@ -58,7 +58,7 @@ static uint32_t _read_io_expander(bsp_io_expander* io)
   return io->state;  
 }
 
-static void _poll_switches(void *pvParameter1 = nullptr, uint32_t ulParameter2 = 0)
+static void _poll_switches(void *pvParameter1, uint32_t ulParameter2)
 {
   (void)ulParameter2;
   _poll_switches_in_queue = false;

--- a/radio/src/targets/taranis/gx12/bsp_io.cpp
+++ b/radio/src/targets/taranis/gx12/bsp_io.cpp
@@ -38,7 +38,7 @@ struct bsp_io_expander {
   uint32_t state;
 };
 
-static bool _poll_switches_in_queue = false;
+static volatile bool _poll_switches_in_queue = false;
 static bsp_io_expander _io_switches;
 static bsp_io_expander _io_fs_switches;
 

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -205,12 +205,15 @@ void telemetryStop()
   }
 }
 
+static bool _poll_frame_queued[NUM_MODULES] = {false};
+
 static void _poll_frame(void *pvParameter1, uint32_t ulParameter2)
 {
   _telemetryIsPolling = true;
 
   auto drv = (const etx_proto_driver_t*)pvParameter1;
   auto module = (uint8_t)ulParameter2;
+  _poll_frame_queued[module] = false;
 
   auto mod = pulsesGetModuleDriver(module);
   if (!mod || !mod->drv || !mod->ctx || (drv != mod->drv))
@@ -245,16 +248,15 @@ static void _poll_frame(void *pvParameter1, uint32_t ulParameter2)
 
 void telemetryFrameTrigger_ISR(uint8_t module, const etx_proto_driver_t* drv)
 {
-  static bool _poll_frame_in_queue = false;
   BaseType_t xHigherPriorityTaskWoken = pdFALSE;
   BaseType_t xReturn = pdFALSE;
 
-  if (!_poll_frame_in_queue && xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED) {
+  if (!_poll_frame_queued[module] && xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED) {
     xReturn = xTimerPendFunctionCallFromISR(_poll_frame, (void*)drv, module, &xHigherPriorityTaskWoken);
     portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 
     if (xReturn == pdPASS) {
-      _poll_frame_in_queue = true;
+      _poll_frame_queued[module] = true;
     } else {
       TRACE("xTimerPendFunctionCallFromISR() queue full");
     }

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -205,7 +205,7 @@ void telemetryStop()
   }
 }
 
-static bool _poll_frame_queued[NUM_MODULES] = {false};
+static volatile bool _poll_frame_queued[NUM_MODULES] = {false};
 
 static void _poll_frame(void *pvParameter1, uint32_t ulParameter2)
 {

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -253,13 +253,13 @@ void telemetryFrameTrigger_ISR(uint8_t module, const etx_proto_driver_t* drv)
 
   if (!_poll_frame_queued[module] && xTaskGetSchedulerState() != taskSCHEDULER_NOT_STARTED) {
     xReturn = xTimerPendFunctionCallFromISR(_poll_frame, (void*)drv, module, &xHigherPriorityTaskWoken);
-    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
 
     if (xReturn == pdPASS) {
       _poll_frame_queued[module] = true;
     } else {
       TRACE("xTimerPendFunctionCallFromISR() queue full");
     }
+    portYIELD_FROM_ISR( xHigherPriorityTaskWoken );
   }
 }
 #endif


### PR DESCRIPTION
First, I would like to thanks Radiomaster devs for their investigation and contribution to bring to surface this issue. Great work guys.

Bottom line is that we have an issue with async call handling based on xTimerPendFunctionCallFromISR(). We need some time to understand why we have that issue.

In the meantime, this workaround allows the switch to be read even if the call to xTimerPendFunctionCallFromISR() was not successful.

Another part of EdgeTX relying heavily on xTimerPendFunctionCallFromISR() is telemetry handling, but the protocol is handling it so this is not critical, so the workaround is not applied there.