### PR TITLE
chore(radio): tweak POWER_LED_BLUE, fix Flysky startup sequence

### DIFF
--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -62,7 +62,12 @@ if(PCB STREQUAL X9D+ AND PCBREV STREQUAL 2019)
 else()
   option(USBJ_EX "Enable USB Joystick Extension" ON)
 endif()
-option(POWER_LED_BLUE  "Override Power LED to be normally Blue" OFF)
+
+if(PCB STREQUAL X7 AND PCBREV STREQUAL LR3PRO)
+  option(POWER_LED_BLUE  "Override Power LED to be normally Blue" ON)
+else()
+  option(POWER_LED_BLUE  "Override Power LED to be normally Blue" OFF)
+endif()
 
 # since we reset all default CMAKE compiler flags for firmware builds, provide an alternate way for user to specify additional flags.
 set(FIRMWARE_C_FLAGS "" CACHE STRING "Additional flags for firmware target c compiler (note: all CMAKE_C_FLAGS[_*] are ignored for firmware/bootloader).")

--- a/radio/src/edgetx.h
+++ b/radio/src/edgetx.h
@@ -598,8 +598,8 @@ constexpr uint8_t OPENTX_START_NO_CHECKS = 0x04;
 
 #if defined(STATUS_LEDS)
   #define LED_ERROR_BEGIN()            ledRed()
-  // Green is preferred "ready to use" color for these radios, unless overridden by user
-#if !defined(POWER_LED_BLUE) && (defined(MANUFACTURER_RADIOMASTER) || defined(MANUFACTURER_JUMPER) || defined(RADIO_COMMANDO8))
+  // Green "ready to use" if available, unless overridden by user or mfg preference
+#if !defined(POWER_LED_BLUE) && (defined(LED_GREEN_GPIO) || defined(LED_STRIP_GPIO))
   #define LED_ERROR_END() ledGreen()
   #define LED_BIND() ledBlue()
 #else

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -167,7 +167,7 @@ void boardInit()
 
 #if defined(STATUS_LEDS)
   ledInit();
-#if !defined(POWER_LED_BLUE) && (defined(MANUFACTURER_RADIOMASTER) || defined(MANUFACTURER_JUMPER) || defined(RADIO_COMMANDO8))
+#if !defined(POWER_LED_BLUE)
   ledBlue();
 #else
   ledGreen();


### PR DESCRIPTION
Summary of changes:
 - make power led sequence conditional on presence of LED_GREEN_GPIO or RGB capability rather than MFG defines
- sole exception is LR3PRO

Fixes standard power on sequence for Flysky radios, as they were omitting the startup green phase. 
