### PR TITLE
fix(pl18/pl18ev): YAML datastructs not updated properly

### DIFF
--- a/radio/src/storage/yaml/yaml_datastructs_pl18.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_pl18.cpp
@@ -786,23 +786,23 @@ static const struct YamlNode struct_WidgetPersistentData[] = {
 };
 static const struct YamlNode struct_ZonePersistentData[] = {
   YAML_IDX,
-  YAML_STRING("widgetName", 12),
+  YAML_STRING("widgetName", 20),
   YAML_STRUCT("widgetData", 1280, struct_WidgetPersistentData, NULL),
   YAML_END
 };
 static const struct YamlNode struct_LayoutPersistentData[] = {
-  YAML_ARRAY("zones", 1376, 10, struct_ZonePersistentData, NULL),
+  YAML_ARRAY("zones", 1440, 10, struct_ZonePersistentData, NULL),
   YAML_ARRAY("options", 128, 10, struct_ZoneOptionValueTyped, NULL),
   YAML_END
 };
 static const struct YamlNode struct_CustomScreenData[] = {
   YAML_IDX,
   YAML_STRING("LayoutId", 12),
-  YAML_STRUCT("layoutData", 15040, struct_LayoutPersistentData, NULL),
+  YAML_STRUCT("layoutData", 15680, struct_LayoutPersistentData, NULL),
   YAML_END
 };
 static const struct YamlNode struct_TopBarPersistentData[] = {
-  YAML_ARRAY("zones", 1376, 6, struct_ZonePersistentData, NULL),
+  YAML_ARRAY("zones", 1440, 6, struct_ZonePersistentData, NULL),
   YAML_ARRAY("options", 128, 1, struct_ZoneOptionValueTyped, NULL),
   YAML_END
 };
@@ -868,8 +868,8 @@ static const struct YamlNode struct_ModelData[] = {
   YAML_UNSIGNED( "potsWarnEnabled", 16 ),
   YAML_ARRAY("potsWarnPosition", 8, 16, struct_signed_8, NULL),
   YAML_ARRAY("telemetrySensors", 112, 60, struct_TelemetrySensor, NULL),
-  YAML_ARRAY("screenData", 15136, 10, struct_CustomScreenData, NULL),
-  YAML_STRUCT("topbarData", 8384, struct_TopBarPersistentData, NULL),
+  YAML_ARRAY("screenData", 15776, 10, struct_CustomScreenData, NULL),
+  YAML_STRUCT("topbarData", 8768, struct_TopBarPersistentData, NULL),
   YAML_ARRAY("topbarWidgetWidth", 8, 6, struct_unsigned_8, NULL),
   YAML_UNSIGNED( "view", 8 ),
   YAML_STRING("modelRegistrationID", 8),

--- a/tools/generate-yaml.sh
+++ b/tools/generate-yaml.sh
@@ -11,7 +11,7 @@ if [[ -n ${GCC_ARM} ]] ; then
   export PATH=${GCC_ARM}:$PATH
 fi
 
-: ${FLAVOR:="t15;tx16s;nv14;pl18;nb4p;x9d;x9dp2019;x9e;xlite;xlites;x7;tpro;t20;f16;gx12;st16"}
+: ${FLAVOR:="t15;tx16s;pl18;nv14;nb4p;x9d;x9dp2019;x9e;xlite;xlites;x7;tpro;t20;f16;gx12;st16"}
 : ${SRCDIR:=$(dirname "$(pwd)/$0")/..}
 
 : ${COMMON_OPTIONS:="-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_RULE_MESSAGES=OFF -Wno-dev -DDISABLE_COMPANION=YES -DCMAKE_MESSAGE_LOG_LEVEL=WARNING"}


### PR DESCRIPTION
The PL18 yaml datastruct is not updated properly.  Seems the order of generation will affect the generation of PL18 datastruct.
