### PR TITLE
fix(color): minor layout issues on mixes and curves screens

### DIFF
--- a/radio/src/gui/colorlcd/model/model_curves.cpp
+++ b/radio/src/gui/colorlcd/model/model_curves.cpp
@@ -67,7 +67,7 @@ class CurveButton : public Button
     CurveHeader &curve = g_model.curves[index];
     snprintf(buf, 32, "%s %d %s", STR_CURVE_TYPES[curve.type], 5 + curve.points,
              STR_PTS);
-    new StaticText(this, {0, height() - INFO_H + 1, LV_PCT(100), 16}, buf, 
+    new StaticText(this, {0, height() - INFO_H, LV_PCT(100), 0}, buf, 
                    COLOR_THEME_SECONDARY1_INDEX, CENTERED | FONT(BOLD));
   }
 

--- a/radio/src/gui/colorlcd/model/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model/model_mixes.cpp
@@ -181,7 +181,7 @@ class MixGroup : public InputMixGroupBase
       etx_font(chText, FONT_XS_INDEX);
       lv_label_set_text_fmt(chText, TR_CH "%" PRIu32,
                             UINT32_C(idx - MIXSRC_FIRST_CH + 1));
-      lv_obj_set_pos(chText, PAD_TINY, CHNUM_Y);
+      lv_obj_set_pos(chText, PAD_TINY, CHNUM_Y-1);
     }
 
     refresh();


### PR DESCRIPTION
Fixes:
- mix line with a single mix has a 1 pixel vertical scroll
- curve type string is clipped along the bottom
