### PR TITLE
fix(bw): changing some model and radio settings does not update corresponding yaml file.

### DIFF
--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -690,6 +690,7 @@ void menuModelCFSOne(event_t event)
           if (config == SWITCH_TOGGLE) {
             FSWITCH_SET_STARTUP(cfsIndex, FS_START_PREVIOUS);  // Toggle switches do not have startup position
           }
+          storageDirty(EE_MODEL);
         }
         break;
 
@@ -709,6 +710,7 @@ void menuModelCFSOne(event_t event)
             FSWITCH_SET_STARTUP(cfsIndex, FS_START_PREVIOUS);
           }
           setGroupSwitchState(oldGroup);
+          storageDirty(EE_MODEL);
         }
         break;
 
@@ -718,6 +720,7 @@ void menuModelCFSOne(event_t event)
         if (attr) {
           startPos = checkIncDec(event, startPos, FS_START_ON, FS_START_PREVIOUS, EE_MODEL);
           FSWITCH_SET_STARTUP(cfsIndex, startPos);
+          storageDirty(EE_MODEL);
         }
         break;
 

--- a/radio/src/gui/common/stdlcd/menus.cpp
+++ b/radio/src/gui/common/stdlcd/menus.cpp
@@ -59,7 +59,7 @@ void pushMenu(MenuHandlerFunc newMenu)
   killAllEvents();
 
   if (menuLevel == 0) {
-    if (newMenu == menuRadioSetup)
+    if (newMenu == menuTabGeneral[0].menuFunc)
       menuVerticalPositions[0] = 1;
     if (newMenu == menuModelSelect)
       menuVerticalPositions[0] = 0;

--- a/radio/src/gui/common/stdlcd/radio_hardware.cpp
+++ b/radio/src/gui/common/stdlcd/radio_hardware.cpp
@@ -516,7 +516,7 @@ void menuRadioHardware(event_t event)
             flags = menuHorizontalPosition == 2 ? attr : 0;
             bool potinversion = getPotInversion(idx);
             lcdDrawChar(LCD_W - 8, y, potinversion ? 127 : 126, flags);
-            if (flags & (~RIGHT)) potinversion = checkIncDec(event, potinversion, 0, 1, (isModelMenuDisplayed()) ? EE_MODEL : EE_GENERAL);
+            if (flags & (~RIGHT)) potinversion = checkIncDec(event, potinversion, 0, 1, EE_GENERAL);
             setPotInversion(idx, potinversion);
           } else if (getPotInversion(idx)) {
             setPotInversion(idx, 0);
@@ -537,7 +537,7 @@ void menuRadioHardware(event_t event)
             flags = menuHorizontalPosition == 0 ? attr : 0;
             auto source = switchGetFlexConfig(index);
             lcdDrawText(HW_SETTINGS_COLUMN1, y, (source < 0) ? STR_NONE : adcGetInputLabel(ADC_INPUT_FLEX, source), flags);
-            if (flags & (~RIGHT)) source = checkIncDec(event, source, -1, adcGetMaxInputs(ADC_INPUT_FLEX) - 1, (isModelMenuDisplayed()) ? EE_MODEL : EE_GENERAL, isFlexSwitchSourceValid);
+            if (flags & (~RIGHT)) source = checkIncDec(event, source, -1, adcGetMaxInputs(ADC_INPUT_FLEX) - 1, EE_GENERAL, isFlexSwitchSourceValid);
             switchConfigFlex(index, source);
 
             //Name
@@ -561,6 +561,7 @@ void menuRadioHardware(event_t event)
               g_eeGeneral.switchConfig =
                   (g_eeGeneral.switchConfig & ~mask) |
                   ((swconfig_t(config) & SW_CFG_MASK) << (SW_CFG_BITS * index));
+              storageDirty(EE_GENERAL);
             }
           }
           else {
@@ -584,6 +585,7 @@ void menuRadioHardware(event_t event)
               g_eeGeneral.switchConfig =
                   (g_eeGeneral.switchConfig & ~mask) |
                   ((swconfig_t(config) & SW_CFG_MASK) << (SW_CFG_BITS * index));
+              storageDirty(EE_GENERAL);
             }
           }
         } else if (k <= ITEM_RADIO_HARDWARE_SERIAL_PORT_END) {


### PR DESCRIPTION
Issues:
- Editing model custom function switch settings did not set dirty flag for model
- Editing switch type did not set dirty flag for radio settings.
- Logic to determine whether model or radio settings page was loaded was wrong, so changing radio settings flags the model file as dirty instead.

Easiest to see in the simulator trace log.
