### PR TITLE
fix(radio): half-duplex UART

### DIFF
--- a/radio/src/boards/generic_stm32/module_ports.cpp
+++ b/radio/src/boards/generic_stm32/module_ports.cpp
@@ -293,9 +293,15 @@ static const stm32_usart_t sportUSART = {
   .txDMA = TELEMETRY_DMA,
   .txDMA_Stream = TELEMETRY_DMA_Stream_TX,
   .txDMA_Channel = TELEMETRY_DMA_Channel_TX,
+#if defined(TELEMETRY_DMA_Stream_RX)
+  .rxDMA = TELEMETRY_DMA,
+  .rxDMA_Stream = TELEMETRY_DMA_Stream_RX,
+  .rxDMA_Channel = TELEMETRY_DMA_Channel_RX,
+#else
   .rxDMA = nullptr,
   .rxDMA_Stream = 0,
   .rxDMA_Channel = 0,
+#endif
 #if defined(STM32H7) || (STM32H7RS)
   .set_input = nullptr,
 #else

--- a/radio/src/targets/common/arm/stm32/stm32_usart_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_usart_driver.cpp
@@ -591,6 +591,7 @@ void stm32_usart_send_buffer(const stm32_usart_t* usart, const uint8_t * data, u
 
     if (IS_HALF_DUPLEX(usart) && (int32_t)(usart->txDMA_IRQn) >= 0) {
       LL_DMA_EnableIT_TC(usart->txDMA, usart->txDMA_Stream);
+      LL_USART_ClearFlag_TC(usart->USARTx);
     }
     LL_DMA_EnableStream(usart->txDMA, usart->txDMA_Stream);
 #endif // !STM32H7RS
@@ -795,13 +796,5 @@ void stm32_usart_tx_dma_isr(const stm32_usart_t* usart)
     return;
 
   auto USARTx = usart->USARTx;
-
-  // clear TC flag before enabling USART TC interrupt:
-  //  -> TC flag will be re-triggered once the last byte which has
-  //     just been transfered from DMA to USART will be transmitted,
-  //     thus triggering TELEMETRY_USART_IRQHandler(), which will
-  //     switch from output to input mode.
-  //
-  LL_USART_ClearFlag_TC(USARTx);
   LL_USART_EnableIT_TC(USARTx);
 }


### PR DESCRIPTION
Summary of changes:
- force idle level via internal pull-up/down on H7.
- fix a race condition between DMA TC IRQ and actual UART TC.
- enable RX DMA on S.PORT where possible.
- improved DMA buffer detection in UART send.
