### PR TITLE
fix(cpn): moving input line up to an empty line resulted in input data loss

### DIFF
--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -1427,6 +1427,48 @@ void ModelData::sortMixes()
   memcpy(&mixData[0], &sortedMixData[0], CPN_MAX_MIXERS * sizeof(MixData));
 }
 
+void ModelData::sortInputs()
+{
+  unsigned int lastchn = 0;
+  bool sortreq = false;
+
+  for (int i = 0; i < CPN_MAX_EXPOS; i++) {
+    ExpoData *ed = &expoData[i];
+    if (!ed->isEmpty()) {
+      if (ed->chn < lastchn) {
+        sortreq = true;
+        break;
+      }
+      else
+        lastchn = ed->chn;
+    }
+  }
+
+  if (!sortreq)
+    return;
+
+  //  QMap automatically sorts based on key
+  QMap<int, int> map;
+  for (int i = 0; i < CPN_MAX_EXPOS; i++) {
+    ExpoData *ed = &expoData[i];
+    if (!ed->isEmpty()) {
+      //  chn may not be unique so build a compound sort key
+      map.insert(ed->chn * (CPN_MAX_EXPOS + 1) + i, i);
+    }
+  }
+
+  ExpoData sortedExpoData[CPN_MAX_EXPOS];
+  int destidx = 0;
+
+  QMap<int, int>::const_iterator i;
+  for (i = map.constBegin(); i != map.constEnd(); ++i) {
+    memcpy(&sortedExpoData[destidx], &expoData[i.value()], sizeof(ExpoData));
+    destidx++;
+  }
+
+  memcpy(&expoData[0], &sortedExpoData[0], CPN_MAX_EXPOS * sizeof(ExpoData));
+}
+
 void ModelData::updateResetParam(CustomFunctionData * cfd)
 {
   if (cfd->func != FuncReset)

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -282,6 +282,7 @@ class ModelData {
     void clearMixes();
     void sortMixes();
     void clearInputs();
+    void sortInputs();
 
     int getChannelsMax(bool forceExtendedLimits=false) const;
 

--- a/companion/src/modeledit/inputs.cpp
+++ b/companion/src/modeledit/inputs.cpp
@@ -656,41 +656,15 @@ void InputsPanel::cmInputSwapData(int idx1, int idx2)
 {
   if (idx1 >= idx2 || (!model->hasExpos(idx1) && !model->hasExpos(idx2)))
     return;
-  //  save expos
-  int expoidx = -1;
-  QVector<ExpoData> edtmp;
-  int i;
-  for (i = 0; i < CPN_MAX_EXPOS; i++) {
+
+  for (int i = 0; i < CPN_MAX_EXPOS; i++) {
     ExpoData *ed = &model->expoData[i];
-    if ((int)ed->chn == idx1) {
-      edtmp << model->expoData[i];
-      if (expoidx < 0)
-        expoidx = i;
+    if (!ed->isEmpty()) {
+      if ((int)ed->chn == idx1)
+        ed->chn = idx2;
+      else if ((int)ed->chn == idx2)
+        ed->chn = idx1;
     }
-    else if ((int)ed->chn > idx1)
-      break;
-  }
-  //  move expos up
-  const int offset = i - expoidx;
-  int expocnt = 0;
-  for (int j = i; j < CPN_MAX_EXPOS; j++) {
-    ExpoData *ed = &model->expoData[j];
-    if ((int)ed->chn == idx2) {
-      ExpoData *dest = &model->expoData[j - offset];
-      memcpy(dest, &model->expoData[j], sizeof(ExpoData));
-      dest->chn = idx1;
-      expocnt++;
-    }
-    else if ((int)ed->chn > idx2)
-      break;
-  }
-  //  copy back saved expos
-  int cnt = 0;
-  foreach (ExpoData ed, edtmp) {
-    ExpoData *dest = &model->expoData[expoidx + expocnt + cnt];
-    memcpy(dest, &ed, sizeof(ExpoData));
-    dest->chn = idx2;
-    cnt++;
   }
 
   //  swap names
@@ -698,6 +672,7 @@ void InputsPanel::cmInputSwapData(int idx1, int idx2)
   strncpy(model->inputNames[idx2], model->inputNames[idx1], sizeof(model->inputNames[idx2]) - 1);
   strncpy(model->inputNames[idx1], tname->data(), sizeof(model->inputNames[idx1]) - 1);
 
+  model->sortInputs();
   model->updateAllReferences(ModelData::REF_UPD_TYPE_INPUT, ModelData::REF_UPD_ACT_SWAP, idx1, idx2);
   update();
   updateItemModels();

--- a/companion/src/modeledit/inputs.h
+++ b/companion/src/modeledit/inputs.h
@@ -19,8 +19,7 @@
  * GNU General Public License for more details.
  */
 
-#ifndef _INPUTS_H_
-#define _INPUTS_H_
+#pragma once
 
 #include "modeledit.h"
 #include "mixerslistwidget.h"
@@ -98,5 +97,3 @@ class InputsPanel : public ModelPanel
     void updateItemModels();
     void connectItemModelEvents(const int id);
 };
-
-#endif // _INPUTS_H_


### PR DESCRIPTION
Fixes #5988

Summary of changes:
- new sort inputs function (based on sort mixes)
- replace complex shuffles with simple reference swap and sort (much lower risk)
- move down uses same method
- minor housekeeping