### PR TITLE
fix(color): build-breaking typo in startup_shutdown.cpp

### DIFF
--- a/radio/src/gui/colorlcd/startup_shutdown.cpp
+++ b/radio/src/gui/colorlcd/startup_shutdown.cpp
@@ -31,7 +31,7 @@ extern void checkSpeakerVolume();
 const std::string ver_str = "" VERSION_TAG;
 const std::string nam_str = "" CODENAME;
 #if PORTRAIT_LCD
-#define TXT_Y (LCD_H * 21 / 25))
+#define TXT_Y (LCD_H * 21 / 25)
 #else
 #define TXT_Y (LCD_H * 3 / 4)
 #endif


### PR DESCRIPTION
removed an extra closing parenthesis in the TXT_Y macro definition introduced in #6012
