### PR TITLE
fix(color): scroll wheel direction is not intuitive when editing color bars

### DIFF
--- a/radio/src/gui/colorlcd/controls/color_editor.cpp
+++ b/radio/src/gui/colorlcd/controls/color_editor.cpp
@@ -33,7 +33,7 @@ class ColorBar : public FormField
 {
  public:
   ColorBar(Window* parent, const rect_t& r, uint32_t value = 0,
-           uint32_t maxValue = 0, bool invert = false) :
+           uint32_t maxValue = 0) :
       FormField(parent, r)
   {
     lv_obj_add_flag(lvobj, LV_OBJ_FLAG_ENCODER_ACCEL);
@@ -55,7 +55,6 @@ class ColorBar : public FormField
     auto h = height() - 4;  // exclude border
 
     int scaledValue = (val * h + maxValue / 2) / maxValue;
-    if (invert) scaledValue = h - scaledValue;
     return scaledValue;
   }
 
@@ -68,7 +67,6 @@ class ColorBar : public FormField
     pos = max<int>(pos, 0);
 
     uint32_t scaledValue = ((pos * maxValue + h / 2) / h);
-    if (invert) scaledValue = maxValue - scaledValue;
     return scaledValue;
   }
 
@@ -106,8 +104,6 @@ class ColorBar : public FormField
     if (!bar) return;
 
     uint32_t key = *(uint32_t*)lv_event_get_param(e);
-    if (bar->invert)
-      key = (key == LV_KEY_LEFT) ? LV_KEY_RIGHT : (key == LV_KEY_RIGHT) ? LV_KEY_LEFT : key;
 
     if (key == LV_KEY_LEFT) {
       if (bar->value > 0) {
@@ -194,7 +190,6 @@ class ColorBar : public FormField
 
   uint32_t maxValue = 0;
   uint32_t value = 0;
-  bool invert = false;
   getRGBFromPos getRGB = nullptr;
 };
 
@@ -303,7 +298,6 @@ class HSVColorType : public BarColorType
 
     for (auto i = 0; i < MAX_BARS; i++) {
       bars[i]->maxValue = (i == 0) ? MAX_HUE : (i == 1) ? MAX_SATURATION : MAX_BRIGHTNESS;
-      bars[i]->invert = i != 0;
       bars[i]->value = values[i];
     }
 
@@ -352,7 +346,6 @@ class RGBColorType : public BarColorType
     for (auto i = 0; i < MAX_BARS; i++) {
       bars[i]->maxValue = 255;
       bars[i]->value = values[i];
-      bars[i]->invert = true;
     }
 
     bars[0]->getRGB = [=](int pos) { return RGB32(pos, 0, 0); };

--- a/radio/src/gui/colorlcd/controls/color_editor.cpp
+++ b/radio/src/gui/colorlcd/controls/color_editor.cpp
@@ -106,6 +106,9 @@ class ColorBar : public FormField
     if (!bar) return;
 
     uint32_t key = *(uint32_t*)lv_event_get_param(e);
+    if (bar->invert)
+      key = (key == LV_KEY_LEFT) ? LV_KEY_RIGHT : (key == LV_KEY_RIGHT) ? LV_KEY_LEFT : key;
+
     if (key == LV_KEY_LEFT) {
       if (bar->value > 0) {
         uint32_t accel = rotaryEncoderGetAccel();

--- a/radio/src/gui/colorlcd/controls/color_picker.cpp
+++ b/radio/src/gui/colorlcd/controls/color_picker.cpp
@@ -149,7 +149,7 @@ class ColorEditorPopup : public BaseDialog
 
     hbox = new Window(vbox, rect_t{});
     hbox->padTop(BTN_PAD_TOP);
-    hbox->setFlexLayout(LV_FLEX_FLOW_ROW, EdgeTxStyles::STD_FONT_HEIGHT);
+    hbox->setFlexLayout(LV_FLEX_FLOW_ROW, PAD_MEDIUM);
     lv_obj_set_flex_align(hbox->getLvObj(), LV_FLEX_ALIGN_CENTER,
                           LV_FLEX_ALIGN_END, LV_FLEX_ALIGN_SPACE_BETWEEN);
     lv_obj_set_flex_grow(hbox->getLvObj(), 1);


### PR DESCRIPTION
Currently when changing the values of the color bars in the color editor with the scroll wheel, moving the wheel left decreases the bar value and right increases the value.

Since most of the bars have 0 at the bottom, this means that scrolling left moves the indicator down and scrolling right moves the indicator up.

This is backwards compared to the rest of the UI, left moves up the screen and right moves down.

This PR makes the scroll wheel consistent on all the color bars - left moves the indicator up and right moves it down.
