### PR TITLE
fix: tlite vbat voltage

### DIFF
--- a/radio/src/targets/taranis/board.h
+++ b/radio/src/targets/taranis/board.h
@@ -355,7 +355,10 @@ void setTopBatteryValue(uint32_t volts);
 
 #define INTMODULE_FIFO_SIZE            128
 
-#if defined(MANUFACTURER_RADIOMASTER) || defined(MANUFACTURER_JUMPER)
+#if defined(RADIO_TLITE)
+  #define BATTERY_DIVIDER 27500    // TODO: fix when we have proper schematics
+  #define VOLTAGE_DROP 20
+#elif defined(MANUFACTURER_RADIOMASTER) || defined(MANUFACTURER_JUMPER)
 // --- MOSFET ---- R2 --- MCU
 //                     |__ R1 --- GND
 //


### PR DESCRIPTION
This is a quick and dirty fix for TLite main voltage display. Unfortunately, the schematics we have do not allo proper encoding of the divider, so this is an empiric reverse engineering.

If/when we get proper schematics, will issue a follow up