### PR TITLE
fix(radio): missing translation strings

### DIFF
--- a/radio/src/translations/cn.h
+++ b/radio/src/translations/cn.h
@@ -288,6 +288,8 @@
 #define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
+#define TR_FS_ON_COLOR                 TR("ON:","ON Color")
+#define TR_FS_OFF_COLOR                TR("OFF:","OFF Color")
 #define TR_GROUPS                      "Always on groups"
 #define TR_LAST                        "Last"
 #define TR_MORE_INFO                   "More info"

--- a/radio/src/translations/cz.h
+++ b/radio/src/translations/cz.h
@@ -302,6 +302,8 @@
 #define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
+#define TR_FS_ON_COLOR                 TR("ON:","ON Color")
+#define TR_FS_OFF_COLOR                TR("OFF:","OFF Color")
 #define TR_GROUPS                      "Always on groups"
 #define TR_LAST                        "Last"
 #define TR_MORE_INFO                   "More info"

--- a/radio/src/translations/da.h
+++ b/radio/src/translations/da.h
@@ -295,6 +295,8 @@
 #define TR_FS_COLOR_LIST               "Bruger","Fra","Hvid","Rød","Grøn","Gul","Orange","Blå","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Altid til"
+#define TR_FS_ON_COLOR                 TR("ON:","ON Color")
+#define TR_FS_OFF_COLOR                TR("OFF:","OFF Color")
 #define TR_GROUPS                      "Altid til gruppe"
 #define TR_LAST                        "Sidste"
 #define TR_MORE_INFO                   "Mere info"

--- a/radio/src/translations/es.h
+++ b/radio/src/translations/es.h
@@ -290,6 +290,8 @@
 #define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
+#define TR_FS_ON_COLOR                 TR("ON:","ON Color")
+#define TR_FS_OFF_COLOR                TR("OFF:","OFF Color")
 #define TR_GROUPS                      "Always on groups"
 #define TR_LAST                        "Last"
 #define TR_MORE_INFO                   "More info"

--- a/radio/src/translations/fi.h
+++ b/radio/src/translations/fi.h
@@ -303,6 +303,8 @@
 #define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
+#define TR_FS_ON_COLOR                 TR("ON:","ON Color")
+#define TR_FS_OFF_COLOR                TR("OFF:","OFF Color")
 #define TR_GROUPS                      "Always on groups"
 #define TR_LAST                        "Last"
 #define TR_MORE_INFO                   "More info"

--- a/radio/src/translations/fr.h
+++ b/radio/src/translations/fr.h
@@ -298,6 +298,8 @@
 #define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
+#define TR_FS_ON_COLOR                 TR("ON:","ON Color")
+#define TR_FS_OFF_COLOR                TR("OFF:","OFF Color")
 #define TR_GROUPS                      "Always on groups"
 #define TR_LAST                        "Last"
 #define TR_MORE_INFO                   "More info"

--- a/radio/src/translations/he.h
+++ b/radio/src/translations/he.h
@@ -296,6 +296,8 @@
 #define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
+#define TR_FS_ON_COLOR                 TR("ON:","ON Color")
+#define TR_FS_OFF_COLOR                TR("OFF:","OFF Color")
 #define TR_GROUPS                      "Always on groups"
 #define TR_LAST                        "Last"
 #define TR_MORE_INFO                   "More info"

--- a/radio/src/translations/it.h
+++ b/radio/src/translations/it.h
@@ -292,6 +292,8 @@
 #define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
+#define TR_FS_ON_COLOR                 TR("ON:","ON Color")
+#define TR_FS_OFF_COLOR                TR("OFF:","OFF Color")
 #define TR_GROUPS                      "Always on groups"
 #define TR_LAST                        "Last"
 #define TR_MORE_INFO                   "More info"

--- a/radio/src/translations/jp.h
+++ b/radio/src/translations/jp.h
@@ -291,6 +291,8 @@
 #define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
+#define TR_FS_ON_COLOR                 TR("ON:","ON Color")
+#define TR_FS_OFF_COLOR                TR("OFF:","OFF Color")
 #define TR_GROUPS                      "Always on groups"
 #define TR_LAST                        "Last"
 #define TR_MORE_INFO                   "More info"

--- a/radio/src/translations/nl.h
+++ b/radio/src/translations/nl.h
@@ -289,6 +289,8 @@
 #define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
+#define TR_FS_ON_COLOR                 TR("ON:","ON Color")
+#define TR_FS_OFF_COLOR                TR("OFF:","OFF Color")
 #define TR_GROUPS                      "Always on groups"
 #define TR_LAST                        "Last"
 #define TR_MORE_INFO                   "More info"

--- a/radio/src/translations/pl.h
+++ b/radio/src/translations/pl.h
@@ -288,6 +288,8 @@
 #define TR_FUNCTION_SWITCHES   "Ustawiane przełączniki"
 #define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP_ALWAYS_ON             "Always on"
+#define TR_FS_ON_COLOR                 TR("ON:","ON Color")
+#define TR_FS_OFF_COLOR                TR("OFF:","OFF Color")
 #define TR_GROUPS                      "Always on groups"
 #define TR_LAST                        "Last"
 #define TR_MORE_INFO                   "More info"

--- a/radio/src/translations/pt.h
+++ b/radio/src/translations/pt.h
@@ -295,6 +295,8 @@
 #define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
+#define TR_FS_ON_COLOR                 TR("ON:","ON Color")
+#define TR_FS_OFF_COLOR                TR("OFF:","OFF Color")
 #define TR_GROUPS                      "Always on groups"
 #define TR_LAST                        "Last"
 #define TR_MORE_INFO                   "More info"

--- a/radio/src/translations/ru.h
+++ b/radio/src/translations/ru.h
@@ -294,6 +294,8 @@
 #define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
+#define TR_FS_ON_COLOR                 TR("ON:","ON Color")
+#define TR_FS_OFF_COLOR                TR("OFF:","OFF Color")
 #define TR_GROUPS                      "Always on groups"
 #define TR_LAST                        "Last"
 #define TR_MORE_INFO                   "More info"

--- a/radio/src/translations/se.h
+++ b/radio/src/translations/se.h
@@ -301,7 +301,7 @@
 #define TR_MS                           "ms"
 #define TR_SWITCH                       "Brytare"
 #define TR_FUNCTION_SWITCHES            "Anpassningsbara brytare"
-#define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
+#define TR_FS_COLOR_LIST                "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                        "Grupp"
 #define TR_GROUP_ALWAYS_ON              "Alltid på"
 #define TR_FS_ON_COLOR                  TR("PÅ:","PÅ färg")

--- a/radio/src/translations/se.h
+++ b/radio/src/translations/se.h
@@ -304,8 +304,8 @@
 #define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                        "Grupp"
 #define TR_GROUP_ALWAYS_ON              "Alltid på"
-#define TR_FS_ON_COLOR                 TR("ON:","ON Color")
-#define TR_FS_OFF_COLOR                TR("OFF:","OFF Color")
+#define TR_FS_ON_COLOR                  TR("PÅ:","PÅ färg")
+#define TR_FS_OFF_COLOR                 TR("AV:","AV färg")
 #define TR_GROUPS                       "Always on groups"
 #define TR_LAST                         "Last"
 #define TR_MORE_INFO                    "More info"

--- a/radio/src/translations/se.h
+++ b/radio/src/translations/se.h
@@ -304,6 +304,8 @@
 #define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                        "Grupp"
 #define TR_GROUP_ALWAYS_ON              "Alltid på"
+#define TR_FS_ON_COLOR                 TR("ON:","ON Color")
+#define TR_FS_OFF_COLOR                TR("OFF:","OFF Color")
 #define TR_GROUPS                       "Always on groups"
 #define TR_LAST                         "Last"
 #define TR_MORE_INFO                    "More info"

--- a/radio/src/translations/tw.h
+++ b/radio/src/translations/tw.h
@@ -293,6 +293,8 @@
 #define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
+#define TR_FS_ON_COLOR                 TR("ON:","ON Color")
+#define TR_FS_OFF_COLOR                TR("OFF:","OFF Color")
 #define TR_GROUPS                      "Always on groups"
 #define TR_LAST                        "Last"
 #define TR_MORE_INFO                   "More info"

--- a/radio/src/translations/ua.h
+++ b/radio/src/translations/ua.h
@@ -294,6 +294,8 @@
 #define TR_FS_COLOR_LIST               "Custom","Off","White","Red","Green","Yellow","Orange","Blue","Pink"
 #define TR_GROUP                       "Group"
 #define TR_GROUP_ALWAYS_ON             "Always on"
+#define TR_FS_ON_COLOR                 TR("ON:","ON Color")
+#define TR_FS_OFF_COLOR                TR("OFF:","OFF Color")
 #define TR_GROUPS                      "Always on groups"
 #define TR_LAST                        "Last"
 #define TR_MORE_INFO                   "More info"


### PR DESCRIPTION
Summary of changes:
Translation definition missing in other languages.  Changes in #5703 only updated en and de, with other languages missing.
