### PR TITLE
fix(color): LVGL file picker may crash if 'get' function is not set in Lua

### DIFF
--- a/radio/src/lua/lua_lvgl_widget.cpp
+++ b/radio/src/lua/lua_lvgl_widget.cpp
@@ -330,7 +330,7 @@ void LvglWidgetObjectBase::pcallSetIntVal(lua_State *L, int setFuncRef, int val)
 
 const char* LvglWidgetObjectBase::pcallGetStringVal(lua_State *L, int getFuncRef)
 {
-  const char* val = nullptr;
+  const char* val = "";
   if (getFuncRef != LUA_REFNIL) {
     auto save = luaScriptManager;
     luaScriptManager = lvglManager;


### PR DESCRIPTION
Don't pass null to file picker for selected filename.