### PR TITLE
chore(color): radio hardware page layout breaks if additional lines added

### DIFF
--- a/radio/src/gui/colorlcd/radio/hw_bluetooth.cpp
+++ b/radio/src/gui/colorlcd/radio/hw_bluetooth.cpp
@@ -68,6 +68,7 @@ class BTDetailsDialog : public BaseDialog
 BluetoothConfigWindow::BluetoothConfigWindow(Window* parent, FlexGridLayout& grid)
 {
   auto line = parent->newLine(grid);
+  line->padLeft(PAD_SMALL);
   new StaticText(line, rect_t{}, STR_MODE);
 
   auto box = new Window(line, rect_t{});
@@ -93,6 +94,7 @@ BluetoothConfigWindow::BluetoothConfigWindow(Window* parent, FlexGridLayout& gri
 
   // BT radio name
   nameEdit = parent->newLine(grid);
+  nameEdit->padLeft(PAD_SMALL);
   new StaticText(nameEdit, rect_t{}, STR_NAME);
 
   box = new Window(nameEdit, rect_t{});

--- a/radio/src/gui/colorlcd/radio/hw_extmodule.cpp
+++ b/radio/src/gui/colorlcd/radio/hw_extmodule.cpp
@@ -28,6 +28,7 @@
 ExternalModuleWindow::ExternalModuleWindow(Window *parent, FlexGridLayout& grid)
 {
   auto line = parent->newLine(grid);
+  line->padLeft(PAD_SMALL);
 
   new StaticText(line, rect_t{}, STR_SAMPLE_MODE);
 

--- a/radio/src/gui/colorlcd/radio/hw_intmodule.cpp
+++ b/radio/src/gui/colorlcd/radio/hw_intmodule.cpp
@@ -32,6 +32,7 @@
 InternalModuleWindow::InternalModuleWindow(Window *parent, FlexGridLayout& grid)
 {
   auto line = parent->newLine(grid);
+  line->padLeft(PAD_SMALL);
   new StaticText(line, rect_t{}, STR_TYPE);
   auto internalModule =
       new Choice(line, rect_t{}, STR_MODULE_PROTOCOLS, MODULE_TYPE_NONE,
@@ -43,6 +44,7 @@ InternalModuleWindow::InternalModuleWindow(Window *parent, FlexGridLayout& grid)
 
 #if defined(INTERNAL_MODULE_PXX1) && defined(EXTERNAL_ANTENNA)
   ant_box = parent->newLine(grid);
+  ant_box->padLeft(PAD_SMALL);
   new StaticText(ant_box, rect_t{}, STR_ANTENNA);
   new Choice(
       ant_box, rect_t{}, STR_ANTENNA_MODES, ANTENNA_MODE_INTERNAL,
@@ -69,6 +71,7 @@ InternalModuleWindow::InternalModuleWindow(Window *parent, FlexGridLayout& grid)
 
 #if defined(CROSSFIRE)
   br_box = parent->newLine(grid);
+  br_box->padLeft(PAD_SMALL);
   new StaticText(br_box, rect_t{}, STR_BAUDRATE);
   new Choice(
       br_box, rect_t{}, STR_CRSF_BAUDRATE, 0, CROSSFIRE_MAX_INTERNAL_BAUDRATE,

--- a/radio/src/gui/colorlcd/radio/radio_hardware.cpp
+++ b/radio/src/gui/colorlcd/radio/radio_hardware.cpp
@@ -46,14 +46,12 @@
 #if PORTRAIT_LCD
 static const lv_coord_t col_dsc[] = {LV_GRID_FR(13), LV_GRID_FR(19),
                                      LV_GRID_TEMPLATE_LAST};
-static const lv_coord_t row_dsc[] = {LV_GRID_CONTENT, LV_GRID_CONTENT,
-                                     LV_GRID_TEMPLATE_LAST};
 #else
 static const lv_coord_t col_dsc[] = {LV_GRID_FR(1), LV_GRID_FR(2),
                                      LV_GRID_TEMPLATE_LAST};
-static const lv_coord_t row_dsc[] = {LV_GRID_CONTENT, LV_GRID_CONTENT,
-                                     LV_GRID_TEMPLATE_LAST};
 #endif
+
+static const lv_coord_t row_dsc[] = {LV_GRID_CONTENT, LV_GRID_TEMPLATE_LAST};
 
 RadioHardwarePage::RadioHardwarePage() :
     PageTab(STR_HARDWARE, ICON_RADIO_HARDWARE, PAD_TINY)
@@ -169,26 +167,18 @@ void RadioHardwarePage::build(Window* window)
 
   FlexGridLayout grid(col_dsc, row_dsc, PAD_TINY);
 
-  FormLine* line;
-
 #if defined(HARDWARE_INTERNAL_MODULE)
   new Subtitle(window, STR_INTERNALRF);
-  line = window->newLine(grid);
-  line->padLeft(PAD_SMALL);
-  new InternalModuleWindow(line, grid);
+  new InternalModuleWindow(window, grid);
 #endif
 
 #if defined(HARDWARE_EXTERNAL_MODULE)
   new Subtitle(window, STR_EXTERNALRF);
-  line = window->newLine(grid);
-  line->padLeft(PAD_SMALL);
-  new ExternalModuleWindow(line, grid);
+  new ExternalModuleWindow(window, grid);
 #endif
 
 #if defined(BLUETOOTH)
   new Subtitle(window, STR_BLUETOOTH);
-  line = window->newLine(grid);
-  line->padLeft(PAD_SMALL);
   new BluetoothConfigWindow(window, grid);
 #endif
 


### PR DESCRIPTION
The radio hardware page layout does not work correctly if additional lines are added to the internal or external module sections.

This fixes the layout code for future radios.
