### PR TITLE
chore(radio): save some ram in radios with RGB LEDs

### DIFF
--- a/radio/src/boards/generic_stm32/rgb_leds.cpp
+++ b/radio/src/boards/generic_stm32/rgb_leds.cpp
@@ -36,6 +36,8 @@
 #include <FreeRTOS/include/timers.h>
 #endif
 
+static uint8_t _led_colors[WS2812_BYTES_PER_LED * LED_STRIP_LENGTH];
+
 extern const stm32_pulse_timer_t _led_timer;
 
 static TimerHandle_t rgbLedTimer = nullptr;
@@ -55,7 +57,6 @@ uint32_t rgbGetLedColor(uint8_t led)
   return ws2812_get_color(led);
 }
 
-
 bool rgbGetState(uint8_t led)
 {
   return ws2812_get_state(led);
@@ -63,7 +64,15 @@ bool rgbGetState(uint8_t led)
 
 void rgbLedColorApply()
 {
-  ws2812_update(&_led_timer);;
+  ws2812_update(&_led_timer);
+}
+
+void rgbLedClearAll()
+{
+  for (uint8_t i = 0; i < LED_STRIP_LENGTH; i++) {
+    ws2812_set_color(i, 0, 0, 0);
+  }
+  ws2812_update(&_led_timer);
 }
 
 static void rgbLedTimerCb(TimerHandle_t xTimer)
@@ -110,6 +119,12 @@ const stm32_pulse_timer_t _led_timer = {
   .DMA_IRQn = LED_STRIP_TIMER_DMA_IRQn,
   .DMA_TC_CallbackPtr = nullptr,
 };
+
+void rgbLedInit()
+{
+  ws2812_init(&_led_timer, _led_colors, LED_STRIP_LENGTH, WS2812_GRB);
+  rgbLedClearAll();
+}
 
 // Make sure the timer channel is supported
 static_assert(__STM32_PULSE_IS_TIMER_CHANNEL_SUPPORTED(LED_STRIP_TIMER_CHANNEL),

--- a/radio/src/boards/generic_stm32/rgb_leds.h
+++ b/radio/src/boards/generic_stm32/rgb_leds.h
@@ -21,9 +21,16 @@
 
 #pragma once
 
+#include <stdint.h>
+
+void rgbLedInit();
 void rgbLedStart();
 void rgbLedStop();
-void rgbSetLedColor(unsigned char, unsigned char, unsigned char, unsigned char);
+
+void rgbSetLedColor(uint8_t led, uint8_t r, uint8_t g, uint8_t b);
 uint32_t rgbGetLedColor(uint8_t led);
-bool rgbGetState(unsigned char);
+
+void rgbLedClearAll();
+
+bool rgbGetState(uint8_t led);
 void rgbLedColorApply();

--- a/radio/src/targets/common/arm/stm32/stm32_ws2812.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_ws2812.cpp
@@ -32,10 +32,7 @@
 #include <string.h>
 
 // Pixel values
-static uint8_t _led_colors[WS2812_BYTES_PER_LED * WS2812_MAX_LEDS];
-
-// Timer used
-// static const stm32_pulse_timer_t* _led_timer;
+static uint8_t* _led_colors = nullptr;
 
 // LED strip length
 static uint8_t _led_strip_len;
@@ -200,19 +197,16 @@ static void _init_timer(const stm32_pulse_timer_t* tim)
   NVIC_SetPriority(tim->DMA_IRQn, WS2812_DMA_IRQ_PRIO);
 }
 
-void ws2812_init(const stm32_pulse_timer_t* timer, uint8_t strip_len, uint8_t type)
+void ws2812_init(const stm32_pulse_timer_t* timer, uint8_t* strip_colors,
+                 uint8_t strip_len, uint8_t type)
 {
   WS2812_DBG_INIT;
   pulse_inc = IS_TIM_32B_COUNTER_INSTANCE(timer->TIMx) ? 2 : 1;
 
-  memset(_led_colors, 0, sizeof(_led_colors));
+  _led_colors = strip_colors;
+  _led_strip_len = strip_len;
+  memset(_led_colors, 0, strip_len * WS2812_BYTES_PER_LED);
   memset(_led_dma_buffer, 0, sizeof(_led_dma_buffer));
-
-  if (strip_len <= WS2812_MAX_LEDS) {
-    _led_strip_len = strip_len;
-  } else {
-    _led_strip_len = WS2812_MAX_LEDS;
-  }
 
   _r_offset = (type >> 4) & 0b11;
   _g_offset = (type >> 2) & 0b11;

--- a/radio/src/targets/common/arm/stm32/stm32_ws2812.h
+++ b/radio/src/targets/common/arm/stm32/stm32_ws2812.h
@@ -30,17 +30,13 @@
 // RGB
 #define WS2812_BYTES_PER_LED 3
 
-// Maximum number of supported LEDs
-#if !defined(WS2812_MAX_LEDS)
-#  define WS2812_MAX_LEDS 48
-#endif
-
 // Number of LED periods used for trailing reset
 #if !defined(WS2812_TRAILING_RESET)
 #  define WS2812_TRAILING_RESET 10
 #endif
 
-void ws2812_init(const stm32_pulse_timer_t* timer, uint8_t strip_len, uint8_t type);
+void ws2812_init(const stm32_pulse_timer_t* timer, uint8_t* strip_colors,
+                 uint8_t strip_len, uint8_t type);
 void ws2812_update(const stm32_pulse_timer_t* timer);
 bool ws2812_get_state(uint8_t led);
 void ws2812_dma_isr(const stm32_pulse_timer_t* timer);

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -131,12 +131,13 @@ uint16_t getSixPosAnalogValue(uint16_t adcValue)
   }
   if (dirty) {
     for (uint8_t i = 0; i < 6; i++) {
-      if (i == sixPosState)
+      if (i == sixPosState) {
         ws2812_set_color(i, SIXPOS_LED_RED, SIXPOS_LED_GREEN, SIXPOS_LED_BLUE);
-      else
+      } else {
         ws2812_set_color(i, 0, 0, 0);
+      }
     }
-    ws2812_update(&_led_timer);
+    rgbLedColorApply();
   }
   return (4096/5)*(sixPosState);
 }

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -57,19 +57,6 @@
   #include "csd203_sensor.h"
 #endif
 
-#if defined(LED_STRIP_GPIO)
-// Common LED driver
-extern const stm32_pulse_timer_t _led_timer;
-
-void ledStripOff()
-{
-  for (uint8_t i = 0; i < LED_STRIP_LENGTH; i++) {
-    ws2812_set_color(i, 0, 0, 0);
-  }
-  ws2812_update(&_led_timer);
-}
-#endif
-
 HardwareOptions hardwareOptions;
 bool boardBacklightOn = false;
 
@@ -232,8 +219,7 @@ void boardInit()
   hapticInit();
 
 #if defined(LED_STRIP_GPIO)
-  ws2812_init(&_led_timer, LED_STRIP_LENGTH, WS2812_GRB);
-  ledStripOff();
+  rgbLedInit();
 #endif
 
 #if defined(BLUETOOTH)

--- a/radio/src/targets/pl18/board.cpp
+++ b/radio/src/targets/pl18/board.cpp
@@ -234,8 +234,7 @@ void boardInit()
   usbInit();
 
 #if defined(LED_STRIP_GPIO)
-  ws2812_init(&_led_timer, LED_STRIP_LENGTH, WS2812_GRB);
-  ledStripOff();
+  rgbLedInit();
 #endif
 
   uint32_t press_start = 0;

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -62,10 +62,6 @@
 
 HardwareOptions hardwareOptions;
 
-#if defined(LED_STRIP_GPIO)
-extern const stm32_pulse_timer_t _led_timer;
-#endif
-
 #if !defined(BOOT)
 
 #if defined(FUNCTION_SWITCHES)
@@ -104,7 +100,7 @@ uint16_t getSixPosAnalogValue(uint16_t adcValue)
       else
         ws2812_set_color(i, 0, 0, 0);
     }
-    ws2812_update(&_led_timer);
+    rgbLedColorApply();
   }
   return (4096/5)*(sixPosState);
 }
@@ -244,11 +240,7 @@ void boardInit()
   usbInit();
 
 #if defined(LED_STRIP_GPIO)
-  ws2812_init(&_led_timer, LED_STRIP_LENGTH, WS2812_GRB);
-  for (uint8_t i = 0; i < LED_STRIP_LENGTH; i++) {
-    ws2812_set_color(i, 0, 0, 50);
-  }
-  ws2812_update(&_led_timer);
+  rgbLedInit();
 #endif
 
 #if defined(HAPTIC)

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -1963,11 +1963,11 @@
 
   // LED Strip
 #if defined(RGBLEDS)
-  #if defined(RADIO_GX12)
-    #define LED_STRIP_LENGTH                8
-  #else
-    #define LED_STRIP_LENGTH                7
-  #endif
+#if defined(RADIO_GX12)
+  #define LED_STRIP_LENGTH                  8
+#else
+  #define LED_STRIP_LENGTH                  7
+#endif
   #define LED_STRIP_GPIO                    GPIO_PIN(GPIOA, 8) // PA.08 / TIM1_CH1
   #define LED_STRIP_GPIO_AF                 LL_GPIO_AF_1   // TIM1 / TIM2
   #define LED_STRIP_TIMER                   TIM1


### PR DESCRIPTION
Get back around 120 bytes on GX12 and MT12

Remove some duplicates declarations between WS2812_MAX_LEDS  and LED_STRIP_LENGTH, and other cleanups and rationalisation (thx @raphaelcoeffic )