### PR TITLE
fix(color): logical switch list page crash

### DIFF
--- a/radio/src/gui/colorlcd/model/model_logical_switches.cpp
+++ b/radio/src/gui/colorlcd/model/model_logical_switches.cpp
@@ -386,6 +386,8 @@ class LogicalSwitchButton : public ListLineButton
 
   void checkEvents() override
   {
+    if (!init) return;
+
     ListLineButton::checkEvents();
     check(isActive());
 


### PR DESCRIPTION
Don't try and process LS events if not initialised.
