### PR TITLE
fix(horus): detection for Flysky Hall Gimbals not working

### DIFF
--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -195,13 +195,14 @@ void boardInit()
   switchInit();
   rotaryEncoderInit();
 
-  bool fsGimbalsDetected=false;
-#if defined(FLYSKY_GIMBAL)
-  fsGimbalsDetected = flysky_gimbal_init();
-#endif
-
-#if defined(PWM_STICKS)
-  if (!fsGimbalsDetected) sticksPwmDetect();
+#if defined(FLYSKY_GIMBAL) && defined(PWM_STICKS)
+  if (!flysky_gimbal_init()) {
+    sticksPwmDetect();
+  }
+#elif defined(FLYSKY_GIMBAL)
+  flysky_gimbal_init();
+#elif defined(PWM_STICKS)
+  sticksPwmDetect();
 #endif
 
   if (!adcInit(&_adc_driver))

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -195,13 +195,13 @@ void boardInit()
   switchInit();
   rotaryEncoderInit();
 
-  bool fsgimbals=false;
+  bool fsGimbalsDetected=false;
 #if defined(FLYSKY_GIMBAL)
-  fsgimbals = flysky_gimbal_init();
+  fsGimbalsDetected = flysky_gimbal_init();
 #endif
 
 #if defined(PWM_STICKS)
-  if (!fsgimbals) sticksPwmDetect();
+  if (!fsGimbalsDetected) sticksPwmDetect();
 #endif
 
   if (!adcInit(&_adc_driver))

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -195,12 +195,13 @@ void boardInit()
   switchInit();
   rotaryEncoderInit();
 
-#if defined(PWM_STICKS)
-  sticksPwmDetect();
-#endif
-  
+  bool fsgimbals=false;
 #if defined(FLYSKY_GIMBAL)
-  flysky_gimbal_init();
+  fsgimbals = flysky_gimbal_init();
+#endif
+
+#if defined(PWM_STICKS)
+  if (!fsgimbals) sticksPwmDetect();
 #endif
 
   if (!adcInit(&_adc_driver))


### PR DESCRIPTION
Fixes # https://github.com/EdgeTX/edgetx/issues/4859

Summary of changes:
On Horus Radios with PWM_STICKS the optional support for the Flysky Hall gimbals is disfunctional since 2.10. The problem is that both use the same GPIOs. With sticksPwmDetect() the GPIOs get blocked thus flysky_gimbal_init() does not work any more. So I turned the order to first look for the Flysky Gimbals and go to PWM_Sticks if not found.