### PR TITLE
fix(color): lvgl.clear() not working correctly for Lua child layouts

### DIFF
--- a/radio/src/lua/lua_lvgl_widget.cpp
+++ b/radio/src/lua/lua_lvgl_widget.cpp
@@ -321,14 +321,18 @@ void LvglWidgetObjectBase::parseParam(lua_State *L, const char *key)
   }
 }
 
+void LvglWidgetObjectBase::clear()
+{
+  clearRequest = true;
+  if (getWindow())
+    getWindow()->clear();
+}
+
 bool LvglWidgetObjectBase::callRefs(lua_State *L)
 {
   if (clearRequest) {
     clearRequest = false;
-    if (getWindow()) {
-      getWindow()->clear();
-      clearChildRefs(L);
-    }
+    clearChildRefs(L);
     return true;
   }
 
@@ -352,6 +356,11 @@ bool LvglWidgetObjectBase::callRefs(lua_State *L)
     auto p = LvglWidgetObjectBase::checkLvgl(L, -1);
     lua_pop(L, 1);
     if (p) if (!p->callRefs(L)) return false;
+    if (clearRequest) {
+      clearRequest = false;
+      clearChildRefs(L);
+      return true;
+    }
   }
 
   return true;

--- a/radio/src/lua/lua_lvgl_widget.h
+++ b/radio/src/lua/lua_lvgl_widget.h
@@ -82,7 +82,7 @@ class LvglWidgetObjectBase
 
   static LvglWidgetObjectBase *checkLvgl(lua_State *L, int index);
 
-  void clear() { clearRequest = true; }
+  void clear();
 
  protected:
   int luaRef = LUA_REFNIL;


### PR DESCRIPTION
Fixes an issue when trying to clear part of a layout.
Using lvgl.clear() works and clears the entire layout.
Using lvgl.clear(child) does not clear the child part of the layout correctly.