### PR TITLE
feat(lua): add additional properties to the Lua Lvgl arc object.

### DIFF
--- a/radio/src/gui/colorlcd/libui/etx_lv_theme.cpp
+++ b/radio/src/gui/colorlcd/libui/etx_lv_theme.cpp
@@ -395,7 +395,7 @@ void etx_bg_color_from_flags(lv_obj_t* obj, LcdFlags colorFlags,
   if (colorFlags & RGB_FLAG) {
     etx_remove_bg_color(obj, selector);
     lv_obj_set_style_bg_color(obj,
-                              makeLvColor(colorToRGB(colorFlags)), selector);
+                              makeLvColor(colorFlags), selector);
   } else {
     lv_obj_remove_local_style_prop(obj, LV_STYLE_BG_COLOR, selector);
     etx_bg_color(obj, (LcdColorIndex)COLOR_VAL(colorFlags), selector);
@@ -423,7 +423,7 @@ void etx_txt_color_from_flags(lv_obj_t* obj, LcdFlags colorFlags,
   if (colorFlags & RGB_FLAG) {
     etx_remove_txt_color(obj, selector);
     lv_obj_set_style_text_color(obj,
-                                makeLvColor(colorToRGB(colorFlags)), selector);
+                                makeLvColor(colorFlags), selector);
   } else {
     lv_obj_remove_local_style_prop(obj, LV_STYLE_TEXT_COLOR, selector);
     etx_txt_color(obj, (LcdColorIndex)COLOR_VAL(colorFlags), selector);
@@ -460,6 +460,19 @@ void etx_arc_color(lv_obj_t* obj, LcdColorIndex colorIdx,
   etx_obj_add_style(obj, styles->arc_color[colorIdx], selector);
 }
 
+void etx_arc_color_from_flags(lv_obj_t* obj, LcdFlags colorFlags,
+                             lv_style_selector_t selector)
+{
+  if (colorFlags & RGB_FLAG) {
+    etx_remove_arc_color(obj, selector);
+    lv_obj_set_style_arc_color(obj,
+                              makeLvColor(colorFlags), selector);
+  } else {
+    lv_obj_remove_local_style_prop(obj, LV_STYLE_ARC_COLOR, selector);
+    etx_arc_color(obj, (LcdColorIndex)COLOR_VAL(colorFlags), selector);
+  }
+}
+
 void etx_remove_line_color(lv_obj_t* obj, lv_style_selector_t selector)
 {
   // Remove styles
@@ -473,6 +486,19 @@ void etx_line_color(lv_obj_t* obj, LcdColorIndex colorIdx,
   // Remove old style first
   etx_remove_line_color(obj, selector);
   etx_obj_add_style(obj, styles->line_color[colorIdx], selector);
+}
+
+void etx_line_color_from_flags(lv_obj_t* obj, LcdFlags colorFlags,
+                             lv_style_selector_t selector)
+{
+  if (colorFlags & RGB_FLAG) {
+    etx_remove_line_color(obj, selector);
+    lv_obj_set_style_line_color(obj,
+                              makeLvColor(colorFlags), selector);
+  } else {
+    lv_obj_remove_local_style_prop(obj, LV_STYLE_LINE_COLOR, selector);
+    etx_line_color(obj, (LcdColorIndex)COLOR_VAL(colorFlags), selector);
+  }
 }
 
 void etx_remove_img_color(lv_obj_t* obj, lv_style_selector_t selector)

--- a/radio/src/gui/colorlcd/libui/etx_lv_theme.h
+++ b/radio/src/gui/colorlcd/libui/etx_lv_theme.h
@@ -186,10 +186,14 @@ void etx_border_color(lv_obj_t* obj, LcdColorIndex colorIdx,
 void etx_remove_arc_color(lv_obj_t* obj, lv_style_selector_t selector = LV_PART_MAIN);
 void etx_arc_color(lv_obj_t* obj, LcdColorIndex colorIdx,
                   lv_style_selector_t selector = LV_PART_MAIN);
+void etx_arc_color_from_flags(lv_obj_t* obj, LcdFlags colorFlags,
+                             lv_style_selector_t selector = LV_PART_MAIN);
 
 void etx_remove_line_color(lv_obj_t* obj, lv_style_selector_t selector = LV_PART_MAIN);
 void etx_line_color(lv_obj_t* obj, LcdColorIndex colorIdx,
                   lv_style_selector_t selector = LV_PART_MAIN);
+void etx_line_color_from_flags(lv_obj_t* obj, LcdFlags colorFlags,
+                             lv_style_selector_t selector = LV_PART_MAIN);
 
 void etx_remove_img_color(lv_obj_t* obj, lv_style_selector_t selector = LV_PART_MAIN);
 void etx_img_color(lv_obj_t* obj, LcdColorIndex colorIdx,

--- a/radio/src/gui/colorlcd/widgets/timer.cpp
+++ b/radio/src/gui/colorlcd/widgets/timer.cpp
@@ -92,7 +92,7 @@ class TimerWidget : public Widget
     lv_obj_set_style_arc_width(timerArc, TMR_ARC_W, LV_PART_MAIN);
     lv_obj_set_style_arc_opa(timerArc, LV_OPA_COVER, LV_PART_INDICATOR);
     lv_obj_set_style_arc_width(timerArc, TMR_ARC_W, LV_PART_INDICATOR);
-    etx_obj_add_style(timerArc, styles->arc_color[COLOR_THEME_SECONDARY1_INDEX], LV_PART_INDICATOR);
+    etx_arc_color(timerArc, COLOR_THEME_SECONDARY1_INDEX, LV_PART_INDICATOR);
     lv_obj_add_flag(timerArc, LV_OBJ_FLAG_HIDDEN);
 
     update();


### PR DESCRIPTION
Adds the following properties to the arc object:
- rounded
- bgColor
- bgOpacity
- bgStartAngle
- bgEndAngle

Example:
```Lua
lvgl.arc({radius=30, thickness=8, startAngle=155, endAngle=25,
          bgStartAngle=120, bgEndAngle=60, bgColor=GREY, bgOpacity=255,
          color=RED, rounded=true})
```

<img width="75" alt="Screenshot 2025-04-07 at 10 02 29 AM" src="https://github.com/user-attachments/assets/c00f63bc-b838-437b-b98c-a4c0636383f8" />
