### PR TITLE
chore: CMake 4.0 compatibility

### DIFF
--- a/cmake/FetchMaxLibQt.cmake
+++ b/cmake/FetchMaxLibQt.cmake
@@ -5,7 +5,7 @@ include(FetchContent)
 FetchContent_Declare(
   maxLibQt
   GIT_REPOSITORY https://github.com/edgetx/maxLibQt
-  GIT_TAG        b5418f76cc4891e09f4e21276175d39dbb130f66
+  GIT_TAG        4ff912ed9f2ba9cea12c6633fef34028da767a6c
 )
 
 FetchContent_MakeAvailable(maxLibQt)

--- a/cmake/FetchMaxLibQt.cmake
+++ b/cmake/FetchMaxLibQt.cmake
@@ -5,7 +5,7 @@ include(FetchContent)
 FetchContent_Declare(
   maxLibQt
   GIT_REPOSITORY https://github.com/edgetx/maxLibQt
-  GIT_TAG        4ff912ed9f2ba9cea12c6633fef34028da767a6c
+  GIT_TAG        ac1988ffd005cd15a8449b92150ce6c08574a4f1
 )
 
 FetchContent_MakeAvailable(maxLibQt)

--- a/cmake/FetchMiniz.cmake
+++ b/cmake/FetchMiniz.cmake
@@ -5,7 +5,7 @@ include(FetchContent)
 FetchContent_Declare(
   miniz
   GIT_REPOSITORY https://github.com/richgel999/miniz
-  GIT_TAG        293d4db1b7d0ffee9756d035b9ac6f7431ef8492 # v3.0.2
+  GIT_TAG        89d7a5f6c3ce8893ea042b0a9d2a2d9975589ac9
 )
 
 FetchContent_MakeAvailable(miniz)

--- a/cmake/FetchYamlCpp.cmake
+++ b/cmake/FetchYamlCpp.cmake
@@ -5,7 +5,7 @@ include(FetchContent)
 FetchContent_Declare(
   yaml-cpp
   GIT_REPOSITORY https://github.com/jbeder/yaml-cpp
-  GIT_TAG        f7320141120f720aecc4c32be25586e7da9eb978 # v0.8.0
+  GIT_TAG        28f93bdec6387d42332220afa9558060c8016795
 )
 
 FetchContent_MakeAvailable(yaml-cpp)

--- a/cmake/GenericDefinitions.cmake
+++ b/cmake/GenericDefinitions.cmake
@@ -2,10 +2,6 @@
 # https://cmake.org/cmake/help/latest/policy/CMP0020.html
 cmake_policy(SET CMP0020 NEW)
 
-# Allow keyword and plain target_link_libraries() signatures to be mixed
-# https://cmake.org/cmake/help/latest/policy/CMP0023.html
-cmake_policy(SET CMP0023 OLD)
-
 # Use @rpath in a target's install name on MacOS X for locating shared libraries
 # https://cmake.org/cmake/help/latest/policy/CMP0042.html
 if(POLICY CMP0042)

--- a/companion/src/CMakeLists.txt
+++ b/companion/src/CMakeLists.txt
@@ -361,9 +361,6 @@ elseif(PCB STREQUAL PL18)
 else()
   string(TOLOWER ${PCB} FLAVOUR)
 endif()
-if(POLICY CMP0026)
-  cmake_policy(SET CMP0026 OLD)  # https://cmake.org/cmake/help/v3.0/policy/CMP0026.html
-endif()
 
 include(FindDfuutil)
 include(FindLibusb1)


### PR DESCRIPTION
Summary of changes:
- bumps commits for  EdgeTX/maxLibQt, miniz, yamp-cpp to latest commits, which are 4.0 compatible
- removes two no longer valid policies. CMP0023 appears to be a safe removal, CMP0026 *might* only be an issue for QT5 libraries (if at all - all three Companion builds were successful on my fork) (regex search `get_target_property\(.*LOCATION\)`)
