### PR TITLE
fix(radio): prevent bootloader overflow with non-english

### DIFF
--- a/radio/src/targets/common/arm/stm32/bootloader/CMakeLists.txt
+++ b/radio/src/targets/common/arm/stm32/bootloader/CMakeLists.txt
@@ -43,6 +43,11 @@ remove_definitions(-DCLI)
 remove_definitions(-DSEMIHOSTING)
 remove_definitions(-DUSB_SERIAL)
 
+# remove these languages in bootloader
+# as they mostly overflow
+remove_definitions(-DTRANSLATIONS_RU)
+remove_definitions(-DTRANSLATIONS_UA)
+
 if(NOT NO_LTO)
   message("-- Use LTO to compile bootloader")
   target_compile_options(stm32cube_ll PRIVATE -flto)


### PR DESCRIPTION
Custom builds from `nightly` for `RU` and `UA` mostly overflow in bootloader, thus failing the build. These 2 are the top most cause of build errors in Cloudbuild.