### PR TITLE
fix(color): widget 'Choice' option popup may show duplicate entries

### DIFF
--- a/radio/src/lua/lua_widget_factory.cpp
+++ b/radio/src/lua/lua_widget_factory.cpp
@@ -231,6 +231,7 @@ const void LuaWidgetFactory::parseOptionDefaults() const
               option->min.signedValue = luaL_checkinteger(lsWidgets, -1);
             } else if (option->type == ZoneOption::Choice) {
               luaL_checktype(lsWidgets, -1, LUA_TTABLE); // value is a table
+              option->choiceValues.clear();
               for (lua_pushnil(lsWidgets); lua_next(lsWidgets, -2); lua_pop(lsWidgets, 1)) {
                 option->choiceValues.push_back(luaL_checkstring(lsWidgets, -1));
               }


### PR DESCRIPTION
Clear list before reloading choice values.