### PR TITLE
fix(color): when the personal templates folder is empty the description section shows 'Text'

### DIFF
--- a/radio/src/gui/colorlcd/model/model_templates.cpp
+++ b/radio/src/gui/colorlcd/model/model_templates.cpp
@@ -49,6 +49,7 @@ TemplatePage::TemplatePage() : Page(ICON_MODEL_SELECT, PAD_ZERO)
                        LV_GRID_ALIGN_START, 0, 1);
 
   infoLabel = lv_label_create(line->getLvObj());
+  lv_label_set_text(infoLabel, "");
   lv_obj_set_height(infoLabel, body->height() - PAD_SMALL * 2);
   etx_obj_add_style(infoLabel, styles->text_align_left, LV_PART_MAIN);
   etx_txt_color(infoLabel, COLOR_THEME_PRIMARY1_INDEX);


### PR DESCRIPTION
To reproduce, try and create a new model from the personal templates folder when there are no templates on the SD card.