### PR TITLE
fix: don't deinit non initialised Flysky gimbal interface

### DIFF
--- a/radio/src/targets/common/arm/stm32/flysky_gimbal_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/flysky_gimbal_driver.cpp
@@ -162,7 +162,10 @@ static void flysky_gimbal_loop(void*)
 
 void flysky_gimbal_deinit()
 {
-  STM32SerialDriver.deinit(_fs_usart_ctx);
+  if (_fs_usart_ctx != nullptr) {
+    STM32SerialDriver.deinit(_fs_usart_ctx);
+  }
+  _fs_usart_ctx = 0;
 }
 
 bool flysky_gimbal_init(bool force)


### PR DESCRIPTION
Prevent EM when trying do deinit gimbal serial driver through serial passthrough (VCP) when boot gimbal detection did fail and already did deinit the serial port. 

This complement #6089, and has been tested by RM.

I know it's late in the process, by is needed in 2.11