### PR TITLE
fix(bw): switch display may overlap other elements if switches are disabled

### DIFF
--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -517,17 +517,10 @@ void menuMainView(event_t event)
         
         // Switches
         // -> 2 columns: one for each side
-        // -> 4 slots on each side (3 normal / 1 small)
+        // -> 4 slots on each side
         uint8_t switches = switchGetMaxSwitches();
-        uint8_t configured_switches = 0;
 
-        for (uint8_t i = 0; i < switches; i++) {
-          if (SWITCH_EXISTS(i) && !switchIsFlex(i)) {
-            configured_switches ++;
-          }
-        }
-
-        if (configured_switches < 7) {
+        if (switches < 7) {
           for (int i = 0; i < switches; ++i) {
             if (SWITCH_EXISTS(i) && !switchIsFlex(i)) {
               auto switch_display = switchGetDisplayPosition(i);
@@ -547,7 +540,7 @@ void menuMainView(event_t event)
             if (SWITCH_EXISTS(i) && !switchIsFlex(i)) {
               auto switch_display = switchGetDisplayPosition(i);
               coord_t x = (switch_display.col == 0 ? 8 : 96) + switch_display.row * 5;
-              if (configured_switches < 9) x += 3;
+              if (switches < 9) x += 3;
               drawSmallSwitch(x, 5 * FH + 1, 4, i);
             }
           }


### PR DESCRIPTION
Fixes #6073 

On radios with more than 6 switches the default is to use the small switch display layout.
If multiple switches are disabled the code tried to use the large switch display layout; but the switch position array values do not cater for this.

Changed to always use the small switch display if there are more than 6 physical switches.
