### PR TITLE
fix(radio): a 2POS switch connected to a 3POS socket may not behave as expected

### DIFF
--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -727,15 +727,22 @@ bool getSwitch(swsrc_t swtch, uint8_t flags)
     } else
 #endif
     {
-      if (flags & GETSWITCH_MIDPOS_DELAY) {
-        result = SWITCH_POSITION(cs_idx);
-      } else {
-        div_t qr = div(cs_idx, 3);
-        if (SWITCH_EXISTS(qr.quot)) {
-          result = switchState(cs_idx);
+      div_t qr = div(cs_idx, 3);
+      if (SWITCH_EXISTS(qr.quot)) {
+        auto sw_cfg = (SwitchConfig)SWITCH_CONFIG(qr.quot);
+        if (flags & GETSWITCH_MIDPOS_DELAY) {
+          result = SWITCH_POSITION(cs_idx);
+          // Handle 2POS switch installed in 3POS slot
+          if (!result && qr.rem == SWITCH_HW_DOWN && sw_cfg == SWITCH_2POS)
+            result = SWITCH_POSITION(cs_idx - 1);
         } else {
-          result = false;
+          result = switchState(cs_idx);
+          // Handle 2POS switch installed in 3POS slot
+          if (!result && qr.rem == SWITCH_HW_DOWN && sw_cfg == SWITCH_2POS)
+            result = switchState(cs_idx - 1);
         }
+      } else {
+         result = false;
       }
     }
   }

--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -733,12 +733,12 @@ bool getSwitch(swsrc_t swtch, uint8_t flags)
         if (flags & GETSWITCH_MIDPOS_DELAY) {
           result = SWITCH_POSITION(cs_idx);
           // Handle 2POS switch installed in 3POS slot
-          if (!result && qr.rem == SWITCH_HW_DOWN && sw_cfg == SWITCH_2POS)
+          if (!result && qr.rem == SWITCH_HW_DOWN && (sw_cfg == SWITCH_2POS || sw_cfg == SWITCH_TOGGLE))
             result = SWITCH_POSITION(cs_idx - 1);
         } else {
           result = switchState(cs_idx);
           // Handle 2POS switch installed in 3POS slot
-          if (!result && qr.rem == SWITCH_HW_DOWN && sw_cfg == SWITCH_2POS)
+          if (!result && qr.rem == SWITCH_HW_DOWN && (sw_cfg == SWITCH_2POS || sw_cfg == SWITCH_TOGGLE))
             result = switchState(cs_idx - 1);
         }
       } else {

--- a/radio/src/tests/mixer.cpp
+++ b/radio/src/tests/mixer.cpp
@@ -810,11 +810,14 @@ TEST_F(MixerTest, DelayOnSwitch)
   evalFlightModeMixes(e_perout_mode_normal, 1);
   EXPECT_EQ(chans[0], CHANNEL_MAX);
 
-  simuSetSwitch(switch_index, 0);
-  CHECK_DELAY(0, 500);
+  auto sw_cfg = (SwitchConfig)SWITCH_CONFIG(switch_index);
+  if (sw_cfg == SWITCH_3POS) {
+    simuSetSwitch(switch_index, 0);
+    CHECK_DELAY(0, 500);
 
-  evalFlightModeMixes(e_perout_mode_normal, 1);
-  EXPECT_EQ(chans[0], 0);
+    evalFlightModeMixes(e_perout_mode_normal, 1);
+    EXPECT_EQ(chans[0], 0);
+  }
 }
 
 TEST_F(MixerTest, DelayOnSwitch2)


### PR DESCRIPTION
Fixes #5975 

If a 2POS switch is wired to a 3POS connector, then treat the mid switch position as equivalent to the down position.
