### PR TITLE
chore: test edgetx/build-edgetx#24

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -74,7 +74,7 @@ jobs:
           - nb4p
           - st16
     container:
-      image: ghcr.io/edgetx/edgetx-dev:latest
+      image: ghcr.io/edgetx/edgetx-dev:pr-24
       volumes:
         - ${{ github.workspace }}:/src
     steps:
@@ -121,7 +121,7 @@ jobs:
           - nb4p
           - st16
     container:
-      image: ghcr.io/edgetx/edgetx-dev:latest
+      image: ghcr.io/edgetx/edgetx-dev:pr-24
       volumes:
         - ${{ github.workspace }}:/src
     steps:


### PR DESCRIPTION
Only testing fw build / tests-radio, as cpn has it's own PR. Basically expecting radio tests to fail due to pillow version change. 

Summary of changes:
-  testing edgetx/build-edgetx#24