### PR TITLE
fix(color): clipped second line for mixer adv edit header

### DIFF
--- a/radio/src/gui/colorlcd/model/mixer_edit_adv.cpp
+++ b/radio/src/gui/colorlcd/model/mixer_edit_adv.cpp
@@ -32,10 +32,9 @@
 MixEditAdvanced::MixEditAdvanced(int8_t channel, uint8_t index) :
     Page(ICON_MODEL_MIXER, PAD_MEDIUM), channel(channel), index(index)
 {
-  std::string title(STR_MIXES);
-  title += "\n";
-  title += getSourceString(MIXSRC_FIRST_CH + channel);
-  header->setTitle(title);
+  std::string title2(getSourceString(MIXSRC_FIRST_CH + channel));
+  header->setTitle(STR_MIXES);
+  header->setTitle2(title2);
 
   buildBody(body);
 }


### PR DESCRIPTION
Summary of changes:
 - second header line not being generated/drawn properly
 
 Before:
![snapshot_03](https://github.com/user-attachments/assets/33f8d146-8c2b-44cb-be2b-0ebc05997241)

After:
![snapshot_04](https://github.com/user-attachments/assets/74243e1c-5aae-4c3b-a9a5-9a3844f3cc6e)
