### PR TITLE
fix(radio): fix inverted source causing EM on PlayValue SF trigger

### DIFF
--- a/radio/src/functions.cpp
+++ b/radio/src/functions.cpp
@@ -56,7 +56,7 @@ void testFunc()
 }
 #endif
 
-PLAY_FUNCTION(playValue, source_t idx)
+PLAY_FUNCTION(playValue, mixsrc_t idx)
 {
   if (IS_FAI_FORBIDDEN(idx))
     return;

--- a/radio/src/functions.cpp
+++ b/radio/src/functions.cpp
@@ -65,9 +65,10 @@ PLAY_FUNCTION(playValue, mixsrc_t idx)
     return;
 
   getvalue_t val = getValue(idx);
+  idx = abs(idx); // Don't need negative form any longer
 
-  if (abs(idx) >= MIXSRC_FIRST_TELEM) {
-    TelemetrySensor & telemetrySensor = g_model.telemetrySensors[(abs(idx)-MIXSRC_FIRST_TELEM) / 3];
+  if (idx >= MIXSRC_FIRST_TELEM) {
+    TelemetrySensor & telemetrySensor = g_model.telemetrySensors[(idx-MIXSRC_FIRST_TELEM) / 3];
     uint8_t attr = 0;
 
     // Preserve the sign
@@ -98,18 +99,18 @@ PLAY_FUNCTION(playValue, mixsrc_t idx)
 
     PLAY_NUMBER(val, telemetrySensor.unit == UNIT_CELLS ? UNIT_VOLTS : telemetrySensor.unit, attr);
   }
-  else if (abs(idx) >= MIXSRC_FIRST_TIMER && abs(idx) <= MIXSRC_LAST_TIMER) {
+  else if (idx >= MIXSRC_FIRST_TIMER && idx <= MIXSRC_LAST_TIMER) {
     int flag = 0;
     if (abs(val) > LONG_TIMER_DURATION) {
       flag = PLAY_LONG_TIMER;
     }
     PLAY_DURATION(val, flag);
-  } else if (abs(idx) == MIXSRC_TX_TIME) {
+  } else if (idx == MIXSRC_TX_TIME) {
     PLAY_DURATION(val * 60, PLAY_TIME);
-  } else if (abs(idx) == MIXSRC_TX_VOLTAGE) {
+  } else if (idx == MIXSRC_TX_VOLTAGE) {
     PLAY_NUMBER(val, UNIT_VOLTS, PREC1);
   } else {
-    if (abs(idx) <= MIXSRC_LAST_CH) {
+    if (idx <= MIXSRC_LAST_CH) {
       val = calcRESXto100(val);
     }
     PLAY_NUMBER(val, 0, 0);

--- a/radio/src/functions.cpp
+++ b/radio/src/functions.cpp
@@ -66,9 +66,14 @@ PLAY_FUNCTION(playValue, mixsrc_t idx)
 
   getvalue_t val = getValue(idx);
 
-  if (idx >= MIXSRC_FIRST_TELEM) {
-    TelemetrySensor & telemetrySensor = g_model.telemetrySensors[(idx-MIXSRC_FIRST_TELEM) / 3];
+  if (abs(idx) >= MIXSRC_FIRST_TELEM) {
+    TelemetrySensor & telemetrySensor = g_model.telemetrySensors[(abs(idx)-MIXSRC_FIRST_TELEM) / 3];
     uint8_t attr = 0;
+
+    // Preserve the sign
+    int sign = (val >= 0) ? 1 : -1;
+    val = abs(val);
+
     if (telemetrySensor.prec > 0) {
       if (telemetrySensor.prec == 2) {
         if (val >= 5000) {
@@ -88,20 +93,23 @@ PLAY_FUNCTION(playValue, mixsrc_t idx)
         }
       }
     }
+
+    val *= sign; // Reapply sign if needed
+
     PLAY_NUMBER(val, telemetrySensor.unit == UNIT_CELLS ? UNIT_VOLTS : telemetrySensor.unit, attr);
   }
-  else if (idx >= MIXSRC_FIRST_TIMER && idx <= MIXSRC_LAST_TIMER) {
+  else if (abs(idx) >= MIXSRC_FIRST_TIMER && abs(idx) <= MIXSRC_LAST_TIMER) {
     int flag = 0;
-    if (val > LONG_TIMER_DURATION || -val > LONG_TIMER_DURATION) {
+    if (abs(val) > LONG_TIMER_DURATION) {
       flag = PLAY_LONG_TIMER;
     }
     PLAY_DURATION(val, flag);
-  } else if (idx == MIXSRC_TX_TIME) {
+  } else if (abs(idx) == MIXSRC_TX_TIME) {
     PLAY_DURATION(val * 60, PLAY_TIME);
-  } else if (idx == MIXSRC_TX_VOLTAGE) {
+  } else if (abs(idx) == MIXSRC_TX_VOLTAGE) {
     PLAY_NUMBER(val, UNIT_VOLTS, PREC1);
   } else {
-    if (idx <= MIXSRC_LAST_CH) {
+    if (abs(idx) <= MIXSRC_LAST_CH) {
       val = calcRESXto100(val);
     }
     PLAY_NUMBER(val, 0, 0);
@@ -399,7 +407,7 @@ void evalFunctions(CustomFunctionData * functions, CustomFunctionsContext & func
 
             getvalue_t raw = getValue(CFN_PARAM(cfn));
 #if defined(COLORLCD)
-            requiredBacklightBright = BACKLIGHT_LEVEL_MAX - (g_eeGeneral.blOffBright + 
+            requiredBacklightBright = BACKLIGHT_LEVEL_MAX - (g_eeGeneral.blOffBright +
                 ((1024 + raw) * ((BACKLIGHT_LEVEL_MAX - g_eeGeneral.backlightBright) - g_eeGeneral.blOffBright) / 2048));
 #elif defined(OLED_SCREEN)
             requiredBacklightBright = (raw + 1024) * 254 / 2048;


### PR DESCRIPTION
Fixes #5955, alternative to #5963

Summary of changes:
- change from uint16_t to int32_t data type, since we are getting a signed (negative) value also now
- preserve sign for source/value when needed, otherwise strip it to allow conditional processing to continue to work "normally"

Prior to this, it was going into the `if (idx >= MIXSRC_FIRST_TELEM)` branch for sources such as Inv Thr, since (using example of Inv Thr) idx was `65535`, not `-1`... :hand_over_mouth: 