### PR TITLE
fix(ci): add missing fw build, correct v14 switch defs

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -109,7 +109,7 @@ jobs:
           - tx12;tx12mk2;boxer;gx12
           - tx16s
           - f16
-          - v16
+          - v12;v14;v16
           - x10;x10express
           - x12s
           - x7;x7access

--- a/radio/util/build-firmware.py
+++ b/radio/util/build-firmware.py
@@ -199,6 +199,16 @@ def main():
         cmake_options["PCBREV"] = "F16"
         firmware_options = options_fatfish_f16
         maxsize = 2 * 1024 * 1024
+    elif board_name == "v12":
+        cmake_options["PCB"] = "X7"
+        cmake_options["PCBREV"] = "V12"
+        firmware_options = options_helloradiosky_v12
+        maxsize = 65536 * 8 * 2
+    elif board_name == "v14":
+        cmake_options["PCB"] = "X7"
+        cmake_options["PCBREV"] = "V14"
+        firmware_options = options_helloradiosky_v14
+        maxsize = 65536 * 8 * 2
     elif board_name == "v16":
         cmake_options["PCB"] = "X10"
         cmake_options["PCBREV"] = "V16"

--- a/radio/util/fwoptions.py
+++ b/radio/util/fwoptions.py
@@ -331,6 +331,30 @@ options_fatfish_f16 = {
     "externalaccessmod": ("HARDWARE_EXTERNAL_ACCESS_MOD", "YES", "NO"),
 }
 
+options_helloradiosky_v12 = {
+    "noheli": ("HELI", "NO", "YES"),
+    "lua": ("LUA", "YES", "NO_MODEL_SCRIPTS"),
+    "nogvars": ("GVARS", "NO", "YES"),
+    "faimode": ("FAI", "YES", None),
+    "faichoice": ("FAI", "CHOICE", None),
+    "nooverridech": ("OVERRIDE_CHANNEL_FUNCTION", "NO", "YES"),
+    "flexr9m": ("MODULE_PROTOCOL_FLEX", "YES", None),
+    "afhds3": ("AFHDS3", "YES", "NO"),
+    "internalelrs": ("INTERNAL_MODULE_ELRS", "YES", "NO"),
+}
+
+options_helloradiosky_v14 = {
+    "noheli": ("HELI", "NO", "YES"),
+    "lua": ("LUA", "YES", "NO_MODEL_SCRIPTS"),
+    "nogvars": ("GVARS", "NO", "YES"),
+    "faimode": ("FAI", "YES", None),
+    "faichoice": ("FAI", "CHOICE", None),
+    "nooverridech": ("OVERRIDE_CHANNEL_FUNCTION", "NO", "YES"),
+    "flexr9m": ("MODULE_PROTOCOL_FLEX", "YES", None),
+    "afhds3": ("AFHDS3", "YES", "NO"),
+    "internalelrs": ("INTERNAL_MODULE_ELRS", "YES", "NO"),
+}
+
 options_helloradiosky_v16 = {
     "noheli": ("HELI", "NO", "YES"),
     "lua": ("LUA", "YES", "NO_MODEL_SCRIPTS"),

--- a/radio/util/hw_defs/switch_config.py
+++ b/radio/util/hw_defs/switch_config.py
@@ -111,11 +111,11 @@ SWITCH_CONFIG = {
     },
     "v14": {
         # left side
-        "SA": {"default": "3POS",   "display": [0, 0]},
+        "SA": {"default": "2POS",   "display": [0, 0]},
         "SB": {"default": "3POS",   "display": [0, 1]},
         "SE": {"default": "2POS",   "display": [0, 2]},
         # right side
-        "SC": {"default": "3POS",   "display": [1, 0]},
+        "SC": {"default": "2POS",   "display": [1, 0]},
         "SD": {"default": "3POS",   "display": [1, 1]},
         "SF": {"default": "TOGGLE", "display": [1, 2]},
     },


### PR DESCRIPTION
Summary of changes:
 - add missed v12/v14 builds - missed in #5494
 - fix v14 default switch options
 - add v12/v14 to build_firmware python script
