### PR TITLE
fix(color): load bootloader bitmaps in bootloaderInitScreen()

### DIFF
--- a/radio/src/gui/colorlcd/bitmaps.cpp
+++ b/radio/src/gui/colorlcd/bitmaps.cpp
@@ -25,8 +25,14 @@
 #include "lz4/lz4.h"
 #include "edgetx_helpers.h"
 
-LZ4BitmapBuffer::LZ4BitmapBuffer(uint8_t format, const LZ4Bitmap* lz4Data) :
+LZ4BitmapBuffer::LZ4BitmapBuffer(uint8_t format) :
     BitmapBuffer(format, 0, 0, nullptr)
+{
+}
+
+LZ4BitmapBuffer::~LZ4BitmapBuffer() { free(data); }
+
+void LZ4BitmapBuffer::load(const LZ4Bitmap* lz4Data)
 {
   _width = lz4Data->width;
   _height = lz4Data->height;
@@ -38,8 +44,6 @@ LZ4BitmapBuffer::LZ4BitmapBuffer(uint8_t format, const LZ4Bitmap* lz4Data) :
                       lz4Data->compressedSize, pixels * sizeof(uint16_t));
   data_end = data + pixels;
 }
-
-LZ4BitmapBuffer::~LZ4BitmapBuffer() { free(data); }
 
 #if !defined(BOOT)
 

--- a/radio/src/gui/colorlcd/bitmaps.h
+++ b/radio/src/gui/colorlcd/bitmaps.h
@@ -154,6 +154,8 @@ struct LZ4Bitmap {
 class LZ4BitmapBuffer : public BitmapBuffer
 {
  public:
-  LZ4BitmapBuffer(uint8_t format, const LZ4Bitmap* compressed_data);
+  LZ4BitmapBuffer(uint8_t format);
   ~LZ4BitmapBuffer();
+
+  void load(const LZ4Bitmap* compressed_data);
 };

--- a/radio/src/targets/horus/bootloader/boot_menu.cpp
+++ b/radio/src/targets/horus/bootloader/boot_menu.cpp
@@ -34,12 +34,12 @@
 const uint8_t __bmp_plug_usb[] {
 #include "bmp_plug_usb.lbm"
 };
-LZ4BitmapBuffer BMP_PLUG_USB(BMP_ARGB4444, (LZ4Bitmap*)__bmp_plug_usb);
+LZ4BitmapBuffer BMP_PLUG_USB(BMP_ARGB4444);
 
 const uint8_t __bmp_usb_plugged[] {
 #include "bmp_usb_plugged.lbm"
 };
-LZ4BitmapBuffer BMP_USB_PLUGGED(BMP_ARGB4444, (LZ4Bitmap*)__bmp_usb_plugged);
+LZ4BitmapBuffer BMP_USB_PLUGGED(BMP_ARGB4444);
 
 #define BL_GREEN      COLOR2FLAGS(RGB(73, 219, 62))
 #define BL_RED        COLOR2FLAGS(RGB(229, 32, 30))
@@ -102,6 +102,9 @@ extern BitmapBuffer * lcd;
 
 void bootloaderInitScreen()
 {
+  BMP_PLUG_USB.load((LZ4Bitmap*)__bmp_plug_usb);
+  BMP_USB_PLUGGED.load((LZ4Bitmap*)__bmp_usb_plugged);
+
   lcdInitDisplayDriver();
 }
 

--- a/radio/src/targets/nv14/bootloader/boot_menu.cpp
+++ b/radio/src/targets/nv14/bootloader/boot_menu.cpp
@@ -45,12 +45,12 @@
 const uint8_t __bmp_plug_usb[] {
 #include "bmp_plug_usb.lbm"
 };
-LZ4BitmapBuffer BMP_PLUG_USB(BMP_ARGB4444, (LZ4Bitmap*)__bmp_plug_usb);
+LZ4BitmapBuffer BMP_PLUG_USB(BMP_ARGB4444);
 
 const uint8_t __bmp_usb_plugged[] {
 #include "bmp_usb_plugged.lbm"
 };
-LZ4BitmapBuffer BMP_USB_PLUGGED(BMP_ARGB4444, (LZ4Bitmap*)__bmp_usb_plugged);
+LZ4BitmapBuffer BMP_USB_PLUGGED(BMP_ARGB4444);
 
 #define BL_GREEN      COLOR2FLAGS(RGB(73, 219, 62))
 #define BL_RED        COLOR2FLAGS(RGB(229, 32, 30))
@@ -64,6 +64,9 @@ static bool rfUsbAccess = false;
 
 void bootloaderInitScreen()
 {
+  BMP_PLUG_USB.load((LZ4Bitmap*)__bmp_plug_usb);
+  BMP_USB_PLUGGED.load((LZ4Bitmap*)__bmp_usb_plugged);
+
   lcdInitDisplayDriver();
   setHatsAsKeys(true);
 }

--- a/radio/src/targets/pl18/bootloader/boot_menu.cpp
+++ b/radio/src/targets/pl18/bootloader/boot_menu.cpp
@@ -43,12 +43,12 @@
 const uint8_t __bmp_plug_usb[] {
 #include "bmp_plug_usb.lbm"
 };
-LZ4BitmapBuffer BMP_PLUG_USB(BMP_ARGB4444, (LZ4Bitmap*)__bmp_plug_usb);
+LZ4BitmapBuffer BMP_PLUG_USB(BMP_ARGB4444);
 
 const uint8_t __bmp_usb_plugged[] {
 #include "bmp_usb_plugged.lbm"
 };
-LZ4BitmapBuffer BMP_USB_PLUGGED(BMP_ARGB4444, (LZ4Bitmap*)__bmp_usb_plugged);
+LZ4BitmapBuffer BMP_USB_PLUGGED(BMP_ARGB4444);
 
 #define BL_GREEN      COLOR2FLAGS(RGB(73, 219, 62))
 #define BL_RED        COLOR2FLAGS(RGB(229, 32, 30))
@@ -66,6 +66,9 @@ extern BitmapBuffer * lcd;
 
 void bootloaderInitScreen()
 {
+  BMP_PLUG_USB.load((LZ4Bitmap*)__bmp_plug_usb);
+  BMP_USB_PLUGGED.load((LZ4Bitmap*)__bmp_usb_plugged);
+
   lcdInitDisplayDriver();
 #if defined(USE_HATS_AS_KEYS)
   setHatsAsKeys(true);

--- a/radio/src/targets/st16/bootloader/boot_menu.cpp
+++ b/radio/src/targets/st16/bootloader/boot_menu.cpp
@@ -31,9 +31,6 @@
 
 #include <lvgl/lvgl.h>
 
-// #define USB_SW_TO_INTERNAL_MODULE() bsp_output_set(BSP_USB_SW);
-// #define USB_SW_TO_MCU()             bsp_output_clear(BSP_USB_SW);
-
 #define SELECTED_COLOR (INVERS | COLOR_THEME_SECONDARY1)
 #define DEFAULT_PADDING 28
 #define DOUBLE_PADDING  56
@@ -46,8 +43,6 @@
 #define BL_SELECTED   COLOR2FLAGS(RGB(11, 65, 244)) // deep blue
 
 extern BitmapBuffer* lcd;
-
-// static bool rfUsbAccess = false;
 
 void bootloaderInitScreen()
 {


### PR DESCRIPTION
Prevents using `malloc()` before `main()`.

*Please note: this PR is necessary for #6172 to be applicable to F4 targets.*