### PR TITLE
fix(color): customisable switch name focus outline not cleared when editing using touch

### DIFF
--- a/radio/src/gui/colorlcd/libui/textedit.cpp
+++ b/radio/src/gui/colorlcd/libui/textedit.cpp
@@ -38,6 +38,15 @@ class TextArea : public FormField
     lv_textarea_set_max_length(lvobj, length);
     lv_textarea_set_placeholder_text(lvobj, "---");
 
+    setFocusHandler([=](bool focus) {
+      if (!focus && editMode) {
+        setEditMode(false);
+        hide();
+        lv_group_focus_obj(parent->getLvObj());
+        lv_obj_clear_state(parent->getLvObj(), LV_STATE_FOCUSED);
+      }
+    });
+
     update();
   }
 


### PR DESCRIPTION
Ensure focus is cleared correctly.

Requires a T15 radio or simulator to reproduce (needs custom switches):
- Open 'Customisable Switches' in Model Setup
- Tap on a switch name to open the keyboard
- Tap on another switch name - edit shifts to the second name field; but both show the focus outline.
