### PR TITLE
feat: force gimbal detection on serial passthrough init

### DIFF
--- a/radio/src/cli.cpp
+++ b/radio/src/cli.cpp
@@ -1115,7 +1115,7 @@ static void spGimbalDeInit(int port_n)
 {
   (void)port_n;
   _sp_drv->deinit(_sp_ctx);
-  flysky_gimbal_init();
+  flysky_gimbal_init(true);
 }
 #endif
 

--- a/radio/src/targets/common/arm/stm32/flysky_gimbal_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/flysky_gimbal_driver.cpp
@@ -165,7 +165,7 @@ void flysky_gimbal_deinit()
   STM32SerialDriver.deinit(_fs_usart_ctx);
 }
 
-bool flysky_gimbal_init()
+bool flysky_gimbal_init(bool force)
 {
   etx_serial_init cfg = {
     .baudrate = FLYSKY_HALL_BAUDRATE,
@@ -174,7 +174,7 @@ bool flysky_gimbal_init()
     .polarity = ETX_Pol_Normal,
   };
 
-  _fs_gimbal_detected = false;
+  _fs_gimbal_detected = force;
   _fs_usart_ctx = STM32SerialDriver.init(REF_STM32_SERIAL_PORT(FSGimbal), &cfg);
   STM32SerialDriver.setIdleCb(_fs_usart_ctx, flysky_gimbal_loop, 0);
 

--- a/radio/src/targets/common/arm/stm32/flysky_gimbal_driver.h
+++ b/radio/src/targets/common/arm/stm32/flysky_gimbal_driver.h
@@ -128,7 +128,7 @@ extern signed short hall_raw_values[FLYSKY_HALL_CHANNEL_COUNT];
 extern unsigned short hall_adc_values[FLYSKY_HALL_CHANNEL_COUNT];
 
 // returns true if the gimbals were detected properly
-bool flysky_gimbal_init();
+bool flysky_gimbal_init(bool force = false);
 
 void flysky_gimbal_deinit();
 const etx_serial_port_t* flysky_gimbal_get_port();


### PR DESCRIPTION
Currently, when enabling serialpassthrough gimbals, an automatic detection of gimbal is made like when radio starts. If for some reason, the gimbal doesn't behave like it uses to (like a failed update), the serial port will be disabled.

Will this change, calling serialpassthrough gimbals will bypass gimbal detection and assumes it is present.

This is needed in 2.11 too please