### PR TITLE
fix(libsim): use different `__weak` syntax depending on target

### DIFF
--- a/radio/src/targets/simu/led_driver.cpp
+++ b/radio/src/targets/simu/led_driver.cpp
@@ -23,14 +23,20 @@
 #include "hal/rgbleds.h"
 #include "definitions.h"
 
+#if defined(SIMU)
+  #define __weak
+#elif !defined(__weak)
+  #define __weak __attribute__((weak))
+#endif
+
 bool usbChargerLed() { return true; }
 void ledRed() {}
 void ledGreen() {}
 void ledBlue() {}
 void ledOff() {}
-__attribute__((weak)) void fsLedOn(uint8_t) {}
-__attribute__((weak)) void fsLedOff(uint8_t) {}
-__attribute__((weak)) void fsLedRGB(uint8_t, uint32_t) {}
+__weak void fsLedOn(uint8_t) {}
+__weak void fsLedOff(uint8_t) {}
+__weak void fsLedRGB(uint8_t, uint32_t) {}
 bool fsLedState(uint8_t) { return false;}
 void rgbSetLedColor(unsigned char, unsigned char, unsigned char, unsigned char) {}
 void rgbLedColorApply() {}


### PR DESCRIPTION
Summary of changes:
- use same conditional `__weak` directives used elsewhere in code
