### PR TITLE
fix(actions): add UF2 to nightly releases

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -61,6 +61,7 @@ jobs:
             fw.json
             LICENSE
             *.bin
+            *.uf2
           retention-days: 15
           if-no-files-found: error
 


### PR DESCRIPTION
I hope this is the only place where it was missing. I could not find any other.