### PR TITLE
fix(lua): display "needs file" rather than "unknown error"

### DIFF
--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -761,6 +761,9 @@ void displayLuaError(bool firstCall = false)
     case SCRIPT_PANIC:
       title = STR_SCRIPT_PANIC;
       break;
+    case SCRIPT_NOFILE:
+      title = STR_NEEDS_FILE;
+      break;
     default:
       title = STR_SCRIPT_ERROR;
   }


### PR DESCRIPTION
i.e. for telemetry screens on bw, when you've deleted/moved the Lua, it will display "unknown error" when we can actually detect the file is missing. 

Resolves #5945

