### PR TITLE
feat(simu): add support for (RGB!!) customisable  switches

### DIFF
--- a/radio/src/simu.cpp
+++ b/radio/src/simu.cpp
@@ -113,7 +113,9 @@ OpenTxSim::OpenTxSim(FXApp* a):
 #endif
 
   FXHorizontalFrame * hf11 = new FXHorizontalFrame(this, LAYOUT_CENTER_X);
+#if defined(FUNCTION_SWITCHES)
   FXHorizontalFrame * hf12 = new FXHorizontalFrame(this, LAYOUT_CENTER_X);
+#endif
   FXHorizontalFrame * hf1 = new FXHorizontalFrame(this, LAYOUT_FILL_X);
 
   //rh lv rv lh
@@ -147,7 +149,7 @@ OpenTxSim::OpenTxSim(FXApp* a):
     knobs[i]->setRange(0, 4095);
     knobs[i]->setValue(2047);
 
-#if defined(PCBHORUS) && !defined(PCBST16)
+#if defined(PCBHORUS) && !defined(FUNCTION_SWITCHES)
     if (i == 1) {  // 6-pos switch
       knobs[i]->setIncrement(4095 / 5);
       knobs[i]->setTickDelta(4095 / 5);
@@ -624,9 +626,11 @@ void OpenTxSim::refreshDisplay()
 
 void OpenTxSim::fsLedRGB(uint8_t idx, uint32_t color)
 {
+#if defined(FUNCTION_SWITCHES)
   uint32_t col = (color&0x00FF0000)>>16 | (color&0x0000FF00) | (color&0x000000FF)<<16;
   fctButtons[idx]->setBaseColor(col);
   fctButtons[idx]->setBackColor(col);
+#endif
 }
 
 OpenTxSim * opentxSim;

--- a/radio/src/targets/simu/led_driver.cpp
+++ b/radio/src/targets/simu/led_driver.cpp
@@ -28,9 +28,9 @@ void ledRed() {}
 void ledGreen() {}
 void ledBlue() {}
 void ledOff() {}
-void fsLedOn(uint8_t) {}
-void fsLedOff(uint8_t) {}
-void fsLedRGB(uint8_t, uint32_t) {}
+__attribute__((weak)) void fsLedOn(uint8_t) {}
+__attribute__((weak)) void fsLedOff(uint8_t) {}
+__attribute__((weak)) void fsLedRGB(uint8_t, uint32_t) {}
 bool fsLedState(uint8_t) { return false;}
 void rgbSetLedColor(unsigned char, unsigned char, unsigned char, unsigned char) {}
 void rgbLedColorApply() {}

--- a/radio/src/targets/simu/switch_driver.cpp
+++ b/radio/src/targets/simu/switch_driver.cpp
@@ -66,8 +66,8 @@ SwitchHwPos boardSwitchGetPosition(SwitchCategory cat, uint8_t idx)
   idx = get_switch_index(cat, idx);
 
 #if defined(FUNCTION_SWITCHES)
-  if (IS_SWITCH_FS(idx + n_switches)) {
-    if (bfSingleBitGet(functionSwitchFunctionState, idx))
+  if (IS_SWITCH_FS(idx)) {
+    if (bfSingleBitGet(functionSwitchFunctionState, idx - n_switches))
       return SWITCH_HW_DOWN;
   }
 #endif


### PR DESCRIPTION
with this PR function switches are displayed as buttons in the simu UI. Button colors are updated to reflect the model settings.
![grafik](https://github.com/user-attachments/assets/894b8e6a-aa56-4e01-9857-745313be9cfe)

For radios without RGB-LEDs the buttons are either black or white