### PR TITLE
fix(bw): name display for custom switches may be incorrect.

### DIFF
--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -995,10 +995,13 @@ void menuModelSetup(event_t event)
           pushMenu(menuModelCFSOne);
         }
 
-        if (ZEXIST(g_model.switchNames[index]))
-          lcdDrawText(35, y, g_model.switchNames[index]);
-        else
+        if (ZEXIST(g_model.switchNames[index])) {
+          char s[LEN_SWITCH_NAME + 1];
+          strAppend(s, g_model.switchNames[index], LEN_SWITCH_NAME);
+          lcdDrawText(35, y, s);
+        } else {
           lcdDrawMMM(35, y, 0);
+        }
 
         int config = FSWITCH_CONFIG(index);
         lcdDrawText(30 + 5 * FW, y, STR_SWTYPES[config]);


### PR DESCRIPTION
On radios with custom function switches (GX12, T20V2, etc) the name set by the user may display incorrectly.

To reproduce:
- Set a custom name for both SW1 and SW2
- On the model setup page the name shown for SW1 will be incorrect.
