### PR TITLE
chore(radio): small board cleanup

### DIFF
--- a/radio/src/boards/generic_stm32/module_ports.cpp
+++ b/radio/src/boards/generic_stm32/module_ports.cpp
@@ -29,8 +29,15 @@
 #include "trainer_driver.h"
 
 #include "module_ports.h"
+#include "intmodule_heartbeat.h"
+
 #include "board.h"
 #include "dataconstants.h"
+
+#include "pulses/pulses.h"
+#include "pulses/pxx1.h"
+
+#include "trainer.h"
 
 #if defined (HARDWARE_INTERNAL_MODULE)
 #if defined(INTMODULE_USART)
@@ -615,6 +622,17 @@ void boardInitModulePorts()
     gpio_init(EXTMODULE_PWR_FIX_GPIO, GPIO_OD, GPIO_PIN_SPEED_LOW);
     gpio_set(EXTMODULE_PWR_FIX_GPIO);
   }
+#endif
+
+#if defined(INTERNAL_MODULE_PXX1) && defined(PXX_FREQUENCY_HIGH)
+  pxx1SetInternalBaudrate(PXX1_FAST_SERIAL_BAUDRATE);
+#endif
+
+#if defined(INTMODULE_HEARTBEAT) &&                                     \
+  (defined(INTERNAL_MODULE_PXX1) || defined(INTERNAL_MODULE_PXX2))
+  pulsesSetModuleInitCb(_intmodule_heartbeat_init);
+  pulsesSetModuleDeInitCb(_intmodule_heartbeat_deinit);
+  trainerSetChangeCb(_intmodule_heartbeat_trainer_hook);
 #endif
 }
 

--- a/radio/src/pulses/pulses.h
+++ b/radio/src/pulses/pulses.h
@@ -24,12 +24,15 @@
 #include "definitions.h"
 #include "dataconstants.h"
 #include "pulses_common.h"
-#include "modules_helpers.h"
 #include "hal/module_driver.h"
 
 #if defined(PXX2)
 #include "pxx2.h"
 #include "pxx2_ota.h"
+#endif
+
+#if defined(MULTIMODULE)
+#include "telemetry/multi.h"
 #endif
 
 #if defined(DSM2)

--- a/radio/src/storage/storage.h
+++ b/radio/src/storage/storage.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include "edgetx_types.h"
+
 #if defined(SIMU)
   #define WRITE_DELAY_10MS 100
 #elif defined(RTC_BACKUP_RAM)

--- a/radio/src/targets/common/arm/stm32/usb_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/usb_driver.cpp
@@ -85,7 +85,7 @@ void setSelectedUsbMode(int mode)
 int usbPlugged()
 {
 #if defined(DEBUG_DISABLE_USB)
-  return(false);
+  return false;
 #endif
 
   static uint8_t debouncedState = 0;
@@ -135,6 +135,8 @@ void usbInit()
 #else
   gpio_init(USB_GPIO_VBUS, GPIO_IN, GPIO_PIN_SPEED_LOW);
 #endif
+  // prime debounce state...
+  usbPlugged();
 #endif
 
 // TODO: seems this is only needed for USB wakeup,

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -141,51 +141,45 @@ uint16_t getSixPosAnalogValue(uint16_t adcValue)
 
 void boardInit()
 {
+  delaysInit();
+  timersInit();
+  __enable_irq();
+
 #if defined(RADIO_FAMILY_T16)
   void board_set_bor_level();
   board_set_bor_level();
 #endif
 
-#if defined(MANUFACTURER_JUMPER) && defined(FUNCTION_SWITCHES) && !defined(DEBUG)
-  // This is needed to prevent radio from starting when usb is plugged to charge
   usbInit();
-  // prime debounce state...
-   usbPlugged();
-   if (usbPlugged()) {
-     delaysInit();
- #if defined(AUDIO_MUTE_GPIO)
-     // Charging can make a buzzing noise
-     gpio_init(AUDIO_MUTE_GPIO, GPIO_OUT, GPIO_PIN_SPEED_LOW);
-     gpio_set(AUDIO_MUTE_GPIO);
- #endif
-     while (usbPlugged()) {
-       delay_ms(1000);
-     }
-     while(1) // Wait power to drain
-       pwrOff();
-   }
+
+#if defined(MANUFACTURER_JUMPER) && defined(FUNCTION_SWITCHES) && \
+    !defined(DEBUG)
+  // This is needed to prevent radio from starting when usb is plugged to charge
+  if (usbPlugged()) {
+    delaysInit();
+#if defined(AUDIO_MUTE_GPIO)
+    // Charging can make a buzzing noise
+    gpio_init(AUDIO_MUTE_GPIO, GPIO_OUT, GPIO_PIN_SPEED_LOW);
+    gpio_set(AUDIO_MUTE_GPIO);
+#endif
+    while (usbPlugged()) {
+      delay_ms(1000);
+    }
+    pwrOff();
+    // Wait power to drain
+    while (true) {
+    }
+  }
 #endif
 
   pwrInit();
-
-  boardInitModulePorts();
-
-#if defined(INTMODULE_HEARTBEAT) &&                                     \
-  (defined(INTERNAL_MODULE_PXX1) || defined(INTERNAL_MODULE_PXX2))
-  pulsesSetModuleInitCb(_intmodule_heartbeat_init);
-  pulsesSetModuleDeInitCb(_intmodule_heartbeat_deinit);
-  trainerSetChangeCb(_intmodule_heartbeat_trainer_hook);
-#endif
-
-  board_trainer_init();
   pwrOn();
-
-  delaysInit();
-  timersInit();
-  __enable_irq();
 
   TRACE("\nHorus board started :)");
   TRACE("RCC->CSR = %08x", RCC->CSR);
+
+  boardInitModulePorts();
+  board_trainer_init();
 
   audioInit();
   keysInit();
@@ -206,7 +200,6 @@ void boardInit()
   initCSD203();
 #endif
 
-  usbInit();
   hapticInit();
 
 #if defined(LED_STRIP_GPIO)

--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -132,19 +132,6 @@ enum {
 #define EXTERNAL_MODULE_ON()    gpio_set(EXTMODULE_PWR_GPIO)
 #define EXTERNAL_MODULE_OFF()   gpio_clear(EXTMODULE_PWR_GPIO)
 
-#if !defined(PXX2)
-  #define IS_PXX2_INTERNAL_ENABLED()            (false)
-  #define IS_PXX1_INTERNAL_ENABLED()            (true)
-#elif !defined(PXX1)
-  #define IS_PXX2_INTERNAL_ENABLED()            (true)
-  #define IS_PXX1_INTERNAL_ENABLED()            (false)
-#else
-  // TODO #define PXX2_PROBE
-  // TODO #define IS_PXX2_INTERNAL_ENABLED()            (hardwareOptions.pxx2Enabled)
-  #define IS_PXX2_INTERNAL_ENABLED()            (true)
-  #define IS_PXX1_INTERNAL_ENABLED()            (true)
-#endif
-
 // POTS and SLIDERS default configuration
 #if defined(RADIO_TX16S) || defined(RADIO_F16) || defined(RADIO_V16)
 #define XPOS_CALIB_DEFAULT  {0x3, 0xc, 0x15, 0x1e, 0x26}

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -111,13 +111,14 @@ void boardInit()
   LL_APB1_GRP1_EnableClock(AUDIO_RCC_APB1Periph);
   LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_SYSCFG);
 
-#if defined(USB_CHARGE_LED) && !defined(DEBUG)
-  usbInit();
-  // prime debounce state...
-  usbPlugged();
+  delaysInit();
+  timersInit();
+  __enable_irq();
 
+  usbInit();
+
+#if defined(USB_CHARGE_LED) && !defined(DEBUG)
   if (usbPlugged()) {
-    delaysInit();
 #if defined(AUDIO_MUTE_GPIO)
      // Charging can make a buzzing noise
      gpio_init(AUDIO_MUTE_GPIO, GPIO_OUT, GPIO_PIN_SPEED_LOW);
@@ -145,22 +146,6 @@ void boardInit()
   pwrInit();
   boardInitModulePorts();
 
-#if defined(INTERNAL_MODULE_PXX1) && defined(PXX_FREQUENCY_HIGH)
-  pxx1SetInternalBaudrate(PXX1_FAST_SERIAL_BAUDRATE);
-#endif
-
-#if defined(INTMODULE_HEARTBEAT) &&                                     \
-  (defined(INTERNAL_MODULE_PXX1) || defined(INTERNAL_MODULE_PXX2))
-  pulsesSetModuleInitCb(_intmodule_heartbeat_init);
-  pulsesSetModuleDeInitCb(_intmodule_heartbeat_deinit);
-  trainerSetChangeCb(_intmodule_heartbeat_trainer_hook);
-#endif
-  
-// #if defined(AUTOUPDATE)
-//   telemetryPortInit(FRSKY_SPORT_BAUDRATE, TELEMETRY_SERIAL_WITHOUT_DMA);
-//   sportSendByteLoop(0x7E);
-// #endif
-
 #if defined(STATUS_LEDS)
   ledInit();
 #if !defined(POWER_LED_BLUE)
@@ -175,14 +160,7 @@ void boardInit()
 // - function switches and the radio supports charging
 // - single USB for data + charge which powers on radio
 #if defined(MANUFACTURER_JUMPER) && !defined(USB_CHARGE_LED)
-  // This is needed to prevent radio from starting when usb is plugged to charge
-  usbInit();
-  // prime debounce state...
-  usbPlugged();
-
   if (usbPlugged()) {
-    delaysInit();
-    __enable_irq();
     adcInit(&_adc_driver);
     getADC();
     pwrOn();  // required to get bat adc reads
@@ -213,10 +191,6 @@ void boardInit()
   }
 #endif
 
-  delaysInit();
-  timersInit();
-  __enable_irq();
-
   keysInit();
   switchInit();
 
@@ -231,7 +205,6 @@ void boardInit()
 
   lcdInit(); // delaysInit() must be called before
   audioInit();
-  usbInit();
 
 #if defined(LED_STRIP_GPIO)
   rgbLedInit();
@@ -239,10 +212,6 @@ void boardInit()
 
 #if defined(HAPTIC)
   hapticInit();
-#endif
-
-#if defined(PXX2_PROBE)
-  intmodulePxx2Probe();
 #endif
 
 #if defined(DEBUG)
@@ -278,7 +247,6 @@ void boardInit()
 #if defined(RADIO_GX12)
   gpio_init(HALL_SYNC, GPIO_OUT, GPIO_PIN_SPEED_LOW);
 #endif
-
 }
 #endif
 


### PR DESCRIPTION
Summary of changes:
- move "FrSky special" into board specific module port definition.
- init timers & delays first once and for all.
