### PR TITLE
fix(lua): setCurve min points should be 2

### DIFF
--- a/radio/src/dataconstants.h
+++ b/radio/src/dataconstants.h
@@ -96,7 +96,7 @@ enum CurveType {
   CURVE_TYPE_LAST = CURVE_TYPE_CUSTOM
 };
 
-#define MIN_POINTS_PER_CURVE           3
+#define MIN_POINTS_PER_CURVE           2
 #define MAX_POINTS_PER_CURVE           17
 
 #if defined(COLORLCD)


### PR DESCRIPTION
Fixes issue reported on Discord. 
https://discord.com/channels/839849772864503828/1353416655216312370/1353416655216312370

Summary of changes:
 - change MIN_POINTS_PER_CURVE to 2 to match UI

Prior to this you could only create 3 point curves onwards via Lua. Tested on TX16S simulator using following mixer Lua. 

```
local curveIdx = 0

local function toint(f)
    if f > 0 then
        return math.floor(f)
    else
        return math.ceil(f)
    end
end

local function updateCurve()
    local value = getValue("s1")
    print("value: " .. value)
    value = value * (100.0 / 1024.0)
    print("value-y: " .. value)
    curve = {}
    curve["x"] = {-100, 100}
  	curve["y"] = {-70, value}
    curve["smooth"] = true
    curve["type"] = 1
    model.setGlobalVariable(8, 0, value * (100.0 / 1024.0) * 0.5 + 50)
    val = model.setCurve(curveIdx, curve)
	print("setCurve0: " .. val)

    -- params = {}
	-- params["x"] =  {-100, -34, 77, 100}
	-- params["y"] = {-70, 20, -89, -100}
	-- params["smooth"] = true
	-- params["type"] = 1
	-- val =  model.setCurve(2, params)
	-- print("setCurve2: " .. val)

    -- val = model.setCurve(3, {smooth=true, y={-100, -50, 0, 50, 100, 80}})
	-- print("setCurve2: " .. val)

    return
end

local function run(event)
    updateCurve()
    return 0
end

return {
    run = run,
    background = updateCurve
}
```
