### PR TITLE
fix(tele): DSM LIPO 6S sensor endian order

### DIFF
--- a/radio/src/telemetry/spektrum.cpp
+++ b/radio/src/telemetry/spektrum.cpp
@@ -1151,13 +1151,13 @@ static char test17data[] = {0x17, 0x00, 0x25, 0x00, 0x00,
 static char test34data[] = {0x34, 0x00, 0x2F, 0x00, 0x30, 0x09, 0x85, 0x01, 
                                         0x2B, 0x00, 0x07, 0x0A, 0x81, 0x01 };
 
-// *********** Lipo monitor (Big-Endian)***************
+// *********** Lipo monitor (Little-Endian)***************
 // Example 0x3A:          0  1    2  3    4  5    6  7    8  9    10 11   12 13
 //                3A 00 | 01 9A | 01 9B | 01 9C | 01 9D | 7F FF | 7F FF | 0F AC 
 //                         4.10V   4.11V   4.12V   4.12v   --      --     40.1C
-static char test3Adata[] = {0x3A, 0x00, 0x01, 0x9A, 0x01, 0x9B, 0x01, 0x9C, 
-                                        0x01, 0x9D, 0x7F, 0xFF, 0x7F, 0xFF,
-                                        0x01, 0x91 };
+static char test3Adata[] = {0x3A, 0x00, 0x9A, 0x01, 0x9B, 0x01, 0x9C, 0x01,  
+                                        0x9D, 0x01,  0x7F, 0xFF, 0x7F, 0xFF,
+                                        0x91, 0x01  };
 
 
 // RemoteID (0x27), embeds Gps data in its frames, but by puting the real I2C frame


### PR DESCRIPTION
Fixes #6013

A bit of History:
The Spektrum Documentation does not say what type of encoding to use.  So we and OpenXSensor assumed big-endian when we initially added support for this sensor.  #4715

Summary of changes:
1. Byte encoding was wrong for the Lipo 6s sensor. Should be little-endian.
2. The NO-DATA for Battery Temp is also an exception to the rule (0x7FFF instead of 0xFFFF for uint16). Added a check to avoid creating a sensor with the wrong value.
3. Added FrSky Style "Cells" (all Cells in a single censor) for Smart Batteries. This allows creation of calculated sensors for the lowest/highest/delta from the entire pack.  

TODO Discussion: Now that all batteries use the "Cels" group sensor. could be a good idea in the future to stop populating the individual cells.. There is a way of using the calculated cell formula to extract individual cells.  Most people are interested in the lowest cell or total voltage for flight alarms.  That will reduce the number of sensors.  Also with only one "Cels", I think we only support up to 6 cells.. For larger batteries, we could use 2 Cels, but we will need 2 different names. In Ethos they are using "Lipo1" and "Lipo2" (both up to 6 cells).

Tested on EdgeTX main branch, 2.11 branch, as well as Spektrum DX6e using a corrected version of OpenXSensor to generate some test values.

![image](https://github.com/user-attachments/assets/37da6231-6af8-41b6-a65f-6b5e1a3c7c06)
![IMG_5144](https://github.com/user-attachments/assets/1067670f-e52e-4df8-ae48-ccd8d8fd8b85)

