### PR TITLE
feat(radio): static disk cache

### DIFF
--- a/radio/src/boards/generic_stm32/linker/stm32h750_sdram/extra_sections.ld
+++ b/radio/src/boards/generic_stm32/linker/stm32h750_sdram/extra_sections.ld
@@ -29,6 +29,13 @@
 
 _stext_iram = LOADADDR(.iram);
 
+/* Disk cache buffers */
+.disk_cache (NOLOAD) :
+{
+  . = ALIGN(4);
+  *(.disk_cache)
+} > RAM_D1
+
 /* Extra DMA section */
 .dram (NOLOAD) :
 {

--- a/radio/src/boards/generic_stm32/linker/stm32h7rs_sdram/extra_sections.ld
+++ b/radio/src/boards/generic_stm32/linker/stm32h7rs_sdram/extra_sections.ld
@@ -29,6 +29,13 @@
 
 _stext_iram = LOADADDR(.iram);
 
+/* Disk cache buffers */
+.disk_cache (NOLOAD) :
+{
+  . = ALIGN(4);
+  *(.disk_cache)
+} > PSRAM
+
 /* Extra DMA section */
 .dram (NOLOAD) :
 {

--- a/radio/src/disk_cache.cpp
+++ b/radio/src/disk_cache.cpp
@@ -38,6 +38,10 @@
 #define BLOCK_SIZE FF_MAX_SS
 #define DISK_CACHE_BLOCK_SIZE (DISK_CACHE_BLOCK_SECTORS * BLOCK_SIZE)
 
+#if !defined(__DISK_CACHE)
+#define __DISK_CACHE __SDRAM
+#endif
+
 DiskCache diskCache;
 
 class DiskCacheBlock
@@ -112,9 +116,11 @@ DiskCache::DiskCache() : lastBlock(0), blocks(nullptr), diskDrv(nullptr)
   stats.noWrites = 0;
 }
 
+static DiskCacheBlock _cache_blocks[DISK_CACHE_BLOCKS_NUM] __DISK_CACHE;
+
 void DiskCache::initialize(const diskio_driver_t* drv)
 {
-  blocks = new DiskCacheBlock[DISK_CACHE_BLOCKS_NUM];
+  blocks = _cache_blocks;
   diskDrv = drv;
 }
 

--- a/radio/src/disk_cache.h
+++ b/radio/src/disk_cache.h
@@ -24,8 +24,13 @@
 #include "hal/fatfs_diskio.h"
 
 // tunable parameters
+#if !defined(DISK_CACHE_BLOCKS_NUM)
 #define DISK_CACHE_BLOCKS_NUM      32   // no cache blocks
+#endif
+
+#if !defined(DISK_CACHE_BLOCK_SECTORS)
 #define DISK_CACHE_BLOCK_SECTORS   16   // no sectors
+#endif
 
 struct DiskCacheStats
 {

--- a/radio/src/targets/common/arm/stm32/h7/memory_sections.h
+++ b/radio/src/targets/common/arm/stm32/h7/memory_sections.h
@@ -27,5 +27,4 @@
 #define __IRAM         __attribute__((section(".iram")))
 #define __SDRAM        __attribute__((section(".sdram"), aligned(4)))
 #define __SDRAMFONTS   __attribute__((section(".sdram_fonts"), aligned(4)))
-
-
+#define __DISK_CACHE   __attribute__((section(".disk_cache"), aligned(4)))


### PR DESCRIPTION
Summary of changes:
- enable relocating the disk cache independently of the heap.
- STM32H750: relocate the cache to AXI SRAM.
