### PR TITLE
chore: pin CMake version for MSYS2

### DIFF
--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -47,10 +47,12 @@ jobs:
           update: true
           install: git make mingw-w64-x86_64-toolchain
 
+      - name: Install CMake 3.31
+        run: wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-ccmake-3.31.6-1-any.pkg.tar.zst && pacman -U mingw-w64-x86_64-ccmake-3.31.6-1-any.pkg.tar.zst
+
       - name: Install Dependencies
         run: |
-          pacman -S --noconfirm mingw-w64-x86_64-cmake \
-                                mingw-w64-x86_64-python-pip \
+          pacman -S --noconfirm mingw-w64-x86_64-python-pip \
                                 mingw-w64-x86_64-python-pillow \
                                 mingw-w64-x86_64-python-lz4 \
                                 mingw-w64-x86_64-libjpeg-turbo \

--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -49,9 +49,11 @@ jobs:
 
       - name: Install CMake 3.31
         run: |
-          grep -q '^IgnorePkg' /etc/pacman.conf && \
-            sed -i '/^IgnorePkg/ s/$/ mingw-w64-x86_64-ccmake/' /etc/pacman.conf || \
-            echo 'IgnorePkg = mingw-w64-x86_64-ccmake' >> /etc/pacman.conf
+          if grep -q '^IgnorePkg' /etc/pacman.conf; then
+              sed -i '/^IgnorePkg/ s/$/ mingw-w64-x86_64-cmake-4.0.0-1/' /etc/pacman.conf
+          else
+              sed -i '/^\[options\]/a IgnorePkg = mingw-w64-x86_64-cmake-4.0.0-1' /etc/pacman.conf
+          fi
           wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-ccmake-3.31.6-1-any.pkg.tar.zst && pacman -U --noconfirm mingw-w64-x86_64-ccmake-3.31.6-1-any.pkg.tar.zst
 
       - name: Install Dependencies

--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -48,7 +48,11 @@ jobs:
           install: git make mingw-w64-x86_64-toolchain
 
       - name: Install CMake 3.31
-        run: wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-ccmake-3.31.6-1-any.pkg.tar.zst && pacman -U --noconfirm mingw-w64-x86_64-ccmake-3.31.6-1-any.pkg.tar.zst
+        run: |
+          grep -q '^IgnorePkg' /etc/pacman.conf && \
+            sed -i '/^IgnorePkg/ s/$/ mingw-w64-x86_64-ccmake/' /etc/pacman.conf || \
+            echo 'IgnorePkg = mingw-w64-x86_64-ccmake' >> /etc/pacman.conf
+          wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-ccmake-3.31.6-1-any.pkg.tar.zst && pacman -U --noconfirm mingw-w64-x86_64-ccmake-3.31.6-1-any.pkg.tar.zst
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -50,11 +50,15 @@ jobs:
       - name: Install CMake 3.31
         run: |
           if grep -q '^IgnorePkg' /etc/pacman.conf; then
-              sed -i '/^IgnorePkg/ s/$/ mingw-w64-x86_64-cmake-4.0.0-1/' /etc/pacman.conf
+              sed -i '/^IgnorePkg/ s/$/ mingw-w64-x86_64-cmake>=4.0.0/' /etc/pacman.conf
           else
-              sed -i '/^\[options\]/a IgnorePkg = mingw-w64-x86_64-cmake-4.0.0-1' /etc/pacman.conf
+              sed -i '/^\[options\]/a IgnorePkg = mingw-w64-x86_64-cmake>=4.0.0' /etc/pacman.conf
           fi
-          wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-ccmake-3.31.6-1-any.pkg.tar.zst && pacman -U --noconfirm mingw-w64-x86_64-ccmake-3.31.6-1-any.pkg.tar.zst
+          wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-ccmake-3.31.6-1-any.pkg.tar.zst
+          pacman -U --noconfirm mingw-w64-x86_64-ccmake-3.31.6-1-any.pkg.tar.zst
+          pacman -R --noconfirm mingw-w64-x86_64-ccmake
+          pacman -U --noconfirm mingw-w64-x86_64-ccmake-3.31.6-1-any.pkg.tar.zst
+          pacman -Qi mingw-w64-x86_64-cmake | grep 'Version' | awk '{print $3}'
 
       - name: Install Dependencies
         run: |

--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -48,7 +48,7 @@ jobs:
           install: git make mingw-w64-x86_64-toolchain
 
       - name: Install CMake 3.31
-        run: wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-ccmake-3.31.6-1-any.pkg.tar.zst && pacman -U mingw-w64-x86_64-ccmake-3.31.6-1-any.pkg.tar.zst
+        run: wget https://repo.msys2.org/mingw/mingw64/mingw-w64-x86_64-ccmake-3.31.6-1-any.pkg.tar.zst && pacman -U --noconfirm mingw-w64-x86_64-ccmake-3.31.6-1-any.pkg.tar.zst
 
       - name: Install Dependencies
         run: |


### PR DESCRIPTION
Summary of changes:
 - pin CMake version used for MSYS2 build container until ready for CMake 4.0
