### PR TITLE
feat(color): add 'menu' popup control to Lua API

### DIFF
--- a/radio/src/lua/api_colorlcd_lvgl.cpp
+++ b/radio/src/lua/api_colorlcd_lvgl.cpp
@@ -369,6 +369,7 @@ LROT_BEGIN(lvgllib, NULL, 0)
   // Dialogs
   LROT_FUNCENTRY(confirm, [](lua_State* L) { return luaLvglPopup(L, []() { return new LvglWidgetConfirmDialog(); }); })
   LROT_FUNCENTRY(message, [](lua_State* L) { return luaLvglPopup(L, []() { return new LvglWidgetMessageDialog(); }); })
+  LROT_FUNCENTRY(menu, [](lua_State* L) { return luaLvglPopup(L, []() { return new LvglWidgetMenu(); }); })
   // Object manipulation functions
   LROT_FUNCENTRY(set, luaLvglSet)
   LROT_FUNCENTRY(show, luaLvglShow)

--- a/radio/src/lua/lua_lvgl_widget.cpp
+++ b/radio/src/lua/lua_lvgl_widget.cpp
@@ -2174,6 +2174,41 @@ void LvglWidgetChoice::build(lua_State *L)
 
 //-----------------------------------------------------------------------------
 
+void LvglWidgetMenu::parseParam(lua_State *L, const char *key)
+{
+  if (!strcmp(key, "title")) {
+    title = luaL_checkstring(L, -1);
+  } else if (!strcmp(key, "values")) {
+    luaL_checktype(L, -1, LUA_TTABLE);
+    for (lua_pushnil(L); lua_next(L, -2); lua_pop(L, 1)) {
+      values.push_back(lua_tostring(L, -1));
+    }
+  } else {
+    LvglWidgetPicker::parseParam(L, key);
+  }
+}
+
+void LvglWidgetMenu::build(lua_State *L)
+{
+  auto menu = new Menu();
+  if (!title.empty()) menu->setTitle(title);
+
+  for (int i = 0; i < values.size(); i += 1) {
+    menu->addLine(values[i], [=]() {
+      pcallSetIntVal(L, setFunction, i + 1);
+    });
+  }
+
+  int selected = pcallGetIntVal(L, getFunction) - 1;
+  if (selected >= 0) {
+    menu->select(selected);
+  }
+
+  window = menu;
+}
+
+//-----------------------------------------------------------------------------
+
 void LvglWidgetFontPicker::build(lua_State *L)
 {
   if (h == LV_SIZE_CONTENT) h = 0;

--- a/radio/src/lua/lua_lvgl_widget.h
+++ b/radio/src/lua/lua_lvgl_widget.h
@@ -774,6 +774,21 @@ class LvglWidgetChoice : public LvglWidgetPicker
 
 //-----------------------------------------------------------------------------
 
+class LvglWidgetMenu : public LvglWidgetPicker
+{
+ public:
+  LvglWidgetMenu() : LvglWidgetPicker() {}
+
+ protected:
+  std::string title;
+  std::vector<std::string> values;
+
+  void build(lua_State *L) override;
+  void parseParam(lua_State *L, const char *key) override;
+};
+
+//-----------------------------------------------------------------------------
+
 class LvglWidgetFontPicker : public LvglWidgetPicker
 {
  public:


### PR DESCRIPTION
Allow Lua scripts to open a popup menu with multiple options for the user to select from.

Sample script:
```Lua
    lvgl.button({text="Menu", x=10, y=10,
      press=function() 
        lvgl.menu({title="Menu",
          values={"Option 1","Option 2","Option 3","Option 4","Option 5","Option 6","Option 7","Option 8","Option 9","Option 10",},
          set=function(n)
              -- 'Do something with the selected value'
          end
        })
      end
    })
```
