### PR TITLE
fix: don't check ELRS version if crossfire disabled

### DIFF
--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -1376,7 +1376,7 @@ uint8_t MENU_FIRST_LINE_EDIT(const uint8_t * horTab, uint8_t horTabMax)
 
 uint8_t MODULE_BIND_ROWS(int moduleIdx)
 {
-  if (isModuleELRS(moduleIdx) && (crossfireModuleStatus[moduleIdx].major >= 4 || (crossfireModuleStatus[moduleIdx].major == 3 && crossfireModuleStatus[moduleIdx].minor >= 4)))
+  if (isModuleELRS(moduleIdx) && CRSF_ELRS_MIN_VER(moduleIdx, 3, 4)) 
     return 1;
 
   if (isModuleCrossfire(moduleIdx))

--- a/radio/src/pulses/modules_helpers.h
+++ b/radio/src/pulses/modules_helpers.h
@@ -619,7 +619,7 @@ inline bool isModuleBindRangeAvailable(uint8_t moduleIdx)
   return isModulePXX2(moduleIdx) || isModulePXX1(moduleIdx) ||
          isModuleDSM2(moduleIdx) || isModuleMultimodule(moduleIdx) ||
          isModuleFlySky(moduleIdx) || isModuleDSMP(moduleIdx) ||
-         (isModuleELRS(moduleIdx) && (crossfireModuleStatus[moduleIdx].major >= 4 || (crossfireModuleStatus[moduleIdx].major == 3 && crossfireModuleStatus[moduleIdx].minor >= 4)));
+         (isModuleELRS(moduleIdx) && CRSF_ELRS_MIN_VER(moduleIdx, 3, 4));
 }
 
 inline uint32_t getNV14RfFwVersion()

--- a/radio/src/telemetry/crossfire.h
+++ b/radio/src/telemetry/crossfire.h
@@ -156,11 +156,15 @@ const uint8_t CROSSFIRE_FRAME_PERIODS[] = {
         % DIM(CROSSFIRE_BAUDRATES)
 #endif
 
+#if defined(CROSSFIRE)
 #define CRSF_ELRS_MIN_VER(moduleIdx, maj, min) \
         (crossfireModuleStatus[moduleIdx].isELRS \
          && (crossfireModuleStatus[moduleIdx].major > maj \
           || (crossfireModuleStatus[moduleIdx].major == maj \
            && crossfireModuleStatus[moduleIdx].minor >= min)))
+#else
+#define CRSF_ELRS_MIN_VER(moduleIdx, maj, min) false
+#endif
 
 #if defined(HARDWARE_INTERNAL_MODULE)
 #define INT_CROSSFIRE_BR_IDX   CROSSFIRE_STORE_TO_INDEX(g_eeGeneral.internalModuleBaudrate)


### PR DESCRIPTION
Fixes #5960

Summary of changes:
- If `-DCROSSFIRE=N` defined at compile time, calls to `CRSF_ELRS_MIN_VER()` are not valid, and response should simply be "no". `crossfireModuleStatus` does not exist, so should not be checked. 
- Also, use the helper function rather than reinvent the wheel