### PR TITLE
fix(bw): tool scripts with long file names not working

### DIFF
--- a/radio/src/edgetx.h
+++ b/radio/src/edgetx.h
@@ -685,7 +685,7 @@ union ReusableBuffer
 
 #if defined(NUM_BODY_LINES)
   #define TOOL_NAME_MAX_LEN (LCD_W / FW)
-  #define TOOL_PATH_MAX_LEN (LEN_FILE_PATH_MAX + 10)
+  #define TOOL_PATH_MAX_LEN (LEN_FILE_PATH_MAX + 40)
   struct scriptInfo{
       uint8_t index;
       char label[TOOL_NAME_MAX_LEN + 1];

--- a/radio/src/edgetx.h
+++ b/radio/src/edgetx.h
@@ -685,13 +685,13 @@ union ReusableBuffer
 
 #if defined(NUM_BODY_LINES)
   #define TOOL_NAME_MAX_LEN (LCD_W / FW)
-  #define TOOL_PATH_MAX_LEN (LEN_FILE_PATH_MAX + 40)
+  #define TOOL_PATH_MAX_LEN 40
   struct scriptInfo{
       uint8_t index;
       char label[TOOL_NAME_MAX_LEN + 1];
       uint8_t module;
       void (* tool)(event_t);
-      char path[TOOL_PATH_MAX_LEN + 1];
+      char filename[TOOL_PATH_MAX_LEN + 1];
   };
 #endif
 


### PR DESCRIPTION
Fixes #6026

Increase the size of the buffer for the path string (changed in #5721).
