### PR TITLE
fix(color): widget option default values are not loaded on radio restart

### DIFF
--- a/radio/src/gui/colorlcd/mainview/widget_settings.cpp
+++ b/radio/src/gui/colorlcd/mainview/widget_settings.cpp
@@ -49,6 +49,8 @@ WidgetSettings::WidgetSettings(Widget* w) :
   FlexGridLayout grid(line_col_dsc, line_row_dsc, PAD_TINY);
 
   uint8_t optIdx = 0;
+
+  widget->getFactory()->parseOptionDefaults();
   auto opt = widget->getOptionDefinitions();
 
   while (opt && opt->name != nullptr) {


### PR DESCRIPTION
Reported on discord => https://discord.com/channels/839849772864503828/839856795781431317/1357351877175414824

The widget options default values are not being loaded on radio start.
When a widget is first added the default are parsed so the settings dialog shows the correct options.
After restart opening the widget settings dialog does not show the correct options.
