### PR TITLE
fix(cpn): widget options may not be saved when models loaded from radio

### DIFF
--- a/companion/src/firmwares/customisation_data.h
+++ b/companion/src/firmwares/customisation_data.h
@@ -37,7 +37,7 @@ constexpr int LEN_ZONE_OPTION_STRING  {8};
 constexpr int MAX_LAYOUT_ZONES        {10};
 constexpr int MAX_LAYOUT_OPTIONS      {10};
 constexpr int WIDGET_NAME_LEN         {20};
-constexpr int MAX_WIDGET_OPTIONS      {5};
+constexpr int MAX_WIDGET_OPTIONS      {10};
 constexpr int MAX_TOPBAR_ZONES        {6};  //  max 4 used for portrait
 constexpr int MAX_TOPBAR_OPTIONS      {1};
 constexpr int LAYOUT_ID_LEN           {12};


### PR DESCRIPTION
Fixes #6128 

Increase the number of widget options to match firmware.
Missed in #5365 
