### PR TITLE
fix(bw): drawPotsBars wrong draw pos if skipping entry

### DIFF
--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -114,7 +114,7 @@ void drawPotsBars()
   for (uint8_t i = 0, j = 0; i < max_pots; i++) {
     if (IS_POT_SLIDER_AVAILABLE(i)) {
       coord_t x = xstart + (j % cols) * 5;
-      coord_t y = lines == 1 ? (LCD_H - 8) : i >= cols ? (LCD_H - 8) : (LCD_H - 8 - BAR_HEIGHT / 2 - 1);
+      coord_t y = lines == 1 ? (LCD_H - 8) : j >= cols ? (LCD_H - 8) : (LCD_H - 8 - BAR_HEIGHT / 2 - 1);
       auto v = calibratedAnalogs[offset + i] + RESX;
       uint8_t len = (v * (BAR_HEIGHT - (lines - 1)) / (RESX * 2 * lines)) + 1l;
       V_BAR(x, y, len);

--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -111,13 +111,14 @@ void drawPotsBars()
   uint8_t cols =  configured_pots > 4 ? 3 : configured_pots % 2 ? 3 : 2;
   coord_t xstart =  LCD_W / 2 - (cols % 2 ? 5 : 3);
 
-  for (uint8_t i = 0; i < max_pots; i++) {
+  for (uint8_t i = 0, j = 0; i < max_pots; i++) {
     if (IS_POT_SLIDER_AVAILABLE(i)) {
-      coord_t x = xstart + (i % cols) * 5;
+      coord_t x = xstart + (j % cols) * 5;
       coord_t y = lines == 1 ? (LCD_H - 8) : i >= cols ? (LCD_H - 8) : (LCD_H - 8 - BAR_HEIGHT / 2 - 1);
       auto v = calibratedAnalogs[offset + i] + RESX;
       uint8_t len = (v * (BAR_HEIGHT - (lines - 1)) / (RESX * 2 * lines)) + 1l;
       V_BAR(x, y, len);
+      j++;
     }
   }
 }


### PR DESCRIPTION
For example, a MT12 transmitter and S1 and S2 built-in, and if you get a external module for two additional inputs, S3 and S4 are available to be configured through the SYS->HARDWARE menu. It is possible for anybody to make custom external modules that had any combination of switches and potentiometer.

If you configure S3 as a slider and S4 as a switch, then three bars are drawn and everything is fine

If you configure S3 as a switch and S4 as a slider, which is my actual hardware configuration, then three bars are drawn, but when I adjust the slider, S1's bar is being moved. This is the bug I am trying to fix.

If you configure S3 as a slider and S4 as a slider, then four bars are drawn and everything is fine

Upon investigation, I found the bit of code `drawPotsBars()` to be the issue. This function will count 3 valid pots but `coord_t x = xstart + (i % cols) * 5;` will cause the draw to skip the switch, and overflow to the first entry as `i` is 3 and `cols` is also 3.

The fix is to keep two counters, `i` is now the input index, and `j` is now the draw index, only incrementing if a draw operation actually occurs.

Discord message containing a video https://discord.com/channels/839849772864503828/839895574244229152/1366667762671419472