### PR TITLE
chore(ci): force use of mirrors for Qt for now

### DIFF
--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -56,7 +56,9 @@ jobs:
         run: cmake -E make_directory ${{github.workspace}}/build
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v3
+        uses: jdpurcell/install-qt-action@v5
+        env:
+          AQT_CONFIG: ${{ github.workspace }}/tools/aqt-settings.ini
         with:
           version: ${{ env.QT_VERSION }}
           setup-python: 'false'

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -62,6 +62,8 @@ jobs:
         with:
           version: ${{ env.QT_VERSION }}
           setup-python: 'false'
+          cache: true
+          cache-key-prefix: 'install-qt-action-macOS'
 
       - name: Install dependencies
         run: python3 -m pip install --upgrade pip Pillow lz4 clang jinja2

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -45,10 +45,10 @@ jobs:
         with:
           submodules: recursive
 
-      - name: Setup Python 3.9
+      - name: Setup Python 3.12
         uses: actions/setup-python@v5
         with:
-          python-version: '3.9'
+          python-version: '3.12'
 
       - name: Create Build Environment
         # Some projects don't allow in-source building, so create a separate build directory

--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -70,7 +70,9 @@ jobs:
           python -m pip install clang jinja2
 
       - name: Install Qt
-        uses: jurplel/install-qt-action@v3
+        uses: jdpurcell/install-qt-action@v5
+        env:
+          AQT_CONFIG: ${{ github.workspace }}/tools/aqt-settings.ini
         with:
           cache: true
           cache-key-prefix: 'install-qt-action-win64'

--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -69,6 +69,11 @@ jobs:
                                 mingw-w64-x86_64-openssl
           python -m pip install clang jinja2
 
+      - name: Check out the repo
+        uses: actions/checkout@v4
+        with:
+          submodules: recursive
+
       - name: Install Qt
         uses: jdpurcell/install-qt-action@v5
         env:
@@ -78,11 +83,6 @@ jobs:
           cache-key-prefix: 'install-qt-action-win64'
           version: ${{ env.QT_VERSION }}
           arch: ${{ env.MINGW_VERSION }}
-
-      - name: Check out the repo
-        uses: actions/checkout@v4
-        with:
-          submodules: recursive
 
       - name: Build
         working-directory: ${{github.workspace}}

--- a/tools/aqt-settings.ini
+++ b/tools/aqt-settings.ini
@@ -1,0 +1,17 @@
+[aqt]
+# Using this mirror instead of download.qt.io because of timeouts in CI
+# Below is the default URL of the mirror
+# baseurl: https://download.qt.io
+baseurl: https://qt.mirror.constant.com
+
+[requests]
+# Mirrors require sha1 instead of sha256
+hash_algorithm: sha1
+
+[mirrors]
+trusted_mirrors:
+    https://qt.mirror.constant.com
+fallbacks:
+    https://qt.mirror.constant.com
+    https://mirrors.ocf.berkeley.edu
+    https://download.qt.io


### PR DESCRIPTION
- uses alternate action to allow for automatic caching to work again, as well as newer aqtinstall verison
- enable automatic caching for macOS builds
- macOS build needed python version bump (3.12, same as in use for win64) due to newer aqtinstall
- force use of backup mirrors for QT libraries via config file

Nothing needed for Linux build as QT libraries are included in the build environment.

QT server is still flutuating at the moment