### PR TITLE
chore(cpn): disable all the warnings in the miniz header

### DIFF
--- a/companion/src/storage/labeled.h
+++ b/companion/src/storage/labeled.h
@@ -22,7 +22,10 @@
 #pragma once
 
 #include "storage.h"
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
 #include "miniz.h"
+#pragma GCC diagnostic pop
 
 #include <QtCore>
 #include <list>

--- a/companion/src/storage/minizinterface.h
+++ b/companion/src/storage/minizinterface.h
@@ -21,7 +21,10 @@
 
 #pragma once
 
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wunused-function"
 #include "miniz.h"
+#pragma GCC diagnostic pop
 
 #include <QtCore>
 #include <QString>


### PR DESCRIPTION
The miniz.h header now generates lots of 'unused function' warnings.
