### PR TITLE
feat(bw): allow user setting of SA & SD Led colors on GX12

### DIFF
--- a/companion/src/constants.h
+++ b/companion/src/constants.h
@@ -41,6 +41,7 @@
 #define CPN_MAX_CYC                    3
 #define CPN_MAX_SWITCHES_FLEX          4 // v2.10 cmake parameter FLEXSW
 #define CPN_MAX_SWITCHES_FUNCTION      6
+#define CPN_MAX_SWITCHES_FUNCTION_LED  8    // Temp: to handle GX12 SA & SD colors (TODO: unify custom switches)
 #define CPN_MAX_SWITCHES_STD           20
 #define CPN_MAX_SWITCHES               (CPN_MAX_SWITCHES_STD + CPN_MAX_SWITCHES_FLEX + CPN_MAX_SWITCHES_FUNCTION)
 #define CPN_MAX_SENSORS                60

--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -411,6 +411,9 @@ int Boards::getCapability(Board::Type board, Board::Capability capability)
     case FunctionSwitchColors:
       return IS_RADIOMASTER_GX12(board);
 
+    case FunctionSwitchColorLedCount:
+      return IS_RADIOMASTER_GX12(board) ? 8 : 0;  // Temp to handle GX12 SA & SD colord (TODO: unify switch handling)
+
     default:
       return getBoardJson(board)->getCapability(capability);
   }

--- a/companion/src/firmwares/boards.h
+++ b/companion/src/firmwares/boards.h
@@ -212,6 +212,7 @@ namespace Board {
     FlexSwitches,
     FunctionSwitches,
     FunctionSwitchColors,
+    FunctionSwitchColorLedCount,  // Temp to handle GX12 SA & SD colord (TODO: unify switch handling)
     Gyros,
     GyroAxes,
     HasAudioMuteGPIO,

--- a/companion/src/firmwares/edgetx/yaml_modeldata.cpp
+++ b/companion/src/firmwares/edgetx/yaml_modeldata.cpp
@@ -1208,12 +1208,12 @@ Node convert<ModelData>::encode(const ModelData& rhs)
     }
 
     if (Boards::getCapability(board, Board::FunctionSwitchColors)) {
-      for (int i = 0; i < CPN_MAX_SWITCHES_FUNCTION; i += 1) {
+      for (int i = 0; i < Boards::getCapability(board, Board::FunctionSwitchColorLedCount); i += 1) {
         node["functionSwitchLedONColor"][std::to_string(i)]["r"] = rhs.functionSwitchLedONColor[i].r;
         node["functionSwitchLedONColor"][std::to_string(i)]["g"] = rhs.functionSwitchLedONColor[i].g;
         node["functionSwitchLedONColor"][std::to_string(i)]["b"] = rhs.functionSwitchLedONColor[i].b;
       }
-      for (int i = 0; i < CPN_MAX_SWITCHES_FUNCTION; i += 1) {
+      for (int i = 0; i < Boards::getCapability(board, Board::FunctionSwitchColorLedCount); i += 1) {
         node["functionSwitchLedOFFColor"][std::to_string(i)]["r"] = rhs.functionSwitchLedOFFColor[i].r;
         node["functionSwitchLedOFFColor"][std::to_string(i)]["g"] = rhs.functionSwitchLedOFFColor[i].g;
         node["functionSwitchLedOFFColor"][std::to_string(i)]["b"] = rhs.functionSwitchLedOFFColor[i].b;
@@ -1488,7 +1488,7 @@ bool convert<ModelData>::decode(const Node& node, ModelData& rhs)
   node["functionSwitchLogicalState"] >> rhs.functionSwitchLogicalState;
   node["switchNames"] >> rhs.functionSwitchNames;
   if (node["functionSwitchLedONColor"]) {
-    for (int i = 0; i < CPN_MAX_SWITCHES_FUNCTION; i += 1) {
+    for (int i = 0; i < Boards::getCapability(board, Board::FunctionSwitchColorLedCount); i += 1) {
       if (node["functionSwitchLedONColor"][std::to_string(i)]) {
         node["functionSwitchLedONColor"][std::to_string(i)]["r"] >> rhs.functionSwitchLedONColor[i].r;
         node["functionSwitchLedONColor"][std::to_string(i)]["g"] >> rhs.functionSwitchLedONColor[i].g;
@@ -1497,7 +1497,7 @@ bool convert<ModelData>::decode(const Node& node, ModelData& rhs)
     }
   }
   if (node["functionSwitchLedOFFColor"]) {
-    for (int i = 0; i < CPN_MAX_SWITCHES_FUNCTION; i += 1) {
+    for (int i = 0; i < Boards::getCapability(board, Board::FunctionSwitchColorLedCount); i += 1) {
       if (node["functionSwitchLedOFFColor"][std::to_string(i)]) {
         node["functionSwitchLedOFFColor"][std::to_string(i)]["r"] >> rhs.functionSwitchLedOFFColor[i].r;
         node["functionSwitchLedOFFColor"][std::to_string(i)]["g"] >> rhs.functionSwitchLedOFFColor[i].g;

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -242,8 +242,8 @@ class ModelData {
     unsigned int functionSwitchStartConfig;
     unsigned int functionSwitchLogicalState;
     char functionSwitchNames[CPN_MAX_SWITCHES_FUNCTION][HARDWARE_NAME_LEN + 1];
-    RGBLedColor functionSwitchLedONColor[CPN_MAX_SWITCHES_FUNCTION];
-    RGBLedColor functionSwitchLedOFFColor[CPN_MAX_SWITCHES_FUNCTION];
+    RGBLedColor functionSwitchLedONColor[CPN_MAX_SWITCHES_FUNCTION_LED];
+    RGBLedColor functionSwitchLedOFFColor[CPN_MAX_SWITCHES_FUNCTION_LED];
 
     // Custom USB joytsick mapping
     unsigned int usbJoystickExtMode;

--- a/radio/src/boards/generic_stm32/switches.cpp
+++ b/radio/src/boards/generic_stm32/switches.cpp
@@ -58,6 +58,10 @@ __weak SwitchHwType boardSwitchGetType(SwitchCategory cat, uint8_t idx)
 
 uint8_t boardGetMaxSwitches() { return n_switches; }
 uint8_t boardGetMaxFctSwitches() { return n_fct_switches; }
+#if defined(SWITCH_LED_COUNT)
+uint8_t boardGetSwitchLedIdx(uint8_t idx) { return _switch_defs[idx].ledIdx; }
+uint8_t boardGetSwitchLedOfst(uint8_t idx) { return _switch_defs[idx].ledOfst; }
+#endif
 
 swconfig_t boardSwitchGetDefaultConfig() { return _switch_default_config; }
 

--- a/radio/src/boards/generic_stm32/switches.cpp
+++ b/radio/src/boards/generic_stm32/switches.cpp
@@ -60,7 +60,6 @@ uint8_t boardGetMaxSwitches() { return n_switches; }
 uint8_t boardGetMaxFctSwitches() { return n_fct_switches; }
 #if defined(SWITCH_LED_COUNT)
 uint8_t boardGetSwitchLedIdx(uint8_t idx) { return _switch_defs[idx].ledIdx; }
-uint8_t boardGetSwitchLedOfst(uint8_t idx) { return _switch_defs[idx].ledOfst; }
 #endif
 
 swconfig_t boardSwitchGetDefaultConfig() { return _switch_default_config; }

--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -86,8 +86,6 @@ static inline void check_struct()
   CHKSIZE(RadioData, 872);
 #elif defined(COLORLCD)
   CHKSIZE(RadioData, 966);
-#elif defined(RADIO_GX12)
-  CHKSIZE(RadioData, 882);
 #else
   CHKSIZE(RadioData, 870);
 #endif
@@ -99,7 +97,7 @@ static inline void check_struct()
 #elif defined(RADIO_FAMILY_T20)
   CHKSIZE(ModelData, 6390);
 #elif defined(RADIO_GX12)
-  CHKSIZE(ModelData, 6390);
+  CHKSIZE(ModelData, 6402);
 #elif defined(PCBX9E)
   CHKSIZE(ModelData, 6771);
 #elif defined(PCBX9D) || defined(PCBX9DP)

--- a/radio/src/datastructs.h
+++ b/radio/src/datastructs.h
@@ -86,6 +86,8 @@ static inline void check_struct()
   CHKSIZE(RadioData, 872);
 #elif defined(COLORLCD)
   CHKSIZE(RadioData, 966);
+#elif defined(RADIO_GX12)
+  CHKSIZE(RadioData, 882);
 #else
   CHKSIZE(RadioData, 870);
 #endif

--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -644,9 +644,14 @@ struct RGBLedColor {
 };
 
 #if defined(FUNCTION_SWITCHES_RGB_LEDS)
+  #if defined(SWITCH_LED_COUNT)
+    #define EXTRA_LEDS SWITCH_LED_COUNT
+  #else
+    #define EXTRA_LEDS 0
+  #endif
   #define FUNCTION_SWITCHS_RGB_LEDS_FIELDS \
-    RGBLedColor functionSwitchLedONColor[NUM_FUNCTIONS_SWITCHES]; \
-    RGBLedColor functionSwitchLedOFFColor[NUM_FUNCTIONS_SWITCHES];
+    RGBLedColor functionSwitchLedONColor[NUM_FUNCTIONS_SWITCHES + EXTRA_LEDS] FUNC(cfs_led_is_active);; \
+    RGBLedColor functionSwitchLedOFFColor[NUM_FUNCTIONS_SWITCHES + EXTRA_LEDS] FUNC(cfs_led_is_active);;
 #else
   #define FUNCTION_SWITCHS_RGB_LEDS_FIELDS
 #endif
@@ -1025,11 +1030,6 @@ PACK(struct RadioData {
 #endif
 
   NOBACKUP(uint8_t pwrOffIfInactive);
-
-#if defined(SWITCH_LED_COUNT)
-  RGBLedColor switchLedONColor[SWITCH_LED_COUNT];
-  RGBLedColor switchLedOFFColor[SWITCH_LED_COUNT];
-#endif
 
   NOBACKUP(uint8_t getBrightness() const
   {

--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -1026,6 +1026,11 @@ PACK(struct RadioData {
 
   NOBACKUP(uint8_t pwrOffIfInactive);
 
+#if defined(SWITCH_LED_COUNT)
+  RGBLedColor switchLedONColor[SWITCH_LED_COUNT];
+  RGBLedColor switchLedOFFColor[SWITCH_LED_COUNT];
+#endif
+
   NOBACKUP(uint8_t getBrightness() const
   {
 #if defined(OLED_SCREEN)

--- a/radio/src/gui/common/stdlcd/radio_hardware.cpp
+++ b/radio/src/gui/common/stdlcd/radio_hardware.cpp
@@ -24,6 +24,7 @@
 #include "hal/adc_driver.h"
 #include "hal/switch_driver.h"
 #include "hal/module_port.h"
+#include "hal/rgbleds.h"
 
 #include "analogs.h"
 #include "switches.h"
@@ -34,6 +35,10 @@
 
 #if defined(CROSSFIRE)
   #include "telemetry/crossfire.h"
+#endif
+
+#if defined(SWITCH_LED_COUNT)
+uint8_t boardGetSwitchLedIdx(uint8_t idx);
 #endif
 
 #if LCD_W >= 212
@@ -114,6 +119,90 @@ static void onHardwareAntennaSwitchConfirm(const char * result)
 }
 #endif
 
+#if defined(SWITCH_LED_COUNT)
+static int swIndex;
+
+static bool checkSwitchColorAvailable(int col)
+{
+  return col > 0;
+}
+
+enum CFSFields {
+  CFS_FIELD_COLOR_LABEL,
+  CFS_FIELD_ON_COLOR,
+  CFS_FIELD_OFF_COLOR,
+  CFS_FIELD_COUNT
+};
+
+static void menuSwitchColor(coord_t y, RGBLedColor& color, const char* title, LcdFlags attr, event_t event)
+{
+  uint8_t selectedColor = getRGBColorIndex(color.getColor());
+  selectedColor = editChoice(30, y, title, \
+    STR_FS_COLOR_LIST, selectedColor, 0, DIM(colorTable), menuHorizontalPosition == 0 ? attr : 0, event, INDENT_WIDTH, checkSwitchColorAvailable);
+  if (attr && menuHorizontalPosition == 0 && checkIncDec_Ret) {
+    color.setColor(colorTable[selectedColor - 1]);
+    storageDirty(EE_GENERAL);
+  }
+
+  lcdDrawNumber(LCD_W - 6 * FW, y, color.r, (menuHorizontalPosition == 1 ? attr : 0) | RIGHT);
+  if (attr && menuHorizontalPosition == 1)
+    color.r = checkIncDecGen(event, color.r, 0, 255);
+
+  lcdDrawNumber(LCD_W - 3 * FW, y, color.g, (menuHorizontalPosition == 2 ? attr : 0) | RIGHT);
+  if (attr && menuHorizontalPosition == 2)
+    color.g = checkIncDecGen(event, color.g, 0, 255);
+
+  lcdDrawNumber(LCD_W, y, color.b, (menuHorizontalPosition == 3 ? attr : 0) | RIGHT);
+  if (attr && menuHorizontalPosition == 3)
+    color.b = checkIncDecGen(event, color.b, 0, 255);
+}
+
+void menuSwitchLedOne(event_t event)
+{
+  std::string s(STR_CHAR_SWITCH);
+  s += switchGetName(swIndex);
+
+  SUBMENU(s.c_str(), CFS_FIELD_COUNT,
+    {
+      LABEL(), 3, 3,
+    });
+  
+  int8_t sub = menuVerticalPosition;
+  int8_t editMode = s_editMode;
+
+  coord_t y = MENU_HEADER_HEIGHT + 1;
+
+  for (int k = 0; k < NUM_BODY_LINES; k += 1) {
+    int i = k + menuVerticalOffset;
+    for (int j = 0; j <= i; j += 1) {
+      if (j < (int)DIM(mstate_tab) && mstate_tab[j] == HIDDEN_ROW) {
+        i += 1;
+      }
+    }
+    LcdFlags attr = (sub == i ? (editMode > 0 ? BLINK | INVERS : INVERS) : 0);
+
+    switch(i) {
+      case CFS_FIELD_COLOR_LABEL:
+        lcdDrawText(0, y, STR_BLCOLOR);
+        lcdDrawText(LCD_W - 6 * FW, y, "R", RIGHT | SMLSIZE);
+        lcdDrawText(LCD_W - 3 * FW, y, "G", RIGHT | SMLSIZE);
+        lcdDrawText(LCD_W, y, "B", RIGHT | SMLSIZE);
+        break;
+
+      case CFS_FIELD_ON_COLOR:
+        menuSwitchColor(y, g_eeGeneral.switchLedONColor[boardGetSwitchLedIdx(swIndex) - 1], STR_OFFON[1], attr, event);
+        break;
+
+      case CFS_FIELD_OFF_COLOR:
+        menuSwitchColor(y, g_eeGeneral.switchLedOFFColor[boardGetSwitchLedIdx(swIndex) - 1], STR_OFFON[0], attr, event);
+        break;
+    }
+
+    y += FH;
+  }
+}
+#endif
+
 static uint8_t _dispSerialPort(uint8_t port_nr)
 {
   auto port = serialGetPort(port_nr);
@@ -150,7 +239,11 @@ static void _init_menu_tab_array(uint8_t* tab, size_t len)
   auto max_switches = switchGetMaxSwitches();
   for (int i = ITEM_RADIO_HARDWARE_SWITCH; i <= ITEM_RADIO_HARDWARE_SWITCH_END; i++) {
     uint8_t idx = i - ITEM_RADIO_HARDWARE_SWITCH;
+#if defined(SWITCH_LED_COUNT)
+    tab[i] = switchIsFlex(idx) ? 2 : (idx < max_switches ? (boardGetSwitchLedIdx(idx) ? 2 : 1) : HIDDEN_ROW);
+#else
     tab[i] = switchIsFlex(idx) ? 2 : idx < max_switches ? 1 : HIDDEN_ROW;
+#endif
   }
 
 #if defined(BATTGRAPH)
@@ -578,6 +671,18 @@ void menuRadioHardware(event_t event)
             config =
                 editChoice(HW_SETTINGS_COLUMN2, y, "", STR_SWTYPES, config,
                            SWITCH_NONE, switchGetMaxType(index), flags, event);
+
+#if defined(SWITCH_LED_COUNT)
+            flags = menuHorizontalPosition == 2 ? attr : 0;
+            if (boardGetSwitchLedIdx(index)) {
+              lcdDrawText(LCD_W - 3 * FW, y, "LED", flags);
+            }
+
+            if (attr && event == EVT_KEY_BREAK(KEY_ENTER)) {
+              swIndex = index;
+              pushMenu(menuSwitchLedOne);
+            }
+#endif
 
             if (attr && checkIncDec_Ret) {
               swconfig_t mask = SWITCH_CONFIG_MASK(index);

--- a/radio/src/gui/common/stdlcd/radio_hardware.cpp
+++ b/radio/src/gui/common/stdlcd/radio_hardware.cpp
@@ -678,7 +678,7 @@ void menuRadioHardware(event_t event)
               lcdDrawText(LCD_W - 3 * FW, y, "LED", flags);
             }
 
-            if (attr && event == EVT_KEY_BREAK(KEY_ENTER)) {
+            if (attr && menuHorizontalPosition == 2 && event == EVT_KEY_BREAK(KEY_ENTER)) {
               swIndex = index;
               pushMenu(menuSwitchLedOne);
             }

--- a/radio/src/gui/common/stdlcd/radio_hardware.cpp
+++ b/radio/src/gui/common/stdlcd/radio_hardware.cpp
@@ -190,11 +190,11 @@ void menuSwitchLedOne(event_t event)
         break;
 
       case CFS_FIELD_ON_COLOR:
-        menuSwitchColor(y, g_eeGeneral.switchLedONColor[boardGetSwitchLedIdx(swIndex) - 1], STR_OFFON[1], attr, event);
+        menuSwitchColor(y, g_model.functionSwitchLedONColor[boardGetSwitchLedIdx(swIndex)], STR_OFFON[1], attr, event);
         break;
 
       case CFS_FIELD_OFF_COLOR:
-        menuSwitchColor(y, g_eeGeneral.switchLedOFFColor[boardGetSwitchLedIdx(swIndex) - 1], STR_OFFON[0], attr, event);
+        menuSwitchColor(y, g_model.functionSwitchLedOFFColor[boardGetSwitchLedIdx(swIndex)], STR_OFFON[0], attr, event);
         break;
     }
 

--- a/radio/src/model_init.cpp
+++ b/radio/src/model_init.cpp
@@ -100,6 +100,21 @@ void setVendorSpecificModelDefaults(uint8_t id)
 #endif
 }
 
+#if defined(SWITCH_LED_COUNT)
+void initCustomSwitchColors()
+{
+  // Ensure GX12 SA & SD have default colors if not set in model yaml
+  extern uint8_t boardGetMaxSwitches();
+  extern uint8_t boardGetSwitchLedIdx(uint8_t idx);
+  for (int i = 0; i < boardGetMaxSwitches(); i += 1) {
+    if (boardGetSwitchLedIdx(i) > 0) {
+      g_model.functionSwitchLedOFFColor[i].setColor(0);
+      g_model.functionSwitchLedONColor[i].setColor(0xFFFFFF);
+    }
+  }
+}
+#endif
+
 void applyDefaultTemplate()
 {
   setDefaultInputs();
@@ -114,12 +129,6 @@ void applyDefaultTemplate()
   g_model.functionSwitchGroup = DEFAULT_FS_GROUPS;
   g_model.functionSwitchStartConfig = DEFAULT_FS_STARTUP_CONFIG;
   g_model.functionSwitchLogicalState = 0;
-#if defined(FUNCTION_SWITCHES_RGB_LEDS)
-  for (uint8_t i = 0; i < NUM_FUNCTIONS_SWITCHES; i++) {
-    g_model.functionSwitchLedOFFColor[i].setColor(0);
-    g_model.functionSwitchLedONColor[i].setColor(0xFFFFFF);
-  }
-#endif
 #endif
 
 #if defined(FUNCTION_SWITCHES_RGB_LEDS)
@@ -127,6 +136,10 @@ void applyDefaultTemplate()
     g_model.functionSwitchLedOFFColor[i].setColor(0);
     g_model.functionSwitchLedONColor[i].setColor(0xFFFFFF);
   }
+#endif
+
+#if defined(SWITCH_LED_COUNT)
+  initCustomSwitchColors();
 #endif
 
 #if defined(COLORLCD)

--- a/radio/src/storage/sdcard_yaml.cpp
+++ b/radio/src/storage/sdcard_yaml.cpp
@@ -182,12 +182,6 @@ const char * loadRadioSettings()
 
     adcCalibDefaults();
 
-#if defined(SWITCH_LED_COUNT)
-    // Default colors if not set in radio yaml
-    memset(g_eeGeneral.switchLedOFFColor, 0, sizeof(g_eeGeneral.switchLedOFFColor));
-    memset(g_eeGeneral.switchLedONColor, 0xFF, sizeof(g_eeGeneral.switchLedONColor));
-#endif
-
     const char* error = loadRadioSettingsYaml(true);
     if (!error) {
       g_eeGeneral.chkSum = evalChkSum();
@@ -345,6 +339,10 @@ const char * readModelYaml(const char * filename, uint8_t * buffer, uint32_t siz
     memset(buffer,0,size);
 
     if (init_model) {
+#if defined(SWITCH_LED_COUNT)
+      extern void initCustomSwitchColors();
+      initCustomSwitchColors();
+#endif
       auto md = reinterpret_cast<ModelData*>(buffer);
 #if defined(FLIGHT_MODES) && defined(GVARS)
       // reset GVars to default values

--- a/radio/src/storage/sdcard_yaml.cpp
+++ b/radio/src/storage/sdcard_yaml.cpp
@@ -182,6 +182,12 @@ const char * loadRadioSettings()
 
     adcCalibDefaults();
 
+#if defined(SWITCH_LED_COUNT)
+    // Default colors if not set in radio yaml
+    memset(g_eeGeneral.switchLedOFFColor, 0, sizeof(g_eeGeneral.switchLedOFFColor));
+    memset(g_eeGeneral.switchLedONColor, 0xFF, sizeof(g_eeGeneral.switchLedONColor));
+#endif
+
     const char* error = loadRadioSettingsYaml(true);
     if (!error) {
       g_eeGeneral.chkSum = evalChkSum();
@@ -190,8 +196,6 @@ const char * loadRadioSettings()
 
     return error;
 }
-
-
 
 struct yaml_checksummer_ctx {
     FRESULT result;

--- a/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
@@ -1160,6 +1160,13 @@ bool w_swtchSrc(const YamlNode* node, uint32_t val, yaml_writer_func wf, void* o
   return true;
 }
 
+#if defined(FUNCTION_SWITCHES_RGB_LEDS)
+bool cfs_led_is_active(void* user, uint8_t* data, uint32_t bitoffs)
+{
+  return true;
+}
+#endif
+
 bool cfn_is_active(void* user, uint8_t* data, uint32_t bitoffs)
 {
   data += bitoffs >> 3UL;

--- a/radio/src/storage/yaml/yaml_datastructs_gx12.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_gx12.cpp
@@ -263,13 +263,6 @@ static const struct YamlNode struct_CustomFunctionData[] = {
   YAML_PADDING( 7 ),
   YAML_END
 };
-static const struct YamlNode struct_RGBLedColor[] = {
-  YAML_IDX,
-  YAML_UNSIGNED( "r", 8 ),
-  YAML_UNSIGNED( "g", 8 ),
-  YAML_UNSIGNED( "b", 8 ),
-  YAML_END
-};
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
@@ -371,8 +364,6 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "invertLCD", 1 ),
   YAML_PADDING( 3 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
-  YAML_ARRAY("switchLedONColor", 24, 2, struct_RGBLedColor, NULL),
-  YAML_ARRAY("switchLedOFFColor", 24, 2, struct_RGBLedColor, NULL),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {
@@ -783,6 +774,13 @@ static const struct YamlNode struct_TelemetryScreenData[] = {
   YAML_UNION("u", 192, union_TelemetryScreenData_u_elmts, select_tele_screen_data),
   YAML_END
 };
+static const struct YamlNode struct_RGBLedColor[] = {
+  YAML_IDX,
+  YAML_UNSIGNED( "r", 8 ),
+  YAML_UNSIGNED( "g", 8 ),
+  YAML_UNSIGNED( "b", 8 ),
+  YAML_END
+};
 static const struct YamlNode struct_USBJoystickChData[] = {
   YAML_IDX,
   YAML_ENUM("mode", 3, enum_USBJoystickCh),
@@ -853,8 +851,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "functionSwitchStartConfig", 16 ),
   YAML_UNSIGNED( "functionSwitchLogicalState", 8 ),
   YAML_ARRAY("switchNames", 24, 6, struct_string_24, NULL),
-  YAML_ARRAY("functionSwitchLedONColor", 24, 6, struct_RGBLedColor, NULL),
-  YAML_ARRAY("functionSwitchLedOFFColor", 24, 6, struct_RGBLedColor, NULL),
+  YAML_ARRAY("functionSwitchLedONColor", 24, 8, struct_RGBLedColor, cfs_led_is_active),
+  YAML_ARRAY("functionSwitchLedOFFColor", 24, 8, struct_RGBLedColor, cfs_led_is_active),
   YAML_UNSIGNED( "usbJoystickExtMode", 1 ),
   YAML_ENUM("usbJoystickIfMode", 3, enum_USBJoystickIfMode),
   YAML_UNSIGNED( "usbJoystickCircularCut", 4 ),

--- a/radio/src/storage/yaml/yaml_datastructs_gx12.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_gx12.cpp
@@ -263,6 +263,13 @@ static const struct YamlNode struct_CustomFunctionData[] = {
   YAML_PADDING( 7 ),
   YAML_END
 };
+static const struct YamlNode struct_RGBLedColor[] = {
+  YAML_IDX,
+  YAML_UNSIGNED( "r", 8 ),
+  YAML_UNSIGNED( "g", 8 ),
+  YAML_UNSIGNED( "b", 8 ),
+  YAML_END
+};
 static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "manuallyEdited", 1 ),
   YAML_SIGNED( "timezoneMinutes", 3 ),
@@ -364,6 +371,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "invertLCD", 1 ),
   YAML_PADDING( 3 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
+  YAML_ARRAY("switchLedONColor", 24, 2, struct_RGBLedColor, NULL),
+  YAML_ARRAY("switchLedOFFColor", 24, 2, struct_RGBLedColor, NULL),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {
@@ -772,13 +781,6 @@ static const struct YamlNode struct_TelemetryScreenData[] = {
   YAML_IDX,
   YAML_CUSTOM("type",r_tele_screen_type,w_tele_screen_type),
   YAML_UNION("u", 192, union_TelemetryScreenData_u_elmts, select_tele_screen_data),
-  YAML_END
-};
-static const struct YamlNode struct_RGBLedColor[] = {
-  YAML_IDX,
-  YAML_UNSIGNED( "r", 8 ),
-  YAML_UNSIGNED( "g", 8 ),
-  YAML_UNSIGNED( "b", 8 ),
   YAML_END
 };
 static const struct YamlNode struct_USBJoystickChData[] = {

--- a/radio/src/targets/common/arm/stm32/stm32_switch_driver.h
+++ b/radio/src/targets/common/arm/stm32/stm32_switch_driver.h
@@ -21,6 +21,7 @@
 
 #pragma once
 
+#include "hal.h"
 #include "stm32_hal_ll.h"
 #include "hal/switch_driver.h"
 
@@ -35,6 +36,10 @@ struct stm32_switch_t
 
   SwitchHwType type;
   uint8_t      flags;
+#if defined(SWITCH_LED_COUNT)
+  uint8_t      ledIdx;
+  uint8_t      ledOfst;
+#endif
 };
 
 SwitchHwPos stm32_switch_get_position(const stm32_switch_t* sw);

--- a/radio/src/targets/simu/switch_driver.cpp
+++ b/radio/src/targets/simu/switch_driver.cpp
@@ -30,6 +30,10 @@
 struct hw_switch_def {
   const char*  name;
   SwitchHwType type;
+#if defined(SWITCH_LED_COUNT)
+  uint8_t      ledIdx;
+  uint8_t      ledOfst;
+#endif
 };
 
 #include "simu_switches.inc"
@@ -96,6 +100,11 @@ uint8_t boardGetMaxSwitches() { return n_switches; }
 uint8_t boardGetMaxFctSwitches() { return n_fct_switches; }
 
 swconfig_t boardSwitchGetDefaultConfig() { return _switch_default_config; }
+
+#if defined(SWITCH_LED_COUNT)
+uint8_t boardGetSwitchLedIdx(uint8_t idx) { return _switch_defs[idx].ledIdx; }
+uint8_t boardGetSwitchLedOfst(uint8_t idx) { return _switch_defs[idx].ledOfst; }
+#endif
 
 switch_display_pos_t switchGetDisplayPosition(uint8_t idx)
 {

--- a/radio/src/targets/simu/switch_driver.cpp
+++ b/radio/src/targets/simu/switch_driver.cpp
@@ -32,7 +32,6 @@ struct hw_switch_def {
   SwitchHwType type;
 #if defined(SWITCH_LED_COUNT)
   uint8_t      ledIdx;
-  uint8_t      ledOfst;
 #endif
 };
 
@@ -103,7 +102,6 @@ swconfig_t boardSwitchGetDefaultConfig() { return _switch_default_config; }
 
 #if defined(SWITCH_LED_COUNT)
 uint8_t boardGetSwitchLedIdx(uint8_t idx) { return _switch_defs[idx].ledIdx; }
-uint8_t boardGetSwitchLedOfst(uint8_t idx) { return _switch_defs[idx].ledOfst; }
 #endif
 
 switch_display_pos_t switchGetDisplayPosition(uint8_t idx)

--- a/radio/src/targets/taranis/gx12/bsp_io.cpp
+++ b/radio/src/targets/taranis/gx12/bsp_io.cpp
@@ -34,7 +34,6 @@
 #include "timers_driver.h"
 
 uint8_t boardGetSwitchLedIdx(uint8_t idx);
-uint8_t boardGetSwitchLedOfst(uint8_t idx);
 
 struct bsp_io_expander {
   pca95xx_t exp;
@@ -184,11 +183,11 @@ static SwitchHwPos _get_switch_pos(uint8_t idx)
 
     const RGBLedColor* c;
     if (pos == SWITCH_HW_UP) {
-      c = &g_eeGeneral.switchLedOFFColor[ledIdx - 1];
+      c = &g_model.functionSwitchLedOFFColor[ledIdx];
     } else {
-      c = &g_eeGeneral.switchLedONColor[ledIdx - 1];
+      c = &g_model.functionSwitchLedONColor[ledIdx];
     }
-    ws2812_set_color(boardGetSwitchLedOfst(idx), c->r, c->g, c->b);
+    ws2812_set_color(ledIdx, c->r, c->g, c->b);
   }
   else if (!def->pin_low) {
     // 2POS switch

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -645,8 +645,7 @@
   #define SWITCHES_GPIO_PIN_A           LL_GPIO_PIN_13  // PC.13
 #elif defined(RADIO_GX12)
   #define SWITCHES_A_2POS
-  #define SWITCHES_A_LED_IDX            1
-  #define SWITCHES_A_LED_OFST           7
+  #define SWITCHES_A_LED_IDX            7
 #elif defined(RADIO_T14) || defined(RADIO_T12MAX)
   #define SWITCHES_GPIO_REG_A           GPIOC
   #define SWITCHES_GPIO_PIN_A           LL_GPIO_PIN_5   // PC.05
@@ -891,8 +890,7 @@
   #define SWITCHES_GPIO_PIN_D           LL_GPIO_PIN_3  // PC.03
 #elif defined(RADIO_GX12)
   #define SWITCHES_D_2POS
-  #define SWITCHES_D_LED_IDX            2
-  #define SWITCHES_D_LED_OFST           6
+  #define SWITCHES_D_LED_IDX            6
 #elif defined(RADIO_V14) || defined(RADIO_V12)
 // ADC based switch
 #elif defined(PCBX7) && !defined(RADIO_COMMANDO8)

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -645,6 +645,8 @@
   #define SWITCHES_GPIO_PIN_A           LL_GPIO_PIN_13  // PC.13
 #elif defined(RADIO_GX12)
   #define SWITCHES_A_2POS
+  #define SWITCHES_A_LED_IDX            1
+  #define SWITCHES_A_LED_OFST           7
 #elif defined(RADIO_T14) || defined(RADIO_T12MAX)
   #define SWITCHES_GPIO_REG_A           GPIOC
   #define SWITCHES_GPIO_PIN_A           LL_GPIO_PIN_5   // PC.05
@@ -889,6 +891,8 @@
   #define SWITCHES_GPIO_PIN_D           LL_GPIO_PIN_3  // PC.03
 #elif defined(RADIO_GX12)
   #define SWITCHES_D_2POS
+  #define SWITCHES_D_LED_IDX            2
+  #define SWITCHES_D_LED_OFST           6
 #elif defined(RADIO_V14) || defined(RADIO_V12)
 // ADC based switch
 #elif defined(PCBX7) && !defined(RADIO_COMMANDO8)
@@ -1966,6 +1970,7 @@
 #if defined(RADIO_GX12)
   #define LED_STRIP_LENGTH                  8
   #define RGB_LED_OFFSET                    8
+  #define SWITCH_LED_COUNT                  2
 #else
   #define LED_STRIP_LENGTH                  7
 #endif

--- a/radio/util/hw_defs/hal_switches.py
+++ b/radio/util/hw_defs/hal_switches.py
@@ -86,6 +86,9 @@ def parse_switches(target, hw_defs, adc_parser):
         adc_input_name = f"SW{s}"
         custom = f"SWITCHES_{s}_"
 
+        led_idx = f"SWITCHES_{s}_LED_IDX"
+        led_ofst = f"SWITCHES_{s}_LED_OFST"
+
         switch = None
         if reg in hw_defs:
             # 2POS switch
@@ -110,6 +113,11 @@ def parse_switches(target, hw_defs, adc_parser):
         if switch:
             if inverted in hw_defs:
                 switch.inverted = True
+
+            if led_idx in hw_defs:
+                switch.led_idx = hw_defs[led_idx]
+            if led_ofst in hw_defs:
+                switch.led_ofst = hw_defs[led_ofst]
 
             cfg = switch_cfg_by_target(target, name)
             if cfg:

--- a/radio/util/hw_defs/hal_switches.py
+++ b/radio/util/hw_defs/hal_switches.py
@@ -87,7 +87,6 @@ def parse_switches(target, hw_defs, adc_parser):
         custom = f"SWITCHES_{s}_"
 
         led_idx = f"SWITCHES_{s}_LED_IDX"
-        led_ofst = f"SWITCHES_{s}_LED_OFST"
 
         switch = None
         if reg in hw_defs:
@@ -116,8 +115,6 @@ def parse_switches(target, hw_defs, adc_parser):
 
             if led_idx in hw_defs:
                 switch.led_idx = hw_defs[led_idx]
-            if led_ofst in hw_defs:
-                switch.led_ofst = hw_defs[led_ofst]
 
             cfg = switch_cfg_by_target(target, name)
             if cfg:

--- a/radio/util/hw_defs/simu_switches.jinja
+++ b/radio/util/hw_defs/simu_switches.jinja
@@ -4,7 +4,7 @@
 const hw_switch_def _switch_defs[] = {
 {% for switch in regular_switches %}
   {% if switch.led_idx %}
-  { "{{ switch.name }}", SWITCH_HW_{{ switch.type }}, {{ switch.led_idx }}, {{ switch.led_ofst }} },
+  { "{{ switch.name }}", SWITCH_HW_{{ switch.type }}, {{ switch.led_idx }} },
   {% else %}
   { "{{ switch.name }}", SWITCH_HW_{{ switch.type }} },
   {% endif %}

--- a/radio/util/hw_defs/simu_switches.jinja
+++ b/radio/util/hw_defs/simu_switches.jinja
@@ -3,7 +3,11 @@
 
 const hw_switch_def _switch_defs[] = {
 {% for switch in regular_switches %}
+  {% if switch.led_idx %}
+  { "{{ switch.name }}", SWITCH_HW_{{ switch.type }}, {{ switch.led_idx }}, {{ switch.led_ofst }} },
+  {% else %}
   { "{{ switch.name }}", SWITCH_HW_{{ switch.type }} },
+  {% endif %}
 {% endfor %}
 {% for switch in function_switches %}
   { "{{ switch.name }}", SWITCH_HW_2POS },

--- a/radio/util/hw_defs/stm32_switches.jinja
+++ b/radio/util/hw_defs/stm32_switches.jinja
@@ -16,7 +16,7 @@ static const stm32_switch_t _switch_defs[] = {
     nullptr, 0,
     SWITCH_HW_2POS, {{ 'SWITCH_HW_INVERTED' if switch.inverted else 0 }},
     {% if switch.led_idx %}
-    {{ switch.led_idx }}, {{ switch.led_ofst }},
+    {{ switch.led_idx }}
     {% endif %}
   },
   {% elif switch.type == '3POS' %}

--- a/radio/util/hw_defs/stm32_switches.jinja
+++ b/radio/util/hw_defs/stm32_switches.jinja
@@ -14,7 +14,10 @@ static const stm32_switch_t _switch_defs[] = {
     {{ switch.gpio or "nullptr" }},
     {{ switch.pin or 0 }},
     nullptr, 0,
-    SWITCH_HW_2POS, {{ 'SWITCH_HW_INVERTED' if switch.inverted else 0 }}
+    SWITCH_HW_2POS, {{ 'SWITCH_HW_INVERTED' if switch.inverted else 0 }},
+    {% if switch.led_idx %}
+    {{ switch.led_idx }}, {{ switch.led_ofst }},
+    {% endif %}
   },
   {% elif switch.type == '3POS' %}
   {
@@ -23,14 +26,14 @@ static const stm32_switch_t _switch_defs[] = {
     {{ switch.pin_high or 0 }},
     {{ switch.gpio_low or "nullptr" }},
     {{ switch.pin_low or 0 }},
-    SWITCH_HW_3POS, {{ 'SWITCH_HW_INVERTED' if switch.inverted else 0 }}
+    SWITCH_HW_3POS, {{ 'SWITCH_HW_INVERTED' if switch.inverted else 0 }},
   },
   {% elif switch.type == 'ADC' %}
   {
     "{{ switch.name }}",
     nullptr, {{ adc_index[switch.adc_input] }},
     nullptr, 0,
-    SWITCH_HW_ADC, {{ 'SWITCH_HW_INVERTED' if switch.inverted else 0 }}
+    SWITCH_HW_ADC, {{ 'SWITCH_HW_INVERTED' if switch.inverted else 0 }},
   },
   {% endif %}
 {% endfor %}


### PR DESCRIPTION
Planned to be superseded by #6095

Add the ability for users to set the Led colors of the SA and SD switches on the GX12.

![screenshot_gx12_25-04-05_09-29-05](https://github.com/user-attachments/assets/650e67d5-9fda-4985-9147-847234c3cea9)

![screenshot_gx12_25-04-05_09-29-10](https://github.com/user-attachments/assets/96142674-4fbd-4782-a466-e1d62193d079)

Todo:

- [x] Companion support
