### PR TITLE
fix(color): allow long press of RTN key to also exit setup pages

### DIFF
--- a/radio/src/gui/colorlcd/libui/page.cpp
+++ b/radio/src/gui/colorlcd/libui/page.cpp
@@ -117,6 +117,10 @@ void Page::enableRefresh()
   lv_obj_refresh_style(lvobj, LV_PART_ANY, LV_STYLE_PROP_ANY);
 }
 
+#if defined(HARDWARE_KEYS)
+void Page::onLongPressRTN() { onCancel(); }
+#endif
+
 SubPage::SubPage(EdgeTxIcon icon, const char* title, const char* subtitle, bool pauseRefresh) :
   Page(icon, PAD_SMALL, pauseRefresh)
 {

--- a/radio/src/gui/colorlcd/libui/page.h
+++ b/radio/src/gui/colorlcd/libui/page.h
@@ -66,6 +66,10 @@ class Page : public NavWindow
 
   void checkEvents() override;
   bool bubbleEvents() override { return false; }
+
+#if defined(HARDWARE_KEYS)
+  void onLongPressRTN() override;
+#endif
 };
 
 class SubPage : public Page

--- a/radio/src/gui/colorlcd/libui/tabsgroup.cpp
+++ b/radio/src/gui/colorlcd/libui/tabsgroup.cpp
@@ -363,6 +363,7 @@ void TabsGroup::checkEvents()
 #if defined(HARDWARE_KEYS)
 void TabsGroup::onPressPGUP() { header->prevTab(); }
 void TabsGroup::onPressPGDN() { header->nextTab(); }
+void TabsGroup::onLongPressRTN() { onCancel(); }
 #endif
 
 void TabsGroup::onClicked() { Keyboard::hide(false); }

--- a/radio/src/gui/colorlcd/libui/tabsgroup.h
+++ b/radio/src/gui/colorlcd/libui/tabsgroup.h
@@ -100,5 +100,6 @@ class TabsGroup : public NavWindow
 #if defined(HARDWARE_KEYS)
   void onPressPGUP() override;
   void onPressPGDN() override;
+  void onLongPressRTN() override;
 #endif
 };

--- a/radio/src/gui/colorlcd/libui/window.cpp
+++ b/radio/src/gui/colorlcd/libui/window.cpp
@@ -445,6 +445,10 @@ void NavWindow::onEvent(event_t event)
     case EVT_KEY_BREAK(KEY_PAGEUP):
       onPressPGUP();
       break;
+
+    case EVT_KEY_LONG(KEY_EXIT):
+      onLongPressRTN();
+      break;
 #endif
 
     default:

--- a/radio/src/gui/colorlcd/libui/window.h
+++ b/radio/src/gui/colorlcd/libui/window.h
@@ -228,6 +228,7 @@ class NavWindow : public Window
   virtual void onPressPGDN() {}
   virtual void onLongPressPGUP() {}
   virtual void onLongPressPGDN() {}
+  virtual void onLongPressRTN() {}
 #endif
   virtual bool bubbleEvents() { return true; }
   void onEvent(event_t event) override;

--- a/radio/src/gui/colorlcd/model/model_templates.cpp
+++ b/radio/src/gui/colorlcd/model/model_templates.cpp
@@ -79,17 +79,6 @@ void TemplatePage::updateInfo()
   }
 }
 
-#if defined(HARDWARE_KEYS)
-void TemplatePage::onEvent(event_t event)
-{
-  if (event == EVT_KEY_LONG(KEY_EXIT) || event == EVT_KEY_BREAK(KEY_EXIT)) {
-    deleteLater();
-  } else {
-    Page::onEvent(event);
-  }
-}
-#endif
-
 class SelectTemplate : public TemplatePage
 {
  public:

--- a/radio/src/gui/colorlcd/model/model_templates.h
+++ b/radio/src/gui/colorlcd/model/model_templates.h
@@ -33,10 +33,6 @@ class TemplatePage : public Page
 
     void updateInfo();
 
-#if defined(HARDWARE_KEYS)
-    void onEvent(event_t event) override;
-#endif
-
 #if defined(DEBUG_WINDOWS)
     std::string getName() const override { return "TemplatePage"; }
 #endif

--- a/radio/src/gui/colorlcd/radio/radio_ghost_module_config.cpp
+++ b/radio/src/gui/colorlcd/radio/radio_ghost_module_config.cpp
@@ -124,15 +124,6 @@ static void ghostmoduleconfig_cb(lv_event_t* e)
   }
 }
 
-#if defined(HARDWARE_KEYS) && !defined(PCBPL18)
-void RadioGhostModuleConfig::onCancel()
-{
-  reusableBuffer.ghostMenu.buttonAction = GHST_BTN_JOYLEFT;
-  reusableBuffer.ghostMenu.menuAction = GHST_MENU_CTRL_NONE;
-  moduleState[EXTERNAL_MODULE].counter = GHST_MENU_CONTROL;
-}
-#endif
-
 RadioGhostModuleConfig::RadioGhostModuleConfig(uint8_t moduleIdx) :
     Page(ICON_RADIO_TOOLS), moduleIdx(moduleIdx)
 {
@@ -162,21 +153,23 @@ void RadioGhostModuleConfig::buildBody(Window* window)
 }
 
 #if defined(HARDWARE_KEYS) && !defined(PCBPL18)
-void RadioGhostModuleConfig::onEvent(event_t event)
+void RadioGhostModuleConfig::onCancel()
 {
-  switch (event) {
-    case EVT_KEY_LONG(KEY_EXIT):
-      memclear(&reusableBuffer.ghostMenu, sizeof(reusableBuffer.ghostMenu));
-      reusableBuffer.ghostMenu.buttonAction = GHST_BTN_NONE;
-      reusableBuffer.ghostMenu.menuAction = GHST_MENU_CTRL_CLOSE;
-      moduleState[EXTERNAL_MODULE].counter = GHST_MENU_CONTROL;
-      RTOS_WAIT_MS(10);
-      Page::onEvent(event);
+  reusableBuffer.ghostMenu.buttonAction = GHST_BTN_JOYLEFT;
+  reusableBuffer.ghostMenu.menuAction = GHST_MENU_CTRL_NONE;
+  moduleState[EXTERNAL_MODULE].counter = GHST_MENU_CONTROL;
+}
+
+void RadioGhostModuleConfig::onLongPressRTN()
+{
+  memclear(&reusableBuffer.ghostMenu, sizeof(reusableBuffer.ghostMenu));
+  reusableBuffer.ghostMenu.buttonAction = GHST_BTN_NONE;
+  reusableBuffer.ghostMenu.menuAction = GHST_MENU_CTRL_CLOSE;
+  moduleState[EXTERNAL_MODULE].counter = GHST_MENU_CONTROL;
+  RTOS_WAIT_MS(10);
 #if defined(TRIMS_EMULATE_BUTTONS)
-      setHatsAsKeys(false);  // switch trims back to normal
+  setHatsAsKeys(false);  // switch trims back to normal
 #endif
-      break;
-  }
 }
 
 void RadioGhostModuleConfig::checkEvents()

--- a/radio/src/gui/colorlcd/radio/radio_ghost_module_config.h
+++ b/radio/src/gui/colorlcd/radio/radio_ghost_module_config.h
@@ -35,7 +35,7 @@ class RadioGhostModuleConfig: public Page
   void buildBody(Window * window);
   void init();
 
-#if defined(HARDWARE_KEYS)
+#if defined(HARDWARE_KEYS) && !defined(PCBPL18)
   void checkEvents() override;
   void onCancel() override;
   void onLongPressRTN() override;

--- a/radio/src/gui/colorlcd/radio/radio_ghost_module_config.h
+++ b/radio/src/gui/colorlcd/radio/radio_ghost_module_config.h
@@ -25,20 +25,19 @@
 
 class RadioGhostModuleConfig: public Page
 {
-  public:
-    explicit RadioGhostModuleConfig(uint8_t moduleIdx);
+ public:
+  explicit RadioGhostModuleConfig(uint8_t moduleIdx);
 
-#if defined(HARDWARE_KEYS) && !defined(PCBPL18)
-    void onEvent(event_t event) override;
-    void checkEvents() override;
-    void onCancel() override;
+ protected:
+  uint8_t moduleIdx;
+
+  void buildHeader(Window * window);
+  void buildBody(Window * window);
+  void init();
+
+#if defined(HARDWARE_KEYS)
+  void checkEvents() override;
+  void onCancel() override;
+  void onLongPressRTN() override;
 #endif
-
-  protected:
-    uint8_t moduleIdx;
-
-    void buildHeader(Window * window);
-    void buildBody(Window * window);
-    void init();
 };
-


### PR DESCRIPTION
In 2.10 and earlier a long press of the RTN key would exit setup pages because the long press event was always followed by a short press event (unless cancelled).

This PR restores this functionality to 2.11.
