### PR TITLE
chore(x10): LED_GREEN_GPIO should not be configured

### DIFF
--- a/radio/src/targets/horus/hal.h
+++ b/radio/src/targets/horus/hal.h
@@ -635,7 +635,9 @@
   #define LED_BLUE_GPIO                 GPIO_PIN(GPIOE, 3)   //PE.03
 #elif defined(PCBX10)
   #define LED_RED_GPIO                  GPIO_PIN(GPIOE, 2) // PE.02
-  #define LED_GREEN_GPIO                GPIO_PIN(GPIOE, 4) // PE.04
+  #if !defined(MANUFACTURER_FRSKY)                         // no green on X10/X10 Express
+    #define LED_GREEN_GPIO              GPIO_PIN(GPIOE, 4) // PE.04
+  #endif
   #define LED_BLUE_GPIO                 GPIO_PIN(GPIOE, 5) // PE.05
 #endif
 

--- a/radio/src/targets/horus/led_driver.cpp
+++ b/radio/src/targets/horus/led_driver.cpp
@@ -94,7 +94,7 @@ void ledBlue()
   gpio_clear(LED_GPIO);
 }
 
-#else
+#elif defined(LED_RED_GPIO) || defined(LED_GREEN_GPIO) || defined(LED_BLUE_GPIO)
 
 void ledOff()
 {

--- a/radio/src/targets/horus/led_driver.cpp
+++ b/radio/src/targets/horus/led_driver.cpp
@@ -19,11 +19,11 @@
  * GNU General Public License for more details.
  */
 
+#include "board.h"
+#include "boards/generic_stm32/rgb_leds.h"
+#include "colors.h"
 #include "hal/gpio.h"
 #include "stm32_gpio.h"
-#include "boards/generic_stm32/rgb_leds.h"
-#include "board.h"
-#include "colors.h"
 
 void ledInit()
 {
@@ -48,7 +48,6 @@ void ledInit()
   gpio_init(FSLED_GPIO_5, GPIO_OUT, GPIO_PIN_SPEED_LOW);
   gpio_init(FSLED_GPIO_6, GPIO_OUT, GPIO_PIN_SPEED_LOW);
 #endif
-
 }
 
 #if defined(FUNCTION_SWITCHES_RGB_LEDS)
@@ -57,44 +56,31 @@ uint8_t ledMapping[] = {1, 2, 3, 4, 5, 6};
 
 void fsLedOff(uint8_t index, uint32_t color)
 {
-   rgbSetLedColor(ledMapping[index], GET_RED(color), \
-   GET_GREEN(color),GET_BLUE(color));
+  rgbSetLedColor(ledMapping[index], GET_RED(color), GET_GREEN(color),
+                 GET_BLUE(color));
 }
 
 void fsLedOn(uint8_t index, uint32_t color)
 {
-   rgbSetLedColor(ledMapping[index], GET_RED(color), \
-   GET_GREEN(color),GET_BLUE(color));
+  rgbSetLedColor(ledMapping[index], GET_RED(color), GET_GREEN(color),
+                 GET_BLUE(color));
 }
 
 #elif defined(FUNCTION_SWITCHES)
-gpio_t fsLeds[] = {FSLED_GPIO_1, FSLED_GPIO_2,
-                   FSLED_GPIO_3, FSLED_GPIO_4,
-                   FSLED_GPIO_5, FSLED_GPIO_6};
+gpio_t fsLeds[] = {FSLED_GPIO_1, FSLED_GPIO_2, FSLED_GPIO_3,
+                   FSLED_GPIO_4, FSLED_GPIO_5, FSLED_GPIO_6};
 
-void fsLedOff(uint8_t index)
-{
-   gpio_clear(fsLeds[index]);
-}
+void fsLedOff(uint8_t index) { gpio_clear(fsLeds[index]); }
 
-void fsLedOn(uint8_t index)
-{
-  gpio_set(fsLeds[index]);
-}
+void fsLedOn(uint8_t index) { gpio_set(fsLeds[index]); }
 
-bool fsLedState(uint8_t index)
-{
-  return (gpio_read(fsLeds[index]));
-}
+bool fsLedState(uint8_t index) { return (gpio_read(fsLeds[index])); }
 #endif
 
 #if defined(LED_GPIO)
 
 // Single GPIO for dual color LED
-void ledOff()
-{
-  gpio_init(LED_GPIO, GPIO_IN_PU, GPIO_PIN_SPEED_LOW);
-}
+void ledOff() { gpio_init(LED_GPIO, GPIO_IN_PU, GPIO_PIN_SPEED_LOW); }
 
 void ledRed()
 {

--- a/radio/src/targets/horus/led_driver.cpp
+++ b/radio/src/targets/horus/led_driver.cpp
@@ -108,7 +108,7 @@ void ledBlue()
   gpio_clear(LED_GPIO);
 }
 
-#else 
+#else
 
 void ledOff()
 {
@@ -119,7 +119,7 @@ void ledOff()
   gpio_clear(LED_GREEN_GPIO);
 #endif
 #if defined(LED_BLUE_GPIO)
-  gpio_clear(LED_BLUE_GPIO); 
+  gpio_clear(LED_BLUE_GPIO);
 #endif
 }
 

--- a/radio/src/targets/horus/led_driver.cpp
+++ b/radio/src/targets/horus/led_driver.cpp
@@ -108,31 +108,43 @@ void ledBlue()
   gpio_clear(LED_GPIO);
 }
 
-#elif defined(LED_RED_GPIO) && defined(LED_GREEN_GPIO) && defined(LED_BLUE_GPIO)
+#else 
 
 void ledOff()
 {
+#if defined(LED_RED_GPIO)
   gpio_clear(LED_RED_GPIO);
+#endif
+#if defined(LED_GREEN_GPIO)
   gpio_clear(LED_GREEN_GPIO);
-  gpio_clear(LED_BLUE_GPIO);
+#endif
+#if defined(LED_BLUE_GPIO)
+  gpio_clear(LED_BLUE_GPIO); 
+#endif
 }
 
+#if defined(LED_RED_GPIO)
 void ledRed()
 {
   ledOff();
   gpio_set(LED_RED_GPIO);
 }
+#endif
 
+#if defined(LED_GREEN_GPIO)
 void ledGreen()
 {
   ledOff();
   gpio_set(LED_GREEN_GPIO);
 }
+#endif
 
+#if defined(LED_BLUE_GPIO)
 void ledBlue()
 {
   ledOff();
   gpio_set(LED_BLUE_GPIO);
 }
+#endif
 
 #endif


### PR DESCRIPTION
Fixes #6040

Summary of changes:
- LED_GREEN_GPIO should not be configured on X10/X10 Express as it is not MCU controlled
