### PR TITLE
feat(cpn): Korean (ko_KR) translation support

### DIFF
--- a/companion/src/CMakeLists.txt
+++ b/companion/src/CMakeLists.txt
@@ -102,7 +102,7 @@ configure_file(${COMPANION_SRC_DIRECTORY}/simulator.desktop.in ${CMAKE_CURRENT_B
 ### Generate .qm files and assemble resource (qrc) file.
 
 # available Companion translations (src/translations/*.ts)
-set(LANGUAGES cs da de en es fi fr he it ja nl pl pt ru sv zh_CN zh_TW)
+set(LANGUAGES cs da de en es fi fr he it ja ko nl pl pt ru sv zh_CN zh_TW)
 foreach(language ${LANGUAGES})
   list(APPEND companion_TS translations/companion_${language}.ts)
 endforeach(language)
@@ -354,7 +354,7 @@ elseif(PCB STREQUAL X10 AND PCBREV STREQUAL T18)
   set(FLAVOUR t18)
 elseif(PCB STREQUAL PL18 AND PCBREV STREQUAL EL18)
   set(FLAVOUR el18)
-elseif(PCB STREQUAL PL18 AND PCBREV STREQUAL PL18EV)  
+elseif(PCB STREQUAL PL18 AND PCBREV STREQUAL PL18EV)
   set(FLAVOUR pl18ev)
 elseif(PCB STREQUAL PL18)
   set(FLAVOUR pl18)

--- a/companion/src/translations.cpp
+++ b/companion/src/translations.cpp
@@ -73,8 +73,8 @@ QStringList const Translations::getTranslationPaths()
   QStringList paths;
 
   // Prefer path set in environment variable, makes it possible to test/replace translations w/out rebuilding.
-  if (qEnvironmentVariableIsSet("OPENTX_APP_TRANSLATIONS_PATH") && QDir(qgetenv("OPENTX_APP_TRANSLATIONS_PATH").constData()).exists()) {
-    paths << qgetenv("OPENTX_APP_TRANSLATIONS_PATH").constData();
+  if (qEnvironmentVariableIsSet("EDGETX_APP_TRANSLATIONS_PATH") && QDir(qgetenv("EDGETX_APP_TRANSLATIONS_PATH").constData()).exists()) {
+    paths << qgetenv("EDGETX_APP_TRANSLATIONS_PATH").constData();
   }
   // Try application subfolder first, also eg. to test/replace translations quickly.
   paths << APP_TRANSLATIONS_FILE_PATH;

--- a/companion/src/translations.cpp
+++ b/companion/src/translations.cpp
@@ -22,7 +22,7 @@
 #include "translations.h"
 #include "appdata.h"
 
-#include <QCoreApplication> 
+#include <QCoreApplication>
 #include <QDir>
 #include <QLibraryInfo>
 #include <QTranslator>
@@ -45,7 +45,7 @@ QStringList const Translations::getAvailableTranslations()
             << "he_IL"
             << "it_IT"
             << "ja_JP"
-            << "ko-KR"
+            << "ko_KR"
             << "nl_NL"
             << "pl_PL"
             << "pt_PT"

--- a/companion/src/translations/companion_cs.ts
+++ b/companion/src/translations/companion_cs.ts
@@ -1022,274 +1022,274 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="422"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>Left Horizontal</source>
         <translation>Levá horizontální</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="423"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>Left Vertical</source>
         <translation>Levá vertikální</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="424"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>Right Vertical</source>
         <translation>Pravá vertikální</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="425"/>
+        <location filename="../firmwares/boards.cpp" line="429"/>
         <source>Right Horizontal</source>
         <translation>Pravá horizontální</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="426"/>
+        <location filename="../firmwares/boards.cpp" line="430"/>
         <source>Aux. 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="427"/>
+        <location filename="../firmwares/boards.cpp" line="431"/>
         <source>Aux. 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="443"/>
+        <location filename="../firmwares/boards.cpp" line="447"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="444"/>
+        <location filename="../firmwares/boards.cpp" line="448"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="449"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
         <source>RH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="459"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <source>TILT_X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="460"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <source>TILT_Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="506"/>
+        <location filename="../firmwares/boards.cpp" line="516"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
+        <location filename="../firmwares/boards.cpp" line="532"/>
+        <location filename="../firmwares/boards.cpp" line="548"/>
+        <location filename="../firmwares/boards.cpp" line="555"/>
+        <source>SL1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="475"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <source>P4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="517"/>
+        <location filename="../firmwares/boards.cpp" line="525"/>
+        <location filename="../firmwares/boards.cpp" line="533"/>
+        <location filename="../firmwares/boards.cpp" line="549"/>
+        <location filename="../firmwares/boards.cpp" line="556"/>
+        <source>SL2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="478"/>
+        <location filename="../firmwares/boards.cpp" line="557"/>
+        <source>SL3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="479"/>
+        <location filename="../firmwares/boards.cpp" line="558"/>
+        <source>SL4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <source>P5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="943"/>
+        <source>Slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="945"/>
+        <source>Multipos Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="947"/>
+        <source>Axis X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="949"/>
+        <source>Axis Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="951"/>
+        <source>Switch</source>
+        <translation type="unfinished">Spínač</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Flight</source>
+        <translation type="unfinished">Let</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="488"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="498"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
+        <location filename="../firmwares/boards.cpp" line="529"/>
+        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="553"/>
+        <source>P1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="473"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="504"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
+        <location filename="../firmwares/boards.cpp" line="530"/>
+        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="554"/>
+        <source>P2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="474"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="505"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
+        <location filename="../firmwares/boards.cpp" line="531"/>
+        <location filename="../firmwares/boards.cpp" line="543"/>
+        <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="455"/>
         <location filename="../firmwares/boards.cpp" line="457"/>
-        <source>TILT_X</source>
+        <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="456"/>
         <location filename="../firmwares/boards.cpp" line="458"/>
-        <source>TILT_Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="463"/>
-        <location filename="../firmwares/boards.cpp" line="472"/>
-        <location filename="../firmwares/boards.cpp" line="502"/>
-        <location filename="../firmwares/boards.cpp" line="512"/>
-        <location filename="../firmwares/boards.cpp" line="520"/>
-        <location filename="../firmwares/boards.cpp" line="528"/>
-        <location filename="../firmwares/boards.cpp" line="544"/>
-        <location filename="../firmwares/boards.cpp" line="551"/>
-        <source>SL1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="471"/>
-        <location filename="../firmwares/boards.cpp" line="510"/>
-        <source>P4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="473"/>
-        <location filename="../firmwares/boards.cpp" line="503"/>
-        <location filename="../firmwares/boards.cpp" line="513"/>
-        <location filename="../firmwares/boards.cpp" line="521"/>
-        <location filename="../firmwares/boards.cpp" line="529"/>
-        <location filename="../firmwares/boards.cpp" line="545"/>
-        <location filename="../firmwares/boards.cpp" line="552"/>
-        <source>SL2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="474"/>
-        <location filename="../firmwares/boards.cpp" line="553"/>
-        <source>SL3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="475"/>
-        <location filename="../firmwares/boards.cpp" line="554"/>
-        <source>SL4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="511"/>
-        <source>P5</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="933"/>
-        <source>Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="935"/>
-        <source>Multipos Switch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="937"/>
-        <source>Axis X</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="939"/>
-        <source>Axis Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="941"/>
-        <source>Switch</source>
-        <translation type="unfinished">Spínač</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Flight</source>
-        <translation type="unfinished">Let</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Drive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="464"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
-        <location filename="../firmwares/boards.cpp" line="479"/>
-        <location filename="../firmwares/boards.cpp" line="484"/>
-        <location filename="../firmwares/boards.cpp" line="490"/>
-        <location filename="../firmwares/boards.cpp" line="494"/>
-        <location filename="../firmwares/boards.cpp" line="499"/>
-        <location filename="../firmwares/boards.cpp" line="507"/>
-        <location filename="../firmwares/boards.cpp" line="517"/>
-        <location filename="../firmwares/boards.cpp" line="525"/>
-        <location filename="../firmwares/boards.cpp" line="537"/>
-        <location filename="../firmwares/boards.cpp" line="549"/>
-        <source>P1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="469"/>
-        <location filename="../firmwares/boards.cpp" line="480"/>
-        <location filename="../firmwares/boards.cpp" line="485"/>
-        <location filename="../firmwares/boards.cpp" line="495"/>
-        <location filename="../firmwares/boards.cpp" line="500"/>
-        <location filename="../firmwares/boards.cpp" line="508"/>
-        <location filename="../firmwares/boards.cpp" line="518"/>
-        <location filename="../firmwares/boards.cpp" line="526"/>
-        <location filename="../firmwares/boards.cpp" line="538"/>
-        <location filename="../firmwares/boards.cpp" line="550"/>
-        <source>P2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="470"/>
-        <location filename="../firmwares/boards.cpp" line="486"/>
-        <location filename="../firmwares/boards.cpp" line="501"/>
-        <location filename="../firmwares/boards.cpp" line="509"/>
-        <location filename="../firmwares/boards.cpp" line="519"/>
-        <location filename="../firmwares/boards.cpp" line="527"/>
-        <location filename="../firmwares/boards.cpp" line="539"/>
-        <source>P3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
-        <source>JSx</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="454"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="530"/>
-        <location filename="../firmwares/boards.cpp" line="540"/>
+        <location filename="../firmwares/boards.cpp" line="534"/>
+        <location filename="../firmwares/boards.cpp" line="544"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="531"/>
-        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="535"/>
+        <location filename="../firmwares/boards.cpp" line="545"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="532"/>
-        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="536"/>
+        <location filename="../firmwares/boards.cpp" line="546"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="533"/>
-        <location filename="../firmwares/boards.cpp" line="543"/>
+        <location filename="../firmwares/boards.cpp" line="537"/>
+        <location filename="../firmwares/boards.cpp" line="547"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="678"/>
-        <location filename="../firmwares/boards.cpp" line="897"/>
-        <location filename="../firmwares/boards.cpp" line="927"/>
+        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="907"/>
+        <location filename="../firmwares/boards.cpp" line="937"/>
         <source>None</source>
         <translation type="unfinished">Žádný</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="929"/>
+        <location filename="../firmwares/boards.cpp" line="939"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="931"/>
+        <location filename="../firmwares/boards.cpp" line="941"/>
         <source>Pot with detent</source>
         <translation type="unfinished">Pot s aretací</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="680"/>
+        <location filename="../firmwares/boards.cpp" line="686"/>
         <source>2 Positions Toggle</source>
         <translation type="unfinished">2 pozice bez aretace</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="682"/>
+        <location filename="../firmwares/boards.cpp" line="688"/>
         <source>2 Positions</source>
         <translation type="unfinished">2 pozice</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="690"/>
         <source>3 Positions</source>
         <translation type="unfinished">3 pozice</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="686"/>
+        <location filename="../firmwares/boards.cpp" line="692"/>
         <source>Function</source>
         <translation type="unfinished">Funkce</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="899"/>
+        <location filename="../firmwares/boards.cpp" line="909"/>
         <source>Standard</source>
         <translation type="unfinished">Rastr-X</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="901"/>
+        <location filename="../firmwares/boards.cpp" line="911"/>
         <source>Small</source>
         <translation type="unfinished">Malá</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="903"/>
+        <location filename="../firmwares/boards.cpp" line="913"/>
         <source>Both</source>
         <translation type="unfinished">Obě</translation>
     </message>
@@ -1643,34 +1643,50 @@ Error description: %4</source>
         <translation type="unfinished">Simulátor pro tuto verzi firmware zatím není dostupný</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="380"/>
+        <location filename="../helpers.cpp" line="388"/>
+        <source>Uknown error during Simulator startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Data Load Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Error occurred while starting simulator.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="405"/>
         <source>Error creating temporary directory for models and settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="388"/>
+        <location filename="../helpers.cpp" line="413"/>
         <source>Error writing models and settings to temporary directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="419"/>
+        <location filename="../helpers.cpp" line="444"/>
         <source>Unable to start.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="421"/>
+        <location filename="../helpers.cpp" line="446"/>
         <source>Crashed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="423"/>
+        <location filename="../helpers.cpp" line="448"/>
         <source>Exited with result code:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="381"/>
         <location filename="../helpers.cpp" line="389"/>
-        <location filename="../helpers.cpp" line="426"/>
+        <location filename="../helpers.cpp" line="406"/>
+        <location filename="../helpers.cpp" line="414"/>
+        <location filename="../helpers.cpp" line="451"/>
         <source>Simulator Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3521,59 +3537,59 @@ FAI je soutěžní mód (www.fai.org), zablokuje vario, zobrazení telemetrie a 
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="448"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="612"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="622"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="632"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="642"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="652"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="662"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="672"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="742"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="761"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="772"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="782"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="807"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="619"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="629"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="639"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="649"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="659"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="669"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="679"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="739"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="749"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="768"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="779"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="789"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="814"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation type="unfinished">Odstranit funkce pro heli a nastavení typu mechaniky</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="449"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="613"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="623"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="633"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="643"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="653"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="663"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="673"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="733"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="743"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="752"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="762"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="773"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="783"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="680"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="769"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="815"/>
         <source>Disable Global variables</source>
         <translation type="unfinished">Odstranit Globální proměnné</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="450"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="474"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="614"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="624"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="634"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="644"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="654"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="664"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="674"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="734"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="744"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="753"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="763"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="784"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="809"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="621"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="631"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="641"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="651"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="661"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="671"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="741"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="751"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="760"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="781"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="791"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="816"/>
         <source>Enable Lua custom scripts screen</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3583,7 +3599,7 @@ FAI je soutěžní mód (www.fai.org), zablokuje vario, zobrazení telemetrie a 
         <translation type="unfinished">Použít alternativní znakovou sadu písma (jiný font)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
         <source>FrSky Taranis X9D+</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3598,104 +3614,104 @@ FAI je soutěžní mód (www.fai.org), zablokuje vario, zobrazení telemetrie a 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="590"/>
         <source>Disable RAS (SWR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="574"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="581"/>
         <source>FrSky Taranis X9D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="576"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
         <source>Haptic module installed</source>
         <translation type="unfinished">Podpora pro vibrační modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="595"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="602"/>
         <source>FrSky Taranis X9E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
         <source>Confirmation before radio shutdown</source>
         <translation type="unfinished">Přidá potvrzování před vypnutím rádia</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="597"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="604"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="562"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="569"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="537"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="544"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="563"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="549"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
         <source>FrSky Taranis X-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="530"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="529"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="536"/>
         <source>FrSky Horus X12S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="539"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="677"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="675"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="703"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="682"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="710"/>
         <source>Support for MULTI internal module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="627"/>
         <source>Jumper T-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="637"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="701"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="708"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3705,26 +3721,26 @@ FAI je soutěžní mód (www.fai.org), zablokuje vario, zobrazení telemetrie a 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="777"/>
         <source>Radiomaster TX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="787"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="805"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="812"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="683"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="690"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="718"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="697"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="725"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="810"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="817"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3734,82 +3750,87 @@ FAI je soutěžní mód (www.fai.org), zablokuje vario, zobrazení telemetrie a 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <source>FlySky ST16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
         <source>HelloRadioSky V16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="647"/>
         <source>Jumper T-Pro V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="657"/>
         <source>Jumper T-Pro S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="667"/>
         <source>Jumper Bumblebee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
         <source>Jumper T12 MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
         <source>Jumper T14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="702"/>
         <source>Jumper T15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
         <source>Jumper T20 V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="737"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="747"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="757"/>
         <source>Radiomaster MT12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="766"/>
         <source>Radiomaster T8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="767"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
         <source>Allow bind using bind key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
         <source>Radiomaster GX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="804"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3820,12 +3841,12 @@ FAI je soutěžní mód (www.fai.org), zablokuje vario, zobrazení telemetrie a 
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="484"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="801"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="709"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
         <source>Jumper T18</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3840,7 +3861,7 @@ FAI je soutěžní mód (www.fai.org), zablokuje vario, zobrazení telemetrie a 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="617"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3865,18 +3886,18 @@ FAI je soutěžní mód (www.fai.org), zablokuje vario, zobrazení telemetrie a 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="568"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="543"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="550"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="518"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="525"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="538"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4866,206 +4887,206 @@ Tyto volby jsou platné pro všechny modely v jedné EEPROM.</translation>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="412"/>
+        <location filename="../firmwares/generalsettings.cpp" line="414"/>
         <source>Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="414"/>
+        <location filename="../firmwares/generalsettings.cpp" line="416"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="415"/>
+        <location filename="../firmwares/generalsettings.cpp" line="417"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="430"/>
+        <location filename="../firmwares/generalsettings.cpp" line="432"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="464"/>
+        <location filename="../firmwares/generalsettings.cpp" line="466"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="469"/>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="471"/>
+        <location filename="../firmwares/generalsettings.cpp" line="483"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Switch</source>
         <translation type="unfinished">Spínač</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="499"/>
+        <location filename="../firmwares/generalsettings.cpp" line="501"/>
         <source>None</source>
         <translation type="unfinished">Žádný</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="553"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Internal</source>
         <translation type="unfinished">Interní</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="555"/>
+        <location filename="../firmwares/generalsettings.cpp" line="557"/>
         <source>Ask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="557"/>
+        <location filename="../firmwares/generalsettings.cpp" line="559"/>
         <source>Per model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>Internal + External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="573"/>
-        <location filename="../firmwares/generalsettings.cpp" line="589"/>
+        <location filename="../firmwares/generalsettings.cpp" line="575"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>OFF</source>
         <translation type="unfinished">Vypnuto</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Telemetry</source>
         <translation type="unfinished">Telemetrie</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="578"/>
+        <location filename="../firmwares/generalsettings.cpp" line="580"/>
         <source>Trainer</source>
         <translation type="unfinished">Trenér</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="591"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="593"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="595"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished">SBUS trenér</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="597"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="599"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="601"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="603"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="605"/>
+        <location filename="../firmwares/generalsettings.cpp" line="607"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="607"/>
+        <location filename="../firmwares/generalsettings.cpp" line="609"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="640"/>
+        <location filename="../firmwares/generalsettings.cpp" line="642"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="739"/>
+        <location filename="../firmwares/generalsettings.cpp" line="741"/>
         <source>Normal</source>
         <translation type="unfinished">Normální</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="741"/>
+        <location filename="../firmwares/generalsettings.cpp" line="743"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="787"/>
+        <location filename="../firmwares/generalsettings.cpp" line="789"/>
         <source>Trims only</source>
         <translation type="unfinished">Pouze trimy</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="789"/>
+        <location filename="../firmwares/generalsettings.cpp" line="791"/>
         <source>Keys only</source>
         <translation type="unfinished">Pouze tlačítka</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="791"/>
+        <location filename="../firmwares/generalsettings.cpp" line="793"/>
         <source>Switchable</source>
         <translation type="unfinished">Přepinatelné</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="793"/>
+        <location filename="../firmwares/generalsettings.cpp" line="795"/>
         <source>Global</source>
         <translation type="unfinished">Globální</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="927"/>
+        <location filename="../firmwares/generalsettings.cpp" line="929"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation type="unfinished">Mód1 (Směr.Výšk.Plyn.Křid)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="931"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation type="unfinished">Mód2 (Směr.Plyn.Výšk.Křid)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="933"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation type="unfinished">Mód3 (Křid.Výšk.Plyn.Směr)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="935"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation type="unfinished">Mód4 (Křid.Plyn.Výšk.Směr)</translation>
     </message>
@@ -5986,32 +6007,32 @@ p, li { white-space: pre-wrap; }
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="434"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Slovak</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="435"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Spanish</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Polish</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="432"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Portuguese</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="433"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Russian</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="436"/>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Swedish</source>
         <translation></translation>
     </message>
@@ -6021,7 +6042,7 @@ p, li { white-space: pre-wrap; }
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6056,64 +6077,69 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="437"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <source>Korean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="438"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>No</source>
         <translation type="unfinished">Ne</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>RotEnc A</source>
         <translation type="unfinished">Otočný enkodér :A</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc B</source>
         <translation type="unfinished">Otočný enkodér :B</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc C</source>
         <translation type="unfinished">Otočný enkodér :C</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc D</source>
         <translation type="unfinished">Otočný enkodér :D</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc E</source>
         <translation type="unfinished">Otočný enkodér :E</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="617"/>
+        <location filename="../generaledit/generalsetup.cpp" line="618"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal</source>
         <translation type="unfinished">Normální</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15680,22 +15706,22 @@ Timestamp</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="873"/>
+        <location filename="../firmwares/generalsettings.cpp" line="875"/>
         <source>OFF</source>
         <translation type="unfinished">Vypnuto</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="875"/>
+        <location filename="../firmwares/generalsettings.cpp" line="877"/>
         <source>+= (Sum)</source>
         <translation type="unfinished">+= (Sečíst)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="877"/>
+        <location filename="../firmwares/generalsettings.cpp" line="879"/>
         <source>:= (Replace)</source>
         <translation type="unfinished">:= (Nahradit)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="886"/>
+        <location filename="../firmwares/generalsettings.cpp" line="888"/>
         <source>CH%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17394,14 +17420,14 @@ Do you wish to continue?</source>
 <context>
     <name>YamlModelSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1288"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1287"/>
         <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
 
 Model settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1291"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1290"/>
         <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/companion/src/translations/companion_da.ts
+++ b/companion/src/translations/companion_da.ts
@@ -1023,274 +1023,274 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="422"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>Left Horizontal</source>
         <translation>Venstre horisontal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="423"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>Left Vertical</source>
         <translation>Venstre vertikal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="424"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>Right Vertical</source>
         <translation>Højre vertikal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="425"/>
+        <location filename="../firmwares/boards.cpp" line="429"/>
         <source>Right Horizontal</source>
         <translation>Højre horisontal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="426"/>
+        <location filename="../firmwares/boards.cpp" line="430"/>
         <source>Aux. 1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="427"/>
+        <location filename="../firmwares/boards.cpp" line="431"/>
         <source>Aux. 2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="443"/>
+        <location filename="../firmwares/boards.cpp" line="447"/>
         <source>LH</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="444"/>
+        <location filename="../firmwares/boards.cpp" line="448"/>
         <source>LV</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="449"/>
         <source>RV</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
         <source>RH</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="459"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <source>TILT_X</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="460"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <source>TILT_Y</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="506"/>
+        <location filename="../firmwares/boards.cpp" line="516"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
+        <location filename="../firmwares/boards.cpp" line="532"/>
+        <location filename="../firmwares/boards.cpp" line="548"/>
+        <location filename="../firmwares/boards.cpp" line="555"/>
+        <source>SL1</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="475"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <source>P4</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="517"/>
+        <location filename="../firmwares/boards.cpp" line="525"/>
+        <location filename="../firmwares/boards.cpp" line="533"/>
+        <location filename="../firmwares/boards.cpp" line="549"/>
+        <location filename="../firmwares/boards.cpp" line="556"/>
+        <source>SL2</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="478"/>
+        <location filename="../firmwares/boards.cpp" line="557"/>
+        <source>SL3</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="479"/>
+        <location filename="../firmwares/boards.cpp" line="558"/>
+        <source>SL4</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <source>P5</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="534"/>
+        <location filename="../firmwares/boards.cpp" line="544"/>
+        <source>EXT1</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="535"/>
+        <location filename="../firmwares/boards.cpp" line="545"/>
+        <source>EXT2</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="536"/>
+        <location filename="../firmwares/boards.cpp" line="546"/>
+        <source>EXT3</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="537"/>
+        <location filename="../firmwares/boards.cpp" line="547"/>
+        <source>EXT4</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="907"/>
+        <location filename="../firmwares/boards.cpp" line="937"/>
+        <source>None</source>
+        <translation>Ingen</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="692"/>
+        <source>Function</source>
+        <translation>Funktion</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="939"/>
+        <source>Pot</source>
+        <translation>Drejekontakt</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="941"/>
+        <source>Pot with detent</source>
+        <translation>Drejekontakt med midtklik</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="943"/>
+        <source>Slider</source>
+        <translation>Skyder</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="945"/>
+        <source>Multipos Switch</source>
+        <translation>Multipos kontakt</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="947"/>
+        <source>Axis X</source>
+        <translation>Akse X</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="949"/>
+        <source>Axis Y</source>
+        <translation>Akse Y</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="951"/>
+        <source>Switch</source>
+        <translation>Kontakt</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Flight</source>
+        <translation>Flyvning</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="686"/>
+        <source>2 Positions Toggle</source>
+        <translation>2 position skifter</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="688"/>
+        <source>2 Positions</source>
+        <translation>2 positioner</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="690"/>
+        <source>3 Positions</source>
+        <translation>3 positioner</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="488"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="498"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
+        <location filename="../firmwares/boards.cpp" line="529"/>
+        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="553"/>
+        <source>P1</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="473"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="504"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
+        <location filename="../firmwares/boards.cpp" line="530"/>
+        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="554"/>
+        <source>P2</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="474"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="505"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
+        <location filename="../firmwares/boards.cpp" line="531"/>
+        <location filename="../firmwares/boards.cpp" line="543"/>
+        <source>P3</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="455"/>
         <location filename="../firmwares/boards.cpp" line="457"/>
-        <source>TILT_X</source>
+        <source>JSx</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="456"/>
         <location filename="../firmwares/boards.cpp" line="458"/>
-        <source>TILT_Y</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="463"/>
-        <location filename="../firmwares/boards.cpp" line="472"/>
-        <location filename="../firmwares/boards.cpp" line="502"/>
-        <location filename="../firmwares/boards.cpp" line="512"/>
-        <location filename="../firmwares/boards.cpp" line="520"/>
-        <location filename="../firmwares/boards.cpp" line="528"/>
-        <location filename="../firmwares/boards.cpp" line="544"/>
-        <location filename="../firmwares/boards.cpp" line="551"/>
-        <source>SL1</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="471"/>
-        <location filename="../firmwares/boards.cpp" line="510"/>
-        <source>P4</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="473"/>
-        <location filename="../firmwares/boards.cpp" line="503"/>
-        <location filename="../firmwares/boards.cpp" line="513"/>
-        <location filename="../firmwares/boards.cpp" line="521"/>
-        <location filename="../firmwares/boards.cpp" line="529"/>
-        <location filename="../firmwares/boards.cpp" line="545"/>
-        <location filename="../firmwares/boards.cpp" line="552"/>
-        <source>SL2</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="474"/>
-        <location filename="../firmwares/boards.cpp" line="553"/>
-        <source>SL3</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="475"/>
-        <location filename="../firmwares/boards.cpp" line="554"/>
-        <source>SL4</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="511"/>
-        <source>P5</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="530"/>
-        <location filename="../firmwares/boards.cpp" line="540"/>
-        <source>EXT1</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="531"/>
-        <location filename="../firmwares/boards.cpp" line="541"/>
-        <source>EXT2</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="532"/>
-        <location filename="../firmwares/boards.cpp" line="542"/>
-        <source>EXT3</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="533"/>
-        <location filename="../firmwares/boards.cpp" line="543"/>
-        <source>EXT4</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="678"/>
-        <location filename="../firmwares/boards.cpp" line="897"/>
-        <location filename="../firmwares/boards.cpp" line="927"/>
-        <source>None</source>
-        <translation>Ingen</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="686"/>
-        <source>Function</source>
-        <translation>Funktion</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="929"/>
-        <source>Pot</source>
-        <translation>Drejekontakt</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="931"/>
-        <source>Pot with detent</source>
-        <translation>Drejekontakt med midtklik</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="933"/>
-        <source>Slider</source>
-        <translation>Skyder</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="935"/>
-        <source>Multipos Switch</source>
-        <translation>Multipos kontakt</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="937"/>
-        <source>Axis X</source>
-        <translation>Akse X</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="939"/>
-        <source>Axis Y</source>
-        <translation>Akse Y</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="941"/>
-        <source>Switch</source>
-        <translation>Kontakt</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Flight</source>
-        <translation>Flyvning</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Drive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="680"/>
-        <source>2 Positions Toggle</source>
-        <translation>2 position skifter</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="682"/>
-        <source>2 Positions</source>
-        <translation>2 positioner</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="684"/>
-        <source>3 Positions</source>
-        <translation>3 positioner</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="464"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
-        <location filename="../firmwares/boards.cpp" line="479"/>
-        <location filename="../firmwares/boards.cpp" line="484"/>
-        <location filename="../firmwares/boards.cpp" line="490"/>
-        <location filename="../firmwares/boards.cpp" line="494"/>
-        <location filename="../firmwares/boards.cpp" line="499"/>
-        <location filename="../firmwares/boards.cpp" line="507"/>
-        <location filename="../firmwares/boards.cpp" line="517"/>
-        <location filename="../firmwares/boards.cpp" line="525"/>
-        <location filename="../firmwares/boards.cpp" line="537"/>
-        <location filename="../firmwares/boards.cpp" line="549"/>
-        <source>P1</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="469"/>
-        <location filename="../firmwares/boards.cpp" line="480"/>
-        <location filename="../firmwares/boards.cpp" line="485"/>
-        <location filename="../firmwares/boards.cpp" line="495"/>
-        <location filename="../firmwares/boards.cpp" line="500"/>
-        <location filename="../firmwares/boards.cpp" line="508"/>
-        <location filename="../firmwares/boards.cpp" line="518"/>
-        <location filename="../firmwares/boards.cpp" line="526"/>
-        <location filename="../firmwares/boards.cpp" line="538"/>
-        <location filename="../firmwares/boards.cpp" line="550"/>
-        <source>P2</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="470"/>
-        <location filename="../firmwares/boards.cpp" line="486"/>
-        <location filename="../firmwares/boards.cpp" line="501"/>
-        <location filename="../firmwares/boards.cpp" line="509"/>
-        <location filename="../firmwares/boards.cpp" line="519"/>
-        <location filename="../firmwares/boards.cpp" line="527"/>
-        <location filename="../firmwares/boards.cpp" line="539"/>
-        <source>P3</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
-        <source>JSx</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="454"/>
         <source>JSy</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="899"/>
+        <location filename="../firmwares/boards.cpp" line="909"/>
         <source>Standard</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="901"/>
+        <location filename="../firmwares/boards.cpp" line="911"/>
         <source>Small</source>
         <translation>Små</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="903"/>
+        <location filename="../firmwares/boards.cpp" line="913"/>
         <source>Both</source>
         <translation>Begge</translation>
     </message>
@@ -1612,9 +1612,10 @@ Error description: %4</source>
         <translation>Der er endnu ikke en simulator for denne firmware</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="381"/>
         <location filename="../helpers.cpp" line="389"/>
-        <location filename="../helpers.cpp" line="426"/>
+        <location filename="../helpers.cpp" line="406"/>
+        <location filename="../helpers.cpp" line="414"/>
+        <location filename="../helpers.cpp" line="451"/>
         <source>Simulator Error</source>
         <translation>Simuator Fejl</translation>
     </message>
@@ -1711,27 +1712,42 @@ Vil du indlæse indstillinger fra en fil?</translation>
         <translation>Tryk på &quot;Prøv igen&quot; at vælge anden fil.</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="380"/>
+        <location filename="../helpers.cpp" line="388"/>
+        <source>Uknown error during Simulator startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Data Load Error</source>
+        <translation type="unfinished">Fejl ved data indlæsning</translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Error occurred while starting simulator.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="405"/>
         <source>Error creating temporary directory for models and settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="388"/>
+        <location filename="../helpers.cpp" line="413"/>
         <source>Error writing models and settings to temporary directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="419"/>
+        <location filename="../helpers.cpp" line="444"/>
         <source>Unable to start.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="421"/>
+        <location filename="../helpers.cpp" line="446"/>
         <source>Crashed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="423"/>
+        <location filename="../helpers.cpp" line="448"/>
         <source>Exited with result code:</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3531,39 +3547,39 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="448"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="612"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="622"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="632"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="642"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="652"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="662"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="672"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="742"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="761"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="772"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="782"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="807"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="619"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="629"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="639"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="649"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="659"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="669"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="679"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="739"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="749"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="768"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="779"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="789"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="814"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation>Aktiver helikopter menu og søtte til rotor mix</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="449"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="613"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="623"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="633"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="643"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="653"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="663"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="673"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="733"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="743"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="752"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="762"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="773"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="783"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="680"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="769"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="815"/>
         <source>Disable Global variables</source>
         <translation>Deaktiver globale variable</translation>
     </message>
@@ -3575,20 +3591,20 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="450"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="474"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="614"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="624"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="634"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="644"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="654"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="664"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="674"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="734"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="744"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="753"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="763"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="784"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="809"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="621"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="631"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="641"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="651"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="661"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="671"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="741"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="751"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="760"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="781"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="791"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="816"/>
         <source>Enable Lua custom scripts screen</source>
         <translation>Aktiver tilpasning af Lua script</translation>
     </message>
@@ -3598,68 +3614,68 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>Anvend SQT5 font</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
         <source>FrSky Taranis X9D+</source>
         <translation>FrSky Taranis X9D+</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="590"/>
         <source>Disable RAS (SWR)</source>
         <translation>Aktiver RAS (SWR)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="574"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="581"/>
         <source>FrSky Taranis X9D</source>
         <translation>FrSky Taranis X9D</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="576"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
         <source>Haptic module installed</source>
         <translation>Vibratormodul er installeret</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="595"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="602"/>
         <source>FrSky Taranis X9E</source>
         <translation>FrSky Taranis X9E</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
         <source>Confirmation before radio shutdown</source>
         <translation>Bekræft før radio slukkes</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="597"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="604"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="537"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="544"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation>FrSky Taranis X7 / X7S</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="549"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
         <source>FrSky Taranis X-Lite</source>
         <translation>FrSky Taranis X-Lite</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation>FrSky Horus X10 / X10S</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="529"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="536"/>
         <source>FrSky Horus X12S</source>
         <translation>FrSky Horus X12S</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="539"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
         <source>Jumper T20</source>
         <translation>Jumper T20</translation>
     </message>
@@ -3679,47 +3695,52 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <source>FlySky ST16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
         <source>HelloRadioSky V16</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="647"/>
         <source>Jumper T-Pro V2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="657"/>
         <source>Jumper T-Pro S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="667"/>
         <source>Jumper Bumblebee</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
         <source>Jumper T12 MAX</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
         <source>Jumper T14</source>
         <translation>Jumper T14</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="702"/>
         <source>Jumper T15</source>
         <translation>Jumper T15</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
         <source>Jumper T20 V2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="747"/>
         <source>Radiomaster Pocket</source>
         <translation></translation>
     </message>
@@ -3729,23 +3750,23 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>Tillad ikke certificeret firmware</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation>FrSky Taranis X9D+ 2019</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="562"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="569"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation>FrSky Taranis X9-Lite</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="563"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation>FrSky Taranis X-Lite S/PRO</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="518"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="525"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="538"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation>Understøttelse af internt ACCESS modul</translation>
     </message>
@@ -3760,43 +3781,43 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>Aktiver AFHDS2A support</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="568"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="543"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="550"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="530"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="677"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="675"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="703"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="682"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="710"/>
         <source>Support for MULTI internal module</source>
         <translation>Understøttelse af MULTI internt modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="627"/>
         <source>Jumper T-Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="637"/>
         <source>Jumper T-Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="701"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="708"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation></translation>
     </message>
@@ -3806,62 +3827,62 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>Understøttelse af bluetooth modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="757"/>
         <source>Radiomaster MT12</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="777"/>
         <source>Radiomaster TX12</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="787"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
         <source>Radiomaster GX12</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="805"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="812"/>
         <source>Radiomaster Zorro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="683"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="690"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="718"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="697"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="725"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="810"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="817"/>
         <source>Select if internal ELRS module is installed</source>
         <translation>Vælg hvis internt ELRS modul er installeret</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="766"/>
         <source>Radiomaster T8</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="767"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
         <source>Allow bind using bind key</source>
         <translation>Tillad tilslutning med tilslut tast</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="804"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="484"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="801"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation>Understøttelse af hardware modul: FlySky Paladin EV Gimbals</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="709"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
         <source>Jumper T18</source>
         <translation>Jumper T18</translation>
     </message>
@@ -3881,12 +3902,12 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="617"/>
         <source>iFlight Commando8</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="737"/>
         <source>Radiomaster Boxer</source>
         <translation></translation>
     </message>
@@ -4919,206 +4940,206 @@ Disse indstillinger gælder for alle modeller.</translation>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="412"/>
+        <location filename="../firmwares/generalsettings.cpp" line="414"/>
         <source>Radio Settings</source>
         <translation>Radio indstillinger</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="414"/>
+        <location filename="../firmwares/generalsettings.cpp" line="416"/>
         <source>Hardware</source>
         <translation>Kontroller</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="415"/>
+        <location filename="../firmwares/generalsettings.cpp" line="417"/>
         <source>Internal Module</source>
         <translation>Internt modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="430"/>
+        <location filename="../firmwares/generalsettings.cpp" line="432"/>
         <source>Axis &amp; Pots</source>
         <translation>Akse &amp; drejekontakt</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Axis</source>
         <translation>Akse</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Pot</source>
         <translation>Drejekontakt</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="464"/>
+        <location filename="../firmwares/generalsettings.cpp" line="466"/>
         <source>Switches</source>
         <translation>Kontakter</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="469"/>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="471"/>
+        <location filename="../firmwares/generalsettings.cpp" line="483"/>
         <source>Flex Switch</source>
         <translation>Fleksibel kontakt</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Function Switch</source>
         <translation>Funktion kontakt</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Switch</source>
         <translation>Kontakt</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="499"/>
+        <location filename="../firmwares/generalsettings.cpp" line="501"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="553"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Internal</source>
         <translation>Intern</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="555"/>
+        <location filename="../firmwares/generalsettings.cpp" line="557"/>
         <source>Ask</source>
         <translation>Spørg</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="557"/>
+        <location filename="../firmwares/generalsettings.cpp" line="559"/>
         <source>Per model</source>
         <translation>Per model</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>Internal + External</source>
         <translation>Intern + Ekstern</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="573"/>
-        <location filename="../firmwares/generalsettings.cpp" line="589"/>
+        <location filename="../firmwares/generalsettings.cpp" line="575"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>OFF</source>
         <translation>FRA</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Enabled</source>
         <translation>Aktiveret</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Telemetry</source>
         <translation>Telemetri</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="578"/>
+        <location filename="../firmwares/generalsettings.cpp" line="580"/>
         <source>Trainer</source>
         <translation>Træner</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="591"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>Telemetry Mirror</source>
         <translation>Telemetri spejlet</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="593"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>Telemetry In</source>
         <translation>Telemetri ind</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="595"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>SBUS Trainer</source>
         <translation>SBUS-træner</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="597"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>LUA</source>
         <translation>LUA</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="599"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>CLI</source>
         <translation>CLI</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="601"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>GPS</source>
         <translation>GPS</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="603"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>Debug</source>
         <translation>Debug</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="605"/>
+        <location filename="../firmwares/generalsettings.cpp" line="607"/>
         <source>SpaceMouse</source>
         <translation>SpaceMouse</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="640"/>
+        <location filename="../firmwares/generalsettings.cpp" line="642"/>
         <source>mA</source>
         <translation>mA</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="739"/>
+        <location filename="../firmwares/generalsettings.cpp" line="741"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="741"/>
+        <location filename="../firmwares/generalsettings.cpp" line="743"/>
         <source>OneBit</source>
         <translation>OneBit</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="787"/>
+        <location filename="../firmwares/generalsettings.cpp" line="789"/>
         <source>Trims only</source>
         <translation>Kun trim</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="789"/>
+        <location filename="../firmwares/generalsettings.cpp" line="791"/>
         <source>Keys only</source>
         <translation>Kun knap</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="791"/>
+        <location filename="../firmwares/generalsettings.cpp" line="793"/>
         <source>Switchable</source>
         <translation>Trim / Knap</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="793"/>
+        <location filename="../firmwares/generalsettings.cpp" line="795"/>
         <source>Global</source>
         <translation>Global</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="927"/>
+        <location filename="../firmwares/generalsettings.cpp" line="929"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation>Mode 1 (SID HØJ GAS KRÆ)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="931"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation>Mode 2 (SID GAS HØJ KRÆ)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="933"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation>Mode 3 (KRÆ HØJ GAS SID)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="935"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation>Mode 4 (KRÆ GAS HØJ SID)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>External</source>
         <translation>Eksternt</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="607"/>
+        <location filename="../firmwares/generalsettings.cpp" line="609"/>
         <source>External module</source>
         <translation>Eksternt modul</translation>
     </message>
@@ -6058,32 +6079,32 @@ Værdier mellem 5 og 12 volt accepteres</translation>
         <translation>Tjekkisk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="434"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Slovak</source>
         <translation>Slovakisk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="435"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Spanish</source>
         <translation>Spansk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Polish</source>
         <translation>Polsk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="432"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Portuguese</source>
         <translation>Portugisisk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="433"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Russian</source>
         <translation>Russisk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="436"/>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Swedish</source>
         <translation>Svensk</translation>
     </message>
@@ -6103,42 +6124,47 @@ Værdier mellem 5 og 12 volt accepteres</translation>
         <translation>Knap + styring</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="437"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <source>Korean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="438"/>
         <source>Ukrainian</source>
         <translation>Ukranisk</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>No</source>
         <translation>Nej</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>RotEnc A</source>
         <translation>Inm.hjul A</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc B</source>
         <translation>Inm.hjul B</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc C</source>
         <translation>Inm.hjul C</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc D</source>
         <translation>Inm.hjul D</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc E</source>
         <translation>Inm.hjul E</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="617"/>
+        <location filename="../generaledit/generalsetup.cpp" line="618"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
@@ -6147,27 +6173,27 @@ Det kan ikke deaktiveres af senderen.
 Er du sikker?</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal</source>
         <translation>Normal</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Inverted</source>
         <translation>Invers</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation>Lodret invers, vandret normal</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation>Lodret invers, vandret alternativ</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal, Edit Inverted</source>
         <translation>Normal, rediger invers</translation>
     </message>
@@ -15785,22 +15811,22 @@ Tidstempel</translation>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="873"/>
+        <location filename="../firmwares/generalsettings.cpp" line="875"/>
         <source>OFF</source>
         <translation>FRA</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="875"/>
+        <location filename="../firmwares/generalsettings.cpp" line="877"/>
         <source>+= (Sum)</source>
         <translation>+= (Sum)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="877"/>
+        <location filename="../firmwares/generalsettings.cpp" line="879"/>
         <source>:= (Replace)</source>
         <translation>:= (Erstat)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="886"/>
+        <location filename="../firmwares/generalsettings.cpp" line="888"/>
         <source>CH%1</source>
         <translation>KA%1</translation>
     </message>
@@ -17508,14 +17534,14 @@ Vil du fortsætte?</translation>
 <context>
     <name>YamlModelSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1288"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1287"/>
         <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
 
 Model settings may be corrupted if you continue.</source>
         <translation>Advarsel: &apos;%1&apos; har version %2 indstillinger som ikke understøttes af denne version af Companion. Model og radio indstillinger kan blive ødelagt hvis du fortsætter.</translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1291"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1290"/>
         <source>Read Model Settings</source>
         <translation>Indlæser radio indstillinger</translation>
     </message>

--- a/companion/src/translations/companion_de.ts
+++ b/companion/src/translations/companion_de.ts
@@ -1026,274 +1026,274 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="422"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>Left Horizontal</source>
         <translation>Links Horizontal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="423"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>Left Vertical</source>
         <translation>Links Vertikal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="424"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>Right Vertical</source>
         <translation>Rechts Vertikal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="425"/>
+        <location filename="../firmwares/boards.cpp" line="429"/>
         <source>Right Horizontal</source>
         <translation>Rechts Horizontal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="426"/>
+        <location filename="../firmwares/boards.cpp" line="430"/>
         <source>Aux. 1</source>
         <translation>Aux1</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="427"/>
+        <location filename="../firmwares/boards.cpp" line="431"/>
         <source>Aux. 2</source>
         <translation>Aux2</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="443"/>
+        <location filename="../firmwares/boards.cpp" line="447"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="444"/>
+        <location filename="../firmwares/boards.cpp" line="448"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="449"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
         <source>RH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="459"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <source>TILT_X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="460"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <source>TILT_Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="506"/>
+        <location filename="../firmwares/boards.cpp" line="516"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
+        <location filename="../firmwares/boards.cpp" line="532"/>
+        <location filename="../firmwares/boards.cpp" line="548"/>
+        <location filename="../firmwares/boards.cpp" line="555"/>
+        <source>SL1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="475"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <source>P4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="517"/>
+        <location filename="../firmwares/boards.cpp" line="525"/>
+        <location filename="../firmwares/boards.cpp" line="533"/>
+        <location filename="../firmwares/boards.cpp" line="549"/>
+        <location filename="../firmwares/boards.cpp" line="556"/>
+        <source>SL2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="478"/>
+        <location filename="../firmwares/boards.cpp" line="557"/>
+        <source>SL3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="479"/>
+        <location filename="../firmwares/boards.cpp" line="558"/>
+        <source>SL4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <source>P5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="943"/>
+        <source>Slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="945"/>
+        <source>Multipos Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="947"/>
+        <source>Axis X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="949"/>
+        <source>Axis Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="951"/>
+        <source>Switch</source>
+        <translation type="unfinished">Schalter</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Flight</source>
+        <translation type="unfinished">Flug</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="488"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="498"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
+        <location filename="../firmwares/boards.cpp" line="529"/>
+        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="553"/>
+        <source>P1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="473"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="504"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
+        <location filename="../firmwares/boards.cpp" line="530"/>
+        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="554"/>
+        <source>P2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="474"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="505"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
+        <location filename="../firmwares/boards.cpp" line="531"/>
+        <location filename="../firmwares/boards.cpp" line="543"/>
+        <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="455"/>
         <location filename="../firmwares/boards.cpp" line="457"/>
-        <source>TILT_X</source>
+        <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="456"/>
         <location filename="../firmwares/boards.cpp" line="458"/>
-        <source>TILT_Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="463"/>
-        <location filename="../firmwares/boards.cpp" line="472"/>
-        <location filename="../firmwares/boards.cpp" line="502"/>
-        <location filename="../firmwares/boards.cpp" line="512"/>
-        <location filename="../firmwares/boards.cpp" line="520"/>
-        <location filename="../firmwares/boards.cpp" line="528"/>
-        <location filename="../firmwares/boards.cpp" line="544"/>
-        <location filename="../firmwares/boards.cpp" line="551"/>
-        <source>SL1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="471"/>
-        <location filename="../firmwares/boards.cpp" line="510"/>
-        <source>P4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="473"/>
-        <location filename="../firmwares/boards.cpp" line="503"/>
-        <location filename="../firmwares/boards.cpp" line="513"/>
-        <location filename="../firmwares/boards.cpp" line="521"/>
-        <location filename="../firmwares/boards.cpp" line="529"/>
-        <location filename="../firmwares/boards.cpp" line="545"/>
-        <location filename="../firmwares/boards.cpp" line="552"/>
-        <source>SL2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="474"/>
-        <location filename="../firmwares/boards.cpp" line="553"/>
-        <source>SL3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="475"/>
-        <location filename="../firmwares/boards.cpp" line="554"/>
-        <source>SL4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="511"/>
-        <source>P5</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="933"/>
-        <source>Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="935"/>
-        <source>Multipos Switch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="937"/>
-        <source>Axis X</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="939"/>
-        <source>Axis Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="941"/>
-        <source>Switch</source>
-        <translation type="unfinished">Schalter</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Flight</source>
-        <translation type="unfinished">Flug</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Drive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="464"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
-        <location filename="../firmwares/boards.cpp" line="479"/>
-        <location filename="../firmwares/boards.cpp" line="484"/>
-        <location filename="../firmwares/boards.cpp" line="490"/>
-        <location filename="../firmwares/boards.cpp" line="494"/>
-        <location filename="../firmwares/boards.cpp" line="499"/>
-        <location filename="../firmwares/boards.cpp" line="507"/>
-        <location filename="../firmwares/boards.cpp" line="517"/>
-        <location filename="../firmwares/boards.cpp" line="525"/>
-        <location filename="../firmwares/boards.cpp" line="537"/>
-        <location filename="../firmwares/boards.cpp" line="549"/>
-        <source>P1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="469"/>
-        <location filename="../firmwares/boards.cpp" line="480"/>
-        <location filename="../firmwares/boards.cpp" line="485"/>
-        <location filename="../firmwares/boards.cpp" line="495"/>
-        <location filename="../firmwares/boards.cpp" line="500"/>
-        <location filename="../firmwares/boards.cpp" line="508"/>
-        <location filename="../firmwares/boards.cpp" line="518"/>
-        <location filename="../firmwares/boards.cpp" line="526"/>
-        <location filename="../firmwares/boards.cpp" line="538"/>
-        <location filename="../firmwares/boards.cpp" line="550"/>
-        <source>P2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="470"/>
-        <location filename="../firmwares/boards.cpp" line="486"/>
-        <location filename="../firmwares/boards.cpp" line="501"/>
-        <location filename="../firmwares/boards.cpp" line="509"/>
-        <location filename="../firmwares/boards.cpp" line="519"/>
-        <location filename="../firmwares/boards.cpp" line="527"/>
-        <location filename="../firmwares/boards.cpp" line="539"/>
-        <source>P3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
-        <source>JSx</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="454"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="530"/>
-        <location filename="../firmwares/boards.cpp" line="540"/>
+        <location filename="../firmwares/boards.cpp" line="534"/>
+        <location filename="../firmwares/boards.cpp" line="544"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="531"/>
-        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="535"/>
+        <location filename="../firmwares/boards.cpp" line="545"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="532"/>
-        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="536"/>
+        <location filename="../firmwares/boards.cpp" line="546"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="533"/>
-        <location filename="../firmwares/boards.cpp" line="543"/>
+        <location filename="../firmwares/boards.cpp" line="537"/>
+        <location filename="../firmwares/boards.cpp" line="547"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="678"/>
-        <location filename="../firmwares/boards.cpp" line="897"/>
-        <location filename="../firmwares/boards.cpp" line="927"/>
+        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="907"/>
+        <location filename="../firmwares/boards.cpp" line="937"/>
         <source>None</source>
         <translation type="unfinished">Kein</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="929"/>
+        <location filename="../firmwares/boards.cpp" line="939"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="931"/>
+        <location filename="../firmwares/boards.cpp" line="941"/>
         <source>Pot with detent</source>
         <translation type="unfinished">Poti mit Raste</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="680"/>
+        <location filename="../firmwares/boards.cpp" line="686"/>
         <source>2 Positions Toggle</source>
         <translation type="unfinished">2 Position Taster</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="682"/>
+        <location filename="../firmwares/boards.cpp" line="688"/>
         <source>2 Positions</source>
         <translation type="unfinished">2 Positionen</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="690"/>
         <source>3 Positions</source>
         <translation type="unfinished">3 Positionen</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="686"/>
+        <location filename="../firmwares/boards.cpp" line="692"/>
         <source>Function</source>
         <translation type="unfinished">Funktion</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="899"/>
+        <location filename="../firmwares/boards.cpp" line="909"/>
         <source>Standard</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="901"/>
+        <location filename="../firmwares/boards.cpp" line="911"/>
         <source>Small</source>
         <translation type="unfinished">Klein</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="903"/>
+        <location filename="../firmwares/boards.cpp" line="913"/>
         <source>Both</source>
         <translation type="unfinished">Beide</translation>
     </message>
@@ -1633,34 +1633,50 @@ Error description: %4</source>
         <translation>Simulation für diese Firmware ist noch nicht verfügbar</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="380"/>
+        <location filename="../helpers.cpp" line="388"/>
+        <source>Uknown error during Simulator startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Data Load Error</source>
+        <translation type="unfinished">Daten Ladefehler</translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Error occurred while starting simulator.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="405"/>
         <source>Error creating temporary directory for models and settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="388"/>
+        <location filename="../helpers.cpp" line="413"/>
         <source>Error writing models and settings to temporary directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="419"/>
+        <location filename="../helpers.cpp" line="444"/>
         <source>Unable to start.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="421"/>
+        <location filename="../helpers.cpp" line="446"/>
         <source>Crashed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="423"/>
+        <location filename="../helpers.cpp" line="448"/>
         <source>Exited with result code:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="381"/>
         <location filename="../helpers.cpp" line="389"/>
-        <location filename="../helpers.cpp" line="426"/>
+        <location filename="../helpers.cpp" line="406"/>
+        <location filename="../helpers.cpp" line="414"/>
+        <location filename="../helpers.cpp" line="451"/>
         <source>Simulator Error</source>
         <translation>Simulator Fehler</translation>
     </message>
@@ -3522,59 +3538,59 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="448"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="612"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="622"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="632"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="642"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="652"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="662"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="672"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="742"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="761"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="772"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="782"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="807"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="619"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="629"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="639"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="649"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="659"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="669"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="679"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="739"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="749"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="768"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="779"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="789"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="814"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation>Kein Helimenü und zykl. Mischer </translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="449"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="613"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="623"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="633"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="643"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="653"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="663"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="673"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="733"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="743"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="752"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="762"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="773"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="783"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="680"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="769"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="815"/>
         <source>Disable Global variables</source>
         <translation>Keine Globale Variablen</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="450"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="474"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="614"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="624"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="634"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="644"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="654"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="664"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="674"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="734"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="744"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="753"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="763"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="784"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="809"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="621"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="631"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="641"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="651"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="661"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="671"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="741"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="751"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="760"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="781"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="791"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="816"/>
         <source>Enable Lua custom scripts screen</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3584,7 +3600,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>Alternative SQT5 Schrift verw</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
         <source>FrSky Taranis X9D+</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3599,104 +3615,104 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="590"/>
         <source>Disable RAS (SWR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="574"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="581"/>
         <source>FrSky Taranis X9D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="576"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
         <source>Haptic module installed</source>
         <translation>Haptikmodul installiert</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="595"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="602"/>
         <source>FrSky Taranis X9E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
         <source>Confirmation before radio shutdown</source>
         <translation>Ausschalten bestätigung vor Sender runterfährt</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="597"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="604"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation>Horus Knüppel installiert(Hallgeber)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="562"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="569"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="537"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="544"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="563"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="549"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
         <source>FrSky Taranis X-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="530"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="529"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="536"/>
         <source>FrSky Horus X12S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="539"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="677"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="675"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="703"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="682"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="710"/>
         <source>Support for MULTI internal module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="627"/>
         <source>Jumper T-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="637"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="701"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="708"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3706,26 +3722,26 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="777"/>
         <source>Radiomaster TX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="787"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="805"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="812"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="683"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="690"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="718"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="697"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="725"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="810"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="817"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3735,82 +3751,87 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <source>FlySky ST16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
         <source>HelloRadioSky V16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="647"/>
         <source>Jumper T-Pro V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="657"/>
         <source>Jumper T-Pro S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="667"/>
         <source>Jumper Bumblebee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
         <source>Jumper T12 MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
         <source>Jumper T14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="702"/>
         <source>Jumper T15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
         <source>Jumper T20 V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="737"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="747"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="757"/>
         <source>Radiomaster MT12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="766"/>
         <source>Radiomaster T8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="767"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
         <source>Allow bind using bind key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
         <source>Radiomaster GX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="804"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3821,12 +3842,12 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="484"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="801"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="709"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
         <source>Jumper T18</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3841,7 +3862,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="617"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3866,18 +3887,18 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="568"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="543"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="550"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="518"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="525"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="538"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4858,206 +4879,206 @@ Dieses sind für alle Modelle im gleichen EEPROM gültig.</translation>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="412"/>
+        <location filename="../firmwares/generalsettings.cpp" line="414"/>
         <source>Radio Settings</source>
         <translation>Sender Grunfeinstellungen</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="414"/>
+        <location filename="../firmwares/generalsettings.cpp" line="416"/>
         <source>Hardware</source>
         <translation type="unfinished">Hardware</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="415"/>
+        <location filename="../firmwares/generalsettings.cpp" line="417"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="430"/>
+        <location filename="../firmwares/generalsettings.cpp" line="432"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="464"/>
+        <location filename="../firmwares/generalsettings.cpp" line="466"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="469"/>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="471"/>
+        <location filename="../firmwares/generalsettings.cpp" line="483"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Switch</source>
         <translation type="unfinished">Schalter</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="499"/>
+        <location filename="../firmwares/generalsettings.cpp" line="501"/>
         <source>None</source>
         <translation type="unfinished">Kein</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="553"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Internal</source>
         <translation type="unfinished">Interne</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="555"/>
+        <location filename="../firmwares/generalsettings.cpp" line="557"/>
         <source>Ask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="557"/>
+        <location filename="../firmwares/generalsettings.cpp" line="559"/>
         <source>Per model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>Internal + External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>External</source>
         <translation type="unfinished">Externe</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="573"/>
-        <location filename="../firmwares/generalsettings.cpp" line="589"/>
+        <location filename="../firmwares/generalsettings.cpp" line="575"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>OFF</source>
         <translation type="unfinished">AUS</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Telemetry</source>
         <translation type="unfinished">Telemetrie</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="578"/>
+        <location filename="../firmwares/generalsettings.cpp" line="580"/>
         <source>Trainer</source>
         <translation type="unfinished">Schüler Signaleingang</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="591"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="593"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="595"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished">SBus Schüler</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="597"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="599"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="601"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>GPS</source>
         <translation type="unfinished">GPS</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="603"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>Debug</source>
         <translation type="unfinished">Debugmode</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="605"/>
+        <location filename="../firmwares/generalsettings.cpp" line="607"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="607"/>
+        <location filename="../firmwares/generalsettings.cpp" line="609"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="640"/>
+        <location filename="../firmwares/generalsettings.cpp" line="642"/>
         <source>mA</source>
         <translation type="unfinished">mA</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="739"/>
+        <location filename="../firmwares/generalsettings.cpp" line="741"/>
         <source>Normal</source>
         <translation type="unfinished">Normal</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="741"/>
+        <location filename="../firmwares/generalsettings.cpp" line="743"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="787"/>
+        <location filename="../firmwares/generalsettings.cpp" line="789"/>
         <source>Trims only</source>
         <translation type="unfinished">Nur Trimmung</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="789"/>
+        <location filename="../firmwares/generalsettings.cpp" line="791"/>
         <source>Keys only</source>
         <translation type="unfinished">Nur Tasten</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="791"/>
+        <location filename="../firmwares/generalsettings.cpp" line="793"/>
         <source>Switchable</source>
         <translation type="unfinished">Umschaltbar</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="793"/>
+        <location filename="../firmwares/generalsettings.cpp" line="795"/>
         <source>Global</source>
         <translation type="unfinished">Global</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="927"/>
+        <location filename="../firmwares/generalsettings.cpp" line="929"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation type="unfinished">Mode 1 (Seite Höhe Gas Quer)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="931"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation type="unfinished">Mode 2 (Seite Gas Höhe Quer)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="933"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation type="unfinished">Mode 3 (Quer Höhe Gas Seite)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="935"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation type="unfinished">Mode 4 (Quer Gas Höhe Seite)</translation>
     </message>
@@ -5985,32 +6006,32 @@ Warnung stummer Betrieb - Wird angezeigt, wenn der Piepser komplett ausgeschalte
         <translation>Tschechisch</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="434"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Slovak</source>
         <translation>Slowakisch</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="435"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Spanish</source>
         <translation>Spanisch</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Polish</source>
         <translation>Polnisch</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="432"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Portuguese</source>
         <translation>Portugiesisch</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="433"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Russian</source>
         <translation>Russisch</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="436"/>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Swedish</source>
         <translation>Schwedisch</translation>
     </message>
@@ -6020,7 +6041,7 @@ Warnung stummer Betrieb - Wird angezeigt, wenn der Piepser komplett ausgeschalte
         <translation>Ungarisch</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6055,42 +6076,47 @@ Warnung stummer Betrieb - Wird angezeigt, wenn der Piepser komplett ausgeschalte
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="437"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <source>Korean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="438"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>No</source>
         <translation>Nein</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>RotEnc A</source>
         <translation>Drehgeber A</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc B</source>
         <translation>Drehgeber B</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc C</source>
         <translation>Drehgeber C</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc D</source>
         <translation>Drehgeber D</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc E</source>
         <translation>Drehgeber E</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="617"/>
+        <location filename="../generaledit/generalsetup.cpp" line="618"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
@@ -6099,22 +6125,22 @@ Diese Funktion kann im Sender nicht mehr abgewählt werden.
 Sind Sie sicher?</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal</source>
         <translation type="unfinished">Normal</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15695,22 +15721,22 @@ Timestamp</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="873"/>
+        <location filename="../firmwares/generalsettings.cpp" line="875"/>
         <source>OFF</source>
         <translation type="unfinished">AUS</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="875"/>
+        <location filename="../firmwares/generalsettings.cpp" line="877"/>
         <source>+= (Sum)</source>
         <translation type="unfinished">+= (Add)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="877"/>
+        <location filename="../firmwares/generalsettings.cpp" line="879"/>
         <source>:= (Replace)</source>
         <translation type="unfinished">:= (Ersetzen)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="886"/>
+        <location filename="../firmwares/generalsettings.cpp" line="888"/>
         <source>CH%1</source>
         <translation type="unfinished">CH%1</translation>
     </message>
@@ -17410,14 +17436,14 @@ Do you wish to continue?</source>
 <context>
     <name>YamlModelSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1288"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1287"/>
         <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
 
 Model settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1291"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1290"/>
         <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/companion/src/translations/companion_en.ts
+++ b/companion/src/translations/companion_en.ts
@@ -1002,274 +1002,274 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="422"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>Left Horizontal</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="423"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>Left Vertical</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="424"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>Right Vertical</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="425"/>
+        <location filename="../firmwares/boards.cpp" line="429"/>
         <source>Right Horizontal</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="426"/>
+        <location filename="../firmwares/boards.cpp" line="430"/>
         <source>Aux. 1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="427"/>
+        <location filename="../firmwares/boards.cpp" line="431"/>
         <source>Aux. 2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="443"/>
+        <location filename="../firmwares/boards.cpp" line="447"/>
         <source>LH</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="444"/>
+        <location filename="../firmwares/boards.cpp" line="448"/>
         <source>LV</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="449"/>
         <source>RV</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
         <source>RH</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="459"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <source>TILT_X</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="460"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <source>TILT_Y</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="506"/>
+        <location filename="../firmwares/boards.cpp" line="516"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
+        <location filename="../firmwares/boards.cpp" line="532"/>
+        <location filename="../firmwares/boards.cpp" line="548"/>
+        <location filename="../firmwares/boards.cpp" line="555"/>
+        <source>SL1</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="475"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <source>P4</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="517"/>
+        <location filename="../firmwares/boards.cpp" line="525"/>
+        <location filename="../firmwares/boards.cpp" line="533"/>
+        <location filename="../firmwares/boards.cpp" line="549"/>
+        <location filename="../firmwares/boards.cpp" line="556"/>
+        <source>SL2</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="478"/>
+        <location filename="../firmwares/boards.cpp" line="557"/>
+        <source>SL3</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="479"/>
+        <location filename="../firmwares/boards.cpp" line="558"/>
+        <source>SL4</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <source>P5</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="943"/>
+        <source>Slider</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="945"/>
+        <source>Multipos Switch</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="947"/>
+        <source>Axis X</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="949"/>
+        <source>Axis Y</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="951"/>
+        <source>Switch</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Flight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="488"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="498"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
+        <location filename="../firmwares/boards.cpp" line="529"/>
+        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="553"/>
+        <source>P1</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="473"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="504"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
+        <location filename="../firmwares/boards.cpp" line="530"/>
+        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="554"/>
+        <source>P2</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="474"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="505"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
+        <location filename="../firmwares/boards.cpp" line="531"/>
+        <location filename="../firmwares/boards.cpp" line="543"/>
+        <source>P3</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="455"/>
         <location filename="../firmwares/boards.cpp" line="457"/>
-        <source>TILT_X</source>
+        <source>JSx</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="456"/>
         <location filename="../firmwares/boards.cpp" line="458"/>
-        <source>TILT_Y</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="463"/>
-        <location filename="../firmwares/boards.cpp" line="472"/>
-        <location filename="../firmwares/boards.cpp" line="502"/>
-        <location filename="../firmwares/boards.cpp" line="512"/>
-        <location filename="../firmwares/boards.cpp" line="520"/>
-        <location filename="../firmwares/boards.cpp" line="528"/>
-        <location filename="../firmwares/boards.cpp" line="544"/>
-        <location filename="../firmwares/boards.cpp" line="551"/>
-        <source>SL1</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="471"/>
-        <location filename="../firmwares/boards.cpp" line="510"/>
-        <source>P4</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="473"/>
-        <location filename="../firmwares/boards.cpp" line="503"/>
-        <location filename="../firmwares/boards.cpp" line="513"/>
-        <location filename="../firmwares/boards.cpp" line="521"/>
-        <location filename="../firmwares/boards.cpp" line="529"/>
-        <location filename="../firmwares/boards.cpp" line="545"/>
-        <location filename="../firmwares/boards.cpp" line="552"/>
-        <source>SL2</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="474"/>
-        <location filename="../firmwares/boards.cpp" line="553"/>
-        <source>SL3</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="475"/>
-        <location filename="../firmwares/boards.cpp" line="554"/>
-        <source>SL4</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="511"/>
-        <source>P5</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="933"/>
-        <source>Slider</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="935"/>
-        <source>Multipos Switch</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="937"/>
-        <source>Axis X</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="939"/>
-        <source>Axis Y</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="941"/>
-        <source>Switch</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Flight</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Drive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="464"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
-        <location filename="../firmwares/boards.cpp" line="479"/>
-        <location filename="../firmwares/boards.cpp" line="484"/>
-        <location filename="../firmwares/boards.cpp" line="490"/>
-        <location filename="../firmwares/boards.cpp" line="494"/>
-        <location filename="../firmwares/boards.cpp" line="499"/>
-        <location filename="../firmwares/boards.cpp" line="507"/>
-        <location filename="../firmwares/boards.cpp" line="517"/>
-        <location filename="../firmwares/boards.cpp" line="525"/>
-        <location filename="../firmwares/boards.cpp" line="537"/>
-        <location filename="../firmwares/boards.cpp" line="549"/>
-        <source>P1</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="469"/>
-        <location filename="../firmwares/boards.cpp" line="480"/>
-        <location filename="../firmwares/boards.cpp" line="485"/>
-        <location filename="../firmwares/boards.cpp" line="495"/>
-        <location filename="../firmwares/boards.cpp" line="500"/>
-        <location filename="../firmwares/boards.cpp" line="508"/>
-        <location filename="../firmwares/boards.cpp" line="518"/>
-        <location filename="../firmwares/boards.cpp" line="526"/>
-        <location filename="../firmwares/boards.cpp" line="538"/>
-        <location filename="../firmwares/boards.cpp" line="550"/>
-        <source>P2</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="470"/>
-        <location filename="../firmwares/boards.cpp" line="486"/>
-        <location filename="../firmwares/boards.cpp" line="501"/>
-        <location filename="../firmwares/boards.cpp" line="509"/>
-        <location filename="../firmwares/boards.cpp" line="519"/>
-        <location filename="../firmwares/boards.cpp" line="527"/>
-        <location filename="../firmwares/boards.cpp" line="539"/>
-        <source>P3</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
-        <source>JSx</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="454"/>
         <source>JSy</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="530"/>
-        <location filename="../firmwares/boards.cpp" line="540"/>
+        <location filename="../firmwares/boards.cpp" line="534"/>
+        <location filename="../firmwares/boards.cpp" line="544"/>
         <source>EXT1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="531"/>
-        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="535"/>
+        <location filename="../firmwares/boards.cpp" line="545"/>
         <source>EXT2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="532"/>
-        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="536"/>
+        <location filename="../firmwares/boards.cpp" line="546"/>
         <source>EXT3</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="533"/>
-        <location filename="../firmwares/boards.cpp" line="543"/>
+        <location filename="../firmwares/boards.cpp" line="537"/>
+        <location filename="../firmwares/boards.cpp" line="547"/>
         <source>EXT4</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="678"/>
-        <location filename="../firmwares/boards.cpp" line="897"/>
-        <location filename="../firmwares/boards.cpp" line="927"/>
+        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="907"/>
+        <location filename="../firmwares/boards.cpp" line="937"/>
         <source>None</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="929"/>
+        <location filename="../firmwares/boards.cpp" line="939"/>
         <source>Pot</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="931"/>
+        <location filename="../firmwares/boards.cpp" line="941"/>
         <source>Pot with detent</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="680"/>
+        <location filename="../firmwares/boards.cpp" line="686"/>
         <source>2 Positions Toggle</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="682"/>
+        <location filename="../firmwares/boards.cpp" line="688"/>
         <source>2 Positions</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="690"/>
         <source>3 Positions</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="686"/>
+        <location filename="../firmwares/boards.cpp" line="692"/>
         <source>Function</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="899"/>
+        <location filename="../firmwares/boards.cpp" line="909"/>
         <source>Standard</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="901"/>
+        <location filename="../firmwares/boards.cpp" line="911"/>
         <source>Small</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="903"/>
+        <location filename="../firmwares/boards.cpp" line="913"/>
         <source>Both</source>
         <translation></translation>
     </message>
@@ -1606,34 +1606,50 @@ Error description: %4</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="380"/>
+        <location filename="../helpers.cpp" line="388"/>
+        <source>Uknown error during Simulator startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Data Load Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Error occurred while starting simulator.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="405"/>
         <source>Error creating temporary directory for models and settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="388"/>
+        <location filename="../helpers.cpp" line="413"/>
         <source>Error writing models and settings to temporary directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="419"/>
+        <location filename="../helpers.cpp" line="444"/>
         <source>Unable to start.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="421"/>
+        <location filename="../helpers.cpp" line="446"/>
         <source>Crashed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="423"/>
+        <location filename="../helpers.cpp" line="448"/>
         <source>Exited with result code:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="381"/>
         <location filename="../helpers.cpp" line="389"/>
-        <location filename="../helpers.cpp" line="426"/>
+        <location filename="../helpers.cpp" line="406"/>
+        <location filename="../helpers.cpp" line="414"/>
+        <location filename="../helpers.cpp" line="451"/>
         <source>Simulator Error</source>
         <translation></translation>
     </message>
@@ -3494,59 +3510,59 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="448"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="612"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="622"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="632"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="642"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="652"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="662"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="672"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="742"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="761"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="772"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="782"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="807"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="619"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="629"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="639"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="649"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="659"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="669"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="679"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="739"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="749"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="768"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="779"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="789"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="814"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="449"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="613"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="623"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="633"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="643"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="653"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="663"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="673"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="733"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="743"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="752"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="762"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="773"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="783"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="680"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="769"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="815"/>
         <source>Disable Global variables</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="450"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="474"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="614"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="624"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="634"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="644"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="654"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="664"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="674"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="734"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="744"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="753"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="763"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="784"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="809"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="621"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="631"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="641"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="651"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="661"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="671"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="741"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="751"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="760"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="781"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="791"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="816"/>
         <source>Enable Lua custom scripts screen</source>
         <translation></translation>
     </message>
@@ -3556,7 +3572,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
         <source>FrSky Taranis X9D+</source>
         <translation></translation>
     </message>
@@ -3571,104 +3587,104 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="590"/>
         <source>Disable RAS (SWR)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="574"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="581"/>
         <source>FrSky Taranis X9D</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="576"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
         <source>Haptic module installed</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="595"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="602"/>
         <source>FrSky Taranis X9E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
         <source>Confirmation before radio shutdown</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="597"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="604"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="562"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="569"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="537"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="544"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="563"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="549"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
         <source>FrSky Taranis X-Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="530"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="529"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="536"/>
         <source>FrSky Horus X12S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="539"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="677"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="675"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="703"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="682"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="710"/>
         <source>Support for MULTI internal module</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="627"/>
         <source>Jumper T-Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="637"/>
         <source>Jumper T-Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="701"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="708"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation></translation>
     </message>
@@ -3678,26 +3694,26 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="777"/>
         <source>Radiomaster TX12</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="787"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="805"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="812"/>
         <source>Radiomaster Zorro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="683"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="690"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="718"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="697"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="725"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="810"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="817"/>
         <source>Select if internal ELRS module is installed</source>
         <translation></translation>
     </message>
@@ -3707,82 +3723,87 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <source>FlySky ST16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
         <source>HelloRadioSky V16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="647"/>
         <source>Jumper T-Pro V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="657"/>
         <source>Jumper T-Pro S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="667"/>
         <source>Jumper Bumblebee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
         <source>Jumper T12 MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
         <source>Jumper T14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="702"/>
         <source>Jumper T15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
         <source>Jumper T20</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
         <source>Jumper T20 V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="737"/>
         <source>Radiomaster Boxer</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="747"/>
         <source>Radiomaster Pocket</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="757"/>
         <source>Radiomaster MT12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="766"/>
         <source>Radiomaster T8</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="767"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
         <source>Allow bind using bind key</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
         <source>Radiomaster GX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="804"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation></translation>
     </message>
@@ -3793,12 +3814,12 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="484"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="801"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="709"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
         <source>Jumper T18</source>
         <translation></translation>
     </message>
@@ -3813,7 +3834,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="617"/>
         <source>iFlight Commando8</source>
         <translation></translation>
     </message>
@@ -3838,18 +3859,18 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="568"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="543"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="550"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="518"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="525"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="538"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation></translation>
     </message>
@@ -4823,206 +4844,206 @@ These will be relevant for all models in the same EEPROM.</source>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="412"/>
+        <location filename="../firmwares/generalsettings.cpp" line="414"/>
         <source>Radio Settings</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="414"/>
+        <location filename="../firmwares/generalsettings.cpp" line="416"/>
         <source>Hardware</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="415"/>
+        <location filename="../firmwares/generalsettings.cpp" line="417"/>
         <source>Internal Module</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="430"/>
+        <location filename="../firmwares/generalsettings.cpp" line="432"/>
         <source>Axis &amp; Pots</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Axis</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Pot</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="464"/>
+        <location filename="../firmwares/generalsettings.cpp" line="466"/>
         <source>Switches</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="469"/>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="471"/>
+        <location filename="../firmwares/generalsettings.cpp" line="483"/>
         <source>Flex Switch</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Function Switch</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Switch</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="499"/>
+        <location filename="../firmwares/generalsettings.cpp" line="501"/>
         <source>None</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="553"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Internal</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="555"/>
+        <location filename="../firmwares/generalsettings.cpp" line="557"/>
         <source>Ask</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="557"/>
+        <location filename="../firmwares/generalsettings.cpp" line="559"/>
         <source>Per model</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>Internal + External</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>External</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="573"/>
-        <location filename="../firmwares/generalsettings.cpp" line="589"/>
+        <location filename="../firmwares/generalsettings.cpp" line="575"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>OFF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Enabled</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Telemetry</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="578"/>
+        <location filename="../firmwares/generalsettings.cpp" line="580"/>
         <source>Trainer</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="591"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>Telemetry Mirror</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="593"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>Telemetry In</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="595"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>SBUS Trainer</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="597"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>LUA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="599"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>CLI</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="601"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>GPS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="603"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>Debug</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="605"/>
+        <location filename="../firmwares/generalsettings.cpp" line="607"/>
         <source>SpaceMouse</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="607"/>
+        <location filename="../firmwares/generalsettings.cpp" line="609"/>
         <source>External module</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="640"/>
+        <location filename="../firmwares/generalsettings.cpp" line="642"/>
         <source>mA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="739"/>
+        <location filename="../firmwares/generalsettings.cpp" line="741"/>
         <source>Normal</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="741"/>
+        <location filename="../firmwares/generalsettings.cpp" line="743"/>
         <source>OneBit</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="787"/>
+        <location filename="../firmwares/generalsettings.cpp" line="789"/>
         <source>Trims only</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="789"/>
+        <location filename="../firmwares/generalsettings.cpp" line="791"/>
         <source>Keys only</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="791"/>
+        <location filename="../firmwares/generalsettings.cpp" line="793"/>
         <source>Switchable</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="793"/>
+        <location filename="../firmwares/generalsettings.cpp" line="795"/>
         <source>Global</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="927"/>
+        <location filename="../firmwares/generalsettings.cpp" line="929"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="931"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="933"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="935"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5913,32 +5934,32 @@ p, li { white-space: pre-wrap; }
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="434"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Slovak</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="435"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Spanish</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Polish</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="432"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Portuguese</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="433"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Russian</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="436"/>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Swedish</source>
         <translation></translation>
     </message>
@@ -5948,7 +5969,7 @@ p, li { white-space: pre-wrap; }
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal, Edit Inverted</source>
         <translation></translation>
     </message>
@@ -5983,64 +6004,69 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="437"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <source>Korean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="438"/>
         <source>Ukrainian</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>No</source>
         <translation>No</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>RotEnc A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc B</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc D</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="617"/>
+        <location filename="../generaledit/generalsetup.cpp" line="618"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Inverted</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation></translation>
     </message>
@@ -15574,22 +15600,22 @@ Timestamp</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="873"/>
+        <location filename="../firmwares/generalsettings.cpp" line="875"/>
         <source>OFF</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="875"/>
+        <location filename="../firmwares/generalsettings.cpp" line="877"/>
         <source>+= (Sum)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="877"/>
+        <location filename="../firmwares/generalsettings.cpp" line="879"/>
         <source>:= (Replace)</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="886"/>
+        <location filename="../firmwares/generalsettings.cpp" line="888"/>
         <source>CH%1</source>
         <translation></translation>
     </message>
@@ -17287,14 +17313,14 @@ Do you wish to continue?</source>
 <context>
     <name>YamlModelSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1288"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1287"/>
         <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
 
 Model settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1291"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1290"/>
         <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/companion/src/translations/companion_es.ts
+++ b/companion/src/translations/companion_es.ts
@@ -1023,274 +1023,274 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="422"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>Left Horizontal</source>
         <translation>Izquierda horizontal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="423"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>Left Vertical</source>
         <translation>Izquierda vertical</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="424"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>Right Vertical</source>
         <translation>Derecha vertical</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="425"/>
+        <location filename="../firmwares/boards.cpp" line="429"/>
         <source>Right Horizontal</source>
         <translation>Derecha horizontal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="426"/>
+        <location filename="../firmwares/boards.cpp" line="430"/>
         <source>Aux. 1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="427"/>
+        <location filename="../firmwares/boards.cpp" line="431"/>
         <source>Aux. 2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="443"/>
+        <location filename="../firmwares/boards.cpp" line="447"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="444"/>
+        <location filename="../firmwares/boards.cpp" line="448"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="449"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
         <source>RH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="459"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <source>TILT_X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="460"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <source>TILT_Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="506"/>
+        <location filename="../firmwares/boards.cpp" line="516"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
+        <location filename="../firmwares/boards.cpp" line="532"/>
+        <location filename="../firmwares/boards.cpp" line="548"/>
+        <location filename="../firmwares/boards.cpp" line="555"/>
+        <source>SL1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="475"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <source>P4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="517"/>
+        <location filename="../firmwares/boards.cpp" line="525"/>
+        <location filename="../firmwares/boards.cpp" line="533"/>
+        <location filename="../firmwares/boards.cpp" line="549"/>
+        <location filename="../firmwares/boards.cpp" line="556"/>
+        <source>SL2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="478"/>
+        <location filename="../firmwares/boards.cpp" line="557"/>
+        <source>SL3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="479"/>
+        <location filename="../firmwares/boards.cpp" line="558"/>
+        <source>SL4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <source>P5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="943"/>
+        <source>Slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="945"/>
+        <source>Multipos Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="947"/>
+        <source>Axis X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="949"/>
+        <source>Axis Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="951"/>
+        <source>Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Flight</source>
+        <translation type="unfinished">Vuelo</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="488"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="498"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
+        <location filename="../firmwares/boards.cpp" line="529"/>
+        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="553"/>
+        <source>P1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="473"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="504"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
+        <location filename="../firmwares/boards.cpp" line="530"/>
+        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="554"/>
+        <source>P2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="474"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="505"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
+        <location filename="../firmwares/boards.cpp" line="531"/>
+        <location filename="../firmwares/boards.cpp" line="543"/>
+        <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="455"/>
         <location filename="../firmwares/boards.cpp" line="457"/>
-        <source>TILT_X</source>
+        <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="456"/>
         <location filename="../firmwares/boards.cpp" line="458"/>
-        <source>TILT_Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="463"/>
-        <location filename="../firmwares/boards.cpp" line="472"/>
-        <location filename="../firmwares/boards.cpp" line="502"/>
-        <location filename="../firmwares/boards.cpp" line="512"/>
-        <location filename="../firmwares/boards.cpp" line="520"/>
-        <location filename="../firmwares/boards.cpp" line="528"/>
-        <location filename="../firmwares/boards.cpp" line="544"/>
-        <location filename="../firmwares/boards.cpp" line="551"/>
-        <source>SL1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="471"/>
-        <location filename="../firmwares/boards.cpp" line="510"/>
-        <source>P4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="473"/>
-        <location filename="../firmwares/boards.cpp" line="503"/>
-        <location filename="../firmwares/boards.cpp" line="513"/>
-        <location filename="../firmwares/boards.cpp" line="521"/>
-        <location filename="../firmwares/boards.cpp" line="529"/>
-        <location filename="../firmwares/boards.cpp" line="545"/>
-        <location filename="../firmwares/boards.cpp" line="552"/>
-        <source>SL2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="474"/>
-        <location filename="../firmwares/boards.cpp" line="553"/>
-        <source>SL3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="475"/>
-        <location filename="../firmwares/boards.cpp" line="554"/>
-        <source>SL4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="511"/>
-        <source>P5</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="933"/>
-        <source>Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="935"/>
-        <source>Multipos Switch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="937"/>
-        <source>Axis X</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="939"/>
-        <source>Axis Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="941"/>
-        <source>Switch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Flight</source>
-        <translation type="unfinished">Vuelo</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Drive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="464"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
-        <location filename="../firmwares/boards.cpp" line="479"/>
-        <location filename="../firmwares/boards.cpp" line="484"/>
-        <location filename="../firmwares/boards.cpp" line="490"/>
-        <location filename="../firmwares/boards.cpp" line="494"/>
-        <location filename="../firmwares/boards.cpp" line="499"/>
-        <location filename="../firmwares/boards.cpp" line="507"/>
-        <location filename="../firmwares/boards.cpp" line="517"/>
-        <location filename="../firmwares/boards.cpp" line="525"/>
-        <location filename="../firmwares/boards.cpp" line="537"/>
-        <location filename="../firmwares/boards.cpp" line="549"/>
-        <source>P1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="469"/>
-        <location filename="../firmwares/boards.cpp" line="480"/>
-        <location filename="../firmwares/boards.cpp" line="485"/>
-        <location filename="../firmwares/boards.cpp" line="495"/>
-        <location filename="../firmwares/boards.cpp" line="500"/>
-        <location filename="../firmwares/boards.cpp" line="508"/>
-        <location filename="../firmwares/boards.cpp" line="518"/>
-        <location filename="../firmwares/boards.cpp" line="526"/>
-        <location filename="../firmwares/boards.cpp" line="538"/>
-        <location filename="../firmwares/boards.cpp" line="550"/>
-        <source>P2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="470"/>
-        <location filename="../firmwares/boards.cpp" line="486"/>
-        <location filename="../firmwares/boards.cpp" line="501"/>
-        <location filename="../firmwares/boards.cpp" line="509"/>
-        <location filename="../firmwares/boards.cpp" line="519"/>
-        <location filename="../firmwares/boards.cpp" line="527"/>
-        <location filename="../firmwares/boards.cpp" line="539"/>
-        <source>P3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
-        <source>JSx</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="454"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="530"/>
-        <location filename="../firmwares/boards.cpp" line="540"/>
+        <location filename="../firmwares/boards.cpp" line="534"/>
+        <location filename="../firmwares/boards.cpp" line="544"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="531"/>
-        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="535"/>
+        <location filename="../firmwares/boards.cpp" line="545"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="532"/>
-        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="536"/>
+        <location filename="../firmwares/boards.cpp" line="546"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="533"/>
-        <location filename="../firmwares/boards.cpp" line="543"/>
+        <location filename="../firmwares/boards.cpp" line="537"/>
+        <location filename="../firmwares/boards.cpp" line="547"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="678"/>
-        <location filename="../firmwares/boards.cpp" line="897"/>
-        <location filename="../firmwares/boards.cpp" line="927"/>
+        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="907"/>
+        <location filename="../firmwares/boards.cpp" line="937"/>
         <source>None</source>
         <translation type="unfinished">Ninguno</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="929"/>
+        <location filename="../firmwares/boards.cpp" line="939"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="931"/>
+        <location filename="../firmwares/boards.cpp" line="941"/>
         <source>Pot with detent</source>
         <translation type="unfinished">Pos con fijador</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="680"/>
+        <location filename="../firmwares/boards.cpp" line="686"/>
         <source>2 Positions Toggle</source>
         <translation type="unfinished">2 posiciones palanca</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="682"/>
+        <location filename="../firmwares/boards.cpp" line="688"/>
         <source>2 Positions</source>
         <translation type="unfinished">2 posiciones</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="690"/>
         <source>3 Positions</source>
         <translation type="unfinished">3 posiciones</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="686"/>
+        <location filename="../firmwares/boards.cpp" line="692"/>
         <source>Function</source>
         <translation type="unfinished">Función</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="899"/>
+        <location filename="../firmwares/boards.cpp" line="909"/>
         <source>Standard</source>
         <translation type="unfinished">Estándar</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="901"/>
+        <location filename="../firmwares/boards.cpp" line="911"/>
         <source>Small</source>
         <translation type="unfinished">Pequeño</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="903"/>
+        <location filename="../firmwares/boards.cpp" line="913"/>
         <source>Both</source>
         <translation type="unfinished">Ambos</translation>
     </message>
@@ -1632,34 +1632,50 @@ Error description: %4</source>
         <translation>El simulador para este firmware aún no está disponible</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="380"/>
+        <location filename="../helpers.cpp" line="388"/>
+        <source>Uknown error during Simulator startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Data Load Error</source>
+        <translation type="unfinished">Error de carga de de datos</translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Error occurred while starting simulator.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="405"/>
         <source>Error creating temporary directory for models and settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="388"/>
+        <location filename="../helpers.cpp" line="413"/>
         <source>Error writing models and settings to temporary directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="419"/>
+        <location filename="../helpers.cpp" line="444"/>
         <source>Unable to start.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="421"/>
+        <location filename="../helpers.cpp" line="446"/>
         <source>Crashed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="423"/>
+        <location filename="../helpers.cpp" line="448"/>
         <source>Exited with result code:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="381"/>
         <location filename="../helpers.cpp" line="389"/>
-        <location filename="../helpers.cpp" line="426"/>
+        <location filename="../helpers.cpp" line="406"/>
+        <location filename="../helpers.cpp" line="414"/>
+        <location filename="../helpers.cpp" line="451"/>
         <source>Simulator Error</source>
         <translation>Error del simulador</translation>
     </message>
@@ -3532,59 +3548,59 @@ Vacío significa incluir todos. Comodines ?, *, y [...] aceptados.</translation>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="448"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="612"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="622"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="632"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="642"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="652"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="662"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="672"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="742"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="761"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="772"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="782"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="807"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="619"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="629"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="639"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="649"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="659"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="669"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="679"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="739"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="749"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="768"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="779"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="789"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="814"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation>Desactiva el menú de HELI y el soporte de mezcla de cíclico</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="449"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="613"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="623"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="633"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="643"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="653"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="663"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="673"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="733"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="743"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="752"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="762"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="773"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="783"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="680"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="769"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="815"/>
         <source>Disable Global variables</source>
         <translation>Desactiva las variables globales</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="450"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="474"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="614"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="624"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="634"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="644"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="654"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="664"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="674"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="734"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="744"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="753"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="763"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="784"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="809"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="621"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="631"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="641"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="651"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="661"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="671"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="741"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="751"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="760"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="781"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="791"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="816"/>
         <source>Enable Lua custom scripts screen</source>
         <translation>Habilita la pantalla de Lua custom scripts</translation>
     </message>
@@ -3594,7 +3610,7 @@ Vacío significa incluir todos. Comodines ?, *, y [...] aceptados.</translation>
         <translation>Usa la fuente alternativa SQT5</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
         <source>FrSky Taranis X9D+</source>
         <translation></translation>
     </message>
@@ -3609,104 +3625,104 @@ Vacío significa incluir todos. Comodines ?, *, y [...] aceptados.</translation>
         <translation>Habilitar soporte AFHDS3</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="590"/>
         <source>Disable RAS (SWR)</source>
         <translation>Desactiva RAS (SWR)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="574"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="581"/>
         <source>FrSky Taranis X9D</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="576"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
         <source>Haptic module installed</source>
         <translation>Módulo haptic instalado</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="595"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="602"/>
         <source>FrSky Taranis X9E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
         <source>Confirmation before radio shutdown</source>
         <translation>Confirmar antes de apagar la radio</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="597"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="604"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation>Gimbals Horus instalados (sensores Hall)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="562"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="569"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="537"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="544"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="563"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="549"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
         <source>FrSky Taranis X-Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="530"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="529"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="536"/>
         <source>FrSky Horus X12S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="539"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation>Usar SÓLO con la primera versión DEV pcb</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="677"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="675"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="703"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="682"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="710"/>
         <source>Support for MULTI internal module</source>
         <translation>Soporte para módulo interno MULTI</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="627"/>
         <source>Jumper T-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="637"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="701"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="708"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation></translation>
     </message>
@@ -3716,26 +3732,26 @@ Vacío significa incluir todos. Comodines ?, *, y [...] aceptados.</translation>
         <translation>Soporte para módulo bluetooth</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="777"/>
         <source>Radiomaster TX12</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="787"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="805"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="812"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="683"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="690"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="718"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="697"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="725"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="810"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="817"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3745,82 +3761,87 @@ Vacío significa incluir todos. Comodines ?, *, y [...] aceptados.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <source>FlySky ST16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
         <source>HelloRadioSky V16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="647"/>
         <source>Jumper T-Pro V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="657"/>
         <source>Jumper T-Pro S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="667"/>
         <source>Jumper Bumblebee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
         <source>Jumper T12 MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
         <source>Jumper T14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="702"/>
         <source>Jumper T15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
         <source>Jumper T20 V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="737"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="747"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="757"/>
         <source>Radiomaster MT12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="766"/>
         <source>Radiomaster T8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="767"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
         <source>Allow bind using bind key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
         <source>Radiomaster GX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="804"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation></translation>
     </message>
@@ -3831,12 +3852,12 @@ Vacío significa incluir todos. Comodines ?, *, y [...] aceptados.</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="484"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="801"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="709"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
         <source>Jumper T18</source>
         <translation></translation>
     </message>
@@ -3851,7 +3872,7 @@ Vacío significa incluir todos. Comodines ?, *, y [...] aceptados.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="617"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3876,18 +3897,18 @@ Vacío significa incluir todos. Comodines ?, *, y [...] aceptados.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="568"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="543"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="550"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation>FrSky Taranis X7 / X7S Access</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="518"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="525"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="538"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation>Soporte para módulo interno ACCESS de reemplazo</translation>
     </message>
@@ -4916,206 +4937,206 @@ Estos puede ser relevantes para todos los modelos en el mismo EEPROM.</translati
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="412"/>
+        <location filename="../firmwares/generalsettings.cpp" line="414"/>
         <source>Radio Settings</source>
         <translation>Ajustes de radio</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="414"/>
+        <location filename="../firmwares/generalsettings.cpp" line="416"/>
         <source>Hardware</source>
         <translation type="unfinished">Hardware</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="415"/>
+        <location filename="../firmwares/generalsettings.cpp" line="417"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="430"/>
+        <location filename="../firmwares/generalsettings.cpp" line="432"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="464"/>
+        <location filename="../firmwares/generalsettings.cpp" line="466"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="469"/>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="471"/>
+        <location filename="../firmwares/generalsettings.cpp" line="483"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="499"/>
+        <location filename="../firmwares/generalsettings.cpp" line="501"/>
         <source>None</source>
         <translation type="unfinished">Ninguno</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="553"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Internal</source>
         <translation type="unfinished">Interno</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="555"/>
+        <location filename="../firmwares/generalsettings.cpp" line="557"/>
         <source>Ask</source>
         <translation type="unfinished">Preguntar</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="557"/>
+        <location filename="../firmwares/generalsettings.cpp" line="559"/>
         <source>Per model</source>
         <translation type="unfinished">Por modelo</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>Internal + External</source>
         <translation type="unfinished">Interno + Externo</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>External</source>
         <translation type="unfinished">Externo</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="573"/>
-        <location filename="../firmwares/generalsettings.cpp" line="589"/>
+        <location filename="../firmwares/generalsettings.cpp" line="575"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>OFF</source>
         <translation type="unfinished">APAGADO</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Enabled</source>
         <translation type="unfinished">Activado</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Telemetry</source>
         <translation type="unfinished">Telemetría</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="578"/>
+        <location filename="../firmwares/generalsettings.cpp" line="580"/>
         <source>Trainer</source>
         <translation type="unfinished">Entrenador</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="591"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="593"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="595"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished">Entrenador SBUS</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="597"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="599"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="601"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>GPS</source>
         <translation type="unfinished">GPS</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="603"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>Debug</source>
         <translation type="unfinished">Depuración</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="605"/>
+        <location filename="../firmwares/generalsettings.cpp" line="607"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="607"/>
+        <location filename="../firmwares/generalsettings.cpp" line="609"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="640"/>
+        <location filename="../firmwares/generalsettings.cpp" line="642"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="739"/>
+        <location filename="../firmwares/generalsettings.cpp" line="741"/>
         <source>Normal</source>
         <translation type="unfinished">Normal</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="741"/>
+        <location filename="../firmwares/generalsettings.cpp" line="743"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="787"/>
+        <location filename="../firmwares/generalsettings.cpp" line="789"/>
         <source>Trims only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="789"/>
+        <location filename="../firmwares/generalsettings.cpp" line="791"/>
         <source>Keys only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="791"/>
+        <location filename="../firmwares/generalsettings.cpp" line="793"/>
         <source>Switchable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="793"/>
+        <location filename="../firmwares/generalsettings.cpp" line="795"/>
         <source>Global</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="927"/>
+        <location filename="../firmwares/generalsettings.cpp" line="929"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation type="unfinished">Modo 1 (RUD ELE THR AIL)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="931"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation type="unfinished">Modo 2 (RUD THR ELE AIL)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="933"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation type="unfinished">Modo 3 (AIL ELE THR RUD)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="935"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation type="unfinished">Modo 4 (AIL THR ELE RUD)</translation>
     </message>
@@ -6050,32 +6071,32 @@ p, li { white-space: pre-wrap; }
         <translation>Checo</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="434"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Slovak</source>
         <translation>Eslovaco</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="435"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Spanish</source>
         <translation>Español</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Polish</source>
         <translation>Polaco</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="432"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Portuguese</source>
         <translation>Portugués</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="433"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Russian</source>
         <translation>Ruso</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="436"/>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Swedish</source>
         <translation>Sueco</translation>
     </message>
@@ -6085,7 +6106,7 @@ p, li { white-space: pre-wrap; }
         <translation>Húngaro</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6120,42 +6141,47 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="437"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <source>Korean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="438"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>No</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>RotEnc A</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc B</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc D</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="617"/>
+        <location filename="../generaledit/generalsetup.cpp" line="618"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
@@ -6164,22 +6190,22 @@ Esta función no puede ser deshabilitada en la radio.
 ¿ Estás seguro ?</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal</source>
         <translation type="unfinished">Normal</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15756,22 +15782,22 @@ Tiempo</translation>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="873"/>
+        <location filename="../firmwares/generalsettings.cpp" line="875"/>
         <source>OFF</source>
         <translation type="unfinished">APAGADO</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="875"/>
+        <location filename="../firmwares/generalsettings.cpp" line="877"/>
         <source>+= (Sum)</source>
         <translation type="unfinished">+= (Suma)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="877"/>
+        <location filename="../firmwares/generalsettings.cpp" line="879"/>
         <source>:= (Replace)</source>
         <translation type="unfinished">:= (Reemplazar)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="886"/>
+        <location filename="../firmwares/generalsettings.cpp" line="888"/>
         <source>CH%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17471,14 +17497,14 @@ Do you wish to continue?</source>
 <context>
     <name>YamlModelSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1288"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1287"/>
         <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
 
 Model settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1291"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1290"/>
         <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/companion/src/translations/companion_fi.ts
+++ b/companion/src/translations/companion_fi.ts
@@ -1024,274 +1024,274 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="422"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>Left Horizontal</source>
         <translation type="unfinished">Vasen vaaka</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="423"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>Left Vertical</source>
         <translation type="unfinished">Vasen pysty</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="424"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>Right Vertical</source>
         <translation type="unfinished">Oikea pysty</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="425"/>
+        <location filename="../firmwares/boards.cpp" line="429"/>
         <source>Right Horizontal</source>
         <translation type="unfinished">Oikea vaaka</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="426"/>
+        <location filename="../firmwares/boards.cpp" line="430"/>
         <source>Aux. 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="427"/>
+        <location filename="../firmwares/boards.cpp" line="431"/>
         <source>Aux. 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="443"/>
+        <location filename="../firmwares/boards.cpp" line="447"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="444"/>
+        <location filename="../firmwares/boards.cpp" line="448"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="449"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
         <source>RH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="459"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <source>TILT_X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="460"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <source>TILT_Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="506"/>
+        <location filename="../firmwares/boards.cpp" line="516"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
+        <location filename="../firmwares/boards.cpp" line="532"/>
+        <location filename="../firmwares/boards.cpp" line="548"/>
+        <location filename="../firmwares/boards.cpp" line="555"/>
+        <source>SL1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="475"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <source>P4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="517"/>
+        <location filename="../firmwares/boards.cpp" line="525"/>
+        <location filename="../firmwares/boards.cpp" line="533"/>
+        <location filename="../firmwares/boards.cpp" line="549"/>
+        <location filename="../firmwares/boards.cpp" line="556"/>
+        <source>SL2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="478"/>
+        <location filename="../firmwares/boards.cpp" line="557"/>
+        <source>SL3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="479"/>
+        <location filename="../firmwares/boards.cpp" line="558"/>
+        <source>SL4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <source>P5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="943"/>
+        <source>Slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="945"/>
+        <source>Multipos Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="947"/>
+        <source>Axis X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="949"/>
+        <source>Axis Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="951"/>
+        <source>Switch</source>
+        <translation type="unfinished">Kytkin</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Flight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="488"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="498"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
+        <location filename="../firmwares/boards.cpp" line="529"/>
+        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="553"/>
+        <source>P1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="473"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="504"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
+        <location filename="../firmwares/boards.cpp" line="530"/>
+        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="554"/>
+        <source>P2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="474"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="505"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
+        <location filename="../firmwares/boards.cpp" line="531"/>
+        <location filename="../firmwares/boards.cpp" line="543"/>
+        <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="455"/>
         <location filename="../firmwares/boards.cpp" line="457"/>
-        <source>TILT_X</source>
+        <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="456"/>
         <location filename="../firmwares/boards.cpp" line="458"/>
-        <source>TILT_Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="463"/>
-        <location filename="../firmwares/boards.cpp" line="472"/>
-        <location filename="../firmwares/boards.cpp" line="502"/>
-        <location filename="../firmwares/boards.cpp" line="512"/>
-        <location filename="../firmwares/boards.cpp" line="520"/>
-        <location filename="../firmwares/boards.cpp" line="528"/>
-        <location filename="../firmwares/boards.cpp" line="544"/>
-        <location filename="../firmwares/boards.cpp" line="551"/>
-        <source>SL1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="471"/>
-        <location filename="../firmwares/boards.cpp" line="510"/>
-        <source>P4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="473"/>
-        <location filename="../firmwares/boards.cpp" line="503"/>
-        <location filename="../firmwares/boards.cpp" line="513"/>
-        <location filename="../firmwares/boards.cpp" line="521"/>
-        <location filename="../firmwares/boards.cpp" line="529"/>
-        <location filename="../firmwares/boards.cpp" line="545"/>
-        <location filename="../firmwares/boards.cpp" line="552"/>
-        <source>SL2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="474"/>
-        <location filename="../firmwares/boards.cpp" line="553"/>
-        <source>SL3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="475"/>
-        <location filename="../firmwares/boards.cpp" line="554"/>
-        <source>SL4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="511"/>
-        <source>P5</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="933"/>
-        <source>Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="935"/>
-        <source>Multipos Switch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="937"/>
-        <source>Axis X</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="939"/>
-        <source>Axis Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="941"/>
-        <source>Switch</source>
-        <translation type="unfinished">Kytkin</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Flight</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Drive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="464"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
-        <location filename="../firmwares/boards.cpp" line="479"/>
-        <location filename="../firmwares/boards.cpp" line="484"/>
-        <location filename="../firmwares/boards.cpp" line="490"/>
-        <location filename="../firmwares/boards.cpp" line="494"/>
-        <location filename="../firmwares/boards.cpp" line="499"/>
-        <location filename="../firmwares/boards.cpp" line="507"/>
-        <location filename="../firmwares/boards.cpp" line="517"/>
-        <location filename="../firmwares/boards.cpp" line="525"/>
-        <location filename="../firmwares/boards.cpp" line="537"/>
-        <location filename="../firmwares/boards.cpp" line="549"/>
-        <source>P1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="469"/>
-        <location filename="../firmwares/boards.cpp" line="480"/>
-        <location filename="../firmwares/boards.cpp" line="485"/>
-        <location filename="../firmwares/boards.cpp" line="495"/>
-        <location filename="../firmwares/boards.cpp" line="500"/>
-        <location filename="../firmwares/boards.cpp" line="508"/>
-        <location filename="../firmwares/boards.cpp" line="518"/>
-        <location filename="../firmwares/boards.cpp" line="526"/>
-        <location filename="../firmwares/boards.cpp" line="538"/>
-        <location filename="../firmwares/boards.cpp" line="550"/>
-        <source>P2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="470"/>
-        <location filename="../firmwares/boards.cpp" line="486"/>
-        <location filename="../firmwares/boards.cpp" line="501"/>
-        <location filename="../firmwares/boards.cpp" line="509"/>
-        <location filename="../firmwares/boards.cpp" line="519"/>
-        <location filename="../firmwares/boards.cpp" line="527"/>
-        <location filename="../firmwares/boards.cpp" line="539"/>
-        <source>P3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
-        <source>JSx</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="454"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="530"/>
-        <location filename="../firmwares/boards.cpp" line="540"/>
+        <location filename="../firmwares/boards.cpp" line="534"/>
+        <location filename="../firmwares/boards.cpp" line="544"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="531"/>
-        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="535"/>
+        <location filename="../firmwares/boards.cpp" line="545"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="532"/>
-        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="536"/>
+        <location filename="../firmwares/boards.cpp" line="546"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="533"/>
-        <location filename="../firmwares/boards.cpp" line="543"/>
+        <location filename="../firmwares/boards.cpp" line="537"/>
+        <location filename="../firmwares/boards.cpp" line="547"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="678"/>
-        <location filename="../firmwares/boards.cpp" line="897"/>
-        <location filename="../firmwares/boards.cpp" line="927"/>
+        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="907"/>
+        <location filename="../firmwares/boards.cpp" line="937"/>
         <source>None</source>
         <translation type="unfinished">Ei mitään</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="929"/>
+        <location filename="../firmwares/boards.cpp" line="939"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="931"/>
+        <location filename="../firmwares/boards.cpp" line="941"/>
         <source>Pot with detent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="680"/>
+        <location filename="../firmwares/boards.cpp" line="686"/>
         <source>2 Positions Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="682"/>
+        <location filename="../firmwares/boards.cpp" line="688"/>
         <source>2 Positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="690"/>
         <source>3 Positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="686"/>
+        <location filename="../firmwares/boards.cpp" line="692"/>
         <source>Function</source>
         <translation type="unfinished">Toiminto</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="899"/>
+        <location filename="../firmwares/boards.cpp" line="909"/>
         <source>Standard</source>
         <translation type="unfinished">Vakio</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="901"/>
+        <location filename="../firmwares/boards.cpp" line="911"/>
         <source>Small</source>
         <translation type="unfinished">Pieni</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="903"/>
+        <location filename="../firmwares/boards.cpp" line="913"/>
         <source>Both</source>
         <translation type="unfinished">Molemmat</translation>
     </message>
@@ -1629,34 +1629,50 @@ Error description: %4</source>
         <translation type="unfinished">Tämän firmwaren simulointi ei ole vielä mahdollista</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="380"/>
+        <location filename="../helpers.cpp" line="388"/>
+        <source>Uknown error during Simulator startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Data Load Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Error occurred while starting simulator.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="405"/>
         <source>Error creating temporary directory for models and settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="388"/>
+        <location filename="../helpers.cpp" line="413"/>
         <source>Error writing models and settings to temporary directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="419"/>
+        <location filename="../helpers.cpp" line="444"/>
         <source>Unable to start.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="421"/>
+        <location filename="../helpers.cpp" line="446"/>
         <source>Crashed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="423"/>
+        <location filename="../helpers.cpp" line="448"/>
         <source>Exited with result code:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="381"/>
         <location filename="../helpers.cpp" line="389"/>
-        <location filename="../helpers.cpp" line="426"/>
+        <location filename="../helpers.cpp" line="406"/>
+        <location filename="../helpers.cpp" line="414"/>
+        <location filename="../helpers.cpp" line="451"/>
         <source>Simulator Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3519,59 +3535,59 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="448"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="612"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="622"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="632"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="642"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="652"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="662"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="672"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="742"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="761"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="772"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="782"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="807"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="619"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="629"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="639"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="649"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="659"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="669"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="679"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="739"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="749"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="768"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="779"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="789"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="814"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation type="unfinished">HELI valikko pois ,myös cyclic mix tuki</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="449"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="613"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="623"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="633"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="643"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="653"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="663"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="673"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="733"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="743"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="752"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="762"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="773"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="783"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="680"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="769"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="815"/>
         <source>Disable Global variables</source>
         <translation type="unfinished">Globaalit muuttujat pois päältä</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="450"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="474"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="614"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="624"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="634"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="644"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="654"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="664"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="674"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="734"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="744"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="753"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="763"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="784"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="809"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="621"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="631"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="641"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="651"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="661"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="671"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="741"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="751"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="760"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="781"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="791"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="816"/>
         <source>Enable Lua custom scripts screen</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3581,7 +3597,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished">Käytä vaihtoehtoista SQT5 fonttia</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
         <source>FrSky Taranis X9D+</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3596,104 +3612,104 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="590"/>
         <source>Disable RAS (SWR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="574"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="581"/>
         <source>FrSky Taranis X9D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="576"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
         <source>Haptic module installed</source>
         <translation type="unfinished">Värinä moduli asennettu</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="595"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="602"/>
         <source>FrSky Taranis X9E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
         <source>Confirmation before radio shutdown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="597"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="604"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="562"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="569"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="537"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="544"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="563"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="549"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
         <source>FrSky Taranis X-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="530"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="529"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="536"/>
         <source>FrSky Horus X12S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="539"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="677"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="675"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="703"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="682"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="710"/>
         <source>Support for MULTI internal module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="627"/>
         <source>Jumper T-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="637"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="701"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="708"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3703,26 +3719,26 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="777"/>
         <source>Radiomaster TX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="787"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="805"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="812"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="683"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="690"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="718"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="697"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="725"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="810"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="817"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3732,82 +3748,87 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <source>FlySky ST16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
         <source>HelloRadioSky V16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="647"/>
         <source>Jumper T-Pro V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="657"/>
         <source>Jumper T-Pro S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="667"/>
         <source>Jumper Bumblebee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
         <source>Jumper T12 MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
         <source>Jumper T14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="702"/>
         <source>Jumper T15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
         <source>Jumper T20 V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="737"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="747"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="757"/>
         <source>Radiomaster MT12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="766"/>
         <source>Radiomaster T8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="767"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
         <source>Allow bind using bind key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
         <source>Radiomaster GX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="804"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3818,12 +3839,12 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="484"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="801"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="709"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
         <source>Jumper T18</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3838,7 +3859,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="617"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3863,18 +3884,18 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="568"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="543"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="550"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="518"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="525"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="538"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4904,206 +4925,206 @@ Nämä vaikuttaa kaikkiin malleihin jotka on EEPROMilla.</translation>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="412"/>
+        <location filename="../firmwares/generalsettings.cpp" line="414"/>
         <source>Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="414"/>
+        <location filename="../firmwares/generalsettings.cpp" line="416"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="415"/>
+        <location filename="../firmwares/generalsettings.cpp" line="417"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="430"/>
+        <location filename="../firmwares/generalsettings.cpp" line="432"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="464"/>
+        <location filename="../firmwares/generalsettings.cpp" line="466"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="469"/>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="471"/>
+        <location filename="../firmwares/generalsettings.cpp" line="483"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Switch</source>
         <translation type="unfinished">Kytkin</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="499"/>
+        <location filename="../firmwares/generalsettings.cpp" line="501"/>
         <source>None</source>
         <translation type="unfinished">Ei mitään</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="553"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="555"/>
+        <location filename="../firmwares/generalsettings.cpp" line="557"/>
         <source>Ask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="557"/>
+        <location filename="../firmwares/generalsettings.cpp" line="559"/>
         <source>Per model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>Internal + External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="573"/>
-        <location filename="../firmwares/generalsettings.cpp" line="589"/>
+        <location filename="../firmwares/generalsettings.cpp" line="575"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>OFF</source>
         <translation type="unfinished">Pois</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Telemetry</source>
         <translation type="unfinished">Telemetria</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="578"/>
+        <location filename="../firmwares/generalsettings.cpp" line="580"/>
         <source>Trainer</source>
         <translation type="unfinished">Traineri</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="591"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="593"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="595"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="597"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="599"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="601"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="603"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>Debug</source>
         <translation type="unfinished">Korjaus</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="605"/>
+        <location filename="../firmwares/generalsettings.cpp" line="607"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="607"/>
+        <location filename="../firmwares/generalsettings.cpp" line="609"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="640"/>
+        <location filename="../firmwares/generalsettings.cpp" line="642"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="739"/>
+        <location filename="../firmwares/generalsettings.cpp" line="741"/>
         <source>Normal</source>
         <translation type="unfinished">Normaali</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="741"/>
+        <location filename="../firmwares/generalsettings.cpp" line="743"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="787"/>
+        <location filename="../firmwares/generalsettings.cpp" line="789"/>
         <source>Trims only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="789"/>
+        <location filename="../firmwares/generalsettings.cpp" line="791"/>
         <source>Keys only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="791"/>
+        <location filename="../firmwares/generalsettings.cpp" line="793"/>
         <source>Switchable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="793"/>
+        <location filename="../firmwares/generalsettings.cpp" line="795"/>
         <source>Global</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="927"/>
+        <location filename="../firmwares/generalsettings.cpp" line="929"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation type="unfinished">Mode 1 (PER KOR KAA SII)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="931"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation type="unfinished">Mode 2 (PER KAA KOR SII)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="933"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation type="unfinished">Mode 3 (SII KOR KAA PER)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="935"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation type="unfinished">Mode 4 (SII KAA KOR PER)</translation>
     </message>
@@ -6041,32 +6062,32 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished">Tsekki</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="434"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Slovak</source>
         <translation type="unfinished">Slovakia</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="435"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Spanish</source>
         <translation type="unfinished">Espanja</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Polish</source>
         <translation type="unfinished">Puola</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="432"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Portuguese</source>
         <translation type="unfinished">Portugali</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="433"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Russian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="436"/>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Swedish</source>
         <translation type="unfinished">Ruotsi</translation>
     </message>
@@ -6076,7 +6097,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6111,64 +6132,69 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="437"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <source>Korean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="438"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>No</source>
         <translation type="unfinished">Ei</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>RotEnc A</source>
         <translation type="unfinished">RotEnc A</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc B</source>
         <translation type="unfinished">RotEnc B</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc C</source>
         <translation type="unfinished">RotEnc C</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc D</source>
         <translation type="unfinished">RotEnc D</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc E</source>
         <translation type="unfinished">RotEnc E</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="617"/>
+        <location filename="../generaledit/generalsetup.cpp" line="618"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal</source>
         <translation type="unfinished">Normaali</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15711,22 +15737,22 @@ Timestamp</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="873"/>
+        <location filename="../firmwares/generalsettings.cpp" line="875"/>
         <source>OFF</source>
         <translation type="unfinished">Pois</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="875"/>
+        <location filename="../firmwares/generalsettings.cpp" line="877"/>
         <source>+= (Sum)</source>
         <translation type="unfinished">+= (Sum)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="877"/>
+        <location filename="../firmwares/generalsettings.cpp" line="879"/>
         <source>:= (Replace)</source>
         <translation type="unfinished">:= (Korvaa)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="886"/>
+        <location filename="../firmwares/generalsettings.cpp" line="888"/>
         <source>CH%1</source>
         <translation type="unfinished">CH%1</translation>
     </message>
@@ -17425,14 +17451,14 @@ Do you wish to continue?</source>
 <context>
     <name>YamlModelSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1288"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1287"/>
         <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
 
 Model settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1291"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1290"/>
         <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/companion/src/translations/companion_fr.ts
+++ b/companion/src/translations/companion_fr.ts
@@ -1023,274 +1023,274 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
-        <source>JSx</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="454"/>
-        <source>JSy</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="530"/>
-        <location filename="../firmwares/boards.cpp" line="540"/>
-        <source>EXT1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="531"/>
-        <location filename="../firmwares/boards.cpp" line="541"/>
-        <source>EXT2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="532"/>
-        <location filename="../firmwares/boards.cpp" line="542"/>
-        <source>EXT3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="533"/>
-        <location filename="../firmwares/boards.cpp" line="543"/>
-        <source>EXT4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="678"/>
-        <location filename="../firmwares/boards.cpp" line="897"/>
-        <location filename="../firmwares/boards.cpp" line="927"/>
-        <source>None</source>
-        <translation type="unfinished">Aucun</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="929"/>
-        <source>Pot</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="931"/>
-        <source>Pot with detent</source>
-        <translation type="unfinished">Potentiomètre avec centre</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="422"/>
-        <source>Left Horizontal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="423"/>
-        <source>Left Vertical</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="424"/>
-        <source>Right Vertical</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="425"/>
-        <source>Right Horizontal</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="426"/>
-        <source>Aux. 1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="427"/>
-        <source>Aux. 2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="443"/>
-        <source>LH</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="444"/>
-        <source>LV</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="445"/>
-        <source>RV</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="446"/>
-        <source>RH</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
         <location filename="../firmwares/boards.cpp" line="455"/>
         <location filename="../firmwares/boards.cpp" line="457"/>
-        <source>TILT_X</source>
+        <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="456"/>
         <location filename="../firmwares/boards.cpp" line="458"/>
-        <source>TILT_Y</source>
+        <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="463"/>
-        <location filename="../firmwares/boards.cpp" line="472"/>
-        <location filename="../firmwares/boards.cpp" line="502"/>
-        <location filename="../firmwares/boards.cpp" line="512"/>
-        <location filename="../firmwares/boards.cpp" line="520"/>
-        <location filename="../firmwares/boards.cpp" line="528"/>
+        <location filename="../firmwares/boards.cpp" line="534"/>
         <location filename="../firmwares/boards.cpp" line="544"/>
-        <location filename="../firmwares/boards.cpp" line="551"/>
-        <source>SL1</source>
+        <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="464"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
-        <location filename="../firmwares/boards.cpp" line="479"/>
-        <location filename="../firmwares/boards.cpp" line="484"/>
-        <location filename="../firmwares/boards.cpp" line="490"/>
-        <location filename="../firmwares/boards.cpp" line="494"/>
-        <location filename="../firmwares/boards.cpp" line="499"/>
-        <location filename="../firmwares/boards.cpp" line="507"/>
-        <location filename="../firmwares/boards.cpp" line="517"/>
-        <location filename="../firmwares/boards.cpp" line="525"/>
-        <location filename="../firmwares/boards.cpp" line="537"/>
-        <location filename="../firmwares/boards.cpp" line="549"/>
-        <source>P1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="469"/>
-        <location filename="../firmwares/boards.cpp" line="480"/>
-        <location filename="../firmwares/boards.cpp" line="485"/>
-        <location filename="../firmwares/boards.cpp" line="495"/>
-        <location filename="../firmwares/boards.cpp" line="500"/>
-        <location filename="../firmwares/boards.cpp" line="508"/>
-        <location filename="../firmwares/boards.cpp" line="518"/>
-        <location filename="../firmwares/boards.cpp" line="526"/>
-        <location filename="../firmwares/boards.cpp" line="538"/>
-        <location filename="../firmwares/boards.cpp" line="550"/>
-        <source>P2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="470"/>
-        <location filename="../firmwares/boards.cpp" line="486"/>
-        <location filename="../firmwares/boards.cpp" line="501"/>
-        <location filename="../firmwares/boards.cpp" line="509"/>
-        <location filename="../firmwares/boards.cpp" line="519"/>
-        <location filename="../firmwares/boards.cpp" line="527"/>
-        <location filename="../firmwares/boards.cpp" line="539"/>
-        <source>P3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="471"/>
-        <location filename="../firmwares/boards.cpp" line="510"/>
-        <source>P4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="473"/>
-        <location filename="../firmwares/boards.cpp" line="503"/>
-        <location filename="../firmwares/boards.cpp" line="513"/>
-        <location filename="../firmwares/boards.cpp" line="521"/>
-        <location filename="../firmwares/boards.cpp" line="529"/>
+        <location filename="../firmwares/boards.cpp" line="535"/>
         <location filename="../firmwares/boards.cpp" line="545"/>
-        <location filename="../firmwares/boards.cpp" line="552"/>
-        <source>SL2</source>
+        <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="474"/>
-        <location filename="../firmwares/boards.cpp" line="553"/>
-        <source>SL3</source>
+        <location filename="../firmwares/boards.cpp" line="536"/>
+        <location filename="../firmwares/boards.cpp" line="546"/>
+        <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="475"/>
-        <location filename="../firmwares/boards.cpp" line="554"/>
-        <source>SL4</source>
+        <location filename="../firmwares/boards.cpp" line="537"/>
+        <location filename="../firmwares/boards.cpp" line="547"/>
+        <source>EXT4</source>
         <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="511"/>
-        <source>P5</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="680"/>
-        <source>2 Positions Toggle</source>
-        <translation>2 Positions momentané</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="682"/>
-        <source>2 Positions</source>
-        <translation>2 Positions</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="684"/>
-        <source>3 Positions</source>
-        <translation type="unfinished">3 Positions</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="686"/>
-        <source>Function</source>
-        <translation type="unfinished">Fonction</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="899"/>
-        <source>Standard</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="901"/>
-        <source>Small</source>
-        <translation type="unfinished">Petites</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="903"/>
-        <source>Both</source>
-        <translation type="unfinished">Les 2</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="933"/>
-        <source>Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="935"/>
-        <source>Multipos Switch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
+        <location filename="../firmwares/boards.cpp" line="907"/>
         <location filename="../firmwares/boards.cpp" line="937"/>
-        <source>Axis X</source>
-        <translation type="unfinished"></translation>
+        <source>None</source>
+        <translation type="unfinished">Aucun</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="939"/>
-        <source>Axis Y</source>
+        <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="941"/>
+        <source>Pot with detent</source>
+        <translation type="unfinished">Potentiomètre avec centre</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="426"/>
+        <source>Left Horizontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="427"/>
+        <source>Left Vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="428"/>
+        <source>Right Vertical</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="429"/>
+        <source>Right Horizontal</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="430"/>
+        <source>Aux. 1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="431"/>
+        <source>Aux. 2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="447"/>
+        <source>LH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="448"/>
+        <source>LV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="449"/>
+        <source>RV</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="450"/>
+        <source>RH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="459"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <source>TILT_X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="460"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <source>TILT_Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="506"/>
+        <location filename="../firmwares/boards.cpp" line="516"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
+        <location filename="../firmwares/boards.cpp" line="532"/>
+        <location filename="../firmwares/boards.cpp" line="548"/>
+        <location filename="../firmwares/boards.cpp" line="555"/>
+        <source>SL1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="488"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="498"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
+        <location filename="../firmwares/boards.cpp" line="529"/>
+        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="553"/>
+        <source>P1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="473"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="504"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
+        <location filename="../firmwares/boards.cpp" line="530"/>
+        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="554"/>
+        <source>P2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="474"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="505"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
+        <location filename="../firmwares/boards.cpp" line="531"/>
+        <location filename="../firmwares/boards.cpp" line="543"/>
+        <source>P3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="475"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <source>P4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="517"/>
+        <location filename="../firmwares/boards.cpp" line="525"/>
+        <location filename="../firmwares/boards.cpp" line="533"/>
+        <location filename="../firmwares/boards.cpp" line="549"/>
+        <location filename="../firmwares/boards.cpp" line="556"/>
+        <source>SL2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="478"/>
+        <location filename="../firmwares/boards.cpp" line="557"/>
+        <source>SL3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="479"/>
+        <location filename="../firmwares/boards.cpp" line="558"/>
+        <source>SL4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <source>P5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="686"/>
+        <source>2 Positions Toggle</source>
+        <translation>2 Positions momentané</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="688"/>
+        <source>2 Positions</source>
+        <translation>2 Positions</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="690"/>
+        <source>3 Positions</source>
+        <translation type="unfinished">3 Positions</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="692"/>
+        <source>Function</source>
+        <translation type="unfinished">Fonction</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="909"/>
+        <source>Standard</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="911"/>
+        <source>Small</source>
+        <translation type="unfinished">Petites</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="913"/>
+        <source>Both</source>
+        <translation type="unfinished">Les 2</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="943"/>
+        <source>Slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="945"/>
+        <source>Multipos Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="947"/>
+        <source>Axis X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="949"/>
+        <source>Axis Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="951"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
         <source>Flight</source>
         <translation type="unfinished">Vol</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
         <source>Drive</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1643,34 +1643,50 @@ Error description: %4</source>
         <translation>Le simulateur n&apos;est pas encore disponible pour ce firmware</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="380"/>
+        <location filename="../helpers.cpp" line="388"/>
+        <source>Uknown error during Simulator startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Data Load Error</source>
+        <translation type="unfinished">Erreur de lecture des données</translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Error occurred while starting simulator.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="405"/>
         <source>Error creating temporary directory for models and settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="388"/>
+        <location filename="../helpers.cpp" line="413"/>
         <source>Error writing models and settings to temporary directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="419"/>
+        <location filename="../helpers.cpp" line="444"/>
         <source>Unable to start.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="421"/>
+        <location filename="../helpers.cpp" line="446"/>
         <source>Crashed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="423"/>
+        <location filename="../helpers.cpp" line="448"/>
         <source>Exited with result code:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="381"/>
         <location filename="../helpers.cpp" line="389"/>
-        <location filename="../helpers.cpp" line="426"/>
+        <location filename="../helpers.cpp" line="406"/>
+        <location filename="../helpers.cpp" line="414"/>
+        <location filename="../helpers.cpp" line="451"/>
         <source>Simulator Error</source>
         <translation>Erreur Simulateur</translation>
     </message>
@@ -3525,59 +3541,59 @@ Blanc signifie &quot;inclure tous&quot;.Les métacaractères ?, * et [...] sont 
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="448"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="612"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="622"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="632"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="642"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="652"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="662"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="672"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="742"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="761"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="772"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="782"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="807"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="619"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="629"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="639"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="649"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="659"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="669"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="679"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="739"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="749"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="768"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="779"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="789"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="814"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation>Supprimer le menu HELICO et les mixages cycliques</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="449"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="613"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="623"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="633"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="643"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="653"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="663"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="673"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="733"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="743"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="752"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="762"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="773"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="783"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="680"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="769"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="815"/>
         <source>Disable Global variables</source>
         <translation>Supprimer le support des variables globales</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="450"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="474"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="614"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="624"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="634"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="644"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="654"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="664"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="674"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="734"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="744"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="753"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="763"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="784"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="809"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="621"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="631"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="641"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="651"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="661"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="671"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="741"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="751"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="760"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="781"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="791"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="816"/>
         <source>Enable Lua custom scripts screen</source>
         <translation>Activer l&apos;écran des scripts Lua personnalisés</translation>
     </message>
@@ -3587,8 +3603,8 @@ Blanc signifie &quot;inclure tous&quot;.Les métacaractères ?, * et [...] sont 
         <translation>Utiliser la police alternative SQT5</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="590"/>
         <source>Disable RAS (SWR)</source>
         <translation>Désactiver le RAS (SWR). Utile uniquement pour les X9D+ avec un RAS/SWR non fonctionnel</translation>
     </message>
@@ -3598,67 +3614,67 @@ Blanc signifie &quot;inclure tous&quot;.Les métacaractères ?, * et [...] sont 
         <translation>Activer le support du AFHDS3</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
         <source>FrSky Taranis X9D+</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="574"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="581"/>
         <source>FrSky Taranis X9D</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="576"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
         <source>Haptic module installed</source>
         <translation>Module vibreur installé</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="595"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="602"/>
         <source>FrSky Taranis X9E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
         <source>Confirmation before radio shutdown</source>
         <translation>Confirmation avant l&apos;arrêt de la radio</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="597"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="604"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation>Manches Horus à effet HALL installés</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="562"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="569"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="568"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="537"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="544"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="543"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="550"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="563"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="549"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
         <source>FrSky Taranis X-Lite</source>
         <translation></translation>
     </message>
@@ -3669,63 +3685,68 @@ Blanc signifie &quot;inclure tous&quot;.Les métacaractères ?, * et [...] sont 
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <source>FlySky ST16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="518"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="525"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="538"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation>Prise en charge du module de remplacement interne ACCESS</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="530"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="529"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="536"/>
         <source>FrSky Horus X12S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="539"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation>Exclusivement pour les Horus DEV</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
         <source>HelloRadioSky V16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="647"/>
         <source>Jumper T-Pro V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="657"/>
         <source>Jumper T-Pro S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="667"/>
         <source>Jumper Bumblebee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="675"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="703"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="682"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="710"/>
         <source>Support for MULTI internal module</source>
         <translation>Prise en charge du module MULTI interne</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="627"/>
         <source>Jumper T-Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="637"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3735,61 +3756,61 @@ Blanc signifie &quot;inclure tous&quot;.Les métacaractères ?, * et [...] sont 
         <translation>Prise en charge du module Bluetooth</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="787"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="805"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="812"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="683"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="690"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="718"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="697"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="725"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="810"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="817"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
         <source>Jumper T12 MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
         <source>Jumper T14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="702"/>
         <source>Jumper T15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
         <source>Jumper T20 V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="737"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="757"/>
         <source>Radiomaster MT12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="766"/>
         <source>Radiomaster T8</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="767"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
         <source>Allow bind using bind key</source>
         <translation>Autoriser l&apos;appairage avec le bouton&quot;bind&quot;</translation>
     </message>
@@ -3800,12 +3821,12 @@ Blanc signifie &quot;inclure tous&quot;.Les métacaractères ?, * et [...] sont 
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="484"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="801"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="709"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
         <source>Jumper T18</source>
         <translation></translation>
     </message>
@@ -3820,7 +3841,7 @@ Blanc signifie &quot;inclure tous&quot;.Les métacaractères ?, * et [...] sont 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="617"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3850,37 +3871,37 @@ Blanc signifie &quot;inclure tous&quot;.Les métacaractères ?, * et [...] sont 
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="747"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="777"/>
         <source>Radiomaster TX12</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
         <source>Radiomaster GX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="804"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="677"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="701"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="708"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation></translation>
     </message>
@@ -4910,206 +4931,206 @@ Communs à tous les modèles d&apos;une même EEPROM.</translation>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="412"/>
+        <location filename="../firmwares/generalsettings.cpp" line="414"/>
         <source>Radio Settings</source>
         <translation>Paramètres de la radio</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="414"/>
+        <location filename="../firmwares/generalsettings.cpp" line="416"/>
         <source>Hardware</source>
         <translation type="unfinished">Matériel</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="415"/>
+        <location filename="../firmwares/generalsettings.cpp" line="417"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="430"/>
+        <location filename="../firmwares/generalsettings.cpp" line="432"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="464"/>
+        <location filename="../firmwares/generalsettings.cpp" line="466"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="469"/>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="471"/>
+        <location filename="../firmwares/generalsettings.cpp" line="483"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="499"/>
+        <location filename="../firmwares/generalsettings.cpp" line="501"/>
         <source>None</source>
         <translation type="unfinished">Aucun</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="553"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Internal</source>
         <translation type="unfinished">Interne</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="555"/>
+        <location filename="../firmwares/generalsettings.cpp" line="557"/>
         <source>Ask</source>
         <translation type="unfinished">Demander</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="557"/>
+        <location filename="../firmwares/generalsettings.cpp" line="559"/>
         <source>Per model</source>
         <translation type="unfinished">Par modèle</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>Internal + External</source>
         <translation type="unfinished">Interne + Externe</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>External</source>
         <translation type="unfinished">Externe</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="573"/>
-        <location filename="../firmwares/generalsettings.cpp" line="589"/>
+        <location filename="../firmwares/generalsettings.cpp" line="575"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>OFF</source>
         <translation type="unfinished">Eteint</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Enabled</source>
         <translation type="unfinished">Activé</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="578"/>
+        <location filename="../firmwares/generalsettings.cpp" line="580"/>
         <source>Trainer</source>
         <translation type="unfinished">Écolage</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="591"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="593"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="595"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished">Écolage SBUS</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="597"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="599"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="601"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="603"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>Debug</source>
         <translation type="unfinished">Débogage</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="605"/>
+        <location filename="../firmwares/generalsettings.cpp" line="607"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="607"/>
+        <location filename="../firmwares/generalsettings.cpp" line="609"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="640"/>
+        <location filename="../firmwares/generalsettings.cpp" line="642"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="739"/>
+        <location filename="../firmwares/generalsettings.cpp" line="741"/>
         <source>Normal</source>
         <translation type="unfinished">Normales</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="741"/>
+        <location filename="../firmwares/generalsettings.cpp" line="743"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="787"/>
+        <location filename="../firmwares/generalsettings.cpp" line="789"/>
         <source>Trims only</source>
         <translation type="unfinished">Trims uniquement</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="789"/>
+        <location filename="../firmwares/generalsettings.cpp" line="791"/>
         <source>Keys only</source>
         <translation type="unfinished">Touches uniquement</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="791"/>
+        <location filename="../firmwares/generalsettings.cpp" line="793"/>
         <source>Switchable</source>
         <translation type="unfinished">Commutable</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="793"/>
+        <location filename="../firmwares/generalsettings.cpp" line="795"/>
         <source>Global</source>
         <translation type="unfinished">Global</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="927"/>
+        <location filename="../firmwares/generalsettings.cpp" line="929"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation type="unfinished">Mode 1 (DIR PROF GAZ AIL)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="931"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation type="unfinished">Mode 2 (DIR GAZ PROF AIL)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="933"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation type="unfinished">Mode 3 (AIL PROF GAZ DIR)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="935"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation type="unfinished">Mode 4 (AIL GAZ PROF DIR)</translation>
     </message>
@@ -6043,27 +6064,27 @@ Extra long : bips extra longs.</translation>
         <translation>Tchèque</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="434"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Slovak</source>
         <translation>Slovaque</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="435"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Spanish</source>
         <translation>Espagnol</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Polish</source>
         <translation>Polonais</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="432"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Portuguese</source>
         <translation>Portugais</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="436"/>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Swedish</source>
         <translation>Suédois</translation>
     </message>
@@ -6073,12 +6094,12 @@ Extra long : bips extra longs.</translation>
         <translation>Hongrois</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="433"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Russian</source>
         <translation>Russe</translation>
     </message>
@@ -6113,42 +6134,47 @@ Extra long : bips extra longs.</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="437"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <source>Korean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="438"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>No</source>
         <translation>Non</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>RotEnc A</source>
         <translation>Sel.Rot. A</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc B</source>
         <translation>Sel.Rot. B</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc C</source>
         <translation>Sel.Rot. C</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc D</source>
         <translation>Sel.Rot. D</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc E</source>
         <translation>Sel.Rot. E</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="617"/>
+        <location filename="../generaledit/generalsetup.cpp" line="618"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
@@ -6157,22 +6183,22 @@ Cette fonction ne peut pas être désactivée sur la radio.
 Êtes-vous sûr d&apos;activer cette option ?</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal</source>
         <translation type="unfinished">Normales</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15766,22 +15792,22 @@ Horodatage</translation>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="873"/>
+        <location filename="../firmwares/generalsettings.cpp" line="875"/>
         <source>OFF</source>
         <translation type="unfinished">Eteint</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="875"/>
+        <location filename="../firmwares/generalsettings.cpp" line="877"/>
         <source>+= (Sum)</source>
         <translation type="unfinished">+= (Additionner)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="877"/>
+        <location filename="../firmwares/generalsettings.cpp" line="879"/>
         <source>:= (Replace)</source>
         <translation type="unfinished">:= (Remplacer)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="886"/>
+        <location filename="../firmwares/generalsettings.cpp" line="888"/>
         <source>CH%1</source>
         <translation type="unfinished">VOIE%1</translation>
     </message>
@@ -17481,14 +17507,14 @@ Do you wish to continue?</source>
 <context>
     <name>YamlModelSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1288"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1287"/>
         <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
 
 Model settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1291"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1290"/>
         <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/companion/src/translations/companion_he.ts
+++ b/companion/src/translations/companion_he.ts
@@ -1002,274 +1002,274 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="422"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>Left Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="423"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>Left Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="424"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>Right Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="425"/>
+        <location filename="../firmwares/boards.cpp" line="429"/>
         <source>Right Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="426"/>
+        <location filename="../firmwares/boards.cpp" line="430"/>
         <source>Aux. 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="427"/>
+        <location filename="../firmwares/boards.cpp" line="431"/>
         <source>Aux. 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="443"/>
+        <location filename="../firmwares/boards.cpp" line="447"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="444"/>
+        <location filename="../firmwares/boards.cpp" line="448"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="449"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
         <source>RH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="459"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <source>TILT_X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="460"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <source>TILT_Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="506"/>
+        <location filename="../firmwares/boards.cpp" line="516"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
+        <location filename="../firmwares/boards.cpp" line="532"/>
+        <location filename="../firmwares/boards.cpp" line="548"/>
+        <location filename="../firmwares/boards.cpp" line="555"/>
+        <source>SL1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="475"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <source>P4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="517"/>
+        <location filename="../firmwares/boards.cpp" line="525"/>
+        <location filename="../firmwares/boards.cpp" line="533"/>
+        <location filename="../firmwares/boards.cpp" line="549"/>
+        <location filename="../firmwares/boards.cpp" line="556"/>
+        <source>SL2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="478"/>
+        <location filename="../firmwares/boards.cpp" line="557"/>
+        <source>SL3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="479"/>
+        <location filename="../firmwares/boards.cpp" line="558"/>
+        <source>SL4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <source>P5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="943"/>
+        <source>Slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="945"/>
+        <source>Multipos Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="947"/>
+        <source>Axis X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="949"/>
+        <source>Axis Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="951"/>
+        <source>Switch</source>
+        <translation type="unfinished">Switch</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Flight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="488"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="498"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
+        <location filename="../firmwares/boards.cpp" line="529"/>
+        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="553"/>
+        <source>P1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="473"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="504"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
+        <location filename="../firmwares/boards.cpp" line="530"/>
+        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="554"/>
+        <source>P2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="474"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="505"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
+        <location filename="../firmwares/boards.cpp" line="531"/>
+        <location filename="../firmwares/boards.cpp" line="543"/>
+        <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="455"/>
         <location filename="../firmwares/boards.cpp" line="457"/>
-        <source>TILT_X</source>
+        <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="456"/>
         <location filename="../firmwares/boards.cpp" line="458"/>
-        <source>TILT_Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="463"/>
-        <location filename="../firmwares/boards.cpp" line="472"/>
-        <location filename="../firmwares/boards.cpp" line="502"/>
-        <location filename="../firmwares/boards.cpp" line="512"/>
-        <location filename="../firmwares/boards.cpp" line="520"/>
-        <location filename="../firmwares/boards.cpp" line="528"/>
-        <location filename="../firmwares/boards.cpp" line="544"/>
-        <location filename="../firmwares/boards.cpp" line="551"/>
-        <source>SL1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="471"/>
-        <location filename="../firmwares/boards.cpp" line="510"/>
-        <source>P4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="473"/>
-        <location filename="../firmwares/boards.cpp" line="503"/>
-        <location filename="../firmwares/boards.cpp" line="513"/>
-        <location filename="../firmwares/boards.cpp" line="521"/>
-        <location filename="../firmwares/boards.cpp" line="529"/>
-        <location filename="../firmwares/boards.cpp" line="545"/>
-        <location filename="../firmwares/boards.cpp" line="552"/>
-        <source>SL2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="474"/>
-        <location filename="../firmwares/boards.cpp" line="553"/>
-        <source>SL3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="475"/>
-        <location filename="../firmwares/boards.cpp" line="554"/>
-        <source>SL4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="511"/>
-        <source>P5</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="933"/>
-        <source>Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="935"/>
-        <source>Multipos Switch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="937"/>
-        <source>Axis X</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="939"/>
-        <source>Axis Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="941"/>
-        <source>Switch</source>
-        <translation type="unfinished">Switch</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Flight</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Drive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="464"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
-        <location filename="../firmwares/boards.cpp" line="479"/>
-        <location filename="../firmwares/boards.cpp" line="484"/>
-        <location filename="../firmwares/boards.cpp" line="490"/>
-        <location filename="../firmwares/boards.cpp" line="494"/>
-        <location filename="../firmwares/boards.cpp" line="499"/>
-        <location filename="../firmwares/boards.cpp" line="507"/>
-        <location filename="../firmwares/boards.cpp" line="517"/>
-        <location filename="../firmwares/boards.cpp" line="525"/>
-        <location filename="../firmwares/boards.cpp" line="537"/>
-        <location filename="../firmwares/boards.cpp" line="549"/>
-        <source>P1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="469"/>
-        <location filename="../firmwares/boards.cpp" line="480"/>
-        <location filename="../firmwares/boards.cpp" line="485"/>
-        <location filename="../firmwares/boards.cpp" line="495"/>
-        <location filename="../firmwares/boards.cpp" line="500"/>
-        <location filename="../firmwares/boards.cpp" line="508"/>
-        <location filename="../firmwares/boards.cpp" line="518"/>
-        <location filename="../firmwares/boards.cpp" line="526"/>
-        <location filename="../firmwares/boards.cpp" line="538"/>
-        <location filename="../firmwares/boards.cpp" line="550"/>
-        <source>P2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="470"/>
-        <location filename="../firmwares/boards.cpp" line="486"/>
-        <location filename="../firmwares/boards.cpp" line="501"/>
-        <location filename="../firmwares/boards.cpp" line="509"/>
-        <location filename="../firmwares/boards.cpp" line="519"/>
-        <location filename="../firmwares/boards.cpp" line="527"/>
-        <location filename="../firmwares/boards.cpp" line="539"/>
-        <source>P3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
-        <source>JSx</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="454"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="530"/>
-        <location filename="../firmwares/boards.cpp" line="540"/>
+        <location filename="../firmwares/boards.cpp" line="534"/>
+        <location filename="../firmwares/boards.cpp" line="544"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="531"/>
-        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="535"/>
+        <location filename="../firmwares/boards.cpp" line="545"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="532"/>
-        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="536"/>
+        <location filename="../firmwares/boards.cpp" line="546"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="533"/>
-        <location filename="../firmwares/boards.cpp" line="543"/>
+        <location filename="../firmwares/boards.cpp" line="537"/>
+        <location filename="../firmwares/boards.cpp" line="547"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="678"/>
-        <location filename="../firmwares/boards.cpp" line="897"/>
-        <location filename="../firmwares/boards.cpp" line="927"/>
+        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="907"/>
+        <location filename="../firmwares/boards.cpp" line="937"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="929"/>
+        <location filename="../firmwares/boards.cpp" line="939"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="931"/>
+        <location filename="../firmwares/boards.cpp" line="941"/>
         <source>Pot with detent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="680"/>
+        <location filename="../firmwares/boards.cpp" line="686"/>
         <source>2 Positions Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="682"/>
+        <location filename="../firmwares/boards.cpp" line="688"/>
         <source>2 Positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="690"/>
         <source>3 Positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="686"/>
+        <location filename="../firmwares/boards.cpp" line="692"/>
         <source>Function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="899"/>
+        <location filename="../firmwares/boards.cpp" line="909"/>
         <source>Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="901"/>
+        <location filename="../firmwares/boards.cpp" line="911"/>
         <source>Small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="903"/>
+        <location filename="../firmwares/boards.cpp" line="913"/>
         <source>Both</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1682,34 +1682,50 @@ Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="380"/>
+        <location filename="../helpers.cpp" line="388"/>
+        <source>Uknown error during Simulator startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Data Load Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Error occurred while starting simulator.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="405"/>
         <source>Error creating temporary directory for models and settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="388"/>
+        <location filename="../helpers.cpp" line="413"/>
         <source>Error writing models and settings to temporary directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="419"/>
+        <location filename="../helpers.cpp" line="444"/>
         <source>Unable to start.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="421"/>
+        <location filename="../helpers.cpp" line="446"/>
         <source>Crashed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="423"/>
+        <location filename="../helpers.cpp" line="448"/>
         <source>Exited with result code:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="381"/>
         <location filename="../helpers.cpp" line="389"/>
-        <location filename="../helpers.cpp" line="426"/>
+        <location filename="../helpers.cpp" line="406"/>
+        <location filename="../helpers.cpp" line="414"/>
+        <location filename="../helpers.cpp" line="451"/>
         <source>Simulator Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3514,59 +3530,59 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="448"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="612"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="622"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="632"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="642"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="652"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="662"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="672"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="742"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="761"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="772"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="782"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="807"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="619"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="629"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="639"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="649"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="659"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="669"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="679"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="739"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="749"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="768"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="779"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="789"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="814"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="449"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="613"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="623"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="633"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="643"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="653"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="663"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="673"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="733"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="743"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="752"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="762"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="773"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="783"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="680"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="769"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="815"/>
         <source>Disable Global variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="450"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="474"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="614"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="624"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="634"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="644"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="654"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="664"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="674"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="734"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="744"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="753"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="763"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="784"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="809"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="621"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="631"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="641"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="651"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="661"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="671"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="741"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="751"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="760"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="781"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="791"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="816"/>
         <source>Enable Lua custom scripts screen</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3586,125 +3602,125 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
         <source>FrSky Taranis X9D+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="590"/>
         <source>Disable RAS (SWR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="574"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="581"/>
         <source>FrSky Taranis X9D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="576"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
         <source>Haptic module installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="595"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="602"/>
         <source>FrSky Taranis X9E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
         <source>Confirmation before radio shutdown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="597"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="604"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="562"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="569"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="568"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="537"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="544"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="543"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="550"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="563"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="549"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
         <source>FrSky Taranis X-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="518"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="525"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="538"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="530"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="529"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="536"/>
         <source>FrSky Horus X12S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="539"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="677"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="675"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="703"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="682"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="710"/>
         <source>Support for MULTI internal module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="627"/>
         <source>Jumper T-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="637"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="701"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="708"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3714,26 +3730,26 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="777"/>
         <source>Radiomaster TX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="787"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="805"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="812"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="683"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="690"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="718"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="697"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="725"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="810"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="817"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3743,82 +3759,87 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <source>FlySky ST16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
         <source>HelloRadioSky V16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="647"/>
         <source>Jumper T-Pro V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="657"/>
         <source>Jumper T-Pro S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="667"/>
         <source>Jumper Bumblebee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
         <source>Jumper T12 MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
         <source>Jumper T14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="702"/>
         <source>Jumper T15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
         <source>Jumper T20 V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="737"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="747"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="757"/>
         <source>Radiomaster MT12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="766"/>
         <source>Radiomaster T8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="767"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
         <source>Allow bind using bind key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
         <source>Radiomaster GX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="804"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3829,12 +3850,12 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="484"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="801"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="709"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
         <source>Jumper T18</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3849,7 +3870,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="617"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4823,206 +4844,206 @@ These will be relevant for all models in the same EEPROM.</source>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="412"/>
+        <location filename="../firmwares/generalsettings.cpp" line="414"/>
         <source>Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="414"/>
+        <location filename="../firmwares/generalsettings.cpp" line="416"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="415"/>
+        <location filename="../firmwares/generalsettings.cpp" line="417"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="430"/>
+        <location filename="../firmwares/generalsettings.cpp" line="432"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="464"/>
+        <location filename="../firmwares/generalsettings.cpp" line="466"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="469"/>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="471"/>
+        <location filename="../firmwares/generalsettings.cpp" line="483"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Switch</source>
         <translation type="unfinished">Switch</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="499"/>
+        <location filename="../firmwares/generalsettings.cpp" line="501"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="553"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="555"/>
+        <location filename="../firmwares/generalsettings.cpp" line="557"/>
         <source>Ask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="557"/>
+        <location filename="../firmwares/generalsettings.cpp" line="559"/>
         <source>Per model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>Internal + External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="573"/>
-        <location filename="../firmwares/generalsettings.cpp" line="589"/>
+        <location filename="../firmwares/generalsettings.cpp" line="575"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="578"/>
+        <location filename="../firmwares/generalsettings.cpp" line="580"/>
         <source>Trainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="591"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="593"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="595"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="597"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="599"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="601"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="603"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="605"/>
+        <location filename="../firmwares/generalsettings.cpp" line="607"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="607"/>
+        <location filename="../firmwares/generalsettings.cpp" line="609"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="640"/>
+        <location filename="../firmwares/generalsettings.cpp" line="642"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="739"/>
+        <location filename="../firmwares/generalsettings.cpp" line="741"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="741"/>
+        <location filename="../firmwares/generalsettings.cpp" line="743"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="787"/>
+        <location filename="../firmwares/generalsettings.cpp" line="789"/>
         <source>Trims only</source>
         <translation type="unfinished">קיזוזים בלבד</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="789"/>
+        <location filename="../firmwares/generalsettings.cpp" line="791"/>
         <source>Keys only</source>
         <translation type="unfinished">ניווט בלבד</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="791"/>
+        <location filename="../firmwares/generalsettings.cpp" line="793"/>
         <source>Switchable</source>
         <translation type="unfinished">משולב</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="793"/>
+        <location filename="../firmwares/generalsettings.cpp" line="795"/>
         <source>Global</source>
         <translation type="unfinished">גלובאלי</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="927"/>
+        <location filename="../firmwares/generalsettings.cpp" line="929"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="931"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="933"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="935"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5918,32 +5939,32 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="434"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Slovak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="435"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Polish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="432"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Portuguese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="433"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Russian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="436"/>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Swedish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5978,69 +5999,74 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="437"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <source>Korean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="438"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>RotEnc A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="617"/>
+        <location filename="../generaledit/generalsetup.cpp" line="618"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15574,22 +15600,22 @@ Timestamp</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="873"/>
+        <location filename="../firmwares/generalsettings.cpp" line="875"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="875"/>
+        <location filename="../firmwares/generalsettings.cpp" line="877"/>
         <source>+= (Sum)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="877"/>
+        <location filename="../firmwares/generalsettings.cpp" line="879"/>
         <source>:= (Replace)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="886"/>
+        <location filename="../firmwares/generalsettings.cpp" line="888"/>
         <source>CH%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17287,14 +17313,14 @@ Do you wish to continue?</source>
 <context>
     <name>YamlModelSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1288"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1287"/>
         <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
 
 Model settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1291"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1290"/>
         <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/companion/src/translations/companion_it.ts
+++ b/companion/src/translations/companion_it.ts
@@ -1021,274 +1021,274 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="422"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>Left Horizontal</source>
         <translation type="unfinished">Orizzontale Sinistro</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="423"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>Left Vertical</source>
         <translation type="unfinished">Verticale Sinistro</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="424"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>Right Vertical</source>
         <translation type="unfinished">Verticale Destro</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="425"/>
+        <location filename="../firmwares/boards.cpp" line="429"/>
         <source>Right Horizontal</source>
         <translation type="unfinished">Orizzontale Destro</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="426"/>
+        <location filename="../firmwares/boards.cpp" line="430"/>
         <source>Aux. 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="427"/>
+        <location filename="../firmwares/boards.cpp" line="431"/>
         <source>Aux. 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="443"/>
+        <location filename="../firmwares/boards.cpp" line="447"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="444"/>
+        <location filename="../firmwares/boards.cpp" line="448"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="449"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
         <source>RH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="459"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <source>TILT_X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="460"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <source>TILT_Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="506"/>
+        <location filename="../firmwares/boards.cpp" line="516"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
+        <location filename="../firmwares/boards.cpp" line="532"/>
+        <location filename="../firmwares/boards.cpp" line="548"/>
+        <location filename="../firmwares/boards.cpp" line="555"/>
+        <source>SL1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="475"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <source>P4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="517"/>
+        <location filename="../firmwares/boards.cpp" line="525"/>
+        <location filename="../firmwares/boards.cpp" line="533"/>
+        <location filename="../firmwares/boards.cpp" line="549"/>
+        <location filename="../firmwares/boards.cpp" line="556"/>
+        <source>SL2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="478"/>
+        <location filename="../firmwares/boards.cpp" line="557"/>
+        <source>SL3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="479"/>
+        <location filename="../firmwares/boards.cpp" line="558"/>
+        <source>SL4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <source>P5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="943"/>
+        <source>Slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="945"/>
+        <source>Multipos Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="947"/>
+        <source>Axis X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="949"/>
+        <source>Axis Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="951"/>
+        <source>Switch</source>
+        <translation type="unfinished">Interruttore</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Flight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="488"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="498"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
+        <location filename="../firmwares/boards.cpp" line="529"/>
+        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="553"/>
+        <source>P1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="473"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="504"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
+        <location filename="../firmwares/boards.cpp" line="530"/>
+        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="554"/>
+        <source>P2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="474"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="505"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
+        <location filename="../firmwares/boards.cpp" line="531"/>
+        <location filename="../firmwares/boards.cpp" line="543"/>
+        <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="455"/>
         <location filename="../firmwares/boards.cpp" line="457"/>
-        <source>TILT_X</source>
+        <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="456"/>
         <location filename="../firmwares/boards.cpp" line="458"/>
-        <source>TILT_Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="463"/>
-        <location filename="../firmwares/boards.cpp" line="472"/>
-        <location filename="../firmwares/boards.cpp" line="502"/>
-        <location filename="../firmwares/boards.cpp" line="512"/>
-        <location filename="../firmwares/boards.cpp" line="520"/>
-        <location filename="../firmwares/boards.cpp" line="528"/>
-        <location filename="../firmwares/boards.cpp" line="544"/>
-        <location filename="../firmwares/boards.cpp" line="551"/>
-        <source>SL1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="471"/>
-        <location filename="../firmwares/boards.cpp" line="510"/>
-        <source>P4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="473"/>
-        <location filename="../firmwares/boards.cpp" line="503"/>
-        <location filename="../firmwares/boards.cpp" line="513"/>
-        <location filename="../firmwares/boards.cpp" line="521"/>
-        <location filename="../firmwares/boards.cpp" line="529"/>
-        <location filename="../firmwares/boards.cpp" line="545"/>
-        <location filename="../firmwares/boards.cpp" line="552"/>
-        <source>SL2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="474"/>
-        <location filename="../firmwares/boards.cpp" line="553"/>
-        <source>SL3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="475"/>
-        <location filename="../firmwares/boards.cpp" line="554"/>
-        <source>SL4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="511"/>
-        <source>P5</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="933"/>
-        <source>Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="935"/>
-        <source>Multipos Switch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="937"/>
-        <source>Axis X</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="939"/>
-        <source>Axis Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="941"/>
-        <source>Switch</source>
-        <translation type="unfinished">Interruttore</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Flight</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Drive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="464"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
-        <location filename="../firmwares/boards.cpp" line="479"/>
-        <location filename="../firmwares/boards.cpp" line="484"/>
-        <location filename="../firmwares/boards.cpp" line="490"/>
-        <location filename="../firmwares/boards.cpp" line="494"/>
-        <location filename="../firmwares/boards.cpp" line="499"/>
-        <location filename="../firmwares/boards.cpp" line="507"/>
-        <location filename="../firmwares/boards.cpp" line="517"/>
-        <location filename="../firmwares/boards.cpp" line="525"/>
-        <location filename="../firmwares/boards.cpp" line="537"/>
-        <location filename="../firmwares/boards.cpp" line="549"/>
-        <source>P1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="469"/>
-        <location filename="../firmwares/boards.cpp" line="480"/>
-        <location filename="../firmwares/boards.cpp" line="485"/>
-        <location filename="../firmwares/boards.cpp" line="495"/>
-        <location filename="../firmwares/boards.cpp" line="500"/>
-        <location filename="../firmwares/boards.cpp" line="508"/>
-        <location filename="../firmwares/boards.cpp" line="518"/>
-        <location filename="../firmwares/boards.cpp" line="526"/>
-        <location filename="../firmwares/boards.cpp" line="538"/>
-        <location filename="../firmwares/boards.cpp" line="550"/>
-        <source>P2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="470"/>
-        <location filename="../firmwares/boards.cpp" line="486"/>
-        <location filename="../firmwares/boards.cpp" line="501"/>
-        <location filename="../firmwares/boards.cpp" line="509"/>
-        <location filename="../firmwares/boards.cpp" line="519"/>
-        <location filename="../firmwares/boards.cpp" line="527"/>
-        <location filename="../firmwares/boards.cpp" line="539"/>
-        <source>P3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
-        <source>JSx</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="454"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="530"/>
-        <location filename="../firmwares/boards.cpp" line="540"/>
+        <location filename="../firmwares/boards.cpp" line="534"/>
+        <location filename="../firmwares/boards.cpp" line="544"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="531"/>
-        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="535"/>
+        <location filename="../firmwares/boards.cpp" line="545"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="532"/>
-        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="536"/>
+        <location filename="../firmwares/boards.cpp" line="546"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="533"/>
-        <location filename="../firmwares/boards.cpp" line="543"/>
+        <location filename="../firmwares/boards.cpp" line="537"/>
+        <location filename="../firmwares/boards.cpp" line="547"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="678"/>
-        <location filename="../firmwares/boards.cpp" line="897"/>
-        <location filename="../firmwares/boards.cpp" line="927"/>
+        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="907"/>
+        <location filename="../firmwares/boards.cpp" line="937"/>
         <source>None</source>
         <translation type="unfinished">Nessuno</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="929"/>
+        <location filename="../firmwares/boards.cpp" line="939"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="931"/>
+        <location filename="../firmwares/boards.cpp" line="941"/>
         <source>Pot with detent</source>
         <translation type="unfinished">Pot con fermo centrale</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="680"/>
+        <location filename="../firmwares/boards.cpp" line="686"/>
         <source>2 Positions Toggle</source>
         <translation type="unfinished">Momentaneo 2 posizioni</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="682"/>
+        <location filename="../firmwares/boards.cpp" line="688"/>
         <source>2 Positions</source>
         <translation type="unfinished">2 Posizioni</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="690"/>
         <source>3 Positions</source>
         <translation type="unfinished">3 Posizioni</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="686"/>
+        <location filename="../firmwares/boards.cpp" line="692"/>
         <source>Function</source>
         <translation type="unfinished">Funzione</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="899"/>
+        <location filename="../firmwares/boards.cpp" line="909"/>
         <source>Standard</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="901"/>
+        <location filename="../firmwares/boards.cpp" line="911"/>
         <source>Small</source>
         <translation type="unfinished">Piccole</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="903"/>
+        <location filename="../firmwares/boards.cpp" line="913"/>
         <source>Both</source>
         <translation type="unfinished">Entrambi</translation>
     </message>
@@ -1626,34 +1626,50 @@ Error description: %4</source>
         <translation type="unfinished">Il simulatore per questo firmware non è ancora disponibile</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="380"/>
+        <location filename="../helpers.cpp" line="388"/>
+        <source>Uknown error during Simulator startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Data Load Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Error occurred while starting simulator.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="405"/>
         <source>Error creating temporary directory for models and settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="388"/>
+        <location filename="../helpers.cpp" line="413"/>
         <source>Error writing models and settings to temporary directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="419"/>
+        <location filename="../helpers.cpp" line="444"/>
         <source>Unable to start.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="421"/>
+        <location filename="../helpers.cpp" line="446"/>
         <source>Crashed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="423"/>
+        <location filename="../helpers.cpp" line="448"/>
         <source>Exited with result code:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="381"/>
         <location filename="../helpers.cpp" line="389"/>
-        <location filename="../helpers.cpp" line="426"/>
+        <location filename="../helpers.cpp" line="406"/>
+        <location filename="../helpers.cpp" line="414"/>
+        <location filename="../helpers.cpp" line="451"/>
         <source>Simulator Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3519,59 +3535,59 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="448"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="612"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="622"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="632"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="642"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="652"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="662"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="672"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="742"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="761"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="772"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="782"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="807"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="619"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="629"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="639"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="649"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="659"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="669"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="679"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="739"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="749"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="768"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="779"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="789"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="814"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation type="unfinished">Disabilita il menù HELI e le funzioni del piatto ciclico</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="449"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="613"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="623"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="633"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="643"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="653"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="663"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="673"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="733"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="743"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="752"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="762"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="773"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="783"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="680"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="769"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="815"/>
         <source>Disable Global variables</source>
         <translation type="unfinished">Disabilita variabili globali</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="450"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="474"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="614"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="624"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="634"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="644"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="654"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="664"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="674"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="734"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="744"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="753"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="763"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="784"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="809"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="621"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="631"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="641"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="651"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="661"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="671"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="741"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="751"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="760"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="781"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="791"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="816"/>
         <source>Enable Lua custom scripts screen</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3581,7 +3597,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished">Usa font alternativo SQT5 (Leggermente quadrato)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
         <source>FrSky Taranis X9D+</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3596,104 +3612,104 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="590"/>
         <source>Disable RAS (SWR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="574"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="581"/>
         <source>FrSky Taranis X9D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="576"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
         <source>Haptic module installed</source>
         <translation type="unfinished">Modulo vibrazione installato </translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="595"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="602"/>
         <source>FrSky Taranis X9E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
         <source>Confirmation before radio shutdown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="597"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="604"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="562"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="569"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="537"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="544"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="563"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="549"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
         <source>FrSky Taranis X-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="530"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="529"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="536"/>
         <source>FrSky Horus X12S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="539"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="677"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="675"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="703"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="682"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="710"/>
         <source>Support for MULTI internal module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="627"/>
         <source>Jumper T-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="637"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="701"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="708"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3703,26 +3719,26 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="777"/>
         <source>Radiomaster TX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="787"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="805"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="812"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="683"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="690"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="718"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="697"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="725"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="810"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="817"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3732,82 +3748,87 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <source>FlySky ST16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
         <source>HelloRadioSky V16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="647"/>
         <source>Jumper T-Pro V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="657"/>
         <source>Jumper T-Pro S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="667"/>
         <source>Jumper Bumblebee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
         <source>Jumper T12 MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
         <source>Jumper T14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="702"/>
         <source>Jumper T15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
         <source>Jumper T20 V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="737"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="747"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="757"/>
         <source>Radiomaster MT12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="766"/>
         <source>Radiomaster T8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="767"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
         <source>Allow bind using bind key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
         <source>Radiomaster GX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="804"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3818,12 +3839,12 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="484"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="801"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="709"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
         <source>Jumper T18</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3838,7 +3859,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="617"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3863,18 +3884,18 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="568"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="543"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="550"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="518"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="525"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="538"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4904,206 +4925,206 @@ Queste impostazioni sono comuni a tutti i modelli nella stessa EEPROM.</translat
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="412"/>
+        <location filename="../firmwares/generalsettings.cpp" line="414"/>
         <source>Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="414"/>
+        <location filename="../firmwares/generalsettings.cpp" line="416"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="415"/>
+        <location filename="../firmwares/generalsettings.cpp" line="417"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="430"/>
+        <location filename="../firmwares/generalsettings.cpp" line="432"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="464"/>
+        <location filename="../firmwares/generalsettings.cpp" line="466"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="469"/>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="471"/>
+        <location filename="../firmwares/generalsettings.cpp" line="483"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Switch</source>
         <translation type="unfinished">Interruttore</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="499"/>
+        <location filename="../firmwares/generalsettings.cpp" line="501"/>
         <source>None</source>
         <translation type="unfinished">Nessuno</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="553"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="555"/>
+        <location filename="../firmwares/generalsettings.cpp" line="557"/>
         <source>Ask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="557"/>
+        <location filename="../firmwares/generalsettings.cpp" line="559"/>
         <source>Per model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>Internal + External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="573"/>
-        <location filename="../firmwares/generalsettings.cpp" line="589"/>
+        <location filename="../firmwares/generalsettings.cpp" line="575"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>OFF</source>
         <translation type="unfinished">Spento</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Telemetry</source>
         <translation type="unfinished">Telemetria</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="578"/>
+        <location filename="../firmwares/generalsettings.cpp" line="580"/>
         <source>Trainer</source>
         <translation type="unfinished">Maestro/Allievo</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="591"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="593"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="595"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished">Maestro/Allievo SBUS</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="597"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="599"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="601"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="603"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>Debug</source>
         <translation type="unfinished">Debug</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="605"/>
+        <location filename="../firmwares/generalsettings.cpp" line="607"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="607"/>
+        <location filename="../firmwares/generalsettings.cpp" line="609"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="640"/>
+        <location filename="../firmwares/generalsettings.cpp" line="642"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="739"/>
+        <location filename="../firmwares/generalsettings.cpp" line="741"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="741"/>
+        <location filename="../firmwares/generalsettings.cpp" line="743"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="787"/>
+        <location filename="../firmwares/generalsettings.cpp" line="789"/>
         <source>Trims only</source>
         <translation type="unfinished">Solo trims</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="789"/>
+        <location filename="../firmwares/generalsettings.cpp" line="791"/>
         <source>Keys only</source>
         <translation type="unfinished">Solo keys</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="791"/>
+        <location filename="../firmwares/generalsettings.cpp" line="793"/>
         <source>Switchable</source>
         <translation type="unfinished">Commutabile</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="793"/>
+        <location filename="../firmwares/generalsettings.cpp" line="795"/>
         <source>Global</source>
         <translation type="unfinished">Globale</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="927"/>
+        <location filename="../firmwares/generalsettings.cpp" line="929"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation type="unfinished">Modo 1 (DIR ELE MOT ALE)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="931"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation type="unfinished">Modo 2 (DIR MOTO ELE ALE)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="933"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation type="unfinished">Modo 3 (ALE ELE MOT DIR)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="935"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation type="unfinished">Modo 4 (ALE MOT ELE DIR)</translation>
     </message>
@@ -6036,32 +6057,32 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished">Ceco</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="434"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Slovak</source>
         <translation type="unfinished">Slovacco</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="435"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Spanish</source>
         <translation type="unfinished">Spagnolo</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Polish</source>
         <translation type="unfinished">Polacco</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="432"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Portuguese</source>
         <translation type="unfinished">Portoghese</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="433"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Russian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="436"/>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Swedish</source>
         <translation type="unfinished">Svedese</translation>
     </message>
@@ -6071,7 +6092,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6106,64 +6127,69 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="437"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <source>Korean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="438"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>No</source>
         <translation type="unfinished">No</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>RotEnc A</source>
         <translation type="unfinished">EncRot A</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc B</source>
         <translation type="unfinished">EncRot B</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc C</source>
         <translation type="unfinished">EncRot C</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc D</source>
         <translation type="unfinished">EncRot D</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc E</source>
         <translation type="unfinished">EncRot E</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="617"/>
+        <location filename="../generaledit/generalsetup.cpp" line="618"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15717,22 +15743,22 @@ Timestamp</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="873"/>
+        <location filename="../firmwares/generalsettings.cpp" line="875"/>
         <source>OFF</source>
         <translation type="unfinished">Spento</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="875"/>
+        <location filename="../firmwares/generalsettings.cpp" line="877"/>
         <source>+= (Sum)</source>
         <translation type="unfinished">+= (Somma)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="877"/>
+        <location filename="../firmwares/generalsettings.cpp" line="879"/>
         <source>:= (Replace)</source>
         <translation type="unfinished">:= (Sostituisci)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="886"/>
+        <location filename="../firmwares/generalsettings.cpp" line="888"/>
         <source>CH%1</source>
         <translation type="unfinished">CH%1</translation>
     </message>
@@ -17431,14 +17457,14 @@ Do you wish to continue?</source>
 <context>
     <name>YamlModelSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1288"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1287"/>
         <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
 
 Model settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1291"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1290"/>
         <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/companion/src/translations/companion_ja.ts
+++ b/companion/src/translations/companion_ja.ts
@@ -1008,274 +1008,274 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="422"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>Left Horizontal</source>
         <translation>左・横</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="423"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>Left Vertical</source>
         <translation>左・縦</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="424"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>Right Vertical</source>
         <translation>右・縦</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="425"/>
+        <location filename="../firmwares/boards.cpp" line="429"/>
         <source>Right Horizontal</source>
         <translation>右・横</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="426"/>
+        <location filename="../firmwares/boards.cpp" line="430"/>
         <source>Aux. 1</source>
         <translation>AUX. 1</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="427"/>
+        <location filename="../firmwares/boards.cpp" line="431"/>
         <source>Aux. 2</source>
         <translation>AUX. 2</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="443"/>
+        <location filename="../firmwares/boards.cpp" line="447"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="444"/>
+        <location filename="../firmwares/boards.cpp" line="448"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="449"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
         <source>RH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="455"/>
-        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="459"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
         <source>TILT_X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="456"/>
-        <location filename="../firmwares/boards.cpp" line="458"/>
+        <location filename="../firmwares/boards.cpp" line="460"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
         <source>TILT_Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="463"/>
-        <location filename="../firmwares/boards.cpp" line="472"/>
-        <location filename="../firmwares/boards.cpp" line="502"/>
-        <location filename="../firmwares/boards.cpp" line="512"/>
-        <location filename="../firmwares/boards.cpp" line="520"/>
-        <location filename="../firmwares/boards.cpp" line="528"/>
-        <location filename="../firmwares/boards.cpp" line="544"/>
-        <location filename="../firmwares/boards.cpp" line="551"/>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="506"/>
+        <location filename="../firmwares/boards.cpp" line="516"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
+        <location filename="../firmwares/boards.cpp" line="532"/>
+        <location filename="../firmwares/boards.cpp" line="548"/>
+        <location filename="../firmwares/boards.cpp" line="555"/>
         <source>SL1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="471"/>
-        <location filename="../firmwares/boards.cpp" line="510"/>
+        <location filename="../firmwares/boards.cpp" line="475"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
         <source>P4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="473"/>
-        <location filename="../firmwares/boards.cpp" line="503"/>
-        <location filename="../firmwares/boards.cpp" line="513"/>
-        <location filename="../firmwares/boards.cpp" line="521"/>
-        <location filename="../firmwares/boards.cpp" line="529"/>
-        <location filename="../firmwares/boards.cpp" line="545"/>
-        <location filename="../firmwares/boards.cpp" line="552"/>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="517"/>
+        <location filename="../firmwares/boards.cpp" line="525"/>
+        <location filename="../firmwares/boards.cpp" line="533"/>
+        <location filename="../firmwares/boards.cpp" line="549"/>
+        <location filename="../firmwares/boards.cpp" line="556"/>
         <source>SL2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="474"/>
-        <location filename="../firmwares/boards.cpp" line="553"/>
+        <location filename="../firmwares/boards.cpp" line="478"/>
+        <location filename="../firmwares/boards.cpp" line="557"/>
         <source>SL3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="475"/>
-        <location filename="../firmwares/boards.cpp" line="554"/>
+        <location filename="../firmwares/boards.cpp" line="479"/>
+        <location filename="../firmwares/boards.cpp" line="558"/>
         <source>SL4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="511"/>
+        <location filename="../firmwares/boards.cpp" line="515"/>
         <source>P5</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="933"/>
+        <location filename="../firmwares/boards.cpp" line="943"/>
         <source>Slider</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="935"/>
+        <location filename="../firmwares/boards.cpp" line="945"/>
         <source>Multipos Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="937"/>
+        <location filename="../firmwares/boards.cpp" line="947"/>
         <source>Axis X</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="939"/>
+        <location filename="../firmwares/boards.cpp" line="949"/>
         <source>Axis Y</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="941"/>
+        <location filename="../firmwares/boards.cpp" line="951"/>
         <source>Switch</source>
         <translation type="unfinished">スイッチ</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
         <source>Flight</source>
         <translation type="unfinished">フライト</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
         <source>Drive</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="464"/>
         <location filename="../firmwares/boards.cpp" line="468"/>
-        <location filename="../firmwares/boards.cpp" line="479"/>
-        <location filename="../firmwares/boards.cpp" line="484"/>
-        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="488"/>
         <location filename="../firmwares/boards.cpp" line="494"/>
-        <location filename="../firmwares/boards.cpp" line="499"/>
-        <location filename="../firmwares/boards.cpp" line="507"/>
-        <location filename="../firmwares/boards.cpp" line="517"/>
-        <location filename="../firmwares/boards.cpp" line="525"/>
-        <location filename="../firmwares/boards.cpp" line="537"/>
-        <location filename="../firmwares/boards.cpp" line="549"/>
+        <location filename="../firmwares/boards.cpp" line="498"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
+        <location filename="../firmwares/boards.cpp" line="529"/>
+        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="553"/>
         <source>P1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="469"/>
-        <location filename="../firmwares/boards.cpp" line="480"/>
-        <location filename="../firmwares/boards.cpp" line="485"/>
-        <location filename="../firmwares/boards.cpp" line="495"/>
-        <location filename="../firmwares/boards.cpp" line="500"/>
-        <location filename="../firmwares/boards.cpp" line="508"/>
-        <location filename="../firmwares/boards.cpp" line="518"/>
-        <location filename="../firmwares/boards.cpp" line="526"/>
-        <location filename="../firmwares/boards.cpp" line="538"/>
-        <location filename="../firmwares/boards.cpp" line="550"/>
+        <location filename="../firmwares/boards.cpp" line="473"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="504"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
+        <location filename="../firmwares/boards.cpp" line="530"/>
+        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="554"/>
         <source>P2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="470"/>
-        <location filename="../firmwares/boards.cpp" line="486"/>
-        <location filename="../firmwares/boards.cpp" line="501"/>
-        <location filename="../firmwares/boards.cpp" line="509"/>
-        <location filename="../firmwares/boards.cpp" line="519"/>
-        <location filename="../firmwares/boards.cpp" line="527"/>
-        <location filename="../firmwares/boards.cpp" line="539"/>
+        <location filename="../firmwares/boards.cpp" line="474"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="505"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
+        <location filename="../firmwares/boards.cpp" line="531"/>
+        <location filename="../firmwares/boards.cpp" line="543"/>
         <source>P3</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="457"/>
         <source>JSx</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="458"/>
         <source>JSy</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="530"/>
-        <location filename="../firmwares/boards.cpp" line="540"/>
+        <location filename="../firmwares/boards.cpp" line="534"/>
+        <location filename="../firmwares/boards.cpp" line="544"/>
         <source>EXT1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="531"/>
-        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="535"/>
+        <location filename="../firmwares/boards.cpp" line="545"/>
         <source>EXT2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="532"/>
-        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="536"/>
+        <location filename="../firmwares/boards.cpp" line="546"/>
         <source>EXT3</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="533"/>
-        <location filename="../firmwares/boards.cpp" line="543"/>
+        <location filename="../firmwares/boards.cpp" line="537"/>
+        <location filename="../firmwares/boards.cpp" line="547"/>
         <source>EXT4</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="678"/>
-        <location filename="../firmwares/boards.cpp" line="897"/>
-        <location filename="../firmwares/boards.cpp" line="927"/>
+        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="907"/>
+        <location filename="../firmwares/boards.cpp" line="937"/>
         <source>None</source>
         <translation>なし</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="929"/>
+        <location filename="../firmwares/boards.cpp" line="939"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="931"/>
+        <location filename="../firmwares/boards.cpp" line="941"/>
         <source>Pot with detent</source>
         <translation>ダイヤル (ノッチあり)</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="680"/>
+        <location filename="../firmwares/boards.cpp" line="686"/>
         <source>2 Positions Toggle</source>
         <translation>2 ポジション トグル</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="682"/>
+        <location filename="../firmwares/boards.cpp" line="688"/>
         <source>2 Positions</source>
         <translation>2 ポジション</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="690"/>
         <source>3 Positions</source>
         <translation>3 ポジション</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="686"/>
+        <location filename="../firmwares/boards.cpp" line="692"/>
         <source>Function</source>
         <translation type="unfinished">機能</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="899"/>
+        <location filename="../firmwares/boards.cpp" line="909"/>
         <source>Standard</source>
         <translation>標準</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="901"/>
+        <location filename="../firmwares/boards.cpp" line="911"/>
         <source>Small</source>
         <translation>小サイズ</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="903"/>
+        <location filename="../firmwares/boards.cpp" line="913"/>
         <source>Both</source>
         <translation>両方</translation>
     </message>
@@ -1616,34 +1616,50 @@ Error description: %4</source>
         <translation>このファームウェアのシミュレータはまだ利用できません</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="380"/>
+        <location filename="../helpers.cpp" line="388"/>
+        <source>Uknown error during Simulator startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Data Load Error</source>
+        <translation type="unfinished">データロード エラー</translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Error occurred while starting simulator.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="405"/>
         <source>Error creating temporary directory for models and settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="388"/>
+        <location filename="../helpers.cpp" line="413"/>
         <source>Error writing models and settings to temporary directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="419"/>
+        <location filename="../helpers.cpp" line="444"/>
         <source>Unable to start.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="421"/>
+        <location filename="../helpers.cpp" line="446"/>
         <source>Crashed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="423"/>
+        <location filename="../helpers.cpp" line="448"/>
         <source>Exited with result code:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="381"/>
         <location filename="../helpers.cpp" line="389"/>
-        <location filename="../helpers.cpp" line="426"/>
+        <location filename="../helpers.cpp" line="406"/>
+        <location filename="../helpers.cpp" line="414"/>
+        <location filename="../helpers.cpp" line="451"/>
         <source>Simulator Error</source>
         <translation>シミュレータ エラー</translation>
     </message>
@@ -3517,59 +3533,59 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="448"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="612"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="622"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="632"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="642"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="652"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="662"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="672"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="742"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="761"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="772"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="782"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="807"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="619"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="629"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="639"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="649"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="659"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="669"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="679"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="739"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="749"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="768"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="779"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="789"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="814"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation>HELIメニューとサイクリックミックスサポートを無効にする</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="449"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="613"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="623"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="633"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="643"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="653"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="663"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="673"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="733"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="743"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="752"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="762"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="773"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="783"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="680"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="769"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="815"/>
         <source>Disable Global variables</source>
         <translation>グローバル変数を無効にする</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="450"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="474"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="614"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="624"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="634"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="644"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="654"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="664"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="674"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="734"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="744"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="753"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="763"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="784"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="809"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="621"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="631"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="641"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="651"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="661"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="671"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="741"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="751"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="760"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="781"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="791"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="816"/>
         <source>Enable Lua custom scripts screen</source>
         <translation>Luaカスタムスクリプト画面を有効にする</translation>
     </message>
@@ -3579,7 +3595,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>SQT5 代替フォントを使用する</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
         <source>FrSky Taranis X9D+</source>
         <translation>FrSky Taranis X9D+</translation>
     </message>
@@ -3594,104 +3610,104 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>AFHDS3サポート 有効</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="590"/>
         <source>Disable RAS (SWR)</source>
         <translation>RAS (SWR)を無効にする</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="574"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="581"/>
         <source>FrSky Taranis X9D</source>
         <translation>FrSky Taranis X9D</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="576"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
         <source>Haptic module installed</source>
         <translation>バイブレーション対応モジュールをインストール</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="595"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="602"/>
         <source>FrSky Taranis X9E</source>
         <translation>FrSky Taranis X9E</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
         <source>Confirmation before radio shutdown</source>
         <translation>送信機シャットダウン前の確認</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="597"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="604"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation>Horusジンバル (ホールセンサー) をインストール</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="562"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="569"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation>FrSky Taranis X9-Lite</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="537"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="544"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation>FrSky Taranis X7 / X7S</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="563"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation>FrSky Taranis X-Lite S/PRO</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="549"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
         <source>FrSky Taranis X-Lite</source>
         <translation>FrSky Taranis X-Lite</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation>FrSky Horus X10 / X10S</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="530"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="529"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="536"/>
         <source>FrSky Horus X12S</source>
         <translation>FrSky Horus X12S</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="539"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation>初期DEV pcbバージョンでのみ使用</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="677"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="675"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="703"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="682"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="710"/>
         <source>Support for MULTI internal module</source>
         <translation>MULTI内部モジュールのサポート</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="627"/>
         <source>Jumper T-Lite</source>
         <translation>Jumper T-Lite</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="637"/>
         <source>Jumper T-Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="701"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="708"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation></translation>
     </message>
@@ -3701,26 +3717,26 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>Bluetoothモジュールのサポート</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="777"/>
         <source>Radiomaster TX12</source>
         <translation>Radiomaster TX12</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="787"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="805"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="812"/>
         <source>Radiomaster Zorro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="683"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="690"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="718"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="697"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="725"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="810"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="817"/>
         <source>Select if internal ELRS module is installed</source>
         <translation>内蔵ELRSモジュールが搭載されているか否かを選択</translation>
     </message>
@@ -3730,82 +3746,87 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <source>FlySky ST16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
         <source>HelloRadioSky V16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="647"/>
         <source>Jumper T-Pro V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="657"/>
         <source>Jumper T-Pro S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="667"/>
         <source>Jumper Bumblebee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
         <source>Jumper T12 MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
         <source>Jumper T14</source>
         <translation type="unfinished">Jumper T14</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="702"/>
         <source>Jumper T15</source>
         <translation type="unfinished">Jumper T15</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
         <source>Jumper T20</source>
         <translation>Jumper T20</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
         <source>Jumper T20 V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="737"/>
         <source>Radiomaster Boxer</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="747"/>
         <source>Radiomaster Pocket</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="757"/>
         <source>Radiomaster MT12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="766"/>
         <source>Radiomaster T8</source>
         <translation>Radiomaster T8</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="767"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
         <source>Allow bind using bind key</source>
         <translation>バインドキーを使用したバインドを許可</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
         <source>Radiomaster GX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="804"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation>Radiomaster TX16S / SE / Hall / Masterfire</translation>
     </message>
@@ -3816,12 +3837,12 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="484"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="801"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation>ハードウェアMODサポート: FlySky Paladin EV Gimbals</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="709"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
         <source>Jumper T18</source>
         <translation>Jumper T18</translation>
     </message>
@@ -3836,7 +3857,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="617"/>
         <source>iFlight Commando8</source>
         <translation></translation>
     </message>
@@ -3861,18 +3882,18 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="568"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="543"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="550"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation>FrSky Taranis X7 / X7S ACCESS</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="518"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="525"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="538"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation>ACCESS内部モジュール変更のサポート</translation>
     </message>
@@ -4902,206 +4923,206 @@ These will be relevant for all models in the same EEPROM.</source>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="412"/>
+        <location filename="../firmwares/generalsettings.cpp" line="414"/>
         <source>Radio Settings</source>
         <translation>送信機設定</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="414"/>
+        <location filename="../firmwares/generalsettings.cpp" line="416"/>
         <source>Hardware</source>
         <translation type="unfinished">ハードウェア</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="415"/>
+        <location filename="../firmwares/generalsettings.cpp" line="417"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="430"/>
+        <location filename="../firmwares/generalsettings.cpp" line="432"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="464"/>
+        <location filename="../firmwares/generalsettings.cpp" line="466"/>
         <source>Switches</source>
         <translation type="unfinished">スイッチ</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="469"/>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="471"/>
+        <location filename="../firmwares/generalsettings.cpp" line="483"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Switch</source>
         <translation type="unfinished">スイッチ</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="499"/>
+        <location filename="../firmwares/generalsettings.cpp" line="501"/>
         <source>None</source>
         <translation type="unfinished">なし</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="553"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Internal</source>
         <translation>内部</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="555"/>
+        <location filename="../firmwares/generalsettings.cpp" line="557"/>
         <source>Ask</source>
         <translation>確認</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="557"/>
+        <location filename="../firmwares/generalsettings.cpp" line="559"/>
         <source>Per model</source>
         <translation>Per モデル</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>Internal + External</source>
         <translation>内部 + 外部</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>External</source>
         <translation>外部</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="573"/>
-        <location filename="../firmwares/generalsettings.cpp" line="589"/>
+        <location filename="../firmwares/generalsettings.cpp" line="575"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>OFF</source>
         <translation>OFF</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Enabled</source>
         <translation>有効</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Telemetry</source>
         <translation>テレメトリー</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="578"/>
+        <location filename="../firmwares/generalsettings.cpp" line="580"/>
         <source>Trainer</source>
         <translation>トレーナー</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="591"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>Telemetry Mirror</source>
         <translation>テレメトリーミラー</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="593"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>Telemetry In</source>
         <translation>テレメトリー IN</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="595"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>SBUS Trainer</source>
         <translation>SBUS トレーナー</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="597"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>LUA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="599"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>CLI</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="601"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>GPS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="603"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>Debug</source>
         <translation>デバッグ</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="605"/>
+        <location filename="../firmwares/generalsettings.cpp" line="607"/>
         <source>SpaceMouse</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="607"/>
+        <location filename="../firmwares/generalsettings.cpp" line="609"/>
         <source>External module</source>
         <translation>外部モジュール</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="640"/>
+        <location filename="../firmwares/generalsettings.cpp" line="642"/>
         <source>mA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="739"/>
+        <location filename="../firmwares/generalsettings.cpp" line="741"/>
         <source>Normal</source>
         <translation>標準</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="741"/>
+        <location filename="../firmwares/generalsettings.cpp" line="743"/>
         <source>OneBit</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="787"/>
+        <location filename="../firmwares/generalsettings.cpp" line="789"/>
         <source>Trims only</source>
         <translation>トリムのみ</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="789"/>
+        <location filename="../firmwares/generalsettings.cpp" line="791"/>
         <source>Keys only</source>
         <translation>キーのみ</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="791"/>
+        <location filename="../firmwares/generalsettings.cpp" line="793"/>
         <source>Switchable</source>
         <translation>スイッチ</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="793"/>
+        <location filename="../firmwares/generalsettings.cpp" line="795"/>
         <source>Global</source>
         <translation>すべて</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="927"/>
+        <location filename="../firmwares/generalsettings.cpp" line="929"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation type="unfinished">モード1&#x3000;(左:エレベーター・ラダー&#x3000;右:スロットル・エルロン)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="931"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation type="unfinished">モード2&#x3000;(左:スロットル・ラダー&#x3000;右:エレベーター・エルロン)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="933"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation type="unfinished">モード3&#x3000;(左:エレベーター・エルロン&#x3000;右:スロットル・ラダー)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="935"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation type="unfinished">モード4&#x3000;(左:スロットル・エルロン&#x3000;右:エレベーター・ラダー)</translation>
     </message>
@@ -6036,32 +6057,32 @@ p, li { white-space: pre-wrap; }
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="434"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Slovak</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="435"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Spanish</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Polish</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="432"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Portuguese</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="433"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Russian</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="436"/>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Swedish</source>
         <translation></translation>
     </message>
@@ -6071,7 +6092,7 @@ p, li { white-space: pre-wrap; }
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal, Edit Inverted</source>
         <translation>標準, リバース編集</translation>
     </message>
@@ -6106,42 +6127,47 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="437"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <source>Korean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="438"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>No</source>
         <translation>いいえ</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>RotEnc A</source>
         <translation>Rot Enc A</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc B</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc C</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc D</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="617"/>
+        <location filename="../generaledit/generalsetup.cpp" line="618"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
@@ -6150,22 +6176,22 @@ Are you sure ?</source>
 よろしいですか？</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal</source>
         <translation>標準</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Inverted</source>
         <translation>リバース</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation>垂直 リバース, 水平 標準</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation>垂直 リバース, 水平 交互</translation>
     </message>
@@ -15760,22 +15786,22 @@ Timestamp</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="873"/>
+        <location filename="../firmwares/generalsettings.cpp" line="875"/>
         <source>OFF</source>
         <translation>OFF</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="875"/>
+        <location filename="../firmwares/generalsettings.cpp" line="877"/>
         <source>+= (Sum)</source>
         <translation>+= (合計)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="877"/>
+        <location filename="../firmwares/generalsettings.cpp" line="879"/>
         <source>:= (Replace)</source>
         <translation>:= (置換)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="886"/>
+        <location filename="../firmwares/generalsettings.cpp" line="888"/>
         <source>CH%1</source>
         <translation>CH%1</translation>
     </message>
@@ -17485,14 +17511,14 @@ Do you wish to continue?</source>
 <context>
     <name>YamlModelSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1288"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1287"/>
         <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
 
 Model settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1291"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1290"/>
         <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/companion/src/translations/companion_ko.ts
+++ b/companion/src/translations/companion_ko.ts
@@ -1028,274 +1028,274 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="422"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>Left Horizontal</source>
         <translation>왼쪽 수평</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="423"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>Left Vertical</source>
         <translation>왼쪽 수직</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="424"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>Right Vertical</source>
         <translation>오른쪽 수직</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="425"/>
+        <location filename="../firmwares/boards.cpp" line="429"/>
         <source>Right Horizontal</source>
         <translation>오른쪽 수평</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="426"/>
+        <location filename="../firmwares/boards.cpp" line="430"/>
         <source>Aux. 1</source>
         <translation>Aux. 1(보조1)</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="427"/>
+        <location filename="../firmwares/boards.cpp" line="431"/>
         <source>Aux. 2</source>
         <translation>Aux. 2(보조2)</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="443"/>
+        <location filename="../firmwares/boards.cpp" line="447"/>
         <source>LH</source>
         <translation>LH(왼쪽 수평)</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="444"/>
+        <location filename="../firmwares/boards.cpp" line="448"/>
         <source>LV</source>
         <translation>LV(왼쪽 수직)</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="449"/>
         <source>RV</source>
         <translation>RV(오른쪽 수직)</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
         <source>RH</source>
         <translation>RH(오른쪽 수평)</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="455"/>
-        <location filename="../firmwares/boards.cpp" line="457"/>
+        <location filename="../firmwares/boards.cpp" line="459"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
         <source>TILT_X</source>
         <translation>TILT_X(기울기X축)</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="456"/>
-        <location filename="../firmwares/boards.cpp" line="458"/>
+        <location filename="../firmwares/boards.cpp" line="460"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
         <source>TILT_Y</source>
         <translation>TILT_Y(기울기Y축)</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="463"/>
-        <location filename="../firmwares/boards.cpp" line="472"/>
-        <location filename="../firmwares/boards.cpp" line="502"/>
-        <location filename="../firmwares/boards.cpp" line="512"/>
-        <location filename="../firmwares/boards.cpp" line="520"/>
-        <location filename="../firmwares/boards.cpp" line="528"/>
-        <location filename="../firmwares/boards.cpp" line="544"/>
-        <location filename="../firmwares/boards.cpp" line="551"/>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="506"/>
+        <location filename="../firmwares/boards.cpp" line="516"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
+        <location filename="../firmwares/boards.cpp" line="532"/>
+        <location filename="../firmwares/boards.cpp" line="548"/>
+        <location filename="../firmwares/boards.cpp" line="555"/>
         <source>SL1</source>
         <translation>SL1(슬라이더1)</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="471"/>
-        <location filename="../firmwares/boards.cpp" line="510"/>
+        <location filename="../firmwares/boards.cpp" line="475"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
         <source>P4</source>
         <translation>P4(포트4)</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="473"/>
-        <location filename="../firmwares/boards.cpp" line="503"/>
-        <location filename="../firmwares/boards.cpp" line="513"/>
-        <location filename="../firmwares/boards.cpp" line="521"/>
-        <location filename="../firmwares/boards.cpp" line="529"/>
-        <location filename="../firmwares/boards.cpp" line="545"/>
-        <location filename="../firmwares/boards.cpp" line="552"/>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="517"/>
+        <location filename="../firmwares/boards.cpp" line="525"/>
+        <location filename="../firmwares/boards.cpp" line="533"/>
+        <location filename="../firmwares/boards.cpp" line="549"/>
+        <location filename="../firmwares/boards.cpp" line="556"/>
         <source>SL2</source>
         <translation>SL2(슬라이더2)</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="474"/>
-        <location filename="../firmwares/boards.cpp" line="553"/>
+        <location filename="../firmwares/boards.cpp" line="478"/>
+        <location filename="../firmwares/boards.cpp" line="557"/>
         <source>SL3</source>
         <translation>SL3(슬라이더3)</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="475"/>
-        <location filename="../firmwares/boards.cpp" line="554"/>
+        <location filename="../firmwares/boards.cpp" line="479"/>
+        <location filename="../firmwares/boards.cpp" line="558"/>
         <source>SL4</source>
         <translation>SL4(슬라이더4)</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="511"/>
+        <location filename="../firmwares/boards.cpp" line="515"/>
         <source>P5</source>
         <translation>P5(포트5)</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="933"/>
+        <location filename="../firmwares/boards.cpp" line="943"/>
         <source>Slider</source>
         <translation>슬라이더</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="935"/>
+        <location filename="../firmwares/boards.cpp" line="945"/>
         <source>Multipos Switch</source>
         <translation>다단 스위치</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="937"/>
+        <location filename="../firmwares/boards.cpp" line="947"/>
         <source>Axis X</source>
         <translation>X축</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="939"/>
+        <location filename="../firmwares/boards.cpp" line="949"/>
         <source>Axis Y</source>
         <translation>Y축</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="941"/>
+        <location filename="../firmwares/boards.cpp" line="951"/>
         <source>Switch</source>
         <translation>스위치</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
         <source>Flight</source>
         <translation>비행</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
         <source>Drive</source>
         <translation>주행</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="464"/>
         <location filename="../firmwares/boards.cpp" line="468"/>
-        <location filename="../firmwares/boards.cpp" line="479"/>
-        <location filename="../firmwares/boards.cpp" line="484"/>
-        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="488"/>
         <location filename="../firmwares/boards.cpp" line="494"/>
-        <location filename="../firmwares/boards.cpp" line="499"/>
-        <location filename="../firmwares/boards.cpp" line="507"/>
-        <location filename="../firmwares/boards.cpp" line="517"/>
-        <location filename="../firmwares/boards.cpp" line="525"/>
-        <location filename="../firmwares/boards.cpp" line="537"/>
-        <location filename="../firmwares/boards.cpp" line="549"/>
+        <location filename="../firmwares/boards.cpp" line="498"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
+        <location filename="../firmwares/boards.cpp" line="529"/>
+        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="553"/>
         <source>P1</source>
         <translation>P1(포트1)</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="469"/>
-        <location filename="../firmwares/boards.cpp" line="480"/>
-        <location filename="../firmwares/boards.cpp" line="485"/>
-        <location filename="../firmwares/boards.cpp" line="495"/>
-        <location filename="../firmwares/boards.cpp" line="500"/>
-        <location filename="../firmwares/boards.cpp" line="508"/>
-        <location filename="../firmwares/boards.cpp" line="518"/>
-        <location filename="../firmwares/boards.cpp" line="526"/>
-        <location filename="../firmwares/boards.cpp" line="538"/>
-        <location filename="../firmwares/boards.cpp" line="550"/>
+        <location filename="../firmwares/boards.cpp" line="473"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="504"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
+        <location filename="../firmwares/boards.cpp" line="530"/>
+        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="554"/>
         <source>P2</source>
         <translation>P2(포트2)</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="470"/>
-        <location filename="../firmwares/boards.cpp" line="486"/>
-        <location filename="../firmwares/boards.cpp" line="501"/>
-        <location filename="../firmwares/boards.cpp" line="509"/>
-        <location filename="../firmwares/boards.cpp" line="519"/>
-        <location filename="../firmwares/boards.cpp" line="527"/>
-        <location filename="../firmwares/boards.cpp" line="539"/>
+        <location filename="../firmwares/boards.cpp" line="474"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="505"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
+        <location filename="../firmwares/boards.cpp" line="531"/>
+        <location filename="../firmwares/boards.cpp" line="543"/>
         <source>P3</source>
         <translation>P3(포트3)</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
+        <location filename="../firmwares/boards.cpp" line="455"/>
+        <location filename="../firmwares/boards.cpp" line="457"/>
         <source>JSx</source>
         <translation>조이스틱 X</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="454"/>
+        <location filename="../firmwares/boards.cpp" line="456"/>
+        <location filename="../firmwares/boards.cpp" line="458"/>
         <source>JSy</source>
         <translation>조이스틱 Y</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="530"/>
-        <location filename="../firmwares/boards.cpp" line="540"/>
+        <location filename="../firmwares/boards.cpp" line="534"/>
+        <location filename="../firmwares/boards.cpp" line="544"/>
         <source>EXT1</source>
         <translation>확장1</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="531"/>
-        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="535"/>
+        <location filename="../firmwares/boards.cpp" line="545"/>
         <source>EXT2</source>
         <translation>확장2</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="532"/>
-        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="536"/>
+        <location filename="../firmwares/boards.cpp" line="546"/>
         <source>EXT3</source>
         <translation>확장3</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="533"/>
-        <location filename="../firmwares/boards.cpp" line="543"/>
+        <location filename="../firmwares/boards.cpp" line="537"/>
+        <location filename="../firmwares/boards.cpp" line="547"/>
         <source>EXT4</source>
         <translation>확장4</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="678"/>
-        <location filename="../firmwares/boards.cpp" line="897"/>
-        <location filename="../firmwares/boards.cpp" line="927"/>
+        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="907"/>
+        <location filename="../firmwares/boards.cpp" line="937"/>
         <source>None</source>
         <translation>없음</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="929"/>
+        <location filename="../firmwares/boards.cpp" line="939"/>
         <source>Pot</source>
         <translation>가변 저항</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="931"/>
+        <location filename="../firmwares/boards.cpp" line="941"/>
         <source>Pot with detent</source>
         <translation>중간 고정점 있는 가변 저항</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="680"/>
+        <location filename="../firmwares/boards.cpp" line="686"/>
         <source>2 Positions Toggle</source>
         <translation>2단 토글 스위치</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="682"/>
+        <location filename="../firmwares/boards.cpp" line="688"/>
         <source>2 Positions</source>
         <translation>2단 스위치</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="690"/>
         <source>3 Positions</source>
         <translation>3단 스위치</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="686"/>
+        <location filename="../firmwares/boards.cpp" line="692"/>
         <source>Function</source>
         <translation>기능</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="899"/>
+        <location filename="../firmwares/boards.cpp" line="909"/>
         <source>Standard</source>
         <translation>표준</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="901"/>
+        <location filename="../firmwares/boards.cpp" line="911"/>
         <source>Small</source>
         <translation>소형</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="903"/>
+        <location filename="../firmwares/boards.cpp" line="913"/>
         <source>Both</source>
         <translation>둘 다</translation>
     </message>
@@ -1637,34 +1637,50 @@ Error description: %4</source>
         <translation>이 펌웨어에 대한 시뮬레이터는 아직 사용할 수 없습니다</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="380"/>
+        <location filename="../helpers.cpp" line="388"/>
+        <source>Uknown error during Simulator startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Data Load Error</source>
+        <translation type="unfinished">데이터 불러오기 오류</translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Error occurred while starting simulator.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="405"/>
         <source>Error creating temporary directory for models and settings.</source>
         <translation>모델 및 설정을 위한 임시 디렉터리 생성에 실패했습니다.</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="388"/>
+        <location filename="../helpers.cpp" line="413"/>
         <source>Error writing models and settings to temporary directory.</source>
         <translation>모델 및 설정을 임시 디렉터리에 쓰는 중 오류가 발생했습니다.</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="419"/>
+        <location filename="../helpers.cpp" line="444"/>
         <source>Unable to start.</source>
         <translation>시작할 수 없습니다.</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="421"/>
+        <location filename="../helpers.cpp" line="446"/>
         <source>Crashed.</source>
         <translation>충돌이 발생했습니다.</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="423"/>
+        <location filename="../helpers.cpp" line="448"/>
         <source>Exited with result code:</source>
         <translation>다음 결과 코드로 종료됨:</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="381"/>
         <location filename="../helpers.cpp" line="389"/>
-        <location filename="../helpers.cpp" line="426"/>
+        <location filename="../helpers.cpp" line="406"/>
+        <location filename="../helpers.cpp" line="414"/>
+        <location filename="../helpers.cpp" line="451"/>
         <source>Simulator Error</source>
         <translation>시뮬레이터 오류</translation>
     </message>
@@ -3538,59 +3554,59 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="448"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="612"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="622"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="632"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="642"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="652"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="662"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="672"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="742"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="761"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="772"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="782"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="807"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="619"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="629"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="639"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="649"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="659"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="669"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="679"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="739"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="749"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="768"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="779"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="789"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="814"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation>HELI 메뉴 및 cyclic 믹스 지원 비활성화</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="449"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="613"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="623"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="633"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="643"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="653"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="663"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="673"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="733"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="743"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="752"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="762"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="773"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="783"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="680"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="769"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="815"/>
         <source>Disable Global variables</source>
         <translation>글로벌 변수 비활성화</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="450"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="474"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="614"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="624"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="634"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="644"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="654"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="664"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="674"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="734"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="744"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="753"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="763"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="784"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="809"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="621"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="631"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="641"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="651"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="661"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="671"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="741"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="751"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="760"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="781"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="791"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="816"/>
         <source>Enable Lua custom scripts screen</source>
         <translation>Lua 사용자 스크립트 화면 활성화</translation>
     </message>
@@ -3600,7 +3616,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>대체 SQT5 글꼴 사용</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
         <source>FrSky Taranis X9D+</source>
         <translation></translation>
     </message>
@@ -3615,104 +3631,104 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>AFHDS3 지원 활성화</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="590"/>
         <source>Disable RAS (SWR)</source>
         <translation>RAS(SWR) 비활성화</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="574"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="581"/>
         <source>FrSky Taranis X9D</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="576"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
         <source>Haptic module installed</source>
         <translation>햅틱 모듈이 설치되어 있음</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="595"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="602"/>
         <source>FrSky Taranis X9E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
         <source>Confirmation before radio shutdown</source>
         <translation>조종기 종료 전 확인 메시지 표시</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="597"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="604"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation>Horus 짐벌이 설치됨 (홀 센서 사용)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="562"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="569"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="537"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="544"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="563"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="549"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
         <source>FrSky Taranis X-Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="530"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="529"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="536"/>
         <source>FrSky Horus X12S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="539"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation>최초 DEV PCB 버전에서만 사용하십시오</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="677"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="675"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="703"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="682"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="710"/>
         <source>Support for MULTI internal module</source>
         <translation>MULTI 내장 모듈 지원</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="627"/>
         <source>Jumper T-Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="637"/>
         <source>Jumper T-Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="701"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="708"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation></translation>
     </message>
@@ -3722,26 +3738,26 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation>블루투스 모듈 지원</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="777"/>
         <source>Radiomaster TX12</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="787"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="805"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="812"/>
         <source>Radiomaster Zorro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="683"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="690"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="718"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="697"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="725"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="810"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="817"/>
         <source>Select if internal ELRS module is installed</source>
         <translation>내장 ELRS 모듈이 설치된 경우 선택</translation>
     </message>
@@ -3751,82 +3767,87 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <source>FlySky ST16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
         <source>HelloRadioSky V16</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="647"/>
         <source>Jumper T-Pro V2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="657"/>
         <source>Jumper T-Pro S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="667"/>
         <source>Jumper Bumblebee</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
         <source>Jumper T12 MAX</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
         <source>Jumper T14</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="702"/>
         <source>Jumper T15</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
         <source>Jumper T20</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
         <source>Jumper T20 V2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="737"/>
         <source>Radiomaster Boxer</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="747"/>
         <source>Radiomaster Pocket</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="757"/>
         <source>Radiomaster MT12</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="766"/>
         <source>Radiomaster T8</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="767"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
         <source>Allow bind using bind key</source>
         <translation>Bind 키를 사용하여 바인딩 허용</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
         <source>Radiomaster GX12</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="804"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation></translation>
     </message>
@@ -3837,12 +3858,12 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="484"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="801"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation>하드웨어 개조 지원: FlySky Paladin EV 짐벌</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="709"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
         <source>Jumper T18</source>
         <translation></translation>
     </message>
@@ -3857,7 +3878,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="617"/>
         <source>iFlight Commando8</source>
         <translation></translation>
     </message>
@@ -3882,18 +3903,18 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="568"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="543"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="550"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="518"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="525"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="538"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation>ACCESS 내장 모듈 교체 지원</translation>
     </message>
@@ -4662,7 +4683,6 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;의문이 있다면 프로젝트 페이지나 9x 포럼(http://9xforums.com/forum/)을 참고하세요.&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;혹시 잠금 문제가 발생했다면, &amp;quot;Fuse Bricks 복구 방법&amp;quot;을 구글에서 검색해보세요.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
 </translation>
-
     </message>
     <message>
         <location filename="../fusesdialog.ui" line="59"/>
@@ -4928,206 +4948,206 @@ These will be relevant for all models in the same EEPROM.</source>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="412"/>
+        <location filename="../firmwares/generalsettings.cpp" line="414"/>
         <source>Radio Settings</source>
         <translation>송신기 설정</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="414"/>
+        <location filename="../firmwares/generalsettings.cpp" line="416"/>
         <source>Hardware</source>
         <translation>하드웨어</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="415"/>
+        <location filename="../firmwares/generalsettings.cpp" line="417"/>
         <source>Internal Module</source>
         <translation>내장 모듈</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="430"/>
+        <location filename="../firmwares/generalsettings.cpp" line="432"/>
         <source>Axis &amp; Pots</source>
         <translation>축 &amp; 포트</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Axis</source>
         <translation>축</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Pot</source>
         <translation>포트</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="464"/>
+        <location filename="../firmwares/generalsettings.cpp" line="466"/>
         <source>Switches</source>
         <translation>스위치</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="469"/>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="471"/>
+        <location filename="../firmwares/generalsettings.cpp" line="483"/>
         <source>Flex Switch</source>
         <translation>플렉스 스위치</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Function Switch</source>
         <translation>기능 스위치</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Switch</source>
         <translation>스위치</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="499"/>
+        <location filename="../firmwares/generalsettings.cpp" line="501"/>
         <source>None</source>
         <translation>없음</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="553"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Internal</source>
         <translation>내장</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="555"/>
+        <location filename="../firmwares/generalsettings.cpp" line="557"/>
         <source>Ask</source>
         <translation>묻기</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="557"/>
+        <location filename="../firmwares/generalsettings.cpp" line="559"/>
         <source>Per model</source>
         <translation>모델별</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>Internal + External</source>
         <translation>내장 + 외부</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>External</source>
         <translation>외부</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="573"/>
-        <location filename="../firmwares/generalsettings.cpp" line="589"/>
+        <location filename="../firmwares/generalsettings.cpp" line="575"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>OFF</source>
         <translation>꺼짐</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Enabled</source>
         <translation>활성화됨</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Telemetry</source>
         <translation>텔레메트리</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="578"/>
+        <location filename="../firmwares/generalsettings.cpp" line="580"/>
         <source>Trainer</source>
         <translation>트레이너</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="591"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>Telemetry Mirror</source>
         <translation>텔레메트리 미러</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="593"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>Telemetry In</source>
         <translation>텔레메트리 입력</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="595"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>SBUS Trainer</source>
         <translation>SBUS 트레이너</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="597"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>LUA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="599"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>CLI</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="601"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>GPS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="603"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>Debug</source>
         <translation>디버그</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="605"/>
+        <location filename="../firmwares/generalsettings.cpp" line="607"/>
         <source>SpaceMouse</source>
         <translation>스페이스마우스</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="607"/>
+        <location filename="../firmwares/generalsettings.cpp" line="609"/>
         <source>External module</source>
         <translation>외부 모듈</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="640"/>
+        <location filename="../firmwares/generalsettings.cpp" line="642"/>
         <source>mA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="739"/>
+        <location filename="../firmwares/generalsettings.cpp" line="741"/>
         <source>Normal</source>
         <translation>일반</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="741"/>
+        <location filename="../firmwares/generalsettings.cpp" line="743"/>
         <source>OneBit</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="787"/>
+        <location filename="../firmwares/generalsettings.cpp" line="789"/>
         <source>Trims only</source>
         <translation>트림만</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="789"/>
+        <location filename="../firmwares/generalsettings.cpp" line="791"/>
         <source>Keys only</source>
         <translation>버튼만</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="791"/>
+        <location filename="../firmwares/generalsettings.cpp" line="793"/>
         <source>Switchable</source>
         <translation>전환 가능</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="793"/>
+        <location filename="../firmwares/generalsettings.cpp" line="795"/>
         <source>Global</source>
         <translation>글로벌</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="927"/>
+        <location filename="../firmwares/generalsettings.cpp" line="929"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation>모드 1 (RUD ELE THR AIL)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="931"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation>모드 2 (RUD THR ELE AIL)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="933"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation>모드 3 (AIL ELE THR RUD)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="935"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation>모드 4 (AIL THR ELE RUD)</translation>
     </message>
@@ -6044,32 +6064,32 @@ p, li { white-space: pre-wrap; }
         <translation>체코어</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="434"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Slovak</source>
         <translation>슬로바키아어</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="435"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Spanish</source>
         <translation>스페인어</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Polish</source>
         <translation>폴란드어</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="432"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Portuguese</source>
         <translation>포르투갈어</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="433"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Russian</source>
         <translation>러시아어</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="436"/>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Swedish</source>
         <translation>스웨덴어</translation>
     </message>
@@ -6079,7 +6099,7 @@ p, li { white-space: pre-wrap; }
         <translation>헝가리어</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal, Edit Inverted</source>
         <translation>일반, 편집 시 반전</translation>
     </message>
@@ -6114,42 +6134,47 @@ p, li { white-space: pre-wrap; }
         <translation>키 + 조작</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="437"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <source>Korean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="438"/>
         <source>Ukrainian</source>
         <translation>우크라이나어</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>No</source>
         <translation>없음</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>RotEnc A</source>
         <translation>로터리 인코더 A</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc B</source>
         <translation>로터리 인코더 B</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc C</source>
         <translation>로터리 인코더 C</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc D</source>
         <translation>로터리 인코더 D</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc E</source>
         <translation>로터리 인코더 E</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="617"/>
+        <location filename="../generaledit/generalsetup.cpp" line="618"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
@@ -6158,22 +6183,22 @@ Are you sure ?</source>
 계속하시겠습니까?</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal</source>
         <translation>일반</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Inverted</source>
         <translation>반전</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation>수직 반전, 수평 일반</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation>수직 반전, 수평 대체</translation>
     </message>
@@ -15492,13 +15517,6 @@ hh:mm:ss</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../simulation/telemetrysimu.ui" line="350"/>
-        <source>Row #
-Timestamp</source>
-        <translation>행 번호
-타임스탬프</translation>
-    </message>
-    <message>
         <location filename="../simulation/telemetrysimu.ui" line="369"/>
         <source>1/5x</source>
         <translation>1/5배속</translation>
@@ -15551,6 +15569,12 @@ Timestamp</source>
         <location filename="../simulation/telemetrysimu.ui" line="413"/>
         <source>Setting RSSI to zero simulates telemetry and radio link loss.</source>
         <translation>RSSI를 0으로 설정하면 텔레메트리 및 무선 링크 손실을 시뮬레이션합니다.</translation>
+    </message>
+    <message>
+        <location filename="../simulation/telemetrysimu.ui" line="350"/>
+        <source>Row # 
+Timestamp</source>
+        <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="416"/>
@@ -15761,22 +15785,22 @@ Timestamp</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="873"/>
+        <location filename="../firmwares/generalsettings.cpp" line="875"/>
         <source>OFF</source>
         <translation>꺼짐</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="875"/>
+        <location filename="../firmwares/generalsettings.cpp" line="877"/>
         <source>+= (Sum)</source>
         <translation>+= (합산)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="877"/>
+        <location filename="../firmwares/generalsettings.cpp" line="879"/>
         <source>:= (Replace)</source>
         <translation>:= (대체)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="886"/>
+        <location filename="../firmwares/generalsettings.cpp" line="888"/>
         <source>CH%1</source>
         <translation>채널 %1</translation>
     </message>
@@ -17486,7 +17510,7 @@ Do you wish to continue?</source>
 <context>
     <name>YamlModelSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1288"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1287"/>
         <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
 
 Model settings may be corrupted if you continue.</source>
@@ -17494,7 +17518,7 @@ Model settings may be corrupted if you continue.</source>
 계속 진행할 경우 모델 설정이 손상될 수 있습니다.</translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1291"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1290"/>
         <source>Read Model Settings</source>
         <translation>모델 설정 읽기</translation>
     </message>

--- a/companion/src/translations/companion_ko.ts
+++ b/companion/src/translations/companion_ko.ts
@@ -1,32 +1,32 @@
 <?xml version="1.0" encoding="utf-8"?>
 <!DOCTYPE TS>
-<TS version="2.1" language="ko">
+<TS version="2.1" language="ko_KR">
 <context>
     <name>AileronsPage</name>
     <message>
         <location filename="../wizarddialog.cpp" line="436"/>
         <source>No</source>
-        <translation>No</translation>
+        <translation>아니오</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="437"/>
         <source>Yes, controlled by a single channel</source>
-        <translation></translation>
+        <translation>예, 하나의 채널로 제어됩니다</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="438"/>
         <source>Yes, controlled by two channels</source>
-        <translation></translation>
+        <translation>예, 두 개의 채널로 제어됩니다</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="450"/>
         <source>&lt;br&gt;First Aileron Channel:</source>
-        <translation></translation>
+        <translation>&lt;br&gt;첫 번째 에일러론 채널:</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="452"/>
         <source>Second Aileron Channel:</source>
-        <translation></translation>
+        <translation>두 번째 에일러론 채널:</translation>
     </message>
 </context>
 <context>
@@ -34,27 +34,27 @@
     <message>
         <location filename="../wizarddialog.cpp" line="565"/>
         <source>No</source>
-        <translation>No</translation>
+        <translation>아니오</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="566"/>
         <source>Yes, controlled by a single channel</source>
-        <translation></translation>
+        <translation>예, 하나의 채널로 제어됩니다</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="567"/>
         <source>Yes, controlled by two channels</source>
-        <translation></translation>
+        <translation>예, 두 개의 채널로 제어됩니다</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="579"/>
         <source>&lt;br&gt;First Airbrake Channel:</source>
-        <translation></translation>
+        <translation>&lt;br&gt;첫 번째 에어브레이크 채널:</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="581"/>
         <source>Second Airbrake Channel:</source>
-        <translation></translation>
+        <translation>두 번째 에어브레이크 채널:</translation>
     </message>
 </context>
 <context>
@@ -63,112 +63,113 @@
         <location filename="../storage/appdata.cpp" line="859"/>
         <source>Application Settings have been saved to
  %1</source>
-        <translation></translation>
+        <translation>애플리케이션 설정이 다음 위치에 저장되었습니다:
+ %1</translation>
     </message>
     <message>
         <location filename="../storage/appdata.cpp" line="862"/>
         <source>Could not save Application Settings to file &quot;%1&quot;</source>
-        <translation></translation>
+        <translation>애플리케이션 설정을 파일 &quot;%1&quot;에 저장할 수 없습니다</translation>
     </message>
     <message>
         <location filename="../storage/appdata.cpp" line="864"/>
         <source>because the file could not be saved (check access permissions).</source>
-        <translation></translation>
+        <translation>파일을 저장할 수 없기 때문입니다 (접근 권한을 확인하세요).</translation>
     </message>
     <message>
         <location filename="../storage/appdata.cpp" line="866"/>
         <source>for unknown reasons.</source>
-        <translation></translation>
+        <translation>알 수 없는 이유로 인해 저장할 수 없습니다.</translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="665"/>
         <source>None</source>
-        <translation></translation>
+        <translation>없음</translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="665"/>
         <source>Wizard</source>
-        <translation></translation>
+        <translation>마법사</translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="665"/>
         <source>Editor</source>
-        <translation></translation>
+        <translation>편집기</translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="665"/>
         <source>Template</source>
-        <translation></translation>
+        <translation>템플릿</translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="665"/>
         <source>Prompt</source>
-        <translation></translation>
+        <translation>프롬프트</translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="666"/>
         <source>Manual</source>
-        <translation></translation>
+        <translation>수동</translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="666"/>
         <source>Startup</source>
-        <translation></translation>
+        <translation>시작 시</translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="666"/>
         <source>Daily</source>
-        <translation></translation>
+        <translation>매일</translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="666"/>
         <source>Weekly</source>
-        <translation></translation>
+        <translation>매주</translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="666"/>
         <source>Monthly</source>
-        <translation></translation>
+        <translation>매월</translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="668"/>
         <source>Debug</source>
-        <translation></translation>
+        <translation>디버그</translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="668"/>
         <source>Warning</source>
-        <translation></translation>
+        <translation>경고</translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="668"/>
         <source>Critical</source>
-        <translation></translation>
+        <translation>치명적</translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="668"/>
         <source>Fatal</source>
-        <translation></translation>
+        <translation>심각한 오류</translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="668"/>
         <source>Information</source>
-        <translation></translation>
+        <translation>정보</translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="669"/>
         <source>Default</source>
-        <translation type="unfinished"></translation>
+        <translation>기본값</translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="669"/>
         <source>Left</source>
-        <translation type="unfinished"></translation>
+        <translation>왼쪽</translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="669"/>
         <source>Right</source>
-        <translation type="unfinished"></translation>
+        <translation>오른쪽</translation>
     </message>
 </context>
 <context>
@@ -176,74 +177,74 @@
     <message>
         <location filename="../apppreferencesdialog.ui" line="20"/>
         <source>Edit Settings</source>
-        <translation></translation>
+        <translation>설정 편집</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="52"/>
         <source>Radio Profile</source>
-        <translation></translation>
+        <translation>조종기 프로파일</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="514"/>
         <source>Profile Name</source>
-        <translation></translation>
+        <translation>프로파일 이름</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="686"/>
         <source>Radio Type</source>
-        <translation></translation>
+        <translation>조종기 유형</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="253"/>
         <source>Splash Screen</source>
-        <translation></translation>
+        <translation>시작 화면</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="533"/>
         <source>Other Settings</source>
-        <translation></translation>
+        <translation>기타 설정</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="64"/>
         <source>SD Structure path</source>
-        <translation></translation>
+        <translation>SD 구조 경로</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="450"/>
         <location filename="../apppreferencesdialog.ui" line="621"/>
         <source>The profile specific folder,  if set, will override general Backup folder</source>
-        <translation></translation>
+        <translation>프로파일별 폴더가 설정되면 일반 백업 폴더를 덮어씁니다</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="624"/>
         <source>Backup folder</source>
-        <translation></translation>
+        <translation>백업 폴더</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="463"/>
         <source>If set it will override the application general setting</source>
-        <translation></translation>
+        <translation>설정 시 애플리케이션의 일반 설정을 덮어씁니다</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="440"/>
         <source>if set, will override general backup enable</source>
-        <translation></translation>
+        <translation>설정 시 일반 백업 사용 여부를 덮어씁니다</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="443"/>
         <location filename="../apppreferencesdialog.ui" line="1036"/>
         <source>Enable automatic backup before writing firmware</source>
-        <translation></translation>
+        <translation>펌웨어를 쓰기 전에 자동 백업 활성화</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="479"/>
         <source>General Settings</source>
-        <translation></translation>
+        <translation>일반 설정</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="591"/>
         <source>Default Stick Mode</source>
-        <translation></translation>
+        <translation>기본 스틱 모드</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="379"/>
@@ -266,317 +267,334 @@ Mode 4:
   Right stick:  Elevator, Rudder
 
 </source>
-        <translation></translation>
+        <translation>모드 선택:
+
+모드 1:
+    왼쪽 스틱: 엘리베이터, 러더
+    오른쪽 스틱: 스로틀, 에일러론
+
+모드 2:
+    왼쪽 스틱: 스로틀, 러더
+    오른쪽 스틱: 엘리베이터, 에일러론
+
+모드 3:
+    왼쪽 스틱: 엘리베이터, 에일러론
+    오른쪽 스틱: 스로틀, 러더
+
+모드 4:
+    왼쪽 스틱: 스로틀, 에일러론
+    오른쪽 스틱: 엘리베이터, 러더
+</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="404"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
-        <translation></translation>
+        <translation>모드 1 (러더, 엘리베이터, 스로틀, 에일러론)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="409"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
-        <translation></translation>
+        <translation>모드 2 (러더, 스로틀, 엘리베이터, 에일러론)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="414"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
-        <translation></translation>
+        <translation>모드 3 (에일러론, 엘리베이터, 스로틀, 러더)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="419"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
-        <translation></translation>
+        <translation>모드 4 (에일러론, 스로틀, 엘리베이터, 러더)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="492"/>
         <source>Default Channel Order</source>
-        <translation></translation>
+        <translation>기본 채널 순서</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="93"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;채널 순서&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;새 모델을 생성할 때 기본 믹스가 생성되는 순서를 정의합니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="549"/>
         <source>Language</source>
-        <translation></translation>
+        <translation>언어</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="80"/>
         <source>Prompt to write firmware to radio after update</source>
-        <translation></translation>
+        <translation>업데이트 후 조종기에 펌웨어를 쓸지 확인</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="100"/>
         <source>R E T A</source>
-        <translation></translation>
+        <translation>R E T A (러더, 엘리베이터, 스로틀, 에일러론)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="105"/>
         <source>R E A T</source>
-        <translation></translation>
+        <translation>R E A T (러더, 엘리베이터, 에일러론, 스로틀)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="110"/>
         <source>R T E A</source>
-        <translation></translation>
+        <translation>R T E A (러더, 스로틀, 엘리베이터, 에일러론)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="115"/>
         <source>R T A E</source>
-        <translation></translation>
+        <translation>R T A E (러더, 스로틀, 에일러론, 엘리베이터)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="120"/>
         <source>R A E T</source>
-        <translation></translation>
+        <translation>R A E T (러더, 에일러론, 엘리베이터, 스로틀)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="125"/>
         <source>R A T E</source>
-        <translation></translation>
+        <translation>R A T E (러더, 에일러론, 스로틀, 엘리베이터)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="130"/>
         <source>E R T A</source>
-        <translation></translation>
+        <translation>E R T A (엘리베이터, 러더, 스로틀, 에일러론)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="135"/>
         <source>E R A T</source>
-        <translation></translation>
+        <translation>E R A T (엘리베이터, 러더, 에일러론, 스로틀)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="140"/>
         <source>E T R A</source>
-        <translation></translation>
+        <translation>E T R A (엘리베이터, 스로틀, 러더, 에일러론)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="145"/>
         <source>E T A R</source>
-        <translation></translation>
+        <translation>E T A R (엘리베이터, 스로틀, 에일러론, 러더)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="150"/>
         <source>E A R T</source>
-        <translation></translation>
+        <translation>E A R T (엘리베이터, 에일러론, 러더, 스로틀)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="155"/>
         <source>E A T R</source>
-        <translation></translation>
+        <translation>E A T R (엘리베이터, 에일러론, 스로틀, 러더)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="160"/>
         <source>T R E A</source>
-        <translation></translation>
+        <translation>T R E A (스로틀, 러더, 엘리베이터, 에일러론)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="165"/>
         <source>T R A E</source>
-        <translation></translation>
+        <translation>T R A E (스로틀, 러더, 에일러론, 엘리베이터)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="170"/>
         <source>T E R A</source>
-        <translation></translation>
+        <translation>T E R A (스로틀, 엘리베이터, 러더, 에일러론)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="175"/>
         <source>T E A R</source>
-        <translation></translation>
+        <translation>T E A R (스로틀, 엘리베이터, 에일러론, 러더)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="180"/>
         <source>T A R E</source>
-        <translation></translation>
+        <translation>T A R E (스로틀, 에일러론, 러더, 엘리베이터)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="185"/>
         <source>T A E R</source>
-        <translation></translation>
+        <translation>T A E R (스로틀, 에일러론, 엘리베이터, 러더)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="190"/>
         <source>A R E T</source>
-        <translation></translation>
+        <translation>A R E T (에일러론, 러더, 엘리베이터, 스로틀)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="195"/>
         <source>A R T E</source>
-        <translation></translation>
+        <translation>A R T E (에일러론, 러더, 스로틀, 엘리베이터)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="200"/>
         <source>A E R T</source>
-        <translation></translation>
+        <translation>A E R T (에일러론, 엘리베이터, 러더, 스로틀)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="205"/>
         <source>A E T R</source>
-        <translation></translation>
+        <translation>A E T R (에일러론, 엘리베이터, 스로틀, 러더)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="210"/>
         <source>A T R E</source>
-        <translation></translation>
+        <translation>A T R E (에일러론, 스로틀, 러더, 엘리베이터)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="215"/>
         <source>A T E R</source>
-        <translation></translation>
+        <translation>A T E R (에일러론, 스로틀, 엘리베이터, 러더)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="608"/>
         <source>External Module</source>
-        <translation></translation>
+        <translation>외부 모듈</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="729"/>
         <source>Simulator Case Colour</source>
-        <translation type="unfinished"></translation>
+        <translation>시뮬레이터 외형 색상</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="746"/>
         <source>Select Colour</source>
-        <translation type="unfinished"></translation>
+        <translation>색상 선택</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1122"/>
         <source>Remove empty model slots when deleting models (only applies for radios w/out labels)</source>
-        <translation></translation>
+        <translation>모델 삭제 시 빈 모델 슬롯 제거 (라벨 없는 송신기에만 적용됨)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1150"/>
         <source>Radio Profiles</source>
-        <translation></translation>
+        <translation>송신기 프로파일</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1157"/>
         <source>Move selected Radio Profile to the top of the list</source>
-        <translation></translation>
+        <translation>선택한 송신기 프로파일을 목록 맨 위로 이동</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1196"/>
         <source>Display Scroll Buttons</source>
-        <translation type="unfinished"></translation>
+        <translation>스크롤 버튼 표시</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1326"/>
         <source>BackLight Color</source>
-        <translation type="unfinished"></translation>
+        <translation>백라이트 색상</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1378"/>
         <source>Enable for mouse without scroll wheel</source>
-        <translation type="unfinished"></translation>
+        <translation>스크롤휠 없는 마우스를 위한 활성화</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1416"/>
         <source>Position of Keys</source>
-        <translation type="unfinished"></translation>
+        <translation>키 위치</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1423"/>
         <source>Simulator controls</source>
-        <translation></translation>
+        <translation>시뮬레이터 조작</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1306"/>
         <source>Save switch/pot positions on simulator exit</source>
-        <translation></translation>
+        <translation>시뮬레이터 종료 시 스위치/포트 위치 저장</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1313"/>
         <source>Clear saved positions</source>
-        <translation></translation>
+        <translation>저장된 위치 초기화</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1280"/>
         <source>Disable &apos;Cannot open joystick, joystick disabled&apos; warning</source>
-        <translation></translation>
+        <translation>&apos;조이스틱 열기 실패&apos; 경고 표시 안 함</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1467"/>
         <source>Update Settings</source>
-        <translation></translation>
+        <translation>업데이트 설정</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1475"/>
         <source>Check frequency</source>
-        <translation></translation>
+        <translation>업데이트 확인 주기</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1498"/>
         <source>Reset to Defaults</source>
-        <translation></translation>
+        <translation>기본값으로 초기화</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1507"/>
         <source>Folders</source>
-        <translation></translation>
+        <translation>폴더</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1513"/>
         <source>Download</source>
-        <translation></translation>
+        <translation>다운로드</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1530"/>
         <source>Create sub-folders in Download folder</source>
-        <translation></translation>
+        <translation>다운로드 폴더 내에 하위 폴더 생성</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1547"/>
         <source>Decompress</source>
-        <translation></translation>
+        <translation>압축 해제</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1554"/>
         <source>Use Radio Profile SD Structure</source>
-        <translation></translation>
+        <translation>송신기 프로파일의 SD 구조 사용</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1601"/>
         <source>Components</source>
-        <translation></translation>
+        <translation>구성 요소</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1614"/>
         <source>Delete downloads</source>
-        <translation></translation>
+        <translation>다운로드 항목 삭제</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1621"/>
         <source>Delete decompressions</source>
-        <translation></translation>
+        <translation>압축 해제 항목 삭제</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1641"/>
         <source>Logging</source>
-        <translation></translation>
+        <translation>로그 기록</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1010"/>
         <source>Action on New Model</source>
-        <translation></translation>
+        <translation>새 모델 생성 시 동작</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1342"/>
         <source>Screenshot capture folder</source>
-        <translation></translation>
+        <translation>스크린샷 저장 폴더</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="314"/>
         <source>Clear Image</source>
-        <translation></translation>
+        <translation>이미지 지우기</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="270"/>
         <source>Select Image</source>
-        <translation></translation>
+        <translation>이미지 선택</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="453"/>
@@ -589,317 +607,317 @@ Mode 4:
         <location filename="../apppreferencesdialog.ui" line="1584"/>
         <location filename="../apppreferencesdialog.ui" line="1591"/>
         <source>Select Folder</source>
-        <translation></translation>
+        <translation>폴더 선택</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="754"/>
         <source>Application Settings</source>
-        <translation></translation>
+        <translation>애플리케이션 설정</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1077"/>
         <source>most recently used files</source>
-        <translation></translation>
+        <translation>최근 사용한 파일</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1105"/>
         <source>Startup Settings</source>
-        <translation></translation>
+        <translation>시작 설정</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="771"/>
         <source>Remember</source>
-        <translation></translation>
+        <translation>기억하기</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="940"/>
         <source>Output Logs Folder</source>
-        <translation></translation>
+        <translation>출력 로그 폴더</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1119"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This option  maintains the behaviour from older OpenTx versions where empty model slots are preserved when a model is deleted or moved. &lt;/p&gt;&lt;p&gt;When this option is de-selected, the other models may be re-arranged to fill the gap left by the removed  model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;이 옵션은 모델을 삭제하거나 이동할 때 빈 모델 슬롯을 유지하던 이전 OpenTX 버전의 동작을 유지합니다.&lt;/p&gt;&lt;p&gt;이 옵션을 선택 해제하면, 삭제된 모델의 자리를 채우기 위해 다른 모델들이 자동으로 재배열됩니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="859"/>
         <source>Debug Output Logging</source>
-        <translation></translation>
+        <translation>디버그 출력 로그</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="821"/>
         <source>Application (Companion/Simulator)</source>
-        <translation></translation>
+        <translation>애플리케이션 (Companion/시뮬레이터)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="828"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all messages generated by the radio firmware when running in Simulator. This is the same information one would also see in the Simulator &lt;span style=&quot; font-style:italic;&quot;&gt;Debug Output&lt;/span&gt; window.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;시뮬레이터에서 실행 중일 때 조종기 펌웨어가 생성하는 모든 메시지를 기록합니다. 이 정보는 시뮬레이터의 &lt;span style=&quot; font-style:italic;&quot;&gt;디버그 출력&lt;/span&gt; 창에서 볼 수 있는 내용과 동일합니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="831"/>
         <source>Radio Firmware (in Simulator)</source>
-        <translation></translation>
+        <translation>송신기 펌웨어 (시뮬레이터 내)</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1092"/>
         <source>Splash Screen Library</source>
-        <translation></translation>
+        <translation>스플래시 화면 라이브러리</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="846"/>
         <source>Google Earth Executable</source>
-        <translation></translation>
+        <translation>Google Earth 실행 파일</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1023"/>
         <source>User Splash Screens</source>
-        <translation></translation>
+        <translation>사용자 스플래시 화면</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="875"/>
         <source>Automatic Backup Folder</source>
-        <translation></translation>
+        <translation>자동 백업 폴더</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="964"/>
         <source>Only show user splash images</source>
-        <translation></translation>
+        <translation>사용자 스플래시 이미지만 표시</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="969"/>
         <source>Show user and companion splash images</source>
-        <translation></translation>
+        <translation>사용자 및 Companion 스플래시 이미지 표시</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="807"/>
         <source>Select Executable</source>
-        <translation></translation>
+        <translation>실행 파일 선택</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="475"/>
         <source>Release channel</source>
-        <translation></translation>
+        <translation>릴리즈 채널</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1187"/>
         <source>Simulator Settings</source>
-        <translation></translation>
+        <translation>시뮬레이터 설정</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1238"/>
         <source>Calibrate</source>
-        <translation></translation>
+        <translation>보정</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1252"/>
         <source>Blue</source>
-        <translation></translation>
+        <translation>파란색</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="575"/>
         <location filename="../apppreferencesdialog.ui" line="1608"/>
         <location filename="../apppreferencesdialog.cpp" line="503"/>
         <source>Options</source>
-        <translation></translation>
+        <translation>옵션</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="427"/>
         <source>Default Int. Module</source>
-        <translation></translation>
+        <translation>기본 내부 모듈</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="337"/>
         <source>Prompt to run SD Sync after update</source>
-        <translation></translation>
+        <translation>업데이트 후 SD 동기화를 실행할지 묻기</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="818"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Keep a log of all debugging messages generated by the desktop Companion/Simulator applications. An EdgeTX developer may request this to help diagnose an issue.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;데스크톱 Companion/시뮬레이터 애플리케이션에서 생성된 모든 디버깅 메시지를 기록합니다. EdgeTX 개발자가 문제 진단을 위해 이 로그를 요청할 수 있습니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="947"/>
         <source>Show splash screen</source>
-        <translation></translation>
+        <translation>스플래시 화면 표시</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1043"/>
         <source>Prompt for radio profile</source>
-        <translation></translation>
+        <translation>송신기 프로파일 선택 요청</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="785"/>
         <source>Prompt to run installer after update</source>
-        <translation></translation>
+        <translation>업데이트 후 설치 프로그램 실행 여부 묻기</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="778"/>
         <location filename="../apppreferencesdialog.ui" line="1523"/>
         <source>Update</source>
-        <translation></translation>
+        <translation>업데이트</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1257"/>
         <source>Green</source>
-        <translation></translation>
+        <translation>초록색</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1262"/>
         <source>Red</source>
-        <translation></translation>
+        <translation>빨간색</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1267"/>
         <source>Orange</source>
-        <translation></translation>
+        <translation>주황색</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1272"/>
         <source>Yellow</source>
-        <translation></translation>
+        <translation>노란색</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1293"/>
         <source>Only capture to clipboard</source>
-        <translation></translation>
+        <translation>클립보드에만 캡처</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1358"/>
         <source>Enable</source>
-        <translation></translation>
+        <translation>활성화</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1459"/>
         <source>Joystick</source>
-        <translation></translation>
+        <translation>조이스틱</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="1371"/>
         <source>Simulator Volume Gain</source>
-        <translation></translation>
+        <translation>시뮬레이터 볼륨 증폭</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="183"/>
         <source>My Radio</source>
-        <translation></translation>
+        <translation>내 조종기</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="193"/>
         <source>&lt;p&gt;&lt;b&gt;You cannot switch Radio Type or change Build Options while there are unsaved file changes. What do you wish to do?&lt;/b&gt;&lt;/p&gt; &lt;ul&gt;&lt;li&gt;&lt;i&gt;Save All&lt;/i&gt; - Save any open file(s) before saving Settings.&lt;li&gt;&lt;li&gt;&lt;i&gt;Reset&lt;/i&gt; - Revert to the previous Radio Type and Build Options before saving Settings.&lt;/li&gt;&lt;li&gt;&lt;i&gt;Cancel&lt;/i&gt; - Return to the Settings editor dialog.&lt;/li&gt;&lt;/ul&gt;</source>
-        <translation></translation>
+        <translation>&lt;p&gt;&lt;b&gt;저장되지 않은 파일 변경 사항이 있으므로 송신기 유형 변경이나 빌드 옵션 수정을 할 수 없습니다. 어떻게 하시겠습니까?&lt;/b&gt;&lt;/p&gt;&lt;ul&gt;&lt;li&gt;&lt;i&gt;모두 저장&lt;/i&gt; - 설정을 저장하기 전에 열린 파일을 모두 저장합니다.&lt;/li&gt;&lt;li&gt;&lt;i&gt;초기화&lt;/i&gt; - 설정 저장 전에 이전 라디오 유형 및 빌드 옵션으로 되돌립니다.&lt;/li&gt;&lt;li&gt;&lt;i&gt;취소&lt;/i&gt; - 설정 편집 화면으로 돌아갑니다.&lt;/li&gt;&lt;/ul&gt;</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="227"/>
         <source>Select your snapshot folder</source>
-        <translation></translation>
+        <translation>스냅샷 저장 폴더 선택</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="126"/>
         <source>Update Settings: Download folder path missing!</source>
-        <translation></translation>
+        <translation>업데이트 설정: 다운로드 폴더 경로가 없습니다!</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="131"/>
         <source>Update Settings: Decompress folder path missing!</source>
-        <translation></translation>
+        <translation>업데이트 설정: 압축 해제 폴더 경로가 없습니다!</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="136"/>
         <source>Update Settings: Update folder path missing!</source>
-        <translation></translation>
+        <translation>업데이트 설정: 업데이트 폴더 경로가 없습니다!</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="142"/>
         <source>Update Settings: Decompress and download folders have the same path!</source>
-        <translation></translation>
+        <translation>업데이트 설정: 압축 해제 폴더와 다운로드 폴더 경로가 동일합니다!</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="303"/>
         <location filename="../apppreferencesdialog.cpp" line="633"/>
         <source>No joysticks found</source>
-        <translation></translation>
+        <translation>조이스틱을 찾을 수 없습니다</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="361"/>
         <source>EMPTY: No radio settings stored in profile</source>
-        <translation></translation>
+        <translation>비어 있음: 프로파일에 저장된 송신기 설정이 없습니다</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="366"/>
         <source>AVAILABLE: Radio settings of unknown age</source>
-        <translation></translation>
+        <translation>사용 가능: 시점을 알 수 없는 송신기 설정</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="368"/>
         <source>AVAILABLE: Radio settings stored %1</source>
-        <translation></translation>
+        <translation>사용 가능: 송신기 설정 저장 시점 %1</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="389"/>
         <source>Reset all update settings to defaults. Are you sure?</source>
-        <translation></translation>
+        <translation>모든 업데이트 설정을 기본값으로 초기화합니다. 계속하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="393"/>
         <source>Update settings have been reset. Please close and restart Companion to avoid unexpected behaviour!</source>
-        <translation></translation>
+        <translation>업데이트 설정이 초기화되었습니다. 예기치 않은 동작을 방지하려면 Companion을 종료 후 다시 실행해 주세요!</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="433"/>
         <source>Select your download folder</source>
-        <translation></translation>
+        <translation>다운로드 폴더 선택</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="440"/>
         <source>Select your decompress folder</source>
-        <translation></translation>
+        <translation>압축 해제 폴더 선택</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="447"/>
         <source>Select your update destination folder</source>
-        <translation></translation>
+        <translation>업데이트 대상 폴더 선택</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="472"/>
         <source>Check</source>
-        <translation></translation>
+        <translation>확인</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="564"/>
         <source>Select your library folder</source>
-        <translation></translation>
+        <translation>라이브러리 폴더 선택</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="588"/>
         <location filename="../apppreferencesdialog.cpp" line="598"/>
         <source>Select your Models and Settings backup folder</source>
-        <translation></translation>
+        <translation>모델 및 설정 백업 폴더 선택</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="608"/>
         <source>Select a folder for application logs</source>
-        <translation></translation>
+        <translation>애플리케이션 로그 저장 폴더 선택</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="616"/>
         <source>Select Google Earth executable</source>
-        <translation></translation>
+        <translation>Google Earth 실행 파일 선택</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="667"/>
         <source>Select the folder replicating your SD structure</source>
-        <translation></translation>
+        <translation>SD 카드 구조를 복제할 폴더 선택</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="699"/>
         <source>Open Image to load</source>
-        <translation></translation>
+        <translation>불러올 이미지 열기</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="699"/>
         <source>Images (%1)</source>
-        <translation></translation>
+        <translation>이미지 (%1)</translation>
     </message>
 </context>
 <context>
@@ -907,29 +925,31 @@ Mode 4:
     <message>
         <location filename="../storage/bineeprom.cpp" line="43"/>
         <source>Error reading %1: %2</source>
-        <translation></translation>
+        <translation>%1 읽기 오류: %2</translation>
     </message>
     <message>
         <location filename="../storage/bineeprom.cpp" line="66"/>
         <source>Cannot save EEPROM</source>
-        <translation></translation>
+        <translation>EEPROM을 저장할 수 없습니다</translation>
     </message>
     <message>
         <location filename="../storage/bineeprom.cpp" line="77"/>
         <source>Cannot open file %1:
 %2.</source>
-        <translation></translation>
+        <translation>파일 %1을(를) 열 수 없습니다:
+%2.</translation>
     </message>
     <message>
         <location filename="../storage/bineeprom.cpp" line="84"/>
         <source>Error writing file %1:
 %2.</source>
-        <translation></translation>
+        <translation>파일 %1 쓰기 오류:
+%2.</translation>
     </message>
     <message>
         <location filename="../storage/bineeprom.cpp" line="109"/>
         <source>Invalid binary EEPROM file %1</source>
-        <translation></translation>
+        <translation>잘못된 바이너리 EEPROM 파일: %1</translation>
     </message>
 </context>
 <context>
@@ -937,32 +957,32 @@ Mode 4:
     <message>
         <location filename="../firmwares/boardjson.cpp" line="58"/>
         <source>Rud</source>
-        <translation></translation>
+        <translation>러더</translation>
     </message>
     <message>
         <location filename="../firmwares/boardjson.cpp" line="59"/>
         <source>Ele</source>
-        <translation></translation>
+        <translation>엘리베이터</translation>
     </message>
     <message>
         <location filename="../firmwares/boardjson.cpp" line="60"/>
         <source>Thr</source>
-        <translation></translation>
+        <translation>스로틀</translation>
     </message>
     <message>
         <location filename="../firmwares/boardjson.cpp" line="61"/>
         <source>Ail</source>
-        <translation></translation>
+        <translation>에일러론</translation>
     </message>
     <message>
         <location filename="../firmwares/boardjson.cpp" line="62"/>
         <source>ST</source>
-        <translation></translation>
+        <translation>ST(조향)</translation>
     </message>
     <message>
         <location filename="../firmwares/boardjson.cpp" line="63"/>
         <source>TH</source>
-        <translation></translation>
+        <translation>TH(스로틀)</translation>
     </message>
     <message>
         <location filename="../firmwares/boardjson.cpp" line="876"/>
@@ -970,25 +990,28 @@ Mode 4:
         <location filename="../firmwares/boardjson.cpp" line="891"/>
         <location filename="../firmwares/boardjson.cpp" line="901"/>
         <source>Load Board Hardware Definition</source>
-        <translation></translation>
+        <translation>보드 하드웨어 정의 불러오기</translation>
     </message>
     <message>
         <location filename="../firmwares/boardjson.cpp" line="877"/>
         <source>Board: %1
 Error: Unable to load file %2</source>
-        <translation></translation>
+        <translation>보드: %1
+오류: 파일 %2을(를) 불러올 수 없습니다</translation>
     </message>
     <message>
         <location filename="../firmwares/boardjson.cpp" line="883"/>
         <source>Board: %1
 Error: Unable to open file %2</source>
-        <translation></translation>
+        <translation>보드: %1
+오류: 파일 %2을(를) 열 수 없습니다</translation>
     </message>
     <message>
         <location filename="../firmwares/boardjson.cpp" line="892"/>
         <source>Board: %1
 Error: Unable to read file %2</source>
-        <translation></translation>
+        <translation>보드: %1
+오류: 파일 %2을(를) 읽을 수 없습니다</translation>
     </message>
     <message>
         <location filename="../firmwares/boardjson.cpp" line="902"/>
@@ -996,7 +1019,10 @@ Error: Unable to read file %2</source>
 Error: %2 is not a valid json formatted file.
 Error code: %3
 Error description: %4</source>
-        <translation></translation>
+        <translation>보드: %1
+오류: %2은(는) 올바른 JSON 형식의 파일이 아닙니다.
+오류 코드: %3
+오류 설명: %4</translation>
     </message>
 </context>
 <context>
@@ -1004,64 +1030,64 @@ Error description: %4</source>
     <message>
         <location filename="../firmwares/boards.cpp" line="422"/>
         <source>Left Horizontal</source>
-        <translation></translation>
+        <translation>왼쪽 수평</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="423"/>
         <source>Left Vertical</source>
-        <translation></translation>
+        <translation>왼쪽 수직</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="424"/>
         <source>Right Vertical</source>
-        <translation></translation>
+        <translation>오른쪽 수직</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="425"/>
         <source>Right Horizontal</source>
-        <translation></translation>
+        <translation>오른쪽 수평</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="426"/>
         <source>Aux. 1</source>
-        <translation></translation>
+        <translation>Aux. 1(보조1)</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="427"/>
         <source>Aux. 2</source>
-        <translation></translation>
+        <translation>Aux. 2(보조2)</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="443"/>
         <source>LH</source>
-        <translation></translation>
+        <translation>LH(왼쪽 수평)</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="444"/>
         <source>LV</source>
-        <translation></translation>
+        <translation>LV(왼쪽 수직)</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="445"/>
         <source>RV</source>
-        <translation></translation>
+        <translation>RV(오른쪽 수직)</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="446"/>
         <source>RH</source>
-        <translation></translation>
+        <translation>RH(오른쪽 수평)</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="455"/>
         <location filename="../firmwares/boards.cpp" line="457"/>
         <source>TILT_X</source>
-        <translation></translation>
+        <translation>TILT_X(기울기X축)</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="456"/>
         <location filename="../firmwares/boards.cpp" line="458"/>
         <source>TILT_Y</source>
-        <translation></translation>
+        <translation>TILT_Y(기울기Y축)</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="463"/>
@@ -1073,13 +1099,13 @@ Error description: %4</source>
         <location filename="../firmwares/boards.cpp" line="544"/>
         <location filename="../firmwares/boards.cpp" line="551"/>
         <source>SL1</source>
-        <translation></translation>
+        <translation>SL1(슬라이더1)</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="471"/>
         <location filename="../firmwares/boards.cpp" line="510"/>
         <source>P4</source>
-        <translation></translation>
+        <translation>P4(포트4)</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="473"/>
@@ -1090,59 +1116,59 @@ Error description: %4</source>
         <location filename="../firmwares/boards.cpp" line="545"/>
         <location filename="../firmwares/boards.cpp" line="552"/>
         <source>SL2</source>
-        <translation></translation>
+        <translation>SL2(슬라이더2)</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="474"/>
         <location filename="../firmwares/boards.cpp" line="553"/>
         <source>SL3</source>
-        <translation></translation>
+        <translation>SL3(슬라이더3)</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="475"/>
         <location filename="../firmwares/boards.cpp" line="554"/>
         <source>SL4</source>
-        <translation></translation>
+        <translation>SL4(슬라이더4)</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="511"/>
         <source>P5</source>
-        <translation></translation>
+        <translation>P5(포트5)</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="933"/>
         <source>Slider</source>
-        <translation></translation>
+        <translation>슬라이더</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="935"/>
         <source>Multipos Switch</source>
-        <translation></translation>
+        <translation>다단 스위치</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="937"/>
         <source>Axis X</source>
-        <translation></translation>
+        <translation>X축</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="939"/>
         <source>Axis Y</source>
-        <translation></translation>
+        <translation>Y축</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="941"/>
         <source>Switch</source>
-        <translation></translation>
+        <translation>스위치</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="1137"/>
         <source>Flight</source>
-        <translation type="unfinished"></translation>
+        <translation>비행</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="1137"/>
         <source>Drive</source>
-        <translation type="unfinished"></translation>
+        <translation>주행</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="464"/>
@@ -1158,7 +1184,7 @@ Error description: %4</source>
         <location filename="../firmwares/boards.cpp" line="537"/>
         <location filename="../firmwares/boards.cpp" line="549"/>
         <source>P1</source>
-        <translation></translation>
+        <translation>P1(포트1)</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="469"/>
@@ -1172,7 +1198,7 @@ Error description: %4</source>
         <location filename="../firmwares/boards.cpp" line="538"/>
         <location filename="../firmwares/boards.cpp" line="550"/>
         <source>P2</source>
-        <translation></translation>
+        <translation>P2(포트2)</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="470"/>
@@ -1183,95 +1209,95 @@ Error description: %4</source>
         <location filename="../firmwares/boards.cpp" line="527"/>
         <location filename="../firmwares/boards.cpp" line="539"/>
         <source>P3</source>
-        <translation></translation>
+        <translation>P3(포트3)</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="451"/>
         <location filename="../firmwares/boards.cpp" line="453"/>
         <source>JSx</source>
-        <translation></translation>
+        <translation>조이스틱 X</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="452"/>
         <location filename="../firmwares/boards.cpp" line="454"/>
         <source>JSy</source>
-        <translation></translation>
+        <translation>조이스틱 Y</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="530"/>
         <location filename="../firmwares/boards.cpp" line="540"/>
         <source>EXT1</source>
-        <translation></translation>
+        <translation>확장1</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="531"/>
         <location filename="../firmwares/boards.cpp" line="541"/>
         <source>EXT2</source>
-        <translation></translation>
+        <translation>확장2</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="532"/>
         <location filename="../firmwares/boards.cpp" line="542"/>
         <source>EXT3</source>
-        <translation></translation>
+        <translation>확장3</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="533"/>
         <location filename="../firmwares/boards.cpp" line="543"/>
         <source>EXT4</source>
-        <translation></translation>
+        <translation>확장4</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="678"/>
         <location filename="../firmwares/boards.cpp" line="897"/>
         <location filename="../firmwares/boards.cpp" line="927"/>
         <source>None</source>
-        <translation></translation>
+        <translation>없음</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="929"/>
         <source>Pot</source>
-        <translation></translation>
+        <translation>가변 저항</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="931"/>
         <source>Pot with detent</source>
-        <translation></translation>
+        <translation>중간 고정점 있는 가변 저항</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="680"/>
         <source>2 Positions Toggle</source>
-        <translation></translation>
+        <translation>2단 토글 스위치</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="682"/>
         <source>2 Positions</source>
-        <translation></translation>
+        <translation>2단 스위치</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="684"/>
         <source>3 Positions</source>
-        <translation></translation>
+        <translation>3단 스위치</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="686"/>
         <source>Function</source>
-        <translation></translation>
+        <translation>기능</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="899"/>
         <source>Standard</source>
-        <translation></translation>
+        <translation>표준</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="901"/>
         <source>Small</source>
-        <translation></translation>
+        <translation>소형</translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="903"/>
         <source>Both</source>
-        <translation></translation>
+        <translation>둘 다</translation>
     </message>
 </context>
 <context>
@@ -1279,17 +1305,17 @@ Error description: %4</source>
     <message>
         <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Negative span</source>
-        <translation></translation>
+        <translation>음수 범위</translation>
     </message>
     <message>
         <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Mid value</source>
-        <translation></translation>
+        <translation>중간값</translation>
     </message>
     <message>
         <location filename="../generaledit/calibration.cpp" line="33"/>
         <source>Positive span</source>
-        <translation></translation>
+        <translation>양수 범위</translation>
     </message>
 </context>
 <context>
@@ -1297,57 +1323,57 @@ Error description: %4</source>
     <message>
         <location filename="../modeledit/channels.cpp" line="114"/>
         <source>Name</source>
-        <translation></translation>
+        <translation>이름</translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Subtrim</source>
-        <translation></translation>
+        <translation>서브트림</translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Min</source>
-        <translation></translation>
+        <translation>최소값</translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Max</source>
-        <translation></translation>
+        <translation>최대값</translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="116"/>
         <source>Direction</source>
-        <translation></translation>
+        <translation>방향</translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Curve</source>
-        <translation></translation>
+        <translation>곡선</translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="118"/>
         <source>Plot</source>
-        <translation></translation>
+        <translation>그래프</translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="120"/>
         <source>PPM Center</source>
-        <translation></translation>
+        <translation>PPM 중심</translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="122"/>
         <source>Linear Subtrim</source>
-        <translation></translation>
+        <translation>선형 서브트림</translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="130"/>
         <source>CH%1</source>
-        <translation></translation>
+        <translation>채널%1</translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="134"/>
         <source>Popup menu available</source>
-        <translation></translation>
+        <translation>팝업 메뉴 사용 가능</translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="160"/>
@@ -1357,72 +1383,72 @@ Error description: %4</source>
     <message>
         <location filename="../modeledit/channels.cpp" line="160"/>
         <source>INV</source>
-        <translation></translation>
+        <translation>INV(역방향)</translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="325"/>
         <source>Delete Channel. Are you sure?</source>
-        <translation></translation>
+        <translation>채널을 삭제하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="347"/>
         <source>Cut Channel. Are you sure?</source>
-        <translation></translation>
+        <translation>채널을 잘라내시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="361"/>
         <source>Copy</source>
-        <translation></translation>
+        <translation>복사</translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="362"/>
         <source>Cut</source>
-        <translation></translation>
+        <translation>잘라내기</translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="363"/>
         <source>Paste</source>
-        <translation></translation>
+        <translation>붙여넣기</translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="364"/>
         <source>Clear</source>
-        <translation></translation>
+        <translation>지우기</translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="366"/>
         <source>Insert</source>
-        <translation></translation>
+        <translation>삽입</translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="367"/>
         <source>Delete</source>
-        <translation></translation>
+        <translation>삭제</translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="368"/>
         <source>Move Up</source>
-        <translation></translation>
+        <translation>위로 이동</translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="369"/>
         <source>Move Down</source>
-        <translation></translation>
+        <translation>아래로 이동</translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="371"/>
         <source>Clear All</source>
-        <translation></translation>
+        <translation>모두 지우기</translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="422"/>
         <source>Clear Channel. Are you sure?</source>
-        <translation></translation>
+        <translation>채널을 초기화하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/channels.cpp" line="433"/>
         <source>Clear all Channels. Are you sure?</source>
-        <translation></translation>
+        <translation>모든 채널을 초기화하시겠습니까?</translation>
     </message>
 </context>
 <context>
@@ -1430,47 +1456,47 @@ Error description: %4</source>
     <message>
         <location filename="../modeledit/checklistdialog.ui" line="14"/>
         <source>Edit Checklist</source>
-        <translation></translation>
+        <translation>체크리스트 편집</translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.ui" line="71"/>
         <source>Line nn, Col nn</source>
-        <translation></translation>
+        <translation>줄 nn, 열 nn</translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.ui" line="100"/>
         <source>&amp;Import...</source>
-        <translation></translation>
+        <translation>가져오기(&amp;I)...</translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.ui" line="113"/>
         <source>&amp;Cancel</source>
-        <translation></translation>
+        <translation>취소(&amp;C)</translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.ui" line="126"/>
         <source>&amp;OK</source>
-        <translation></translation>
+        <translation>확인(&amp;O)</translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.ui" line="141"/>
         <source>Please note, the maximum width displayable is radio model limited. Also, renaming the model will break the link to this checklist file.</source>
-        <translation></translation>
+        <translation>참고: 표시 가능한 최대 너비는 송신기 모델에 따라 제한됩니다. 또한, 모델 이름을 변경하면 이 체크리스트 파일과의 연결이 끊어집니다.</translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.ui" line="151"/>
         <source>File: unknown</source>
-        <translation></translation>
+        <translation>파일: 알 수 없음</translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Open Checklist</source>
-        <translation></translation>
+        <translation>체크리스트 열기</translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.cpp" line="66"/>
         <source>Checklist Files (*.txt)</source>
-        <translation></translation>
+        <translation>체크리스트 파일 (*.txt)</translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.cpp" line="77"/>
@@ -1479,42 +1505,47 @@ Error description: %4</source>
         <location filename="../modeledit/checklistdialog.cpp" line="103"/>
         <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Model Checklist</source>
-        <translation></translation>
+        <translation>모델 체크리스트</translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.cpp" line="77"/>
         <source>Cannot open file for writing %1:
 %2.</source>
-        <translation></translation>
+        <translation>파일을 열 수 없습니다 (쓰기용) %1:
+%2.</translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.cpp" line="84"/>
         <source>Cannot write to file %1:
 %2.</source>
-        <translation></translation>
+        <translation>파일에 쓸 수 없습니다 %1:
+%2.</translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.cpp" line="86"/>
         <source>Cannot write file %1:
 %2.</source>
-        <translation></translation>
+        <translation>파일을 저장할 수 없습니다 %1:
+%2.</translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.cpp" line="103"/>
         <source>Cannot open file %1:
 %2.</source>
-        <translation></translation>
+        <translation>파일을 열 수 없습니다 %1:
+%2.</translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.cpp" line="111"/>
         <source>Cannot read file %1:
 %2.</source>
-        <translation></translation>
+        <translation>파일을 읽을 수 없습니다 %1:
+%2.</translation>
     </message>
     <message>
         <location filename="../modeledit/checklistdialog.cpp" line="124"/>
         <source>Line %1, Col %2</source>
-        <translation></translation>
+        <translation>%1행, %2열</translation>
     </message>
 </context>
 <context>
@@ -1522,7 +1553,7 @@ Error description: %4</source>
     <message>
         <location filename="../updates/chooserdialog.ui" line="14"/>
         <source>Dialog</source>
-        <translation></translation>
+        <translation>대화상자</translation>
     </message>
 </context>
 <context>
@@ -1530,12 +1561,12 @@ Error description: %4</source>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="450"/>
         <source>User Interface</source>
-        <translation></translation>
+        <translation>사용자 인터페이스</translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="452"/>
         <source>Main View %1</source>
-        <translation></translation>
+        <translation>메인 화면 %1</translation>
     </message>
 </context>
 <context>
@@ -1543,37 +1574,37 @@ Error description: %4</source>
     <message>
         <location filename="../constants.h" line="63"/>
         <source>Information</source>
-        <translation></translation>
+        <translation>정보</translation>
     </message>
     <message>
         <location filename="../constants.h" line="64"/>
         <source>Warning</source>
-        <translation></translation>
+        <translation>경고</translation>
     </message>
     <message>
         <location filename="../constants.h" line="65"/>
         <source>Error</source>
-        <translation></translation>
+        <translation>오류</translation>
     </message>
     <message>
         <location filename="../constants.h" line="66"/>
         <source>Accept</source>
-        <translation type="unfinished"></translation>
+        <translation>수락</translation>
     </message>
     <message>
         <location filename="../constants.h" line="67"/>
         <source>Decline</source>
-        <translation type="unfinished"></translation>
+        <translation>거부</translation>
     </message>
     <message>
         <location filename="../constants.h" line="85"/>
         <source>Application Settings</source>
-        <translation></translation>
+        <translation>애플리케이션 설정</translation>
     </message>
     <message>
         <location filename="../constants.h" line="69"/>
         <source>files</source>
-        <translation></translation>
+        <translation>파일</translation>
     </message>
     <message>
         <location filename="../constants.h" line="61"/>
@@ -1583,155 +1614,156 @@ Error description: %4</source>
     <message>
         <location filename="../constants.h" line="62"/>
         <source>EdgeTX Simulator</source>
-        <translation></translation>
+        <translation>EdgeTX 시뮬레이터</translation>
     </message>
     <message>
         <location filename="../constants.h" line="70"/>
         <source>Radio and Models settings</source>
-        <translation></translation>
+        <translation>송신기 및 모델 설정</translation>
     </message>
     <message>
         <location filename="../helpers.cpp" line="286"/>
         <source>Select or create a file for exported Settings:</source>
-        <translation></translation>
+        <translation>내보낼 설정 파일을 선택하거나 새로 만드세요:</translation>
     </message>
     <message>
         <location filename="../helpers.cpp" line="296"/>
         <source>Press the &apos;Retry&apos; button to choose another file.</source>
-        <translation></translation>
+        <translation>다른 파일을 선택하려면 &apos;다시 시도&apos; 버튼을 누르세요.</translation>
     </message>
     <message>
         <location filename="../helpers.cpp" line="362"/>
         <source>Simulator for this firmware is not yet available</source>
-        <translation></translation>
+        <translation>이 펌웨어에 대한 시뮬레이터는 아직 사용할 수 없습니다</translation>
     </message>
     <message>
         <location filename="../helpers.cpp" line="380"/>
         <source>Error creating temporary directory for models and settings.</source>
-        <translation type="unfinished"></translation>
+        <translation>모델 및 설정을 위한 임시 디렉터리 생성에 실패했습니다.</translation>
     </message>
     <message>
         <location filename="../helpers.cpp" line="388"/>
         <source>Error writing models and settings to temporary directory.</source>
-        <translation type="unfinished"></translation>
+        <translation>모델 및 설정을 임시 디렉터리에 쓰는 중 오류가 발생했습니다.</translation>
     </message>
     <message>
         <location filename="../helpers.cpp" line="419"/>
         <source>Unable to start.</source>
-        <translation type="unfinished"></translation>
+        <translation>시작할 수 없습니다.</translation>
     </message>
     <message>
         <location filename="../helpers.cpp" line="421"/>
         <source>Crashed.</source>
-        <translation type="unfinished"></translation>
+        <translation>충돌이 발생했습니다.</translation>
     </message>
     <message>
         <location filename="../helpers.cpp" line="423"/>
         <source>Exited with result code:</source>
-        <translation type="unfinished"></translation>
+        <translation>다음 결과 코드로 종료됨:</translation>
     </message>
     <message>
         <location filename="../helpers.cpp" line="381"/>
         <location filename="../helpers.cpp" line="389"/>
         <location filename="../helpers.cpp" line="426"/>
         <source>Simulator Error</source>
-        <translation></translation>
+        <translation>시뮬레이터 오류</translation>
     </message>
     <message>
         <location filename="../warnings.h" line="31"/>
         <source>&lt;p&gt;&lt;b&gt;Welcome to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;As the first step, please configure the initial Radio Profile by selecting your Radio Type, Menu Language, and Build Options.&lt;/p&gt;&lt;p&gt;You may also want to take this time to review the other available options in the displayed Settings dialog.&lt;/p&gt;&lt;p&gt;After saving your settings, we recommend you download the latest firmware for your radio by using the &lt;i&gt;File -&amp;gt; Download&lt;/i&gt; menu option.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for latest news, updates and documentation. Thank you for choosing EdgeTX!&lt;/p&gt;- The EdgeTX Team.</source>
-        <translation></translation>
+        <translation>&lt;p&gt;&lt;b&gt;EdgeTX %1에 오신 것을 환영합니다.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;먼저 송신기 종류, 메뉴 언어, 빌드 옵션을 선택하여 초기 송신기 프로필을 설정해 주세요.&lt;/p&gt;&lt;p&gt;이 기회에 표시된 설정 창에서 다른 옵션들도 함께 확인해 보시기 바랍니다.&lt;/p&gt;&lt;p&gt;설정을 저장한 후, &lt;i&gt;파일 -&gt; 다운로드&lt;/i&gt; 메뉴를 통해 최신 펌웨어를 받는 것을 권장합니다.&lt;/p&gt;&lt;p&gt;최신 소식과 문서는 &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt;에서 확인할 수 있습니다. EdgeTX를 선택해 주셔서 감사합니다!&lt;/p&gt;- EdgeTX 팀</translation>
     </message>
     <message>
         <location filename="../warnings.h" line="39"/>
         <source>&lt;p&gt;&lt;b&gt;Thank you for upgrading to EdgeTX %1.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;This is a major upgrade that adds and modifies a lot of things, so please make sure that you read release notes carefully  to learn about the changes, and thoroughly check each of your models for proper function.&lt;/p&gt;&lt;p&gt;Please visit &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt; for release notes and other documentation.&lt;/p&gt;- The EdgeTX Team.</source>
-        <translation></translation>
+        <translation>&lt;p&gt;&lt;b&gt;EdgeTX %1로 업그레이드해 주셔서 감사합니다.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;이번 업그레이드는 많은 기능이 추가되고 변경된 주요 업데이트입니다. 변경사항을 이해하기 위해 릴리스 노트를 꼭 확인해 주시고, 모든 모델이 제대로 동작하는지 꼼꼼히 점검해 주세요.&lt;/p&gt;&lt;p&gt;릴리스 노트와 문서는 &lt;a href=&apos;https://edgetx.org&apos;&gt;edgetx.org&lt;/a&gt;에서 확인할 수 있습니다.&lt;/p&gt;- EdgeTX 팀</translation>
     </message>
     <message>
         <location filename="../warnings.h" line="46"/>
         <source>&lt;p&gt;The radio type in the selected profile does not exist. Using the default type instead.&lt;/p&gt; &lt;p&gt;&lt;b&gt;Please update your profile settings!&lt;/b&gt;&lt;/p&gt;</source>
-        <translation></translation>
+        <translation>&lt;p&gt;선택한 프로필의 송신기 종류가 존재하지 않습니다. 기본 값으로 대체됩니다.&lt;/p&gt; &lt;p&gt;&lt;b&gt;프로필 설정을 업데이트해 주세요!&lt;/b&gt;&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="62"/>
         <source>The saved settings could not be imported, please try again or continue with current settings.</source>
-        <translation></translation>
+        <translation>저장된 설정을 가져올 수 없습니다. 다시 시도하거나 현재 설정으로 계속 진행해 주세요.</translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="77"/>
         <source>Import from File</source>
-        <translation></translation>
+        <translation>파일에서 가져오기</translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="78"/>
         <source>Do not import</source>
-        <translation></translation>
+        <translation>가져오지 않기</translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="81"/>
         <source>We have found possible Companion settings backup file(s).
 Do you want to import settings from a file?</source>
-        <translation></translation>
+        <translation>Companion 설정 백업 파일이 감지되었습니다.
+파일에서 설정을 가져오시겠습니까?</translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="83"/>
         <source>Import settings from a file, or start with current values.</source>
-        <translation></translation>
+        <translation>파일에서 설정을 가져오거나 현재 값으로 시작하세요.</translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="102"/>
         <source>Select %1:</source>
-        <translation></translation>
+        <translation>%1을(를) 선택하세요:</translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="123"/>
         <source>Save application settings to file...</source>
-        <translation></translation>
+        <translation>애플리케이션 설정을 파일로 저장...</translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="124"/>
         <source>Load application settings from file or previous version...</source>
-        <translation></translation>
+        <translation>파일 또는 이전 버전에서 애플리케이션 설정 불러오기...</translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="125"/>
         <source>Reset ALL application settings to default and remove radio profiles...</source>
-        <translation></translation>
+        <translation>모든 애플리케이션 설정을 초기화하고 송신기 프로필 삭제...</translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="126"/>
         <source>Exit before settings initialization and application startup.</source>
-        <translation></translation>
+        <translation>설정 초기화 및 애플리케이션 시작 전에 종료합니다.</translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="127"/>
         <source>Print version number and exit.</source>
-        <translation></translation>
+        <translation>버전 번호를 출력하고 종료합니다.</translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="128"/>
         <source>Print this help text.</source>
-        <translation></translation>
+        <translation>이 도움말을 출력합니다.</translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="176"/>
         <source>Reset ALL application settings to default values and remove radio profiles, are you sure?</source>
-        <translation></translation>
+        <translation>모든 애플리케이션 설정을 초기화하고 송신기 프로필을 삭제하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="181"/>
         <source>Would you like to perform a backup first?</source>
-        <translation></translation>
+        <translation>먼저 백업을 수행하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../companion.cpp" line="188"/>
         <source>Application settings were reset and saved.</source>
-        <translation></translation>
+        <translation>애플리케이션 설정이 초기화되고 저장되었습니다.</translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="60"/>
         <source>settings</source>
-        <translation></translation>
+        <translation>설정</translation>
     </message>
 </context>
 <context>
@@ -1739,52 +1771,52 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../comparedialog.ui" line="29"/>
         <source>Compare Models</source>
-        <translation></translation>
+        <translation>모델 비교</translation>
     </message>
     <message>
         <location filename="../comparedialog.ui" line="44"/>
         <source>To compare models, drag and drop them anywhere in this window.</source>
-        <translation></translation>
+        <translation>모델을 비교하려면 이 창 아무 곳에나 끌어다 놓으세요.</translation>
     </message>
     <message>
         <location filename="../comparedialog.ui" line="67"/>
         <source>Close</source>
-        <translation></translation>
+        <translation>닫기</translation>
     </message>
     <message>
         <location filename="../comparedialog.ui" line="74"/>
         <source>Style</source>
-        <translation></translation>
+        <translation>스타일</translation>
     </message>
     <message>
         <location filename="../comparedialog.ui" line="81"/>
         <source>Print</source>
-        <translation></translation>
+        <translation>인쇄</translation>
     </message>
     <message>
         <location filename="../comparedialog.ui" line="88"/>
         <source>Print to file</source>
-        <translation></translation>
+        <translation>파일로 인쇄</translation>
     </message>
     <message>
         <location filename="../comparedialog.cpp" line="128"/>
         <source>Unnamed Model %1</source>
-        <translation></translation>
+        <translation>이름 없는 모델 %1</translation>
     </message>
     <message>
         <location filename="../comparedialog.cpp" line="139"/>
         <source>Click to remove this model.</source>
-        <translation></translation>
+        <translation>이 모델을 제거하려면 클릭하세요.</translation>
     </message>
     <message>
         <location filename="../comparedialog.cpp" line="171"/>
         <source>Print Document</source>
-        <translation></translation>
+        <translation>문서 인쇄</translation>
     </message>
     <message>
         <location filename="../comparedialog.cpp" line="180"/>
         <source>Select PDF output file</source>
-        <translation></translation>
+        <translation>PDF 출력 파일 선택</translation>
     </message>
 </context>
 <context>
@@ -1792,17 +1824,17 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../storage/appdata.h" line="592"/>
         <source>Releases</source>
-        <translation></translation>
+        <translation>정식 릴리즈</translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="592"/>
         <source>Pre-release</source>
-        <translation></translation>
+        <translation>프리릴리즈</translation>
     </message>
     <message>
         <location filename="../storage/appdata.h" line="592"/>
         <source>Nightly</source>
-        <translation></translation>
+        <translation>나이트리 빌드</translation>
     </message>
 </context>
 <context>
@@ -1810,7 +1842,7 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../wizarddialog.cpp" line="983"/>
         <source>OK, I understand.</source>
-        <translation></translation>
+        <translation>확인했습니다.</translation>
     </message>
 </context>
 <context>
@@ -1818,17 +1850,17 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../process_copy.cpp" line="72"/>
         <source>Write error</source>
-        <translation></translation>
+        <translation>쓰기 오류</translation>
     </message>
     <message>
         <location filename="../process_copy.cpp" line="80"/>
         <source>Cannot write %1 (reason: %2)</source>
-        <translation></translation>
+        <translation>%1을(를) 쓸 수 없습니다 (이유: %2)</translation>
     </message>
     <message>
         <location filename="../process_copy.cpp" line="85"/>
         <source>Cannot open %1 (reason: %2)</source>
-        <translation></translation>
+        <translation>%1을(를) 열 수 없습니다 (이유: %2)</translation>
     </message>
 </context>
 <context>
@@ -1841,17 +1873,17 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../firmwares/curvedata.cpp" line="76"/>
         <source>Standard</source>
-        <translation></translation>
+        <translation>표준</translation>
     </message>
     <message>
         <location filename="../firmwares/curvedata.cpp" line="78"/>
         <source>Custom</source>
-        <translation></translation>
+        <translation>사용자 정의</translation>
     </message>
     <message>
         <location filename="../firmwares/curvedata.cpp" line="128"/>
         <source>%1 points</source>
-        <translation></translation>
+        <translation>%1 포인트</translation>
     </message>
 </context>
 <context>
@@ -1859,57 +1891,57 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../shared/curvedialog.ui" line="60"/>
         <source>Name</source>
-        <translation></translation>
+        <translation>이름</translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="77"/>
         <source>Type</source>
-        <translation></translation>
+        <translation>유형</translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="93"/>
         <source>Smooth</source>
-        <translation></translation>
+        <translation>부드럽게</translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="142"/>
         <source>Curve Creator</source>
-        <translation></translation>
+        <translation>곡선 생성기</translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="148"/>
         <source>Template</source>
-        <translation></translation>
+        <translation>템플릿</translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="158"/>
         <source>Coefficient</source>
-        <translation></translation>
+        <translation>계수</translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="181"/>
         <source>Y at X=-100</source>
-        <translation></translation>
+        <translation>X=-100일 때 Y</translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="204"/>
         <source>Y at X=0</source>
-        <translation></translation>
+        <translation>X=0일 때 Y</translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="227"/>
         <source>Y at X=100</source>
-        <translation></translation>
+        <translation>X=100일 때 Y</translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="250"/>
         <source>Side</source>
-        <translation></translation>
+        <translation>측면</translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="258"/>
         <source>Both</source>
-        <translation></translation>
+        <translation>양쪽</translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="263"/>
@@ -1924,42 +1956,42 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../shared/curvedialog.ui" line="276"/>
         <source>Apply</source>
-        <translation></translation>
+        <translation>적용</translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.ui" line="290"/>
         <source>Point size</source>
-        <translation></translation>
+        <translation>포인트 크기</translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.cpp" line="186"/>
         <source>Linear</source>
-        <translation></translation>
+        <translation>선형</translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.cpp" line="187"/>
         <source>Single Expo</source>
-        <translation></translation>
+        <translation>단일 곡선(Expo)</translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.cpp" line="188"/>
         <source>Symmetrical f(x)=-f(-x)</source>
-        <translation></translation>
+        <translation>대칭형 f(x) = -f(-x)</translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.cpp" line="189"/>
         <source>Symmetrical f(x)=f(-x)</source>
-        <translation></translation>
+        <translation>대칭형 f(x) = f(-x)</translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.cpp" line="420"/>
         <source>Not enough free points in global points array to store the curve.</source>
-        <translation></translation>
+        <translation>곡선을 저장하기 위한 전역 포인트 배열에 여유 공간이 부족합니다.</translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.cpp" line="430"/>
         <source>Editing curve %1: %2</source>
-        <translation></translation>
+        <translation>곡선 %1 편집 중: %2</translation>
     </message>
 </context>
 <context>
@@ -1967,7 +1999,7 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../shared/curveimagewidget.cpp" line="32"/>
         <source>Double click to edit</source>
-        <translation></translation>
+        <translation>더블 클릭하여 편집</translation>
     </message>
 </context>
 <context>
@@ -1975,22 +2007,22 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Diff</source>
-        <translation></translation>
+        <translation>차등</translation>
     </message>
     <message>
         <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Expo</source>
-        <translation></translation>
+        <translation>지수</translation>
     </message>
     <message>
         <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Func</source>
-        <translation></translation>
+        <translation>함수</translation>
     </message>
     <message>
         <location filename="../firmwares/curvereference.cpp" line="90"/>
         <source>Custom</source>
-        <translation></translation>
+        <translation>사용자 정의</translation>
     </message>
 </context>
 <context>
@@ -1998,7 +2030,7 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../modeledit/curves.cpp" line="36"/>
         <source>Note: to create a curve right click on the curve row label</source>
-        <translation></translation>
+        <translation>참고: 곡선을 생성하려면 곡선 행 레이블을 마우스 오른쪽 버튼으로 클릭하세요</translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="49"/>
@@ -2009,102 +2041,102 @@ Do you want to import settings from a file?</source>
         <location filename="../modeledit/curves.cpp" line="53"/>
         <location filename="../modeledit/curves.cpp" line="64"/>
         <source>Popup menu available</source>
-        <translation></translation>
+        <translation>팝업 메뉴 사용 가능</translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="76"/>
         <source>Name:</source>
-        <translation></translation>
+        <translation>이름:</translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="80"/>
         <source>Type:</source>
-        <translation></translation>
+        <translation>유형:</translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="84"/>
         <source>Points:</source>
-        <translation></translation>
+        <translation>포인트 수:</translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="97"/>
         <source>Smooth:</source>
-        <translation></translation>
+        <translation>부드럽게:</translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="180"/>
         <source>Add</source>
-        <translation></translation>
+        <translation>추가</translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="181"/>
         <source>Edit</source>
-        <translation></translation>
+        <translation>편집</translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="183"/>
         <source>Copy</source>
-        <translation></translation>
+        <translation>복사</translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="184"/>
         <source>Cut</source>
-        <translation></translation>
+        <translation>잘라내기</translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="185"/>
         <source>Paste</source>
-        <translation></translation>
+        <translation>붙여넣기</translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="186"/>
         <source>Clear</source>
-        <translation></translation>
+        <translation>초기화</translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="188"/>
         <source>Insert</source>
-        <translation></translation>
+        <translation>삽입</translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="189"/>
         <source>Delete</source>
-        <translation></translation>
+        <translation>삭제</translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="190"/>
         <source>Move Up</source>
-        <translation></translation>
+        <translation>위로 이동</translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="191"/>
         <source>Move Down</source>
-        <translation></translation>
+        <translation>아래로 이동</translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="193"/>
         <source>Clear All</source>
-        <translation></translation>
+        <translation>모두 초기화</translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="233"/>
         <source>Clear curve %1:%2. Are you sure?</source>
-        <translation></translation>
+        <translation>곡선 %1:%2 을(를) 초기화하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="246"/>
         <source>Clear all curves. Are you sure?</source>
-        <translation></translation>
+        <translation>모든 곡선을 초기화하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="270"/>
         <source>Cut curve %1:%2. Are you sure?</source>
-        <translation></translation>
+        <translation>곡선 %1:%2 을(를) 잘라내시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/curves.cpp" line="278"/>
         <source>Delete curve %1:%2. Are you sure?</source>
-        <translation></translation>
+        <translation>곡선 %1:%2 을(를) 삭제하시겠습니까?</translation>
     </message>
 </context>
 <context>
@@ -2122,97 +2154,97 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="66"/>
         <source>Override %1</source>
-        <translation></translation>
+        <translation>%1 오버라이드</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="70"/>
         <source>Trainer RUD</source>
-        <translation></translation>
+        <translation>트레이너 러더</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="72"/>
         <source>Trainer ELE</source>
-        <translation></translation>
+        <translation>트레이너 엘리베이터</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="74"/>
         <source>Trainer THR</source>
-        <translation></translation>
+        <translation>트레이너 스로틀</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="76"/>
         <source>Trainer AIL</source>
-        <translation></translation>
+        <translation>트레이너 에일러론</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="78"/>
         <source>Trainer Channels</source>
-        <translation></translation>
+        <translation>트레이너 채널</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="80"/>
         <source>Instant Trim</source>
-        <translation></translation>
+        <translation>즉시 트림</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="82"/>
         <source>Play Sound</source>
-        <translation></translation>
+        <translation>사운드 재생</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="84"/>
         <source>Haptic</source>
-        <translation></translation>
+        <translation>진동</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="86"/>
         <source>Reset</source>
-        <translation></translation>
+        <translation>리셋</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="88"/>
         <source>Set %1</source>
-        <translation></translation>
+        <translation>%1 설정</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="98"/>
         <source>Lua Script</source>
-        <translation></translation>
+        <translation>Lua 스크립트</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="114"/>
         <source>Set Failsafe</source>
-        <translation></translation>
+        <translation>페일세이프 설정</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="116"/>
         <source>Range Check Int. Module</source>
-        <translation></translation>
+        <translation>내장 모듈 범위 확인</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="118"/>
         <source>Range Check Ext. Module</source>
-        <translation></translation>
+        <translation>외장 모듈 범위 확인</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="124"/>
         <source>Racing Mode</source>
-        <translation></translation>
+        <translation>레이싱 모드</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="126"/>
         <source>Disable Touch</source>
-        <translation></translation>
+        <translation>터치 비활성화</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="128"/>
         <source>Set Main Screen</source>
-        <translation></translation>
+        <translation>메인 화면 설정</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="130"/>
         <source>Audio Amp Off</source>
-        <translation></translation>
+        <translation>오디오 앰프 끄기</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="132"/>
@@ -2222,253 +2254,253 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="134"/>
         <source>LCD to Video</source>
-        <translation type="unfinished"></translation>
+        <translation>LCD → 비디오 출력</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="137"/>
         <source>Push Custom Switch %1</source>
-        <translation type="unfinished"></translation>
+        <translation>사용자 스위치 %1 누르기</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>Played once, not during startup</source>
-        <translation></translation>
+        <translation>한 번만 재생 (시작 시 제외)</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="228"/>
         <source>!1x</source>
-        <translation></translation>
+        <translation>!1회</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
         <source>No repeat</source>
-        <translation></translation>
+        <translation>반복 없음</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="231"/>
         <location filename="../firmwares/customfunctiondata.cpp" line="420"/>
         <source>1x</source>
-        <translation></translation>
+        <translation>1회</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>Repeat %1s</source>
-        <translation></translation>
+        <translation>%1초마다 반복</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="234"/>
         <source>%1s</source>
-        <translation></translation>
+        <translation>%1초</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="305"/>
         <source>Trims</source>
-        <translation type="unfinished"></translation>
+        <translation>트림</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 1</source>
-        <translation></translation>
+        <translation>삑 1</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 2</source>
-        <translation></translation>
+        <translation>삑 2</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Beep 3</source>
-        <translation></translation>
+        <translation>삑 3</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 1</source>
-        <translation></translation>
+        <translation>경고 1</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Warn 2</source>
-        <translation></translation>
+        <translation>경고 2</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Cheep</source>
-        <translation></translation>
+        <translation>짹</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Ratata</source>
-        <translation></translation>
+        <translation>라타타</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="356"/>
         <source>Tick</source>
-        <translation></translation>
+        <translation>틱</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Siren</source>
-        <translation></translation>
+        <translation>사이렌</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Ring</source>
-        <translation></translation>
+        <translation>벨소리</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Sci Fi</source>
-        <translation></translation>
+        <translation>SF 효과음</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Robot</source>
-        <translation></translation>
+        <translation>로봇</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Chirp</source>
-        <translation></translation>
+        <translation>새소리</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Tada</source>
-        <translation></translation>
+        <translation>짜잔</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Cricket</source>
-        <translation></translation>
+        <translation>귀뚜라미</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="357"/>
         <source>Alarm Clock</source>
-        <translation></translation>
+        <translation>알람시계</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="385"/>
         <source>Value</source>
-        <translation></translation>
+        <translation>값</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="387"/>
         <source>Source (%)</source>
-        <translation type="unfinished"></translation>
+        <translation>소스 (%)</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="389"/>
         <source>Source (value)</source>
-        <translation type="unfinished"></translation>
+        <translation>소스 (값)</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="391"/>
         <source>Global Variable</source>
-        <translation></translation>
+        <translation>전역 변수</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="393"/>
         <source>Inc/Decrement</source>
-        <translation></translation>
+        <translation>증가/감소</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="419"/>
         <source>On</source>
-        <translation></translation>
+        <translation>켜짐</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="90"/>
         <source>Vario</source>
-        <translation></translation>
+        <translation>바리오</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="68"/>
         <source>Trainer Axis</source>
-        <translation></translation>
+        <translation>트레이너 축</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="92"/>
         <source>Play Track</source>
-        <translation></translation>
+        <translation>트랙 재생</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="94"/>
         <source>Play Both</source>
-        <translation></translation>
+        <translation>모두 재생</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="96"/>
         <source>Play Value</source>
-        <translation></translation>
+        <translation>값 읽기</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="100"/>
         <source>SD Logs</source>
-        <translation></translation>
+        <translation>SD 로그</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="102"/>
         <source>Volume</source>
-        <translation></translation>
+        <translation>볼륨</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="104"/>
         <source>Backlight</source>
-        <translation></translation>
+        <translation>백라이트</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="106"/>
         <source>Screenshot</source>
-        <translation></translation>
+        <translation>스크린샷</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="108"/>
         <source>Background Music</source>
-        <translation></translation>
+        <translation>배경 음악</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="110"/>
         <source>Background Music Pause</source>
-        <translation></translation>
+        <translation>배경 음악 일시정지</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="112"/>
         <source>Adjust %1</source>
-        <translation></translation>
+        <translation>%1 조정</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="120"/>
         <source>Bind Int. Module</source>
-        <translation></translation>
+        <translation>내장 모듈 바인딩</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="122"/>
         <source>Bind Ext. Module</source>
-        <translation></translation>
+        <translation>외장 모듈 바인딩</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="299"/>
         <source>Flight</source>
-        <translation></translation>
+        <translation>비행</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="302"/>
         <source>Telemetry</source>
-        <translation></translation>
+        <translation>텔레메트리</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="154"/>
         <source>s</source>
-        <translation></translation>
+        <translation>초</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="241"/>
         <source>DISABLED</source>
-        <translation></translation>
+        <translation>비활성화됨</translation>
     </message>
     <message>
         <location filename="../firmwares/customfunctiondata.cpp" line="30"/>
         <source>CFN</source>
-        <translation></translation>
+        <translation>사용자 기능 (CFN)</translation>
     </message>
 </context>
 <context>
@@ -2476,32 +2508,32 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Switch</source>
-        <translation></translation>
+        <translation>스위치</translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Action</source>
-        <translation></translation>
+        <translation>동작</translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Parameters</source>
-        <translation></translation>
+        <translation>매개변수</translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Repeat</source>
-        <translation></translation>
+        <translation>반복</translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="117"/>
         <source>Enable</source>
-        <translation></translation>
+        <translation>활성화</translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="124"/>
         <source>Popup menu available</source>
-        <translation></translation>
+        <translation>팝업 메뉴 사용 가능</translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="128"/>
@@ -2521,78 +2553,79 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="257"/>
         <source>Error occurred while trying to play sound, possibly the file is already opened. (Err: %1 [%2])</source>
-        <translation></translation>
+        <translation>사운드 재생 중 오류가 발생했습니다. 파일이 이미 열려 있을 수 있습니다. (오류: %1 [%2])</translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="284"/>
         <source>Unable to find or open sound file:
 %1</source>
-        <translation></translation>
+        <translation>사운드 파일을 찾거나 열 수 없습니다:
+%1</translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="635"/>
         <source>Delete Function. Are you sure?</source>
-        <translation></translation>
+        <translation>기능을 삭제하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="658"/>
         <source>Cut Special Function. Are you sure?</source>
-        <translation></translation>
+        <translation>특수 기능을 잘라내시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="671"/>
         <source>Copy</source>
-        <translation></translation>
+        <translation>복사</translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="672"/>
         <source>Cut</source>
-        <translation></translation>
+        <translation>잘라내기</translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="673"/>
         <source>Paste</source>
-        <translation></translation>
+        <translation>붙여넣기</translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="674"/>
         <source>Clear</source>
-        <translation></translation>
+        <translation>지우기</translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="676"/>
         <source>Insert</source>
-        <translation></translation>
+        <translation>삽입</translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="677"/>
         <source>Delete</source>
-        <translation></translation>
+        <translation>삭제</translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="678"/>
         <source>Move Up</source>
-        <translation></translation>
+        <translation>위로 이동</translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="679"/>
         <source>Move Down</source>
-        <translation></translation>
+        <translation>아래로 이동</translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="681"/>
         <source>Clear All</source>
-        <translation></translation>
+        <translation>모두 지우기</translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="756"/>
         <source>Clear Function. Are you sure?</source>
-        <translation></translation>
+        <translation>기능을 지우시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/customfunctions.cpp" line="767"/>
         <source>Clear all Functions. Are you sure?</source>
-        <translation></translation>
+        <translation>모든 기능을 지우시겠습니까?</translation>
     </message>
 </context>
 <context>
@@ -2600,22 +2633,22 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../modeledit/telemetry_customscreens.cpp" line="97"/>
         <source>None</source>
-        <translation></translation>
+        <translation>없음</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_customscreens.cpp" line="98"/>
         <source>Numbers</source>
-        <translation></translation>
+        <translation>숫자</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_customscreens.cpp" line="99"/>
         <source>Bars</source>
-        <translation></translation>
+        <translation>바</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_customscreens.cpp" line="101"/>
         <source>Script</source>
-        <translation></translation>
+        <translation>스크립트</translation>
     </message>
 </context>
 <context>
@@ -2623,47 +2656,47 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="239"/>
         <source>Layout:</source>
-        <translation></translation>
+        <translation>레이아웃:</translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="243"/>
         <source>None</source>
-        <translation></translation>
+        <translation>없음</translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="271"/>
         <source>Widgets:</source>
-        <translation></translation>
+        <translation>위젯:</translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="333"/>
         <source>Top bar</source>
-        <translation></translation>
+        <translation>상단 바</translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="336"/>
         <source>%1 mode</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 모드</translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="339"/>
         <source>Sliders</source>
-        <translation></translation>
+        <translation>슬라이더</translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="342"/>
         <source>Trims</source>
-        <translation></translation>
+        <translation>트림</translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="345"/>
         <source>Mirror</source>
-        <translation></translation>
+        <translation>미러</translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="348"/>
         <source>Option #%1</source>
-        <translation></translation>
+        <translation>옵션 #%1</translation>
     </message>
 </context>
 <context>
@@ -2671,19 +2704,19 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../customizesplashdialog.ui" line="23"/>
         <source>Transmitter Splash Screen Editor</source>
-        <translation></translation>
+        <translation>송신기 시작 화면 편집기</translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.ui" line="209"/>
         <location filename="../customizesplashdialog.ui" line="517"/>
         <source>Invert</source>
-        <translation></translation>
+        <translation>반전</translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.ui" line="232"/>
         <location filename="../customizesplashdialog.ui" line="540"/>
         <source>Open Splash Library</source>
-        <translation></translation>
+        <translation>스플래시 라이브러리 열기</translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.ui" line="235"/>
@@ -2697,105 +2730,105 @@ Do you want to import settings from a file?</source>
         <location filename="../customizesplashdialog.ui" line="262"/>
         <location filename="../customizesplashdialog.ui" line="570"/>
         <source>Load Profile</source>
-        <translation></translation>
+        <translation>프로파일 불러오기</translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.ui" line="272"/>
         <location filename="../customizesplashdialog.ui" line="583"/>
         <source>Load FW</source>
-        <translation></translation>
+        <translation>펌웨어 불러오기</translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.ui" line="282"/>
         <location filename="../customizesplashdialog.ui" line="593"/>
         <source>Load Pict</source>
-        <translation></translation>
+        <translation>이미지 불러오기</translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.ui" line="308"/>
         <location filename="../customizesplashdialog.ui" line="619"/>
         <source>Save</source>
-        <translation></translation>
+        <translation>저장</translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="210"/>
         <source>Open Firmware File</source>
-        <translation></translation>
+        <translation>펌웨어 파일 열기</translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="96"/>
         <source>FW: %1</source>
-        <translation></translation>
+        <translation>펌웨어: %1</translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="101"/>
         <source>Pict: %1</source>
-        <translation></translation>
+        <translation>이미지: %1</translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="106"/>
         <source>Profile image</source>
-        <translation></translation>
+        <translation>프로파일 이미지</translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="213"/>
         <source>Can not load embedded image from firmware file %1.</source>
-        <translation></translation>
+        <translation>펌웨어 파일 %1에서 내장 이미지를 불러올 수 없습니다.</translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Open Image to load</source>
-        <translation></translation>
+        <translation>불러올 이미지 열기</translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="229"/>
         <source>Images (%1)</source>
-        <translation></translation>
+        <translation>이미지 파일 (%1)</translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="233"/>
         <source>Cannot load the image file %1.</source>
-        <translation></translation>
+        <translation>이미지 파일 %1을(를) 불러올 수 없습니다.</translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="248"/>
         <source>Cannot load profile image %1.</source>
-        <translation></translation>
+        <translation>프로파일 이미지 %1을(를) 불러올 수 없습니다.</translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="262"/>
         <source>Cannot load the library image %1.</source>
-        <translation></translation>
+        <translation>라이브러리 이미지 %1을(를) 불러올 수 없습니다.</translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>File Saved</source>
-        <translation></translation>
+        <translation>파일 저장됨</translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="271"/>
         <source>The image was saved to the file %1</source>
-        <translation></translation>
+        <translation>이미지가 파일 %1에 저장되었습니다</translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Image Refresh Error</source>
-        <translation></translation>
+        <translation>이미지 새로 고침 오류</translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="273"/>
         <source>Failed to refresh image from file %1</source>
-        <translation></translation>
+        <translation>파일 %1에서 이미지를 새로 고침하는 데 실패했습니다</translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>File Save Error</source>
-        <translation></translation>
+        <translation>파일 저장 오류</translation>
     </message>
     <message>
         <location filename="../customizesplashdialog.cpp" line="277"/>
         <source>Failed to write image to %1</source>
-        <translation></translation>
+        <translation>이미지를 %1에 저장하지 못했습니다</translation>
     </message>
 </context>
 <context>
@@ -2826,52 +2859,52 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../firmwares/datahelpers.cpp" line="27"/>
         <source>Disabled</source>
-        <translation></translation>
+        <translation>비활성화됨</translation>
     </message>
     <message>
         <location filename="../firmwares/datahelpers.cpp" line="28"/>
         <source>Enabled</source>
-        <translation></translation>
+        <translation>활성화됨</translation>
     </message>
     <message>
         <location filename="../firmwares/datahelpers.cpp" line="29"/>
         <source>OFF</source>
-        <translation></translation>
+        <translation>꺼짐</translation>
     </message>
     <message>
         <location filename="../firmwares/datahelpers.cpp" line="30"/>
         <source>ON</source>
-        <translation></translation>
+        <translation>켜짐</translation>
     </message>
     <message>
         <location filename="../firmwares/datahelpers.cpp" line="31"/>
         <source>False</source>
-        <translation></translation>
+        <translation>거짓</translation>
     </message>
     <message>
         <location filename="../firmwares/datahelpers.cpp" line="32"/>
         <source>True</source>
-        <translation></translation>
+        <translation>참</translation>
     </message>
     <message>
         <location filename="../firmwares/datahelpers.cpp" line="33"/>
         <source>N</source>
-        <translation></translation>
+        <translation>아니오</translation>
     </message>
     <message>
         <location filename="../firmwares/datahelpers.cpp" line="34"/>
         <source>Y</source>
-        <translation></translation>
+        <translation>예</translation>
     </message>
     <message>
         <location filename="../firmwares/datahelpers.cpp" line="35"/>
         <source>No</source>
-        <translation>No</translation>
+        <translation>아니오</translation>
     </message>
     <message>
         <location filename="../firmwares/datahelpers.cpp" line="36"/>
         <source>Yes</source>
-        <translation></translation>
+        <translation>예</translation>
     </message>
 </context>
 <context>
@@ -2879,83 +2912,89 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../simulation/debugoutput.ui" line="20"/>
         <source>Debug Output</source>
-        <translation></translation>
+        <translation>디버그 출력</translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="68"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enable or disable the filter. If the button won&apos;t stay enabled, it is likely there is a syntax error in the Regular Expression entered.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;필터를 활성화하거나 비활성화합니다. 버튼이 활성화되지 않는 경우, 입력한 정규식에 문법 오류가 있을 수 있습니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="74"/>
         <source>Filter:</source>
-        <translation></translation>
+        <translation>필터:</translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="105"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Enter filter text here. Click the help/info button for details about using the filter. &lt;/p&gt;&lt;p&gt;
 To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first choose it, and then press &lt;code&gt;Shift-Delete&lt;/code&gt; (or &lt;code&gt;Shift-Backspace&lt;/code&gt;) key combination.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;여기에 필터 텍스트를 입력하세요. 필터 사용법에 대한 자세한 내용은 도움말 버튼을 클릭하세요. &lt;/p&gt;&lt;p&gt;
+필터 목록에서 저장된 항목을 삭제하려면 항목을 선택한 후 Shift-Delete(또는 Shift-Backspace)를 누르세요.</translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="164"/>
         <source>Buffer:</source>
-        <translation></translation>
+        <translation>버퍼:</translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="177"/>
         <source>Number of lines to keep in display.</source>
-        <translation></translation>
+        <translation>화면에 유지할 출력 줄 수입니다.</translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="274"/>
         <source>Filter &amp;Help</source>
-        <translation></translation>
+        <translation>필터 도움말(&amp;H)</translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="277"/>
         <source>Show information about using the filter.</source>
-        <translation></translation>
+        <translation>필터 사용에 대한 정보를 표시합니다.</translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="289"/>
         <source>Word &amp;Wrap</source>
-        <translation></translation>
+        <translation>자동 줄바꿈(&amp;W)</translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="292"/>
         <source>Toggle word wrapping on/off.</source>
-        <translation></translation>
+        <translation>자동 줄바꿈을 켜거나 끕니다.</translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="301"/>
         <source>&amp;Clear</source>
-        <translation></translation>
+        <translation>지우기(&amp;C)</translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="304"/>
         <source>Clear the output window of all text.</source>
-        <translation></translation>
+        <translation>출력 창의 모든 텍스트를 지웁니다.</translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="316"/>
         <source>Enable &amp;Filter</source>
-        <translation></translation>
+        <translation>필터 사용(&amp;F)</translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.ui" line="319"/>
         <source>Turn the filter on/off.</source>
-        <translation></translation>
+        <translation>필터를 켜거나 끕니다.</translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.cpp" line="267"/>
         <source>&lt;html&gt;&lt;head&gt;&lt;style&gt;kbd {background-color: palette(alternate-base); font-size: large; white-space: nowrap;}&lt;/style&gt;&lt;/head&gt;&lt;body&gt;&lt;p&gt;The filter supports two syntax types: basic matching with common wildcards as well as full Perl-style (&lt;code&gt;pcre&lt;/code&gt;) Regular Expressions.&lt;/p&gt;&lt;p&gt;By default a filter will only show lines which match (&lt;b&gt;inclusive&lt;/b&gt;). To make an &lt;b&gt;exclusive&lt;/b&gt; filter which removes matching lines, prefix the filter expression with a &lt;kbd&gt;!&lt;/kbd&gt; (exclamation mark).&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;Regular Expressions&lt;/b&gt; (RegEx), prefix the filter text with a &lt;kbd&gt;/&lt;/kbd&gt; (slash) or &lt;kbd&gt;^&lt;/kbd&gt; (up caret). &lt;ul&gt;&lt;li&gt;Put the &lt;kbd&gt;/&lt;/kbd&gt; or &lt;kbd&gt;^&lt;/kbd&gt; after the exclusive &lt;kbd&gt;!&lt;/kbd&gt; indicator if you&apos;re using one.&lt;/li&gt;&lt;li&gt;By default the match is case-sensitive. To make it insensitive, add the typical &lt;kbd&gt;/i&lt;/kbd&gt; (slash i) operator at the end of your RegEx.&lt;/li&gt;&lt;li&gt;If you use a caret (^) to denote a RegEx, it will become part of the Reg. Ex. (that is, matches from start of line).&lt;/li&gt;&lt;li&gt;If the RegEx is invalid, the filter edit field should show a red border and you will not be able to enable the filter.&lt;/li&gt;&lt;li&gt;A useful resource for testing REs (with a full reference) can be found at &lt;a href=&quot;http://www.regexr.com/&quot;&gt;http://www.regexr.com/&lt;/a&gt;&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;To use &lt;b&gt;basic matching&lt;/b&gt; just type any text.&lt;ul&gt;&lt;li&gt;Wildcards: &lt;kbd&gt;*&lt;/kbd&gt; (asterisk) matches zero or more of any character(s), and &lt;kbd&gt;?&lt;/kbd&gt; (question mark) matches any single character.&lt;/li&gt;&lt;li&gt;The match is always case-insensitive.&lt;/li&gt;&lt;li&gt;The match always starts from the beginning of a log line. To ignore characters at the start, use a leading &lt;kbd&gt;*&lt;/kbd&gt; wildcard.&lt;/li&gt;&lt;li&gt;A trailing &lt;kbd&gt;*&lt;/kbd&gt; is always implied (that is, matches anything to the end of the log line). To avoid this, use a RegEx.&lt;/li&gt;&lt;li&gt;You can match literal wildcard characters by prefixing them with a &lt;kbd&gt;\&lt;/kbd&gt; (backslash) character (eg. &quot;foo\*bar&quot; matches &quot;foo*bar&quot;).&lt;/li&gt;&lt;/ul&gt;&lt;/p&gt;&lt;p&gt;After &lt;b&gt;editing text&lt;/b&gt;, press ENTER or TAB key (or click anywhere outside the box) to update the filter.&lt;/p&gt;&lt;p&gt;To &lt;b&gt;remove an entry&lt;/b&gt; from the filter selector list, first choose it, and while in the line editor press &lt;kbd&gt;Shift-Delete&lt;/kbd&gt; (or &lt;kbd&gt;Shift-Backspace&lt;/kbd&gt;) key combination. The default filters cannot be removed. Up to 50 filters are stored.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
+        <translation>&lt;p&gt;&lt;b&gt;필터는 두 가지 문법을 지원합니다: 일반적인 와일드카드를 사용하는 기본 매칭과 Perl 스타일의 정규식(pcre)&lt;/b&gt;입니다.&lt;/p&gt;
+&lt;p&gt;&lt;b&gt;제외 필터&lt;/b&gt;를 사용하려면 필터 문자열 앞에 &lt;kbd&gt;!&lt;/kbd&gt;(느낌표)를 붙이세요.&lt;/p&gt;
+&lt;p&gt;정규식을 사용하려면 &lt;kbd&gt;/&lt;/kbd&gt;(슬래시) 또는 &lt;kbd&gt;^&lt;/kbd&gt;(캐럿)을 접두사로 사용하세요. 대소문자 무시 옵션으로는 &lt;kbd&gt;/i&lt;/kbd&gt;를 사용하세요.&lt;/p&gt;
+&lt;p&gt;&lt;b&gt;기본 매칭&lt;/b&gt;은 일반 텍스트 입력으로 가능하며, &lt;kbd&gt;*&lt;/kbd&gt;와 &lt;kbd&gt;?&lt;/kbd&gt; 와일드카드를 사용할 수 있습니다. 기본적으로 대소문자를 구분하지 않습니다.&lt;/p&gt;
+&lt;p&gt;편집 후 &lt;kbd&gt;Enter&lt;/kbd&gt; 또는 &lt;kbd&gt;Tab&lt;/kbd&gt; 키를 눌러 필터를 적용하세요.&lt;/p&gt;
+&lt;p&gt;저장된 필터 항목을 삭제하려면 항목을 선택한 뒤 &lt;kbd&gt;Shift-Delete&lt;/kbd&gt; 또는 &lt;kbd&gt;Shift-Backspace&lt;/kbd&gt;를 누르세요.&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../simulation/debugoutput.cpp" line="293"/>
         <source>Debug Console Filter Help</source>
-        <translation></translation>
+        <translation>디버그 콘솔 필터 도움말</translation>
     </message>
 </context>
 <context>
@@ -2963,12 +3002,12 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
     <message>
         <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="158"/>
         <source>Radio settings file checksum error. You are advised to review the settings</source>
-        <translation></translation>
+        <translation>송신기 설정 파일의 체크섬 오류입니다. 설정을 다시 확인하는 것이 좋습니다.</translation>
     </message>
     <message>
         <location filename="../firmwares/edgetx/edgetxinterface.cpp" line="172"/>
         <source>Companion does not support settings version %1!</source>
-        <translation></translation>
+        <translation>Companion은 설정 버전 %1을(를) 지원하지 않습니다!</translation>
     </message>
 </context>
 <context>
@@ -2976,12 +3015,12 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
     <message>
         <location filename="../storage/eepe.cpp" line="32"/>
         <source>Unable to open %1: %2</source>
-        <translation></translation>
+        <translation>%1을(를) 열 수 없습니다: %2</translation>
     </message>
     <message>
         <location filename="../storage/eepe.cpp" line="48"/>
         <source>Invalid EEPROM file %1</source>
-        <translation></translation>
+        <translation>잘못된 EEPROM 파일: %1</translation>
     </message>
 </context>
 <context>
@@ -2989,12 +3028,12 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
     <message>
         <location filename="../wizarddialog.cpp" line="634"/>
         <source>&lt;br&gt;First Elevon Channel:</source>
-        <translation></translation>
+        <translation>&lt;br&gt;첫 번째 Elevon 채널:</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="636"/>
         <source>Second Elevon Channel:</source>
-        <translation></translation>
+        <translation>두 번째 Elevon 채널:</translation>
     </message>
 </context>
 <context>
@@ -3003,39 +3042,39 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
         <location filename="../storage/etx.cpp" line="32"/>
         <source>Error opening file %1:
 %2.</source>
-        <translation></translation>
+        <translation>파일 %1을(를) 여는 중 오류 발생: %2</translation>
     </message>
     <message>
         <location filename="../storage/etx.cpp" line="43"/>
         <source>Error opening EdgeTX archive %1</source>
-        <translation></translation>
+        <translation>EdgeTX 아카이브 %1을(를) 여는 중 오류 발생</translation>
     </message>
     <message>
         <location filename="../storage/etx.cpp" line="58"/>
         <source>Error initializing EdgeTX archive writer</source>
-        <translation></translation>
+        <translation>EdgeTX 아카이브 쓰기 초기화 오류</translation>
     </message>
     <message>
         <location filename="../storage/etx.cpp" line="74"/>
         <source>Error writing file %1:
 %2.</source>
-        <translation></translation>
+        <translation>파일 %1 쓰기 오류: %2</translation>
     </message>
     <message>
         <location filename="../storage/etx.cpp" line="79"/>
         <source>Error creating EdgeTX file %1:
 %2.</source>
-        <translation></translation>
+        <translation>EdgeTX 파일 %1 생성 오류: %2</translation>
     </message>
     <message>
         <location filename="../storage/etx.cpp" line="84"/>
         <source>Error creating EdgeTX archive</source>
-        <translation></translation>
+        <translation>EdgeTX 아카이브 생성 오류</translation>
     </message>
     <message>
         <location filename="../storage/etx.cpp" line="111"/>
         <source>Error adding %1 to EdgeTX archive</source>
-        <translation></translation>
+        <translation>%1을(를) EdgeTX 아카이브에 추가하는 중 오류 발생</translation>
     </message>
 </context>
 <context>
@@ -3043,7 +3082,7 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
     <message>
         <location filename="../firmwares/input_data.cpp" line="29"/>
         <source>INP</source>
-        <translation></translation>
+        <translation>입력</translation>
     </message>
     <message>
         <location filename="../firmwares/input_data.cpp" line="30"/>
@@ -3054,12 +3093,12 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
         <location filename="../firmwares/input_data.cpp" line="43"/>
         <location filename="../firmwares/input_data.cpp" line="48"/>
         <source>OFF</source>
-        <translation></translation>
+        <translation>끔</translation>
     </message>
     <message>
         <location filename="../firmwares/input_data.cpp" line="46"/>
         <source>ON</source>
-        <translation></translation>
+        <translation>켬</translation>
     </message>
 </context>
 <context>
@@ -3067,67 +3106,67 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
     <message>
         <location filename="../modeledit/expodialog.ui" line="79"/>
         <source>Input name</source>
-        <translation></translation>
+        <translation>입력 이름</translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="45"/>
         <source>Weight</source>
-        <translation></translation>
+        <translation>가중치</translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="114"/>
         <source>Switch</source>
-        <translation></translation>
+        <translation>스위치</translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="93"/>
         <source>Stick Side</source>
-        <translation></translation>
+        <translation>조이스틱 방향</translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="507"/>
         <source>NEG</source>
-        <translation></translation>
+        <translation>음수</translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="512"/>
         <source>POS</source>
-        <translation></translation>
+        <translation>양수</translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="517"/>
         <source>ALL</source>
-        <translation></translation>
+        <translation>전체</translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="136"/>
         <source>unit</source>
-        <translation></translation>
+        <translation>단위</translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="65"/>
         <source>Scale</source>
-        <translation></translation>
+        <translation>스케일</translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="405"/>
         <source>image</source>
-        <translation></translation>
+        <translation>이미지</translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="58"/>
         <source>Include Trim</source>
-        <translation></translation>
+        <translation>트림 포함</translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="100"/>
         <source>Curve</source>
-        <translation></translation>
+        <translation>커브</translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="366"/>
         <source>Curve applied to the source.</source>
-        <translation></translation>
+        <translation>소스에 적용된 커브입니다.</translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="38"/>
@@ -3135,52 +3174,52 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
         <location filename="../modeledit/expodialog.ui" line="373"/>
         <location filename="../modeledit/expodialog.ui" line="429"/>
         <source>Source</source>
-        <translation></translation>
+        <translation>소스</translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="72"/>
         <source>Line name</source>
-        <translation></translation>
+        <translation>라인 이름</translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="86"/>
         <source>Modes</source>
-        <translation type="unfinished"></translation>
+        <translation>모드</translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="107"/>
         <source>Offset</source>
-        <translation></translation>
+        <translation>오프셋</translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.ui" line="451"/>
         <source>The source for the mixer</source>
-        <translation></translation>
+        <translation>믹서에 사용할 소스</translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.cpp" line="52"/>
         <source>Edit %1</source>
-        <translation></translation>
+        <translation>%1 편집</translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.cpp" line="95"/>
         <source>Popup menu available</source>
-        <translation></translation>
+        <translation>팝업 메뉴 사용 가능</translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.cpp" line="255"/>
         <source>Clear All</source>
-        <translation></translation>
+        <translation>모두 초기화</translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.cpp" line="256"/>
         <source>Set All</source>
-        <translation></translation>
+        <translation>모두 설정</translation>
     </message>
     <message>
         <location filename="../modeledit/expodialog.cpp" line="257"/>
         <source>Invert All</source>
-        <translation></translation>
+        <translation>모두 반전</translation>
     </message>
 </context>
 <context>
@@ -3188,22 +3227,22 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
     <message>
         <location filename="../wizarddialog.cpp" line="853"/>
         <source>Throttle Channel:</source>
-        <translation></translation>
+        <translation>스로틀 채널:</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="855"/>
         <source>Yaw Channel:</source>
-        <translation></translation>
+        <translation>요우 채널:</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="857"/>
         <source>Pitch Channel:</source>
-        <translation></translation>
+        <translation>피치 채널:</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="859"/>
         <source>Roll Channel:</source>
-        <translation></translation>
+        <translation>롤 채널:</translation>
     </message>
 </context>
 <context>
@@ -3211,209 +3250,214 @@ To &lt;b&gt;remove a remembered entry&lt;/b&gt; from the filter  list, first cho
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="51"/>
         <source>Synchronize Files</source>
-        <translation></translation>
+        <translation>파일 동기화</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="65"/>
         <source>Are you sure you wish to abort the sync?</source>
-        <translation></translation>
+        <translation>정말로 동기화를 중단하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="127"/>
         <source>Folder A</source>
-        <translation></translation>
+        <translation>폴더 A</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="128"/>
         <source>Folder B</source>
-        <translation></translation>
+        <translation>폴더 B</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="151"/>
         <source>How to handle overwriting files which already exist in the destination folder.</source>
-        <translation></translation>
+        <translation>대상 폴더에 이미 존재하는 파일을 덮어쓸지 여부를 설정합니다.</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="152"/>
         <source>Copy only if newer and different (compare contents)</source>
-        <translation></translation>
+        <translation>새롭고 내용이 다를 경우에만 복사 (내용 비교)</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="153"/>
         <source>Copy only if newer (do not compare contents)</source>
-        <translation></translation>
+        <translation>더 최신일 경우에만 복사 (내용 비교 안 함)</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="154"/>
         <source>Copy only if different (ignore file time stamps)</source>
-        <translation></translation>
+        <translation>내용이 다를 경우에만 복사 (타임스탬프 무시)</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="155"/>
         <source>Always copy (force overwite existing files)</source>
-        <translation></translation>
+        <translation>항상 복사 (기존 파일 덮어쓰기 강제 수행)</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="161"/>
         <source>Any size</source>
-        <translation></translation>
+        <translation>모든 크기</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="162"/>
         <source>Skip files larger than this size. Enter zero for unlimited.</source>
-        <translation></translation>
+        <translation>이 크기보다 큰 파일은 건너뜁니다. 무제한은 0을 입력하세요.</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="167"/>
         <source>Minimum reporting level. Events of this type and of higher importance are shown.
 WARNING: High log rates may make the user interface temporarily unresponsive.</source>
-        <translation></translation>
+        <translation>최소 보고 수준. 이 수준 이상의 중요도를 가진 이벤트만 표시됩니다.
+경고: 로그 발생률이 높을 경우 UI가 일시적으로 반응하지 않을 수 있습니다.</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="169"/>
         <source>Skipped</source>
-        <translation></translation>
+        <translation>건너뜀</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="170"/>
         <source>Created</source>
-        <translation></translation>
+        <translation>생성됨</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="171"/>
         <source>Updated</source>
-        <translation></translation>
+        <translation>업데이트됨</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="173"/>
         <source>Errors Only</source>
-        <translation></translation>
+        <translation>오류만</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="176"/>
         <source>Test-run only</source>
-        <translation></translation>
+        <translation>테스트 실행만</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="177"/>
         <source>Run as normal but do not actually copy anything. Useful for verifying results before real sync.</source>
-        <translation></translation>
+        <translation>정상 실행하되 실제 복사는 하지 않습니다. 실제 동기화 전에 결과를 확인할 때 유용합니다.</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="183"/>
         <source>Log Level:</source>
-        <translation></translation>
+        <translation>로그 수준:</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="188"/>
         <source>Filters:</source>
-        <translation></translation>
+        <translation>필터:</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="189"/>
         <source>The &quot;Include&quot; filter will only copy files which match the pattern(s).
 The &quot;Exclude&quot; filter will skip files matching the filter pattern(s).
 The Include filter is evaluated first.</source>
-        <translation></translation>
+        <translation>&quot;포함&quot; 필터는 패턴과 일치하는 파일만 복사합니다.
+&quot;제외&quot; 필터는 해당 패턴과 일치하는 파일을 건너뜁니다.
+포함 필터가 먼저 평가됩니다.</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="195"/>
         <source>One or more file pattern(s) to exclude, separated by commas.
 Blank means exclude none. ?, *, and [...] wildcards accepted.</source>
-        <translation></translation>
+        <translation>제외할 파일 패턴을 쉼표로 구분하여 입력하세요.
+비워두면 아무것도 제외하지 않습니다. ?, *, [...] 와일드카드를 사용할 수 있습니다.</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="199"/>
         <source>One or more file pattern(s) to include, separated by commas.
 Blank means include all. ?, *, and [...] wildcards accepted.</source>
-        <translation></translation>
+        <translation>포함할 파일 패턴을 쉼표로 구분하여 입력하세요.
+비워두면 모든 파일이 포함됩니다. ?, *, [...] 와일드카드를 사용할 수 있습니다.</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="203"/>
         <source>Include:</source>
-        <translation></translation>
+        <translation>포함:</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="205"/>
         <source>Exclude:</source>
-        <translation></translation>
+        <translation>제외:</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="210"/>
         <source>Case sensitive</source>
-        <translation></translation>
+        <translation>대소문자 구분</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="211"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="217"/>
         <source>Follow links</source>
-        <translation></translation>
+        <translation>링크 따라가기</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="212"/>
         <source>Include hidden</source>
-        <translation></translation>
+        <translation>숨김 파일 포함</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="216"/>
         <source>Recursive</source>
-        <translation></translation>
+        <translation>하위 폴더 포함</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="218"/>
         <source>Skip empty</source>
-        <translation></translation>
+        <translation>빈 파일 건너뛰기</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="219"/>
         <source>Apply filters</source>
-        <translation></translation>
+        <translation>필터 적용</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="229"/>
         <source>Filter Options:</source>
-        <translation></translation>
+        <translation>필터 옵션:</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="231"/>
         <source>Folder Options:</source>
-        <translation></translation>
+        <translation>폴더 옵션:</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="243"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="272"/>
         <source>Options</source>
-        <translation></translation>
+        <translation>옵션</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="244"/>
         <source>Show extra options</source>
-        <translation></translation>
+        <translation>추가 옵션 표시</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="247"/>
         <source>Reset to defaults</source>
-        <translation></translation>
+        <translation>기본값으로 재설정</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="262"/>
         <source>Close</source>
-        <translation></translation>
+        <translation>닫기</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="279"/>
         <source>Sync. Direction:</source>
-        <translation></translation>
+        <translation>동기화 방향:</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="281"/>
         <source>Existing Files:</source>
-        <translation></translation>
+        <translation>기존 파일:</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="283"/>
         <source>Max. File Size:</source>
-        <translation></translation>
+        <translation>최대 파일 크기:</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="324"/>
@@ -3428,45 +3472,45 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Abort</source>
-        <translation></translation>
+        <translation>중단</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="427"/>
         <source>Start</source>
-        <translation></translation>
+        <translation>시작</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="438"/>
         <source>Total: &lt;b&gt;%1&lt;/b&gt;; Created: &lt;b&gt;%2&lt;/b&gt;; Updated: &lt;b&gt;%3&lt;/b&gt;; Skipped: &lt;b&gt;%4&lt;/b&gt;; Errors: &lt;font color=%6&gt;&lt;b&gt;%5&lt;/b&gt;&lt;/font&gt;;</source>
-        <translation></translation>
+        <translation>총: &lt;b&gt;%1&lt;/b&gt;; 생성됨: &lt;b&gt;%2&lt;/b&gt;; 업데이트됨: &lt;b&gt;%3&lt;/b&gt;; 건너뜀: &lt;b&gt;%4&lt;/b&gt;; 오류: &lt;font color=%6&gt;&lt;b&gt;%5&lt;/b&gt;&lt;/font&gt;;</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="439"/>
         <source>Current: &lt;b&gt;%1&lt;/b&gt; of </source>
-        <translation></translation>
+        <translation>현재: &lt;b&gt;%1&lt;/b&gt; / </translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="490"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="492"/>
         <source>%1 not found.</source>
-        <translation></translation>
+        <translation>%1을(를) 찾을 수 없습니다.</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="494"/>
         <source>Folders are the same.</source>
-        <translation></translation>
+        <translation>두 폴더는 동일합니다.</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="512"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="513"/>
         <source>%1%2 Both directions, to %3 first</source>
-        <translation></translation>
+        <translation>%1%2 양방향 동기화, 먼저 %3으로</translation>
     </message>
     <message>
         <location filename="../dialogs/filesyncdialog.cpp" line="514"/>
         <location filename="../dialogs/filesyncdialog.cpp" line="515"/>
         <source> %1  Only from %2 to %3</source>
-        <translation></translation>
+        <translation> %1  %2에서 %3으로만</translation>
     </message>
 </context>
 <context>
@@ -3474,22 +3518,22 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="409"/>
         <source>No OverrideCH functions available</source>
-        <translation></translation>
+        <translation>OverrideCH 기능을 사용할 수 없습니다</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="405"/>
         <source>Possibility to enable FAI MODE (no telemetry) at field</source>
-        <translation></translation>
+        <translation>현장에서 FAI 모드(텔레메트리 없음)를 활성화할 수 있습니다</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="406"/>
         <source>FAI MODE (no telemetry) always enabled</source>
-        <translation></translation>
+        <translation>FAI 모드(텔레메트리 없음)가 항상 활성화됩니다</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="422"/>
         <source>Removes D8 FrSky protocol support which is not legal for use in the EU on radios sold after Jan 1st, 2015</source>
-        <translation></translation>
+        <translation>2015년 1월 1일 이후 판매된 송신기에서 EU 내에서 합법적이지 않은 D8 FrSky 프로토콜 지원을 제거합니다</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="448"/>
@@ -3508,7 +3552,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="782"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="807"/>
         <source>Disable HELI menu and cyclic mix support</source>
-        <translation></translation>
+        <translation>HELI 메뉴 및 cyclic 믹스 지원 비활성화</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="449"/>
@@ -3528,7 +3572,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="783"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
         <source>Disable Global variables</source>
-        <translation></translation>
+        <translation>글로벌 변수 비활성화</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="450"/>
@@ -3548,12 +3592,12 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="784"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="809"/>
         <source>Enable Lua custom scripts screen</source>
-        <translation></translation>
+        <translation>Lua 사용자 스크립트 화면 활성화</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="442"/>
         <source>Use alternative SQT5 font</source>
-        <translation></translation>
+        <translation>대체 SQT5 글꼴 사용</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
@@ -3563,18 +3607,18 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="423"/>
         <source>Enable non certified firmwares</source>
-        <translation></translation>
+        <translation>인증되지 않은 펌웨어 허용</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="425"/>
         <source>Enable AFHDS3 support</source>
-        <translation></translation>
+        <translation>AFHDS3 지원 활성화</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
         <source>Disable RAS (SWR)</source>
-        <translation></translation>
+        <translation>RAS(SWR) 비활성화</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
@@ -3589,7 +3633,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="576"/>
         <source>Haptic module installed</source>
-        <translation></translation>
+        <translation>햅틱 모듈이 설치되어 있음</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="595"/>
@@ -3599,12 +3643,12 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
         <source>Confirmation before radio shutdown</source>
-        <translation></translation>
+        <translation>조종기 종료 전 확인 메시지 표시</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="597"/>
         <source>Horus gimbals installed (Hall sensors)</source>
-        <translation></translation>
+        <translation>Horus 짐벌이 설치됨 (홀 센서 사용)</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="562"/>
@@ -3644,7 +3688,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="532"/>
         <source>Use ONLY with first DEV pcb version</source>
-        <translation></translation>
+        <translation>최초 DEV PCB 버전에서만 사용하십시오</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
@@ -3655,7 +3699,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="675"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="703"/>
         <source>Support for MULTI internal module</source>
-        <translation></translation>
+        <translation>MULTI 내장 모듈 지원</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
@@ -3675,7 +3719,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="466"/>
         <source>Support for bluetooth module</source>
-        <translation></translation>
+        <translation>블루투스 모듈 지원</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
@@ -3699,47 +3743,47 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="725"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="810"/>
         <source>Select if internal ELRS module is installed</source>
-        <translation></translation>
+        <translation>내장 ELRS 모듈이 설치된 경우 선택</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="509"/>
         <source>FlySky PL18EV</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
         <source>HelloRadioSky V16</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
         <source>Jumper T-Pro V2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
         <source>Jumper T-Pro S</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
         <source>Jumper Bumblebee</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
         <source>Jumper T12 MAX</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
         <source>Jumper T14</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
         <source>Jumper T15</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
@@ -3749,7 +3793,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
         <source>Jumper T20 V2</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
@@ -3764,7 +3808,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
         <source>Radiomaster MT12</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
@@ -3774,12 +3818,12 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="767"/>
         <source>Allow bind using bind key</source>
-        <translation></translation>
+        <translation>Bind 키를 사용하여 바인딩 허용</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
         <source>Radiomaster GX12</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
@@ -3789,13 +3833,13 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="467"/>
         <source>Support internal GPS</source>
-        <translation></translation>
+        <translation>내장 GPS 지원</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="484"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="801"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
-        <translation></translation>
+        <translation>하드웨어 개조 지원: FlySky Paladin EV 짐벌</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="709"/>
@@ -3820,12 +3864,12 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="424"/>
         <source>Enable AFHDS2A support</source>
-        <translation></translation>
+        <translation>AFHDS2A 지원 활성화</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="480"/>
         <source>Fatfish F16</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="495"/>
@@ -3851,7 +3895,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="518"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="531"/>
         <source>Support for ACCESS internal module replacement</source>
-        <translation></translation>
+        <translation>ACCESS 내장 모듈 교체 지원</translation>
     </message>
 </context>
 <context>
@@ -3859,27 +3903,27 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../wizarddialog.cpp" line="501"/>
         <source>No</source>
-        <translation>No</translation>
+        <translation>아니오</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="502"/>
         <source>Yes, controlled by a single channel</source>
-        <translation></translation>
+        <translation>예, 하나의 채널로 제어</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="503"/>
         <source>Yes, controlled by two channels</source>
-        <translation></translation>
+        <translation>예, 두 개의 채널로 제어</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="515"/>
         <source>&lt;br&gt;First Flap Channel:</source>
-        <translation></translation>
+        <translation>&lt;br&gt;첫 번째 플랩 채널:</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="517"/>
         <source>Second Flap Channel:</source>
-        <translation></translation>
+        <translation>두 번째 플랩 채널:</translation>
     </message>
 </context>
 <context>
@@ -3887,153 +3931,153 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="26"/>
         <source>Flash Firmware</source>
-        <translation></translation>
+        <translation>펌웨어 플래시</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="66"/>
         <source>Load...</source>
-        <translation></translation>
+        <translation>불러오기...</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="90"/>
         <source>Date &amp; Time</source>
-        <translation></translation>
+        <translation>날짜 및 시간</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="104"/>
         <source>Variant</source>
-        <translation></translation>
+        <translation>변형</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="118"/>
         <source>Version</source>
-        <translation></translation>
+        <translation>버전</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="152"/>
         <source>Use profile start screen</source>
-        <translation></translation>
+        <translation>프로필 시작 화면 사용</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="159"/>
         <source>Use firmware start screen</source>
-        <translation></translation>
+        <translation>펌웨어 시작 화면 사용</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="166"/>
         <source>Use library start screen</source>
-        <translation></translation>
+        <translation>라이브러리 시작 화면 사용</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="173"/>
         <source>Use another start screen</source>
-        <translation></translation>
+        <translation>다른 시작 화면 사용</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="228"/>
         <source>Allows Companion to write to older version of the firmware</source>
-        <translation></translation>
+        <translation>Companion이 구버전 펌웨어에 쓰기를 허용</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="231"/>
         <source>Check Hardware compatibility</source>
-        <translation></translation>
+        <translation>하드웨어 호환성 확인</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="241"/>
         <source>Backup and restore Models and Settings</source>
-        <translation></translation>
+        <translation>모델 및 설정 백업 및 복원</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="285"/>
         <source>Cancel</source>
-        <translation></translation>
+        <translation>취소</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.ui" line="301"/>
         <source>Write to TX</source>
-        <translation></translation>
+        <translation>TX에 쓰기</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="141"/>
         <source>Open Firmware File</source>
-        <translation></translation>
+        <translation>펌웨어 파일 열기</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="145"/>
         <source>%1 may not be a valid firmware file</source>
-        <translation></translation>
+        <translation>%1 은(는) 유효한 펌웨어 파일이 아닐 수 있습니다</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="155"/>
         <source>The firmware file is not valid.</source>
-        <translation></translation>
+        <translation>펌웨어 파일이 유효하지 않습니다.</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="158"/>
         <source>There is no start screen image in the firmware file.</source>
-        <translation></translation>
+        <translation>펌웨어 파일에 시작 화면 이미지가 없습니다.</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="172"/>
         <source>Profile image %1 is invalid.</source>
-        <translation></translation>
+        <translation>프로필 이미지 %1 이(가) 유효하지 않습니다.</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Open image file to use as radio start screen</source>
-        <translation></translation>
+        <translation>조종기 시작 화면으로 사용할 이미지 파일 열기</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="187"/>
         <source>Images (%1)</source>
-        <translation></translation>
+        <translation>이미지 (%1)</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="192"/>
         <source>Image could not be loaded from %1</source>
-        <translation></translation>
+        <translation>%1 에서 이미지를 불러올 수 없습니다</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="210"/>
         <source>The library image could not be loaded</source>
-        <translation></translation>
+        <translation>라이브러리 이미지를 불러올 수 없습니다</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="235"/>
         <source>Splash image not found</source>
-        <translation></translation>
+        <translation>시작 화면 이미지가 없습니다</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="248"/>
         <source>Cannot save customized firmware</source>
-        <translation></translation>
+        <translation>사용자 정의 펌웨어를 저장할 수 없습니다</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="274"/>
         <source>Write Firmware to Radio</source>
-        <translation></translation>
+        <translation>펌웨어를 조종기에 쓰기</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="281"/>
         <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>Firmware check failed</source>
-        <translation></translation>
+        <translation>펌웨어 확인 실패</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="281"/>
         <source>Could not check firmware from radio</source>
-        <translation></translation>
+        <translation>조종기에서 펌웨어를 확인할 수 없습니다</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="289"/>
         <source>New firmware is not compatible with the one currently installed!</source>
-        <translation></translation>
+        <translation>새 펌웨어가 현재 설치된 버전과 호환되지 않습니다!</translation>
     </message>
     <message>
         <location filename="../flashfirmwaredialog.cpp" line="330"/>
         <source>Flashing done</source>
-        <translation></translation>
+        <translation>펌웨어 플래시 완료</translation>
     </message>
 </context>
 <context>
@@ -4041,83 +4085,89 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../process_flash.cpp" line="70"/>
         <source>Executable %1 not found</source>
-        <translation></translation>
+        <translation>실행 파일 %1 을(를) 찾을 수 없습니다</translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="215"/>
         <source>Writing...</source>
-        <translation></translation>
+        <translation>쓰기 중...</translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="220"/>
         <source>Reading...</source>
-        <translation></translation>
+        <translation>읽기 중...</translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="224"/>
         <source>Verifying...</source>
-        <translation></translation>
+        <translation>검증 중...</translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="262"/>
         <source>unknown</source>
-        <translation></translation>
+        <translation>알 수 없음</translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="269"/>
         <source>ie: OpenTX for 9X board or OpenTX for 9XR board</source>
-        <translation></translation>
+        <translation>예: 9X 보드용 OpenTX 또는 9XR 보드용 OpenTX</translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="274"/>
         <source>ie: OpenTX for M128 / 9X board or OpenTX for 9XR board with M128 chip</source>
-        <translation></translation>
+        <translation>예: M128 / 9X 보드용 OpenTX 또는 M128 칩이 있는 9XR 보드용 OpenTX</translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="285"/>
         <source>ie: OpenTX for Gruvin9X  board</source>
-        <translation></translation>
+        <translation>예: Gruvin9X 보드용 OpenTX</translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="293"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please check advanced burn options to set the correct cpu type.</source>
-        <translation></translation>
+        <translation>사용 중인 송신기는 %1 CPU를 사용합니다!!!
+
+올바른 CPU 유형을 설정하려면 고급 burn 옵션을 확인하세요.</translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="297"/>
         <source>Your radio uses a %1 CPU!!!
 
 Please select an appropriate firmware type to program it.</source>
-        <translation></translation>
+        <translation>사용 중인 송신기는 %1 CPU를 사용합니다!!!
+
+해당되는 펌웨어 유형을 선택하여 프로그래밍하세요.</translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="297"/>
         <source>
 You are currently using:
  %1</source>
-        <translation></translation>
+        <translation>
+현재 사용 중인 항목:
+%1</translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="301"/>
         <source>Your radio does not seem connected to USB or the driver is not initialized!!!.</source>
-        <translation></translation>
+        <translation>송신기가 USB에 연결되지 않았거나 드라이버가 초기화되지 않은 것 같습니다!!!</translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="312"/>
         <source>Flashing done (exit code = %1)</source>
-        <translation></translation>
+        <translation>플래시 완료 (종료 코드 = %1)</translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="318"/>
         <source>Flashing done with errors</source>
-        <translation></translation>
+        <translation>플래시 완료 – 오류 발생</translation>
     </message>
     <message>
         <location filename="../process_flash.cpp" line="331"/>
         <source>FUSES: Low=%1 High=%2 Ext=%3</source>
-        <translation></translation>
+        <translation>퓨즈 설정: Low=%1 High=%2 Ext=%3</translation>
     </message>
 </context>
 <context>
@@ -4125,7 +4175,7 @@ You are currently using:
     <message>
         <location filename="../datamodels/compounditemmodels.cpp" line="636"/>
         <source>None</source>
-        <translation></translation>
+        <translation>없음</translation>
     </message>
 </context>
 <context>
@@ -4133,42 +4183,42 @@ You are currently using:
     <message>
         <location filename="../modeledit/flightmode.ui" line="22"/>
         <source>Fade In</source>
-        <translation></translation>
+        <translation>페이드 인</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmode.ui" line="43"/>
         <source>Fade Out</source>
-        <translation></translation>
+        <translation>페이드 아웃</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmode.ui" line="57"/>
         <source>Name</source>
-        <translation></translation>
+        <translation>이름</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmode.ui" line="77"/>
         <source>Switch</source>
-        <translation></translation>
+        <translation>스위치</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmode.ui" line="444"/>
         <source>trim6</source>
-        <translation></translation>
+        <translation>트림6</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmode.ui" line="510"/>
         <source>trim8</source>
-        <translation></translation>
+        <translation>트림8</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmode.ui" line="589"/>
         <source>trim5</source>
-        <translation></translation>
+        <translation>트림5</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmode.ui" line="655"/>
         <source>trim7</source>
-        <translation></translation>
+        <translation>트림7</translation>
     </message>
 </context>
 <context>
@@ -4181,7 +4231,7 @@ You are currently using:
     <message>
         <location filename="../firmwares/flightmodedata.cpp" line="46"/>
         <source>DM</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -4189,68 +4239,68 @@ You are currently using:
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="155"/>
         <source>Rotary Encoder %1</source>
-        <translation></translation>
+        <translation>로터리 엔코더 %1</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="187"/>
         <source>Name</source>
-        <translation></translation>
+        <translation>이름</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="193"/>
         <source>Value source</source>
-        <translation></translation>
+        <translation>값 소스</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="198"/>
         <source>Value</source>
-        <translation></translation>
+        <translation>값</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="219"/>
         <source>Popup enabled</source>
-        <translation></translation>
+        <translation>팝업 사용</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="41"/>
         <location filename="../modeledit/flightmodes.cpp" line="230"/>
         <source>Popup menu available</source>
-        <translation></translation>
+        <translation>팝업 메뉴 사용 가능</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="115"/>
         <source>Trim disabled</source>
-        <translation></translation>
+        <translation>트림 비활성화</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="116"/>
         <source>3POS toggle switch</source>
-        <translation></translation>
+        <translation>3단 토글 스위치</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="120"/>
         <source>Own Trim</source>
-        <translation></translation>
+        <translation>고유 트림</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="203"/>
         <source>Unit</source>
-        <translation></translation>
+        <translation>단위</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="207"/>
         <source>Prec</source>
-        <translation></translation>
+        <translation>정밀도</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="211"/>
         <source>Min</source>
-        <translation></translation>
+        <translation>최소값</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="215"/>
         <source>Max</source>
-        <translation></translation>
+        <translation>최대값</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="402"/>
@@ -4265,151 +4315,151 @@ You are currently using:
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="123"/>
         <source>Use Trim from %1 Mode %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 모드 %2의 트림 사용</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="125"/>
         <source>Use Trim from %1 Mode %2 + Own Trim as an offset</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 모드 %2의 트림 + 고유 트림을 오프셋으로 사용</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="227"/>
         <source>GV%1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="356"/>
         <source>Own value</source>
-        <translation type="unfinished"></translation>
+        <translation>고유 값</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="359"/>
         <source>%1 Mode %2 value</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 모드 %2 값</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="512"/>
         <source>Warning: Global variable links back to itself. %1 Mode 0 value used.</source>
-        <translation type="unfinished"></translation>
+        <translation>경고: 전역 변수가 자기 자신을 참조합니다. %1 모드 0 값이 사용됩니다.</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="621"/>
         <source>Warning: Rotary encoder links back to itself. %1 Mode 0 value used.</source>
-        <translation type="unfinished"></translation>
+        <translation>경고: 로터리 엔코더가 자기 자신을 참조합니다. %1 모드 0 값이 사용됩니다.</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="695"/>
         <location filename="../modeledit/flightmodes.cpp" line="1076"/>
         <source>Copy</source>
-        <translation></translation>
+        <translation>복사</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="696"/>
         <location filename="../modeledit/flightmodes.cpp" line="1077"/>
         <source>Cut</source>
-        <translation></translation>
+        <translation>잘라내기</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="697"/>
         <location filename="../modeledit/flightmodes.cpp" line="1078"/>
         <source>Paste</source>
-        <translation></translation>
+        <translation>붙여넣기</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="700"/>
         <location filename="../modeledit/flightmodes.cpp" line="1081"/>
         <source>Insert</source>
-        <translation></translation>
+        <translation>삽입</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="701"/>
         <location filename="../modeledit/flightmodes.cpp" line="1082"/>
         <source>Delete</source>
-        <translation></translation>
+        <translation>삭제</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="702"/>
         <location filename="../modeledit/flightmodes.cpp" line="1083"/>
         <source>Move Up</source>
-        <translation></translation>
+        <translation>위로 이동</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="703"/>
         <location filename="../modeledit/flightmodes.cpp" line="1084"/>
         <source>Move Down</source>
-        <translation></translation>
+        <translation>아래로 이동</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="705"/>
         <location filename="../modeledit/flightmodes.cpp" line="1086"/>
         <source>Clear All</source>
-        <translation></translation>
+        <translation>모두 초기화</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="740"/>
         <source>Clear %1 Mode. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 모드를 초기화하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="777"/>
         <source>Clear all %1 Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation>모든 %1 모드를 초기화하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="812"/>
         <source>Cut %1 Mode. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 모드를 잘라내시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="820"/>
         <source>Delete %1 Mode. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 모드를 삭제하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="1176"/>
         <source>Clear Global Variable across all %1 Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation>모든 %1 모드에서 전역 변수를 초기화하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="1200"/>
         <source>Clear all Global Variables for all %1 Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation>모든 %1 모드의 전역 변수를 전부 초기화하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="1211"/>
         <source>Clear all Global Variables for this %1 Mode. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation>이 %1 모드의 모든 전역 변수를 초기화하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="1263"/>
         <source>Cut Global Variable across all %1 Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation>모든 %1 모드에서 전역 변수를 잘라내시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="1341"/>
         <source>Paste to selected Global Variable across all %1 Modes. Are you sure?</source>
-        <translation type="unfinished"></translation>
+        <translation>선택한 전역 변수에 모든 %1 모드에 붙여넣으시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="1187"/>
         <source>Clear Global Variable. Are you sure?</source>
-        <translation></translation>
+        <translation>전역 변수를 초기화하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="1267"/>
         <source>Cut Global Variable. Are you sure?</source>
-        <translation></translation>
+        <translation>전역 변수를 잘라내시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="1280"/>
         <source>Delete Global Variable. Are you sure?</source>
-        <translation></translation>
+        <translation>전역 변수를 삭제하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="698"/>
         <location filename="../modeledit/flightmodes.cpp" line="1079"/>
         <source>Clear</source>
-        <translation></translation>
+        <translation>초기화</translation>
     </message>
 </context>
 <context>
@@ -4417,7 +4467,7 @@ You are currently using:
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="1462"/>
         <source>%1 Mode %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 모드 %2</translation>
     </message>
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="1465"/>
@@ -4427,7 +4477,7 @@ You are currently using:
     <message>
         <location filename="../modeledit/flightmodes.cpp" line="1468"/>
         <source> (default)</source>
-        <translation></translation>
+        <translation> (기본값)</translation>
     </message>
 </context>
 <context>
@@ -4435,17 +4485,17 @@ You are currently using:
     <message>
         <location filename="../wizarddialog.cpp" line="378"/>
         <source>Has Flybar</source>
-        <translation></translation>
+        <translation>플라이바 있음</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="380"/>
         <source>Flybarless</source>
-        <translation></translation>
+        <translation>플라이바 없음</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="383"/>
         <source>Flybar:</source>
-        <translation></translation>
+        <translation>플라이바:</translation>
     </message>
 </context>
 <context>
@@ -4453,17 +4503,17 @@ You are currently using:
     <message>
         <location filename="../firmwares/telem_data.h" line="44"/>
         <source>Yellow</source>
-        <translation></translation>
+        <translation>노랑</translation>
     </message>
     <message>
         <location filename="../firmwares/telem_data.h" line="46"/>
         <source>Orange</source>
-        <translation></translation>
+        <translation>주황</translation>
     </message>
     <message>
         <location filename="../firmwares/telem_data.h" line="48"/>
         <source>Red</source>
-        <translation></translation>
+        <translation>빨강</translation>
     </message>
 </context>
 <context>
@@ -4485,43 +4535,43 @@ You are currently using:
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="14"/>
         <source>Form</source>
-        <translation></translation>
+        <translation>폼</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="47"/>
         <source>Customizable Switches</source>
-        <translation></translation>
+        <translation>사용자 설정 가능한 스위치</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="76"/>
         <source>Type</source>
-        <translation></translation>
+        <translation>종류</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="69"/>
         <source>Name</source>
-        <translation></translation>
+        <translation>이름</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="83"/>
         <location filename="../modeledit/setup_function_switches.ui" line="157"/>
         <source>Start</source>
-        <translation></translation>
+        <translation>시작</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="96"/>
         <source>Group</source>
-        <translation></translation>
+        <translation>그룹</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="128"/>
         <source>Switch Groups</source>
-        <translation type="unfinished"></translation>
+        <translation>스위치 그룹</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.ui" line="150"/>
         <source>Always On</source>
-        <translation></translation>
+        <translation>항상 켜짐</translation>
     </message>
 </context>
 <context>
@@ -4529,12 +4579,12 @@ You are currently using:
     <message>
         <location filename="../modeledit/setup_function_switches.cpp" line="75"/>
         <source>SW%1</source>
-        <translation></translation>
+        <translation>스위치 %1</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_function_switches.cpp" line="119"/>
         <source>Group %1</source>
-        <translation type="unfinished"></translation>
+        <translation>그룹 %1</translation>
     </message>
 </context>
 <context>
@@ -4542,7 +4592,7 @@ You are currently using:
     <message>
         <location filename="../fusesdialog.ui" line="14"/>
         <source>Fuses</source>
-        <translation></translation>
+        <translation>퓨즈</translation>
     </message>
     <message>
         <location filename="../fusesdialog.ui" line="20"/>
@@ -4559,12 +4609,25 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;Proper states for AtMega 2560 :&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;EEPROM erase fuse not set: D7, 11, FC&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;EEPROM erase fuse set: D7, 19, FC&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;현재 AVR 컨트롤러의 퓨즈 값을 읽어옵니다.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;AtMega64의 올바른 상태:&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;EEPROM 삭제 퓨즈 설정되지 않음: 0E, 81, FF&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;EEPROM 삭제 퓨즈 설정됨: 0E, 89, FF&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;AtMega2560의 올바른 상태:&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;EEPROM 삭제 퓨즈 설정되지 않음: D7, 11, FC&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;EEPROM 삭제 퓨즈 설정됨: D7, 19, FC&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+</translation>
     </message>
     <message>
         <location filename="../fusesdialog.ui" line="35"/>
         <source>Read Fuses</source>
-        <translation></translation>
+        <translation>퓨즈 읽기</translation>
     </message>
     <message>
         <location filename="../fusesdialog.ui" line="42"/>
@@ -4583,13 +4646,30 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;When in doubt consult either the project&apos;s page or the 9xforum (http://9xforums.com/forum/)&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;If you do get locked out - google lookup for &amp;quot;dealing with Fuse Bricks&amp;quot;.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt; font-weight:600; text-decoration: underline;&quot;&gt;퓨즈 초기화&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;AVR의 퓨즈는 동작 방식을 설정하는 역할을 합니다. 이 버튼을 누르면 펌웨어(FW)에 필요한 기본 설정으로 퓨즈가 초기화됩니다. 이 기본값은 기본 칩셋과 4.1MB 칩셋에서 서로 다르므로, 환경설정에서 적절한 프로세서 유형을 선택했는지 반드시 확인하세요.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;이 버튼은 &amp;quot;EEPROM 보호&amp;quot; 퓨즈도 함께 설정합니다.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;이 설정은 플래시 메모리를 쓸 때 EEPROM이 지워지는 것을 방지합니다.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt; font-weight:600; text-decoration: underline;&quot;&gt;경고&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;퓨즈 설정은 문제를 일으킬 수 있으며, 컨트롤러가 완전히 잠길 수도 있습니다. 이 작업은 정확히 알고 있을 때만 수행하세요.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;의문이 있다면 프로젝트 페이지나 9x 포럼(http://9xforums.com/forum/)을 참고하세요.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;혹시 잠금 문제가 발생했다면, &amp;quot;Fuse Bricks 복구 방법&amp;quot;을 구글에서 검색해보세요.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+</translation>
+
     </message>
     <message>
         <location filename="../fusesdialog.ui" line="59"/>
         <source>Reset Fuses
 EEPROM - PROTECT</source>
-        <translation></translation>
+        <translation>퓨즈 초기화
+EEPROM 보호</translation>
     </message>
     <message>
         <location filename="../fusesdialog.ui" line="67"/>
@@ -4608,13 +4688,29 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;When in doubt consult either the project&apos;s page or the 9xforum (http://9xforums.com/forum/)&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;If you do get locked out - google lookup for &amp;quot;dealing with Fuse Bricks&amp;quot;.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Sans Serif&apos;; font-size:9pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt; font-weight:600; text-decoration: underline;&quot;&gt;퓨즈 초기화&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;AVR의 퓨즈는 컨트롤러의 동작 방식을 결정합니다. 이 버튼을 누르면 펌웨어(FW)에서 요구하는 기본값으로 퓨즈가 설정됩니다. 기본값은 일반 버전과 4.1MB 버전에서 다르므로, 환경 설정에서 올바른 프로세서 유형을 선택했는지 확인하세요.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;이 버튼은 &amp;quot;EEPROM 보호&amp;quot; 퓨즈도 해제합니다.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;이렇게 하면 플래시 메모리를 쓸 때 EEPROM이 지워지게 됩니다.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt; font-weight:600; text-decoration: underline;&quot;&gt;경고&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;퓨즈 설정은 문제를 일으키거나 컨트롤러에 완전히 접근할 수 없게 만들 수 있습니다. 정확히 알고 있는 경우에만 진행하세요.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;&lt;br /&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;잘 모르겠다면 프로젝트 페이지나 9x 포럼(http://9xforums.com/forum/)을 참조하세요.&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8pt;&quot;&gt;잠겼을 경우에는 &amp;quot;Fuse Bricks 복구 방법&amp;quot;을 구글에서 검색해보세요.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+</translation>
     </message>
     <message>
         <location filename="../fusesdialog.ui" line="84"/>
         <source>Reset Fuses
 EEPROM - DELETE</source>
-        <translation></translation>
+        <translation>퓨즈 초기화
+EEPROM 삭제</translation>
     </message>
     <message>
         <location filename="../fusesdialog.ui" line="101"/>
@@ -4626,18 +4722,26 @@ p, li { white-space: pre-wrap; }
 &lt;p align=&quot;center&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-weight:600; text-decoration: underline;&quot;&gt;&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Changing the fuses can mess up your radio.&lt;/p&gt;
 &lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Proceed only if you know what you are doing.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;Ubuntu&apos;; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;경고&lt;/span&gt;&lt;/p&gt;
+&lt;p align=&quot;center&quot; style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-weight:600; text-decoration: underline;&quot;&gt;&lt;/p&gt;
+&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;퓨즈 설정을 변경하면 라디오가 손상될 수 있습니다.&lt;/p&gt;
+&lt;p align=&quot;center&quot; style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;정확히 알고 있는 경우에만 진행하세요.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+</translation>
     </message>
     <message>
         <location filename="../fusesdialog.cpp" line="43"/>
         <location filename="../fusesdialog.cpp" line="49"/>
         <source>Reset Radio Fuses</source>
-        <translation></translation>
+        <translation>조종기 퓨즈 초기화</translation>
     </message>
     <message>
         <location filename="../fusesdialog.cpp" line="55"/>
         <source>Read Fuses from Radio</source>
-        <translation></translation>
+        <translation>조종기에서 퓨즈 읽기</translation>
     </message>
 </context>
 <context>
@@ -4678,78 +4782,79 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../generaledit/generaledit.ui" line="20"/>
         <source>Radio settings</source>
-        <translation></translation>
+        <translation>조종기 설정</translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.ui" line="55"/>
         <source>Retrieve calib. and hw settings from profile</source>
-        <translation></translation>
+        <translation>프로필에서 보정 및 하드웨어 설정 가져오기</translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.ui" line="84"/>
         <source>Store calib. and hw settings in selected profile</source>
-        <translation></translation>
+        <translation>선택한 프로필에 보정 및 하드웨어 설정 저장</translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.ui" line="105"/>
         <source>General settings used throught the transmitter.
 These will be relevant for all models in the same EEPROM.</source>
-        <translation></translation>
+        <translation>조종기 전반에서 사용되는 일반 설정입니다.
+같은 EEPROM 내의 모든 모델에 적용됩니다.</translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.cpp" line="68"/>
         <source>Setup</source>
-        <translation></translation>
+        <translation>설정</translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.cpp" line="69"/>
         <source>Global Functions</source>
-        <translation></translation>
+        <translation>글로벌 기능</translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.cpp" line="70"/>
         <source>Trainer</source>
-        <translation></translation>
+        <translation>트레이너</translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.cpp" line="72"/>
         <source>Hardware</source>
-        <translation></translation>
+        <translation>하드웨어</translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.cpp" line="73"/>
         <source>Calibration</source>
-        <translation></translation>
+        <translation>보정</translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.cpp" line="74"/>
         <source>Enabled Features</source>
-        <translation></translation>
+        <translation>활성화된 기능</translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.cpp" line="172"/>
         <source>Wrong data in profile, radio calibration was not retrieved</source>
-        <translation></translation>
+        <translation>프로필에 잘못된 데이터가 있어 조종기 보정을 가져올 수 없습니다</translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.cpp" line="198"/>
         <source>Wrong data in profile, Switch/pot config not retrieved</source>
-        <translation></translation>
+        <translation>프로필에 잘못된 데이터가 있어 스위치/포트 설정을 가져올 수 없습니다</translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.cpp" line="239"/>
         <source>Wrong data in profile, hw related parameters were not retrieved</source>
-        <translation></translation>
+        <translation>프로필에 잘못된 데이터가 있어 하드웨어 관련 설정을 가져올 수 없습니다</translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.cpp" line="262"/>
         <source>Do you want to store calibration in %1 profile&lt;br&gt;overwriting existing calibration?</source>
-        <translation></translation>
+        <translation>%1 프로필에 보정 값을 저장하시겠습니까?&lt;br&gt;기존 보정 값이 덮어쓰기 됩니다.</translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.cpp" line="316"/>
         <source>Calibration and HW parameters saved.</source>
-        <translation></translation>
+        <translation>보정 및 하드웨어 설정이 저장되었습니다.</translation>
     </message>
 </context>
 <context>
@@ -4757,67 +4862,67 @@ These will be relevant for all models in the same EEPROM.</source>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="37"/>
         <source>Radio Menus</source>
-        <translation></translation>
+        <translation>송신기 메뉴</translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="40"/>
         <source>Themes</source>
-        <translation></translation>
+        <translation>테마</translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="47"/>
         <source>Global Functions</source>
-        <translation></translation>
+        <translation>글로벌 기능</translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="53"/>
         <source>Trainer</source>
-        <translation></translation>
+        <translation>트레이너</translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="61"/>
         <source>Model Menus</source>
-        <translation></translation>
+        <translation>모델 메뉴</translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="64"/>
         <source>Heli</source>
-        <translation></translation>
+        <translation>헬리콥터</translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="71"/>
         <source>%1 Modes</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 모드</translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="77"/>
         <source>Curves</source>
-        <translation></translation>
+        <translation>커브</translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="84"/>
         <source>Global Variables</source>
-        <translation></translation>
+        <translation>글로벌 변수</translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="91"/>
         <source>Logical Switches</source>
-        <translation></translation>
+        <translation>논리 스위치</translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="97"/>
         <source>Special Functions</source>
-        <translation></translation>
+        <translation>특수 기능</translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="103"/>
         <source>Custom Mix Scripts</source>
-        <translation></translation>
+        <translation>사용자 믹스 스크립트</translation>
     </message>
     <message>
         <location filename="../generaledit/generaloptions.cpp" line="109"/>
         <source>Telemetry</source>
-        <translation></translation>
+        <translation>텔레메트리</translation>
     </message>
 </context>
 <context>
@@ -4825,121 +4930,121 @@ These will be relevant for all models in the same EEPROM.</source>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="412"/>
         <source>Radio Settings</source>
-        <translation></translation>
+        <translation>송신기 설정</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="414"/>
         <source>Hardware</source>
-        <translation></translation>
+        <translation>하드웨어</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="415"/>
         <source>Internal Module</source>
-        <translation></translation>
+        <translation>내장 모듈</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="430"/>
         <source>Axis &amp; Pots</source>
-        <translation></translation>
+        <translation>축 &amp; 포트</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="435"/>
         <source>Axis</source>
-        <translation></translation>
+        <translation>축</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="435"/>
         <source>Pot</source>
-        <translation></translation>
+        <translation>포트</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="464"/>
         <source>Switches</source>
-        <translation></translation>
+        <translation>스위치</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="469"/>
         <location filename="../firmwares/generalsettings.cpp" line="481"/>
         <source>Flex Switch</source>
-        <translation></translation>
+        <translation>플렉스 스위치</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="470"/>
         <location filename="../firmwares/generalsettings.cpp" line="482"/>
         <source>Function Switch</source>
-        <translation></translation>
+        <translation>기능 스위치</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="470"/>
         <location filename="../firmwares/generalsettings.cpp" line="482"/>
         <source>Switch</source>
-        <translation></translation>
+        <translation>스위치</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="499"/>
         <source>None</source>
-        <translation></translation>
+        <translation>없음</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="553"/>
         <source>Internal</source>
-        <translation></translation>
+        <translation>내장</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Ask</source>
-        <translation></translation>
+        <translation>묻기</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="557"/>
         <source>Per model</source>
-        <translation></translation>
+        <translation>모델별</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="560"/>
         <source>Internal + External</source>
-        <translation></translation>
+        <translation>내장 + 외부</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="560"/>
         <source>External</source>
-        <translation></translation>
+        <translation>외부</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="573"/>
         <location filename="../firmwares/generalsettings.cpp" line="589"/>
         <source>OFF</source>
-        <translation></translation>
+        <translation>꺼짐</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="576"/>
         <source>Enabled</source>
-        <translation></translation>
+        <translation>활성화됨</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="576"/>
         <source>Telemetry</source>
-        <translation></translation>
+        <translation>텔레메트리</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Trainer</source>
-        <translation></translation>
+        <translation>트레이너</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>Telemetry Mirror</source>
-        <translation></translation>
+        <translation>텔레메트리 미러</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>Telemetry In</source>
-        <translation></translation>
+        <translation>텔레메트리 입력</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>SBUS Trainer</source>
-        <translation></translation>
+        <translation>SBUS 트레이너</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="597"/>
@@ -4959,17 +5064,17 @@ These will be relevant for all models in the same EEPROM.</source>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>Debug</source>
-        <translation></translation>
+        <translation>디버그</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>SpaceMouse</source>
-        <translation></translation>
+        <translation>스페이스마우스</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="607"/>
         <source>External module</source>
-        <translation></translation>
+        <translation>외부 모듈</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="640"/>
@@ -4979,7 +5084,7 @@ These will be relevant for all models in the same EEPROM.</source>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="739"/>
         <source>Normal</source>
-        <translation></translation>
+        <translation>일반</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="741"/>
@@ -4989,42 +5094,42 @@ These will be relevant for all models in the same EEPROM.</source>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="787"/>
         <source>Trims only</source>
-        <translation></translation>
+        <translation>트림만</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="789"/>
         <source>Keys only</source>
-        <translation></translation>
+        <translation>버튼만</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="791"/>
         <source>Switchable</source>
-        <translation></translation>
+        <translation>전환 가능</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="793"/>
         <source>Global</source>
-        <translation></translation>
+        <translation>글로벌</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="927"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
-        <translation type="unfinished"></translation>
+        <translation>모드 1 (RUD ELE THR AIL)</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="929"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
-        <translation type="unfinished"></translation>
+        <translation>모드 2 (RUD THR ELE AIL)</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="931"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
-        <translation type="unfinished"></translation>
+        <translation>모드 3 (AIL ELE THR RUD)</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="933"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
-        <translation type="unfinished"></translation>
+        <translation>모드 4 (AIL THR ELE RUD)</translation>
     </message>
 </context>
 <context>
@@ -5032,12 +5137,12 @@ These will be relevant for all models in the same EEPROM.</source>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="14"/>
         <source>Form</source>
-        <translation></translation>
+        <translation>폼</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="20"/>
         <source>Readonly Unlock</source>
-        <translation></translation>
+        <translation>읽기 전용 잠금 해제</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="44"/>
@@ -5082,32 +5187,32 @@ These will be relevant for all models in the same EEPROM.</source>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="991"/>
         <source>Stick reverse</source>
-        <translation></translation>
+        <translation>조이스틱 반전</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="640"/>
         <source>Country Code</source>
-        <translation></translation>
+        <translation>국가 코드</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="911"/>
         <source>FAI Mode</source>
-        <translation></translation>
+        <translation>FAI 모드</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="652"/>
         <source>Automatically adjust the radio&apos;s clock if a GPS is connected to telemetry.</source>
-        <translation></translation>
+        <translation>GPS가 텔레메트리에 연결되어 있으면 조종기의 시계를 자동으로 조정합니다.</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="658"/>
         <source>Adjust RTC</source>
-        <translation></translation>
+        <translation>RTC 조정</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1058"/>
         <source>Speaker Volume</source>
-        <translation></translation>
+        <translation>스피커 볼륨</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1039"/>
@@ -5118,120 +5223,120 @@ These will be relevant for all models in the same EEPROM.</source>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1154"/>
         <source>Vario pitch at max</source>
-        <translation></translation>
+        <translation>최대 상승 시 바리오 피치</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="582"/>
         <source>Backlight Switch</source>
-        <translation></translation>
+        <translation>백라이트 스위치</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="607"/>
         <source>Color 1</source>
-        <translation></translation>
+        <translation>색상 1</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="624"/>
         <source>Color 2</source>
-        <translation></translation>
+        <translation>색상 2</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="667"/>
         <source>Sound Mode</source>
-        <translation></translation>
+        <translation>사운드 모드</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1100"/>
         <source>If this value is not 0, any keypress will turn on the backlight and turn it off after the specified number of seconds.</source>
-        <translation></translation>
+        <translation>값이 0이 아니면, 아무 키나 누를 때 백라이트가 켜지고 지정된 시간 후 꺼집니다.</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1103"/>
         <source> sec</source>
-        <translation></translation>
+        <translation> 초</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1161"/>
         <source>Backlight color</source>
-        <translation></translation>
+        <translation>백라이트 색상</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="552"/>
         <source>Speaker Pitch (spkr only)</source>
-        <translation></translation>
+        <translation>스피커 음정 (스피커 전용)</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="999"/>
         <source>Beeper</source>
-        <translation></translation>
+        <translation>삐 소리</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1004"/>
         <source>Speaker</source>
-        <translation></translation>
+        <translation>스피커</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1009"/>
         <source>BeeperVoice</source>
-        <translation></translation>
+        <translation>비퍼 음성</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1014"/>
         <source>SpeakerVoice</source>
-        <translation></translation>
+        <translation>스피커 음성</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1168"/>
         <source>Beep volume</source>
-        <translation></translation>
+        <translation>비프음 볼륨</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="858"/>
         <source>Wav volume</source>
-        <translation></translation>
+        <translation>WAV 볼륨</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="509"/>
         <source>Vario volume</source>
-        <translation></translation>
+        <translation>바리오 볼륨</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="947"/>
         <source>Background volume</source>
-        <translation></translation>
+        <translation>배경음 볼륨</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="757"/>
         <location filename="../generaledit/generalsetup.ui" line="2180"/>
         <source> ms</source>
-        <translation></translation>
+        <translation> 밀리초</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="559"/>
         <source>Backlight flash on alarm</source>
-        <translation></translation>
+        <translation>알람 시 백라이트 깜빡임</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="851"/>
         <source>Vario pitch at zero</source>
-        <translation></translation>
+        <translation>바리오 음 높이 (0일 때)</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1140"/>
         <source>Vario repeat at zero</source>
-        <translation></translation>
+        <translation>바리오 반복 (0일 때)</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="743"/>
         <source>Backlight  Auto OFF after</source>
-        <translation></translation>
+        <translation>백라이트 자동 꺼짐 시간</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="871"/>
         <source>This is the switch selectrion for turning on the backlight (if installed).
 
 </source>
-        <translation></translation>
+        <translation>이 스위치는 백라이트를 켜기 위한 선택입니다 (설치된 경우).</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="823"/>
@@ -5242,57 +5347,63 @@ p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;LCD Screen Contrast&lt;/span&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Values can be 20-45&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;LCD 화면 대비 조절&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;값은 20~45 범위 내에서 설정할 수 있습니다&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1194"/>
         <source>RotEnc Navigation</source>
-        <translation></translation>
+        <translation>로터리 인코더 탐색</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="519"/>
         <source>Backlight Brightness</source>
-        <translation></translation>
+        <translation>백라이트 밝기</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="534"/>
         <source>America</source>
-        <translation></translation>
+        <translation>미국</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="539"/>
         <source>Japan</source>
-        <translation></translation>
+        <translation>일본</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="544"/>
         <source>Europe</source>
-        <translation></translation>
+        <translation>유럽</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="971"/>
         <source>Voice Language</source>
-        <translation></translation>
+        <translation>음성 언어</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="890"/>
         <source>Timeshift from UTC</source>
-        <translation></translation>
+        <translation>UTC로부터 시간차</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="844"/>
         <source>Backlight OFF Brightness</source>
-        <translation></translation>
+        <translation>백라이트 꺼짐 밝기</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2159"/>
         <source>RSSI Poweroff Warning</source>
-        <translation></translation>
+        <translation>RSSI 전원 종료 경고</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2020"/>
         <source>Low EEPROM Warning</source>
-        <translation></translation>
+        <translation>EEPROM 용량 부족 경고</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1887"/>
@@ -5320,128 +5431,128 @@ Mode 4:
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1732"/>
         <source>USB Mode</source>
-        <translation></translation>
+        <translation>USB 모드</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1544"/>
         <location filename="../generaledit/generalsetup.ui" line="2064"/>
         <source>Ask on Connect</source>
-        <translation></translation>
+        <translation>연결 시 선택</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1549"/>
         <source>Joystick (HID)</source>
-        <translation></translation>
+        <translation>조이스틱 (HID)</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1554"/>
         <source>USB Mass Storage</source>
-        <translation></translation>
+        <translation>USB 대용량 저장장치</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1559"/>
         <source>USB Serial (CDC)</source>
-        <translation></translation>
+        <translation>USB 시리얼 (CDC)</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1536"/>
         <source>Hats Mode</source>
-        <translation></translation>
+        <translation>Hats 모드</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1246"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;채널 순서&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;새 모델 생성 시 기본 믹스의 채널 배치를 정의합니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1022"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working. This function cannot be disabled by the radio.</source>
-        <translation></translation>
+        <translation>FAI 모드를 활성화하면 RSSI 및 RxBt 센서만 작동합니다. 이 기능은 송신기에서 해제할 수 없습니다.</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1147"/>
         <source>Label selection mode</source>
-        <translation></translation>
+        <translation>레이블 선택 모드</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="526"/>
         <source>Label matching</source>
-        <translation></translation>
+        <translation>레이블 일치</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1117"/>
         <source>Large image (2 columns)</source>
-        <translation></translation>
+        <translation>큰 이미지 (2열)</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1122"/>
         <source>Small image (3 columns)</source>
-        <translation></translation>
+        <translation>작은 이미지 (3열)</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1127"/>
         <source>Name only (2 columns)</source>
-        <translation></translation>
+        <translation>이름만 (2열)</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1132"/>
         <source>Name only (1 column)</source>
-        <translation></translation>
+        <translation>이름만 (1열)</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="750"/>
         <source>Manage Models layout</source>
-        <translation></translation>
+        <translation>모델 관리 레이아웃</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="883"/>
         <source>Owner Registration ID</source>
-        <translation></translation>
+        <translation>소유자 등록 ID</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="897"/>
         <source>Model quick select</source>
-        <translation></translation>
+        <translation>모델 빠른 선택</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="937"/>
         <source>Enable this to quickly change model on the model select page (a long press can then be used to open the model edit menu).</source>
-        <translation></translation>
+        <translation>이 기능을 활성화하면 모델 선택 페이지에서 빠르게 모델을 전환할 수 있습니다. 길게 누르면 모델 편집 메뉴가 열립니다.</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="633"/>
         <source>Favorites matching</source>
-        <translation></translation>
+        <translation>즐겨찾기 일치</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="790"/>
         <source>Multi select</source>
-        <translation></translation>
+        <translation>다중 선택</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="795"/>
         <source>Single select</source>
-        <translation></translation>
+        <translation>단일 선택</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="804"/>
         <source>Match all</source>
-        <translation></translation>
+        <translation>모두 일치</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="809"/>
         <source>Match any</source>
-        <translation></translation>
+        <translation>하나라도 일치</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="723"/>
         <source>Must match</source>
-        <translation></translation>
+        <translation>반드시 일치</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="728"/>
         <source>Optional match</source>
-        <translation></translation>
+        <translation>선택적 일치</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1701"/>
@@ -5449,27 +5560,30 @@ Mode 4:
 This is the threshold where the battery warning sounds.
 
 Acceptable values are 3v..12v</source>
-        <translation></translation>
+        <translation>배터리 경고 전압입니다.
+이 값은 배터리 경고음이 울리는 임계값입니다.
+
+허용 범위: 3V ~ 12V</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2259"/>
         <source>Power On Delay</source>
-        <translation></translation>
+        <translation>전원 켜짐 지연</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2342"/>
         <source>Jack Mode</source>
-        <translation></translation>
+        <translation>잭 모드</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2140"/>
         <source>Play Startup Sound</source>
-        <translation></translation>
+        <translation>시작음 재생</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1567"/>
         <source>PPM Units</source>
-        <translation></translation>
+        <translation>PPM 단위</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2041"/>
@@ -5490,52 +5604,52 @@ Acceptable values are 3v..12v</source>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2069"/>
         <source>Audio</source>
-        <translation></translation>
+        <translation>오디오</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2074"/>
         <source>Trainer</source>
-        <translation></translation>
+        <translation>트레이너</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1830"/>
         <source>DMS</source>
-        <translation></translation>
+        <translation>DMS (도/분/초)</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2082"/>
         <source>Stick Mode</source>
-        <translation></translation>
+        <translation>조종기 모드</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2001"/>
         <source>Power Off Delay</source>
-        <translation></translation>
+        <translation>전원 꺼짐 지연</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2028"/>
         <source>Metric</source>
-        <translation></translation>
+        <translation>미터법</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2033"/>
         <source>Imperial</source>
-        <translation></translation>
+        <translation>야드법</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1786"/>
         <source>Default Channel Order</source>
-        <translation></translation>
+        <translation>기본 채널 순서</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1488"/>
         <source>GPS Coordinates</source>
-        <translation></translation>
+        <translation>GPS 좌표</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2379"/>
         <source>Min</source>
-        <translation></translation>
+        <translation>최소</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2386"/>
@@ -5546,111 +5660,111 @@ Acceptable values are 3v..12v</source>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2408"/>
         <source>Max</source>
-        <translation></translation>
+        <translation>최대</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1953"/>
         <source>Inactivity Timer</source>
-        <translation></translation>
+        <translation>비활성 타이머</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1773"/>
         <source>Show Splash Screen on Startup</source>
-        <translation></translation>
+        <translation>시작 시 스플래시 화면 표시</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1754"/>
         <source>Contrast</source>
-        <translation></translation>
+        <translation>명암 대비</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2451"/>
         <source>Battery Meter Range</source>
-        <translation></translation>
+        <translation>배터리 측정 범위</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1316"/>
         <source>Haptic Strength</source>
-        <translation></translation>
+        <translation>진동 강도</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1934"/>
         <source>LCD Display Type</source>
-        <translation></translation>
+        <translation>LCD 디스플레이 종류</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2470"/>
         <source>&quot;No Sound&quot; Warning</source>
-        <translation></translation>
+        <translation>“무음” 경고</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1338"/>
         <source>Battery Warning</source>
-        <translation></translation>
+        <translation>배터리 경고</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2252"/>
         <source>Haptic Length</source>
-        <translation></translation>
+        <translation>진동 시간</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1621"/>
         <source>MAVLink Baud Rate</source>
-        <translation></translation>
+        <translation>MAVLink 통신 속도</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1806"/>
         <location filename="../generaledit/generalsetup.ui" line="2117"/>
         <source>Quiet</source>
-        <translation></translation>
+        <translation>조용함</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1811"/>
         <source>Only Alarms</source>
-        <translation></translation>
+        <translation>알람만</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1816"/>
         <location filename="../generaledit/generalsetup.ui" line="2127"/>
         <source>No Keys</source>
-        <translation></translation>
+        <translation>키음 없음</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1821"/>
         <location filename="../generaledit/generalsetup.ui" line="2132"/>
         <source>All</source>
-        <translation></translation>
+        <translation>전체</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1670"/>
         <source>Standard</source>
-        <translation></translation>
+        <translation>표준</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1675"/>
         <source>Optrex</source>
-        <translation></translation>
+        <translation>옵트렉스</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1861"/>
         <source>If not zero will sound beeps if the transmitter has been left without inputs for the specified number of minutes.</source>
-        <translation></translation>
+        <translation>0이 아니면 설정된 시간 동안 조작이 없을 경우 경고음이 울립니다.</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1032"/>
         <source>Keys Backlight</source>
-        <translation></translation>
+        <translation>키 백라이트</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="964"/>
         <source>Rotary Encoder Mode</source>
-        <translation></translation>
+        <translation>로터리 인코더 모드</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1864"/>
         <location filename="../generaledit/generalsetup.ui" line="2526"/>
         <source> min</source>
-        <translation></translation>
+        <translation> 분</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1373"/>
@@ -5661,62 +5775,62 @@ Acceptable values are 3v..12v</source>
         <location filename="../generaledit/generalsetup.ui" line="1212"/>
         <location filename="../generaledit/generalsetup.ui" line="1629"/>
         <source>0s</source>
-        <translation type="unfinished"></translation>
+        <translation>0초</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1217"/>
         <location filename="../generaledit/generalsetup.ui" line="1634"/>
         <source>0.5s</source>
-        <translation type="unfinished"></translation>
+        <translation>0.5초</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1227"/>
         <location filename="../generaledit/generalsetup.ui" line="1378"/>
         <location filename="../generaledit/generalsetup.ui" line="1644"/>
         <source>2s</source>
-        <translation></translation>
+        <translation>2초</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1232"/>
         <location filename="../generaledit/generalsetup.ui" line="1383"/>
         <location filename="../generaledit/generalsetup.ui" line="1649"/>
         <source>3s</source>
-        <translation></translation>
+        <translation>3초</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1388"/>
         <source>4s</source>
-        <translation></translation>
+        <translation>4초</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1393"/>
         <source>6s</source>
-        <translation></translation>
+        <translation>6초</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1398"/>
         <source>8s</source>
-        <translation></translation>
+        <translation>8초</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1403"/>
         <source>10s</source>
-        <translation></translation>
+        <translation>10초</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1408"/>
         <source>15s</source>
-        <translation></translation>
+        <translation>15초</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1418"/>
         <source>Trainer Poweroff Warning</source>
-        <translation type="unfinished"></translation>
+        <translation>트레이너 전원 종료 경고</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1915"/>
         <source>Power ON/OFF Haptic</source>
-        <translation type="unfinished"></translation>
+        <translation>전원 온/오프 진동</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2286"/>
@@ -5761,7 +5875,7 @@ Acceptable values are 3v..12v</source>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2519"/>
         <source>Power Auto Off</source>
-        <translation type="unfinished"></translation>
+        <translation>자동 전원 차단</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1281"/>
@@ -5779,37 +5893,48 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Switch warning - will alert if switches are not in their defaul position&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Memory warning - will alert if there&apos;s not a lot of memory left&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;Silent mode warning - will alert you if the beeper is set to quiet (0)&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; text-decoration: underline;&quot;&gt;경고 설정&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;이 항목들은 시작 시 표시되는 경고를 정의합니다.&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;스로틀 경고 - 시작 시 스로틀이 아이들 상태가 아니면 알림을 표시합니다.&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;스위치 경고 - 시작 시 스위치가 기본 위치에 있지 않으면 알림을 표시합니다.&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;메모리 경고 - 사용 가능한 메모리가 부족할 경우 경고를 표시합니다.&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;무음 모드 경고 - 비퍼가 무음(0)으로 설정된 경우 알림을 표시합니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1587"/>
         <location filename="../generaledit/generalsetup.ui" line="1973"/>
         <source>X-Short</source>
-        <translation></translation>
+        <translation>매우 짧게</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1592"/>
         <location filename="../generaledit/generalsetup.ui" line="1978"/>
         <source>Short</source>
-        <translation></translation>
+        <translation>짧게</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1597"/>
         <location filename="../generaledit/generalsetup.ui" line="1983"/>
         <source>Normal</source>
-        <translation></translation>
+        <translation>보통</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1602"/>
         <location filename="../generaledit/generalsetup.ui" line="1988"/>
         <source>Long</source>
-        <translation></translation>
+        <translation>길게</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1607"/>
         <location filename="../generaledit/generalsetup.ui" line="1993"/>
         <source>X-Long</source>
-        <translation></translation>
+        <translation>매우 길게</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1835"/>
@@ -5819,27 +5944,27 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1262"/>
         <source>Play Delay (switch mid position)</source>
-        <translation></translation>
+        <translation>재생 지연 (스위치 중간 위치)</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1425"/>
         <source>Measurement Units</source>
-        <translation></translation>
+        <translation>측정 단위</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1357"/>
         <source>Haptic Mode</source>
-        <translation></translation>
+        <translation>진동 모드</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1447"/>
         <source>Beeper Length</source>
-        <translation></translation>
+        <translation>비퍼 길이</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2278"/>
         <source>Beeper Mode</source>
-        <translation></translation>
+        <translation>비퍼 모드</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2107"/>
@@ -5850,19 +5975,25 @@ p, li { white-space: pre-wrap; }
 2 - Normal.
 3 - Loud.
 4 - Extra loud.</source>
-        <translation></translation>
+        <translation>비퍼 음량
+
+0 - 무음: 모든 비프음 꺼짐.
+1 - 키 무음: 일반 비프음은 출력되나 메뉴 키 입력음은 없음.
+2 - 보통: 일반적인 음량.
+3 - 큼: 다소 큰 음량.
+4 - 매우 큼: 최대 음량.</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="2122"/>
         <source>Alarms Only</source>
-        <translation></translation>
+        <translation>알람만</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.ui" line="1222"/>
         <location filename="../generaledit/generalsetup.ui" line="1639"/>
         <location filename="../generaledit/generalsetup.cpp" line="292"/>
         <source>1s</source>
-        <translation></translation>
+        <translation>1초</translation>
     </message>
 </context>
 <context>
@@ -5870,179 +6001,181 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>OFF</source>
-        <translation></translation>
+        <translation>끔</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>Keys</source>
-        <translation></translation>
+        <translation>키</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>ON</source>
-        <translation></translation>
+        <translation>켬</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="424"/>
         <source>English</source>
-        <translation></translation>
+        <translation>영어</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="423"/>
         <source>Dutch</source>
-        <translation></translation>
+        <translation>네덜란드어</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="425"/>
         <source>French</source>
-        <translation></translation>
+        <translation>프랑스어</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="429"/>
         <source>Italian</source>
-        <translation></translation>
+        <translation>이탈리아어</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="426"/>
         <source>German</source>
-        <translation></translation>
+        <translation>독일어</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="421"/>
         <source>Czech</source>
-        <translation></translation>
+        <translation>체코어</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Slovak</source>
-        <translation></translation>
+        <translation>슬로바키아어</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Spanish</source>
-        <translation></translation>
+        <translation>스페인어</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="431"/>
         <source>Polish</source>
-        <translation></translation>
+        <translation>폴란드어</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Portuguese</source>
-        <translation></translation>
+        <translation>포르투갈어</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Russian</source>
-        <translation></translation>
+        <translation>러시아어</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Swedish</source>
-        <translation></translation>
+        <translation>스웨덴어</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="428"/>
         <source>Hungarian</source>
-        <translation></translation>
+        <translation>헝가리어</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal, Edit Inverted</source>
-        <translation></translation>
+        <translation>일반, 편집 시 반전</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="422"/>
         <source>Danish</source>
-        <translation></translation>
+        <translation>덴마크어</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="420"/>
         <source>Chinese</source>
-        <translation></translation>
+        <translation>중국어</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="430"/>
         <source>Japanese</source>
-        <translation></translation>
+        <translation>일본어</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="427"/>
         <source>Hebrew</source>
-        <translation></translation>
+        <translation>히브리어</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>Controls</source>
-        <translation type="unfinished"></translation>
+        <translation>조작</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="402"/>
         <source>Keys + Controls</source>
-        <translation type="unfinished"></translation>
+        <translation>키 + 조작</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Ukrainian</source>
-        <translation></translation>
+        <translation>우크라이나어</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>No</source>
-        <translation>No</translation>
+        <translation>없음</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>RotEnc A</source>
-        <translation></translation>
+        <translation>로터리 인코더 A</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc B</source>
-        <translation></translation>
+        <translation>로터리 인코더 B</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc C</source>
-        <translation></translation>
+        <translation>로터리 인코더 C</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc D</source>
-        <translation></translation>
+        <translation>로터리 인코더 D</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="509"/>
         <source>Rot Enc E</source>
-        <translation></translation>
+        <translation>로터리 인코더 E</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="617"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
-        <translation></translation>
+        <translation>FAI 모드를 활성화하면 RSSI 및 RxBt 센서만 작동하게 됩니다.
+이 기능은 송신기에서 비활성화할 수 없습니다.
+계속하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Normal</source>
-        <translation></translation>
+        <translation>일반</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Inverted</source>
-        <translation></translation>
+        <translation>반전</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Normal</source>
-        <translation></translation>
+        <translation>수직 반전, 수평 일반</translation>
     </message>
     <message>
         <location filename="../generaledit/generalsetup.cpp" line="636"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
-        <translation></translation>
+        <translation>수직 반전, 수평 대체</translation>
     </message>
 </context>
 <context>
@@ -6050,17 +6183,17 @@ Are you sure ?</source>
     <message>
         <location filename="../wizarddialog.cpp" line="823"/>
         <source>No</source>
-        <translation>No</translation>
+        <translation>아니요</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="825"/>
         <source>Yes, controled by a switch</source>
-        <translation></translation>
+        <translation>예, 스위치로 제어</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="826"/>
         <source>Yes, controlled by a pot</source>
-        <translation></translation>
+        <translation>예, 포트로 제어</translation>
     </message>
 </context>
 <context>
@@ -6068,48 +6201,48 @@ Are you sure ?</source>
     <message>
         <location filename="../generaledit/hardware.cpp" line="149"/>
         <source>Dead zone</source>
-        <translation></translation>
+        <translation>데드존</translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="160"/>
         <source>Pots</source>
-        <translation></translation>
+        <translation>포텐셔미터</translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="174"/>
         <source>Switches</source>
-        <translation></translation>
+        <translation>스위치</translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="190"/>
         <source>RTC Battery Check</source>
-        <translation></translation>
+        <translation>RTC 배터리 점검</translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="214"/>
         <source>Bluetooth</source>
-        <translation></translation>
+        <translation>블루투스</translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="223"/>
         <source>Device Name:</source>
-        <translation></translation>
+        <translation>장치 이름:</translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="277"/>
         <source>Sample Mode</source>
-        <translation></translation>
+        <translation>샘플 모드</translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="290"/>
         <source>Serial ports</source>
-        <translation></translation>
+        <translation>시리얼 포트</translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="302"/>
         <location filename="../generaledit/hardware.cpp" line="321"/>
         <source>Power</source>
-        <translation></translation>
+        <translation>전원</translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="331"/>
@@ -6119,42 +6252,42 @@ Are you sure ?</source>
     <message>
         <location filename="../generaledit/hardware.cpp" line="198"/>
         <source>ADC Filter</source>
-        <translation></translation>
+        <translation>ADC 필터</translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="139"/>
         <source>Axis</source>
-        <translation></translation>
+        <translation>축</translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="206"/>
         <source>Mute if no sound</source>
-        <translation></translation>
+        <translation>소리가 없으면 음소거</translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="235"/>
         <source>Internal RF</source>
-        <translation></translation>
+        <translation>내장 RF</translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="236"/>
         <source>Type</source>
-        <translation></translation>
+        <translation>유형</translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="245"/>
         <source>Baudrate:</source>
-        <translation></translation>
+        <translation>보레이트:</translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="259"/>
         <source>Antenna:</source>
-        <translation></translation>
+        <translation>안테나:</translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="276"/>
         <source>External RF</source>
-        <translation></translation>
+        <translation>외장 RF</translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="293"/>
@@ -6169,27 +6302,27 @@ Are you sure ?</source>
     <message>
         <location filename="../generaledit/hardware.cpp" line="343"/>
         <source>S.Port Power</source>
-        <translation></translation>
+        <translation>S.Port 전원</translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="351"/>
         <source>Current Offset</source>
-        <translation></translation>
+        <translation>전류 오프셋</translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="361"/>
         <source>Screen</source>
-        <translation type="unfinished"></translation>
+        <translation>화면</translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="363"/>
         <source>Invert</source>
-        <translation type="unfinished"></translation>
+        <translation>반전</translation>
     </message>
     <message>
         <location filename="../generaledit/hardware.cpp" line="383"/>
         <source>Warning: Changing the Internal module may invalidate the internal module protocol of the models!</source>
-        <translation></translation>
+        <translation>경고: 내부 모듈을 변경하면 모델의 내부 모듈 프로토콜이 무효화될 수 있습니다!</translation>
     </message>
 </context>
 <context>
@@ -6197,7 +6330,7 @@ Are you sure ?</source>
     <message>
         <location filename="../modeledit/heli.ui" line="24"/>
         <source>Off</source>
-        <translation></translation>
+        <translation>끄기</translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="29"/>
@@ -6222,47 +6355,47 @@ Are you sure ?</source>
     <message>
         <location filename="../modeledit/heli.ui" line="54"/>
         <source>Invert Elevator</source>
-        <translation></translation>
+        <translation>엘리베이터 반전</translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="61"/>
         <source>Invert Aileron</source>
-        <translation></translation>
+        <translation>에일러론 반전</translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="68"/>
         <source>Invert Collective</source>
-        <translation></translation>
+        <translation>콜렉티브 반전</translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="77"/>
         <source>Long. cyc</source>
-        <translation></translation>
+        <translation>종방향 싸이클릭</translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="103"/>
         <source>Invert</source>
-        <translation></translation>
+        <translation>반전</translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="123"/>
         <source>Swash Ring</source>
-        <translation></translation>
+        <translation>스워시 링</translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="130"/>
         <source>Swash Type</source>
-        <translation></translation>
+        <translation>스워시 타입</translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="166"/>
         <source>Lateral cyc</source>
-        <translation></translation>
+        <translation>횡방향 싸이클릭</translation>
     </message>
     <message>
         <location filename="../modeledit/heli.ui" line="231"/>
         <source>Collective</source>
-        <translation></translation>
+        <translation>콜렉티브</translation>
     </message>
 </context>
 <context>
@@ -6270,22 +6403,22 @@ Are you sure ?</source>
     <message>
         <location filename="../wizarddialog.cpp" line="890"/>
         <source>Throttle Channel:</source>
-        <translation></translation>
+        <translation>스로틀 채널:</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="892"/>
         <source>Yaw Channel:</source>
-        <translation></translation>
+        <translation>요우 채널:</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="894"/>
         <source>Pitch Channel:</source>
-        <translation></translation>
+        <translation>피치 채널:</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="896"/>
         <source>Roll Channel:</source>
-        <translation></translation>
+        <translation>롤 채널:</translation>
     </message>
 </context>
 <context>
@@ -6293,19 +6426,21 @@ Are you sure ?</source>
     <message>
         <location filename="../storage/hexeeprom.cpp" line="40"/>
         <source>Invalid EEPROM File %1</source>
-        <translation></translation>
+        <translation>잘못된 EEPROM 파일: %1</translation>
     </message>
     <message>
         <location filename="../storage/hexeeprom.cpp" line="52"/>
         <source>Cannot open file %1:
 %2.</source>
-        <translation></translation>
+        <translation>파일 %1을(를) 열 수 없습니다:
+%2.</translation>
     </message>
     <message>
         <location filename="../storage/hexeeprom.cpp" line="58"/>
         <source>Error writing file %1:
 %2.</source>
-        <translation></translation>
+        <translation>파일 %1 쓰기 오류:
+%2.</translation>
     </message>
 </context>
 <context>
@@ -6313,7 +6448,7 @@ Are you sure ?</source>
     <message>
         <location filename="../simulation/hostserialconnector.cpp" line="170"/>
         <source>Host Serial Error</source>
-        <translation type="unfinished"></translation>
+        <translation>호스트 시리얼 오류</translation>
     </message>
 </context>
 <context>
@@ -6323,56 +6458,56 @@ Are you sure ?</source>
         <location filename="../modeledit/inputs.cpp" line="416"/>
         <location filename="../modeledit/inputs.cpp" line="422"/>
         <source>Move Up</source>
-        <translation></translation>
+        <translation>위로 이동</translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="52"/>
         <location filename="../modeledit/inputs.cpp" line="416"/>
         <source>Ctrl+Up</source>
-        <translation></translation>
+        <translation>Ctrl+위</translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="53"/>
         <location filename="../modeledit/inputs.cpp" line="417"/>
         <location filename="../modeledit/inputs.cpp" line="423"/>
         <source>Move Down</source>
-        <translation></translation>
+        <translation>아래로 이동</translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="55"/>
         <location filename="../modeledit/inputs.cpp" line="417"/>
         <source>Ctrl+Down</source>
-        <translation></translation>
+        <translation>Ctrl+아래</translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="56"/>
         <source>Clear All Inputs</source>
-        <translation></translation>
+        <translation>모든 입력 지우기</translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="162"/>
         <source>Not enough available Inputs!</source>
-        <translation></translation>
+        <translation>사용 가능한 입력이 부족합니다!</translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="248"/>
         <source>Delete selected Input lines. Are you sure?</source>
-        <translation></translation>
+        <translation>선택한 입력 라인을 삭제합니다. 계속하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="260"/>
         <source>Cut selected Input lines. Are you sure?</source>
-        <translation></translation>
+        <translation>선택한 입력 라인을 잘라냅니다. 계속하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="406"/>
         <source>Lines</source>
-        <translation></translation>
+        <translation>라인</translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="407"/>
         <source>&amp;Add</source>
-        <translation></translation>
+        <translation>추가(&amp;A)</translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="407"/>
@@ -6382,28 +6517,28 @@ Are you sure ?</source>
     <message>
         <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>&amp;Edit</source>
-        <translation></translation>
+        <translation>편집(&amp;E)</translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="408"/>
         <source>Enter</source>
-        <translation></translation>
+        <translation>입력</translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="410"/>
         <source>&amp;Delete</source>
-        <translation></translation>
+        <translation>삭제(&amp;D)</translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="410"/>
         <location filename="../modeledit/inputs.cpp" line="421"/>
         <source>Delete</source>
-        <translation></translation>
+        <translation>삭제</translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="411"/>
         <source>&amp;Copy</source>
-        <translation></translation>
+        <translation>복사(&amp;C)</translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="411"/>
@@ -6413,7 +6548,7 @@ Are you sure ?</source>
     <message>
         <location filename="../modeledit/inputs.cpp" line="412"/>
         <source>&amp;Cut</source>
-        <translation></translation>
+        <translation>잘라내기(&amp;X)</translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="412"/>
@@ -6423,7 +6558,7 @@ Are you sure ?</source>
     <message>
         <location filename="../modeledit/inputs.cpp" line="413"/>
         <source>&amp;Paste</source>
-        <translation></translation>
+        <translation>붙여넣기(&amp;P)</translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="413"/>
@@ -6433,7 +6568,7 @@ Are you sure ?</source>
     <message>
         <location filename="../modeledit/inputs.cpp" line="414"/>
         <source>Du&amp;plicate</source>
-        <translation></translation>
+        <translation>복제(&amp;U)</translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="414"/>
@@ -6443,37 +6578,37 @@ Are you sure ?</source>
     <message>
         <location filename="../modeledit/inputs.cpp" line="419"/>
         <source>Input</source>
-        <translation></translation>
+        <translation>입력</translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="420"/>
         <source>Insert</source>
-        <translation></translation>
+        <translation>삽입</translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="425"/>
         <source>Clear</source>
-        <translation></translation>
+        <translation>지우기</translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="428"/>
         <source>Clear All</source>
-        <translation></translation>
+        <translation>모두 지우기</translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="539"/>
         <source>Clear all Input lines. Are you sure?</source>
-        <translation></translation>
+        <translation>모든 입력 라인을 지우시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="584"/>
         <source>Clear all lines for the selected Input. Are you sure?</source>
-        <translation></translation>
+        <translation>선택한 입력의 모든 라인을 지우시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/inputs.cpp" line="602"/>
         <source>Delete all lines for the selected Input. Are you sure?</source>
-        <translation></translation>
+        <translation>선택한 입력의 모든 라인을 삭제하시겠습니까?</translation>
     </message>
 </context>
 <context>
@@ -6481,32 +6616,32 @@ Are you sure ?</source>
     <message>
         <location filename="../labels.cpp" line="74"/>
         <source>Unable to add label &quot;%1&quot; to model &quot;%2&quot; not enough room</source>
-        <translation></translation>
+        <translation>모델 &quot;%2&quot;에 라벨 &quot;%1&quot;을(를) 추가할 수 없습니다. 공간이 부족합니다.</translation>
     </message>
     <message>
         <location filename="../labels.cpp" line="95"/>
         <source>Unable to rename &quot;%1&quot; to &quot;%2&quot; not enough room in model %3</source>
-        <translation></translation>
+        <translation>모델 %3에서 &quot;%1&quot;을(를) &quot;%2&quot;(으)로 이름을 바꿀 수 없습니다. 공간이 부족합니다.</translation>
     </message>
     <message>
         <location filename="../labels.cpp" line="107"/>
         <source>Unable to rename &quot;%1&quot; to &quot;%2&quot; the label already exists</source>
-        <translation></translation>
+        <translation>&quot;%1&quot;을(를) &quot;%2&quot;(으)로 이름을 바꿀 수 없습니다. 동일한 라벨이 이미 존재합니다.</translation>
     </message>
     <message>
         <location filename="../labels.cpp" line="176"/>
         <source>Labels</source>
-        <translation></translation>
+        <translation>라벨</translation>
     </message>
     <message>
         <location filename="../labels.cpp" line="190"/>
         <source>New%1</source>
-        <translation></translation>
+        <translation>새 라벨%1</translation>
     </message>
     <message>
         <location filename="../labels.cpp" line="192"/>
         <source>New</source>
-        <translation></translation>
+        <translation>새 라벨</translation>
     </message>
 </context>
 <context>
@@ -6514,75 +6649,75 @@ Are you sure ?</source>
     <message>
         <location filename="../storage/labeled.cpp" line="179"/>
         <source>Favorites</source>
-        <translation></translation>
+        <translation>즐겨찾기</translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="44"/>
         <source>Cannot find %1/RADIO/radio.yml</source>
-        <translation></translation>
+        <translation>%1/RADIO/radio.yml 파일을 찾을 수 없습니다</translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="46"/>
         <source>Found %1/RADIO/radio.yml</source>
-        <translation></translation>
+        <translation>%1/RADIO/radio.yml 파일을 찾았습니다</translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="49"/>
         <source>Cannot find %1/MODELS/models.yml</source>
-        <translation></translation>
+        <translation>%1/MODELS/models.yml 파일을 찾을 수 없습니다</translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="51"/>
         <source>Found %1/MODELS/models.yml</source>
-        <translation></translation>
+        <translation>%1/MODELS/models.yml 파일을 찾았습니다</translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="55"/>
         <source>Cannot find %1</source>
-        <translation></translation>
+        <translation>%1을(를) 찾을 수 없습니다</translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="57"/>
         <source>Found %1</source>
-        <translation></translation>
+        <translation>%1을(를) 찾았습니다</translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="62"/>
         <source>Cannot extract RADIO/radio.yml</source>
-        <translation></translation>
+        <translation>RADIO/radio.yml을(를) 추출할 수 없습니다</translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="68"/>
         <location filename="../storage/labeled.cpp" line="72"/>
         <source>Cannot load RADIO/radio.yml</source>
-        <translation></translation>
+        <translation>RADIO/radio.yml을(를) 불러올 수 없습니다</translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="90"/>
         <location filename="../storage/labeled.cpp" line="93"/>
         <source>Can&apos;t load MODELS/labels.yml</source>
-        <translation></translation>
+        <translation>MODELS/labels.yml을(를) 불러올 수 없습니다</translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="144"/>
         <source>Cannot extract </source>
-        <translation></translation>
+        <translation>다음을 추출할 수 없습니다: </translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="155"/>
         <location filename="../storage/labeled.cpp" line="159"/>
         <source>Cannot load </source>
-        <translation></translation>
+        <translation>다음을 불러올 수 없습니다: </translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="201"/>
         <source>Cannot list files</source>
-        <translation></translation>
+        <translation>파일 목록을 가져올 수 없습니다</translation>
     </message>
     <message>
         <location filename="../storage/labeled.cpp" line="212"/>
         <source>Error deleting files</source>
-        <translation></translation>
+        <translation>파일 삭제 중 오류가 발생했습니다</translation>
     </message>
 </context>
 <context>
@@ -6590,17 +6725,17 @@ Are you sure ?</source>
     <message>
         <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>INV</source>
-        <translation></translation>
+        <translation>반전</translation>
     </message>
     <message>
         <location filename="../firmwares/output_data.cpp" line="51"/>
         <source>NOR</source>
-        <translation></translation>
+        <translation>정방향</translation>
     </message>
     <message>
         <location filename="../firmwares/output_data.cpp" line="56"/>
         <source>CH</source>
-        <translation></translation>
+        <translation>채널</translation>
     </message>
 </context>
 <context>
@@ -6608,7 +6743,7 @@ Are you sure ?</source>
     <message>
         <location filename="../modeledit/channels.cpp" line="52"/>
         <source>GV</source>
-        <translation></translation>
+        <translation>글로벌 변수</translation>
     </message>
 </context>
 <context>
@@ -6641,17 +6776,17 @@ Are you sure ?</source>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="77"/>
         <source>AND</source>
-        <translation></translation>
+        <translation>AND (그리고)</translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="79"/>
         <source>OR</source>
-        <translation></translation>
+        <translation>OR (또는)</translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="81"/>
         <source>XOR</source>
-        <translation></translation>
+        <translation>XOR (배타적 또는)</translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="83"/>
@@ -6706,22 +6841,22 @@ Are you sure ?</source>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="103"/>
         <source>Timer</source>
-        <translation></translation>
+        <translation>타이머</translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="105"/>
         <source>Sticky</source>
-        <translation></translation>
+        <translation>스티키</translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="107"/>
         <source>Edge</source>
-        <translation></translation>
+        <translation>에지</translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="109"/>
         <source>Unknown</source>
-        <translation></translation>
+        <translation>알 수 없음</translation>
     </message>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="115"/>
@@ -6731,7 +6866,7 @@ Are you sure ?</source>
     <message>
         <location filename="../firmwares/logicalswitchdata.cpp" line="120"/>
         <source>LSW</source>
-        <translation></translation>
+        <translation>LSW (논리 스위치)</translation>
     </message>
 </context>
 <context>
@@ -6739,117 +6874,117 @@ Are you sure ?</source>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>Function</source>
-        <translation></translation>
+        <translation>함수</translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V1</source>
-        <translation></translation>
+        <translation>입력 V1</translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>V2</source>
-        <translation></translation>
+        <translation>입력 V2</translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="47"/>
         <source>AND Switch</source>
-        <translation></translation>
+        <translation>AND 스위치</translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Duration</source>
-        <translation></translation>
+        <translation>지속 시간</translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="49"/>
         <source>Delay</source>
-        <translation></translation>
+        <translation>지연 시간</translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="51"/>
         <source>Persistent</source>
-        <translation type="unfinished"></translation>
+        <translation>지속 유지</translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="62"/>
         <source>Popup menu available</source>
-        <translation></translation>
+        <translation>팝업 메뉴 사용 가능</translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="430"/>
         <source> (infinite)</source>
-        <translation></translation>
+        <translation> (무한)</translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="526"/>
         <source>Delete Logical Switch. Are you sure?</source>
-        <translation></translation>
+        <translation>논리 스위치를 삭제하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="549"/>
         <source>Cut Logical Switch. Are you sure?</source>
-        <translation></translation>
+        <translation>논리 스위치를 잘라내시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="562"/>
         <source>Copy</source>
-        <translation></translation>
+        <translation>복사</translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="563"/>
         <source>Cut</source>
-        <translation></translation>
+        <translation>잘라내기</translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="564"/>
         <source>Paste</source>
-        <translation></translation>
+        <translation>붙여넣기</translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="565"/>
         <source>Clear</source>
-        <translation></translation>
+        <translation>초기화</translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="567"/>
         <source>Insert</source>
-        <translation></translation>
+        <translation>삽입</translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="568"/>
         <source>Delete</source>
-        <translation></translation>
+        <translation>삭제</translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="569"/>
         <source>Move Up</source>
-        <translation></translation>
+        <translation>위로 이동</translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="570"/>
         <source>Move Down</source>
-        <translation></translation>
+        <translation>아래로 이동</translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="572"/>
         <source>Clear All</source>
-        <translation></translation>
+        <translation>전체 초기화</translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="617"/>
         <source>Clear Logical Switch. Are you sure?</source>
-        <translation></translation>
+        <translation>논리 스위치를 초기화하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="630"/>
         <source>Clear all Logical Switches. Are you sure?</source>
-        <translation></translation>
+        <translation>모든 논리 스위치를 초기화하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/logicalswitches.cpp" line="115"/>
         <source>(instant)</source>
-        <translation></translation>
+        <translation>(즉시)</translation>
     </message>
 </context>
 <context>
@@ -6857,150 +6992,153 @@ Are you sure ?</source>
     <message>
         <location filename="../logsdialog.ui" line="14"/>
         <source>Companion Log Viewer</source>
-        <translation></translation>
+        <translation>Companion 로그 뷰어</translation>
     </message>
     <message>
         <location filename="../logsdialog.ui" line="25"/>
         <source>Fly sessions</source>
-        <translation></translation>
+        <translation>비행 세션</translation>
     </message>
     <message>
         <location filename="../logsdialog.ui" line="42"/>
         <source>Save session CSV</source>
-        <translation></translation>
+        <translation>세션 CSV 저장</translation>
     </message>
     <message>
         <location filename="../logsdialog.ui" line="152"/>
         <source>Zoom</source>
-        <translation></translation>
+        <translation>확대/축소</translation>
     </message>
     <message>
         <location filename="../logsdialog.ui" line="159"/>
         <source>X</source>
-        <translation></translation>
+        <translation>X축</translation>
     </message>
     <message>
         <location filename="../logsdialog.ui" line="166"/>
         <source>Y</source>
-        <translation></translation>
+        <translation>Y축</translation>
     </message>
     <message>
         <location filename="../logsdialog.ui" line="173"/>
         <source>Reset</source>
-        <translation></translation>
+        <translation>초기화</translation>
     </message>
     <message>
         <location filename="../logsdialog.ui" line="232"/>
         <source>Filename</source>
-        <translation></translation>
+        <translation>파일 이름</translation>
     </message>
     <message>
         <location filename="../logsdialog.ui" line="246"/>
         <source>Open LogFile</source>
-        <translation></translation>
+        <translation>로그 파일 열기</translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="66"/>
         <source>Telemetry logs</source>
-        <translation></translation>
+        <translation>텔레메트리 로그</translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="78"/>
         <source>Time (hh:mm:ss.ms)</source>
-        <translation></translation>
+        <translation>시간 (시:분:초.밀리초)</translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="145"/>
         <source>Plot Title Change</source>
-        <translation></translation>
+        <translation>그래프 제목 변경</translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="145"/>
         <source>New plot title:</source>
-        <translation></translation>
+        <translation>새 그래프 제목:</translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="159"/>
         <source>Axis Label Change</source>
-        <translation></translation>
+        <translation>축 라벨 변경</translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="159"/>
         <source>New axis label:</source>
-        <translation></translation>
+        <translation>새 축 라벨:</translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="174"/>
         <source>Graph Name Change</source>
-        <translation></translation>
+        <translation>그래프 이름 변경</translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="174"/>
         <source>New graph name:</source>
-        <translation></translation>
+        <translation>새 그래프 이름:</translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="268"/>
         <source>Error: no GPS data found</source>
-        <translation></translation>
+        <translation>오류: GPS 데이터가 없습니다</translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="269"/>
         <source>The column containing GPS coordinates must be named &quot;GPS&quot;.
 
 The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are optional</source>
-        <translation></translation>
+        <translation>GPS 좌표를 포함하는 열의 이름은 반드시 &quot;GPS&quot;여야 합니다.
+
+고도(GAlt)와 속도(GSpd) 열은 선택 사항입니다.</translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="344"/>
         <source>Cannot write file %1:
 %2.</source>
-        <translation></translation>
+        <translation>파일 %1에 쓸 수 없습니다:
+%2.</translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="495"/>
         <source>Cursor A: %1 m</source>
-        <translation></translation>
+        <translation>커서 A: %1 m</translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="498"/>
         <source>Cursor B: %1 m</source>
-        <translation></translation>
+        <translation>커서 B: %1 m</translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="510"/>
         <source>Time delta: %1</source>
-        <translation></translation>
+        <translation>시간 차이: %1</translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="511"/>
         <source>Climb rate: %1 m/s</source>
-        <translation></translation>
+        <translation>상승률: %1 m/s</translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="583"/>
         <source>Select your log file</source>
-        <translation></translation>
+        <translation>로그 파일을 선택하세요</translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="594"/>
         <source>Available fields</source>
-        <translation></translation>
+        <translation>사용 가능한 필드</translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="710"/>
         <source>The selected logfile contains %1 invalid lines out of  %2 total lines</source>
-        <translation></translation>
+        <translation>선택한 로그 파일에 %2줄 중 %1개의 잘못된 줄이 포함되어 있습니다</translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="777"/>
         <source>time span</source>
-        <translation></translation>
+        <translation>시간 범위</translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="785"/>
         <source>duration </source>
-        <translation></translation>
+        <translation>지속 시간 </translation>
     </message>
     <message>
         <location filename="../logsdialog.cpp" line="1029"/>
@@ -7029,436 +7167,436 @@ The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are opt
         <location filename="../mainwindow.cpp" line="131"/>
         <location filename="../mainwindow.cpp" line="361"/>
         <source>File loaded</source>
-        <translation></translation>
+        <translation>파일이 로드되었습니다</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="282"/>
         <source>The new theme will be loaded the next time you start Companion.</source>
-        <translation></translation>
+        <translation>새 테마는 Companion을 다음에 실행할 때 적용됩니다.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="372"/>
         <source>Open Models and Settings file</source>
-        <translation></translation>
+        <translation>모델 및 설정 파일 열기</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="379"/>
         <location filename="../mainwindow.cpp" line="386"/>
         <source>File saved</source>
-        <translation></translation>
+        <translation>파일이 저장되었습니다</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="496"/>
         <source>Synchronize SD</source>
-        <translation></translation>
+        <translation>SD 동기화</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="528"/>
         <source>Writing models and settings to radio</source>
-        <translation></translation>
+        <translation>모델 및 설정을 송신기로 쓰는 중</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="528"/>
         <location filename="../mainwindow.cpp" line="1521"/>
         <source>In progress...</source>
-        <translation></translation>
+        <translation>진행 중...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="558"/>
         <location filename="../mainwindow.cpp" line="829"/>
         <source>Read Firmware from Radio</source>
-        <translation></translation>
+        <translation>송신기에서 펌웨어 읽기</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="568"/>
         <location filename="../mainwindow.cpp" line="832"/>
         <source>Read Models and Settings from Radio</source>
-        <translation></translation>
+        <translation>송신기에서 모델 및 설정 읽기</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="576"/>
         <location filename="../mainwindow.cpp" line="1514"/>
         <source>Models and Settings read</source>
-        <translation></translation>
+        <translation>모델 및 설정이 읽혔습니다</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="583"/>
         <location filename="../mainwindow.cpp" line="595"/>
         <source>This function is not yet implemented</source>
-        <translation></translation>
+        <translation>이 기능은 아직 구현되지 않았습니다</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="599"/>
         <source>Save Radio Backup to File</source>
-        <translation></translation>
+        <translation>송신기 백업을 파일로 저장</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="608"/>
         <source>Read Radio Firmware to File</source>
-        <translation></translation>
+        <translation>송신기 펌웨어를 파일로 저장</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="646"/>
         <source>The EdgeTX project was originally forked from &lt;a href=&apos;%1&apos;&gt;OpenTX&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>EdgeTX 프로젝트는 원래 &lt;a href=&apos;%1&apos;&gt;OpenTX&lt;/a&gt;에서 포크되었습니다</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="648"/>
         <source>If you&apos;ve found this program useful, please support by &lt;a href=&apos;%1&apos;&gt;donating&lt;/a&gt;</source>
-        <translation></translation>
+        <translation>이 프로그램이 유용했다면 &lt;a href=&apos;%1&apos;&gt;기부&lt;/a&gt;를 통해 후원해 주세요</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="813"/>
         <source>New</source>
-        <translation></translation>
+        <translation>새로 만들기</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="813"/>
         <source>Create a new Models and Settings file</source>
-        <translation></translation>
+        <translation>새 모델 및 설정 파일 생성</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="814"/>
         <source>Open...</source>
-        <translation></translation>
+        <translation>열기...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="815"/>
         <source>Save</source>
-        <translation></translation>
+        <translation>저장</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="816"/>
         <source>Save As...</source>
-        <translation></translation>
+        <translation>다른 이름으로 저장...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="821"/>
         <source>Exit</source>
-        <translation></translation>
+        <translation>종료</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="821"/>
         <source>Exit the application</source>
-        <translation></translation>
+        <translation>애플리케이션 종료</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="857"/>
         <source>Check for updates...</source>
-        <translation></translation>
+        <translation>업데이트 확인...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="857"/>
         <source>Check for updates to EdgeTX and supporting resources</source>
-        <translation></translation>
+        <translation>EdgeTX 및 관련 리소스의 업데이트 확인</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="842"/>
         <source>Create a new Radio Settings Profile</source>
-        <translation></translation>
+        <translation>새 송신기 설정 프로필 생성</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="843"/>
         <source>Copy Current Radio Profile</source>
-        <translation></translation>
+        <translation>현재 송신기 프로필 복사</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="843"/>
         <source>Duplicate current Radio Settings Profile</source>
-        <translation></translation>
+        <translation>현재 송신기 설정 프로필 복제</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="844"/>
         <source>Delete the current Radio Settings Profile</source>
-        <translation></translation>
+        <translation>현재 송신기 설정 프로필 삭제</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="824"/>
         <source>Save all the current %1 and Simulator settings (including radio profiles) to a file.</source>
-        <translation></translation>
+        <translation>현재 %1 및 시뮬레이터 설정(송신기 프로필 포함)을 파일로 저장합니다.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="825"/>
         <source>Load %1 and Simulator settings from a prevously exported settings file.</source>
-        <translation></translation>
+        <translation>이전에 내보낸 설정 파일에서 %1 및 시뮬레이터 설정을 불러옵니다.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="979"/>
         <source>Classical</source>
-        <translation></translation>
+        <translation>클래식</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="979"/>
         <source>The classic companion9x icon theme</source>
-        <translation></translation>
+        <translation>클래식 companion9x 아이콘 테마</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="980"/>
         <source>Yerico</source>
-        <translation></translation>
+        <translation>예리코</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="980"/>
         <source>Yellow round honey sweet icon theme</source>
-        <translation></translation>
+        <translation>노란색 둥근 꿀 느낌의 아이콘 테마</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="981"/>
         <source>Monochrome</source>
-        <translation></translation>
+        <translation>모노크롬</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="981"/>
         <source>A monochrome black icon theme</source>
-        <translation></translation>
+        <translation>흑백 모노크롬 아이콘 테마</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="983"/>
         <source>MonoWhite</source>
-        <translation></translation>
+        <translation>모노화이트</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="983"/>
         <source>A monochrome white icon theme</source>
-        <translation></translation>
+        <translation>백색 모노크롬 아이콘 테마</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1321"/>
         <source>Cannot add profile</source>
-        <translation></translation>
+        <translation>프로필을 추가할 수 없습니다</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1321"/>
         <source>There is no space left to add a new profile. Delete an exsting profile before adding a new one.</source>
-        <translation></translation>
+        <translation>새 프로필을 추가할 공간이 없습니다. 기존 프로필을 삭제한 후 추가해 주세요.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1396"/>
         <source>Please save or close all modified files before importing settings</source>
-        <translation></translation>
+        <translation>설정을 가져오기 전에 모든 수정된 파일을 저장하거나 닫아 주세요</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1399"/>
         <source>&lt;html&gt;&lt;p&gt;%1 and Simulator settings can be imported (restored) from a previosly saved export (backup) file. This will replace current settings with any settings found in the file.&lt;/p&gt;&lt;p&gt;An automatic backup of the current settings will be attempted. But if the current settings are useful then it is recommended that you make a manual backup first.&lt;/p&gt;&lt;p&gt;For best results when importing settings, &lt;b&gt;close any other %1 windows you may have open, and make sure the standalone Simulator application is not running.&lt;/p&gt;&lt;p&gt;Do you wish to continue?&lt;/p&gt;&lt;/html&gt;</source>
-        <translation></translation>
+        <translation>&lt;html&gt;&lt;p&gt;%1 및 시뮬레이터 설정은 이전에 저장된 내보내기(백업) 파일에서 가져올 수 있습니다. 가져온 설정은 현재 설정을 대체합니다.&lt;/p&gt;&lt;p&gt;현재 설정은 자동으로 백업됩니다. 하지만 중요한 설정이라면 수동 백업을 먼저 권장합니다.&lt;/p&gt;&lt;p&gt;가져오기를 성공적으로 수행하려면, &lt;b&gt;열려 있는 %1 창을 모두 닫고 독립 실행형 시뮬레이터가 종료되어 있는지 확인하세요.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;계속하시겠습니까?&lt;/p&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1407"/>
         <source>Confirm Settings Import</source>
-        <translation></translation>
+        <translation>설정 가져오기 확인</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1412"/>
         <source>Select %1:</source>
-        <translation></translation>
+        <translation>%1 선택:</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1417"/>
         <source>backup</source>
-        <translation></translation>
+        <translation>백업</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1419"/>
         <source>Press the &apos;Ignore&apos; button to continue anyway.</source>
-        <translation></translation>
+        <translation>계속하려면 &apos;무시&apos; 버튼을 누르세요.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1429"/>
         <source>The settings could not be imported.</source>
-        <translation></translation>
+        <translation>설정을 가져올 수 없습니다.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1432"/>
         <source>&lt;html&gt;&lt;p&gt;New settings have been imported from:&lt;br&gt; %1.&lt;/p&gt;&lt;p&gt;%2 will now re-initialize.&lt;/p&gt;&lt;p&gt;Note that you may need to close and restart %2 before some settings like language and icon theme take effect.&lt;/p&gt;</source>
-        <translation></translation>
+        <translation>&lt;html&gt;&lt;p&gt;새 설정이 아래에서 가져왔습니다:&lt;br&gt; %1&lt;/p&gt;&lt;p&gt;%2가 다시 초기화됩니다.&lt;/p&gt;&lt;p&gt;언어 및 아이콘 테마와 같은 일부 설정은 %2를 다시 시작해야 적용될 수 있습니다.&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1439"/>
         <source>&lt;p&gt;The previous settings were backed up to:&lt;br&gt; %1&lt;/p&gt;</source>
-        <translation></translation>
+        <translation>&lt;p&gt;이전 설정은 아래 위치에 백업되었습니다:&lt;br&gt; %1&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="852"/>
         <source>Tabbed Windows</source>
-        <translation></translation>
+        <translation>탭 방식 창</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="664"/>
         <source>About EdgeTX Companion</source>
-        <translation type="unfinished"></translation>
+        <translation>EdgeTX Companion 정보</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="743"/>
         <source>%1 %2 - Radio: %3 - Profile: %4</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 %2 - 송신기: %3 - 프로필: %4</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="814"/>
         <source>Open an existing Models and Settings file</source>
-        <translation type="unfinished"></translation>
+        <translation>기존 모델 및 설정 파일 열기</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="815"/>
         <source>Save to Models and Settings file</source>
-        <translation type="unfinished"></translation>
+        <translation>모델 및 설정 파일에 저장</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="816"/>
         <source>Save Models and Settings to another file name</source>
-        <translation type="unfinished"></translation>
+        <translation>모델 및 설정을 다른 이름으로 저장</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="819"/>
         <source>Write Models and Settings to SD Path</source>
-        <translation type="unfinished"></translation>
+        <translation>모델 및 설정을 SD 경로에 기록</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="820"/>
         <source>Read Models and Settings from SD Path</source>
-        <translation type="unfinished"></translation>
+        <translation>SD 경로에서 모델 및 설정 읽기</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="823"/>
         <source>Edit Settings...</source>
-        <translation type="unfinished"></translation>
+        <translation>설정 편집...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="823"/>
         <source>Edit %1 and Simulator settings (including radio profiles) settings</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 및 시뮬레이터 설정(송신기 프로필 포함) 편집</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="824"/>
         <source>Export Settings...</source>
-        <translation type="unfinished"></translation>
+        <translation>설정 내보내기...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="825"/>
         <source>Import Settings...</source>
-        <translation type="unfinished"></translation>
+        <translation>설정 가져오기...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="827"/>
         <source>Configure Radio Communications...</source>
-        <translation type="unfinished"></translation>
+        <translation>송신기 통신 구성...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="827"/>
         <source>Configure Companion for communicating with the Radio</source>
-        <translation type="unfinished"></translation>
+        <translation>송신기와 통신할 수 있도록 Companion을 구성</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="836"/>
         <source>Compare Models</source>
-        <translation type="unfinished"></translation>
+        <translation>모델 비교</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="837"/>
         <source>Update components...</source>
-        <translation type="unfinished"></translation>
+        <translation>구성 요소 업데이트...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="837"/>
         <source>Download and update EdgeTX components and supporting resources</source>
-        <translation type="unfinished"></translation>
+        <translation>EdgeTX 구성 요소 및 지원 리소스를 다운로드 및 업데이트</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="838"/>
         <source>Synchronize SD card...</source>
-        <translation type="unfinished"></translation>
+        <translation>SD 카드 동기화...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="846"/>
         <source>File Toolbar</source>
-        <translation type="unfinished"></translation>
+        <translation>파일 도구 모음</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="846"/>
         <source>Configure File toolbar visibility</source>
-        <translation type="unfinished"></translation>
+        <translation>파일 도구 모음 표시 설정</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="847"/>
         <source>Models Toolbar</source>
-        <translation type="unfinished"></translation>
+        <translation>모델 도구 모음</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="847"/>
         <source>Configure Models toolbar visibility</source>
-        <translation type="unfinished"></translation>
+        <translation>모델 도구 모음 표시 설정</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="848"/>
         <source>Radio Toolbar</source>
-        <translation type="unfinished"></translation>
+        <translation>라디오 도구 모음</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="848"/>
         <source>Configure Radio toolbar visibility</source>
-        <translation type="unfinished"></translation>
+        <translation>라디오 도구 모음 표시 설정</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="849"/>
         <source>Settings Toolbar</source>
-        <translation type="unfinished"></translation>
+        <translation>설정 도구 모음</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="849"/>
         <source>Configure Settings toolbar visibility</source>
-        <translation type="unfinished"></translation>
+        <translation>설정 도구 모음 표시 설정</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="850"/>
         <source>Tools Toolbar</source>
-        <translation type="unfinished"></translation>
+        <translation>도구 도구 모음</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="850"/>
         <source>Configure Tools toolbar visibility</source>
-        <translation type="unfinished"></translation>
+        <translation>도구 도구 모음 표시 설정</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="853"/>
         <source>Tile Windows</source>
-        <translation></translation>
+        <translation>창 타일 배열</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="854"/>
         <source>Cascade Windows</source>
-        <translation></translation>
+        <translation>창 계단식 배열</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="855"/>
         <source>Close All Windows</source>
-        <translation></translation>
+        <translation>모든 창 닫기</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="859"/>
         <source>About</source>
-        <translation type="unfinished"></translation>
+        <translation>정보</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="862"/>
         <source>View</source>
-        <translation type="unfinished"></translation>
+        <translation>보기</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="863"/>
         <location filename="../mainwindow.cpp" line="873"/>
         <source>Models</source>
-        <translation type="unfinished"></translation>
+        <translation>모델</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="867"/>
         <location filename="../mainwindow.cpp" line="874"/>
         <source>Radio</source>
-        <translation type="unfinished"></translation>
+        <translation>라디오</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="868"/>
         <location filename="../mainwindow.cpp" line="876"/>
         <source>Tools</source>
-        <translation type="unfinished"></translation>
+        <translation>도구</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1249"/>
@@ -7468,103 +7606,103 @@ The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are opt
     <message>
         <location filename="../mainwindow.cpp" line="1351"/>
         <source> - Copy</source>
-        <translation></translation>
+        <translation> - 복사본</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1360"/>
         <source>Companion :: Open files warning</source>
-        <translation></translation>
+        <translation>Companion :: 파일 열기 경고</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1360"/>
         <source>Please save or close modified file(s) before deleting the active profile.</source>
-        <translation></translation>
+        <translation>활성 프로필을 삭제하기 전에 수정된 파일을 저장하거나 닫아주세요.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1368"/>
         <source>Not possible to remove profile</source>
-        <translation></translation>
+        <translation>프로필을 삭제할 수 없음</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1368"/>
         <source>The default profile can not be removed.</source>
-        <translation></translation>
+        <translation>기본 프로필은 삭제할 수 없습니다.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1373"/>
         <source>Confirm Delete Profile</source>
-        <translation></translation>
+        <translation>프로필 삭제 확인</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1374"/>
         <source>Are you sure you wish to delete the &quot;%1&quot; radio profile? There is no way to undo this action!</source>
-        <translation></translation>
+        <translation>&quot;%1&quot; 라디오 프로필을 삭제하시겠습니까? 이 작업은 되돌릴 수 없습니다!</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1506"/>
         <source>Read Models and Settings from SD path</source>
-        <translation type="unfinished"></translation>
+        <translation>SD 경로에서 모델 및 설정 읽기</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1521"/>
         <source>Writing models and settings to SD path</source>
-        <translation type="unfinished"></translation>
+        <translation>모델 및 설정을 SD 경로에 쓰는 중</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="982"/>
         <source>MonoBlue</source>
-        <translation></translation>
+        <translation>모노블루</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="246"/>
         <location filename="../mainwindow.cpp" line="253"/>
         <source>Checking for updates...</source>
-        <translation></translation>
+        <translation>업데이트 확인 중...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="644"/>
         <source>EdgeTX Home Page: &lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</source>
-        <translation></translation>
+        <translation>EdgeTX 홈페이지: &lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="658"/>
         <source>File new &lt;a href=&apos;%1&apos;&gt;Issue or Request&lt;/a&gt;</source>
-        <translation></translation>
+        <translation>새 &lt;a href=&apos;%1&apos;&gt;이슈 또는 요청&lt;/a&gt; 등록</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="660"/>
         <source>Copyright</source>
-        <translation></translation>
+        <translation>저작권</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="844"/>
         <source>Delete Current Radio Profile...</source>
-        <translation></translation>
+        <translation>현재 라디오 프로필 삭제...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="852"/>
         <source>Use tabs to arrange open windows.</source>
-        <translation></translation>
+        <translation>열려 있는 창을 탭으로 정렬합니다.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="853"/>
         <source>Arrange open windows across all the available space.</source>
-        <translation></translation>
+        <translation>열려 있는 창을 전체 화면에 분산 배치합니다.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="854"/>
         <source>Arrange all open windows in a stack.</source>
-        <translation></translation>
+        <translation>모든 창을 계단식으로 정렬합니다.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="855"/>
         <source>Closes all open files (prompts to save if necessary.</source>
-        <translation></translation>
+        <translation>열린 모든 파일을 닫습니다 (필요 시 저장 여부 확인).</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="869"/>
         <source>Window</source>
-        <translation></translation>
+        <translation>창</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="889"/>
@@ -7589,251 +7727,253 @@ The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are opt
     <message>
         <location filename="../mainwindow.cpp" line="982"/>
         <source>A monochrome blue icon theme</source>
-        <translation></translation>
+        <translation>단색 파란색 아이콘 테마</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="989"/>
         <source>Small</source>
-        <translation></translation>
+        <translation>작게</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="989"/>
         <source>Use small toolbar icons</source>
-        <translation></translation>
+        <translation>작은 도구 아이콘 사용</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="990"/>
         <source>Normal</source>
-        <translation></translation>
+        <translation>보통</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="990"/>
         <source>Use normal size toolbar icons</source>
-        <translation></translation>
+        <translation>보통 크기 도구 아이콘 사용</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="991"/>
         <source>Big</source>
-        <translation></translation>
+        <translation>크게</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="991"/>
         <source>Use big toolbar icons</source>
-        <translation></translation>
+        <translation>큰 도구 아이콘 사용</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="992"/>
         <source>Huge</source>
-        <translation></translation>
+        <translation>매우 크게</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="992"/>
         <source>Use huge toolbar icons</source>
-        <translation></translation>
+        <translation>매우 큰 도구 아이콘 사용</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1152"/>
         <source>System language</source>
-        <translation></translation>
+        <translation>시스템 언어</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="498"/>
         <source>Local Folder</source>
-        <translation></translation>
+        <translation>로컬 폴더</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="499"/>
         <source>Radio Folder</source>
-        <translation></translation>
+        <translation>라디오 폴더</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="859"/>
         <source>Show the application&apos;s About box</source>
-        <translation></translation>
+        <translation>프로그램 정보 창 보기</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="839"/>
         <source>View Log File...</source>
-        <translation></translation>
+        <translation>로그 파일 보기...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="839"/>
         <source>Open and view log file</source>
-        <translation></translation>
+        <translation>로그 파일 열기 및 보기</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="836"/>
         <source>Compare models</source>
-        <translation></translation>
+        <translation>모델 비교</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="828"/>
         <source>Edit Radio Splash Image...</source>
-        <translation></translation>
+        <translation>라디오 시작 이미지 편집...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="828"/>
         <source>Edit the splash image of your Radio</source>
-        <translation></translation>
+        <translation>라디오의 시작 이미지를 편집합니다</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="829"/>
         <source>Read firmware from Radio</source>
-        <translation></translation>
+        <translation>라디오에서 펌웨어 읽기</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="830"/>
         <source>Write Firmware to Radio</source>
-        <translation></translation>
+        <translation>라디오에 펌웨어 쓰기</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="830"/>
         <source>Write firmware to Radio</source>
-        <translation></translation>
+        <translation>라디오에 펌웨어 쓰기</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="842"/>
         <source>Add Radio Profile</source>
-        <translation></translation>
+        <translation>라디오 프로필 추가</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="432"/>
         <source>There are unsaved file changes which you may lose when switching radio types.
 
 Do you wish to continue?</source>
-        <translation></translation>
+        <translation>저장되지 않은 파일 변경사항이 있어 라디오 유형을 전환하면 손실될 수 있습니다.
+
+계속하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="489"/>
         <source>No local SD structure path configured!</source>
-        <translation></translation>
+        <translation>로컬 SD 구조 경로가 설정되지 않았습니다!</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="491"/>
         <source>No Radio or SD card detected!</source>
-        <translation></translation>
+        <translation>라디오 또는 SD 카드가 감지되지 않았습니다!</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="817"/>
         <source>Close</source>
-        <translation></translation>
+        <translation>닫기</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="817"/>
         <source>Close Models and Settings file</source>
-        <translation></translation>
+        <translation>모델 및 설정 파일 닫기</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="818"/>
         <source>List of recently used files</source>
-        <translation></translation>
+        <translation>최근 사용한 파일 목록</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="841"/>
         <source>Radio Profiles</source>
-        <translation></translation>
+        <translation>라디오 프로필</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="841"/>
         <source>Create or Select Radio Profiles</source>
-        <translation></translation>
+        <translation>라디오 프로필 생성 또는 선택</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="858"/>
         <source>Release notes...</source>
-        <translation></translation>
+        <translation>릴리스 노트...</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="858"/>
         <source>Show release notes</source>
-        <translation></translation>
+        <translation>릴리스 노트 보기</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="831"/>
         <source>Write Models and Settings to Radio</source>
-        <translation></translation>
+        <translation>모델 및 설정을 라디오에 쓰기</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="833"/>
         <source>Write Backup to Radio</source>
-        <translation></translation>
+        <translation>백업을 라디오에 쓰기</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="833"/>
         <source>Write Backup from file to Radio</source>
-        <translation></translation>
+        <translation>파일에서 백업을 라디오에 쓰기</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="834"/>
         <source>Backup Radio to File</source>
-        <translation></translation>
+        <translation>라디오 백업을 파일로 저장</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="834"/>
         <source>Save a complete backup file of all settings and model data in the Radio</source>
-        <translation></translation>
+        <translation>라디오의 모든 설정과 모델 데이터를 포함한 전체 백업 파일 저장</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="838"/>
         <source>SD card synchronization</source>
-        <translation></translation>
+        <translation>SD 카드 동기화</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1152"/>
         <source>Use default system language.</source>
-        <translation></translation>
+        <translation>시스템 기본 언어 사용</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1156"/>
         <source>Use %1 language (some translations may not be complete).</source>
-        <translation></translation>
+        <translation>%1 언어 사용 (일부 번역이 완전하지 않을 수 있음)</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="818"/>
         <source>Recent Files</source>
-        <translation></translation>
+        <translation>최근 파일</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1148"/>
         <source>Set Menu Language</source>
-        <translation></translation>
+        <translation>메뉴 언어 설정</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="865"/>
         <source>Set Icon Theme</source>
-        <translation></translation>
+        <translation>아이콘 테마 설정</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="866"/>
         <source>Set Icon Size</source>
-        <translation></translation>
+        <translation>아이콘 크기 설정</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="861"/>
         <location filename="../mainwindow.cpp" line="872"/>
         <source>File</source>
-        <translation></translation>
+        <translation>파일</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="881"/>
         <source>Some text will not be translated until the next time you start Companion. Please note that some translations may not be complete.</source>
-        <translation></translation>
+        <translation>일부 텍스트는 Companion을 다시 시작해야 번역이 적용됩니다. 일부 번역이 완전하지 않을 수 있습니다.</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="864"/>
         <location filename="../mainwindow.cpp" line="875"/>
         <source>Settings</source>
-        <translation></translation>
+        <translation>설정</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="870"/>
         <source>Help</source>
-        <translation></translation>
+        <translation>도움말</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1168"/>
         <source>Ready</source>
-        <translation></translation>
+        <translation>준비 완료</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="1221"/>
@@ -7851,30 +7991,29 @@ Do you wish to continue?</source>
     <message>
         <location filename="../mdichild.cpp" line="970"/>
         <source>Model already exists! Do you want to overwrite it or insert into a new slot?</source>
-        <translation></translation>
+        <translation>모델이 이미 존재합니다! 덮어쓰시겠습니까, 아니면 새로운 슬롯에 삽입하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="971"/>
         <source>Overwrite</source>
-        <translation></translation>
+        <translation>덮어쓰기</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1042"/>
         <source>Unable to Edit Radio Settings whilst models are open for editing.</source>
-        <translation></translation>
+        <translation>모델이 열려 있는 동안에는 라디오 설정을 편집할 수 없습니다.</translation>
     </message>
     <message numerus="yes">
         <location filename="../mdichild.cpp" line="1136"/>
         <source>Delete %n selected model(s)?</source>
         <translation>
-            <numerusform>Delete %n selected model?</numerusform>
-            <numerusform>Delete %n selected models?</numerusform>
+            <numerusform>%n개의 선택된 모델을 삭제하시겠습니까?</numerusform>
         </translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="383"/>
         <source>Edit Radio Settings</source>
-        <translation></translation>
+        <translation>라디오 설정 편집</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="215"/>
@@ -7885,12 +8024,12 @@ Do you wish to continue?</source>
         <location filename="../mdichild.cpp" line="368"/>
         <location filename="../mdichild.cpp" line="401"/>
         <source>Export</source>
-        <translation></translation>
+        <translation>내보내기</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="384"/>
         <source>Copy Radio Settings</source>
-        <translation></translation>
+        <translation>라디오 설정 복사</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="216"/>
@@ -7900,7 +8039,7 @@ Do you wish to continue?</source>
     <message>
         <location filename="../mdichild.cpp" line="385"/>
         <source>Paste Radio Settings</source>
-        <translation></translation>
+        <translation>라디오 설정 붙여넣기</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="217"/>
@@ -7910,7 +8049,7 @@ Do you wish to continue?</source>
     <message>
         <location filename="../mdichild.cpp" line="386"/>
         <source>Simulate Radio</source>
-        <translation></translation>
+        <translation>라디오 시뮬레이션</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="218"/>
@@ -7935,32 +8074,32 @@ Do you wish to continue?</source>
     <message>
         <location filename="../mdichild.cpp" line="392"/>
         <source>Add</source>
-        <translation></translation>
+        <translation>추가</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="394"/>
         <source>Rename</source>
-        <translation></translation>
+        <translation>이름 변경</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="395"/>
         <source>Move Up</source>
-        <translation></translation>
+        <translation>위로 이동</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="396"/>
         <source>Move Down</source>
-        <translation></translation>
+        <translation>아래로 이동</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="400"/>
         <source>Export Model</source>
-        <translation></translation>
+        <translation>모델 내보내기</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="407"/>
         <source>Duplicate Model</source>
-        <translation></translation>
+        <translation>모델 복제</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="226"/>
@@ -7970,57 +8109,57 @@ Do you wish to continue?</source>
     <message>
         <location filename="../mdichild.cpp" line="405"/>
         <source>Print Model</source>
-        <translation></translation>
+        <translation>모델 인쇄</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="399"/>
         <source>Model</source>
-        <translation></translation>
+        <translation>모델</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="410"/>
         <source>Show Radio Actions Toolbar</source>
-        <translation></translation>
+        <translation>라디오 동작 도구 모음 표시</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="411"/>
         <source>Show Model Actions Toolbar</source>
-        <translation></translation>
+        <translation>모델 동작 도구 모음 표시</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="412"/>
         <source>Show Labels Actions Toolbar</source>
-        <translation></translation>
+        <translation>레이블 동작 도구 모음 표시</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="720"/>
         <source>read only</source>
-        <translation></translation>
+        <translation>읽기 전용</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="788"/>
         <source>Cannot insert model, last model in list would be deleted.</source>
-        <translation></translation>
+        <translation>모델을 삽입할 수 없습니다. 리스트의 마지막 모델이 삭제됩니다.</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="950"/>
         <source>Cannot paste model, out of available model slots.</source>
-        <translation></translation>
+        <translation>모델을 붙여넣을 수 없습니다. 사용 가능한 모델 슬롯이 없습니다.</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1033"/>
         <source>Do you want to overwrite radio general settings?</source>
-        <translation></translation>
+        <translation>라디오 일반 설정을 덮어쓰시겠습니까?</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="830"/>
         <source>Cannot add model, could not find an available model slot.</source>
-        <translation></translation>
+        <translation>모델을 추가할 수 없습니다. 사용 가능한 모델 슬롯을 찾을 수 없습니다.</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="360"/>
         <source>Cut</source>
-        <translation></translation>
+        <translation>잘라내기</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="242"/>
@@ -8051,76 +8190,75 @@ Do you wish to continue?</source>
     <message>
         <location filename="../mdichild.cpp" line="257"/>
         <source>Labels Management</source>
-        <translation></translation>
+        <translation>레이블 관리</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="362"/>
         <source>Copy</source>
-        <translation></translation>
+        <translation>복사</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="364"/>
         <source>Paste</source>
-        <translation></translation>
+        <translation>붙여넣기</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="366"/>
         <location filename="../mdichild.cpp" line="972"/>
         <source>Insert</source>
-        <translation></translation>
+        <translation>삽입</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1659"/>
         <source>Internal module protocol changed to &lt;b&gt;OFF&lt;/b&gt; for %1 models!</source>
-        <translation></translation>
+        <translation>%1 모델에 대해 내부 모듈 프로토콜이 &lt;b&gt;OFF&lt;/b&gt;로 변경되었습니다!</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1671"/>
         <source>Select a model template file</source>
-        <translation></translation>
+        <translation>모델 템플릿 파일 선택</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1713"/>
         <source>Add a new model using</source>
-        <translation></translation>
+        <translation>다음 항목을 사용하여 새 모델 추가</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1714"/>
         <source>Defaults</source>
-        <translation></translation>
+        <translation>기본값</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1715"/>
         <source>Edit</source>
-        <translation></translation>
+        <translation>편집</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1716"/>
         <source>Wizard</source>
-        <translation></translation>
+        <translation>마법사</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1717"/>
         <source>Template</source>
-        <translation></translation>
+        <translation>템플릿</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1724"/>
         <source>Failed to remove temporary model!</source>
-        <translation></translation>
+        <translation>임시 모델을 삭제하지 못했습니다!</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1822"/>
         <source>Export model</source>
-        <translation></translation>
+        <translation>모델 내보내기</translation>
     </message>
     <message numerus="yes">
         <location filename="../mdichild.cpp" line="338"/>
         <source>%n Model(s)</source>
         <comment>As in &quot;Copy 3 Models&quot; or &quot;Cut 1 Model&quot; or &quot;Delete 3 Models&quot; action).</comment>
         <translation>
-            <numerusform>%n Model</numerusform>
-            <numerusform>%n Models</numerusform>
+            <numerusform>%n개 모델</numerusform>
         </translation>
     </message>
     <message numerus="yes">
@@ -8128,209 +8266,211 @@ Do you wish to continue?</source>
         <source>%n Model(s)</source>
         <comment>As in &quot;Paste 3 Models&quot; or &quot;Insert 1 Model.&quot;</comment>
         <translation>
-            <numerusform>%n Model</numerusform>
-            <numerusform>%n Models</numerusform>
+            <numerusform>%n개 모델</numerusform>
         </translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="340"/>
         <source>Nothing selected</source>
-        <translation></translation>
+        <translation>선택된 항목 없음</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="387"/>
         <source>Radio Models Order</source>
-        <translation></translation>
+        <translation>라디오 모델 순서</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="389"/>
         <source>Edit Model</source>
-        <translation></translation>
+        <translation>모델 편집</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="358"/>
         <location filename="../mdichild.cpp" line="393"/>
         <source>Delete</source>
-        <translation></translation>
+        <translation>삭제</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="236"/>
         <source>Ctrl+Alt+E</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="390"/>
         <source>Delete Model</source>
-        <translation type="unfinished"></translation>
+        <translation>모델 삭제</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="398"/>
         <source>Add Model</source>
-        <translation></translation>
+        <translation>모델 추가</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="402"/>
         <source>Restore from Backup</source>
-        <translation></translation>
+        <translation>백업에서 복원</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="403"/>
         <source>Model Wizard</source>
-        <translation></translation>
+        <translation>모델 마법사</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="404"/>
         <source>Set as Default</source>
-        <translation></translation>
+        <translation>기본값으로 설정</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="406"/>
         <source>Simulate Model</source>
-        <translation></translation>
+        <translation>모델 시뮬레이션</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="408"/>
         <source>Show Model Errors</source>
-        <translation type="unfinished"></translation>
+        <translation>모델 오류 표시</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1167"/>
         <source>Cannot duplicate model, could not find an available model slot.</source>
-        <translation></translation>
+        <translation>모델을 복제할 수 없습니다. 사용 가능한 모델 슬롯이 없습니다.</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1214"/>
         <source>Editing model %1: </source>
-        <translation></translation>
+        <translation>모델 %1 편집 중: </translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1268"/>
         <source>Favorites</source>
-        <translation></translation>
+        <translation>즐겨찾기</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1337"/>
         <source>Save As</source>
-        <translation></translation>
+        <translation>다른 이름으로 저장</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1341"/>
         <location filename="../mdichild.cpp" line="1828"/>
         <source>Invalid file extension!</source>
-        <translation></translation>
+        <translation>잘못된 파일 확장자입니다!</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1387"/>
         <source>%1 has been modified.
 Do you want to save your changes?</source>
-        <translation></translation>
+        <translation>%1이(가) 수정되었습니다.
+변경 내용을 저장하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1442"/>
         <source>&lt;p&gt;&lt;b&gt;Currently selected radio type (%1) is not compatible with file %3 (from %2), models and settings need to be converted.&lt;/b&gt;&lt;/p&gt;</source>
-        <translation></translation>
+        <translation>&lt;p&gt;&lt;b&gt;현재 선택된 라디오 유형(%1)은 파일 %3(%2에서 가져옴)과 호환되지 않으며, 모델과 설정을 변환해야 합니다.&lt;/b&gt;&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1444"/>
         <source>Do you wish to continue with the conversion?</source>
-        <translation></translation>
+        <translation>변환을 계속하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1449"/>
         <source>Choose &lt;i&gt;Apply&lt;/i&gt; to convert the file, or &lt;i&gt;Close&lt;/i&gt; to close it without conversion.</source>
-        <translation></translation>
+        <translation>변환하려면 &lt;i&gt;적용&lt;/i&gt;을 선택하고, 변환하지 않으려면 &lt;i&gt;닫기&lt;/i&gt;를 선택하세요.</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1476"/>
         <source>&lt;b&gt;The conversion generated some important messages, please review them below.&lt;/b&gt;</source>
-        <translation></translation>
+        <translation>&lt;b&gt;변환 중 중요한 메시지가 생성되었습니다. 아래 내용을 확인해 주세요.&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1483"/>
         <source>Companion :: Conversion Result for %1</source>
-        <translation></translation>
+        <translation>Companion :: %1에 대한 변환 결과</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1507"/>
         <source>Write Models and Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>모델 및 설정 쓰기</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1507"/>
         <source>Operation aborted as %1 models have significant errors that may affect model operation.</source>
-        <translation type="unfinished"></translation>
+        <translation>%1개의 모델에 작동에 영향을 줄 수 있는 중대한 오류가 있어 작업이 중단되었습니다.</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1513"/>
         <source>You are about to overwrite ALL models.</source>
-        <translation type="unfinished"></translation>
+        <translation>모든 모델을 덮어쓰려 합니다.</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1514"/>
         <source>Continue?</source>
-        <translation type="unfinished"></translation>
+        <translation>계속하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1519"/>
         <source>Do not show this message again</source>
-        <translation></translation>
+        <translation>이 메시지를 다시 표시하지 않음</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1541"/>
         <source>Unable to find SD card!</source>
-        <translation type="unfinished"></translation>
+        <translation>SD 카드를 찾을 수 없습니다!</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1547"/>
         <source>Models and settings written</source>
-        <translation type="unfinished"></translation>
+        <translation>모델 및 설정이 저장되었습니다</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1551"/>
         <source>Error writing models and settings!</source>
-        <translation type="unfinished"></translation>
+        <translation>모델 및 설정 저장 중 오류가 발생했습니다!</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1901"/>
         <source>Models status</source>
-        <translation type="unfinished"></translation>
+        <translation>모델 상태</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1916"/>
         <source>No errors</source>
-        <translation type="unfinished"></translation>
+        <translation>오류 없음</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1920"/>
         <source>Errors</source>
-        <translation type="unfinished"></translation>
+        <translation>오류</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1557"/>
         <source>Open backup Models and Settings file</source>
-        <translation></translation>
+        <translation>백업된 모델 및 설정 파일 열기</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1563"/>
         <source>Unable to find file %1!</source>
-        <translation></translation>
+        <translation>파일 %1을(를) 찾을 수 없습니다!</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1572"/>
         <source>Error opening file %1:
 %2.</source>
-        <translation></translation>
+        <translation>파일 %1 열기 오류:
+%2</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1583"/>
         <source>Error reading file %1:
 %2.</source>
-        <translation></translation>
+        <translation>파일 %1 읽기 오류:
+%2</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1593"/>
         <source>Invalid binary backup File %1</source>
-        <translation></translation>
+        <translation>잘못된 이진 백업 파일: %1</translation>
     </message>
 </context>
 <context>
@@ -8338,148 +8478,148 @@ Do you want to save your changes?</source>
     <message>
         <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>Progress calculation method: file %1</source>
-        <translation></translation>
+        <translation>진행률 계산 방식: 파일 %1</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>count</source>
-        <translation></translation>
+        <translation>갯갯수 기준</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="42"/>
         <source>size</source>
-        <translation></translation>
+        <translation>크기 기준</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="53"/>
         <source>Compressing %1 to %2 with append %3</source>
-        <translation></translation>
+        <translation>%1을(를) %2(으)로 압축 중 (추가 파일: %3)</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="57"/>
         <location filename="../storage/minizinterface.cpp" line="184"/>
         <source>Miniz version: %1</source>
-        <translation></translation>
+        <translation>Miniz 버전: %1</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="67"/>
         <source>Existing archive will be overwritten</source>
-        <translation></translation>
+        <translation>기존 압축 파일이 덮어써집니다</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="71"/>
         <source>Unable to open existing archive</source>
-        <translation></translation>
+        <translation>기존 압축 파일을 열 수 없습니다</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="75"/>
         <source>Existing archive opened</source>
-        <translation></translation>
+        <translation>기존 압축 파일을 열었습니다</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="78"/>
         <source>Unable to write to existing archive</source>
-        <translation></translation>
+        <translation>기존 압축 파일에 쓸 수 없습니다</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="82"/>
         <source>Existing archive initialised</source>
-        <translation></translation>
+        <translation>기존 압축 파일 초기화 완료</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="86"/>
         <source>Failure to initialise archive</source>
-        <translation></translation>
+        <translation>압축 파일 초기화 실패</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="90"/>
         <source>Archive initialised</source>
-        <translation></translation>
+        <translation>압축 파일이 초기화되었습니다</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="99"/>
         <source>Calculating number of items to archive</source>
-        <translation></translation>
+        <translation>압축할 항목 수를 계산 중</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="140"/>
         <source>Failure to finalise archive</source>
-        <translation></translation>
+        <translation>압축 파일 마무리 작업 실패</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="149"/>
         <source>Compress complete</source>
-        <translation></translation>
+        <translation>압축 완료</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="158"/>
         <source>Failure to add %1</source>
-        <translation></translation>
+        <translation>%1 추가 실패</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="170"/>
         <source>Added file: %1</source>
-        <translation></translation>
+        <translation>파일 추가됨: %1</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="180"/>
         <source>Decompressing %1</source>
-        <translation></translation>
+        <translation>%1 압축 해제 중</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="192"/>
         <source>File does not appear to be a compressed archive</source>
-        <translation></translation>
+        <translation>해당 파일은 압축 파일이 아닌 것 같습니다</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="200"/>
         <source>Compressed archive does not contain any files</source>
-        <translation></translation>
+        <translation>압축 파일에 포함된 파일이 없습니다</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="215"/>
         <source>File status error</source>
-        <translation></translation>
+        <translation>파일 상태 오류</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="222"/>
         <source>Decompression interrupted</source>
-        <translation type="unfinished"></translation>
+        <translation>압축 해제가 중단되었습니다</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="228"/>
         <source>Unable to obtain file status for index: %1</source>
-        <translation></translation>
+        <translation>인덱스 %1에 대한 파일 상태를 확인할 수 없습니다</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="249"/>
         <source>Failed to extract %1 to %2</source>
-        <translation></translation>
+        <translation>%1을(를) %2(으)로 추출하는 데 실패했습니다</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="254"/>
         <source>File %1 extracted size %2 does not match original %3</source>
-        <translation></translation>
+        <translation>파일 %1의 추출된 크기(%2)가 원본 크기(%3)와 일치하지 않습니다</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="267"/>
         <source>Extracted file: %1</source>
-        <translation></translation>
+        <translation>파일 추출됨: %1</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="278"/>
         <source>Decompress complete</source>
-        <translation></translation>
+        <translation>압축 해제 완료</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="287"/>
         <source>Failed to create directory: %1</source>
-        <translation></translation>
+        <translation>디렉터리 생성 실패: %1</translation>
     </message>
     <message>
         <location filename="../storage/minizinterface.cpp" line="291"/>
         <source>Created directory: %1</source>
-        <translation></translation>
+        <translation>디렉터리 생성됨: %1</translation>
     </message>
 </context>
 <context>
@@ -8487,7 +8627,7 @@ Do you want to save your changes?</source>
     <message>
         <location filename="../firmwares/mixdata.cpp" line="27"/>
         <source>MIX</source>
-        <translation></translation>
+        <translation>믹스</translation>
     </message>
     <message>
         <location filename="../firmwares/mixdata.cpp" line="28"/>
@@ -8500,12 +8640,12 @@ Do you want to save your changes?</source>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="20"/>
         <source>Dialog</source>
-        <translation></translation>
+        <translation>믹서 설정</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="256"/>
         <source>image</source>
-        <translation></translation>
+        <translation>이미지</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="662"/>
@@ -8522,42 +8662,42 @@ Do you want to save your changes?</source>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="536"/>
         <source>Delay</source>
-        <translation></translation>
+        <translation>지연</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="278"/>
         <source>Modes</source>
-        <translation type="unfinished"></translation>
+        <translation>모드</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="296"/>
         <source>2 Beeps</source>
-        <translation type="unfinished"></translation>
+        <translation>2회 비프음</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="301"/>
         <source>3 Beeps</source>
-        <translation type="unfinished"></translation>
+        <translation>3회 비프음</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="529"/>
         <source>Slow</source>
-        <translation></translation>
+        <translation>느리게</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="543"/>
         <source>Up</source>
-        <translation></translation>
+        <translation>상승</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="553"/>
         <source>Down</source>
-        <translation></translation>
+        <translation>하강</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="651"/>
         <source>Precision</source>
-        <translation type="unfinished"></translation>
+        <translation>정밀도</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="506"/>
@@ -8575,27 +8715,38 @@ p, li { white-space: pre-wrap; }
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If Delay is not zero the actuation of the mix will be delayed by the specified amount of seconds.&lt;/p&gt;
 &lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
 &lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;If Slow is not zero then the speed of the mix will be set by the value specified -&amp;gt; the value states the number of seconds it takes to transit from -100 to 100.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
+        <translation>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:&apos;MS Shell Dlg 2&apos;; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-weight:600; text-decoration: underline;&quot;&gt;지연 및 느림 설정&lt;/span&gt;&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-weight:600; text-decoration: underline;&quot;&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;이 값들은 믹스 출력의 속도와 지연 시간을 제어합니다.&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;지연(Delay)이 0이 아니면, 믹스 작동이 설정된 시간(초)만큼 지연됩니다.&lt;/p&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;/p&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;느림(Slow)이 0이 아니면, 믹스가 -100에서 100까지 전환되는 데 걸리는 시간을 설정된 값(초)으로 지정합니다.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;
+</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="72"/>
         <source>Include Trim</source>
-        <translation></translation>
+        <translation>트림 포함</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="479"/>
         <source>Offset</source>
-        <translation></translation>
+        <translation>오프셋</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="123"/>
         <source>Weight</source>
-        <translation></translation>
+        <translation>가중치</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="215"/>
         <source>Name</source>
-        <translation></translation>
+        <translation>이름</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="37"/>
@@ -8603,104 +8754,104 @@ p, li { white-space: pre-wrap; }
         <location filename="../modeledit/mixerdialog.ui" line="163"/>
         <location filename="../modeledit/mixerdialog.ui" line="224"/>
         <source>Source</source>
-        <translation></translation>
+        <translation>입력 소스</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="170"/>
         <source>Multiplex</source>
-        <translation></translation>
+        <translation>멀티플렉스</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="116"/>
         <source>Warning</source>
-        <translation></translation>
+        <translation>경고</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="201"/>
         <source>The curve used by the mix</source>
-        <translation></translation>
+        <translation>믹서에 사용되는 곡선</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="156"/>
         <source>Include DR/Expo</source>
-        <translation></translation>
+        <translation>DR/Expo 포함</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="130"/>
         <source>Switch</source>
-        <translation></translation>
+        <translation>스위치</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="286"/>
         <source>OFF</source>
-        <translation></translation>
+        <translation>꺼짐</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="291"/>
         <source>1 Beep</source>
-        <translation></translation>
+        <translation>1회 비프음</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="188"/>
         <source>No</source>
-        <translation>No</translation>
+        <translation>아니오</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="193"/>
         <source>Yes</source>
-        <translation></translation>
+        <translation>예</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="44"/>
         <location filename="../modeledit/mixerdialog.ui" line="91"/>
         <location filename="../modeledit/mixerdialog.ui" line="231"/>
         <source>The source for the mixer</source>
-        <translation></translation>
+        <translation>믹서에 사용할 입력 소스</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="138"/>
         <source>ADD</source>
-        <translation></translation>
+        <translation>더하기</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="143"/>
         <source>MULTIPLY</source>
-        <translation></translation>
+        <translation>곱하기</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="148"/>
         <source>REPLACE</source>
-        <translation></translation>
+        <translation>대체</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.ui" line="177"/>
         <source>Curve</source>
-        <translation></translation>
+        <translation>곡선</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.cpp" line="52"/>
         <source>DEST -&gt; %1</source>
-        <translation></translation>
+        <translation>출력 -&gt; %1</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.cpp" line="129"/>
         <source>Click to access popup menu</source>
-        <translation></translation>
+        <translation>클릭하여 팝업 메뉴 열기</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.cpp" line="301"/>
         <source>Clear All</source>
-        <translation></translation>
+        <translation>전체 초기화</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.cpp" line="302"/>
         <source>Set All</source>
-        <translation></translation>
+        <translation>전체 설정</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerdialog.cpp" line="303"/>
         <source>Invert All</source>
-        <translation></translation>
+        <translation>전체 반전</translation>
     </message>
 </context>
 <context>
@@ -8708,17 +8859,17 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modeledit/mixerslistwidget.cpp" line="67"/>
         <source>Increase font size</source>
-        <translation></translation>
+        <translation>글꼴 크기 확대</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerslistwidget.cpp" line="71"/>
         <source>Decrease font size</source>
-        <translation></translation>
+        <translation>글꼴 크기 축소</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerslistwidget.cpp" line="75"/>
         <source>Default font size</source>
-        <translation></translation>
+        <translation>기본 글꼴 크기</translation>
     </message>
     <message>
         <location filename="../modeledit/mixerslistwidget.cpp" line="76"/>
@@ -8732,7 +8883,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../modeledit/mixes.cpp" line="45"/>
         <location filename="../modeledit/mixes.cpp" line="441"/>
         <source>Move Up</source>
-        <translation></translation>
+        <translation>위로 이동</translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="47"/>
@@ -8744,7 +8895,7 @@ p, li { white-space: pre-wrap; }
         <location filename="../modeledit/mixes.cpp" line="48"/>
         <location filename="../modeledit/mixes.cpp" line="442"/>
         <source>Move Down</source>
-        <translation></translation>
+        <translation>아래로 이동</translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="50"/>
@@ -8755,27 +8906,27 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modeledit/mixes.cpp" line="51"/>
         <source>Clear Mixes</source>
-        <translation></translation>
+        <translation>믹스 초기화</translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="160"/>
         <source>Not enough available mixers!</source>
-        <translation></translation>
+        <translation>사용 가능한 믹스 슬롯이 부족합니다!</translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="275"/>
         <source>Delete selected Mix lines. Are you sure?</source>
-        <translation></translation>
+        <translation>선택한 믹스 라인을 삭제하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="287"/>
         <source>Cut selected Mix lines. Are you sure?</source>
-        <translation></translation>
+        <translation>선택한 믹스 라인을 잘라내시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="431"/>
         <source>&amp;Add</source>
-        <translation></translation>
+        <translation>추가(&amp;A)</translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="431"/>
@@ -8785,17 +8936,17 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>&amp;Edit</source>
-        <translation></translation>
+        <translation>편집(&amp;E)</translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="432"/>
         <source>Enter</source>
-        <translation></translation>
+        <translation>입력</translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="433"/>
         <source>&amp;Toggle highlight</source>
-        <translation></translation>
+        <translation>강조 표시 전환(&amp;T)</translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="433"/>
@@ -8805,17 +8956,17 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>&amp;Delete</source>
-        <translation></translation>
+        <translation>삭제(&amp;D)</translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="435"/>
         <source>Delete</source>
-        <translation></translation>
+        <translation>삭제</translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="436"/>
         <source>&amp;Copy</source>
-        <translation></translation>
+        <translation>복사(&amp;C)</translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="436"/>
@@ -8825,7 +8976,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modeledit/mixes.cpp" line="437"/>
         <source>C&amp;ut</source>
-        <translation></translation>
+        <translation>잘라내기(&amp;U)</translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="437"/>
@@ -8835,7 +8986,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modeledit/mixes.cpp" line="438"/>
         <source>&amp;Paste</source>
-        <translation></translation>
+        <translation>붙여넣기(&amp;P)</translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="438"/>
@@ -8845,7 +8996,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modeledit/mixes.cpp" line="439"/>
         <source>Du&amp;plicate</source>
-        <translation></translation>
+        <translation>복제(&amp;L)</translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="439"/>
@@ -8855,12 +9006,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Clear Mixes?</source>
-        <translation></translation>
+        <translation>믹스를 초기화하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/mixes.cpp" line="547"/>
         <source>Really clear all the mixes?</source>
-        <translation></translation>
+        <translation>정말 모든 믹스를 초기화하시겠습니까?</translation>
     </message>
 </context>
 <context>
@@ -8868,135 +9019,135 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../firmwares/modeldata.cpp" line="447"/>
         <source>Model: </source>
-        <translation></translation>
+        <translation>모델: </translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="451"/>
         <source>Throttle Source</source>
-        <translation></translation>
+        <translation>스로틀 소스</translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1548"/>
         <source>THR</source>
-        <translation></translation>
+        <translation>스로틀</translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1548"/>
         <source>TH</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1664"/>
         <source>OFF</source>
-        <translation></translation>
+        <translation>꺼짐</translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1666"/>
         <source>Master/Jack</source>
-        <translation></translation>
+        <translation>마스터 / 잭</translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1668"/>
         <source>Slave/Jack</source>
-        <translation></translation>
+        <translation>슬레이브 / 잭</translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1670"/>
         <source>Master/SBUS Module</source>
-        <translation></translation>
+        <translation>마스터 / SBUS 모듈</translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1672"/>
         <source>Master/CPPM Module</source>
-        <translation></translation>
+        <translation>마스터 / CPPM 모듈</translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1674"/>
         <source>Master/Serial</source>
-        <translation></translation>
+        <translation>마스터 / 시리얼</translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1676"/>
         <source>Master/Bluetooth</source>
-        <translation></translation>
+        <translation>마스터 / 블루투스</translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1678"/>
         <source>Slave/Bluetooth</source>
-        <translation></translation>
+        <translation>슬레이브 / 블루투스</translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1680"/>
         <source>Master/Multi</source>
-        <translation></translation>
+        <translation>마스터 / 멀티</translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1682"/>
         <source>Master/CRSF</source>
-        <translation type="unfinished"></translation>
+        <translation>마스터 / CRSF</translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1769"/>
         <source>NONE</source>
-        <translation></translation>
+        <translation>없음</translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1771"/>
         <source>TOGGLE</source>
-        <translation></translation>
+        <translation>토글</translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1773"/>
         <source>2POS</source>
-        <translation></translation>
+        <translation>2단 스위치</translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1798"/>
         <source>SW</source>
-        <translation type="unfinished"></translation>
+        <translation>스위치</translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1800"/>
         <location filename="../firmwares/modeldata.cpp" line="1936"/>
         <source>Off</source>
-        <translation type="unfinished"></translation>
+        <translation>꺼짐</translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1811"/>
         <source>---</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1813"/>
         <source>Group </source>
-        <translation type="unfinished"></translation>
+        <translation>그룹 </translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1938"/>
         <source>On</source>
-        <translation type="unfinished"></translation>
+        <translation>켜짐</translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1997"/>
         <source>Error - Input %1 Line %2 %3</source>
-        <translation type="unfinished"></translation>
+        <translation>오류 - 입력 %1 줄 %2 %3</translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1997"/>
         <location filename="../firmwares/modeldata.cpp" line="2002"/>
         <source>has no source</source>
-        <translation type="unfinished"></translation>
+        <translation>소스가 없습니다</translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="2002"/>
         <source>Error - Mix %1 Line %2 %3</source>
-        <translation type="unfinished"></translation>
+        <translation>오류 - 믹스 %1 줄 %2 %3</translation>
     </message>
     <message>
         <location filename="../firmwares/modeldata.cpp" line="1796"/>
         <location filename="../firmwares/modeldata.cpp" line="1940"/>
         <source>Restore</source>
-        <translation></translation>
+        <translation>복원</translation>
     </message>
 </context>
 <context>
@@ -9004,73 +9155,73 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modeledit/modeledit.ui" line="20"/>
         <source>Dialog</source>
-        <translation></translation>
+        <translation>모델 편집</translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.ui" line="51"/>
         <source>Simulate</source>
-        <translation></translation>
+        <translation>시뮬레이션</translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.cpp" line="76"/>
         <source>Setup</source>
-        <translation></translation>
+        <translation>설정</translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.cpp" line="80"/>
         <source>Heli</source>
-        <translation></translation>
+        <translation>헬리콥터</translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.cpp" line="84"/>
         <source>%1 Modes</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 모드</translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.cpp" line="89"/>
         <source>Inputs</source>
-        <translation></translation>
+        <translation>입력</translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.cpp" line="92"/>
         <source>Mixes</source>
-        <translation></translation>
+        <translation>믹스</translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.cpp" line="96"/>
         <source>Outputs</source>
-        <translation></translation>
+        <translation>출력</translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.cpp" line="99"/>
         <source>Curves</source>
-        <translation></translation>
+        <translation>커브</translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.cpp" line="102"/>
         <source>Logical Switches</source>
-        <translation></translation>
+        <translation>논리 스위치</translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.cpp" line="105"/>
         <source>Special Functions</source>
-        <translation></translation>
+        <translation>특수 기능</translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.cpp" line="109"/>
         <source>Telemetry</source>
-        <translation></translation>
+        <translation>텔레메트리</translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.cpp" line="114"/>
         <location filename="../modeledit/modeledit.cpp" line="118"/>
         <source>Custom Screens</source>
-        <translation></translation>
+        <translation>사용자 화면</translation>
     </message>
     <message>
         <location filename="../modeledit/modeledit.cpp" line="122"/>
         <source>Enabled Features</source>
-        <translation></translation>
+        <translation>활성화된 기능</translation>
     </message>
 </context>
 <context>
@@ -9078,82 +9229,82 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="42"/>
         <source>Global</source>
-        <translation></translation>
+        <translation>글로벌</translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="43"/>
         <source>Off</source>
-        <translation></translation>
+        <translation>끄기</translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="44"/>
         <source>On</source>
-        <translation></translation>
+        <translation>켜기</translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="47"/>
         <source>Radio Menus</source>
-        <translation></translation>
+        <translation>라디오 메뉴</translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="50"/>
         <source>Themes</source>
-        <translation></translation>
+        <translation>테마</translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="58"/>
         <source>Global Functions</source>
-        <translation></translation>
+        <translation>글로벌 기능</translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="65"/>
         <source>Trainer</source>
-        <translation></translation>
+        <translation>트레이너</translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="74"/>
         <source>Model Menus</source>
-        <translation></translation>
+        <translation>모델 메뉴</translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="77"/>
         <source>Heli</source>
-        <translation></translation>
+        <translation>헬리콥터</translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="85"/>
         <source>%1 Modes</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 모드</translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="92"/>
         <source>Curves</source>
-        <translation></translation>
+        <translation>커브</translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="100"/>
         <source>Global Variables</source>
-        <translation></translation>
+        <translation>글로벌 변수</translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="108"/>
         <source>Logical Switches</source>
-        <translation></translation>
+        <translation>논리 스위치</translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="115"/>
         <source>Special Functions</source>
-        <translation></translation>
+        <translation>특수 기능</translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="122"/>
         <source>Custom Mix Scripts</source>
-        <translation></translation>
+        <translation>사용자 믹스 스크립트</translation>
     </message>
     <message>
         <location filename="../modeledit/modeloptions.cpp" line="129"/>
         <source>Telemetry</source>
-        <translation></translation>
+        <translation>텔레메트리</translation>
     </message>
 </context>
 <context>
@@ -9161,171 +9312,171 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modelprinter.cpp" line="171"/>
         <source>Exponential</source>
-        <translation></translation>
+        <translation>지수 곡선</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="173"/>
         <source>Extra Fine</source>
-        <translation></translation>
+        <translation>초정밀</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="175"/>
         <source>Fine</source>
-        <translation></translation>
+        <translation>정밀</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="177"/>
         <source>Medium</source>
-        <translation></translation>
+        <translation>보통</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="179"/>
         <source>Coarse</source>
-        <translation></translation>
+        <translation>거침</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="181"/>
         <source>Unknown</source>
-        <translation></translation>
+        <translation>알 수 없음</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="143"/>
         <source>Enable</source>
-        <translation></translation>
+        <translation>사용</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="143"/>
         <source>Disable</source>
-        <translation></translation>
+        <translation>사용 안 함</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="145"/>
         <source>True</source>
-        <translation></translation>
+        <translation>참</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="145"/>
         <source>False</source>
-        <translation></translation>
+        <translation>거짓</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="147"/>
         <source>Yes</source>
-        <translation></translation>
+        <translation>예</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="147"/>
         <source>No</source>
-        <translation>No</translation>
+        <translation>아니오</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="149"/>
         <source>Y</source>
-        <translation></translation>
+        <translation>예</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="149"/>
         <source>N</source>
-        <translation></translation>
+        <translation>아니오</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="151"/>
         <source>ON</source>
-        <translation></translation>
+        <translation>켜짐</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="151"/>
         <location filename="../modelprinter.cpp" line="292"/>
         <location filename="../modelprinter.cpp" line="809"/>
         <source>OFF</source>
-        <translation></translation>
+        <translation>꺼짐</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="191"/>
         <location filename="../modelprinter.cpp" line="789"/>
         <source>Mode</source>
-        <translation></translation>
+        <translation>모드</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="194"/>
         <location filename="../modelprinter.cpp" line="207"/>
         <source>Channels</source>
-        <translation></translation>
+        <translation>채널</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="195"/>
         <location filename="../modelprinter.cpp" line="209"/>
         <source>Frame length</source>
-        <translation></translation>
+        <translation>프레임 길이</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="196"/>
         <source>PPM delay</source>
-        <translation></translation>
+        <translation>PPM 지연</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="197"/>
         <location filename="../modelprinter.cpp" line="210"/>
         <source>Polarity</source>
-        <translation></translation>
+        <translation>극성</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="203"/>
         <source>Protocol</source>
-        <translation></translation>
+        <translation>프로토콜</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="212"/>
         <location filename="../modelprinter.cpp" line="645"/>
         <source>Delay</source>
-        <translation></translation>
+        <translation>지연</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="217"/>
         <location filename="../modelprinter.cpp" line="856"/>
         <source>Receiver</source>
-        <translation></translation>
+        <translation>수신기</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="220"/>
         <source>Radio protocol</source>
-        <translation></translation>
+        <translation>라디오 프로토콜</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="221"/>
         <source>Subtype</source>
-        <translation></translation>
+        <translation>하위 유형</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="222"/>
         <source>Option value</source>
-        <translation></translation>
+        <translation>옵션 값</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="206"/>
         <location filename="../modelprinter.cpp" line="225"/>
         <source>Sub Type</source>
-        <translation></translation>
+        <translation>하위 유형</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="226"/>
         <source>RF Output Power</source>
-        <translation></translation>
+        <translation>RF 출력 전력</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="235"/>
         <source>Raw 12 bits</source>
-        <translation></translation>
+        <translation>원시 12비트</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="238"/>
         <source>Arming mode</source>
-        <translation type="unfinished"></translation>
+        <translation>무장 모드</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="240"/>
         <source>Switch</source>
-        <translation type="unfinished">Switch</translation>
+        <translation>스위치</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="257"/>
@@ -9350,7 +9501,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modelprinter.cpp" line="265"/>
         <source>Off</source>
-        <translation></translation>
+        <translation>꺼짐</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="284"/>
@@ -9359,200 +9510,200 @@ p, li { white-space: pre-wrap; }
         <location filename="../modelprinter.cpp" line="1019"/>
         <location filename="../modelprinter.cpp" line="1049"/>
         <source>None</source>
-        <translation></translation>
+        <translation>없음</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="294"/>
         <source>3POS</source>
-        <translation></translation>
+        <translation>3단 스위치</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="452"/>
         <source>Slow precision(0.00)</source>
-        <translation></translation>
+        <translation>느린 정밀도 (0.00)</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="487"/>
         <source>Flight modes</source>
-        <translation></translation>
+        <translation>비행 모드</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="487"/>
         <source>Flight mode</source>
-        <translation></translation>
+        <translation>비행 모드</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="512"/>
         <source>All</source>
-        <translation></translation>
+        <translation>전체</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="532"/>
         <source>Edge</source>
-        <translation></translation>
+        <translation>엣지</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="533"/>
         <source>infinite</source>
-        <translation></translation>
+        <translation>무한</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="538"/>
         <source>Sticky</source>
-        <translation></translation>
+        <translation>스티키</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="540"/>
         <source> Persistent</source>
-        <translation type="unfinished"></translation>
+        <translation> 지속</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="543"/>
         <source>Timer</source>
-        <translation></translation>
+        <translation>타이머</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="570"/>
         <source> missing</source>
-        <translation></translation>
+        <translation> 누락됨</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="643"/>
         <source>Duration</source>
-        <translation></translation>
+        <translation>지속 시간</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="752"/>
         <source>Extended Limits</source>
-        <translation></translation>
+        <translation>확장 제한</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="754"/>
         <source>Display Checklist</source>
-        <translation></translation>
+        <translation>체크리스트 표시</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="756"/>
         <source>Global Functions</source>
-        <translation></translation>
+        <translation>글로벌 기능</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="811"/>
         <source>Manual</source>
-        <translation></translation>
+        <translation>수동</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="813"/>
         <source>Auto</source>
-        <translation></translation>
+        <translation>자동</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="823"/>
         <source>Failsafe Mode</source>
-        <translation></translation>
+        <translation>페일세이프 모드</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="836"/>
         <location filename="../modelprinter.cpp" line="850"/>
         <source>Hold</source>
-        <translation></translation>
+        <translation>유지</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="838"/>
         <source>No Pulse</source>
-        <translation></translation>
+        <translation>펄스 없음</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="848"/>
         <source>Not set</source>
-        <translation></translation>
+        <translation>설정 안됨</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="854"/>
         <source>No pulses</source>
-        <translation></translation>
+        <translation>펄스 없음</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="865"/>
         <source>Step</source>
-        <translation></translation>
+        <translation>단계</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="866"/>
         <source>Display</source>
-        <translation></translation>
+        <translation>표시</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="867"/>
         <source>Extended</source>
-        <translation></translation>
+        <translation>확장됨</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="870"/>
         <source>Hats Mode</source>
-        <translation></translation>
+        <translation>Hats 모드</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="894"/>
         <source>Never</source>
-        <translation></translation>
+        <translation>절대 안 함</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="896"/>
         <source>On Change</source>
-        <translation></translation>
+        <translation>변경 시</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="898"/>
         <source>Always</source>
-        <translation></translation>
+        <translation>항상</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="908"/>
         <source>Trims only</source>
-        <translation></translation>
+        <translation>트림만</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="910"/>
         <source>Keys only</source>
-        <translation></translation>
+        <translation>키만</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="912"/>
         <source>Switchable</source>
-        <translation></translation>
+        <translation>전환 가능</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="914"/>
         <source>Global</source>
-        <translation></translation>
+        <translation>글로벌</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="936"/>
         <location filename="../modelprinter.cpp" line="1071"/>
         <location filename="../modelprinter.cpp" line="1081"/>
         <source>Source</source>
-        <translation></translation>
+        <translation>소스</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="937"/>
         <source>Trim idle only</source>
-        <translation></translation>
+        <translation>유휴 상태에서만 트림</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="938"/>
         <source>Warning</source>
-        <translation></translation>
+        <translation>경고</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="939"/>
         <source>Reversed</source>
-        <translation></translation>
+        <translation>반전</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="943"/>
         <source>Trim source</source>
-        <translation type="unfinished"></translation>
+        <translation>트림 소스</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="957"/>
@@ -9567,22 +9718,22 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modelprinter.cpp" line="961"/>
         <source>FrSky D (cable)</source>
-        <translation></translation>
+        <translation>FrSky D (케이블)</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="976"/>
         <source>Alti</source>
-        <translation></translation>
+        <translation>고도</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="978"/>
         <source>Alti+</source>
-        <translation></translation>
+        <translation>고도+</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="980"/>
         <source>VSpeed</source>
-        <translation></translation>
+        <translation>수직속도</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="982"/>
@@ -9619,142 +9770,142 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modelprinter.cpp" line="1009"/>
         <source>Cells</source>
-        <translation></translation>
+        <translation>셀</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="1081"/>
         <source>Min</source>
-        <translation></translation>
+        <translation>최소</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="1081"/>
         <source>Max</source>
-        <translation></translation>
+        <translation>최대</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="1051"/>
         <source>Numbers</source>
-        <translation></translation>
+        <translation>숫자</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="1053"/>
         <source>Bars</source>
-        <translation></translation>
+        <translation>막대</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="1055"/>
         <source>Script</source>
-        <translation></translation>
+        <translation>스크립트</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="1102"/>
         <source>Filename</source>
-        <translation></translation>
+        <translation>파일 이름</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="1112"/>
         <source>Error: Unable to open or read file!</source>
-        <translation></translation>
+        <translation>오류: 파일을 열거나 읽을 수 없습니다!</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="302"/>
         <location filename="../modelprinter.cpp" line="324"/>
         <location filename="../modelprinter.cpp" line="338"/>
         <source>FM%1</source>
-        <translation></translation>
+        <translation>플라이트모드%1</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="306"/>
         <source>FM%1%2</source>
-        <translation></translation>
+        <translation>플라이트모드%1%2</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="308"/>
         <source>FM%1+%2</source>
-        <translation></translation>
+        <translation>플라이트모드%1+%2</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="430"/>
         <source>NoTrim</source>
-        <translation></translation>
+        <translation>트림 없음</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="392"/>
         <location filename="../modelprinter.cpp" line="437"/>
         <source>Offset(%1)</source>
-        <translation></translation>
+        <translation>오프셋(%1)</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="229"/>
         <source>Options</source>
-        <translation></translation>
+        <translation>옵션</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="232"/>
         <source>Type</source>
-        <translation></translation>
+        <translation>유형</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="369"/>
         <source>Scale(%1)</source>
-        <translation></translation>
+        <translation>스케일(%1)</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="372"/>
         <location filename="../modelprinter.cpp" line="420"/>
         <source>Weight(%1)</source>
-        <translation></translation>
+        <translation>가중치(%1)</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="381"/>
         <location filename="../modelprinter.cpp" line="427"/>
         <source>Switch(%1)</source>
-        <translation></translation>
+        <translation>스위치(%1)</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="386"/>
         <source>No Trim</source>
-        <translation></translation>
+        <translation>트림 없음</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="435"/>
         <source>No DR/Expo</source>
-        <translation></translation>
+        <translation>DR/Expo 없음</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="444"/>
         <source>Delay precision(0.00)</source>
-        <translation type="unfinished"></translation>
+        <translation>딜레이 정밀도(0.00)</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="447"/>
         <source>Delay(u%1:d%2)</source>
-        <translation></translation>
+        <translation>딜레이(상향 %1 : 하향 %2)</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="455"/>
         <source>Slow(u%1:d%2)</source>
-        <translation></translation>
+        <translation>느림(상향 %1 : 하향 %2)</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="457"/>
         <source>Warn(%1)</source>
-        <translation></translation>
+        <translation>경고(%1)</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="478"/>
         <source>Disabled in all flight modes</source>
-        <translation></translation>
+        <translation>모든 플라이트모드에서 비활성화됨</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="533"/>
         <source>instant</source>
-        <translation></translation>
+        <translation>즉시</translation>
     </message>
     <message>
         <location filename="../modelprinter.cpp" line="852"/>
         <source>Custom</source>
-        <translation></translation>
+        <translation>사용자 지정</translation>
     </message>
 </context>
 <context>
@@ -9762,27 +9913,27 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../wizarddialog.cpp" line="284"/>
         <source>Plane</source>
-        <translation></translation>
+        <translation>비행기</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="286"/>
         <source>Multirotor</source>
-        <translation></translation>
+        <translation>멀티로터</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="287"/>
         <source>Helicopter</source>
-        <translation></translation>
+        <translation>헬리콥터</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="292"/>
         <source>Model Name:</source>
-        <translation></translation>
+        <translation>모델 이름:</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="295"/>
         <source>Model Type:</source>
-        <translation></translation>
+        <translation>모델 유형:</translation>
     </message>
 </context>
 <context>
@@ -9790,28 +9941,28 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modelslist.cpp" line="138"/>
         <source>Index</source>
-        <translation></translation>
+        <translation>번호</translation>
     </message>
     <message>
         <location filename="../modelslist.cpp" line="139"/>
         <source>Name</source>
-        <translation></translation>
+        <translation>이름</translation>
     </message>
     <message>
         <location filename="../modelslist.cpp" line="140"/>
         <source>RX #</source>
-        <translation></translation>
+        <translation>수신기 번호</translation>
     </message>
     <message>
         <location filename="../modelslist.cpp" line="142"/>
         <source>Labels</source>
-        <translation></translation>
+        <translation>라벨</translation>
     </message>
     <message>
         <location filename="../modelslist.cpp" line="672"/>
         <source>Model %1</source>
         <extracomment>Translators: do NOT use accents here, this is a default model name.</extracomment>
-        <translation></translation>
+        <translation>모델 %1</translation>
     </message>
 </context>
 <context>
@@ -9819,32 +9970,32 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modeledit/setup_module.ui" line="471"/>
         <source>Start</source>
-        <translation></translation>
+        <translation>시작</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="499"/>
         <source>CH </source>
-        <translation></translation>
+        <translation>채널 </translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="574"/>
         <source>Polarity</source>
-        <translation></translation>
+        <translation>극성</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="600"/>
         <source>Negative</source>
-        <translation></translation>
+        <translation>음극</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="605"/>
         <source>Positive</source>
-        <translation></translation>
+        <translation>양극</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="623"/>
         <source>Receiver 1</source>
-        <translation></translation>
+        <translation>수신기 1</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="668"/>
@@ -9856,47 +10007,47 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modeledit/setup_module.ui" line="680"/>
         <source>Receiver 2</source>
-        <translation></translation>
+        <translation>수신기 2</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="716"/>
         <source>Receiver 3</source>
-        <translation></translation>
+        <translation>수신기 3</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="789"/>
         <source>WARNING: changing RF Output Power needs RE-BIND</source>
-        <translation></translation>
+        <translation>경고: RF 출력 전력을 변경하면 다시 바인딩해야 합니다</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="805"/>
         <source>Low power mode</source>
-        <translation></translation>
+        <translation>저전력 모드</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="1005"/>
         <source>Antenna</source>
-        <translation></translation>
+        <translation>안테나</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="1034"/>
         <source>RX Frequency</source>
-        <translation></translation>
+        <translation>수신 주파수</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="1067"/>
         <source>Output type</source>
-        <translation></translation>
+        <translation>출력 유형</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="1084"/>
         <source>Open Drain</source>
-        <translation></translation>
+        <translation>오픈 드레인</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="1089"/>
         <source>Push Pull</source>
-        <translation></translation>
+        <translation>푸시 풀</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="1125"/>
@@ -9906,152 +10057,152 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modeledit/setup_module.ui" line="1041"/>
         <source>Option value</source>
-        <translation></translation>
+        <translation>옵션 값</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="377"/>
         <source>Disable Telemetry</source>
-        <translation></translation>
+        <translation>텔레메트리 비활성화</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="384"/>
         <source>Disable Ch. Map</source>
-        <translation></translation>
+        <translation>채널 맵 비활성화</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="391"/>
         <source>Racing Mode</source>
-        <translation></translation>
+        <translation>레이싱 모드</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="398"/>
         <source>Raw 12 bits</source>
-        <translation></translation>
+        <translation>12비트 원시 데이터</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="852"/>
         <source>Channels</source>
-        <translation></translation>
+        <translation>채널</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="524"/>
         <source>Receiver No.</source>
-        <translation></translation>
+        <translation>수신기 번호</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="435"/>
         <source>Arm using</source>
-        <translation type="unfinished">Arm using</translation>
+        <translation>Arm 조건</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="613"/>
         <source>RF Output Power</source>
-        <translation></translation>
+        <translation>RF 출력 전력</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="902"/>
         <source>PPM delay</source>
-        <translation></translation>
+        <translation>PPM 지연</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="927"/>
         <source> us</source>
-        <translation></translation>
+        <translation> 마이크로초</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="952"/>
         <source>PPM Frame Length</source>
-        <translation></translation>
+        <translation>PPM 프레임 길이</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="977"/>
         <source> ms</source>
-        <translation></translation>
+        <translation> 밀리초</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="127"/>
         <source>Protocol</source>
-        <translation></translation>
+        <translation>프로토콜</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="163"/>
         <source>Registration ID</source>
-        <translation></translation>
+        <translation>등록 ID</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="183"/>
         <source>Multi Radio Protocol</source>
-        <translation></translation>
+        <translation>멀티 라디오 프로토콜</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="212"/>
         <source>Sub Type</source>
-        <translation></translation>
+        <translation>서브 타입</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="275"/>
         <source>WARNING: Requires non-certified firmware!</source>
-        <translation></translation>
+        <translation>경고: 인증되지 않은 펌웨어가 필요합니다!</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="288"/>
         <source>Failsafe Mode</source>
-        <translation></translation>
+        <translation>페일세이프 모드</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="314"/>
         <source>Not set</source>
-        <translation></translation>
+        <translation>설정되지 않음</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="319"/>
         <source>Hold</source>
-        <translation></translation>
+        <translation>유지</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="324"/>
         <source>Custom</source>
-        <translation></translation>
+        <translation>사용자 지정</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="329"/>
         <source>No Pulses</source>
-        <translation></translation>
+        <translation>펄스 없음</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="334"/>
         <source>Receiver</source>
-        <translation></translation>
+        <translation>수신기</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="348"/>
         <source>Trainer Mode</source>
-        <translation></translation>
+        <translation>트레이너 모드</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="418"/>
         <source>Options</source>
-        <translation></translation>
+        <translation>옵션</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="1138"/>
         <source>Option check</source>
-        <translation></translation>
+        <translation>옵션 확인</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="1152"/>
         <source>Option combo</source>
-        <translation></translation>
+        <translation>옵션 콤보</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="1178"/>
         <source>Failsafe Positions</source>
-        <translation></translation>
+        <translation>페일세이프 위치</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="1220"/>
         <source>Show values in:</source>
-        <translation></translation>
+        <translation>값 단위 표시:</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.ui" line="1227"/>
@@ -10071,23 +10222,23 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../firmwares/moduledata.h" line="222"/>
         <source>Positive</source>
-        <translation></translation>
+        <translation>양극</translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.h" line="222"/>
         <source>Negative</source>
-        <translation></translation>
+        <translation>음극</translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="59"/>
         <source>Current firmware board does not match conversion to board</source>
-        <translation type="unfinished"></translation>
+        <translation>현재 펌웨어 보드가 변환 대상 보드와 일치하지 않습니다</translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="260"/>
         <location filename="../firmwares/moduledata.cpp" line="266"/>
         <source>No Telemetry</source>
-        <translation></translation>
+        <translation>텔레메트리 없음</translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="261"/>
@@ -10098,37 +10249,37 @@ p, li { white-space: pre-wrap; }
         <location filename="../firmwares/moduledata.cpp" line="262"/>
         <location filename="../firmwares/moduledata.cpp" line="267"/>
         <source>SPort</source>
-        <translation type="unfinished"></translation>
+        <translation>S포트</translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="297"/>
         <source>Trainer Port</source>
-        <translation></translation>
+        <translation>트레이너 포트</translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="301"/>
         <source>Internal Radio System</source>
-        <translation></translation>
+        <translation>내장 라디오 시스템</translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="301"/>
         <source>External Radio Module</source>
-        <translation></translation>
+        <translation>외장 라디오 모듈</translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="303"/>
         <source>Extra Radio System</source>
-        <translation></translation>
+        <translation>추가 라디오 시스템</translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="305"/>
         <source>Radio System</source>
-        <translation></translation>
+        <translation>라디오 시스템</translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="312"/>
         <source>OFF</source>
-        <translation></translation>
+        <translation>꺼짐</translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="313"/>
@@ -10178,7 +10329,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../firmwares/moduledata.cpp" line="317"/>
         <source>PPMsim</source>
-        <translation></translation>
+        <translation>PPM 시뮬레이터</translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="318"/>
@@ -10208,7 +10359,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../firmwares/moduledata.cpp" line="320"/>
         <source>Multi</source>
-        <translation></translation>
+        <translation>멀티 프로토콜</translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="321"/>
@@ -10228,7 +10379,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../firmwares/moduledata.cpp" line="324"/>
         <source>SBUS output at VBat</source>
-        <translation></translation>
+        <translation>VBat 전압의 SBUS 출력</translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="325"/>
@@ -10293,50 +10444,50 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../firmwares/moduledata.cpp" line="342"/>
         <source>10mW - 16CH</source>
-        <translation></translation>
+        <translation>10mW - 16채널</translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="342"/>
         <location filename="../firmwares/moduledata.cpp" line="344"/>
         <source>100mW - 16CH</source>
-        <translation></translation>
+        <translation>100mW - 16채널</translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="342"/>
         <source>500mW - 16CH</source>
-        <translation></translation>
+        <translation>500mW - 16채널</translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="342"/>
         <source>Auto &lt;= 1W - 16CH</source>
-        <translation></translation>
+        <translation>자동 &lt;= 1W - 16채널</translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="343"/>
         <location filename="../firmwares/moduledata.cpp" line="345"/>
         <source>25mW - 8CH</source>
-        <translation></translation>
+        <translation>25mW - 8채널</translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="343"/>
         <location filename="../firmwares/moduledata.cpp" line="345"/>
         <source>25mW - 16CH</source>
-        <translation></translation>
+        <translation>25mW - 16채널</translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="343"/>
         <source>200mW - 16CH (no telemetry)</source>
-        <translation></translation>
+        <translation>200mW - 16채널 (텔레메트리 없음)</translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="343"/>
         <source>500mW - 16CH (no telemetry)</source>
-        <translation></translation>
+        <translation>500mW - 16채널 (텔레메트리 없음)</translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="345"/>
         <source>100mW - 16CH (no telemetry)</source>
-        <translation></translation>
+        <translation>100mW - 16채널 (텔레메트리 없음)</translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="348"/>
@@ -10366,12 +10517,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../firmwares/moduledata.cpp" line="794"/>
         <source>CH5</source>
-        <translation type="unfinished">CH5</translation>
+        <translation>CH5</translation>
     </message>
     <message>
         <location filename="../firmwares/moduledata.cpp" line="796"/>
         <source>Switch</source>
-        <translation type="unfinished">Switch</translation>
+        <translation>스위치</translation>
     </message>
 </context>
 <context>
@@ -10379,57 +10530,57 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modeledit/setup_module.cpp" line="102"/>
         <source>internal</source>
-        <translation></translation>
+        <translation>내부</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.cpp" line="102"/>
         <source>external</source>
-        <translation></translation>
+        <translation>외부</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.cpp" line="103"/>
         <source>hardware</source>
-        <translation></translation>
+        <translation>하드웨어</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.cpp" line="103"/>
         <source>profile</source>
-        <translation></translation>
+        <translation>프로파일</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.cpp" line="105"/>
         <source>Warning: The %1 module protocol &lt;b&gt;%2&lt;/b&gt; is incompatible with the &lt;b&gt;%3 %1 module %4&lt;/b&gt; and has been set to &lt;b&gt;OFF&lt;/b&gt;!</source>
-        <translation></translation>
+        <translation>경고: %1 모듈 프로토콜 &lt;b&gt;%2&lt;/b&gt; 은(는) &lt;b&gt;%3 %1 모듈 %4&lt;/b&gt; 와(과) 호환되지 않으며 &lt;b&gt;OFF&lt;/b&gt;로 설정되었습니다!</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.cpp" line="252"/>
         <source>Value</source>
-        <translation></translation>
+        <translation>값</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.cpp" line="253"/>
         <source>Hold</source>
-        <translation></translation>
+        <translation>유지</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.cpp" line="254"/>
         <source>No Pulse</source>
-        <translation></translation>
+        <translation>펄스 없음</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.cpp" line="554"/>
         <source>Bind on channel</source>
-        <translation></translation>
+        <translation>채널 바인딩</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.cpp" line="641"/>
         <source>Options</source>
-        <translation></translation>
+        <translation>옵션</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_module.cpp" line="649"/>
         <source>Type</source>
-        <translation></translation>
+        <translation>종류</translation>
     </message>
 </context>
 <context>
@@ -10437,38 +10588,38 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Input</source>
-        <translation></translation>
+        <translation>입력</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="404"/>
         <source>Weight</source>
-        <translation></translation>
+        <translation>가중치</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="405"/>
         <source>Long. cyc</source>
-        <translation></translation>
+        <translation>전진 싸이클</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="410"/>
         <source>Lateral cyc</source>
-        <translation></translation>
+        <translation>측면 싸이클</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="415"/>
         <source>Collective</source>
-        <translation></translation>
+        <translation>집단 피치</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="427"/>
         <source>Flight modes</source>
-        <translation></translation>
+        <translation>플라이트 모드</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="432"/>
         <location filename="../multimodelprinter.cpp" line="505"/>
         <source>Flight mode</source>
-        <translation></translation>
+        <translation>플라이트 모드</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="340"/>
@@ -10476,246 +10627,246 @@ p, li { white-space: pre-wrap; }
         <location filename="../multimodelprinter.cpp" line="734"/>
         <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Switch</source>
-        <translation></translation>
+        <translation>스위치</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="314"/>
         <source>General</source>
-        <translation></translation>
+        <translation>일반</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="320"/>
         <source>Model Image</source>
-        <translation></translation>
+        <translation>모델 이미지</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="322"/>
         <source>Throttle</source>
-        <translation></translation>
+        <translation>스로틀</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="323"/>
         <source>Trims</source>
-        <translation></translation>
+        <translation>트림</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="324"/>
         <source>Center Beep</source>
-        <translation></translation>
+        <translation>중앙 비프음</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="325"/>
         <source>Switch Warnings</source>
-        <translation></translation>
+        <translation>스위치 경고</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="327"/>
         <source>Pot Warnings</source>
-        <translation></translation>
+        <translation>포텐셔미터 경고</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="329"/>
         <source>Other</source>
-        <translation></translation>
+        <translation>기타</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Timers</source>
-        <translation></translation>
+        <translation>타이머</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Time</source>
-        <translation></translation>
+        <translation>시간</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Countdown</source>
-        <translation></translation>
+        <translation>카운트다운</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Mode</source>
-        <translation></translation>
+        <translation>모드</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="340"/>
         <location filename="../multimodelprinter.cpp" line="989"/>
         <source>Start</source>
-        <translation></translation>
+        <translation>시작</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="364"/>
         <source>Modules</source>
-        <translation></translation>
+        <translation>모듈</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="376"/>
         <source>Trainer port</source>
-        <translation></translation>
+        <translation>트레이너 포트</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="395"/>
         <source>Helicopter</source>
-        <translation></translation>
+        <translation>헬리콥터</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="398"/>
         <source>Swash</source>
-        <translation></translation>
+        <translation>스와시</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="399"/>
         <location filename="../multimodelprinter.cpp" line="838"/>
         <location filename="../multimodelprinter.cpp" line="982"/>
         <source>Type</source>
-        <translation></translation>
+        <translation>종류</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="400"/>
         <source>Ring</source>
-        <translation></translation>
+        <translation>링</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="734"/>
         <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Function</source>
-        <translation></translation>
+        <translation>기능</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="734"/>
         <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Repeat</source>
-        <translation></translation>
+        <translation>반복</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="734"/>
         <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Enabled</source>
-        <translation></translation>
+        <translation>활성화됨</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="770"/>
         <source>Protocol</source>
-        <translation></translation>
+        <translation>프로토콜</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="778"/>
         <source>Low</source>
-        <translation></translation>
+        <translation>낮음</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="781"/>
         <source>Critical</source>
-        <translation></translation>
+        <translation>치명적</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="784"/>
         <source>Telemetry audio</source>
-        <translation></translation>
+        <translation>텔레메트리 오디오</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="791"/>
         <source>Altimetry</source>
-        <translation></translation>
+        <translation>고도계</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="793"/>
         <location filename="../multimodelprinter.cpp" line="796"/>
         <source>Vario source</source>
-        <translation></translation>
+        <translation>바리오 소스</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="801"/>
         <source>Vario limits &gt;</source>
-        <translation></translation>
+        <translation>바리오 제한 &gt;</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="803"/>
         <source>Sink max</source>
-        <translation></translation>
+        <translation>하강 최대</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="804"/>
         <source>Sink min</source>
-        <translation></translation>
+        <translation>하강 최소</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="806"/>
         <source>Climb min</source>
-        <translation></translation>
+        <translation>상승 최소</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="807"/>
         <source>Climb max</source>
-        <translation></translation>
+        <translation>상승 최대</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="808"/>
         <source>Center silent</source>
-        <translation></translation>
+        <translation>중앙 무음</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="815"/>
         <source>Top Bar</source>
-        <translation></translation>
+        <translation>상단 바</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="817"/>
         <source>Volts source</source>
-        <translation></translation>
+        <translation>전압 소스</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="818"/>
         <source>Altitude source</source>
-        <translation></translation>
+        <translation>고도 소스</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="823"/>
         <source>Multi sensors</source>
-        <translation></translation>
+        <translation>다중 센서</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="824"/>
         <source>Show Instance IDs</source>
-        <translation></translation>
+        <translation>인스턴스 ID 표시</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="969"/>
         <source>Customizable Switches</source>
-        <translation></translation>
+        <translation>사용자 정의 스위치</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="971"/>
         <source>Switch %1</source>
-        <translation></translation>
+        <translation>스위치 %1</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="996"/>
         <source>Group</source>
-        <translation></translation>
+        <translation>그룹</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="1003"/>
         <source>Always On</source>
-        <translation></translation>
+        <translation>항상 켜짐</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="734"/>
         <location filename="../multimodelprinter.cpp" line="838"/>
         <location filename="../multimodelprinter.cpp" line="906"/>
         <source>Parameters</source>
-        <translation></translation>
+        <translation>매개변수</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="860"/>
         <source>Telemetry Sensors</source>
-        <translation></translation>
+        <translation>텔레메트리 센서</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="892"/>
         <source>Telemetry Screens</source>
-        <translation></translation>
+        <translation>텔레메트리 화면</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="922"/>
@@ -10725,12 +10876,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../multimodelprinter.cpp" line="933"/>
         <source>Global Functions</source>
-        <translation></translation>
+        <translation>글로벌 기능</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="953"/>
         <source>Checklist</source>
-        <translation></translation>
+        <translation>체크리스트</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="464"/>
@@ -10746,7 +10897,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Channel</source>
-        <translation></translation>
+        <translation>채널</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="318"/>
@@ -10754,37 +10905,37 @@ p, li { white-space: pre-wrap; }
         <location filename="../multimodelprinter.cpp" line="838"/>
         <location filename="../multimodelprinter.cpp" line="975"/>
         <source>Name</source>
-        <translation></translation>
+        <translation>이름</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="483"/>
         <source>Prec</source>
-        <translation></translation>
+        <translation>정밀도</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="498"/>
         <source>Popup</source>
-        <translation></translation>
+        <translation>팝업</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="531"/>
         <source>Outputs</source>
-        <translation></translation>
+        <translation>출력</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Subtrim</source>
-        <translation></translation>
+        <translation>서브트림</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Direct</source>
-        <translation></translation>
+        <translation>직접</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="536"/>
         <source>Curve</source>
-        <translation></translation>
+        <translation>커브</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="538"/>
@@ -10794,69 +10945,69 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../multimodelprinter.cpp" line="540"/>
         <source>Linear</source>
-        <translation></translation>
+        <translation>선형</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="765"/>
         <source>Telemetry</source>
-        <translation></translation>
+        <translation>텔레메트리</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="488"/>
         <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Min</source>
-        <translation></translation>
+        <translation>최소</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Min.call</source>
-        <translation></translation>
+        <translation>최소 호출</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="340"/>
         <source>Persist</source>
-        <translation></translation>
+        <translation>지속</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.In</source>
-        <translation></translation>
+        <translation>입력 필터</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="432"/>
         <source>F.Out</source>
-        <translation></translation>
+        <translation>출력 필터</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="461"/>
         <source>Global vars</source>
-        <translation></translation>
+        <translation>글로벌 변수</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="493"/>
         <location filename="../multimodelprinter.cpp" line="534"/>
         <source>Max</source>
-        <translation></translation>
+        <translation>최대</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="582"/>
         <source>Global Variables</source>
-        <translation></translation>
+        <translation>글로벌 변수</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="603"/>
         <source>Inputs</source>
-        <translation></translation>
+        <translation>입력</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="633"/>
         <source>Mixers</source>
-        <translation></translation>
+        <translation>믹서</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="693"/>
         <source>Curves</source>
-        <translation></translation>
+        <translation>커브</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="715"/>
@@ -10866,7 +11017,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../multimodelprinter.cpp" line="722"/>
         <source>Logical Switches</source>
-        <translation></translation>
+        <translation>논리 스위치</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="746"/>
@@ -10876,17 +11027,17 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../multimodelprinter.cpp" line="757"/>
         <source>Special Functions</source>
-        <translation></translation>
+        <translation>특수 기능</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="478"/>
         <source>Unit</source>
-        <translation></translation>
+        <translation>단위</translation>
     </message>
     <message>
         <location filename="../multimodelprinter.cpp" line="776"/>
         <source>RF Quality Alarms</source>
-        <translation></translation>
+        <translation>RF 품질 경고</translation>
     </message>
 </context>
 <context>
@@ -10894,7 +11045,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modeledit/setup_module.cpp" line="596"/>
         <source>Servo update rate</source>
-        <translation></translation>
+        <translation>서보 업데이트 주기</translation>
     </message>
 </context>
 <context>
@@ -10902,22 +11053,22 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../wizarddialog.cpp" line="927"/>
         <source>Throttle Channel:</source>
-        <translation></translation>
+        <translation>스로틀 채널:</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="929"/>
         <source>Yaw Channel:</source>
-        <translation></translation>
+        <translation>요우 채널:</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="931"/>
         <source>Pitch Channel:</source>
-        <translation></translation>
+        <translation>피치 채널:</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="933"/>
         <source>Roll Channel:</source>
-        <translation></translation>
+        <translation>롤 채널:</translation>
     </message>
 </context>
 <context>
@@ -10925,17 +11076,17 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../wizarddialog.cpp" line="958"/>
         <source>Throttle Cut</source>
-        <translation></translation>
+        <translation>스로틀 컷</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="959"/>
         <source>Throttle Timer</source>
-        <translation></translation>
+        <translation>스로틀 타이머</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="960"/>
         <source>Flight Timer</source>
-        <translation></translation>
+        <translation>비행 타이머</translation>
     </message>
 </context>
 <context>
@@ -10943,37 +11094,37 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../printdialog.ui" line="54"/>
         <source>Close</source>
-        <translation></translation>
+        <translation>닫기</translation>
     </message>
     <message>
         <location filename="../printdialog.ui" line="61"/>
         <source>Style</source>
-        <translation></translation>
+        <translation>스타일</translation>
     </message>
     <message>
         <location filename="../printdialog.ui" line="68"/>
         <source>Print</source>
-        <translation></translation>
+        <translation>인쇄</translation>
     </message>
     <message>
         <location filename="../printdialog.ui" line="75"/>
         <source>Print to file</source>
-        <translation></translation>
+        <translation>파일로 출력</translation>
     </message>
     <message>
         <location filename="../printdialog.cpp" line="63"/>
         <source>Print Document</source>
-        <translation></translation>
+        <translation>문서 인쇄</translation>
     </message>
     <message>
         <location filename="../printdialog.cpp" line="71"/>
         <source>Select output file</source>
-        <translation></translation>
+        <translation>출력 파일 선택</translation>
     </message>
     <message>
         <location filename="../printdialog.cpp" line="71"/>
         <source>PDF files(*.pdf);;HTML files (*.htm *.html);;All files (*)</source>
-        <translation></translation>
+        <translation>PDF 파일 (*.pdf);;HTML 파일 (*.htm *.html);;모든 파일 (*)</translation>
     </message>
 </context>
 <context>
@@ -10981,12 +11132,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../profilechooser.ui" line="20"/>
         <source>Select Profile</source>
-        <translation></translation>
+        <translation>프로필 선택</translation>
     </message>
     <message>
         <location filename="../profilechooser.ui" line="43"/>
         <source>Profile</source>
-        <translation></translation>
+        <translation>프로필</translation>
     </message>
 </context>
 <context>
@@ -10994,18 +11145,18 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../progressdialog.ui" line="20"/>
         <source>Flash Firmware</source>
-        <translation></translation>
+        <translation>펌웨어 플래시</translation>
     </message>
     <message>
         <location filename="../progressdialog.ui" line="79"/>
         <location filename="../progressdialog.cpp" line="93"/>
         <source>Close</source>
-        <translation></translation>
+        <translation>닫기</translation>
     </message>
     <message>
         <location filename="../progressdialog.cpp" line="88"/>
         <source>Cancel</source>
-        <translation></translation>
+        <translation>취소</translation>
     </message>
 </context>
 <context>
@@ -11013,7 +11164,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../progresswidget.ui" line="107"/>
         <source>Show Details</source>
-        <translation></translation>
+        <translation>세부 정보 표시</translation>
     </message>
 </context>
 <context>
@@ -11021,22 +11172,22 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../helpers.cpp" line="238"/>
         <source>WARNING</source>
-        <translation></translation>
+        <translation>경고</translation>
     </message>
     <message>
         <location filename="../helpers.cpp" line="239"/>
         <source>&lt;p&gt;Importing JumperTX data into OpenTX 2.3 is &lt;b&gt;not supported and dangerous.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;It is unfortunately not possible for us to differentiate JumperTX data from legitimate FrSky X10 data, but &lt;b&gt;You should only continue here if the file you opened comes from a real FrSky X10.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;Do you really want to continue?&lt;/p&gt;</source>
-        <translation></translation>
+        <translation>&lt;p&gt;JumperTX 데이터를 OpenTX 2.3으로 가져오는 것은 &lt;b&gt;지원되지 않으며 위험합니다.&lt;/b&gt;&lt;/p&gt;                       &lt;p&gt;불행히도 JumperTX 데이터와 정식 FrSky X10 데이터를 구분할 수 없습니다. 그러나 &lt;b&gt;열려는 파일이 실제 FrSky X10 장치에서 온 것일 때만 계속하십시오.&lt;/b&gt;&lt;/p&gt;&lt;p&gt;                       정말 계속하시겠습니까?&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../storage/firmwareinterface.cpp" line="390"/>
         <source>Compressed image size exceeds reserved space.</source>
-        <translation></translation>
+        <translation>압축된 이미지 크기가 예약된 공간을 초과했습니다.</translation>
     </message>
     <message>
         <location filename="../warnings.h" line="96"/>
         <source>Show this message again at next startup?</source>
-        <translation></translation>
+        <translation>다음 시작 시 이 메시지를 다시 표시하시겠습니까?</translation>
     </message>
 </context>
 <context>
@@ -11044,24 +11195,24 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../firmwares/radiodata.cpp" line="154"/>
         <source>Favorites</source>
-        <translation></translation>
+        <translation>즐겨찾기</translation>
     </message>
     <message>
         <location filename="../firmwares/radiodata.cpp" line="319"/>
         <source>None</source>
-        <translation></translation>
+        <translation>없음</translation>
     </message>
     <message>
         <location filename="../firmwares/radiodata.cpp" line="321"/>
         <location filename="../firmwares/radiodata.cpp" line="323"/>
         <source>Name %1</source>
-        <translation></translation>
+        <translation>이름 %1</translation>
     </message>
     <message>
         <location filename="../firmwares/radiodata.cpp" line="325"/>
         <location filename="../firmwares/radiodata.cpp" line="327"/>
         <source>Last Opened %1</source>
-        <translation></translation>
+        <translation>최근 열림 %1</translation>
     </message>
 </context>
 <context>
@@ -11069,107 +11220,107 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="113"/>
         <source>is invalid</source>
-        <translation></translation>
+        <translation>잘못되었습니다</translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="120"/>
         <source>converted to</source>
-        <translation></translation>
+        <translation>다음으로 변환됨</translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="127"/>
         <source>verify is</source>
-        <translation></translation>
+        <translation>검증 결과</translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="133"/>
         <source>unsupported</source>
-        <translation type="unfinished"></translation>
+        <translation>지원되지 않음</translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[DBG]</source>
-        <translation></translation>
+        <translation>[디버그]</translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[NFO]</source>
-        <translation></translation>
+        <translation>[정보]</translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[WRN]</source>
-        <translation></translation>
+        <translation>[경고]</translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[CVT]</source>
-        <translation></translation>
+        <translation>[변환]</translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[ERR]</source>
-        <translation></translation>
+        <translation>[오류]</translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[INV]</source>
-        <translation></translation>
+        <translation>[무효]</translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="172"/>
         <source>[XSP]</source>
-        <translation type="unfinished"></translation>
+        <translation>[확장]</translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Event</source>
-        <translation></translation>
+        <translation>이벤트</translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Origin</source>
-        <translation></translation>
+        <translation>원본</translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Comp</source>
-        <translation></translation>
+        <translation>컴포넌트</translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Sub-Component</source>
-        <translation></translation>
+        <translation>하위 구성 요소</translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Field</source>
-        <translation></translation>
+        <translation>필드</translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Type</source>
-        <translation></translation>
+        <translation>유형</translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Old</source>
-        <translation></translation>
+        <translation>기존 값</translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>Action</source>
-        <translation></translation>
+        <translation>동작</translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="185"/>
         <source>New</source>
-        <translation></translation>
+        <translation>새 값</translation>
     </message>
     <message>
         <location filename="../firmwares/radiodataconversionstate.cpp" line="199"/>
         <source>Seq</source>
-        <translation></translation>
+        <translation>순번</translation>
     </message>
 </context>
 <context>
@@ -11178,33 +11329,34 @@ p, li { white-space: pre-wrap; }
         <location filename="../radiointerface.cpp" line="69"/>
         <source>Cannot write file %1:
 %2.</source>
-        <translation></translation>
+        <translation>파일 %1을(를) 쓸 수 없습니다:
+%2</translation>
     </message>
     <message>
         <location filename="../radiointerface.cpp" line="208"/>
         <source>Unable to find SD card!</source>
-        <translation type="unfinished"></translation>
+        <translation>SD 카드를 찾을 수 없습니다!</translation>
     </message>
     <message>
         <location filename="../radiointerface.cpp" line="217"/>
         <source>Failed to read Models and Settings from</source>
-        <translation></translation>
+        <translation>모델 및 설정 파일을 읽는 데 실패했습니다:</translation>
     </message>
     <message>
         <location filename="../radiointerface.cpp" line="224"/>
         <source>Failed to write Models and Setting file</source>
-        <translation></translation>
+        <translation>모델 및 설정 파일을 저장하는 데 실패했습니다</translation>
     </message>
     <message>
         <location filename="../radiointerface.cpp" line="328"/>
         <source>found in multiple locations</source>
-        <translation type="unfinished"></translation>
+        <translation>여러 위치에서 발견되었습니다</translation>
     </message>
     <message>
         <location filename="../radiointerface.cpp" line="137"/>
         <location filename="../radiointerface.cpp" line="182"/>
         <source>Could not delete temporary file: %1</source>
-        <translation></translation>
+        <translation>임시 파일을 삭제할 수 없습니다: %1</translation>
     </message>
 </context>
 <context>
@@ -11212,12 +11364,12 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../simulation/widgets/radioknobwidget.h" line="59"/>
         <source>&lt;p&gt;Value (input): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</source>
-        <translation></translation>
+        <translation>&lt;p&gt;입력값: &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</translation>
     </message>
     <message>
         <location filename="../simulation/widgets/radioknobwidget.h" line="61"/>
         <source>Right-double-click to reset to center.</source>
-        <translation></translation>
+        <translation>오른쪽 더블 클릭으로 중심값으로 초기화합니다.</translation>
     </message>
 </context>
 <context>
@@ -11225,17 +11377,17 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../radionotfound.ui" line="32"/>
         <source>No Radio Found</source>
-        <translation></translation>
+        <translation>조종기를 찾을 수 없습니다</translation>
     </message>
     <message>
         <location filename="../radionotfound.ui" line="40"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;No Radio was found!&lt;/p&gt;&lt;p&gt;Make sure that you hold the lower trim buttons towards the center while you turn it on.&lt;/p&gt;&lt;p&gt;Then connect the USB wire.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-family:&apos;arial,sans-serif&apos;; font-size:13px; font-style:italic; color:#222222; background-color:#ffffff;&quot;&gt;Note: if you have a Taranis that has not had the firmware upgraded to 2.0 then this version of Companion will not work.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation></translation>
+        <translation>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;조종기를 찾을 수 없습니다!&lt;/p&gt;&lt;p&gt;전원을 켤 때 하단 트림 버튼을 안쪽으로 누르고 계신지 확인하세요.&lt;/p&gt;&lt;p&gt;그런 다음 USB 케이블을 연결하세요.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-family:&apos;arial,sans-serif&apos;; font-size:13px; font-style:italic; color:#222222; background-color:#ffffff;&quot;&gt;참고: 펌웨어가 2.0으로 업그레이드되지 않은 Taranis는 이 Companion 버전과 호환되지 않습니다.&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</translation>
     </message>
     <message>
         <location filename="../radionotfound.ui" line="92"/>
         <source>OK</source>
-        <translation></translation>
+        <translation>확인</translation>
     </message>
 </context>
 <context>
@@ -11243,32 +11395,32 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../simulation/radiooutputswidget.ui" line="14"/>
         <source>Form</source>
-        <translation></translation>
+        <translation>폼</translation>
     </message>
     <message>
         <location filename="../simulation/radiooutputswidget.ui" line="68"/>
         <source>View:</source>
-        <translation></translation>
+        <translation>보기:</translation>
     </message>
     <message>
         <location filename="../simulation/radiooutputswidget.ui" line="75"/>
         <source>Logical Switches</source>
-        <translation></translation>
+        <translation>논리 스위치</translation>
     </message>
     <message>
         <location filename="../simulation/radiooutputswidget.ui" line="94"/>
         <source>Global Variables</source>
-        <translation></translation>
+        <translation>글로벌 변수</translation>
     </message>
     <message>
         <location filename="../simulation/radiooutputswidget.ui" line="113"/>
         <source>Channel Outputs</source>
-        <translation></translation>
+        <translation>채널 출력</translation>
     </message>
     <message>
         <location filename="../simulation/radiooutputswidget.ui" line="132"/>
         <source>Mix Outputs</source>
-        <translation></translation>
+        <translation>믹스 출력</translation>
     </message>
     <message>
         <location filename="../simulation/radiooutputswidget.ui" line="210"/>
@@ -11277,7 +11429,8 @@ o
 g
 i
 c</source>
-        <translation></translation>
+        <translation>로
+직</translation>
     </message>
     <message>
         <location filename="../simulation/radiooutputswidget.ui" line="287"/>
@@ -11287,7 +11440,9 @@ o
 b
 a
 l</source>
-        <translation></translation>
+        <translation>글
+로
+벌</translation>
     </message>
     <message>
         <location filename="../simulation/radiooutputswidget.ui" line="362"/>
@@ -11299,7 +11454,8 @@ n
 e
 l
 s</source>
-        <translation></translation>
+        <translation>채
+널</translation>
     </message>
     <message>
         <location filename="../simulation/radiooutputswidget.ui" line="439"/>
@@ -11308,17 +11464,18 @@ i
 x
 e
 s</source>
-        <translation></translation>
+        <translation>믹
+스</translation>
     </message>
     <message>
         <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
         <source>FM</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/radiooutputswidget.cpp" line="228"/>
         <source>DM</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/radiooutputswidget.cpp" line="237"/>
@@ -11331,7 +11488,7 @@ s</source>
     <message>
         <location filename="../simulation/widgets/radioswitchwidget.h" line="77"/>
         <source>Latch/unlatch the momentary switch.</source>
-        <translation></translation>
+        <translation>순간 스위치를 고정하거나 해제합니다.</translation>
     </message>
 </context>
 <context>
@@ -11345,91 +11502,91 @@ s</source>
         <location filename="../firmwares/rawsource.cpp" line="99"/>
         <location filename="../firmwares/rawsource.cpp" line="111"/>
         <source>s</source>
-        <translation></translation>
+        <translation>초</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="141"/>
         <source>Trim Rud</source>
-        <translation type="unfinished"></translation>
+        <translation>러더 트림</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="141"/>
         <source>Trim Ele</source>
-        <translation type="unfinished"></translation>
+        <translation>엘리베이터 트림</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="141"/>
         <source>Trim Thr</source>
-        <translation type="unfinished"></translation>
+        <translation>스로틀 트림</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="141"/>
         <source>Trim Ail</source>
-        <translation type="unfinished"></translation>
+        <translation>엘러론 트림</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="141"/>
         <location filename="../firmwares/rawsource.cpp" line="145"/>
         <source>Trim 5</source>
-        <translation type="unfinished"></translation>
+        <translation>트림 5</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="141"/>
         <location filename="../firmwares/rawsource.cpp" line="145"/>
         <source>Trim 6</source>
-        <translation type="unfinished"></translation>
+        <translation>트림 6</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="141"/>
         <location filename="../firmwares/rawsource.cpp" line="145"/>
         <source>Trim 7</source>
-        <translation type="unfinished"></translation>
+        <translation>트림 7</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="141"/>
         <location filename="../firmwares/rawsource.cpp" line="145"/>
         <source>Trim 8</source>
-        <translation type="unfinished"></translation>
+        <translation>트림 8</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="145"/>
         <source>Trim ST</source>
-        <translation type="unfinished"></translation>
+        <translation>조향 트림(ST)</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="145"/>
         <source>Trim TH</source>
-        <translation type="unfinished"></translation>
+        <translation>스로틀 트림(TH)</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="145"/>
         <source>Trim 3</source>
-        <translation type="unfinished"></translation>
+        <translation>트림 3</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="145"/>
         <source>Trim 4</source>
-        <translation type="unfinished"></translation>
+        <translation>트림 4</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmH</source>
-        <translation></translation>
+        <translation>수평 트림</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="149"/>
         <source>TrmV</source>
-        <translation></translation>
+        <translation>수직 트림</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Batt</source>
-        <translation></translation>
+        <translation>배터리</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Time</source>
-        <translation></translation>
+        <translation>시간</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="153"/>
@@ -11439,22 +11596,22 @@ s</source>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved1</source>
-        <translation></translation>
+        <translation>예약됨1</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved2</source>
-        <translation></translation>
+        <translation>예약됨2</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved3</source>
-        <translation></translation>
+        <translation>예약됨3</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="153"/>
         <source>Reserved4</source>
-        <translation></translation>
+        <translation>예약됨4</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="156"/>
@@ -11470,7 +11627,7 @@ s</source>
         <location filename="../firmwares/rawsource.cpp" line="171"/>
         <source>I</source>
         <comment>as in Input</comment>
-        <translation></translation>
+        <translation>입력</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="177"/>
@@ -11480,23 +11637,23 @@ s</source>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="195"/>
         <source>MIN</source>
-        <translation></translation>
+        <translation>최소</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="198"/>
         <source>MAX</source>
-        <translation></translation>
+        <translation>최대</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="221"/>
         <source>CYC%1</source>
-        <translation></translation>
+        <translation>사이클%1</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="224"/>
         <source>TR</source>
         <comment>as in Trainer</comment>
-        <translation></translation>
+        <translation>트레이너</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="265"/>
@@ -11506,22 +11663,22 @@ s</source>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="268"/>
         <source>GR%1</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="400"/>
         <source>Source</source>
-        <translation type="unfinished"></translation>
+        <translation>소스</translation>
     </message>
     <message>
         <location filename="../firmwares/rawsource.cpp" line="412"/>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation>없음</translation>
     </message>
     <message>
         <location filename="../constants.h" line="97"/>
         <source>-</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
 </context>
 <context>
@@ -11549,197 +11706,197 @@ s</source>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Left</source>
-        <translation></translation>
+        <translation>수평 트림 좌</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="63"/>
         <source>TrmH Right</source>
-        <translation></translation>
+        <translation>수평 트림 우</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Down</source>
-        <translation></translation>
+        <translation>수직 트림 하</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="64"/>
         <source>TrmV Up</source>
-        <translation></translation>
+        <translation>수직 트림 상</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REa</source>
-        <translation></translation>
+        <translation>로터리 A</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="73"/>
         <source>REb</source>
-        <translation></translation>
+        <translation>로터리 B</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="41"/>
         <source>Trim Rud-</source>
-        <translation type="unfinished"></translation>
+        <translation>러더 트림 -</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="41"/>
         <source>Trim Rud+</source>
-        <translation type="unfinished"></translation>
+        <translation>러더 트림 +</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
         <source>Trim Ele-</source>
-        <translation type="unfinished"></translation>
+        <translation>엘리베이터 트림 -</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="42"/>
         <source>Trim Ele+</source>
-        <translation type="unfinished"></translation>
+        <translation>엘리베이터 트림 +</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
         <source>Trim Thr-</source>
-        <translation type="unfinished"></translation>
+        <translation>스로틀 트림 -</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="43"/>
         <source>Trim Thr+</source>
-        <translation type="unfinished"></translation>
+        <translation>스로틀 트림 +</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
         <source>Trim Ail-</source>
-        <translation type="unfinished"></translation>
+        <translation>엘러론 트림 -</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="44"/>
         <source>Trim Ail+</source>
-        <translation type="unfinished"></translation>
+        <translation>엘러론 트림 +</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="45"/>
         <location filename="../firmwares/rawswitch.cpp" line="56"/>
         <source>Trim T5-</source>
-        <translation type="unfinished"></translation>
+        <translation>트림 T5 -</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="45"/>
         <location filename="../firmwares/rawswitch.cpp" line="56"/>
         <source>Trim T5+</source>
-        <translation type="unfinished"></translation>
+        <translation>트림 T5 +</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="46"/>
         <location filename="../firmwares/rawswitch.cpp" line="57"/>
         <source>Trim T6-</source>
-        <translation type="unfinished"></translation>
+        <translation>트림 T6 -</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="46"/>
         <location filename="../firmwares/rawswitch.cpp" line="57"/>
         <source>Trim T6+</source>
-        <translation type="unfinished"></translation>
+        <translation>트림 T6 +</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="47"/>
         <location filename="../firmwares/rawswitch.cpp" line="58"/>
         <source>Trim T7-</source>
-        <translation type="unfinished"></translation>
+        <translation>트림 T7 -</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="47"/>
         <location filename="../firmwares/rawswitch.cpp" line="58"/>
         <source>Trim T7+</source>
-        <translation type="unfinished"></translation>
+        <translation>트림 T7 +</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="48"/>
         <location filename="../firmwares/rawswitch.cpp" line="59"/>
         <source>Trim T8-</source>
-        <translation type="unfinished"></translation>
+        <translation>트림 T8 -</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="48"/>
         <location filename="../firmwares/rawswitch.cpp" line="59"/>
         <source>Trim T8+</source>
-        <translation type="unfinished"></translation>
+        <translation>트림 T8 +</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="52"/>
         <source>Trim ST-</source>
-        <translation type="unfinished"></translation>
+        <translation>트림 ST -</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="52"/>
         <source>Trim ST+</source>
-        <translation type="unfinished"></translation>
+        <translation>트림 ST +</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="53"/>
         <source>Trim TH-</source>
-        <translation type="unfinished"></translation>
+        <translation>트림 TH -</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="53"/>
         <source>Trim TH+</source>
-        <translation type="unfinished"></translation>
+        <translation>트림 TH +</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="54"/>
         <source>Trim T3-</source>
-        <translation type="unfinished"></translation>
+        <translation>트림 T3 -</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="54"/>
         <source>Trim T3+</source>
-        <translation type="unfinished"></translation>
+        <translation>트림 T3 +</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="55"/>
         <source>Trim T4-</source>
-        <translation type="unfinished"></translation>
+        <translation>트림 T4 -</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="55"/>
         <source>Trim T4+</source>
-        <translation type="unfinished"></translation>
+        <translation>트림 T4 +</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="68"/>
         <location filename="../firmwares/rawswitch.cpp" line="140"/>
         <source>OFF</source>
-        <translation></translation>
+        <translation>끔</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="68"/>
         <location filename="../firmwares/rawswitch.cpp" line="137"/>
         <source>ON</source>
-        <translation></translation>
+        <translation>켬</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THs</source>
-        <translation></translation>
+        <translation>스로틀 스틱</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>TH%</source>
-        <translation></translation>
+        <translation>스로틀 %</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="69"/>
         <source>THt</source>
-        <translation></translation>
+        <translation>스로틀 타이머</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="143"/>
         <source>One</source>
-        <translation></translation>
+        <translation>1회</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="146"/>
         <source>Act</source>
-        <translation></translation>
+        <translation>동작</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="155"/>
@@ -11749,22 +11906,22 @@ s</source>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="167"/>
         <source>Telemetry</source>
-        <translation></translation>
+        <translation>텔레메트리</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="170"/>
         <source>Trn</source>
-        <translation></translation>
+        <translation>트레이너</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="223"/>
         <source>Switch</source>
-        <translation type="unfinished">Switch</translation>
+        <translation>스위치</translation>
     </message>
     <message>
         <location filename="../firmwares/rawswitch.cpp" line="240"/>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation>없음</translation>
     </message>
 </context>
 <context>
@@ -11772,7 +11929,7 @@ s</source>
     <message>
         <location filename="../updates/repoassets.cpp" line="181"/>
         <source>Generic asset build not implemented</source>
-        <translation type="unfinished"></translation>
+        <translation>일반 에셋 빌드는 아직 구현되지 않았습니다</translation>
     </message>
 </context>
 <context>
@@ -11780,17 +11937,17 @@ s</source>
     <message>
         <location filename="../wizarddialog.cpp" line="657"/>
         <source>No</source>
-        <translation>No</translation>
+        <translation>아니요</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="658"/>
         <source>Yes</source>
-        <translation></translation>
+        <translation>예</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="667"/>
         <source>&lt;br&gt;Rudder Channel:</source>
-        <translation></translation>
+        <translation>&lt;br&gt;러더 채널:</translation>
     </message>
 </context>
 <context>
@@ -11799,18 +11956,20 @@ s</source>
         <location filename="../storage/sdcard.cpp" line="39"/>
         <source>Error opening file %1:
 %2.</source>
-        <translation></translation>
+        <translation>파일 %1을 여는 중 오류 발생:
+%2.</translation>
     </message>
     <message>
         <location filename="../storage/sdcard.cpp" line="52"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
-        <translation></translation>
+        <translation>파일 %1을 쓰기 모드로 여는 중 오류 발생:
+%2.</translation>
     </message>
     <message>
         <location filename="../storage/sdcard.cpp" line="78"/>
         <source>Error deleting file %1</source>
-        <translation></translation>
+        <translation>파일 %1 삭제 중 오류 발생</translation>
     </message>
 </context>
 <context>
@@ -11818,28 +11977,28 @@ s</source>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="133"/>
         <source>Formula</source>
-        <translation></translation>
+        <translation>수식</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="136"/>
         <source>Id</source>
-        <translation></translation>
+        <translation>식별자</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="137"/>
         <source>Instance</source>
-        <translation></translation>
+        <translation>인스턴스</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="141"/>
         <location filename="../firmwares/sensordata.cpp" line="155"/>
         <source>Sensor</source>
-        <translation></translation>
+        <translation>센서</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="146"/>
         <source>Sources</source>
-        <translation></translation>
+        <translation>소스</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="158"/>
@@ -11849,142 +12008,142 @@ s</source>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="159"/>
         <source>Alt</source>
-        <translation></translation>
+        <translation>고도</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="163"/>
         <source>Unit</source>
-        <translation></translation>
+        <translation>단위</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="166"/>
         <source>Precision</source>
-        <translation></translation>
+        <translation>정밀도</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="171"/>
         <source>Ratio</source>
-        <translation></translation>
+        <translation>비율</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="172"/>
         <source>Offset</source>
-        <translation></translation>
+        <translation>오프셋</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="173"/>
         <source>Auto Offset</source>
-        <translation></translation>
+        <translation>자동 오프셋</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="176"/>
         <source>Blades</source>
-        <translation></translation>
+        <translation>날개 수</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="177"/>
         <source>Multiplier</source>
-        <translation></translation>
+        <translation>곱셈 계수</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="182"/>
         <source>Filter</source>
-        <translation></translation>
+        <translation>필터</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="185"/>
         <source>Persist</source>
-        <translation></translation>
+        <translation>유지</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="188"/>
         <source>Positive</source>
-        <translation></translation>
+        <translation>양수</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="190"/>
         <source>Log</source>
-        <translation></translation>
+        <translation>로그</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="270"/>
         <source>Custom</source>
-        <translation></translation>
+        <translation>사용자 정의</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="272"/>
         <source>Calculated</source>
-        <translation></translation>
+        <translation>계산됨</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="283"/>
         <source>Add</source>
-        <translation></translation>
+        <translation>추가</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="285"/>
         <source>Average</source>
-        <translation></translation>
+        <translation>평균</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="287"/>
         <source>Minimum</source>
-        <translation></translation>
+        <translation>최소</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="289"/>
         <source>Maximum</source>
-        <translation></translation>
+        <translation>최대</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="291"/>
         <source>Multiply</source>
-        <translation></translation>
+        <translation>곱하기</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="293"/>
         <source>Totalize</source>
-        <translation></translation>
+        <translation>합계</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="295"/>
         <source>Cell</source>
-        <translation></translation>
+        <translation>셀</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="297"/>
         <source>Consumption</source>
-        <translation></translation>
+        <translation>소모량</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="299"/>
         <source>Distance</source>
-        <translation></translation>
+        <translation>거리</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="309"/>
         <source>Lowest</source>
-        <translation></translation>
+        <translation>최저</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="311"/>
         <source>Cell %1</source>
-        <translation></translation>
+        <translation>셀 %1</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="313"/>
         <source>Highest</source>
-        <translation></translation>
+        <translation>최고</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="315"/>
         <source>Delta</source>
-        <translation></translation>
+        <translation>차이</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="350"/>
         <source>Raw (-)</source>
-        <translation></translation>
+        <translation>원시값 (-)</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="352"/>
@@ -12005,7 +12164,7 @@ s</source>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="358"/>
         <source>kts</source>
-        <translation></translation>
+        <translation>노트</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="360"/>
@@ -12015,7 +12174,7 @@ s</source>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="362"/>
         <source>f/s</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="364"/>
@@ -12095,57 +12254,57 @@ s</source>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="394"/>
         <source>ml</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="396"/>
         <source>fl.oz</source>
-        <translation type="unfinished"></translation>
+        <translation>액량 온스(fl.oz)</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="406"/>
         <source>hours</source>
-        <translation></translation>
+        <translation>시간</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="408"/>
         <source>minutes</source>
-        <translation></translation>
+        <translation>분</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="410"/>
         <source>seconds</source>
-        <translation></translation>
+        <translation>초</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="398"/>
         <source>ml/minute</source>
-        <translation></translation>
+        <translation>ml/분</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="400"/>
         <source>Hertz</source>
-        <translation></translation>
+        <translation>헤르츠</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="402"/>
         <source>mS</source>
-        <translation></translation>
+        <translation>밀리초</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="404"/>
         <source>uS</source>
-        <translation></translation>
+        <translation>마이크로초</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="469"/>
         <source>(default)</source>
-        <translation></translation>
+        <translation>(기본값)</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="37"/>
         <source>TELE</source>
-        <translation></translation>
+        <translation>텔레</translation>
     </message>
 </context>
 <context>
@@ -12153,37 +12312,37 @@ s</source>
     <message>
         <location filename="../simulation/serialportsdialog.ui" line="20"/>
         <source>Configure Serial Ports</source>
-        <translation type="unfinished"></translation>
+        <translation>시리얼 포트 구성</translation>
     </message>
     <message>
         <location filename="../simulation/serialportsdialog.ui" line="35"/>
         <source>AUX1 Port</source>
-        <translation type="unfinished"></translation>
+        <translation>AUX1 포트</translation>
     </message>
     <message>
         <location filename="../simulation/serialportsdialog.ui" line="61"/>
         <source>Cancel</source>
-        <translation type="unfinished"></translation>
+        <translation>취소</translation>
     </message>
     <message>
         <location filename="../simulation/serialportsdialog.ui" line="68"/>
         <source>AUX2 Port</source>
-        <translation type="unfinished"></translation>
+        <translation>AUX2 포트</translation>
     </message>
     <message>
         <location filename="../simulation/serialportsdialog.ui" line="101"/>
         <source>Ok</source>
-        <translation type="unfinished"></translation>
+        <translation>확인</translation>
     </message>
     <message>
         <location filename="../simulation/serialportsdialog.ui" line="108"/>
         <source>Search for Serial Ports</source>
-        <translation type="unfinished"></translation>
+        <translation>시리얼 포트 검색</translation>
     </message>
     <message>
         <location filename="../simulation/serialportsdialog.cpp" line="51"/>
         <source>Not Assigned</source>
-        <translation type="unfinished"></translation>
+        <translation>할당되지 않음</translation>
     </message>
 </context>
 <context>
@@ -12191,97 +12350,97 @@ s</source>
     <message>
         <location filename="../modeledit/setup.ui" line="28"/>
         <source>Timer 1</source>
-        <translation></translation>
+        <translation>타이머 1</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="245"/>
         <source>Top LCD Timer</source>
-        <translation></translation>
+        <translation>상단 LCD 타이머</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="71"/>
         <source>Model Image</source>
-        <translation></translation>
+        <translation>모델 이미지</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="267"/>
         <source>Warnings</source>
-        <translation></translation>
+        <translation>경고</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="341"/>
         <source>Switch Warnings</source>
-        <translation></translation>
+        <translation>스위치 경고</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="391"/>
         <source>OFF</source>
-        <translation></translation>
+        <translation>끔</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="401"/>
         <source>Auto</source>
-        <translation></translation>
+        <translation>자동</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="145"/>
         <source>Model</source>
-        <translation></translation>
+        <translation>모델</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="454"/>
         <source>Center beep</source>
-        <translation></translation>
+        <translation>센터 비프음</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="588"/>
         <source>Interactive Checklist</source>
-        <translation></translation>
+        <translation>인터랙티브 체크리스트</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="601"/>
         <source>ADC filter</source>
-        <translation></translation>
+        <translation>ADC 필터</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="615"/>
         <source>Global</source>
-        <translation></translation>
+        <translation>전역</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="620"/>
         <source>Off</source>
-        <translation></translation>
+        <translation>끔</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="625"/>
         <source>On</source>
-        <translation></translation>
+        <translation>켬</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="642"/>
         <source>Edit Checklist...</source>
-        <translation></translation>
+        <translation>체크리스트 편집...</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="675"/>
         <source>Throttle trim switch</source>
-        <translation></translation>
+        <translation>스로틀 트림 스위치</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="685"/>
         <source>Extended Trims</source>
-        <translation></translation>
+        <translation>확장 트림</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="571"/>
         <source>Display Checklist</source>
-        <translation></translation>
+        <translation>체크리스트 표시</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="695"/>
         <source>Extended Limits</source>
-        <translation></translation>
+        <translation>확장 제한값</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="659"/>
@@ -12289,112 +12448,113 @@ s</source>
 If this is checked the throttle will be reversed.  Idle will be forward, trim will also be reversed and the throttle warning will be reversed as well.
 
 </source>
-        <translation></translation>
+        <translation>스로틀 반전 작동.
+이 항목을 선택하면 스로틀이 반전됩니다. 아이들은 전방, 트림 및 스로틀 경고도 반전됩니다.</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="668"/>
         <source>Reverse Throttle</source>
-        <translation></translation>
+        <translation>스로틀 반전</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="652"/>
         <source>Throttle Trim Idle Only</source>
-        <translation></translation>
+        <translation>스로틀 트림(아이들 상태에서만)</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="535"/>
         <source>Throttle Warning</source>
-        <translation></translation>
+        <translation>스로틀 경고</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="479"/>
         <source>Exponential</source>
-        <translation></translation>
+        <translation>지수</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="195"/>
         <source>Hats Mode</source>
-        <translation></translation>
+        <translation>Hats 모드</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="381"/>
         <source>Pot/Slider Warnings</source>
-        <translation></translation>
+        <translation>가변저항/슬라이더 경고</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="396"/>
         <source>ON</source>
-        <translation></translation>
+        <translation>켬</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="484"/>
         <source>Extra Fine</source>
-        <translation></translation>
+        <translation>초미세</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="489"/>
         <source>Fine</source>
-        <translation></translation>
+        <translation>미세</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="494"/>
         <source>Medium</source>
-        <translation></translation>
+        <translation>보통</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="499"/>
         <source>Coarse</source>
-        <translation></translation>
+        <translation>거침</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="514"/>
         <source>Never</source>
-        <translation></translation>
+        <translation>사용 안함</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="519"/>
         <source>On change</source>
-        <translation></translation>
+        <translation>변경 시</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="524"/>
         <source>Always</source>
-        <translation></translation>
+        <translation>항상</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="545"/>
         <source>Custom Throttle Warning</source>
-        <translation></translation>
+        <translation>사용자 정의 스로틀 경고</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="578"/>
         <source>Global Functions</source>
-        <translation></translation>
+        <translation>전역 기능</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="179"/>
         <source>Throttle Source</source>
-        <translation></translation>
+        <translation>스로틀 소스</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="211"/>
         <source>Trim Step</source>
-        <translation></translation>
+        <translation>트림 단계</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="227"/>
         <source>Trims Display</source>
-        <translation></translation>
+        <translation>트림 표시</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="320"/>
         <source>Timer 2</source>
-        <translation></translation>
+        <translation>타이머 2</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.ui" line="161"/>
         <source>Timer 3</source>
-        <translation></translation>
+        <translation>타이머 3</translation>
     </message>
 </context>
 <context>
@@ -12402,87 +12562,87 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
     <message>
         <location filename="../modeledit/setup.cpp" line="169"/>
         <source>Timer %1</source>
-        <translation></translation>
+        <translation>타이머 %1</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="153"/>
         <source>Popup menu available</source>
-        <translation></translation>
+        <translation>팝업 메뉴 사용 가능</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="672"/>
         <source>Profile Settings</source>
-        <translation></translation>
+        <translation>프로파일 설정</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="672"/>
         <source>SD structure path not specified or invalid</source>
-        <translation></translation>
+        <translation>SD 구조 경로가 지정되지 않았거나 잘못되었습니다</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="687"/>
         <source>Copy</source>
-        <translation></translation>
+        <translation>복사</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="688"/>
         <source>Cut</source>
-        <translation></translation>
+        <translation>잘라내기</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="689"/>
         <source>Paste</source>
-        <translation></translation>
+        <translation>붙여넣기</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="690"/>
         <source>Clear</source>
-        <translation></translation>
+        <translation>지우기</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="692"/>
         <source>Insert</source>
-        <translation></translation>
+        <translation>삽입</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="693"/>
         <source>Delete</source>
-        <translation></translation>
+        <translation>삭제</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="694"/>
         <source>Move Up</source>
-        <translation></translation>
+        <translation>위로 이동</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="695"/>
         <source>Move Down</source>
-        <translation></translation>
+        <translation>아래로 이동</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="697"/>
         <source>Clear All</source>
-        <translation></translation>
+        <translation>모두 지우기</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="732"/>
         <source>Clear Timer. Are you sure?</source>
-        <translation></translation>
+        <translation>타이머를 지우시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="744"/>
         <source>Clear all Timers. Are you sure?</source>
-        <translation></translation>
+        <translation>모든 타이머를 지우시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="766"/>
         <source>Cut Timer. Are you sure?</source>
-        <translation></translation>
+        <translation>타이머를 잘라내시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/setup.cpp" line="774"/>
         <source>Delete Timer. Are you sure?</source>
-        <translation></translation>
+        <translation>타이머를 삭제하시겠습니까?</translation>
     </message>
 </context>
 <context>
@@ -12490,7 +12650,7 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
     <message>
         <location filename="../wizarddialog.cpp" line="777"/>
         <source>Elevator Channel:</source>
-        <translation></translation>
+        <translation>엘리베이터 채널:</translation>
     </message>
 </context>
 <context>
@@ -12499,22 +12659,22 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
         <location filename="../simulation/simulateduiwidget.cpp" line="162"/>
         <source>screenshot</source>
         <comment>Simulator LCD screenshot file name prefix</comment>
-        <translation></translation>
+        <translation>스크린샷</translation>
     </message>
     <message>
         <location filename="../simulation/simulateduiwidget.cpp" line="399"/>
         <source>Scrl Up</source>
-        <translation type="unfinished"></translation>
+        <translation>위로 스크롤</translation>
     </message>
     <message>
         <location filename="../simulation/simulateduiwidget.cpp" line="400"/>
         <source>Scrl Dn</source>
-        <translation type="unfinished"></translation>
+        <translation>아래로 스크롤</translation>
     </message>
     <message>
         <location filename="../simulation/simulateduiwidget.cpp" line="413"/>
         <source>Shortcut: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>단축키: %1</translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="30"/>
@@ -12524,67 +12684,67 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
     <message>
         <location filename="../simulation/simulator_strings.h" line="26"/>
         <source>D</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="27"/>
         <source>F</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="28"/>
         <source>M</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="29"/>
         <source>N</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="31"/>
         <source>T</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="33"/>
         <source>enter</source>
-        <translation type="unfinished"></translation>
+        <translation>엔터</translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="34"/>
         <source>return</source>
-        <translation type="unfinished"></translation>
+        <translation>리턴</translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="35"/>
         <source>page up</source>
-        <translation type="unfinished"></translation>
+        <translation>페이지 업</translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="36"/>
         <source>page down</source>
-        <translation type="unfinished"></translation>
+        <translation>페이지 다운</translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="37"/>
         <source>delete</source>
-        <translation type="unfinished"></translation>
+        <translation>삭제</translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="38"/>
         <source>backspace</source>
-        <translation type="unfinished"></translation>
+        <translation>백스페이스</translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="39"/>
         <source>esc</source>
-        <translation type="unfinished"></translation>
+        <translation>ESC</translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="40"/>
         <source>insert</source>
-        <translation type="unfinished"></translation>
+        <translation>삽입</translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="41"/>
@@ -12599,27 +12759,27 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
     <message>
         <location filename="../simulation/simulator_strings.h" line="43"/>
         <source>&lt;font size=+3&gt;=&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="44"/>
         <source>&lt;font size=+3&gt;&amp;gt;&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="45"/>
         <source>&lt;font size=+3&gt;&amp;lt;&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="46"/>
         <source>&lt;font size=+3&gt;,&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="47"/>
         <source>&lt;font size=+3&gt;.&lt;/font&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="49"/>
@@ -12690,47 +12850,47 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
     <message>
         <location filename="../simulation/simulator_strings.h" line="71"/>
         <source>&lt;pre&gt;[ MENU ]&lt;/pre&gt;</source>
-        <translation></translation>
+        <translation>&lt;pre&gt;[ 메뉴 ]&lt;/pre&gt;</translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="72"/>
         <source>&lt;pre&gt;[ PAGE ]&lt;/pre&gt;</source>
-        <translation></translation>
+        <translation>&lt;pre&gt;[ 페이지 ]&lt;/pre&gt;</translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="73"/>
         <source>&lt;pre&gt;[ EXIT ]&lt;/pre&gt;</source>
-        <translation></translation>
+        <translation>&lt;pre&gt;[ 나가기 ]&lt;/pre&gt;</translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="74"/>
         <source>&lt;pre&gt;[ ENT ]&lt;/pre&gt;</source>
-        <translation></translation>
+        <translation>&lt;pre&gt;[ 확인 ]&lt;/pre&gt;</translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="75"/>
         <source>&lt;pre&gt;[ SHIFT ]&lt;/pre&gt;</source>
-        <translation></translation>
+        <translation>&lt;pre&gt;[ 쉬프트 ]&lt;/pre&gt;</translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="76"/>
         <source>&lt;pre&gt;[ UP ]&lt;/pre&gt;</source>
-        <translation></translation>
+        <translation>&lt;pre&gt;[ 위쪽 ]&lt;/pre&gt;</translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="77"/>
         <source>&lt;pre&gt;[ DN ]&lt;/pre&gt;</source>
-        <translation></translation>
+        <translation>&lt;pre&gt;[ 아래쪽 ]&lt;/pre&gt;</translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="78"/>
         <source>&lt;pre&gt;[ LEFT ]&lt;/pre&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;pre&gt;[ 왼쪽 ]&lt;/pre&gt;</translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="79"/>
         <source>&lt;pre&gt;[ RIGHT ]&lt;/pre&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;pre&gt;[ 오른쪽 ]&lt;/pre&gt;</translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="80"/>
@@ -12745,32 +12905,32 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
     <message>
         <location filename="../simulation/simulator_strings.h" line="82"/>
         <source>&lt;pre&gt;[ PgUp ]&lt;/pre&gt;</source>
-        <translation></translation>
+        <translation>&lt;pre&gt;[ 페이지 위 ]&lt;/pre&gt;</translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="83"/>
         <source>&lt;pre&gt;[ PgDn ]&lt;/pre&gt;</source>
-        <translation></translation>
+        <translation>&lt;pre&gt;[ 페이지 아래 ]&lt;/pre&gt;</translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="84"/>
         <source>&lt;pre&gt;[ MDL ]&lt;/pre&gt;</source>
-        <translation></translation>
+        <translation>&lt;pre&gt;[ 모델 ]&lt;/pre&gt;</translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="85"/>
         <source>&lt;pre&gt;[ RTN ]&lt;/pre&gt;</source>
-        <translation></translation>
+        <translation>&lt;pre&gt;[ 돌아가기 ]&lt;/pre&gt;</translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="86"/>
         <source>&lt;pre&gt;[ SYS ]&lt;/pre&gt;</source>
-        <translation></translation>
+        <translation>&lt;pre&gt;[ 시스템 ]&lt;/pre&gt;</translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="87"/>
         <source>&lt;pre&gt;[ TELE ]&lt;/pre&gt;</source>
-        <translation></translation>
+        <translation>&lt;pre&gt;[ 텔레메트리 ]&lt;/pre&gt;</translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="88"/>
@@ -12780,12 +12940,12 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
     <message>
         <location filename="../simulation/simulator_strings.h" line="90"/>
         <source>&lt;pre&gt;[ Prev/Inc ]&lt;/pre&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;pre&gt;[ 이전/증가 ]&lt;/pre&gt;</translation>
     </message>
     <message>
         <location filename="../simulation/simulator_strings.h" line="91"/>
         <source>&lt;pre&gt;[ Next/Dec ]&lt;/pre&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>&lt;pre&gt;[ 다음/감소 ]&lt;/pre&gt;</translation>
     </message>
 </context>
 <context>
@@ -12793,12 +12953,12 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
     <message>
         <location filename="../simulator.cpp" line="66"/>
         <source>EdgeTx Simulator</source>
-        <translation></translation>
+        <translation>EdgeTX 시뮬레이터</translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="75"/>
         <source>Available profiles:</source>
-        <translation></translation>
+        <translation>사용 가능한 프로필:</translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="79"/>
@@ -12808,117 +12968,122 @@ If this is checked the throttle will be reversed.  Idle will be forward, trim wi
     <message>
         <location filename="../simulator.cpp" line="79"/>
         <source>Name: </source>
-        <translation></translation>
+        <translation>이름: </translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="82"/>
         <source>Available radios:</source>
-        <translation></translation>
+        <translation>사용 가능한 송신기:</translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="117"/>
         <source>Radio profile ID or Name to use for simulator.</source>
-        <translation></translation>
+        <translation>시뮬레이터에서 사용할 송신기 프로필 ID 또는 이름입니다.</translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="118"/>
         <source>profile</source>
-        <translation></translation>
+        <translation>프로필</translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="121"/>
         <source>Radio type to simulate (usually defined in profile).</source>
-        <translation></translation>
+        <translation>시뮬레이션할 송신기 종류 (일반적으로 프로필에 정의됨).</translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="122"/>
         <source>radio</source>
-        <translation></translation>
+        <translation>송신기</translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="125"/>
         <source>Directory containing the SD card image to use. The default is configured in the chosen Radio Profile.</source>
-        <translation></translation>
+        <translation>사용할 SD 카드 이미지가 포함된 디렉터리입니다. 기본 경로는 선택한 송신기 프로필에 설정되어 있습니다.</translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="126"/>
         <source>path</source>
-        <translation></translation>
+        <translation>경로</translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="129"/>
         <source>Data source type to use. One of:</source>
-        <translation></translation>
+        <translation>사용할 데이터 소스 유형 (다음 중 하나):</translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="133"/>
         <source>Flags passed from Companion</source>
-        <translation type="unfinished"></translation>
+        <translation>Companion에서 전달된 플래그</translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="134"/>
         <source>flags</source>
-        <translation type="unfinished"></translation>
+        <translation>플래그</translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="380"/>
         <source>Unknown error during Simulator startup.</source>
-        <translation></translation>
+        <translation>시뮬레이터 시작 중 알 수 없는 오류가 발생했습니다.</translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="130"/>
         <source>type</source>
-        <translation></translation>
+        <translation>유형</translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="136"/>
         <source>data-source</source>
-        <translation></translation>
+        <translation>데이터 소스</translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="137"/>
         <source>Radio data (.bin/.eeprom/.etx) image file to use OR data folder path (for Horus-style radios).
 NOTE: any existing EEPROM data incompatible with the selected radio type may be overwritten!</source>
-        <translation></translation>
+        <translation>사용할 라디오 데이터 (.bin/.eeprom/.etx) 이미지 파일 또는 데이터 폴더 경로 (Horus 계열 송신기용).
+참고: 선택한 송신기와 호환되지 않는 기존 EEPROM 데이터는 덮어써질 수 있습니다!</translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="139"/>
         <source>[data-source]</source>
-        <translation></translation>
+        <translation>[데이터 소스]</translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="178"/>
         <source>Error: Profile ID %1 was not found.</source>
-        <translation></translation>
+        <translation>오류: 프로필 ID %1 을(를) 찾을 수 없습니다.</translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="226"/>
         <source>Unrecognized startup data source type: %1</source>
-        <translation></translation>
+        <translation>알 수 없는 시작 데이터 소스 유형: %1</translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="293"/>
         <source>WARNING: couldn&apos;t initialize SDL:
 %1</source>
-        <translation></translation>
+        <translation>경고: SDL을 초기화할 수 없습니다:
+%1</translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="304"/>
         <source>ERROR: No simulator libraries available.</source>
-        <translation></translation>
+        <translation>오류: 사용 가능한 시뮬레이터 라이브러리가 없습니다.</translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="350"/>
         <source>ERROR: Couldn&apos;t start simulator, missing radio/profile/data file/folder.
   Profile ID: [%1]; Radio ID: [%2];
 Data File: [%3]</source>
-        <translation></translation>
+        <translation>오류: 시뮬레이터를 시작할 수 없습니다. 송신기/프로필/데이터 파일 또는 폴더가 없습니다.
+프로필 ID: [%1]; 송신기 ID: [%2];
+데이터 파일: [%3]</translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="356"/>
         <source>ERROR: Radio profile or simulator firmware not found.
 Profile ID: [%1]; Radio ID: [%2]</source>
-        <translation></translation>
+        <translation>오류: 송신기 프로필 또는 시뮬레이터 펌웨어를 찾을 수 없습니다.
+프로필 ID: [%1]; 송신기 ID: [%2]</translation>
     </message>
 </context>
 <context>
@@ -12926,47 +13091,47 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="14"/>
         <source>EdgeTX Simulator</source>
-        <translation type="unfinished"></translation>
+        <translation>EdgeTX 시뮬레이터</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="48"/>
         <source>View</source>
-        <translation></translation>
+        <translation>보기</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="52"/>
         <source>Radio Window</source>
-        <translation></translation>
+        <translation>송신기 창</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="63"/>
         <source>Reload...</source>
-        <translation></translation>
+        <translation>새로고침...</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="70"/>
         <source>Tools</source>
-        <translation></translation>
+        <translation>도구</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="79"/>
         <source>Help</source>
-        <translation type="unfinished"></translation>
+        <translation>도움말</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="91"/>
         <source>Toolbar</source>
-        <translation></translation>
+        <translation>도구 모음</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="112"/>
         <source>Reload Lua Scripts</source>
-        <translation></translation>
+        <translation>Lua 스크립트 다시 불러오기</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="115"/>
         <source>Reload the Lua environment on the simulated radio.</source>
-        <translation></translation>
+        <translation>시뮬레이션된 송신기에서 Lua 환경을 다시 불러옵니다.</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="118"/>
@@ -12976,12 +13141,12 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="127"/>
         <source>Reload Radio Data</source>
-        <translation></translation>
+        <translation>송신기 데이터 다시 불러오기</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="130"/>
         <source>Reload all radio data without restarting the simulator.</source>
-        <translation></translation>
+        <translation>시뮬레이터를 재시작하지 않고 모든 송신기 데이터를 다시 불러옵니다.</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="133"/>
@@ -12991,12 +13156,12 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="142"/>
         <source>Key Mapping</source>
-        <translation></translation>
+        <translation>키 매핑</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="145"/>
         <source>Show keyboard maping reference.</source>
-        <translation></translation>
+        <translation>키보드 매핑 참조 보기</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="148"/>
@@ -13006,12 +13171,12 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="157"/>
         <source>Joystick Settings</source>
-        <translation></translation>
+        <translation>조이스틱 설정</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="160"/>
         <source>Open joystick configuration settings dialog.</source>
-        <translation></translation>
+        <translation>조이스틱 설정 대화상자를 엽니다.</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="163"/>
@@ -13021,12 +13186,12 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="172"/>
         <source>LCD Screenshot</source>
-        <translation></translation>
+        <translation>LCD 화면 캡처</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="175"/>
         <source>Save a screenshot of the current simulated LCD screen.</source>
-        <translation></translation>
+        <translation>현재 시뮬레이션된 LCD 화면을 캡처하여 저장합니다.</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="178"/>
@@ -13036,22 +13201,22 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="186"/>
         <source>Dock In Main Window</source>
-        <translation></translation>
+        <translation>메인 창에 고정</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="189"/>
         <source>Show the radio in the main window or as a separate &quot;floating&quot; window.</source>
-        <translation></translation>
+        <translation>송신기를 메인 창에 표시하거나 독립된 &quot;플로팅&quot; 창으로 표시합니다.</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="197"/>
         <source>Menu Bar</source>
-        <translation></translation>
+        <translation>메뉴 바</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="200"/>
         <source>Show or hide the top menu bar.</source>
-        <translation></translation>
+        <translation>상단 메뉴 바를 표시하거나 숨깁니다.</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="203"/>
@@ -13061,47 +13226,47 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="211"/>
         <source>Constrain Width</source>
-        <translation></translation>
+        <translation>너비 고정</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="214"/>
         <source>Set radio widget width to be a fixed size.</source>
-        <translation></translation>
+        <translation>송신기 위젯의 너비를 고정된 크기로 설정합니다.</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="222"/>
         <source>Constrain Height</source>
-        <translation></translation>
+        <translation>높이 고정</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="225"/>
         <source>Set radio widget height to be a fixed size.</source>
-        <translation></translation>
+        <translation>송신기 위젯의 높이를 고정된 크기로 설정합니다.</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="230"/>
         <source>Serial Ports</source>
-        <translation type="unfinished"></translation>
+        <translation>시리얼 포트</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="235"/>
         <source>About</source>
-        <translation type="unfinished"></translation>
+        <translation>정보</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="240"/>
         <source>TX Battery Voltage...</source>
-        <translation type="unfinished"></translation>
+        <translation>송신기 배터리 전압...</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.ui" line="243"/>
         <source>Open set transmitter battery voltage dialog</source>
-        <translation type="unfinished"></translation>
+        <translation>송신기 배터리 전압 설정 대화상자를 엽니다</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="74"/>
         <source>ERROR: Failed to create simulator interface, possibly missing or bad library.</source>
-        <translation></translation>
+        <translation>오류: 시뮬레이터 인터페이스 생성 실패 - 라이브러리 누락 또는 손상 가능성</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="115"/>
@@ -13111,7 +13276,7 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="300"/>
         <source>Radio Outputs</source>
-        <translation></translation>
+        <translation>송신기 출력</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="304"/>
@@ -13121,7 +13286,7 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="309"/>
         <source>Telemetry Simulator</source>
-        <translation></translation>
+        <translation>텔레메트리 시뮬레이터</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="313"/>
@@ -13131,7 +13296,7 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="318"/>
         <source>Trainer Simulator</source>
-        <translation></translation>
+        <translation>트레이너 시뮬레이터</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="322"/>
@@ -13141,7 +13306,7 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="327"/>
         <source>Debug Output</source>
-        <translation></translation>
+        <translation>디버그 출력</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="331"/>
@@ -13151,13 +13316,13 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="511"/>
         <source>&lt;b&gt;Simulator Controls:&lt;/b&gt;</source>
-        <translation></translation>
+        <translation>&lt;b&gt;시뮬레이터 조작법:&lt;/b&gt;</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="513"/>
         <source>&lt;tr&gt;&lt;th&gt;Key/Mouse&lt;/th&gt;&lt;th&gt;Action&lt;/th&gt;&lt;/tr&gt;</source>
         <comment>note: must match html layout of each table row (keyTemplate).</comment>
-        <translation></translation>
+        <translation>&lt;tr&gt;&lt;th&gt;키/마우스&lt;/th&gt;&lt;th&gt;동작&lt;/th&gt;&lt;/tr&gt;</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="515"/>
@@ -13168,52 +13333,52 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="531"/>
         <source>Simulator Help</source>
-        <translation></translation>
+        <translation>시뮬레이터 도움말</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="541"/>
         <source>EdgeTX Home Page: &lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>EdgeTX 홈페이지: &lt;a href=&apos;%1&apos;&gt;%1&lt;/a&gt;</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="543"/>
         <source>The EdgeTX project was originally forked from &lt;a href=&apos;%1&apos;&gt;OpenTX&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>EdgeTX 프로젝트는 원래 &lt;a href=&apos;%1&apos;&gt;OpenTX&lt;/a&gt;에서 분기되었습니다</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="545"/>
         <source>If you&apos;ve found this program useful, please support by &lt;a href=&apos;%1&apos;&gt;donating&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>이 프로그램이 유용했다면 &lt;a href=&apos;%1&apos;&gt;기부&lt;/a&gt;로 후원해 주세요</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="555"/>
         <source>File new &lt;a href=&apos;%1&apos;&gt;Issue or Request&lt;/a&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation>새로운 &lt;a href=&apos;%1&apos;&gt;이슈 또는 요청&lt;/a&gt;을 등록하세요</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="557"/>
         <source>Copyright</source>
-        <translation type="unfinished"></translation>
+        <translation>저작권</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="561"/>
         <source>About EdgeTX Simulator</source>
-        <translation type="unfinished"></translation>
+        <translation>EdgeTX 시뮬레이터 정보</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="578"/>
         <source>Set voltage</source>
-        <translation type="unfinished"></translation>
+        <translation>전압 설정</translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="585"/>
         <source>V</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/simulatormainwindow.cpp" line="597"/>
         <source>Battery</source>
-        <translation type="unfinished"></translation>
+        <translation>배터리</translation>
     </message>
 </context>
 <context>
@@ -13221,70 +13386,73 @@ Profile ID: [%1]; Radio ID: [%2]</source>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="20"/>
         <source>EdgeTX Simulator - Startup Options</source>
-        <translation></translation>
+        <translation>EdgeTX 시뮬레이터 - 시작 옵션</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="74"/>
         <source>Radio Profile:</source>
-        <translation></translation>
+        <translation>무선 프로파일:</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="87"/>
         <source>Existing radio profiles are shown here.&lt;br /&gt;
 Create or edit profiles using the Companion application.</source>
-        <translation></translation>
+        <translation>기존 무선 프로파일이 여기에 표시됩니다.&lt;br /&gt;
+프로파일을 생성하거나 수정하려면 Companion 앱을 사용하세요.</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="95"/>
         <source>Radio Type:</source>
-        <translation></translation>
+        <translation>무선 기기 종류:</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="108"/>
         <source>Existing radio simulators are shown here.&lt;br /&gt;
 The radio type specified in the selected profile is used by default.</source>
-        <translation></translation>
+        <translation>사용 가능한 무선 시뮬레이터가 여기에 표시됩니다.&lt;br /&gt;
+기본적으로 선택한 프로파일에 지정된 무선 기기 종류가 사용됩니다.</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="116"/>
         <source>Data Source:</source>
-        <translation></translation>
+        <translation>데이터 소스:</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="123"/>
         <source>Data File:</source>
-        <translation></translation>
+        <translation>데이터 파일:</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="130"/>
         <source>Data Folder:</source>
-        <translation></translation>
+        <translation>데이터 폴더:</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="137"/>
         <source>SD Image Path:</source>
-        <translation></translation>
+        <translation>SD 이미지 경로:</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="168"/>
         <source>Radio data (.etx) settings file to use. A new file with default settings will be created if necessary.&lt;br /&gt;
 &lt;b&gt;NOTE&lt;/b&gt;: any existing data incompatible with the selected radio type may be overwritten!</source>
-        <translation></translation>
+        <translation>사용할 무선 데이터(.etx) 설정 파일입니다. 필요 시 기본 설정으로 새 파일이 생성됩니다.&lt;br /&gt;
+&lt;b&gt;주의&lt;/b&gt;: 선택한 무선 기기와 호환되지 않는 기존 데이터는 덮어쓸 수 있습니다!</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="360"/>
         <source>Simulator:</source>
-        <translation></translation>
+        <translation>시뮬레이터:</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="176"/>
         <source>Select data file...</source>
-        <translation></translation>
+        <translation>데이터 파일 선택...</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="38"/>
         <source>Simulator Startup Options</source>
-        <translation></translation>
+        <translation>시뮬레이터 시작 옵션</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="179"/>
@@ -13297,68 +13465,70 @@ The radio type specified in the selected profile is used by default.</source>
         <location filename="../simulation/simulatorstartupdialog.ui" line="220"/>
         <source>Directory containing RADIO and MODELS folders to use.&lt;br /&gt;
 New folder(s) with default radio/model will be created here if necessary.</source>
-        <translation></translation>
+        <translation>사용할 RADIO 및 MODELS 폴더가 포함된 디렉터리입니다.&lt;br /&gt;
+필요한 경우 기본 무선기/모델 폴더가 새로 생성됩니다.</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="228"/>
         <source>Select data folder...</source>
-        <translation></translation>
+        <translation>데이터 폴더 선택...</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="272"/>
         <source>Directory containing the SD card image to use.&lt;br/&gt;
 The default is configured in the chosen Radio Profile.</source>
-        <translation></translation>
+        <translation>사용할 SD 카드 이미지가 포함된 디렉터리입니다.&lt;br/&gt;
+기본 경로는 선택한 무선 프로파일에 설정되어 있습니다.</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="280"/>
         <source>Select SD card image folder...</source>
-        <translation></translation>
+        <translation>SD 카드 이미지 폴더 선택...</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="306"/>
         <source>Select which of the data sources (File/Folder/SD Card) you would like to start the simulator with.</source>
-        <translation></translation>
+        <translation>시뮬레이터를 시작할 때 사용할 데이터 소스(File/Folder/SD 카드)를 선택하세요.</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="327"/>
         <source>File</source>
-        <translation></translation>
+        <translation>파일</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="337"/>
         <source>Folder</source>
-        <translation></translation>
+        <translation>폴더</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.ui" line="347"/>
         <source>SD Path</source>
-        <translation></translation>
+        <translation>SD 경로</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.cpp" line="51"/>
         <source>Startup Options</source>
-        <translation></translation>
+        <translation>시작 옵션</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.cpp" line="108"/>
         <source>No radio profiles have been found. Use %1 to create.</source>
-        <translation></translation>
+        <translation>무선 프로파일이 없습니다. %1을 사용해 새로 생성하세요.</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.cpp" line="308"/>
         <source>Select a data file</source>
-        <translation></translation>
+        <translation>데이터 파일 선택</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.cpp" line="318"/>
         <source>Select Data Directory</source>
-        <translation></translation>
+        <translation>데이터 디렉터리 선택</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorstartupdialog.cpp" line="329"/>
         <source>Select SD Card Image Folder</source>
-        <translation></translation>
+        <translation>SD 카드 이미지 폴더 선택</translation>
     </message>
 </context>
 <context>
@@ -13366,77 +13536,77 @@ The default is configured in the chosen Radio Profile.</source>
     <message>
         <location filename="../simulation/simulatorwidget.ui" line="20"/>
         <source>Companion Simulator</source>
-        <translation></translation>
+        <translation>Companion 시뮬레이터</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="61"/>
         <source>Radio Simulator (%1)</source>
-        <translation></translation>
+        <translation>무선 시뮬레이터 (%1)</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="219"/>
         <source>Unable to handle byte array.</source>
-        <translation type="unfinished"></translation>
+        <translation>바이트 배열을 처리할 수 없습니다.</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="225"/>
         <source>Could not determine startup data source.</source>
-        <translation></translation>
+        <translation>시작 시 사용할 데이터 소스를 확인할 수 없습니다.</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="230"/>
         <source>Could not load data, possibly wrong format.</source>
-        <translation></translation>
+        <translation>데이터를 불러올 수 없습니다. 형식이 잘못되었을 수 있습니다.</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="231"/>
         <source>Data Load Error</source>
-        <translation></translation>
+        <translation>데이터 불러오기 오류</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="289"/>
         <source>Invalid startup data provided. Plese specify a proper file/path.</source>
-        <translation></translation>
+        <translation>잘못된 시작 데이터가 제공되었습니다. 올바른 파일 또는 경로를 지정해 주세요.</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="290"/>
         <source>Simulator Startup Error</source>
-        <translation></translation>
+        <translation>시뮬레이터 시작 오류</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="350"/>
         <source>Error saving data: could open file for writing: &apos;%1&apos;</source>
-        <translation></translation>
+        <translation>데이터 저장 오류: 파일을 쓰기 모드로 열 수 없습니다: &apos;%1&apos;</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="382"/>
         <source>An unexpected error occurred while attempting to save radio data to file &apos;%1&apos;.</source>
-        <translation></translation>
+        <translation>무선기 데이터를 파일 &apos;%1&apos;에 저장하는 중 예기치 않은 오류가 발생했습니다.</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="383"/>
         <source>Data Save Error</source>
-        <translation></translation>
+        <translation>데이터 저장 오류</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="643"/>
         <source>Cannot open joystick, joystick disabled</source>
-        <translation></translation>
+        <translation>조이스틱을 열 수 없습니다. 조이스틱 기능이 비활성화되어 있습니다.</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="739"/>
         <source>Radio firmware error: %1</source>
-        <translation></translation>
+        <translation>무선기 펌웨어 오류: %1</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="744"/>
         <source>Flight Mode</source>
-        <translation type="unfinished"></translation>
+        <translation>비행 모드</translation>
     </message>
     <message>
         <location filename="../simulation/simulatorwidget.cpp" line="744"/>
         <source>Drive Mode</source>
-        <translation type="unfinished"></translation>
+        <translation>주행 모드</translation>
     </message>
 </context>
 <context>
@@ -13444,12 +13614,12 @@ The default is configured in the chosen Radio Profile.</source>
     <message>
         <location filename="../simulation/widgets/sliderwidget.h" line="37"/>
         <source>Right-double-click to reset to center.</source>
-        <translation></translation>
+        <translation>오른쪽 더블 클릭으로 중앙으로 초기화합니다.</translation>
     </message>
     <message>
         <location filename="../simulation/widgets/sliderwidget.h" line="37"/>
         <source>&lt;p&gt;Value (input): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</source>
-        <translation></translation>
+        <translation>&lt;p&gt;값 (입력): &lt;b&gt;%1&lt;/b&gt;&lt;/p&gt;</translation>
     </message>
 </context>
 <context>
@@ -13463,17 +13633,17 @@ The default is configured in the chosen Radio Profile.</source>
     <message>
         <location filename="../splashlibrarydialog.cpp" line="85"/>
         <source>Splash Library - page %1 of %2</source>
-        <translation></translation>
+        <translation>스플래시 라이브러리 - 페이지 %1 / %2</translation>
     </message>
     <message>
         <location filename="../splashlibrarydialog.cpp" line="117"/>
         <source>Invalid image in library %1</source>
-        <translation></translation>
+        <translation>라이브러리 %1에 유효하지 않은 이미지가 있습니다</translation>
     </message>
     <message>
         <location filename="../splashlibrarydialog.cpp" line="123"/>
         <source>No valid image found in library, check your settings</source>
-        <translation></translation>
+        <translation>라이브러리에 유효한 이미지가 없습니다. 설정을 확인하세요</translation>
     </message>
 </context>
 <context>
@@ -13481,7 +13651,7 @@ The default is configured in the chosen Radio Profile.</source>
     <message>
         <location filename="../wizarddialog.cpp" line="207"/>
         <source>Channel %1</source>
-        <translation></translation>
+        <translation>채널 %1</translation>
     </message>
 </context>
 <context>
@@ -13489,7 +13659,7 @@ The default is configured in the chosen Radio Profile.</source>
     <message>
         <location filename="../storage/storage.cpp" line="67"/>
         <source>Unable to find file %1!</source>
-        <translation></translation>
+        <translation>파일 %1을(를) 찾을 수 없습니다!</translation>
     </message>
 </context>
 <context>
@@ -13500,45 +13670,48 @@ The default is configured in the chosen Radio Profile.</source>
         <location filename="../styleeditdialog.cpp" line="61"/>
         <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Style Sheet Editor</source>
-        <translation></translation>
+        <translation>스타일 시트 편집기</translation>
     </message>
     <message>
         <location filename="../styleeditdialog.ui" line="88"/>
         <source>&amp;Reset to default</source>
-        <translation></translation>
+        <translation>기본값으로 &amp;재설정</translation>
     </message>
     <message>
         <location filename="../styleeditdialog.ui" line="101"/>
         <source>&amp;Cancel</source>
-        <translation></translation>
+        <translation>&amp;취소</translation>
     </message>
     <message>
         <location filename="../styleeditdialog.ui" line="114"/>
         <source>&amp;OK</source>
-        <translation></translation>
+        <translation>&amp;확인</translation>
     </message>
     <message>
         <location filename="../styleeditdialog.ui" line="129"/>
         <source>This feature does not validate your changes and assumes you are familiar with CSS syntax for QT.</source>
-        <translation></translation>
+        <translation>이 기능은 변경 사항을 검증하지 않으며, QT의 CSS 구문에 익숙하다고 가정합니다.</translation>
     </message>
     <message>
         <location filename="../styleeditdialog.cpp" line="35"/>
         <source>Cannot retrieve style %1
 Error: %2</source>
-        <translation></translation>
+        <translation>스타일 %1을(를) 불러올 수 없습니다
+오류: %2</translation>
     </message>
     <message>
         <location filename="../styleeditdialog.cpp" line="61"/>
         <source>Cannot retrieve default style %1
 Error: %2</source>
-        <translation></translation>
+        <translation>기본 스타일 %1을(를) 불러올 수 없습니다
+오류: %2</translation>
     </message>
     <message>
         <location filename="../styleeditdialog.cpp" line="71"/>
         <source>Cannot update custom style %1
 Error: %2</source>
-        <translation></translation>
+        <translation>사용자 정의 스타일 %1을(를) 업데이트할 수 없습니다
+오류: %2</translation>
     </message>
 </context>
 <context>
@@ -13546,47 +13719,47 @@ Error: %2</source>
     <message>
         <location filename="../helpers_html.cpp" line="155"/>
         <source>Style sheet data read from &apos;%1&apos;</source>
-        <translation></translation>
+        <translation>스타일 시트 데이터를 &apos;%1&apos;에서 읽었습니다</translation>
     </message>
     <message>
         <location filename="../helpers_html.cpp" line="157"/>
         <source>Style sheet data unable to be read from &apos;%1&apos;</source>
-        <translation></translation>
+        <translation>스타일 시트 데이터를 &apos;%1&apos;에서 읽을 수 없습니다</translation>
     </message>
     <message>
         <location filename="../helpers_html.cpp" line="170"/>
         <source>Cannot create folder &apos;%1&apos;</source>
-        <translation></translation>
+        <translation>폴더 &apos;%1&apos;을(를) 생성할 수 없습니다</translation>
     </message>
     <message>
         <location filename="../helpers_html.cpp" line="175"/>
         <source>Cannot open file for writing &apos;%1&apos;: Error: %2</source>
-        <translation></translation>
+        <translation>파일 &apos;%1&apos;을(를) 쓰기 위해 열 수 없습니다: 오류: %2</translation>
     </message>
     <message>
         <location filename="../helpers_html.cpp" line="182"/>
         <source>Cannot write to file &apos;%1&apos;: Error: %2</source>
-        <translation></translation>
+        <translation>파일 &apos;%1&apos;에 쓸 수 없습니다: 오류: %2</translation>
     </message>
     <message>
         <location filename="../helpers_html.cpp" line="184"/>
         <source>Cannot flush buffer for file &apos;%1&apos;: Error: %2</source>
-        <translation></translation>
+        <translation>파일 &apos;%1&apos;의 버퍼를 비울 수 없습니다: 오류: %2</translation>
     </message>
     <message>
         <location filename="../helpers_html.cpp" line="189"/>
         <source>Style sheet written to &apos;%1&apos;</source>
-        <translation></translation>
+        <translation>스타일 시트가 &apos;%1&apos;에 저장되었습니다</translation>
     </message>
     <message>
         <location filename="../helpers_html.cpp" line="204"/>
         <source>Custom style sheet deleted: &apos;%1&apos;</source>
-        <translation></translation>
+        <translation>사용자 정의 스타일 시트가 삭제되었습니다: &apos;%1&apos;</translation>
     </message>
     <message>
         <location filename="../helpers_html.cpp" line="206"/>
         <source>Unable to delete custom style sheet: &apos;%1&apos;</source>
-        <translation></translation>
+        <translation>사용자 정의 스타일 시트를 삭제할 수 없습니다: &apos;%1&apos;</translation>
     </message>
 </context>
 <context>
@@ -13594,141 +13767,145 @@ Error: %2</source>
     <message>
         <location filename="../process_sync.cpp" line="79"/>
         <source>[TEST RUN] </source>
-        <translation></translation>
+        <translation>[테스트 실행] </translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="164"/>
         <source>Synchronization failed, nothing found to copy.</source>
-        <translation></translation>
+        <translation>동기화 실패: 복사할 항목이 없습니다.</translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="274"/>
         <source>Skipping large file: %1 (%2KB)</source>
-        <translation></translation>
+        <translation>큰 파일 건너뜀: %1 (%2KB)</translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="324"/>
         <source>Creating directory: %1</source>
-        <translation></translation>
+        <translation>디렉토리 생성 중: %1</translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="326"/>
         <source>Could not create directory: %1</source>
-        <translation></translation>
+        <translation>디렉토리를 생성할 수 없습니다: %1</translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="111"/>
         <source>Gathering file information for %1...</source>
-        <translation></translation>
+        <translation>%1에 대한 파일 정보를 수집하는 중...</translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="112"/>
         <source>No files found in %1</source>
-        <translation></translation>
+        <translation>%1에 파일이 없습니다</translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="178"/>
         <source>Synchronization aborted at %1 of %2 files.</source>
-        <translation></translation>
+        <translation>동기화가 %2개 중 %1개에서 중단되었습니다.</translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="180"/>
         <source>Synchronization finished with %1 files in %2m %3s.</source>
-        <translation></translation>
+        <translation>%2분 %3초 동안 %1개의 파일 동기화를 완료했습니다.</translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="249"/>
         <source>Synchronizing: %1
     To: %2</source>
-        <translation></translation>
+        <translation>동기화 중: %1
+    대상: %2</translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="250"/>
         <source>Starting synchronization:
   %1 -&gt; %2
 </source>
-        <translation></translation>
+        <translation>동기화 시작:
+  %1 -&gt; %2
+</translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="266"/>
         <source>
 Too many errors, giving up.</source>
-        <translation></translation>
+        <translation>
+오류가 너무 많아 중단합니다.</translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="277"/>
         <source>Skipping filtered file: %1</source>
-        <translation></translation>
+        <translation>필터된 파일 건너뜀: %1</translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="280"/>
         <source>Skipping linked file: %1</source>
-        <translation></translation>
+        <translation>링크된 파일 건너뜀: %1</translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="294"/>
         <source>Aborted synchronization of:</source>
-        <translation></translation>
+        <translation>동기화 중단됨:</translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="296"/>
         <source>Finished synchronizing:</source>
-        <translation></translation>
+        <translation>동기화 완료됨:</translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="298"/>
         <source>Created: %1; Updated: %2; Skipped: %3; Errors: %4;</source>
-        <translation></translation>
+        <translation>생성: %1; 업데이트: %2; 건너뜀: %3; 오류: %4;</translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="333"/>
         <source>Directory exists: %1</source>
-        <translation></translation>
+        <translation>디렉토리가 존재합니다: %1</translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="350"/>
         <source>At least one of the file modification dates is in the future, error on: %1</source>
-        <translation></translation>
+        <translation>파일 중 하나 이상의 수정 날짜가 미래입니다. 오류 발생 파일: %1</translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="355"/>
         <source>Skipping older file: %1</source>
-        <translation></translation>
+        <translation>오래된 파일 건너뜀: %1</translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="364"/>
         <source>Could not open source file &apos;%1&apos;: %2</source>
-        <translation></translation>
+        <translation>원본 파일 &apos;%1&apos;을 열 수 없습니다: %2</translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="369"/>
         <source>Could not open destination file &apos;%1&apos;: %2</source>
-        <translation></translation>
+        <translation>대상 파일 &apos;%1&apos;을 열 수 없습니다: %2</translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="378"/>
         <source>Skipping identical file: %1</source>
-        <translation></translation>
+        <translation>동일한 파일 건너뜀: %1</translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="388"/>
         <source>Replacing file: %1</source>
-        <translation></translation>
+        <translation>파일 교체 중: %1</translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="396"/>
         <source>Creating file: %1</source>
-        <translation></translation>
+        <translation>파일 생성 중: %1</translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="390"/>
         <source>Could not delete destination file &apos;%1&apos;: %2</source>
-        <translation></translation>
+        <translation>대상 파일 &apos;%1&apos;을 삭제할 수 없습니다: %2</translation>
     </message>
     <message>
         <location filename="../process_sync.cpp" line="399"/>
         <source>Copy failed: &apos;%1&apos; to &apos;%2&apos;: %3</source>
-        <translation></translation>
+        <translation>복사 실패: &apos;%1&apos; → &apos;%2&apos;: %3</translation>
     </message>
 </context>
 <context>
@@ -13736,17 +13913,17 @@ Too many errors, giving up.</source>
     <message>
         <location filename="../wizarddialog.cpp" line="731"/>
         <source>Rudder Channel:</source>
-        <translation></translation>
+        <translation>러더 채널:</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="733"/>
         <source>Elevator Channel:</source>
-        <translation></translation>
+        <translation>엘리베이터 채널:</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="746"/>
         <source>Only one channel still available!&lt;br&gt;You probably should configure your model without using the wizard.</source>
-        <translation></translation>
+        <translation>사용 가능한 채널이 하나만 남아 있습니다!&lt;br&gt;마법사를 사용하지 않고 직접 모델을 설정하는 것이 좋습니다.</translation>
     </message>
 </context>
 <context>
@@ -13754,22 +13931,22 @@ Too many errors, giving up.</source>
     <message>
         <location filename="../wizarddialog.cpp" line="353"/>
         <source>Elevator and Rudder</source>
-        <translation></translation>
+        <translation>엘리베이터와 러더</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="355"/>
         <source>Only Elevator</source>
-        <translation></translation>
+        <translation>엘리베이터만</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="356"/>
         <source>V-tail</source>
-        <translation></translation>
+        <translation>V-테일</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="359"/>
         <source>Tail Type:</source>
-        <translation></translation>
+        <translation>꼬리날개 형태:</translation>
     </message>
 </context>
 <context>
@@ -13777,7 +13954,7 @@ Too many errors, giving up.</source>
     <message>
         <location filename="../modeledit/telemetry.ui" line="75"/>
         <source>Alarm 1</source>
-        <translation></translation>
+        <translation>알람 1</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="117"/>
@@ -13789,29 +13966,29 @@ Too many errors, giving up.</source>
         <location filename="../modeledit/telemetry.ui" line="122"/>
         <location filename="../modeledit/telemetry.ui" line="219"/>
         <source>Yellow</source>
-        <translation></translation>
+        <translation>노랑</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="127"/>
         <location filename="../modeledit/telemetry.ui" line="224"/>
         <source>Orange</source>
-        <translation></translation>
+        <translation>주황</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="132"/>
         <location filename="../modeledit/telemetry.ui" line="229"/>
         <source>Red</source>
-        <translation></translation>
+        <translation>빨강</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="200"/>
         <source>Alarm 2</source>
-        <translation></translation>
+        <translation>알람 2</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="181"/>
         <source>Disable telemetry audio warnings</source>
-        <translation></translation>
+        <translation>텔레메트리 오디오 경고 비활성화</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="276"/>
@@ -13826,82 +14003,82 @@ Too many errors, giving up.</source>
     <message>
         <location filename="../modeledit/telemetry.ui" line="352"/>
         <source>Sink Max</source>
-        <translation></translation>
+        <translation>최대 하강</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="462"/>
         <source>Climb Max</source>
-        <translation></translation>
+        <translation>최대 상승</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="478"/>
         <source>Sink Min</source>
-        <translation></translation>
+        <translation>최소 하강</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="494"/>
         <source>Climb Min</source>
-        <translation></translation>
+        <translation>최소 상승</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="510"/>
         <source>Center Silent</source>
-        <translation></translation>
+        <translation>중앙 무음</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="532"/>
         <source>Vario limits</source>
-        <translation></translation>
+        <translation>바리오 한계</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="545"/>
         <source>Vario source</source>
-        <translation></translation>
+        <translation>바리오 소스</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="53"/>
         <source>RF Quality</source>
-        <translation></translation>
+        <translation>RF 품질</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="568"/>
         <source>Altimetry</source>
-        <translation></translation>
+        <translation>고도계</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="602"/>
         <source>Altitude source</source>
-        <translation></translation>
+        <translation>고도 소스</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="615"/>
         <source>Volts source</source>
-        <translation></translation>
+        <translation>전압 소스</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="638"/>
         <source>Top Bar</source>
-        <translation></translation>
+        <translation>상단 바</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="706"/>
         <source>Volt source</source>
-        <translation></translation>
+        <translation>전압 소스</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="748"/>
         <source>Current source</source>
-        <translation></translation>
+        <translation>전류 소스</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="783"/>
         <source>Blades</source>
-        <translation></translation>
+        <translation>날개 수</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="790"/>
         <source>mAh count</source>
-        <translation></translation>
+        <translation>mAh 카운트</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="803"/>
@@ -13916,47 +14093,47 @@ Too many errors, giving up.</source>
     <message>
         <location filename="../modeledit/telemetry.ui" line="844"/>
         <source>FAS Offset</source>
-        <translation></translation>
+        <translation>FAS 오프셋</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="851"/>
         <source>Persistent mAh</source>
-        <translation></translation>
+        <translation>지속적인 mAh</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="870"/>
         <source>Various</source>
-        <translation></translation>
+        <translation>기타</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="883"/>
         <source>Serial Protocol</source>
-        <translation></translation>
+        <translation>시리얼 프로토콜</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="897"/>
         <source>None</source>
-        <translation></translation>
+        <translation>없음</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="902"/>
         <source>FrSky Sensor Hub</source>
-        <translation></translation>
+        <translation>FrSky 센서 허브</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="945"/>
         <source>Sensors</source>
-        <translation></translation>
+        <translation>센서</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="952"/>
         <source>Disable multi sensor handling</source>
-        <translation></translation>
+        <translation>다중 센서 처리 비활성화</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="959"/>
         <source>Show Instance IDs</source>
-        <translation></translation>
+        <translation>인스턴스 ID 표시</translation>
     </message>
 </context>
 <context>
@@ -13964,17 +14141,17 @@ Too many errors, giving up.</source>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="34"/>
         <source>Unit</source>
-        <translation></translation>
+        <translation>단위</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="47"/>
         <source>Max Value</source>
-        <translation></translation>
+        <translation>최대값</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="60"/>
         <source>Alarm 1    </source>
-        <translation></translation>
+        <translation>알람 1</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="74"/>
@@ -13986,19 +14163,19 @@ Too many errors, giving up.</source>
         <location filename="../modeledit/telemetry_analog.ui" line="79"/>
         <location filename="../modeledit/telemetry_analog.ui" line="142"/>
         <source>Yellow</source>
-        <translation></translation>
+        <translation>노랑</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="84"/>
         <location filename="../modeledit/telemetry_analog.ui" line="147"/>
         <source>Orange</source>
-        <translation></translation>
+        <translation>주황</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="89"/>
         <location filename="../modeledit/telemetry_analog.ui" line="152"/>
         <source>Red</source>
-        <translation></translation>
+        <translation>빨강</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="104"/>
@@ -14015,57 +14192,57 @@ Too many errors, giving up.</source>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="123"/>
         <source>Alarm 2</source>
-        <translation></translation>
+        <translation>알람 2</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="265"/>
         <source>Offset</source>
-        <translation></translation>
+        <translation>오프셋</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="279"/>
         <source>Volts (V)</source>
-        <translation></translation>
+        <translation>전압 (V)</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="284"/>
         <source>Amps (A)</source>
-        <translation></translation>
+        <translation>전류 (A)</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="289"/>
         <source>Speed (m/s or ft/s)</source>
-        <translation></translation>
+        <translation>속도 (m/s 또는 ft/s)</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="294"/>
         <source>Raw (-)</source>
-        <translation></translation>
+        <translation>원시값 (-)</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="299"/>
         <source>Speed (km/h or miles/h)</source>
-        <translation></translation>
+        <translation>속도 (km/h 또는 mile/h)</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="304"/>
         <source>Meters (m or ft)</source>
-        <translation></translation>
+        <translation>거리 (m 또는 ft)</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="309"/>
         <source>Temp (°)</source>
-        <translation></translation>
+        <translation>온도 (°)</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="314"/>
         <source>Fuel (%)</source>
-        <translation></translation>
+        <translation>연료 (%)</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_analog.ui" line="319"/>
         <source>mAmps (mA)</source>
-        <translation></translation>
+        <translation>전류 (mA)</translation>
     </message>
 </context>
 <context>
@@ -14073,27 +14250,27 @@ Too many errors, giving up.</source>
     <message>
         <location filename="../modeledit/telemetry_customscreen.ui" line="34"/>
         <source>Type</source>
-        <translation></translation>
+        <translation>형식</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_customscreen.ui" line="82"/>
         <source>Min</source>
-        <translation></translation>
+        <translation>최소값</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_customscreen.ui" line="92"/>
         <source>Source</source>
-        <translation></translation>
+        <translation>소스</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_customscreen.ui" line="102"/>
         <source>Gauge</source>
-        <translation></translation>
+        <translation>게이지</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_customscreen.ui" line="112"/>
         <source>Max</source>
-        <translation></translation>
+        <translation>최대값</translation>
     </message>
 </context>
 <context>
@@ -14101,7 +14278,7 @@ Too many errors, giving up.</source>
     <message>
         <location filename="../modeledit/telemetry_customscreens.cpp" line="361"/>
         <source>Telemetry screen %1</source>
-        <translation></translation>
+        <translation>텔레메트리 화면 %1</translation>
     </message>
 </context>
 <context>
@@ -14109,27 +14286,27 @@ Too many errors, giving up.</source>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="515"/>
         <source>Low Alarm</source>
-        <translation></translation>
+        <translation>저전압 경고</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="516"/>
         <source>Critical Alarm</source>
-        <translation></translation>
+        <translation>치명적 경고</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="548"/>
         <source>Winged Shadow How High</source>
-        <translation></translation>
+        <translation>Winged Shadow 고도계</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="551"/>
         <source>Winged Shadow How High (not supported)</source>
-        <translation></translation>
+        <translation>Winged Shadow 고도계 (지원되지 않음)</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="679"/>
         <source>Delete Sensor. Are you sure?</source>
-        <translation></translation>
+        <translation>센서를 삭제하시겠습니까?</translation>
     </message>
 </context>
 <context>
@@ -14137,32 +14314,32 @@ Too many errors, giving up.</source>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="20"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>형식</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="82"/>
         <source>2RSS</source>
-        <translation type="unfinished"></translation>
+        <translation>2RSS (수신기 신호 강도)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="100"/>
         <source>TQly</source>
-        <translation type="unfinished"></translation>
+        <translation>TQly (송신 품질)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="112"/>
         <source>Sats</source>
-        <translation type="unfinished"></translation>
+        <translation>Sats (위성 수)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="139"/>
         <source>RPWR</source>
-        <translation type="unfinished"></translation>
+        <translation>RPWR (수신기 전송 전력)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="157"/>
         <source>RxBt</source>
-        <translation type="unfinished"></translation>
+        <translation>RxBt (수신기 배터리 전압)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="175"/>
@@ -14171,48 +14348,48 @@ Too many errors, giving up.</source>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="945"/>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1278"/>
         <source>dB</source>
-        <translation type="unfinished"></translation>
+        <translation>dB (데시벨)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="193"/>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1206"/>
         <source>GPS</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="211"/>
         <source>dBm</source>
-        <translation type="unfinished"></translation>
+        <translation>dBm (수신 전력)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="229"/>
         <source>m</source>
-        <translation type="unfinished"></translation>
+        <translation>m (미터)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="247"/>
         <source>ANT</source>
-        <translation type="unfinished"></translation>
+        <translation>ANT (안테나)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="265"/>
         <source>km/h</source>
-        <translation type="unfinished"></translation>
+        <translation>km/h (킬로미터/시간)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="283"/>
         <source>VSpd</source>
-        <translation type="unfinished"></translation>
+        <translation>VSpd (수직 속도)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="301"/>
         <source>Hdg</source>
-        <translation type="unfinished"></translation>
+        <translation>Hdg (기수 방향)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="332"/>
         <source>RSNR</source>
-        <translation type="unfinished"></translation>
+        <translation>RSNR (신호 대 잡음비)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="368"/>
@@ -14221,264 +14398,267 @@ Too many errors, giving up.</source>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1038"/>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1441"/>
         <source>%</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="422"/>
         <source>Degrees</source>
-        <translation type="unfinished"></translation>
+        <translation>도 (Degrees)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="464"/>
         <source>Capa</source>
-        <translation type="unfinished"></translation>
+        <translation>Capa (용량)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="498"/>
         <source>0mW</source>
-        <translation type="unfinished"></translation>
+        <translation>0mW (전송 전력)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="503"/>
         <source>10mW</source>
-        <translation type="unfinished"></translation>
+        <translation>10mW (전송 전력)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="508"/>
         <source>25mW</source>
-        <translation type="unfinished"></translation>
+        <translation>25mW (전송 전력)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="513"/>
         <source>50mW</source>
-        <translation type="unfinished"></translation>
+        <translation>50mW (전송 전력)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="518"/>
         <source>100mW</source>
-        <translation type="unfinished"></translation>
+        <translation>100mW (전송 전력)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="523"/>
         <source>250mW</source>
-        <translation type="unfinished"></translation>
+        <translation>250mW (전송 전력)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="528"/>
         <source>500mW</source>
-        <translation type="unfinished"></translation>
+        <translation>500mW (전송 전력)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="533"/>
         <source>1000mW</source>
-        <translation type="unfinished"></translation>
+        <translation>1000mW (전송 전력)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="538"/>
         <source>2000mW</source>
-        <translation type="unfinished"></translation>
+        <translation>2000mW (전송 전력)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="575"/>
         <source>Bat%</source>
-        <translation type="unfinished"></translation>
+        <translation>배터리 잔량 (%)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="605"/>
         <source>Save Telemetry Values</source>
-        <translation type="unfinished"></translation>
+        <translation>배터리 잔량 (%)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="623"/>
         <source>m/s</source>
-        <translation type="unfinished"></translation>
+        <translation>m/s (미터/초)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="641"/>
         <source>Lat,Lon
 (dec.deg.)</source>
-        <translation type="unfinished"></translation>
+        <translation>위도,경도
+(소수도)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="681"/>
         <source>GSpd</source>
-        <translation type="unfinished"></translation>
+        <translation>GSpd (지상 속도)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="729"/>
         <source>Yaw</source>
-        <translation type="unfinished"></translation>
+        <translation>요 (Yaw)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="747"/>
         <source>FM</source>
-        <translation type="unfinished"></translation>
+        <translation>FM (비행 모드)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="783"/>
         <source>V</source>
-        <translation type="unfinished"></translation>
+        <translation>V (전압)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="801"/>
         <source>TPWR</source>
-        <translation type="unfinished"></translation>
+        <translation>TPWR (송신기 전송 전력)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="849"/>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1315"/>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1459"/>
         <source>Radians</source>
-        <translation type="unfinished"></translation>
+        <translation>라디안</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="888"/>
         <source>TRSS</source>
-        <translation type="unfinished"></translation>
+        <translation>TRSS (송신기 수신 강도)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="906"/>
         <source>TSNR</source>
-        <translation type="unfinished"></translation>
+        <translation>TSNR (송신기 신호 대 잡음비)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1002"/>
         <source>RFMD</source>
-        <translation type="unfinished"></translation>
+        <translation>RFMD (RF 모드)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1050"/>
         <source>Battery Monitoring</source>
-        <translation type="unfinished"></translation>
+        <translation>배터리 모니터링</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1068"/>
         <source>Ptch</source>
-        <translation type="unfinished"></translation>
+        <translation>피치</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1086"/>
         <source>RQly</source>
-        <translation type="unfinished"></translation>
+        <translation>수신 품질 (RQly)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1104"/>
         <source>mAh</source>
-        <translation type="unfinished"></translation>
+        <translation>mAh (전류 용량)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1116"/>
         <source>Attitude</source>
-        <translation type="unfinished"></translation>
+        <translation>자세</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1194"/>
         <source>1RSS</source>
-        <translation type="unfinished"></translation>
+        <translation>1RSS (안테나1 수신강도)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1224"/>
         <source>Curr</source>
-        <translation type="unfinished"></translation>
+        <translation>전류 (A)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1242"/>
         <source>TRSP</source>
-        <translation type="unfinished"></translation>
+        <translation>TRSP (TX 응답률)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1260"/>
         <source>Roll</source>
-        <translation type="unfinished"></translation>
+        <translation>롤</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1290"/>
         <source>Load Telemetry Values</source>
-        <translation type="unfinished"></translation>
+        <translation>텔레메트리 값 불러오기</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1348"/>
         <source>Barometer</source>
-        <translation type="unfinished"></translation>
+        <translation>기압계</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1387"/>
         <source>mw</source>
-        <translation type="unfinished"></translation>
+        <translation>mW (밀리와트)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1405"/>
         <source>Alt</source>
-        <translation type="unfinished"></translation>
+        <translation>고도</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1423"/>
         <source>A</source>
-        <translation type="unfinished"></translation>
+        <translation>A (암페어)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1519"/>
         <source>RRSP</source>
-        <translation type="unfinished"></translation>
+        <translation>RRSP (RX 응답률)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1531"/>
         <source>Flight Controller</source>
-        <translation type="unfinished"></translation>
+        <translation>플라이트 컨트롤러</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1543"/>
         <source>GPS Sim</source>
-        <translation type="unfinished"></translation>
+        <translation>GPS 시뮬레이터</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1576"/>
         <location filename="../simulation/telemetryprovidercrossfire.cpp" line="379"/>
         <source>Run</source>
-        <translation type="unfinished"></translation>
+        <translation>시작</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.ui" line="1588"/>
         <source>25.9973,-97.1572</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.cpp" line="382"/>
         <source>Stop</source>
-        <translation type="unfinished"></translation>
+        <translation>중지</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
         <source>Save Telemetry</source>
-        <translation type="unfinished"></translation>
+        <translation>텔레메트리 저장</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.cpp" line="392"/>
         <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
         <source>.tlm Files (*.tlm)</source>
-        <translation type="unfinished"></translation>
+        <translation>.tlm 파일 (*.tlm)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.cpp" line="398"/>
         <source>Unable to open file for writing.
 %1</source>
-        <translation type="unfinished"></translation>
+        <translation>파일을 쓰기 위해 열 수 없습니다.
+%1</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.cpp" line="479"/>
         <source>Open Telemetry File</source>
-        <translation type="unfinished"></translation>
+        <translation>텔레메트리 파일 열기</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.cpp" line="486"/>
         <source>Unable to open file for reading.
 %1</source>
-        <translation type="unfinished"></translation>
+        <translation>파일을 읽기 위해 열 수 없습니다.
+%1</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryprovidercrossfire.cpp" line="498"/>
         <source>Not a CRSF telemetry values file.</source>
-        <translation type="unfinished"></translation>
+        <translation>CRSF 텔레메트리 값 파일이 아닙니다.</translation>
     </message>
 </context>
 <context>
@@ -14486,7 +14666,7 @@ Too many errors, giving up.</source>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="20"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>폼</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="64"/>
@@ -14503,293 +14683,296 @@ Too many errors, giving up.</source>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="2594"/>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="2615"/>
         <source>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="67"/>
         <source>Cels</source>
-        <translation type="unfinished"></translation>
+        <translation>셀 전압</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="140"/>
         <source>Fuel Qty</source>
-        <translation type="unfinished"></translation>
+        <translation>연료량</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="161"/>
         <source>GAlt</source>
-        <translation type="unfinished"></translation>
+        <translation>GPS 고도</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="173"/>
         <source>Save Telemetry Values</source>
-        <translation type="unfinished"></translation>
+        <translation>텔레메트리 값 저장</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="194"/>
         <source>VFAS</source>
-        <translation type="unfinished"></translation>
+        <translation>전체 배터리 전압 (VFAS)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="212"/>
         <source>ml</source>
-        <translation type="unfinished"></translation>
+        <translation>밀리리터 (ml)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="260"/>
         <source>A4</source>
-        <translation type="unfinished"></translation>
+        <translation>A4 센서</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="281"/>
         <source>ASpd</source>
-        <translation type="unfinished"></translation>
+        <translation>대기 속도 (ASpd)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="434"/>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1987"/>
         <source>°C</source>
-        <translation type="unfinished"></translation>
+        <translation>도 (°C)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="482"/>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="2477"/>
         <source>Volts</source>
-        <translation type="unfinished"></translation>
+        <translation>전압 (V)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="711"/>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1394"/>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1884"/>
         <source>G</source>
-        <translation type="unfinished"></translation>
+        <translation>중력 가속도 (G)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="723"/>
         <source>Run/Stop</source>
-        <translation type="unfinished"></translation>
+        <translation>시작/중지</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1070"/>
         <source>Tmp1</source>
-        <translation type="unfinished"></translation>
+        <translation>온도1 (Tmp1)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1088"/>
         <source>RxBt</source>
-        <translation type="unfinished"></translation>
+        <translation>수신기 배터리 전압</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1109"/>
         <source>GPS</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1232"/>
         <source>m/s</source>
-        <translation type="unfinished"></translation>
+        <translation>미터/초 (m/s)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1280"/>
         <source>%</source>
-        <translation type="unfinished"></translation>
+        <translation>퍼센트 (%)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1328"/>
         <source>Degrees</source>
-        <translation type="unfinished"></translation>
+        <translation>도 (°)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1340"/>
         <source>GPS sim</source>
-        <translation type="unfinished"></translation>
+        <translation>GPS 시뮬레이터</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1358"/>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1650"/>
         <source>km/h</source>
-        <translation type="unfinished"></translation>
+        <translation>킬로미터/시 (km/h)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1376"/>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="2350"/>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="2549"/>
         <source>V / ratio</source>
-        <translation type="unfinished"></translation>
+        <translation>전압 / 비율</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1433"/>
         <source>*</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1451"/>
         <source>AccZ</source>
-        <translation type="unfinished"></translation>
+        <translation>Z축 가속도 (AccZ)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1469"/>
         <source>dd-MM-yyyy
 hh:mm:ss</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1491"/>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1942"/>
         <source>Meters</source>
-        <translation type="unfinished"></translation>
+        <translation>미터 (m)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1539"/>
         <source>RAS</source>
-        <translation type="unfinished"></translation>
+        <translation>RAS (수신 안테나 신호)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1557"/>
         <source>AccX</source>
-        <translation type="unfinished"></translation>
+        <translation>X축 가속도 (AccX)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1578"/>
         <source>Tmp2</source>
-        <translation type="unfinished"></translation>
+        <translation>온도2 (Tmp2)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1695"/>
         <source>dB</source>
-        <translation type="unfinished"></translation>
+        <translation>데시벨 (dB)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1713"/>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="2368"/>
         <source>RPM</source>
-        <translation type="unfinished"></translation>
+        <translation>RPM (회전수)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1758"/>
         <source>A1</source>
-        <translation type="unfinished"></translation>
+        <translation>A1 센서</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1776"/>
         <source>AccY</source>
-        <translation type="unfinished"></translation>
+        <translation>Y축 가속도 (AccY)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1797"/>
         <source>VSpd</source>
-        <translation type="unfinished"></translation>
+        <translation>수직 속도 (VSpd)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1809"/>
         <source>Load Telemetry Values</source>
-        <translation type="unfinished"></translation>
+        <translation>텔레메트리 값 불러오기</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1902"/>
         <source>A2</source>
-        <translation type="unfinished"></translation>
+        <translation>A2 센서</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="1920"/>
         <source>Lat,Lon
 (dec.deg.)</source>
-        <translation type="unfinished"></translation>
+        <translation>위도, 경도
+(십진 도)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="2143"/>
         <source>A3</source>
-        <translation type="unfinished"></translation>
+        <translation>A3 센서</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="2161"/>
         <source>Fuel</source>
-        <translation type="unfinished"></translation>
+        <translation>연료</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="2179"/>
         <source>RSSI</source>
-        <translation type="unfinished"></translation>
+        <translation>수신 감도 (RSSI)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="2200"/>
         <source>Hdg</source>
-        <translation type="unfinished"></translation>
+        <translation>방위각 (Hdg)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="2221"/>
         <source>Curr</source>
-        <translation type="unfinished"></translation>
+        <translation>전류 (Curr)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="2284"/>
         <source>Amps</source>
-        <translation type="unfinished"></translation>
+        <translation>전류 (A)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="2302"/>
         <source>25.9973,-97.1572</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="2380"/>
         <location filename="../simulation/telemetryproviderfrsky.cpp" line="878"/>
         <location filename="../simulation/telemetryproviderfrsky.cpp" line="884"/>
         <source>Run</source>
-        <translation type="unfinished"></translation>
+        <translation>시작</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="2459"/>
         <source>Alt</source>
-        <translation type="unfinished"></translation>
+        <translation>고도 (Alt)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="2597"/>
         <source>Date</source>
-        <translation type="unfinished"></translation>
+        <translation>날짜</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.ui" line="2618"/>
         <source>GSpd</source>
-        <translation type="unfinished"></translation>
+        <translation>지상 속도 (GSpd)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
         <source>Save Telemetry</source>
-        <translation type="unfinished"></translation>
+        <translation>텔레메트리 저장</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.cpp" line="624"/>
         <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
         <source>.tlm Files (*.tlm)</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.cpp" line="630"/>
         <source>Unable to open file for writing.
 %1</source>
-        <translation type="unfinished"></translation>
+        <translation>파일을 쓰기 위해 열 수 없습니다.
+%1</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.cpp" line="716"/>
         <source>Open Telemetry File</source>
-        <translation type="unfinished"></translation>
+        <translation>텔레메트리 파일 열기</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.cpp" line="723"/>
         <source>Unable to open file for reading.
 %1</source>
-        <translation type="unfinished"></translation>
+        <translation>파일을 읽기 위해 열 수 없습니다.
+%1</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.cpp" line="741"/>
         <source>Not a FrSky S.Port telemetry values file.</source>
-        <translation type="unfinished"></translation>
+        <translation>FrSky S.Port 텔레메트리 파일이 아닙니다.</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrsky.cpp" line="879"/>
         <source>Stop</source>
-        <translation type="unfinished"></translation>
+        <translation>정지</translation>
     </message>
 </context>
 <context>
@@ -14797,272 +14980,275 @@ hh:mm:ss</source>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="20"/>
         <source>Form</source>
-        <translation type="unfinished"></translation>
+        <translation>폼</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="86"/>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="774"/>
         <source>Fuel</source>
-        <translation type="unfinished"></translation>
+        <translation>연료</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="98"/>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="347"/>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="597"/>
         <source>RPM</source>
-        <translation type="unfinished"></translation>
+        <translation>회전수 (RPM)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="116"/>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="248"/>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1018"/>
         <source>G</source>
-        <translation type="unfinished"></translation>
+        <translation>중력가속도 (G)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="128"/>
         <source>Baro</source>
-        <translation type="unfinished"></translation>
+        <translation>기압계 (Baro)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="146"/>
         <source>Tmp2</source>
-        <translation type="unfinished"></translation>
+        <translation>온도2 (Tmp2)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="158"/>
         <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="326"/>
         <source>Run</source>
-        <translation type="unfinished"></translation>
+        <translation>시작</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="176"/>
         <source>VSpd</source>
-        <translation type="unfinished"></translation>
+        <translation>수직 속도 (VSpd)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="194"/>
         <source>Hdg</source>
-        <translation type="unfinished"></translation>
+        <translation>방위각 (Hdg)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="206"/>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="579"/>
         <source>°C</source>
-        <translation type="unfinished"></translation>
+        <translation>도 (°C)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="266"/>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1048"/>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1108"/>
         <source>V</source>
-        <translation type="unfinished"></translation>
+        <translation>전압 (V)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="311"/>
         <source>Date</source>
-        <translation type="unfinished"></translation>
+        <translation>날짜</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="329"/>
         <source>m/s</source>
-        <translation type="unfinished"></translation>
+        <translation>미터/초 (m/s)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="365"/>
         <source>A2</source>
-        <translation type="unfinished"></translation>
+        <translation>A2 센서</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="425"/>
         <source>AccX</source>
-        <translation type="unfinished"></translation>
+        <translation>X축 가속도 (AccX)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="437"/>
         <source>Accel</source>
-        <translation type="unfinished"></translation>
+        <translation>가속도</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="449"/>
         <source>Batt</source>
-        <translation type="unfinished"></translation>
+        <translation>배터리</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="467"/>
         <source>GAlt</source>
-        <translation type="unfinished"></translation>
+        <translation>GPS 고도</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="485"/>
         <source>A1</source>
-        <translation type="unfinished"></translation>
+        <translation>A1 센서</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="497"/>
         <source>Temp</source>
-        <translation type="unfinished"></translation>
+        <translation>온도</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="515"/>
         <source>RSSI</source>
-        <translation type="unfinished"></translation>
+        <translation>수신 감도 (RSSI)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="567"/>
         <source>VFAS</source>
-        <translation type="unfinished"></translation>
+        <translation>전압 (VFAS)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="615"/>
         <source>Tmp1</source>
-        <translation type="unfinished"></translation>
+        <translation>온도1 (Tmp1)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="633"/>
         <source>%</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="672"/>
         <source>Alt</source>
-        <translation type="unfinished"></translation>
+        <translation>고도</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="690"/>
         <source>AccZ</source>
-        <translation type="unfinished"></translation>
+        <translation>Z축 가속도</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="702"/>
         <source>Degrees</source>
-        <translation type="unfinished"></translation>
+        <translation>도 (°)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="720"/>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="819"/>
         <source>m</source>
-        <translation type="unfinished"></translation>
+        <translation>미터 (m)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="750"/>
         <source>Curr</source>
-        <translation type="unfinished"></translation>
+        <translation>전류</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="801"/>
         <source>A</source>
-        <translation type="unfinished"></translation>
+        <translation>암페어 (A)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="858"/>
         <source>Load Telemetry Values</source>
-        <translation type="unfinished"></translation>
+        <translation>텔레메트리 값 불러오기</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="870"/>
         <source>Save Telemetry Values</source>
-        <translation type="unfinished"></translation>
+        <translation>텔레메트리 값 저장</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="888"/>
         <source>GSpd</source>
-        <translation type="unfinished"></translation>
+        <translation>지상 속도</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="942"/>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1066"/>
         <source>GPS</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="960"/>
         <source>knots</source>
-        <translation type="unfinished"></translation>
+        <translation>노트 (knots)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="978"/>
         <source>Lat,Lon
 (dec.deg.)</source>
-        <translation type="unfinished"></translation>
+        <translation>위도, 경도
+(십진수)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1030"/>
         <source>GPS Sim</source>
-        <translation type="unfinished"></translation>
+        <translation>GPS 시뮬레이션</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1120"/>
         <source>25.9973,-97.1572</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1159"/>
         <source>AccY</source>
-        <translation type="unfinished"></translation>
+        <translation>Y축 가속도</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1231"/>
         <source>MultiModule</source>
-        <translation type="unfinished"></translation>
+        <translation>멀티모듈</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1243"/>
         <source>TRSS</source>
-        <translation type="unfinished"></translation>
+        <translation>송신 RSS</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1255"/>
         <source>RQly</source>
-        <translation type="unfinished"></translation>
+        <translation>수신 품질</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1267"/>
         <source>TQly</source>
-        <translation type="unfinished"></translation>
+        <translation>송신 품질</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.ui" line="1279"/>
         <source>dB</source>
-        <translation type="unfinished"></translation>
+        <translation>dB (데시벨)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="329"/>
         <source>Stop</source>
-        <translation type="unfinished"></translation>
+        <translation>정지</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
         <source>Save Telemetry</source>
-        <translation type="unfinished"></translation>
+        <translation>텔레메트리 저장</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="339"/>
         <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
         <source>.tlm Files (*.tlm)</source>
-        <translation type="unfinished"></translation>
+        <translation>.tlm 파일 (*.tlm)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="345"/>
         <source>Unable to open file for writing.
 %1</source>
-        <translation type="unfinished"></translation>
+        <translation>파일을 쓰기 위해 열 수 없습니다.
+%1</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="393"/>
         <source>Open Telemetry File</source>
-        <translation type="unfinished"></translation>
+        <translation>텔레메트리 파일 열기</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="400"/>
         <source>Unable to open file for reading.
 %1</source>
-        <translation type="unfinished"></translation>
+        <translation>파일을 읽기 위해 열 수 없습니다.
+%1</translation>
     </message>
     <message>
         <location filename="../simulation/telemetryproviderfrskyhub.cpp" line="413"/>
         <source>Not a FrSky Hub telemetry values file.</source>
-        <translation type="unfinished"></translation>
+        <translation>FrSky Hub 텔레메트리 값 파일이 아닙니다.</translation>
     </message>
 </context>
 <context>
@@ -15070,7 +15256,7 @@ hh:mm:ss</source>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="14"/>
         <source>Form</source>
-        <translation></translation>
+        <translation>폼</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="80"/>
@@ -15080,17 +15266,17 @@ hh:mm:ss</source>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="109"/>
         <source>Instance</source>
-        <translation></translation>
+        <translation>인스턴스</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="135"/>
         <source>Rx</source>
-        <translation></translation>
+        <translation>수신기</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="186"/>
         <source>Cells Sensor :</source>
-        <translation></translation>
+        <translation>셀 센서 :</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="200"/>
@@ -15107,17 +15293,17 @@ hh:mm:ss</source>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="224"/>
         <source>GPS Sensor :</source>
-        <translation></translation>
+        <translation>GPS 센서 :</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="252"/>
         <source>Alt. Sensor :</source>
-        <translation></translation>
+        <translation>고도 센서 :</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="280"/>
         <source>Sensor :</source>
-        <translation></translation>
+        <translation>센서 :</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="38"/>
@@ -15127,52 +15313,52 @@ hh:mm:ss</source>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="378"/>
         <source>Precision</source>
-        <translation></translation>
+        <translation>정밀도</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="394"/>
         <source>Ratio</source>
-        <translation></translation>
+        <translation>비율</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="401"/>
         <source>Blades</source>
-        <translation></translation>
+        <translation>블레이드 수</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="436"/>
         <source>Offset</source>
-        <translation></translation>
+        <translation>오프셋</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="443"/>
         <source>Multiplier</source>
-        <translation></translation>
+        <translation>배율</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="475"/>
         <source>Auto Offset</source>
-        <translation></translation>
+        <translation>자동 오프셋</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="485"/>
         <source>Filter</source>
-        <translation></translation>
+        <translation>필터</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="495"/>
         <source>Persistent</source>
-        <translation></translation>
+        <translation>지속 저장</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="505"/>
         <source>Positive</source>
-        <translation></translation>
+        <translation>양수만</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry_sensor.ui" line="515"/>
         <source>Logs</source>
-        <translation></translation>
+        <translation>로그 기록</translation>
     </message>
 </context>
 <context>
@@ -15185,67 +15371,67 @@ hh:mm:ss</source>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="67"/>
         <source>Popup menu available</source>
-        <translation></translation>
+        <translation>팝업 메뉴를 사용할 수 있습니다</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="255"/>
         <source>Copy</source>
-        <translation></translation>
+        <translation>복사</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="256"/>
         <source>Cut</source>
-        <translation></translation>
+        <translation>잘라내기</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="257"/>
         <source>Paste</source>
-        <translation></translation>
+        <translation>붙여넣기</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="258"/>
         <source>Clear</source>
-        <translation></translation>
+        <translation>지우기</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="260"/>
         <source>Insert</source>
-        <translation></translation>
+        <translation>삽입</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="261"/>
         <source>Delete</source>
-        <translation></translation>
+        <translation>삭제</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="262"/>
         <source>Move Up</source>
-        <translation></translation>
+        <translation>위로 이동</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="263"/>
         <source>Move Down</source>
-        <translation></translation>
+        <translation>아래로 이동</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="265"/>
         <source>Clear All</source>
-        <translation></translation>
+        <translation>모두 지우기</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="308"/>
         <source>Cut Telemetry Sensor. Are you sure?</source>
-        <translation></translation>
+        <translation>텔레메트리 센서를 잘라내시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="327"/>
         <source>Clear Telemetry Sensor. Are you sure?</source>
-        <translation></translation>
+        <translation>텔레메트리 센서를 지우시겠습니까?</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.cpp" line="338"/>
         <source>Clear all Telemetry Sensors. Are you sure?</source>
-        <translation></translation>
+        <translation>모든 텔레메트리 센서를 지우시겠습니까?</translation>
     </message>
 </context>
 <context>
@@ -15253,32 +15439,32 @@ hh:mm:ss</source>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="19"/>
         <source>Telemetry Simulator</source>
-        <translation></translation>
+        <translation>텔레메트리 시뮬레이터</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="54"/>
         <source>When enabled, sends any non-blank values as simulated telemetry data.</source>
-        <translation></translation>
+        <translation>활성화되면 공백이 아닌 값을 시뮬레이션된 텔레메트리 데이터로 전송합니다.</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="57"/>
         <source>Simulate</source>
-        <translation></translation>
+        <translation>시뮬레이션</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="91"/>
         <source>Replay SD Log File</source>
-        <translation></translation>
+        <translation>SD 로그 파일 재생</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="114"/>
         <source>Replay rate</source>
-        <translation></translation>
+        <translation>재생 속도</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="130"/>
         <source>Load</source>
-        <translation></translation>
+        <translation>불러오기</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="187"/>
@@ -15307,93 +15493,94 @@ hh:mm:ss</source>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="350"/>
-        <source>Row # 
+        <source>Row #
 Timestamp</source>
-        <translation></translation>
+        <translation>행 번호
+타임스탬프</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="369"/>
         <source>1/5x</source>
-        <translation></translation>
+        <translation>1/5배속</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="385"/>
         <source>5x</source>
-        <translation></translation>
+        <translation>5배속</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="397"/>
         <source>No Log File Currently Loaded</source>
-        <translation></translation>
+        <translation>현재 로드된 로그 파일 없음</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="482"/>
         <source>Internal Module</source>
-        <translation type="unfinished"></translation>
+        <translation>내부 모듈</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="493"/>
         <location filename="../simulation/telemetrysimu.ui" line="601"/>
         <source>None</source>
-        <translation type="unfinished"></translation>
+        <translation>없음</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="498"/>
         <location filename="../simulation/telemetrysimu.ui" line="606"/>
         <source>CRSF / ELRS</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="503"/>
         <location filename="../simulation/telemetrysimu.ui" line="611"/>
         <source>FrSky Hub</source>
-        <translation type="unfinished"></translation>
+        <translation>FrSky 허브</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="508"/>
         <location filename="../simulation/telemetrysimu.ui" line="616"/>
         <source>FrSky S.Port</source>
-        <translation type="unfinished"></translation>
+        <translation></translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="590"/>
         <source>External Module</source>
-        <translation type="unfinished"></translation>
+        <translation>외부 모듈</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="413"/>
         <source>Setting RSSI to zero simulates telemetry and radio link loss.</source>
-        <translation></translation>
+        <translation>RSSI를 0으로 설정하면 텔레메트리 및 무선 링크 손실을 시뮬레이션합니다.</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="416"/>
         <source>Set RSSI to zero when paused.</source>
-        <translation></translation>
+        <translation>일시정지 시 RSSI를 0으로 설정</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="70"/>
         <source>Stop sending telemetry data when the Telemetry Simulator window is hidden.</source>
-        <translation></translation>
+        <translation>텔레메트리 시뮬레이터 창이 숨겨졌을 때 데이터 전송을 중지합니다.</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.ui" line="73"/>
         <source>Pause simulation when hidden.</source>
-        <translation></translation>
+        <translation>창이 숨겨졌을 때 시뮬레이션 일시정지</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>Log File</source>
-        <translation></translation>
+        <translation>로그 파일</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.cpp" line="459"/>
         <source>LOG Files (*.csv)</source>
-        <translation></translation>
+        <translation>LOG 파일 (*.csv)</translation>
     </message>
     <message>
         <location filename="../simulation/telemetrysimu.cpp" line="480"/>
         <source>ERROR - invalid file</source>
-        <translation></translation>
+        <translation>오류 - 유효하지 않은 파일</translation>
     </message>
 </context>
 <context>
@@ -15401,17 +15588,17 @@ Timestamp</source>
     <message>
         <location filename="../wizarddialog.cpp" line="399"/>
         <source>Yes</source>
-        <translation></translation>
+        <translation>예</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="400"/>
         <source>No</source>
-        <translation>No</translation>
+        <translation>아니오</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="407"/>
         <source>&lt;br&gt;Throttle Channel:</source>
-        <translation></translation>
+        <translation>&lt;br&gt;스로틀 채널:</translation>
     </message>
 </context>
 <context>
@@ -15419,17 +15606,17 @@ Timestamp</source>
     <message>
         <location filename="../modeledit/setup_timer.ui" line="67"/>
         <source>Countdown</source>
-        <translation></translation>
+        <translation>카운트다운</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_timer.ui" line="77"/>
         <source>Start</source>
-        <translation></translation>
+        <translation>시작</translation>
     </message>
     <message>
         <location filename="../modeledit/setup_timer.ui" line="87"/>
         <source>Minute Call</source>
-        <translation></translation>
+        <translation>분 단위 알림</translation>
     </message>
 </context>
 <context>
@@ -15437,138 +15624,138 @@ Timestamp</source>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="28"/>
         <source>TMR</source>
-        <translation></translation>
+        <translation>타이머</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="29"/>
         <source>Timer %1</source>
-        <translation></translation>
+        <translation>타이머 %1</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="54"/>
         <source>TMR</source>
         <comment>as in Timer</comment>
-        <translation></translation>
+        <translation>타이머</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="107"/>
         <source>Silent</source>
-        <translation></translation>
+        <translation>무음</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="109"/>
         <source>Beeps</source>
-        <translation></translation>
+        <translation>삐 소리</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="111"/>
         <source>Voice</source>
-        <translation></translation>
+        <translation>음성</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="113"/>
         <source>Haptic</source>
-        <translation></translation>
+        <translation>진동</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="115"/>
         <source>Beeps and Haptic</source>
-        <translation></translation>
+        <translation>삐 소리 및 진동</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="117"/>
         <source>Voice and Haptic</source>
-        <translation></translation>
+        <translation>음성 및 진동</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="128"/>
         <source>5s</source>
-        <translation></translation>
+        <translation>5초</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="130"/>
         <source>10s</source>
-        <translation></translation>
+        <translation>10초</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="132"/>
         <source>20s</source>
-        <translation></translation>
+        <translation>20초</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="134"/>
         <source>30s</source>
-        <translation></translation>
+        <translation>30초</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>Not persistent</source>
-        <translation></translation>
+        <translation>비 지속</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="145"/>
         <source>NOT</source>
-        <translation></translation>
+        <translation>비 지속</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Persistent (flight)</source>
-        <translation></translation>
+        <translation>지속 (비행 유지)</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="147"/>
         <source>Flight</source>
-        <translation></translation>
+        <translation>비행</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Persistent (manual reset)</source>
-        <translation></translation>
+        <translation>지속 (수동 초기화)</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="149"/>
         <source>Manual reset</source>
-        <translation></translation>
+        <translation>수동 초기화</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="172"/>
         <source>OFF</source>
-        <translation></translation>
+        <translation>꺼짐</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="174"/>
         <source>ON</source>
-        <translation></translation>
+        <translation>켜짐</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="176"/>
         <source>Start</source>
-        <translation></translation>
+        <translation>시작</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="178"/>
         <source>THs</source>
-        <translation></translation>
+        <translation>스로틀 스틱</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="180"/>
         <source>TH%</source>
-        <translation></translation>
+        <translation>스로틀 %</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="182"/>
         <source>THt</source>
-        <translation></translation>
+        <translation>스로틀 시간</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Elapsed</source>
-        <translation></translation>
+        <translation>경과 시간 표시</translation>
     </message>
     <message>
         <location filename="../firmwares/timerdata.cpp" line="190"/>
         <source>Show Remaining</source>
-        <translation></translation>
+        <translation>남은 시간 표시</translation>
     </message>
 </context>
 <context>
@@ -15576,22 +15763,22 @@ Timestamp</source>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="873"/>
         <source>OFF</source>
-        <translation></translation>
+        <translation>꺼짐</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="875"/>
         <source>+= (Sum)</source>
-        <translation></translation>
+        <translation>+= (합산)</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="877"/>
         <source>:= (Replace)</source>
-        <translation></translation>
+        <translation>:= (대체)</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="886"/>
         <source>CH%1</source>
-        <translation></translation>
+        <translation>채널 %1</translation>
     </message>
 </context>
 <context>
@@ -15599,27 +15786,27 @@ Timestamp</source>
     <message>
         <location filename="../generaledit/trainer.cpp" line="49"/>
         <source>Mode</source>
-        <translation></translation>
+        <translation>모드</translation>
     </message>
     <message>
         <location filename="../generaledit/trainer.cpp" line="50"/>
         <source>Weight</source>
-        <translation></translation>
+        <translation>가중치</translation>
     </message>
     <message>
         <location filename="../generaledit/trainer.cpp" line="51"/>
         <source>Source</source>
-        <translation></translation>
+        <translation>소스</translation>
     </message>
     <message>
         <location filename="../generaledit/trainer.cpp" line="77"/>
         <source>Multiplier</source>
-        <translation></translation>
+        <translation>배율</translation>
     </message>
     <message>
         <location filename="../generaledit/trainer.cpp" line="91"/>
         <source>Calibration</source>
-        <translation></translation>
+        <translation>보정</translation>
     </message>
 </context>
 <context>
@@ -15627,7 +15814,7 @@ Timestamp</source>
     <message>
         <location filename="../simulation/trainersimu.ui" line="20"/>
         <source>Trainer simulator</source>
-        <translation></translation>
+        <translation>트레이너 시뮬레이터</translation>
     </message>
 </context>
 <context>
@@ -15635,203 +15822,203 @@ Timestamp</source>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="34"/>
         <source>CloudBuild</source>
-        <translation type="unfinished"></translation>
+        <translation>클라우드 빌드</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="54"/>
         <source>waiting</source>
-        <translation type="unfinished"></translation>
+        <translation>대기 중</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="56"/>
         <source>in progress</source>
-        <translation type="unfinished"></translation>
+        <translation>진행 중</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="58"/>
         <source>success</source>
-        <translation type="unfinished"></translation>
+        <translation>성공</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="60"/>
         <source>error</source>
-        <translation type="unfinished"></translation>
+        <translation>오류</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="62"/>
         <source>timeout</source>
-        <translation type="unfinished"></translation>
+        <translation>시간 초과</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="64"/>
         <source>cancelled</source>
-        <translation type="unfinished"></translation>
+        <translation>취소됨</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="66"/>
         <source>unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>알 수 없음</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="113"/>
         <source>Radio profile language &apos;%1&apos; not supported</source>
-        <translation type="unfinished"></translation>
+        <translation>무선 프로파일 언어 &apos;%1&apos;은(는) 지원되지 않습니다</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="128"/>
         <source>fai_mode values do not contain CHOICE and YES</source>
-        <translation type="unfinished"></translation>
+        <translation>fai_mode 값에 CHOICE 및 YES가 포함되어 있지 않습니다</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="160"/>
         <source>Write firmware to radio: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>펌웨어를 송신기에 쓰는 중: %1</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="160"/>
         <source>true</source>
-        <translation type="unfinished"></translation>
+        <translation>참</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="160"/>
         <source>false</source>
-        <translation type="unfinished"></translation>
+        <translation>거짓</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="165"/>
         <source>Install</source>
-        <translation type="unfinished"></translation>
+        <translation>설치</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="168"/>
         <source>Asset filter applied: %1 Assets found: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>에셋 필터 적용됨: %1, 발견된 에셋 수: %2</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="174"/>
         <source>Expected %1 asset for install but %2 found</source>
-        <translation type="unfinished"></translation>
+        <translation>설치에 필요한 에셋 %1개를 기대했으나, %2개 발견됨</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="205"/>
         <source>Firmware not found in %1 using filter %2</source>
-        <translation type="unfinished"></translation>
+        <translation>필터 %2를 사용하여 %1에서 펌웨어를 찾을 수 없음</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="211"/>
         <source>Write the updated firmware to the radio now ?</source>
-        <translation type="unfinished"></translation>
+        <translation>업데이트된 펌웨어를 지금 송신기에 작성하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="228"/>
         <location filename="../updates/updatecloudbuild.cpp" line="229"/>
         <source>Building firmware for: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>%1용 펌웨어를 빌드 중</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="235"/>
         <source>Failed to create directory %1!</source>
-        <translation type="unfinished"></translation>
+        <translation>디렉토리 %1을(를) 생성하지 못했습니다!</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="252"/>
         <source>Unexpected format for build targets meta data</source>
-        <translation type="unfinished"></translation>
+        <translation>빌드 대상 메타데이터의 형식이 예상과 다릅니다</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="260"/>
         <source>No build support for target %1</source>
-        <translation type="unfinished"></translation>
+        <translation>대상 %1에 대한 빌드 지원이 없습니다</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="270"/>
         <source>Build target %1 has no valid tags</source>
-        <translation type="unfinished"></translation>
+        <translation>빌드 대상 %1에 유효한 태그가 없습니다</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="276"/>
         <source>No flag entries found</source>
-        <translation type="unfinished"></translation>
+        <translation>플래그 항목이 없습니다</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="323"/>
         <source>Submit build request</source>
-        <translation type="unfinished"></translation>
+        <translation>빌드 요청 제출</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="329"/>
         <source>Failed to initiate build job</source>
-        <translation type="unfinished"></translation>
+        <translation>빌드 작업을 시작하지 못했습니다</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="334"/>
         <source>Unexpected response format when submitting build job</source>
-        <translation type="unfinished"></translation>
+        <translation>빌드 작업 제출 시 응답 형식이 예상과 다릅니다</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="344"/>
         <source>Build error: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>빌드 오류: %1</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="348"/>
         <source>Process status not returned when submitting build job</source>
-        <translation type="unfinished"></translation>
+        <translation>빌드 작업 제출 시 프로세스 상태가 반환되지 않았습니다</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="358"/>
         <source>Build finish status: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>빌드 완료 상태: %1</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="372"/>
         <source>Build cancelled</source>
-        <translation type="unfinished"></translation>
+        <translation>빌드가 취소되었습니다</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="380"/>
         <source>Build timeout. Retry later.</source>
-        <translation type="unfinished"></translation>
+        <translation>빌드 시간이 초과되었습니다. 나중에 다시 시도하세요.</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="410"/>
         <source>Submit get build status</source>
-        <translation type="unfinished"></translation>
+        <translation>빌드 상태 요청 제출</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="419"/>
         <source>Build status unknown</source>
-        <translation type="unfinished"></translation>
+        <translation>빌드 상태를 알 수 없습니다</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="451"/>
         <source>Build status contains %1 artifacts when only 1 expected</source>
-        <translation type="unfinished"></translation>
+        <translation>빌드 상태에 %1개의 아티팩트가 포함되어 있으며, 1개만 예상되었습니다</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="461"/>
         <source>Build status does not contain download url</source>
-        <translation type="unfinished"></translation>
+        <translation>빌드 상태에 다운로드 URL이 포함되어 있지 않습니다</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="466"/>
         <source>Build status does not contain firmware artifact</source>
-        <translation type="unfinished"></translation>
+        <translation>빌드 상태에 펌웨어 아티팩트가 포함되어 있지 않습니다</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="471"/>
         <source>Build status firmware artifact not in expected format</source>
-        <translation type="unfinished"></translation>
+        <translation>빌드 상태의 펌웨어 아티팩트 형식이 예상과 다릅니다</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="477"/>
         <source>Build status does not contain artifacts</source>
-        <translation type="unfinished"></translation>
+        <translation>빌드 상태에 아티팩트가 포함되어 있지 않습니다</translation>
     </message>
     <message>
         <location filename="../updates/updatecloudbuild.cpp" line="491"/>
         <source>Waiting for build to finish...</source>
-        <translation type="unfinished"></translation>
+        <translation>빌드가 완료되기를 기다리는 중...</translation>
     </message>
 </context>
 <context>
@@ -15839,18 +16026,18 @@ Timestamp</source>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="36"/>
         <source>Would you like to open the disk image to install the new version of Companion?</source>
-        <translation></translation>
+        <translation>Companion의 새 버전을 설치하기 위해 디스크 이미지를 열겠습니까?</translation>
     </message>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="41"/>
         <location filename="../updates/updatecompanion.cpp" line="46"/>
         <source>Would you like to launch the Companion installer?</source>
-        <translation></translation>
+        <translation>Companion 설치 프로그램을 실행하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="52"/>
         <source>No install process support for your operating system</source>
-        <translation></translation>
+        <translation>현재 운영 체제에서는 설치 프로세스를 지원하지 않습니다</translation>
     </message>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="56"/>
@@ -15860,47 +16047,47 @@ Timestamp</source>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="89"/>
         <source>Install</source>
-        <translation></translation>
+        <translation>설치</translation>
     </message>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="92"/>
         <source>Asset filter applied: %1 - %2 found</source>
-        <translation></translation>
+        <translation>에셋 필터 적용됨: %1 - %2개 발견됨</translation>
     </message>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="95"/>
         <source>Expected 1 asset for install but none found</source>
-        <translation></translation>
+        <translation>설치용 에셋 1개가 예상되었지만 발견되지 않았습니다</translation>
     </message>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="115"/>
         <source>Installer not found in %1 using filter %2</source>
-        <translation></translation>
+        <translation>%1에서 필터 %2로 설치 프로그램을 찾을 수 없습니다</translation>
     </message>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="122"/>
         <source>Unable to set file permissions on the AppImage</source>
-        <translation></translation>
+        <translation>AppImage 파일의 권한을 설정할 수 없습니다</translation>
     </message>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="126"/>
         <source>Save File</source>
-        <translation></translation>
+        <translation>파일 저장</translation>
     </message>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="127"/>
         <source>Images (*.AppImage)</source>
-        <translation></translation>
+        <translation>이미지 파일 (*.AppImage)</translation>
     </message>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="135"/>
         <source>Unable to delete file %1</source>
-        <translation></translation>
+        <translation>파일 %1을(를) 삭제할 수 없습니다</translation>
     </message>
     <message>
         <location filename="../updates/updatecompanion.cpp" line="141"/>
         <source>Unable to copy file to %1</source>
-        <translation></translation>
+        <translation>%1으로 파일을 복사할 수 없습니다</translation>
     </message>
 </context>
 <context>
@@ -15908,47 +16095,47 @@ Timestamp</source>
     <message>
         <location filename="../updates/updatefirmware.cpp" line="26"/>
         <source>Firmware</source>
-        <translation></translation>
+        <translation>펌웨어</translation>
     </message>
     <message>
         <location filename="../updates/updatefirmware.cpp" line="56"/>
         <source>Write firmware to radio: %1</source>
-        <translation type="unfinished"></translation>
+        <translation>라디오에 펌웨어를 기록합니다: %1</translation>
     </message>
     <message>
         <location filename="../updates/updatefirmware.cpp" line="56"/>
         <source>true</source>
-        <translation type="unfinished"></translation>
+        <translation>예</translation>
     </message>
     <message>
         <location filename="../updates/updatefirmware.cpp" line="56"/>
         <source>false</source>
-        <translation type="unfinished"></translation>
+        <translation>아니오</translation>
     </message>
     <message>
         <location filename="../updates/updatefirmware.cpp" line="61"/>
         <source>Install</source>
-        <translation></translation>
+        <translation>설치</translation>
     </message>
     <message>
         <location filename="../updates/updatefirmware.cpp" line="64"/>
         <source>Asset filter applied: %1 Assets found: %2</source>
-        <translation type="unfinished"></translation>
+        <translation>에셋 필터 적용됨: %1, 발견된 에셋: %2개</translation>
     </message>
     <message>
         <location filename="../updates/updatefirmware.cpp" line="70"/>
         <source>Expected %1 asset for install but %2 found</source>
-        <translation></translation>
+        <translation>설치에 필요한 에셋 %1개가 예상되었지만 %2개가 발견되었습니다</translation>
     </message>
     <message>
         <location filename="../updates/updatefirmware.cpp" line="101"/>
         <source>Firmware not found in %1 using filter %2</source>
-        <translation></translation>
+        <translation>%1에서 필터 %2를 사용해도 펌웨어를 찾을 수 없습니다</translation>
     </message>
     <message>
         <location filename="../updates/updatefirmware.cpp" line="107"/>
         <source>Write the updated firmware to the radio now ?</source>
-        <translation></translation>
+        <translation>업데이트된 펌웨어를 지금 라디오에 기록하시겠습니까?</translation>
     </message>
 </context>
 <context>
@@ -15956,12 +16143,12 @@ Timestamp</source>
     <message>
         <location filename="../updates/updateinterface.cpp" line="60"/>
         <source>Component id: %1 exceeds maximum application settings components: %2!</source>
-        <translation></translation>
+        <translation>컴포넌트 ID %1이(가) 애플리케이션 설정의 최대 컴포넌트 수 %2을(를) 초과합니다!</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="213"/>
         <source>Copy filter pattern: %1</source>
-        <translation></translation>
+        <translation>필터 패턴 복사: %1</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="137"/>
@@ -15970,303 +16157,303 @@ Timestamp</source>
         <location filename="../updates/updateinterface.cpp" line="523"/>
         <location filename="../updates/updateinterface.cpp" line="556"/>
         <source>Asset filter applied: %1 - %2 found</source>
-        <translation></translation>
+        <translation>에셋 필터 적용됨: %1 - 발견된 항목: %2개</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="302"/>
         <source>Copy directory structure</source>
-        <translation></translation>
+        <translation>디렉터리 구조 복사</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="1092"/>
         <source>Processing updates for: %1</source>
-        <translation></translation>
+        <translation>%1에 대한 업데이트 처리 중</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="699"/>
         <location filename="../updates/updateinterface.cpp" line="1185"/>
         <source>unknown</source>
-        <translation></translation>
+        <translation>알 수 없음</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="158"/>
         <source>%1 directory not configured in application settings!</source>
-        <translation></translation>
+        <translation>%1 디렉터리가 애플리케이션 설정에 구성되어 있지 않습니다!</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="121"/>
         <source>Building assets</source>
-        <translation type="unfinished"></translation>
+        <translation>에셋 빌드 중</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="124"/>
         <source>Unable to build flagged assets</source>
-        <translation type="unfinished"></translation>
+        <translation>표시된 에셋을 빌드할 수 없습니다</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="162"/>
         <source>Failed to create %1 directory %2!</source>
-        <translation></translation>
+        <translation>%1 디렉터리 %2 생성 실패!</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="419"/>
         <source>Copying files to destination</source>
-        <translation type="unfinished"></translation>
+        <translation>대상 위치로 파일 복사 중</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="422"/>
         <source>Unable to copy files</source>
-        <translation type="unfinished"></translation>
+        <translation>파일을 복사할 수 없습니다</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="431"/>
         <source>Decompressing files</source>
-        <translation type="unfinished"></translation>
+        <translation>파일 압축 해제 중</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="434"/>
         <source>Unable to decompress flagged files</source>
-        <translation type="unfinished"></translation>
+        <translation>표시된 파일의 압축을 해제할 수 없습니다</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="542"/>
         <source>Downloading...</source>
-        <translation type="unfinished"></translation>
+        <translation>다운로드 중...</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="545"/>
         <source>Unable to download flagged files</source>
-        <translation type="unfinished"></translation>
+        <translation>표시된 파일을 다운로드할 수 없습니다</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="559"/>
         <source>No assets found in release &apos;%1&apos; using filter &apos;%2&apos;</source>
-        <translation></translation>
+        <translation>릴리스 &apos;%1&apos;에서 필터 &apos;%2&apos;(으)로 검색된 에셋이 없습니다</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="563"/>
         <source>%1 assets found when %2 expected in release &apos;%3&apos; using filter &apos;%4&apos;</source>
-        <translation></translation>
+        <translation>릴리스 &apos;%3&apos;에서 필터 &apos;%4&apos;를 사용했을 때 %2개를 기대했지만 %1개의 에셋이 발견되었습니다</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="719"/>
         <source>Update cancelled by user</source>
-        <translation type="unfinished"></translation>
+        <translation>사용자에 의해 업데이트가 취소되었습니다</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="875"/>
         <source>%1 start async %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 비동기 시작 %2</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="884"/>
         <location filename="../updates/updateinterface.cpp" line="929"/>
         <source>%1 preparation %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 준비 중 %2</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="893"/>
         <source>%1 copy to destination %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1을(를) 대상 위치 %2로 복사 중</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="902"/>
         <source>%1 decompress %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 압축 해제 %2</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="911"/>
         <source>%1 download %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 다운로드 %2</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="920"/>
         <source>%1 housekeeping %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 정리 작업 %2</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="938"/>
         <source>%1 save release settings %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 릴리스 설정 저장 %2</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="951"/>
         <source>Unable to set processing flags for asset %1</source>
-        <translation></translation>
+        <translation>에셋 %1에 대한 처리 플래그를 설정할 수 없습니다</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="956"/>
         <source>Unable to set sub directory for asset %1</source>
-        <translation></translation>
+        <translation>에셋 %1의 하위 디렉토리를 설정할 수 없습니다</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="961"/>
         <source>Unable to set copy filter for asset %1</source>
-        <translation></translation>
+        <translation>에셋 %1의 복사 필터를 설정할 수 없습니다</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="1161"/>
         <location filename="../updates/updateinterface.cpp" line="1164"/>
         <source>%1 update %2</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 업데이트 %2</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="1179"/>
         <source>failed</source>
-        <translation type="unfinished"></translation>
+        <translation>실패함</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="1181"/>
         <source>successful</source>
-        <translation type="unfinished"></translation>
+        <translation>성공함</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="1183"/>
         <source>cancelled</source>
-        <translation type="unfinished"></translation>
+        <translation>취소됨</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="481"/>
         <source>Decompressing %1</source>
-        <translation></translation>
+        <translation>%1 압축 해제 중</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="482"/>
         <source>Decompress: %1</source>
-        <translation></translation>
+        <translation>압축 해제: %1</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="503"/>
         <source>Failed to decompress %1</source>
-        <translation></translation>
+        <translation>%1 압축 해제에 실패했습니다</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="309"/>
         <source>Decompressed file structure not found at %1</source>
-        <translation></translation>
+        <translation>%1 위치에서 압축 해제된 파일 구조를 찾을 수 없습니다</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="313"/>
         <source>Copy file structure from: %1</source>
-        <translation></translation>
+        <translation>파일 구조 복사: %1</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="205"/>
         <location filename="../updates/updateinterface.cpp" line="338"/>
         <source>Failed to create directory %1</source>
-        <translation></translation>
+        <translation>디렉토리 %1을 생성하지 못했습니다</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="209"/>
         <location filename="../updates/updateinterface.cpp" line="342"/>
         <source>Check/create directory: %1</source>
-        <translation></translation>
+        <translation>디렉토리 확인/생성 중: %1</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="210"/>
         <location filename="../updates/updateinterface.cpp" line="347"/>
         <source>Directories checked/created: %1</source>
-        <translation></translation>
+        <translation>디렉토리 확인/생성 완료: %1</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="252"/>
         <location filename="../updates/updateinterface.cpp" line="392"/>
         <source>Failed to delete existing file %1</source>
-        <translation></translation>
+        <translation>기존 파일 %1을(를) 삭제하지 못했습니다</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="259"/>
         <location filename="../updates/updateinterface.cpp" line="398"/>
         <source>Failed to copy file %1</source>
-        <translation></translation>
+        <translation>파일 %1을(를) 복사하지 못했습니다</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="263"/>
         <location filename="../updates/updateinterface.cpp" line="402"/>
         <source>Copied %1 to %2</source>
-        <translation></translation>
+        <translation>%1 → %2 복사 완료</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="275"/>
         <location filename="../updates/updateinterface.cpp" line="409"/>
         <source>Files copied: %1</source>
-        <translation></translation>
+        <translation>복사된 파일 수: %1</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="193"/>
         <source>Unable to determine source directory for asset %1</source>
-        <translation></translation>
+        <translation>에셋 %1의 소스 디렉토리를 확인할 수 없습니다</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="197"/>
         <source>Copy files from %1</source>
-        <translation></translation>
+        <translation>%1에서 파일 복사</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="255"/>
         <source>Deleted file: %1</source>
-        <translation></translation>
+        <translation>삭제된 파일: %1</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="270"/>
         <source>No downloaded or decompressed files matched filter &apos;%1&apos;</source>
-        <translation></translation>
+        <translation>다운로드되거나 압축 해제된 파일 중 필터 &apos;%1&apos;에 일치하는 항목이 없습니다</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="735"/>
         <source>Preparing</source>
-        <translation></translation>
+        <translation>준비 중</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="742"/>
         <source>Set run folders failed</source>
-        <translation></translation>
+        <translation>실행 폴더 설정 실패</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="755"/>
         <source>Set release id from update release &apos;%1&apos; failed</source>
-        <translation></translation>
+        <translation>업데이트 릴리스 &apos;%1&apos;에서 릴리스 ID 설정 실패</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="573"/>
         <source>Flagging assets</source>
-        <translation></translation>
+        <translation>에셋 플래그 설정 중</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="589"/>
         <source>Housekeeping</source>
-        <translation></translation>
+        <translation>정리 작업</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="600"/>
         <source>Delete download directory: %1</source>
-        <translation></translation>
+        <translation>다운로드 디렉토리 삭제: %1</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="603"/>
         <source>Failed to delete downloads folder %1</source>
-        <translation></translation>
+        <translation>다운로드 폴더 %1 삭제 실패</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="610"/>
         <source>Delete decompress directory: %1</source>
-        <translation></translation>
+        <translation>압축 해제 디렉토리 삭제: %1</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="613"/>
         <location filename="../updates/updateinterface.cpp" line="622"/>
         <source>Failed to delete decompress folder %1</source>
-        <translation></translation>
+        <translation>압축 해제 폴더 %1 삭제 실패</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="620"/>
         <source>Delete decompress folder: %1</source>
-        <translation></translation>
+        <translation>압축 해제 폴더 삭제: %1</translation>
     </message>
     <message>
         <location filename="../updates/updateinterface.cpp" line="811"/>
         <source>Save release settings</source>
-        <translation></translation>
+        <translation>릴리스 설정 저장</translation>
     </message>
 </context>
 <context>
@@ -16274,7 +16461,7 @@ Timestamp</source>
     <message>
         <location filename="../updates/updatemultiprotocol.cpp" line="25"/>
         <source>Multiprotocol</source>
-        <translation></translation>
+        <translation>멀티프로토콜</translation>
     </message>
 </context>
 <context>
@@ -16282,70 +16469,72 @@ Timestamp</source>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="209"/>
         <source>Downloading: %1</source>
-        <translation></translation>
+        <translation>다운로드 중: %1</translation>
     </message>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="210"/>
         <source>Download: %1</source>
-        <translation></translation>
+        <translation>다운로드: %1</translation>
     </message>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="213"/>
         <source>File exists: %1</source>
-        <translation></translation>
+        <translation>파일이 존재함: %1</translation>
     </message>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="215"/>
         <source>File %1 exists. Download again?</source>
-        <translation></translation>
+        <translation>파일 %1이(가) 이미 존재합니다. 다시 다운로드하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="218"/>
         <source>Download cancelled by user</source>
-        <translation type="unfinished"></translation>
+        <translation>사용자에 의해 다운로드가 취소되었습니다</translation>
     </message>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="231"/>
         <source>Failed to create directory %1!</source>
-        <translation></translation>
+        <translation>디렉토리 %1 생성 실패!</translation>
     </message>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="297"/>
         <source>Unable to download %1. GET error:%2
 %3</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 다운로드 실패. GET 오류: %2
+%3</translation>
     </message>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="322"/>
         <source>POST error: %2
 %3</source>
-        <translation type="unfinished"></translation>
+        <translation>POST 오류: %2
+%3</translation>
     </message>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="366"/>
         <location filename="../updates/updatenetwork.cpp" line="382"/>
         <source>Failed to open %1 for writing</source>
-        <translation type="unfinished"></translation>
+        <translation>%1 파일을 쓰기 위해 여는 데 실패했습니다</translation>
     </message>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="408"/>
         <source>Download cancelled</source>
-        <translation type="unfinished"></translation>
+        <translation>다운로드 취소됨</translation>
     </message>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="101"/>
         <source>Unable to open the download file %1 for writing. Error: %2</source>
-        <translation></translation>
+        <translation>다운로드 파일 %1을(를) 쓰기 위해 열 수 없습니다. 오류: %2</translation>
     </message>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="93"/>
         <source>Downloading</source>
-        <translation type="unfinished"></translation>
+        <translation>다운로드 중</translation>
     </message>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="266"/>
         <source>Invalid URL: %1</source>
-        <translation></translation>
+        <translation>잘못된 URL: %1</translation>
     </message>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="270"/>
@@ -16355,18 +16544,19 @@ Timestamp</source>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="67"/>
         <source>Network error has occurred. Error code: %1</source>
-        <translation></translation>
+        <translation>네트워크 오류가 발생했습니다. 오류 코드: %1</translation>
     </message>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="72"/>
         <source>Ssl library version: %1</source>
-        <translation></translation>
+        <translation>SSL 라이브러리 버전: %1</translation>
     </message>
     <message>
         <location filename="../updates/updatenetwork.cpp" line="84"/>
         <source>Unable to convert downloaded metadata to json. Error:%1
 %2</source>
-        <translation></translation>
+        <translation>다운로드된 메타데이터를 JSON으로 변환할 수 없습니다. 오류: %1
+%2</translation>
     </message>
 </context>
 <context>
@@ -16374,83 +16564,83 @@ Timestamp</source>
     <message>
         <location filename="../updates/updateoptionsdialog.ui" line="20"/>
         <source>Advanced Options</source>
-        <translation></translation>
+        <translation>고급 옵션</translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.ui" line="28"/>
         <source>Current Release:</source>
-        <translation></translation>
+        <translation>현재 릴리스:</translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.ui" line="41"/>
         <source>unknown</source>
-        <translation></translation>
+        <translation>알 수 없음</translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.ui" line="54"/>
         <source>Clear</source>
-        <translation></translation>
+        <translation>지우기</translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.ui" line="63"/>
         <source>Assets</source>
-        <translation></translation>
+        <translation>에셋</translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="46"/>
         <source>%1 %2</source>
-        <translation></translation>
+        <translation>%1 %2</translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="46"/>
         <source>Options</source>
-        <translation></translation>
+        <translation>옵션</translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="51"/>
         <source>Clear current release information. Are you sure?</source>
-        <translation></translation>
+        <translation>현재 릴리스 정보를 삭제하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="80"/>
         <location filename="../updates/updateoptionsdialog.cpp" line="149"/>
         <source>Filter</source>
-        <translation></translation>
+        <translation>필터</translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="115"/>
         <source>Max.Expected</source>
-        <translation></translation>
+        <translation>최대 기대값</translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="119"/>
         <source>No Limit</source>
-        <translation></translation>
+        <translation>제한 없음</translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="123"/>
         <source>Download</source>
-        <translation></translation>
+        <translation>다운로드</translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="127"/>
         <source>Decompress</source>
-        <translation></translation>
+        <translation>압축 해제</translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="132"/>
         <source>Install</source>
-        <translation></translation>
+        <translation>설치</translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="144"/>
         <source>Copy</source>
-        <translation></translation>
+        <translation>복사</translation>
     </message>
     <message>
         <location filename="../updates/updateoptionsdialog.cpp" line="179"/>
         <source>Sub folder</source>
-        <translation></translation>
+        <translation>하위 폴더</translation>
     </message>
 </context>
 <context>
@@ -16458,32 +16648,32 @@ Timestamp</source>
     <message>
         <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>None</source>
-        <translation></translation>
+        <translation>없음</translation>
     </message>
     <message>
         <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Exact</source>
-        <translation></translation>
+        <translation>정확히 일치</translation>
     </message>
     <message>
         <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Startswith</source>
-        <translation></translation>
+        <translation>앞이 일치</translation>
     </message>
     <message>
         <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Endswith</source>
-        <translation></translation>
+        <translation>뒤가 일치</translation>
     </message>
     <message>
         <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Contains</source>
-        <translation></translation>
+        <translation>포함</translation>
     </message>
     <message>
         <location filename="../updates/updateparameters.cpp" line="81"/>
         <source>Pattern</source>
-        <translation></translation>
+        <translation>패턴</translation>
     </message>
 </context>
 <context>
@@ -16491,27 +16681,27 @@ Timestamp</source>
     <message>
         <location filename="../updates/updatesdcard.cpp" line="27"/>
         <source>SD Card</source>
-        <translation></translation>
+        <translation>SD 카드</translation>
     </message>
     <message>
         <location filename="../updates/updatesdcard.cpp" line="53"/>
         <source>Flagging assets</source>
-        <translation></translation>
+        <translation>에셋 표시 중</translation>
     </message>
     <message>
         <location filename="../updates/updatesdcard.cpp" line="60"/>
         <source>Unable to retrieve asset &apos;%1&apos; from release &apos;%2&apos;</source>
-        <translation></translation>
+        <translation>릴리스 &apos;%2&apos;에서 에셋 &apos;%1&apos;을(를) 가져올 수 없습니다</translation>
     </message>
     <message>
         <location filename="../updates/updatesdcard.cpp" line="63"/>
         <source>Unable to retrieve file &apos;%1&apos; from repo &apos;%2&apos;</source>
-        <translation></translation>
+        <translation>저장소 &apos;%2&apos;에서 파일 &apos;%1&apos;을(를) 가져올 수 없습니다</translation>
     </message>
     <message>
         <location filename="../updates/updatesdcard.cpp" line="109"/>
         <source>Radio flavour &apos;%1&apos; not listed in &apos;%2&apos;</source>
-        <translation></translation>
+        <translation>라디오 유형 &apos;%1&apos;이(가) &apos;%2&apos;에 등록되어 있지 않습니다</translation>
     </message>
 </context>
 <context>
@@ -16519,27 +16709,27 @@ Timestamp</source>
     <message>
         <location filename="../updates/updatesounds.cpp" line="31"/>
         <source>Sounds</source>
-        <translation></translation>
+        <translation>사운드</translation>
     </message>
     <message>
         <location filename="../updates/updatesounds.cpp" line="62"/>
         <source>Processing available sounds</source>
-        <translation></translation>
+        <translation>사용 가능한 사운드 처리 중</translation>
     </message>
     <message>
         <location filename="../updates/updatesounds.cpp" line="79"/>
         <source>Choose Language Packs</source>
-        <translation></translation>
+        <translation>언어 팩 선택</translation>
     </message>
     <message>
         <location filename="../updates/updatesounds.cpp" line="86"/>
         <source>No language packs have been selected. Sounds update will be skipped!</source>
-        <translation></translation>
+        <translation>언어 팩이 선택되지 않았습니다. 사운드 업데이트가 건너뜁니다!</translation>
     </message>
     <message>
         <location filename="../updates/updatesounds.cpp" line="108"/>
         <source>Flagging assets</source>
-        <translation></translation>
+        <translation>에셋 표시 중</translation>
     </message>
 </context>
 <context>
@@ -16547,7 +16737,7 @@ Timestamp</source>
     <message>
         <location filename="../updates/updatestatus.cpp" line="59"/>
         <source>Update Interface</source>
-        <translation></translation>
+        <translation>업데이트 인터페이스</translation>
     </message>
 </context>
 <context>
@@ -16555,7 +16745,7 @@ Timestamp</source>
     <message>
         <location filename="../updates/updatethemes.cpp" line="25"/>
         <source>Themes</source>
-        <translation></translation>
+        <translation>테마</translation>
     </message>
 </context>
 <context>
@@ -16563,12 +16753,12 @@ Timestamp</source>
     <message>
         <location filename="../updates/updates.cpp" line="75"/>
         <source>No updates available at this time</source>
-        <translation></translation>
+        <translation>현재 사용할 수 있는 업데이트가 없습니다</translation>
     </message>
     <message>
         <location filename="../updates/updates.cpp" line="88"/>
         <source>Checking for Updates</source>
-        <translation></translation>
+        <translation>업데이트 확인 중</translation>
     </message>
     <message>
         <location filename="../updates/updates.cpp" line="89"/>
@@ -16576,42 +16766,45 @@ Timestamp</source>
   - %1
 
 Process now?</source>
-        <translation></translation>
+        <translation>다음 항목에 대한 업데이트가 있습니다:
+- %1
+
+지금 진행하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../updates/updates.cpp" line="109"/>
         <source>No components have been flagged to check in Update Settings!</source>
-        <translation></translation>
+        <translation>업데이트 설정에서 확인할 구성 요소가 선택되지 않았습니다!</translation>
     </message>
     <message>
         <location filename="../updates/updates.cpp" line="125"/>
         <source>Update Components</source>
-        <translation></translation>
+        <translation>구성 요소 업데이트</translation>
     </message>
     <message>
         <location filename="../updates/updates.cpp" line="127"/>
         <source>Starting...</source>
-        <translation></translation>
+        <translation>시작 중...</translation>
     </message>
     <message>
         <location filename="../updates/updates.cpp" line="130"/>
         <source>Finished %1</source>
-        <translation></translation>
+        <translation>%1 완료됨</translation>
     </message>
     <message>
         <location filename="../updates/updates.cpp" line="130"/>
         <source>successfully</source>
-        <translation></translation>
+        <translation>성공적으로</translation>
     </message>
     <message>
         <location filename="../updates/updates.cpp" line="130"/>
         <source>with errors</source>
-        <translation></translation>
+        <translation>오류 발생</translation>
     </message>
     <message>
         <location filename="../updates/updates.cpp" line="145"/>
         <source>Run SD card sync now?</source>
-        <translation></translation>
+        <translation>지금 SD 카드 동기화를 실행할까요?</translation>
     </message>
 </context>
 <context>
@@ -16619,140 +16812,140 @@ Process now?</source>
     <message>
         <location filename="../updates/updatesdialog.ui" line="23"/>
         <source>Process Updates</source>
-        <translation></translation>
+        <translation>업데이트 처리</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.ui" line="35"/>
         <source>Folders</source>
-        <translation></translation>
+        <translation>폴더</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.ui" line="41"/>
         <source>Download</source>
-        <translation></translation>
+        <translation>다운로드</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.ui" line="51"/>
         <source>Update</source>
-        <translation></translation>
+        <translation>업데이트</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.ui" line="58"/>
         <source>Create sub-folders in Download folder</source>
-        <translation></translation>
+        <translation>다운로드 폴더에 하위 폴더 생성</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.ui" line="75"/>
         <source>Decompress</source>
-        <translation></translation>
+        <translation>압축 해제</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.ui" line="82"/>
         <source>Use Radio Profile SD structure</source>
-        <translation></translation>
+        <translation>라디오 프로파일 SD 구조 사용</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.ui" line="102"/>
         <location filename="../updates/updatesdialog.ui" line="112"/>
         <location filename="../updates/updatesdialog.ui" line="119"/>
         <source>Select folder</source>
-        <translation></translation>
+        <translation>폴더 선택</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.ui" line="135"/>
         <source>Components</source>
-        <translation></translation>
+        <translation>구성 요소</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.ui" line="142"/>
         <location filename="../updates/updatesdialog.cpp" line="207"/>
         <source>Options</source>
-        <translation></translation>
+        <translation>옵션</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.ui" line="148"/>
         <source>Delete downloads</source>
-        <translation></translation>
+        <translation>다운로드 삭제</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.ui" line="155"/>
         <source>Delete decompressions</source>
-        <translation></translation>
+        <translation>압축 해제 파일 삭제</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="39"/>
         <source>Downloading Release Metadata</source>
-        <translation></translation>
+        <translation>릴리스 메타데이터 다운로드 중</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="105"/>
         <source>Select your download folder</source>
-        <translation></translation>
+        <translation>다운로드 폴더 선택</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="112"/>
         <source>Select your decompress folder</source>
-        <translation></translation>
+        <translation>압축 해제 폴더 선택</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="119"/>
         <source>Select your update destination folder</source>
-        <translation></translation>
+        <translation>업데이트 대상 폴더 선택</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="145"/>
         <source>Name</source>
-        <translation></translation>
+        <translation>이름</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="148"/>
         <source>Channel</source>
-        <translation></translation>
+        <translation>채널</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="151"/>
         <source>Current</source>
-        <translation></translation>
+        <translation>현재</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="154"/>
         <source>Update to</source>
-        <translation></translation>
+        <translation>업데이트 버전</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="174"/>
         <source>Retrieving latest release information for %1</source>
-        <translation></translation>
+        <translation>%1의 최신 릴리스 정보 가져오는 중</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="234"/>
         <source>Save as Defaults</source>
-        <translation></translation>
+        <translation>기본값으로 저장</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="262"/>
         <source>Download folder path missing!</source>
-        <translation></translation>
+        <translation>다운로드 폴더 경로가 없습니다!</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="267"/>
         <source>Decompress folder path missing!</source>
-        <translation></translation>
+        <translation>압축 해제 폴더 경로가 없습니다!</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="272"/>
         <source>Update folder path missing!</source>
-        <translation></translation>
+        <translation>업데이트 폴더 경로가 없습니다!</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="278"/>
         <source>Decompress and download folders have the same path!</source>
-        <translation></translation>
+        <translation>압축 해제 폴더와 다운로드 폴더 경로가 동일합니다!</translation>
     </message>
     <message>
         <location filename="../updates/updatesdialog.cpp" line="312"/>
         <source>No components selected for update!</source>
-        <translation></translation>
+        <translation>업데이트할 구성 요소가 선택되지 않았습니다!</translation>
     </message>
 </context>
 <context>
@@ -16760,32 +16953,32 @@ Process now?</source>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="52"/>
         <source>Information unavailable</source>
-        <translation></translation>
+        <translation>정보를 확인할 수 없습니다</translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="100"/>
         <source>Cannot load %1</source>
-        <translation></translation>
+        <translation>%1을(를) 불러올 수 없습니다</translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="109"/>
         <source>Theme</source>
-        <translation></translation>
+        <translation>테마</translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="113"/>
         <source>Author</source>
-        <translation></translation>
+        <translation>작성자</translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="117"/>
         <source>Information</source>
-        <translation></translation>
+        <translation>정보</translation>
     </message>
     <message>
         <location filename="../modeledit/colorcustomscreens.cpp" line="142"/>
         <source>Top Bar</source>
-        <translation></translation>
+        <translation>상단 바</translation>
     </message>
 </context>
 <context>
@@ -16793,12 +16986,12 @@ Process now?</source>
     <message>
         <location filename="../wizarddialog.cpp" line="704"/>
         <source>First Tail Channel:</source>
-        <translation></translation>
+        <translation>첫 번째 꼬리 날개 채널:</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="706"/>
         <source>Second Tail Channel:</source>
-        <translation></translation>
+        <translation>두 번째 꼬리 날개 채널:</translation>
     </message>
 </context>
 <context>
@@ -16806,42 +16999,42 @@ Process now?</source>
     <message>
         <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="450"/>
         <source>Hld Y</source>
-        <translation></translation>
+        <translation>Y 고정</translation>
     </message>
     <message>
         <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="451"/>
         <source>Hold Vertical position.</source>
-        <translation type="unfinished"></translation>
+        <translation>수직 위치 고정</translation>
     </message>
     <message>
         <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="456"/>
         <source>Prevent Vertical movement.</source>
-        <translation type="unfinished"></translation>
+        <translation>수직 이동 차단</translation>
     </message>
     <message>
         <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="461"/>
         <source>Prevent Horizontal movement.</source>
-        <translation type="unfinished"></translation>
+        <translation>수평 이동 차단</translation>
     </message>
     <message>
         <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="466"/>
         <source>Hold Horizontal position.</source>
-        <translation type="unfinished"></translation>
+        <translation>수평 위치 고정</translation>
     </message>
     <message>
         <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="455"/>
         <source>Fix Y</source>
-        <translation></translation>
+        <translation>Y 차단</translation>
     </message>
     <message>
         <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="460"/>
         <source>Fix X</source>
-        <translation></translation>
+        <translation>X 차단</translation>
     </message>
     <message>
         <location filename="../simulation/widgets/virtualjoystickwidget.cpp" line="465"/>
         <source>Hld X</source>
-        <translation></translation>
+        <translation>X 고정</translation>
     </message>
 </context>
 <context>
@@ -16849,12 +17042,12 @@ Process now?</source>
     <message>
         <location filename="../wizarddialog.cpp" line="333"/>
         <source>Standard Wing</source>
-        <translation></translation>
+        <translation>표준 날개</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="335"/>
         <source>Flying Wing / Deltawing</source>
-        <translation></translation>
+        <translation>플라잉 윙 / 델타윙</translation>
     </message>
 </context>
 <context>
@@ -16862,37 +17055,37 @@ Process now?</source>
     <message>
         <location filename="../wizarddata.cpp" line="73"/>
         <source>FlapUp</source>
-        <translation></translation>
+        <translation>플랩 업</translation>
     </message>
     <message>
         <location filename="../wizarddata.cpp" line="74"/>
         <source>FlapDn</source>
-        <translation></translation>
+        <translation>플랩 다운</translation>
     </message>
     <message>
         <location filename="../wizarddata.cpp" line="78"/>
         <source>ArbkOf</source>
-        <translation></translation>
+        <translation>에어브레이크 해제</translation>
     </message>
     <message>
         <location filename="../wizarddata.cpp" line="79"/>
         <source>ArbkOn</source>
-        <translation></translation>
+        <translation>에어브레이크 작동</translation>
     </message>
     <message>
         <location filename="../wizarddata.cpp" line="121"/>
         <source>Cut</source>
-        <translation type="unfinished"></translation>
+        <translation>스로틀 컷</translation>
     </message>
     <message>
         <location filename="../wizarddata.cpp" line="129"/>
         <source>Flt</source>
-        <translation type="unfinished"></translation>
+        <translation>플라이트 모드</translation>
     </message>
     <message>
         <location filename="../wizarddata.cpp" line="137"/>
         <source>Thr</source>
-        <translation type="unfinished"></translation>
+        <translation>스로틀</translation>
     </message>
 </context>
 <context>
@@ -16900,247 +17093,247 @@ Process now?</source>
     <message>
         <location filename="../wizarddialog.cpp" line="32"/>
         <source>Model Wizard</source>
-        <translation></translation>
+        <translation>모델 설정 마법사</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="34"/>
         <source>Model Type</source>
-        <translation></translation>
+        <translation>모델 유형</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="34"/>
         <source>Enter model name and model type.</source>
-        <translation></translation>
+        <translation>모델 이름과 유형을 입력하세요.</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="35"/>
         <source>Throttle</source>
-        <translation></translation>
+        <translation>스로틀</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="35"/>
         <source>Has your model got a motor or an engine?</source>
-        <translation></translation>
+        <translation>모델에 모터나 엔진이 있습니까?</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="36"/>
         <source>Wing Type</source>
-        <translation></translation>
+        <translation>날개 유형</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="36"/>
         <source>Is your model a flying wing/deltawing or has it a standard wing configuration?</source>
-        <translation></translation>
+        <translation>모델이 플라잉 윙/델타윙인가요, 아니면 일반적인 날개 구조인가요?</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="37"/>
         <source>Ailerons</source>
-        <translation></translation>
+        <translation>에일러론</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="37"/>
         <source>Has your model got ailerons?</source>
-        <translation></translation>
+        <translation>모델에 에일러론이 있습니까?</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="38"/>
         <source>Flaps</source>
-        <translation></translation>
+        <translation>플랩</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="38"/>
         <source>Has your model got flaps?</source>
-        <translation></translation>
+        <translation>모델에 플랩이 있습니까?</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="39"/>
         <source>Airbrakes</source>
-        <translation></translation>
+        <translation>에어브레이크</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="39"/>
         <source>Has your model got airbrakes?</source>
-        <translation></translation>
+        <translation>모델에 에어브레이크가 있습니까?</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="40"/>
         <source>Flying-wing / Delta-wing</source>
-        <translation></translation>
+        <translation>플라잉 윙 / 델타 윙</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="40"/>
         <source>Select the elevons channels</source>
-        <translation></translation>
+        <translation>엘러본 채널을 선택하세요</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="41"/>
         <source>Rudder</source>
-        <translation></translation>
+        <translation>러더</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="41"/>
         <source>Does your model have a rudder?</source>
-        <translation></translation>
+        <translation>모델에 러더가 있습니까?</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="42"/>
         <source>Tail Type</source>
-        <translation></translation>
+        <translation>꼬리날개 유형</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="42"/>
         <source>Select which type of tail your model is equiped with.</source>
-        <translation></translation>
+        <translation>모델에 장착된 꼬리날개의 유형을 선택하세요.</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="43"/>
         <location filename="../wizarddialog.cpp" line="45"/>
         <source>Tail</source>
-        <translation></translation>
+        <translation>꼬리날개</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="43"/>
         <location filename="../wizarddialog.cpp" line="44"/>
         <source>Select channels for tail control.</source>
-        <translation></translation>
+        <translation>꼬리날개 제어를 위한 채널을 선택하세요.</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="44"/>
         <source>V-Tail</source>
-        <translation></translation>
+        <translation>V-테일</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="45"/>
         <source>Select elevator channel.</source>
-        <translation></translation>
+        <translation>엘리베이터 채널을 선택하세요.</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="46"/>
         <source>Cyclic</source>
-        <translation></translation>
+        <translation>사이클릭</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="46"/>
         <source>Which type of swash control is installed in your helicopter?</source>
-        <translation></translation>
+        <translation>헬리콥터에 어떤 스와시 컨트롤 방식이 설치되어 있습니까?</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="47"/>
         <source>Tail Gyro</source>
-        <translation></translation>
+        <translation>테일 자이로</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="47"/>
         <source>Has your helicopter got an adjustable gyro for the tail?</source>
-        <translation></translation>
+        <translation>헬리콥터에 조정 가능한 테일 자이로가 있습니까?</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="48"/>
         <source>Rotor Type</source>
-        <translation></translation>
+        <translation>로터 유형</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="48"/>
         <source>Has your helicopter got a flybar?</source>
-        <translation></translation>
+        <translation>헬리콥터에 플라이바가 있습니까?</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="49"/>
         <location filename="../wizarddialog.cpp" line="50"/>
         <source>Helicopter</source>
-        <translation></translation>
+        <translation>헬리콥터</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="49"/>
         <location filename="../wizarddialog.cpp" line="50"/>
         <source>Select the controls for your helicopter</source>
-        <translation></translation>
+        <translation>헬리콥터의 조종 채널을 선택하세요</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="51"/>
         <source>Multirotor</source>
-        <translation></translation>
+        <translation>멀티로터</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="51"/>
         <source>Select the control channels for your multirotor</source>
-        <translation></translation>
+        <translation>멀티로터의 조종 채널을 선택하세요</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="52"/>
         <source>Model Options</source>
-        <translation></translation>
+        <translation>모델 옵션</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="52"/>
         <source>Select additional options</source>
-        <translation></translation>
+        <translation>추가 옵션을 선택하세요</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="53"/>
         <source>Save Changes</source>
-        <translation></translation>
+        <translation>변경사항 저장</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="53"/>
         <source>Manually check the direction of each control surface and reverse any channels that make controls move in the wrong direction. Remove the propeller/propellers before you try to control your model for the first time.&lt;br&gt;Please note that continuing removes all old model settings!</source>
-        <translation></translation>
+        <translation>각 조종면의 방향을 수동으로 확인하고, 잘못된 방향으로 움직이는 채널은 반전 설정하세요. 처음 조종하기 전에는 반드시 프로펠러를 제거하십시오.&lt;br&gt;주의: 진행 시 기존 모델 설정이 모두 삭제됩니다!</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="76"/>
         <source>Enter a name for your model and select model type.</source>
-        <translation></translation>
+        <translation>모델 이름을 입력하고 유형을 선택하세요.</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="79"/>
         <source>Select the receiver channel that is connected to your ESC or throttle servo.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3</source>
-        <translation></translation>
+        <translation>ESC 또는 스로틀 서보에 연결된 수신기 채널을 선택하세요.&lt;br&gt;&lt;br&gt;스로틀 - Spektrum: CH1, Futaba: CH3</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="83"/>
         <source>Most aircraft have a main wing and a tail with control surfaces. Flying wings and delta winged aircraft only have a single wing. The main control surface on a standard wing controls the roll of the aircraft. This surface is called an aileron.&lt;br&gt;The control surface of a delta wing controls both roll and pitch. This surface is called an elevon. </source>
-        <translation></translation>
+        <translation>대부분의 항공기는 주익과 조종면이 있는 꼬리날개를 가지고 있습니다. 플라잉 윙이나 델타 윙은 하나의 날개만 있습니다. 표준 날개의 주 조종면은 롤을 조절하며, 이를 &apos;엘러론&apos;이라 부릅니다.&lt;br&gt;델타 윙의 조종면은 롤과 피치를 동시에 제어하며, 이를 &apos;엘러본&apos;이라 부릅니다.</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="88"/>
         <source>Models use one or two channels to control the ailerons.&lt;br&gt;A so called Y-cable can be used to connect a single receiver channel to two separate aileron servos. If your servos are connected by a Y-cable you should select the single-servo option.&lt;br&gt;&lt;br&gt;Aileron - Spektrum: CH2, Futaba: CH1</source>
-        <translation></translation>
+        <translation>모델은 하나 또는 두 개의 채널로 엘러론을 제어합니다.&lt;br&gt;Y-케이블을 사용하면 하나의 수신기 채널로 두 개의 엘러론 서보를 연결할 수 있습니다. Y-케이블을 사용하는 경우 단일 서보 옵션을 선택하세요.&lt;br&gt;&lt;br&gt;엘러론 - Spektrum: CH2, Futaba: CH1</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="94"/>
         <source>This wizard assumes that your flaps are controlled by a switch. If your flaps are controlled by a potentiometer you can change that manually later.</source>
-        <translation></translation>
+        <translation>이 마법사는 플랩이 스위치로 제어된다고 가정합니다. 가변저항(potentiometer)으로 제어되는 경우 나중에 수동으로 변경할 수 있습니다.</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="98"/>
         <source>Air brakes are used to reduce the speed of advanced sail planes.&lt;br&gt;They are very uncommon on other types of planes.</source>
-        <translation></translation>
+        <translation>에어브레이크는 고급 글라이더(활공기)의 속도를 줄이기 위해 사용됩니다.&lt;br&gt;다른 유형의 비행기에서는 드뭅니다.</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="102"/>
         <source>Models use two channels to control the elevons.&lt;br&gt;Select these two channels</source>
-        <translation></translation>
+        <translation>모델은 두 개의 채널로 엘러본을 제어합니다.&lt;br&gt;두 채널을 선택하세요</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="106"/>
         <source>Select the receiver channel that is connected to your rudder.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4</source>
-        <translation></translation>
+        <translation>러더에 연결된 수신기 채널을 선택하세요.&lt;br&gt;&lt;br&gt;러더 - Spektrum: CH4, Futaba: CH4</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="110"/>
         <source>Select the tail type of your plane.</source>
-        <translation></translation>
+        <translation>비행기의 꼬리날개 유형을 선택하세요.</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="113"/>
         <location filename="../wizarddialog.cpp" line="118"/>
         <source>Select the Rudder and Elevator channels.&lt;br&gt;&lt;br&gt;Rudder - Spektrum: CH4, Futaba: CH4&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
-        <translation></translation>
+        <translation>러더와 엘리베이터 채널을 선택하세요.&lt;br&gt;&lt;br&gt;러더 - Spektrum: CH4, Futaba: CH4&lt;br&gt;엘리베이터 - Spektrum: CH3, Futaba: CH2</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="123"/>
         <source>Select the Elevator channel.&lt;br&gt;&lt;br&gt;Elevator - Spektrum: CH3, Futaba: CH2</source>
-        <translation></translation>
+        <translation>엘리베이터 채널을 선택하세요.&lt;br&gt;&lt;br&gt;엘리베이터 - Spektrum: CH3, Futaba: CH2</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="127"/>
@@ -17151,22 +17344,22 @@ Process now?</source>
         <location filename="../wizarddialog.cpp" line="149"/>
         <location filename="../wizarddialog.cpp" line="152"/>
         <source>TBD.</source>
-        <translation></translation>
+        <translation>추후 결정됨</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="142"/>
         <source>Select the control channels for your multirotor.&lt;br&gt;&lt;br&gt;Throttle - Spektrum: CH1, Futaba: CH3&lt;br&gt;Yaw - Spektrum: CH4, Futaba: CH4&lt;br&gt;Pitch - Spektrum: CH3, Futaba: CH2&lt;br&gt;Roll - Spektrum: CH2, Futaba: CH1</source>
-        <translation></translation>
+        <translation>멀티로터의 제어 채널을 선택하세요.&lt;br&gt;&lt;br&gt;스로틀 - Spektrum: CH1, Futaba: CH3&lt;br&gt;요(Yaw) - Spektrum: CH4, Futaba: CH4&lt;br&gt;피치(Pitch) - Spektrum: CH3, Futaba: CH2&lt;br&gt;롤(Roll) - Spektrum: CH2, Futaba: CH1</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="155"/>
         <source>There is no help available for the current page.</source>
-        <translation></translation>
+        <translation>현재 페이지에 대한 도움말이 없습니다.</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="158"/>
         <source>Model Wizard Help</source>
-        <translation></translation>
+        <translation>모델 마법사 도움말</translation>
     </message>
 </context>
 <context>
@@ -17174,37 +17367,37 @@ Process now?</source>
     <message>
         <location filename="../wizarddialog.cpp" line="1029"/>
         <source>Plane</source>
-        <translation></translation>
+        <translation>비행기</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="1031"/>
         <source>Multicopter</source>
-        <translation></translation>
+        <translation>멀티콥터</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="1033"/>
         <source>Helicopter</source>
-        <translation></translation>
+        <translation>헬리콥터</translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="1055"/>
         <source>Model Name: </source>
-        <translation></translation>
+        <translation>모델 이름: </translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="1056"/>
         <source>Model Type: </source>
-        <translation></translation>
+        <translation>모델 유형: </translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="1058"/>
         <source>Options: </source>
-        <translation></translation>
+        <translation>옵션: </translation>
     </message>
     <message>
         <location filename="../wizarddialog.cpp" line="1070"/>
         <source>Channel %1: </source>
-        <translation></translation>
+        <translation>채널 %1: </translation>
     </message>
 </context>
 <context>
@@ -17213,44 +17406,46 @@ Process now?</source>
         <location filename="../storage/yaml.cpp" line="35"/>
         <source>Error opening file %1:
 %2.</source>
-        <translation></translation>
+        <translation>파일 %1을(를) 여는 중 오류 발생:
+%2.</translation>
     </message>
     <message>
         <location filename="../storage/yaml.cpp" line="49"/>
         <source>Error opening file %1 in write mode:
 %2.</source>
-        <translation></translation>
+        <translation>쓰기 모드로 파일 %1을(를) 여는 중 오류 발생:
+%2.</translation>
     </message>
     <message>
         <location filename="../storage/yaml.cpp" line="65"/>
         <source>Cannot read %1</source>
-        <translation></translation>
+        <translation>%1을(를) 읽을 수 없습니다</translation>
     </message>
     <message>
         <location filename="../storage/yaml.cpp" line="75"/>
         <source>File %1 is not a valid format</source>
-        <translation></translation>
+        <translation>파일 %1은(는) 유효한 형식이 아닙니다</translation>
     </message>
     <message>
         <location filename="../storage/yaml.cpp" line="93"/>
         <location filename="../storage/yaml.cpp" line="97"/>
         <source>Cannot load </source>
-        <translation></translation>
+        <translation>불러올 수 없습니다 </translation>
     </message>
     <message>
         <location filename="../storage/yaml.cpp" line="111"/>
         <source>Please check all radio and model settings as no conversion could be performed.</source>
-        <translation></translation>
+        <translation>변환을 수행할 수 없으므로 모든 송신기 및 모델 설정을 확인해 주세요.</translation>
     </message>
     <message>
         <location filename="../storage/yaml.cpp" line="115"/>
         <source>File %1 appears to contain radio settings and importing is unsupported.</source>
-        <translation></translation>
+        <translation>파일 %1은(는) 송신기 설정을 포함하는 것으로 보이며, 가져오기를 지원하지 않습니다.</translation>
     </message>
     <message>
         <location filename="../storage/yaml.cpp" line="118"/>
         <source>Unable to determine content type for file %1</source>
-        <translation></translation>
+        <translation>파일 %1의 콘텐츠 유형을 확인할 수 없습니다</translation>
     </message>
 </context>
 <context>
@@ -17260,12 +17455,13 @@ Process now?</source>
         <source>Warning: File version %1 is not supported by this version of Companion!
 
 Model and radio settings may be corrupted if you continue.</source>
-        <translation type="unfinished"></translation>
+        <translation>경고: 파일 버전 %1은 현재 Companion 버전에서 지원되지 않습니다!
+계속 진행할 경우 모델 및 송신기 설정이 손상될 수 있습니다.</translation>
     </message>
     <message>
         <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="376"/>
         <source>Read Radio Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>송신기 설정 읽기</translation>
     </message>
     <message>
         <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="413"/>
@@ -17274,14 +17470,17 @@ Model and radio settings may be corrupted if you continue.</source>
 Current firmware profile board will be used.
 
 Do you wish to continue?</source>
-        <translation></translation>
+        <translation>경고: 송신기 설정 파일에 보드 항목이 없습니다!
+현재 펌웨어 프로파일의 보드가 사용됩니다.
+계속하시겠습니까?</translation>
     </message>
     <message>
         <location filename="../firmwares/edgetx/yaml_generalsettings.cpp" line="424"/>
         <source>Settings file board (%1) does not match current profile board (%2).
 
 Do you wish to continue?</source>
-        <translation></translation>
+        <translation>설정 파일의 보드(%1)가 현재 프로파일의 보드(%2)와 일치하지 않습니다.
+계속하시겠습니까?</translation>
     </message>
 </context>
 <context>
@@ -17291,12 +17490,13 @@ Do you wish to continue?</source>
         <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
 
 Model settings may be corrupted if you continue.</source>
-        <translation type="unfinished"></translation>
+        <translation>경고: &apos;%1&apos;의 설정 버전 %2은(는) 현재 Companion 버전에서 지원되지 않습니다!
+계속 진행할 경우 모델 설정이 손상될 수 있습니다.</translation>
     </message>
     <message>
         <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1291"/>
         <source>Read Model Settings</source>
-        <translation type="unfinished"></translation>
+        <translation>모델 설정 읽기</translation>
     </message>
 </context>
 <context>
@@ -17304,42 +17504,42 @@ Model settings may be corrupted if you continue.</source>
     <message>
         <location filename="../burnconfigdialog.ui" line="26"/>
         <source>Programmer Configuration</source>
-        <translation></translation>
+        <translation>프로그래머 설정</translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="76"/>
         <location filename="../burnconfigdialog.ui" line="106"/>
         <source>Location of sam-ba executable</source>
-        <translation></translation>
+        <translation>sam-ba 실행 파일 위치</translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="79"/>
         <location filename="../burnconfigdialog.ui" line="109"/>
         <location filename="../burnconfigdialog.ui" line="142"/>
         <source>The location of the AVRDUDE executable.</source>
-        <translation></translation>
+        <translation>AVRDUDE 실행 파일의 위치입니다.</translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="89"/>
         <source>DFU-Util Location</source>
-        <translation></translation>
+        <translation>DFU-Util 위치</translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="175"/>
         <location filename="../burnconfigdialog.ui" line="185"/>
         <source>Use this button to browse and look for the AVRDUDE executable file.</source>
-        <translation></translation>
+        <translation>이 버튼을 눌러 AVRDUDE 실행 파일을 찾아보세요.</translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="178"/>
         <location filename="../burnconfigdialog.ui" line="188"/>
         <source>Browse...</source>
-        <translation></translation>
+        <translation>찾아보기...</translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="159"/>
         <source>Extra arguments that will be passed to AVRDUDE on every call</source>
-        <translation></translation>
+        <translation>AVRDUDE 실행 시 추가로 전달될 인자</translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="162"/>
@@ -17347,24 +17547,27 @@ Model settings may be corrupted if you continue.</source>
 This can be used for providing extra information to AVRDUDE.
 
 Please only use this if you know what you are doing.  There are no error checks and you could cripple your controller.</source>
-        <translation></translation>
+        <translation>AVRDUDE에 전달될 추가 인자입니다.
+AVRDUDE에 추가 정보를 제공할 때 사용할 수 있습니다.
+이 기능은 숙련된 사용자만 사용하는 것이 좋습니다. 오류 검사가 없으며 컨트롤러가 손상될 수 있습니다.</translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="129"/>
         <source>Port</source>
-        <translation></translation>
+        <translation>포트</translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="51"/>
         <source>CPU of your TX</source>
-        <translation></translation>
+        <translation>송신기의 CPU</translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="54"/>
         <source>CPU present on your 9x radio
 Should be m64 for stock radios
 m2560 for v4.1 boards</source>
-        <translation></translation>
+        <translation>9x 송신기에 장착된 CPU입니다.
+기본 송신기는 m64, v4.1 보드는 m2560을 사용합니다.</translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="68"/>
@@ -17374,7 +17577,7 @@ m2560 for v4.1 boards</source>
     <message>
         <location filename="../burnconfigdialog.ui" line="96"/>
         <source>SAM-BA Location</source>
-        <translation></translation>
+        <translation>SAM-BA 경로</translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="119"/>
@@ -17384,33 +17587,33 @@ m2560 for v4.1 boards</source>
     <message>
         <location filename="../burnconfigdialog.ui" line="139"/>
         <source>sam-ba serial port</source>
-        <translation></translation>
+        <translation>sam-ba 시리얼 포트</translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="152"/>
         <source>Alternate device</source>
-        <translation></translation>
+        <translation>대체 장치</translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.ui" line="202"/>
         <source>Use advanced controls</source>
-        <translation></translation>
+        <translation>고급 제어 사용</translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.cpp" line="44"/>
         <source>DFU-UTIL Configuration</source>
-        <translation></translation>
+        <translation>DFU-UTIL 설정</translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.cpp" line="52"/>
         <source>SAM-BA Configuration</source>
-        <translation></translation>
+        <translation>SAM-BA 설정</translation>
     </message>
     <message>
         <location filename="../burnconfigdialog.cpp" line="138"/>
         <location filename="../burnconfigdialog.cpp" line="148"/>
         <source>Select Location</source>
-        <translation></translation>
+        <translation>경로 선택</translation>
     </message>
 </context>
 <context>
@@ -17418,99 +17621,105 @@ m2560 for v4.1 boards</source>
     <message>
         <location filename="../simulation/joystickdialog.ui" line="20"/>
         <source>Configure Joystick</source>
-        <translation></translation>
+        <translation>조이스틱 설정</translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.ui" line="65"/>
         <source>Instructions</source>
-        <translation></translation>
+        <translation>사용 안내</translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.ui" line="103"/>
         <source>Enable</source>
-        <translation></translation>
+        <translation>사용</translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.ui" line="120"/>
         <source>Cancel</source>
-        <translation></translation>
+        <translation>취소</translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.ui" line="149"/>
         <source>Back</source>
-        <translation></translation>
+        <translation>뒤로</translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.ui" line="165"/>
         <source>Start</source>
-        <translation></translation>
+        <translation>시작</translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.ui" line="178"/>
         <source>Ok</source>
-        <translation></translation>
+        <translation>확인</translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.cpp" line="158"/>
         <location filename="../simulation/joystickdialog.cpp" line="184"/>
         <source>Not Assigned</source>
-        <translation></translation>
+        <translation>할당되지 않음</translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.cpp" line="218"/>
         <source>No joysticks found</source>
-        <translation></translation>
+        <translation>조이스틱이 발견되지 않았습니다</translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.cpp" line="256"/>
         <source>Cannot open joystick.</source>
-        <translation></translation>
+        <translation>조이스틱을 열 수 없습니다.</translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.cpp" line="301"/>
         <source>Press the Start button to start the stick range calibration procedure.
 You may change the channel assignments or inversion at any time.</source>
-        <translation></translation>
+        <translation>스틱 범위 보정을 시작하려면 시작 버튼을 누르세요.
+채널 할당이나 반전은 언제든지 변경할 수 있습니다.</translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.cpp" line="311"/>
         <source>Move sticks and pots in every direction making full movement
 Press Next when finished</source>
-        <translation></translation>
+        <translation>스틱과 포트를 모든 방향으로 끝까지 움직이세요.
+완료되면 ‘다음’을 누르세요.</translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.cpp" line="312"/>
         <source>Next</source>
-        <translation></translation>
+        <translation>다음</translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.cpp" line="316"/>
         <source>Place sticks and pots in middle position.
 Press Next when done</source>
-        <translation></translation>
+        <translation>스틱과 포트를 중앙 위치에 놓으세요.
+완료되면 ‘다음’을 누르세요.</translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.cpp" line="328"/>
         <source>Map joystick channels to controls using comboboxes.
 Press Next when done.</source>
-        <translation></translation>
+        <translation>콤보박스를 사용하여 조이스틱 채널을 제어기에 매핑하세요.
+완료되면 ‘다음’을 누르세요.</translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.cpp" line="332"/>
         <source>Check inversion checkbox to if necessary to reverse direction.
 Press Next when done.</source>
-        <translation></translation>
+        <translation>방향을 반대로 설정해야 할 경우 반전 체크박스를 선택하세요.
+완료되면 ‘다음’을 누르세요.</translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.cpp" line="336"/>
         <source>Press OK to save configuration
 Press Cancel to abort joystick calibration without saving.</source>
-        <translation></translation>
+        <translation>‘확인’을 눌러 설정을 저장하세요.
+‘취소’를 누르면 저장하지 않고 조이스틱 보정을 종료합니다.</translation>
     </message>
     <message>
         <location filename="../simulation/joystickdialog.cpp" line="377"/>
         <source>Calibration not complete, save anyway?</source>
-        <translation></translation>
+        <translation>보정이 완료되지 않았습니다. 그래도 저장하시겠습니까?</translation>
     </message>
 </context>
 </TS>

--- a/companion/src/translations/companion_nl.ts
+++ b/companion/src/translations/companion_nl.ts
@@ -1002,274 +1002,274 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="422"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>Left Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="423"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>Left Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="424"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>Right Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="425"/>
+        <location filename="../firmwares/boards.cpp" line="429"/>
         <source>Right Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="426"/>
+        <location filename="../firmwares/boards.cpp" line="430"/>
         <source>Aux. 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="427"/>
+        <location filename="../firmwares/boards.cpp" line="431"/>
         <source>Aux. 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="443"/>
+        <location filename="../firmwares/boards.cpp" line="447"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="444"/>
+        <location filename="../firmwares/boards.cpp" line="448"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="449"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
         <source>RH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="459"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <source>TILT_X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="460"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <source>TILT_Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="506"/>
+        <location filename="../firmwares/boards.cpp" line="516"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
+        <location filename="../firmwares/boards.cpp" line="532"/>
+        <location filename="../firmwares/boards.cpp" line="548"/>
+        <location filename="../firmwares/boards.cpp" line="555"/>
+        <source>SL1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="475"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <source>P4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="517"/>
+        <location filename="../firmwares/boards.cpp" line="525"/>
+        <location filename="../firmwares/boards.cpp" line="533"/>
+        <location filename="../firmwares/boards.cpp" line="549"/>
+        <location filename="../firmwares/boards.cpp" line="556"/>
+        <source>SL2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="478"/>
+        <location filename="../firmwares/boards.cpp" line="557"/>
+        <source>SL3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="479"/>
+        <location filename="../firmwares/boards.cpp" line="558"/>
+        <source>SL4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <source>P5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="943"/>
+        <source>Slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="945"/>
+        <source>Multipos Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="947"/>
+        <source>Axis X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="949"/>
+        <source>Axis Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="951"/>
+        <source>Switch</source>
+        <translation type="unfinished">Switch</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Flight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="488"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="498"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
+        <location filename="../firmwares/boards.cpp" line="529"/>
+        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="553"/>
+        <source>P1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="473"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="504"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
+        <location filename="../firmwares/boards.cpp" line="530"/>
+        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="554"/>
+        <source>P2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="474"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="505"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
+        <location filename="../firmwares/boards.cpp" line="531"/>
+        <location filename="../firmwares/boards.cpp" line="543"/>
+        <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="455"/>
         <location filename="../firmwares/boards.cpp" line="457"/>
-        <source>TILT_X</source>
+        <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="456"/>
         <location filename="../firmwares/boards.cpp" line="458"/>
-        <source>TILT_Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="463"/>
-        <location filename="../firmwares/boards.cpp" line="472"/>
-        <location filename="../firmwares/boards.cpp" line="502"/>
-        <location filename="../firmwares/boards.cpp" line="512"/>
-        <location filename="../firmwares/boards.cpp" line="520"/>
-        <location filename="../firmwares/boards.cpp" line="528"/>
-        <location filename="../firmwares/boards.cpp" line="544"/>
-        <location filename="../firmwares/boards.cpp" line="551"/>
-        <source>SL1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="471"/>
-        <location filename="../firmwares/boards.cpp" line="510"/>
-        <source>P4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="473"/>
-        <location filename="../firmwares/boards.cpp" line="503"/>
-        <location filename="../firmwares/boards.cpp" line="513"/>
-        <location filename="../firmwares/boards.cpp" line="521"/>
-        <location filename="../firmwares/boards.cpp" line="529"/>
-        <location filename="../firmwares/boards.cpp" line="545"/>
-        <location filename="../firmwares/boards.cpp" line="552"/>
-        <source>SL2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="474"/>
-        <location filename="../firmwares/boards.cpp" line="553"/>
-        <source>SL3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="475"/>
-        <location filename="../firmwares/boards.cpp" line="554"/>
-        <source>SL4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="511"/>
-        <source>P5</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="933"/>
-        <source>Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="935"/>
-        <source>Multipos Switch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="937"/>
-        <source>Axis X</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="939"/>
-        <source>Axis Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="941"/>
-        <source>Switch</source>
-        <translation type="unfinished">Switch</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Flight</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Drive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="464"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
-        <location filename="../firmwares/boards.cpp" line="479"/>
-        <location filename="../firmwares/boards.cpp" line="484"/>
-        <location filename="../firmwares/boards.cpp" line="490"/>
-        <location filename="../firmwares/boards.cpp" line="494"/>
-        <location filename="../firmwares/boards.cpp" line="499"/>
-        <location filename="../firmwares/boards.cpp" line="507"/>
-        <location filename="../firmwares/boards.cpp" line="517"/>
-        <location filename="../firmwares/boards.cpp" line="525"/>
-        <location filename="../firmwares/boards.cpp" line="537"/>
-        <location filename="../firmwares/boards.cpp" line="549"/>
-        <source>P1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="469"/>
-        <location filename="../firmwares/boards.cpp" line="480"/>
-        <location filename="../firmwares/boards.cpp" line="485"/>
-        <location filename="../firmwares/boards.cpp" line="495"/>
-        <location filename="../firmwares/boards.cpp" line="500"/>
-        <location filename="../firmwares/boards.cpp" line="508"/>
-        <location filename="../firmwares/boards.cpp" line="518"/>
-        <location filename="../firmwares/boards.cpp" line="526"/>
-        <location filename="../firmwares/boards.cpp" line="538"/>
-        <location filename="../firmwares/boards.cpp" line="550"/>
-        <source>P2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="470"/>
-        <location filename="../firmwares/boards.cpp" line="486"/>
-        <location filename="../firmwares/boards.cpp" line="501"/>
-        <location filename="../firmwares/boards.cpp" line="509"/>
-        <location filename="../firmwares/boards.cpp" line="519"/>
-        <location filename="../firmwares/boards.cpp" line="527"/>
-        <location filename="../firmwares/boards.cpp" line="539"/>
-        <source>P3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
-        <source>JSx</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="454"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="530"/>
-        <location filename="../firmwares/boards.cpp" line="540"/>
+        <location filename="../firmwares/boards.cpp" line="534"/>
+        <location filename="../firmwares/boards.cpp" line="544"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="531"/>
-        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="535"/>
+        <location filename="../firmwares/boards.cpp" line="545"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="532"/>
-        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="536"/>
+        <location filename="../firmwares/boards.cpp" line="546"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="533"/>
-        <location filename="../firmwares/boards.cpp" line="543"/>
+        <location filename="../firmwares/boards.cpp" line="537"/>
+        <location filename="../firmwares/boards.cpp" line="547"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="678"/>
-        <location filename="../firmwares/boards.cpp" line="897"/>
-        <location filename="../firmwares/boards.cpp" line="927"/>
+        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="907"/>
+        <location filename="../firmwares/boards.cpp" line="937"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="929"/>
+        <location filename="../firmwares/boards.cpp" line="939"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="931"/>
+        <location filename="../firmwares/boards.cpp" line="941"/>
         <source>Pot with detent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="680"/>
+        <location filename="../firmwares/boards.cpp" line="686"/>
         <source>2 Positions Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="682"/>
+        <location filename="../firmwares/boards.cpp" line="688"/>
         <source>2 Positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="690"/>
         <source>3 Positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="686"/>
+        <location filename="../firmwares/boards.cpp" line="692"/>
         <source>Function</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="899"/>
+        <location filename="../firmwares/boards.cpp" line="909"/>
         <source>Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="901"/>
+        <location filename="../firmwares/boards.cpp" line="911"/>
         <source>Small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="903"/>
+        <location filename="../firmwares/boards.cpp" line="913"/>
         <source>Both</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1682,34 +1682,50 @@ Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="380"/>
+        <location filename="../helpers.cpp" line="388"/>
+        <source>Uknown error during Simulator startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Data Load Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Error occurred while starting simulator.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="405"/>
         <source>Error creating temporary directory for models and settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="388"/>
+        <location filename="../helpers.cpp" line="413"/>
         <source>Error writing models and settings to temporary directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="419"/>
+        <location filename="../helpers.cpp" line="444"/>
         <source>Unable to start.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="421"/>
+        <location filename="../helpers.cpp" line="446"/>
         <source>Crashed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="423"/>
+        <location filename="../helpers.cpp" line="448"/>
         <source>Exited with result code:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="381"/>
         <location filename="../helpers.cpp" line="389"/>
-        <location filename="../helpers.cpp" line="426"/>
+        <location filename="../helpers.cpp" line="406"/>
+        <location filename="../helpers.cpp" line="414"/>
+        <location filename="../helpers.cpp" line="451"/>
         <source>Simulator Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3514,59 +3530,59 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="448"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="612"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="622"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="632"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="642"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="652"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="662"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="672"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="742"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="761"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="772"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="782"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="807"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="619"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="629"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="639"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="649"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="659"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="669"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="679"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="739"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="749"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="768"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="779"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="789"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="814"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="449"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="613"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="623"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="633"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="643"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="653"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="663"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="673"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="733"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="743"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="752"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="762"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="773"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="783"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="680"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="769"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="815"/>
         <source>Disable Global variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="450"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="474"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="614"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="624"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="634"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="644"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="654"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="664"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="674"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="734"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="744"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="753"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="763"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="784"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="809"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="621"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="631"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="641"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="651"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="661"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="671"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="741"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="751"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="760"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="781"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="791"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="816"/>
         <source>Enable Lua custom scripts screen</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3586,125 +3602,125 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
         <source>FrSky Taranis X9D+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="590"/>
         <source>Disable RAS (SWR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="574"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="581"/>
         <source>FrSky Taranis X9D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="576"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
         <source>Haptic module installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="595"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="602"/>
         <source>FrSky Taranis X9E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
         <source>Confirmation before radio shutdown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="597"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="604"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="562"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="569"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="568"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="537"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="544"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="543"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="550"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="563"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="549"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
         <source>FrSky Taranis X-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="518"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="525"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="538"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="530"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="529"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="536"/>
         <source>FrSky Horus X12S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="539"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="677"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="675"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="703"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="682"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="710"/>
         <source>Support for MULTI internal module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="627"/>
         <source>Jumper T-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="637"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="701"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="708"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3714,26 +3730,26 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="777"/>
         <source>Radiomaster TX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="787"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="805"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="812"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="683"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="690"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="718"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="697"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="725"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="810"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="817"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3743,82 +3759,87 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <source>FlySky ST16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
         <source>HelloRadioSky V16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="647"/>
         <source>Jumper T-Pro V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="657"/>
         <source>Jumper T-Pro S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="667"/>
         <source>Jumper Bumblebee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
         <source>Jumper T12 MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
         <source>Jumper T14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="702"/>
         <source>Jumper T15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
         <source>Jumper T20 V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="737"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="747"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="757"/>
         <source>Radiomaster MT12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="766"/>
         <source>Radiomaster T8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="767"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
         <source>Allow bind using bind key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
         <source>Radiomaster GX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="804"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3829,12 +3850,12 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="484"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="801"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="709"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
         <source>Jumper T18</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3849,7 +3870,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="617"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4823,206 +4844,206 @@ These will be relevant for all models in the same EEPROM.</source>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="412"/>
+        <location filename="../firmwares/generalsettings.cpp" line="414"/>
         <source>Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="414"/>
+        <location filename="../firmwares/generalsettings.cpp" line="416"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="415"/>
+        <location filename="../firmwares/generalsettings.cpp" line="417"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="430"/>
+        <location filename="../firmwares/generalsettings.cpp" line="432"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="464"/>
+        <location filename="../firmwares/generalsettings.cpp" line="466"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="469"/>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="471"/>
+        <location filename="../firmwares/generalsettings.cpp" line="483"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Switch</source>
         <translation type="unfinished">Switch</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="499"/>
+        <location filename="../firmwares/generalsettings.cpp" line="501"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="553"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="555"/>
+        <location filename="../firmwares/generalsettings.cpp" line="557"/>
         <source>Ask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="557"/>
+        <location filename="../firmwares/generalsettings.cpp" line="559"/>
         <source>Per model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>Internal + External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="573"/>
-        <location filename="../firmwares/generalsettings.cpp" line="589"/>
+        <location filename="../firmwares/generalsettings.cpp" line="575"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="578"/>
+        <location filename="../firmwares/generalsettings.cpp" line="580"/>
         <source>Trainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="591"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="593"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="595"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="597"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="599"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="601"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="603"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="605"/>
+        <location filename="../firmwares/generalsettings.cpp" line="607"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="607"/>
+        <location filename="../firmwares/generalsettings.cpp" line="609"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="640"/>
+        <location filename="../firmwares/generalsettings.cpp" line="642"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="739"/>
+        <location filename="../firmwares/generalsettings.cpp" line="741"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="741"/>
+        <location filename="../firmwares/generalsettings.cpp" line="743"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="787"/>
+        <location filename="../firmwares/generalsettings.cpp" line="789"/>
         <source>Trims only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="789"/>
+        <location filename="../firmwares/generalsettings.cpp" line="791"/>
         <source>Keys only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="791"/>
+        <location filename="../firmwares/generalsettings.cpp" line="793"/>
         <source>Switchable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="793"/>
+        <location filename="../firmwares/generalsettings.cpp" line="795"/>
         <source>Global</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="927"/>
+        <location filename="../firmwares/generalsettings.cpp" line="929"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="931"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="933"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="935"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5918,32 +5939,32 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="434"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Slovak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="435"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Polish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="432"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Portuguese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="433"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Russian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="436"/>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Swedish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5978,69 +5999,74 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="437"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <source>Korean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="438"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>RotEnc A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="617"/>
+        <location filename="../generaledit/generalsetup.cpp" line="618"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15574,22 +15600,22 @@ Timestamp</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="873"/>
+        <location filename="../firmwares/generalsettings.cpp" line="875"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="875"/>
+        <location filename="../firmwares/generalsettings.cpp" line="877"/>
         <source>+= (Sum)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="877"/>
+        <location filename="../firmwares/generalsettings.cpp" line="879"/>
         <source>:= (Replace)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="886"/>
+        <location filename="../firmwares/generalsettings.cpp" line="888"/>
         <source>CH%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17287,14 +17313,14 @@ Do you wish to continue?</source>
 <context>
     <name>YamlModelSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1288"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1287"/>
         <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
 
 Model settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1291"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1290"/>
         <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/companion/src/translations/companion_pl.ts
+++ b/companion/src/translations/companion_pl.ts
@@ -1004,274 +1004,274 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="422"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>Left Horizontal</source>
         <translation type="unfinished">Lewy poziomy</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="423"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>Left Vertical</source>
         <translation type="unfinished">Lewy pionowy</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="424"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>Right Vertical</source>
         <translation type="unfinished">Prawy pionowy</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="425"/>
+        <location filename="../firmwares/boards.cpp" line="429"/>
         <source>Right Horizontal</source>
         <translation type="unfinished">Prawy poziomy</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="426"/>
+        <location filename="../firmwares/boards.cpp" line="430"/>
         <source>Aux. 1</source>
         <translation type="unfinished">Dodatk. 1</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="427"/>
+        <location filename="../firmwares/boards.cpp" line="431"/>
         <source>Aux. 2</source>
         <translation type="unfinished">Dodatk. 2</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="443"/>
+        <location filename="../firmwares/boards.cpp" line="447"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="444"/>
+        <location filename="../firmwares/boards.cpp" line="448"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="449"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
         <source>RH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="459"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <source>TILT_X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="460"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <source>TILT_Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="506"/>
+        <location filename="../firmwares/boards.cpp" line="516"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
+        <location filename="../firmwares/boards.cpp" line="532"/>
+        <location filename="../firmwares/boards.cpp" line="548"/>
+        <location filename="../firmwares/boards.cpp" line="555"/>
+        <source>SL1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="475"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <source>P4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="517"/>
+        <location filename="../firmwares/boards.cpp" line="525"/>
+        <location filename="../firmwares/boards.cpp" line="533"/>
+        <location filename="../firmwares/boards.cpp" line="549"/>
+        <location filename="../firmwares/boards.cpp" line="556"/>
+        <source>SL2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="478"/>
+        <location filename="../firmwares/boards.cpp" line="557"/>
+        <source>SL3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="479"/>
+        <location filename="../firmwares/boards.cpp" line="558"/>
+        <source>SL4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <source>P5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="943"/>
+        <source>Slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="945"/>
+        <source>Multipos Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="947"/>
+        <source>Axis X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="949"/>
+        <source>Axis Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="951"/>
+        <source>Switch</source>
+        <translation type="unfinished">Przełącznik</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Flight</source>
+        <translation type="unfinished">Lot</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="488"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="498"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
+        <location filename="../firmwares/boards.cpp" line="529"/>
+        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="553"/>
+        <source>P1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="473"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="504"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
+        <location filename="../firmwares/boards.cpp" line="530"/>
+        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="554"/>
+        <source>P2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="474"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="505"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
+        <location filename="../firmwares/boards.cpp" line="531"/>
+        <location filename="../firmwares/boards.cpp" line="543"/>
+        <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="455"/>
         <location filename="../firmwares/boards.cpp" line="457"/>
-        <source>TILT_X</source>
+        <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="456"/>
         <location filename="../firmwares/boards.cpp" line="458"/>
-        <source>TILT_Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="463"/>
-        <location filename="../firmwares/boards.cpp" line="472"/>
-        <location filename="../firmwares/boards.cpp" line="502"/>
-        <location filename="../firmwares/boards.cpp" line="512"/>
-        <location filename="../firmwares/boards.cpp" line="520"/>
-        <location filename="../firmwares/boards.cpp" line="528"/>
-        <location filename="../firmwares/boards.cpp" line="544"/>
-        <location filename="../firmwares/boards.cpp" line="551"/>
-        <source>SL1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="471"/>
-        <location filename="../firmwares/boards.cpp" line="510"/>
-        <source>P4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="473"/>
-        <location filename="../firmwares/boards.cpp" line="503"/>
-        <location filename="../firmwares/boards.cpp" line="513"/>
-        <location filename="../firmwares/boards.cpp" line="521"/>
-        <location filename="../firmwares/boards.cpp" line="529"/>
-        <location filename="../firmwares/boards.cpp" line="545"/>
-        <location filename="../firmwares/boards.cpp" line="552"/>
-        <source>SL2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="474"/>
-        <location filename="../firmwares/boards.cpp" line="553"/>
-        <source>SL3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="475"/>
-        <location filename="../firmwares/boards.cpp" line="554"/>
-        <source>SL4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="511"/>
-        <source>P5</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="933"/>
-        <source>Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="935"/>
-        <source>Multipos Switch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="937"/>
-        <source>Axis X</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="939"/>
-        <source>Axis Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="941"/>
-        <source>Switch</source>
-        <translation type="unfinished">Przełącznik</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Flight</source>
-        <translation type="unfinished">Lot</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Drive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="464"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
-        <location filename="../firmwares/boards.cpp" line="479"/>
-        <location filename="../firmwares/boards.cpp" line="484"/>
-        <location filename="../firmwares/boards.cpp" line="490"/>
-        <location filename="../firmwares/boards.cpp" line="494"/>
-        <location filename="../firmwares/boards.cpp" line="499"/>
-        <location filename="../firmwares/boards.cpp" line="507"/>
-        <location filename="../firmwares/boards.cpp" line="517"/>
-        <location filename="../firmwares/boards.cpp" line="525"/>
-        <location filename="../firmwares/boards.cpp" line="537"/>
-        <location filename="../firmwares/boards.cpp" line="549"/>
-        <source>P1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="469"/>
-        <location filename="../firmwares/boards.cpp" line="480"/>
-        <location filename="../firmwares/boards.cpp" line="485"/>
-        <location filename="../firmwares/boards.cpp" line="495"/>
-        <location filename="../firmwares/boards.cpp" line="500"/>
-        <location filename="../firmwares/boards.cpp" line="508"/>
-        <location filename="../firmwares/boards.cpp" line="518"/>
-        <location filename="../firmwares/boards.cpp" line="526"/>
-        <location filename="../firmwares/boards.cpp" line="538"/>
-        <location filename="../firmwares/boards.cpp" line="550"/>
-        <source>P2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="470"/>
-        <location filename="../firmwares/boards.cpp" line="486"/>
-        <location filename="../firmwares/boards.cpp" line="501"/>
-        <location filename="../firmwares/boards.cpp" line="509"/>
-        <location filename="../firmwares/boards.cpp" line="519"/>
-        <location filename="../firmwares/boards.cpp" line="527"/>
-        <location filename="../firmwares/boards.cpp" line="539"/>
-        <source>P3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
-        <source>JSx</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="454"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="530"/>
-        <location filename="../firmwares/boards.cpp" line="540"/>
+        <location filename="../firmwares/boards.cpp" line="534"/>
+        <location filename="../firmwares/boards.cpp" line="544"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="531"/>
-        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="535"/>
+        <location filename="../firmwares/boards.cpp" line="545"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="532"/>
-        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="536"/>
+        <location filename="../firmwares/boards.cpp" line="546"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="533"/>
-        <location filename="../firmwares/boards.cpp" line="543"/>
+        <location filename="../firmwares/boards.cpp" line="537"/>
+        <location filename="../firmwares/boards.cpp" line="547"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="678"/>
-        <location filename="../firmwares/boards.cpp" line="897"/>
-        <location filename="../firmwares/boards.cpp" line="927"/>
+        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="907"/>
+        <location filename="../firmwares/boards.cpp" line="937"/>
         <source>None</source>
         <translation type="unfinished">Żadne</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="929"/>
+        <location filename="../firmwares/boards.cpp" line="939"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="931"/>
+        <location filename="../firmwares/boards.cpp" line="941"/>
         <source>Pot with detent</source>
         <translation type="unfinished">Potencj. z zapadką</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="680"/>
+        <location filename="../firmwares/boards.cpp" line="686"/>
         <source>2 Positions Toggle</source>
         <translation type="unfinished">2 Poz. Przełącznik chwilowy</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="682"/>
+        <location filename="../firmwares/boards.cpp" line="688"/>
         <source>2 Positions</source>
         <translation type="unfinished">2 Pozycje</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="690"/>
         <source>3 Positions</source>
         <translation type="unfinished">3 Pozycje</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="686"/>
+        <location filename="../firmwares/boards.cpp" line="692"/>
         <source>Function</source>
         <translation type="unfinished">Funkcja</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="899"/>
+        <location filename="../firmwares/boards.cpp" line="909"/>
         <source>Standard</source>
         <translation type="unfinished">Standard</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="901"/>
+        <location filename="../firmwares/boards.cpp" line="911"/>
         <source>Small</source>
         <translation type="unfinished">Małe</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="903"/>
+        <location filename="../firmwares/boards.cpp" line="913"/>
         <source>Both</source>
         <translation type="unfinished">Obie</translation>
     </message>
@@ -1610,34 +1610,50 @@ Error description: %4</source>
         <translation type="unfinished">Nie jest dostępny symulator dla tego firmware</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="380"/>
+        <location filename="../helpers.cpp" line="388"/>
+        <source>Uknown error during Simulator startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Data Load Error</source>
+        <translation type="unfinished">Błąd odczytu danych</translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Error occurred while starting simulator.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="405"/>
         <source>Error creating temporary directory for models and settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="388"/>
+        <location filename="../helpers.cpp" line="413"/>
         <source>Error writing models and settings to temporary directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="419"/>
+        <location filename="../helpers.cpp" line="444"/>
         <source>Unable to start.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="421"/>
+        <location filename="../helpers.cpp" line="446"/>
         <source>Crashed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="423"/>
+        <location filename="../helpers.cpp" line="448"/>
         <source>Exited with result code:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="381"/>
         <location filename="../helpers.cpp" line="389"/>
-        <location filename="../helpers.cpp" line="426"/>
+        <location filename="../helpers.cpp" line="406"/>
+        <location filename="../helpers.cpp" line="414"/>
+        <location filename="../helpers.cpp" line="451"/>
         <source>Simulator Error</source>
         <translation type="unfinished">Błąd Symulatora</translation>
     </message>
@@ -3501,59 +3517,59 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="448"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="612"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="622"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="632"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="642"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="652"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="662"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="672"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="742"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="761"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="772"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="782"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="807"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="619"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="629"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="639"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="649"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="659"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="669"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="679"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="739"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="749"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="768"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="779"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="789"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="814"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation type="unfinished">Dezaktywowane menu Heli i wsparcie dla cyklicznych mikserów</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="449"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="613"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="623"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="633"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="643"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="653"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="663"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="673"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="733"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="743"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="752"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="762"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="773"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="783"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="680"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="769"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="815"/>
         <source>Disable Global variables</source>
         <translation type="unfinished">dezaktywowane zmienne globalne</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="450"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="474"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="614"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="624"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="634"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="644"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="654"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="664"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="674"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="734"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="744"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="753"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="763"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="784"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="809"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="621"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="631"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="641"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="651"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="661"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="671"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="741"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="751"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="760"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="781"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="791"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="816"/>
         <source>Enable Lua custom scripts screen</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3563,7 +3579,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished">Użyj alternatywnego fontu SQT5</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
         <source>FrSky Taranis X9D+</source>
         <translation type="unfinished">FrSky Taranis X9D+</translation>
     </message>
@@ -3578,104 +3594,104 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="590"/>
         <source>Disable RAS (SWR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="574"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="581"/>
         <source>FrSky Taranis X9D</source>
         <translation type="unfinished">FrSky Taranis X9D</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="576"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
         <source>Haptic module installed</source>
         <translation type="unfinished">Moduł wibracji zainstalowany</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="595"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="602"/>
         <source>FrSky Taranis X9E</source>
         <translation type="unfinished">FrSky Taranis X9E</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
         <source>Confirmation before radio shutdown</source>
         <translation type="unfinished">Potwierdzenie przez wyłączeniem radia</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="597"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="604"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation type="unfinished">Zainstalowane gimbale Horusa (na czujnikach Halla)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="562"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="569"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="537"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="544"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="563"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="549"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
         <source>FrSky Taranis X-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="530"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="529"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="536"/>
         <source>FrSky Horus X12S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="539"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation type="unfinished">Użyć tylko dla pierwszych deweloperskich platform</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="677"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="675"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="703"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="682"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="710"/>
         <source>Support for MULTI internal module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="627"/>
         <source>Jumper T-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="637"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="701"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="708"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3685,26 +3701,26 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="777"/>
         <source>Radiomaster TX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="787"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="805"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="812"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="683"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="690"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="718"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="697"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="725"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="810"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="817"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3714,82 +3730,87 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <source>FlySky ST16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
         <source>HelloRadioSky V16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="647"/>
         <source>Jumper T-Pro V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="657"/>
         <source>Jumper T-Pro S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="667"/>
         <source>Jumper Bumblebee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
         <source>Jumper T12 MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
         <source>Jumper T14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="702"/>
         <source>Jumper T15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
         <source>Jumper T20 V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="737"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="747"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="757"/>
         <source>Radiomaster MT12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="766"/>
         <source>Radiomaster T8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="767"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
         <source>Allow bind using bind key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
         <source>Radiomaster GX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="804"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3800,12 +3821,12 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="484"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="801"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="709"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
         <source>Jumper T18</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3820,7 +3841,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="617"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3845,18 +3866,18 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="568"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="543"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="550"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="518"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="525"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="538"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4886,206 +4907,206 @@ Będą one obowiązywać dla wszystkich modeli w tym samym EEPROM-ie.</translati
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="412"/>
+        <location filename="../firmwares/generalsettings.cpp" line="414"/>
         <source>Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="414"/>
+        <location filename="../firmwares/generalsettings.cpp" line="416"/>
         <source>Hardware</source>
         <translation type="unfinished">Sprzęt</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="415"/>
+        <location filename="../firmwares/generalsettings.cpp" line="417"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="430"/>
+        <location filename="../firmwares/generalsettings.cpp" line="432"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="464"/>
+        <location filename="../firmwares/generalsettings.cpp" line="466"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="469"/>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="471"/>
+        <location filename="../firmwares/generalsettings.cpp" line="483"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Switch</source>
         <translation type="unfinished">Przełącznik</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="499"/>
+        <location filename="../firmwares/generalsettings.cpp" line="501"/>
         <source>None</source>
         <translation type="unfinished">Żadne</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="553"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Internal</source>
         <translation type="unfinished">Wewnętrzny</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="555"/>
+        <location filename="../firmwares/generalsettings.cpp" line="557"/>
         <source>Ask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="557"/>
+        <location filename="../firmwares/generalsettings.cpp" line="559"/>
         <source>Per model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>Internal + External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="573"/>
-        <location filename="../firmwares/generalsettings.cpp" line="589"/>
+        <location filename="../firmwares/generalsettings.cpp" line="575"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>OFF</source>
         <translation type="unfinished">Wyłącz</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Telemetry</source>
         <translation type="unfinished">Telemetria</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="578"/>
+        <location filename="../firmwares/generalsettings.cpp" line="580"/>
         <source>Trainer</source>
         <translation type="unfinished">Trener</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="591"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="593"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="595"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished">Trener SBUS</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="597"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="599"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="601"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>GPS</source>
         <translation type="unfinished">GPS</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="603"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>Debug</source>
         <translation type="unfinished">Debugowanie</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="605"/>
+        <location filename="../firmwares/generalsettings.cpp" line="607"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="607"/>
+        <location filename="../firmwares/generalsettings.cpp" line="609"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="640"/>
+        <location filename="../firmwares/generalsettings.cpp" line="642"/>
         <source>mA</source>
         <translation type="unfinished">mA</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="739"/>
+        <location filename="../firmwares/generalsettings.cpp" line="741"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="741"/>
+        <location filename="../firmwares/generalsettings.cpp" line="743"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="787"/>
+        <location filename="../firmwares/generalsettings.cpp" line="789"/>
         <source>Trims only</source>
         <translation type="unfinished">Tylko trymy</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="789"/>
+        <location filename="../firmwares/generalsettings.cpp" line="791"/>
         <source>Keys only</source>
         <translation type="unfinished">Tylko przyciski</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="791"/>
+        <location filename="../firmwares/generalsettings.cpp" line="793"/>
         <source>Switchable</source>
         <translation type="unfinished">Przełączane</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="793"/>
+        <location filename="../firmwares/generalsettings.cpp" line="795"/>
         <source>Global</source>
         <translation type="unfinished">Globalne</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="927"/>
+        <location filename="../firmwares/generalsettings.cpp" line="929"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation type="unfinished">Mod 1 (SK.SW.Gaz.Lot)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="931"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation type="unfinished">Mod 2 (SK.Gaz.SW.Lot)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="933"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation type="unfinished">Mod 2 (Lot.SW.Gaz.SK)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="935"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation type="unfinished">Mod 4 (Lot.Gaz.SW.SK)</translation>
     </message>
@@ -6018,32 +6039,32 @@ Dopuszczalne wartości 3v-12v</translation>
         <translation type="unfinished">Czeski</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="434"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Slovak</source>
         <translation type="unfinished">Słowacki</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="435"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Spanish</source>
         <translation type="unfinished">Hiszpański</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Polish</source>
         <translation type="unfinished">Polski</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="432"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Portuguese</source>
         <translation type="unfinished">Portugalski</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="433"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Russian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="436"/>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Swedish</source>
         <translation type="unfinished">Szwedzki</translation>
     </message>
@@ -6053,7 +6074,7 @@ Dopuszczalne wartości 3v-12v</translation>
         <translation type="unfinished">Węgierski</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6088,64 +6109,69 @@ Dopuszczalne wartości 3v-12v</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="437"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <source>Korean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="438"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>No</source>
         <translation type="unfinished">Nie</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>RotEnc A</source>
         <translation type="unfinished">Pokrętło :A</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc B</source>
         <translation type="unfinished">Pokrętło :B</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc C</source>
         <translation type="unfinished">Pokrętło :C</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc D</source>
         <translation type="unfinished">Pokrętło :D</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc E</source>
         <translation type="unfinished">Pokrętło :E</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="617"/>
+        <location filename="../generaledit/generalsetup.cpp" line="618"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15731,22 +15757,22 @@ Timestamp</translation>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="873"/>
+        <location filename="../firmwares/generalsettings.cpp" line="875"/>
         <source>OFF</source>
         <translation type="unfinished">Wyłącz</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="875"/>
+        <location filename="../firmwares/generalsettings.cpp" line="877"/>
         <source>+= (Sum)</source>
         <translation type="unfinished">+= (Suma)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="877"/>
+        <location filename="../firmwares/generalsettings.cpp" line="879"/>
         <source>:= (Replace)</source>
         <translation type="unfinished">:= (Zastąpienie)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="886"/>
+        <location filename="../firmwares/generalsettings.cpp" line="888"/>
         <source>CH%1</source>
         <translation type="unfinished">Kan %1</translation>
     </message>
@@ -17446,14 +17472,14 @@ Do you wish to continue?</source>
 <context>
     <name>YamlModelSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1288"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1287"/>
         <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
 
 Model settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1291"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1290"/>
         <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/companion/src/translations/companion_pt.ts
+++ b/companion/src/translations/companion_pt.ts
@@ -1002,274 +1002,274 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="422"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>Left Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="423"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>Left Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="424"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>Right Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="425"/>
+        <location filename="../firmwares/boards.cpp" line="429"/>
         <source>Right Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="426"/>
+        <location filename="../firmwares/boards.cpp" line="430"/>
         <source>Aux. 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="427"/>
+        <location filename="../firmwares/boards.cpp" line="431"/>
         <source>Aux. 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="443"/>
+        <location filename="../firmwares/boards.cpp" line="447"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="444"/>
+        <location filename="../firmwares/boards.cpp" line="448"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="449"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
         <source>RH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="459"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <source>TILT_X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="460"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <source>TILT_Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="506"/>
+        <location filename="../firmwares/boards.cpp" line="516"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
+        <location filename="../firmwares/boards.cpp" line="532"/>
+        <location filename="../firmwares/boards.cpp" line="548"/>
+        <location filename="../firmwares/boards.cpp" line="555"/>
+        <source>SL1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="475"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <source>P4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="517"/>
+        <location filename="../firmwares/boards.cpp" line="525"/>
+        <location filename="../firmwares/boards.cpp" line="533"/>
+        <location filename="../firmwares/boards.cpp" line="549"/>
+        <location filename="../firmwares/boards.cpp" line="556"/>
+        <source>SL2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="478"/>
+        <location filename="../firmwares/boards.cpp" line="557"/>
+        <source>SL3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="479"/>
+        <location filename="../firmwares/boards.cpp" line="558"/>
+        <source>SL4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <source>P5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="943"/>
+        <source>Slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="945"/>
+        <source>Multipos Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="947"/>
+        <source>Axis X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="949"/>
+        <source>Axis Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="951"/>
+        <source>Switch</source>
+        <translation type="unfinished">Interruptor</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Flight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="488"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="498"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
+        <location filename="../firmwares/boards.cpp" line="529"/>
+        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="553"/>
+        <source>P1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="473"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="504"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
+        <location filename="../firmwares/boards.cpp" line="530"/>
+        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="554"/>
+        <source>P2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="474"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="505"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
+        <location filename="../firmwares/boards.cpp" line="531"/>
+        <location filename="../firmwares/boards.cpp" line="543"/>
+        <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="455"/>
         <location filename="../firmwares/boards.cpp" line="457"/>
-        <source>TILT_X</source>
+        <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="456"/>
         <location filename="../firmwares/boards.cpp" line="458"/>
-        <source>TILT_Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="463"/>
-        <location filename="../firmwares/boards.cpp" line="472"/>
-        <location filename="../firmwares/boards.cpp" line="502"/>
-        <location filename="../firmwares/boards.cpp" line="512"/>
-        <location filename="../firmwares/boards.cpp" line="520"/>
-        <location filename="../firmwares/boards.cpp" line="528"/>
-        <location filename="../firmwares/boards.cpp" line="544"/>
-        <location filename="../firmwares/boards.cpp" line="551"/>
-        <source>SL1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="471"/>
-        <location filename="../firmwares/boards.cpp" line="510"/>
-        <source>P4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="473"/>
-        <location filename="../firmwares/boards.cpp" line="503"/>
-        <location filename="../firmwares/boards.cpp" line="513"/>
-        <location filename="../firmwares/boards.cpp" line="521"/>
-        <location filename="../firmwares/boards.cpp" line="529"/>
-        <location filename="../firmwares/boards.cpp" line="545"/>
-        <location filename="../firmwares/boards.cpp" line="552"/>
-        <source>SL2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="474"/>
-        <location filename="../firmwares/boards.cpp" line="553"/>
-        <source>SL3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="475"/>
-        <location filename="../firmwares/boards.cpp" line="554"/>
-        <source>SL4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="511"/>
-        <source>P5</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="933"/>
-        <source>Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="935"/>
-        <source>Multipos Switch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="937"/>
-        <source>Axis X</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="939"/>
-        <source>Axis Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="941"/>
-        <source>Switch</source>
-        <translation type="unfinished">Interruptor</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Flight</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Drive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="464"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
-        <location filename="../firmwares/boards.cpp" line="479"/>
-        <location filename="../firmwares/boards.cpp" line="484"/>
-        <location filename="../firmwares/boards.cpp" line="490"/>
-        <location filename="../firmwares/boards.cpp" line="494"/>
-        <location filename="../firmwares/boards.cpp" line="499"/>
-        <location filename="../firmwares/boards.cpp" line="507"/>
-        <location filename="../firmwares/boards.cpp" line="517"/>
-        <location filename="../firmwares/boards.cpp" line="525"/>
-        <location filename="../firmwares/boards.cpp" line="537"/>
-        <location filename="../firmwares/boards.cpp" line="549"/>
-        <source>P1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="469"/>
-        <location filename="../firmwares/boards.cpp" line="480"/>
-        <location filename="../firmwares/boards.cpp" line="485"/>
-        <location filename="../firmwares/boards.cpp" line="495"/>
-        <location filename="../firmwares/boards.cpp" line="500"/>
-        <location filename="../firmwares/boards.cpp" line="508"/>
-        <location filename="../firmwares/boards.cpp" line="518"/>
-        <location filename="../firmwares/boards.cpp" line="526"/>
-        <location filename="../firmwares/boards.cpp" line="538"/>
-        <location filename="../firmwares/boards.cpp" line="550"/>
-        <source>P2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="470"/>
-        <location filename="../firmwares/boards.cpp" line="486"/>
-        <location filename="../firmwares/boards.cpp" line="501"/>
-        <location filename="../firmwares/boards.cpp" line="509"/>
-        <location filename="../firmwares/boards.cpp" line="519"/>
-        <location filename="../firmwares/boards.cpp" line="527"/>
-        <location filename="../firmwares/boards.cpp" line="539"/>
-        <source>P3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
-        <source>JSx</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="454"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="530"/>
-        <location filename="../firmwares/boards.cpp" line="540"/>
+        <location filename="../firmwares/boards.cpp" line="534"/>
+        <location filename="../firmwares/boards.cpp" line="544"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="531"/>
-        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="535"/>
+        <location filename="../firmwares/boards.cpp" line="545"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="532"/>
-        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="536"/>
+        <location filename="../firmwares/boards.cpp" line="546"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="533"/>
-        <location filename="../firmwares/boards.cpp" line="543"/>
+        <location filename="../firmwares/boards.cpp" line="537"/>
+        <location filename="../firmwares/boards.cpp" line="547"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="678"/>
-        <location filename="../firmwares/boards.cpp" line="897"/>
-        <location filename="../firmwares/boards.cpp" line="927"/>
+        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="907"/>
+        <location filename="../firmwares/boards.cpp" line="937"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="929"/>
+        <location filename="../firmwares/boards.cpp" line="939"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="931"/>
+        <location filename="../firmwares/boards.cpp" line="941"/>
         <source>Pot with detent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="680"/>
+        <location filename="../firmwares/boards.cpp" line="686"/>
         <source>2 Positions Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="682"/>
+        <location filename="../firmwares/boards.cpp" line="688"/>
         <source>2 Positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="690"/>
         <source>3 Positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="686"/>
+        <location filename="../firmwares/boards.cpp" line="692"/>
         <source>Function</source>
         <translation type="unfinished">Função</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="899"/>
+        <location filename="../firmwares/boards.cpp" line="909"/>
         <source>Standard</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="901"/>
+        <location filename="../firmwares/boards.cpp" line="911"/>
         <source>Small</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="903"/>
+        <location filename="../firmwares/boards.cpp" line="913"/>
         <source>Both</source>
         <translation type="unfinished"></translation>
     </message>
@@ -1682,34 +1682,50 @@ Do you want to import settings from a file?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="380"/>
+        <location filename="../helpers.cpp" line="388"/>
+        <source>Uknown error during Simulator startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Data Load Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Error occurred while starting simulator.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="405"/>
         <source>Error creating temporary directory for models and settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="388"/>
+        <location filename="../helpers.cpp" line="413"/>
         <source>Error writing models and settings to temporary directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="419"/>
+        <location filename="../helpers.cpp" line="444"/>
         <source>Unable to start.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="421"/>
+        <location filename="../helpers.cpp" line="446"/>
         <source>Crashed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="423"/>
+        <location filename="../helpers.cpp" line="448"/>
         <source>Exited with result code:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="381"/>
         <location filename="../helpers.cpp" line="389"/>
-        <location filename="../helpers.cpp" line="426"/>
+        <location filename="../helpers.cpp" line="406"/>
+        <location filename="../helpers.cpp" line="414"/>
+        <location filename="../helpers.cpp" line="451"/>
         <source>Simulator Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3514,59 +3530,59 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="448"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="612"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="622"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="632"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="642"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="652"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="662"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="672"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="742"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="761"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="772"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="782"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="807"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="619"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="629"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="639"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="649"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="659"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="669"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="679"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="739"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="749"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="768"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="779"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="789"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="814"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="449"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="613"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="623"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="633"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="643"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="653"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="663"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="673"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="733"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="743"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="752"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="762"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="773"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="783"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="680"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="769"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="815"/>
         <source>Disable Global variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="450"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="474"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="614"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="624"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="634"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="644"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="654"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="664"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="674"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="734"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="744"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="753"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="763"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="784"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="809"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="621"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="631"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="641"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="651"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="661"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="671"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="741"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="751"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="760"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="781"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="791"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="816"/>
         <source>Enable Lua custom scripts screen</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3586,125 +3602,125 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
         <source>FrSky Taranis X9D+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="590"/>
         <source>Disable RAS (SWR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="574"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="581"/>
         <source>FrSky Taranis X9D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="576"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
         <source>Haptic module installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="595"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="602"/>
         <source>FrSky Taranis X9E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
         <source>Confirmation before radio shutdown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="597"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="604"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="562"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="569"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="568"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="537"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="544"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="543"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="550"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="563"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="549"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
         <source>FrSky Taranis X-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="518"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="525"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="538"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="530"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="529"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="536"/>
         <source>FrSky Horus X12S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="539"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="677"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="675"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="703"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="682"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="710"/>
         <source>Support for MULTI internal module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="627"/>
         <source>Jumper T-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="637"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="701"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="708"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3714,26 +3730,26 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="777"/>
         <source>Radiomaster TX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="787"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="805"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="812"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="683"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="690"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="718"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="697"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="725"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="810"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="817"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3743,82 +3759,87 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <source>FlySky ST16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
         <source>HelloRadioSky V16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="647"/>
         <source>Jumper T-Pro V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="657"/>
         <source>Jumper T-Pro S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="667"/>
         <source>Jumper Bumblebee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
         <source>Jumper T12 MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
         <source>Jumper T14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="702"/>
         <source>Jumper T15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
         <source>Jumper T20 V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="737"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="747"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="757"/>
         <source>Radiomaster MT12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="766"/>
         <source>Radiomaster T8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="767"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
         <source>Allow bind using bind key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
         <source>Radiomaster GX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="804"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3829,12 +3850,12 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="484"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="801"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="709"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
         <source>Jumper T18</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3849,7 +3870,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="617"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4823,206 +4844,206 @@ These will be relevant for all models in the same EEPROM.</source>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="412"/>
+        <location filename="../firmwares/generalsettings.cpp" line="414"/>
         <source>Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="414"/>
+        <location filename="../firmwares/generalsettings.cpp" line="416"/>
         <source>Hardware</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="415"/>
+        <location filename="../firmwares/generalsettings.cpp" line="417"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="430"/>
+        <location filename="../firmwares/generalsettings.cpp" line="432"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="464"/>
+        <location filename="../firmwares/generalsettings.cpp" line="466"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="469"/>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="471"/>
+        <location filename="../firmwares/generalsettings.cpp" line="483"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Switch</source>
         <translation type="unfinished">Interruptor</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="499"/>
+        <location filename="../firmwares/generalsettings.cpp" line="501"/>
         <source>None</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="553"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="555"/>
+        <location filename="../firmwares/generalsettings.cpp" line="557"/>
         <source>Ask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="557"/>
+        <location filename="../firmwares/generalsettings.cpp" line="559"/>
         <source>Per model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>Internal + External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="573"/>
-        <location filename="../firmwares/generalsettings.cpp" line="589"/>
+        <location filename="../firmwares/generalsettings.cpp" line="575"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>OFF</source>
         <translation type="unfinished">OFF</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Enabled</source>
         <translation type="unfinished">Activo</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Telemetry</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="578"/>
+        <location filename="../firmwares/generalsettings.cpp" line="580"/>
         <source>Trainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="591"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="593"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="595"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="597"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="599"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="601"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="603"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>Debug</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="605"/>
+        <location filename="../firmwares/generalsettings.cpp" line="607"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="607"/>
+        <location filename="../firmwares/generalsettings.cpp" line="609"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="640"/>
+        <location filename="../firmwares/generalsettings.cpp" line="642"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="739"/>
+        <location filename="../firmwares/generalsettings.cpp" line="741"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="741"/>
+        <location filename="../firmwares/generalsettings.cpp" line="743"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="787"/>
+        <location filename="../firmwares/generalsettings.cpp" line="789"/>
         <source>Trims only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="789"/>
+        <location filename="../firmwares/generalsettings.cpp" line="791"/>
         <source>Keys only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="791"/>
+        <location filename="../firmwares/generalsettings.cpp" line="793"/>
         <source>Switchable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="793"/>
+        <location filename="../firmwares/generalsettings.cpp" line="795"/>
         <source>Global</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="927"/>
+        <location filename="../firmwares/generalsettings.cpp" line="929"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation type="unfinished">Modo 1 (RUD ELE THR AIL)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="931"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation type="unfinished">Modo 2 (RUD THR ELE AIL)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="933"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation type="unfinished">Modo 3 (AIL ELE THR RUD)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="935"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation type="unfinished">Modo 4 (AIL THR ELE RUD)</translation>
     </message>
@@ -5918,32 +5939,32 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="434"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Slovak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="435"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Polish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="432"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Portuguese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="433"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Russian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="436"/>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Swedish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5978,69 +5999,74 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="437"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <source>Korean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="438"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>RotEnc A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="617"/>
+        <location filename="../generaledit/generalsetup.cpp" line="618"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15574,22 +15600,22 @@ Timestamp</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="873"/>
+        <location filename="../firmwares/generalsettings.cpp" line="875"/>
         <source>OFF</source>
         <translation type="unfinished">OFF</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="875"/>
+        <location filename="../firmwares/generalsettings.cpp" line="877"/>
         <source>+= (Sum)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="877"/>
+        <location filename="../firmwares/generalsettings.cpp" line="879"/>
         <source>:= (Replace)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="886"/>
+        <location filename="../firmwares/generalsettings.cpp" line="888"/>
         <source>CH%1</source>
         <translation type="unfinished">CH%1</translation>
     </message>
@@ -17287,14 +17313,14 @@ Do you wish to continue?</source>
 <context>
     <name>YamlModelSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1288"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1287"/>
         <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
 
 Model settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1291"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1290"/>
         <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/companion/src/translations/companion_ru.ts
+++ b/companion/src/translations/companion_ru.ts
@@ -1023,274 +1023,274 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="422"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>Left Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="423"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>Left Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="424"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>Right Vertical</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="425"/>
+        <location filename="../firmwares/boards.cpp" line="429"/>
         <source>Right Horizontal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="426"/>
+        <location filename="../firmwares/boards.cpp" line="430"/>
         <source>Aux. 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="427"/>
+        <location filename="../firmwares/boards.cpp" line="431"/>
         <source>Aux. 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="443"/>
+        <location filename="../firmwares/boards.cpp" line="447"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="444"/>
+        <location filename="../firmwares/boards.cpp" line="448"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="449"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
         <source>RH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="459"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <source>TILT_X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="460"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <source>TILT_Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="506"/>
+        <location filename="../firmwares/boards.cpp" line="516"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
+        <location filename="../firmwares/boards.cpp" line="532"/>
+        <location filename="../firmwares/boards.cpp" line="548"/>
+        <location filename="../firmwares/boards.cpp" line="555"/>
+        <source>SL1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="475"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <source>P4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="517"/>
+        <location filename="../firmwares/boards.cpp" line="525"/>
+        <location filename="../firmwares/boards.cpp" line="533"/>
+        <location filename="../firmwares/boards.cpp" line="549"/>
+        <location filename="../firmwares/boards.cpp" line="556"/>
+        <source>SL2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="478"/>
+        <location filename="../firmwares/boards.cpp" line="557"/>
+        <source>SL3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="479"/>
+        <location filename="../firmwares/boards.cpp" line="558"/>
+        <source>SL4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <source>P5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="943"/>
+        <source>Slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="945"/>
+        <source>Multipos Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="947"/>
+        <source>Axis X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="949"/>
+        <source>Axis Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="951"/>
+        <source>Switch</source>
+        <translation type="unfinished">Тумблер</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Flight</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="488"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="498"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
+        <location filename="../firmwares/boards.cpp" line="529"/>
+        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="553"/>
+        <source>P1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="473"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="504"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
+        <location filename="../firmwares/boards.cpp" line="530"/>
+        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="554"/>
+        <source>P2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="474"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="505"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
+        <location filename="../firmwares/boards.cpp" line="531"/>
+        <location filename="../firmwares/boards.cpp" line="543"/>
+        <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="455"/>
         <location filename="../firmwares/boards.cpp" line="457"/>
-        <source>TILT_X</source>
+        <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="456"/>
         <location filename="../firmwares/boards.cpp" line="458"/>
-        <source>TILT_Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="463"/>
-        <location filename="../firmwares/boards.cpp" line="472"/>
-        <location filename="../firmwares/boards.cpp" line="502"/>
-        <location filename="../firmwares/boards.cpp" line="512"/>
-        <location filename="../firmwares/boards.cpp" line="520"/>
-        <location filename="../firmwares/boards.cpp" line="528"/>
-        <location filename="../firmwares/boards.cpp" line="544"/>
-        <location filename="../firmwares/boards.cpp" line="551"/>
-        <source>SL1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="471"/>
-        <location filename="../firmwares/boards.cpp" line="510"/>
-        <source>P4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="473"/>
-        <location filename="../firmwares/boards.cpp" line="503"/>
-        <location filename="../firmwares/boards.cpp" line="513"/>
-        <location filename="../firmwares/boards.cpp" line="521"/>
-        <location filename="../firmwares/boards.cpp" line="529"/>
-        <location filename="../firmwares/boards.cpp" line="545"/>
-        <location filename="../firmwares/boards.cpp" line="552"/>
-        <source>SL2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="474"/>
-        <location filename="../firmwares/boards.cpp" line="553"/>
-        <source>SL3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="475"/>
-        <location filename="../firmwares/boards.cpp" line="554"/>
-        <source>SL4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="511"/>
-        <source>P5</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="933"/>
-        <source>Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="935"/>
-        <source>Multipos Switch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="937"/>
-        <source>Axis X</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="939"/>
-        <source>Axis Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="941"/>
-        <source>Switch</source>
-        <translation type="unfinished">Тумблер</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Flight</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Drive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="464"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
-        <location filename="../firmwares/boards.cpp" line="479"/>
-        <location filename="../firmwares/boards.cpp" line="484"/>
-        <location filename="../firmwares/boards.cpp" line="490"/>
-        <location filename="../firmwares/boards.cpp" line="494"/>
-        <location filename="../firmwares/boards.cpp" line="499"/>
-        <location filename="../firmwares/boards.cpp" line="507"/>
-        <location filename="../firmwares/boards.cpp" line="517"/>
-        <location filename="../firmwares/boards.cpp" line="525"/>
-        <location filename="../firmwares/boards.cpp" line="537"/>
-        <location filename="../firmwares/boards.cpp" line="549"/>
-        <source>P1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="469"/>
-        <location filename="../firmwares/boards.cpp" line="480"/>
-        <location filename="../firmwares/boards.cpp" line="485"/>
-        <location filename="../firmwares/boards.cpp" line="495"/>
-        <location filename="../firmwares/boards.cpp" line="500"/>
-        <location filename="../firmwares/boards.cpp" line="508"/>
-        <location filename="../firmwares/boards.cpp" line="518"/>
-        <location filename="../firmwares/boards.cpp" line="526"/>
-        <location filename="../firmwares/boards.cpp" line="538"/>
-        <location filename="../firmwares/boards.cpp" line="550"/>
-        <source>P2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="470"/>
-        <location filename="../firmwares/boards.cpp" line="486"/>
-        <location filename="../firmwares/boards.cpp" line="501"/>
-        <location filename="../firmwares/boards.cpp" line="509"/>
-        <location filename="../firmwares/boards.cpp" line="519"/>
-        <location filename="../firmwares/boards.cpp" line="527"/>
-        <location filename="../firmwares/boards.cpp" line="539"/>
-        <source>P3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
-        <source>JSx</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="454"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="530"/>
-        <location filename="../firmwares/boards.cpp" line="540"/>
+        <location filename="../firmwares/boards.cpp" line="534"/>
+        <location filename="../firmwares/boards.cpp" line="544"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="531"/>
-        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="535"/>
+        <location filename="../firmwares/boards.cpp" line="545"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="532"/>
-        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="536"/>
+        <location filename="../firmwares/boards.cpp" line="546"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="533"/>
-        <location filename="../firmwares/boards.cpp" line="543"/>
+        <location filename="../firmwares/boards.cpp" line="537"/>
+        <location filename="../firmwares/boards.cpp" line="547"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="678"/>
-        <location filename="../firmwares/boards.cpp" line="897"/>
-        <location filename="../firmwares/boards.cpp" line="927"/>
+        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="907"/>
+        <location filename="../firmwares/boards.cpp" line="937"/>
         <source>None</source>
         <translation type="unfinished">Нет</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="929"/>
+        <location filename="../firmwares/boards.cpp" line="939"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="931"/>
+        <location filename="../firmwares/boards.cpp" line="941"/>
         <source>Pot with detent</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="680"/>
+        <location filename="../firmwares/boards.cpp" line="686"/>
         <source>2 Positions Toggle</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="682"/>
+        <location filename="../firmwares/boards.cpp" line="688"/>
         <source>2 Positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="690"/>
         <source>3 Positions</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="686"/>
+        <location filename="../firmwares/boards.cpp" line="692"/>
         <source>Function</source>
         <translation type="unfinished">Функция</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="899"/>
+        <location filename="../firmwares/boards.cpp" line="909"/>
         <source>Standard</source>
         <translation type="unfinished">Стандартный</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="901"/>
+        <location filename="../firmwares/boards.cpp" line="911"/>
         <source>Small</source>
         <translation type="unfinished">Маленькие</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="903"/>
+        <location filename="../firmwares/boards.cpp" line="913"/>
         <source>Both</source>
         <translation type="unfinished">Обе</translation>
     </message>
@@ -1709,34 +1709,50 @@ Do you want to import settings from a file?</source>
         <translation>Симулятор для этой прошивки пока недоступен</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="380"/>
+        <location filename="../helpers.cpp" line="388"/>
+        <source>Uknown error during Simulator startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Data Load Error</source>
+        <translation type="unfinished">Ошибка загрузки данных</translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Error occurred while starting simulator.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="405"/>
         <source>Error creating temporary directory for models and settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="388"/>
+        <location filename="../helpers.cpp" line="413"/>
         <source>Error writing models and settings to temporary directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="419"/>
+        <location filename="../helpers.cpp" line="444"/>
         <source>Unable to start.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="421"/>
+        <location filename="../helpers.cpp" line="446"/>
         <source>Crashed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="423"/>
+        <location filename="../helpers.cpp" line="448"/>
         <source>Exited with result code:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="381"/>
         <location filename="../helpers.cpp" line="389"/>
-        <location filename="../helpers.cpp" line="426"/>
+        <location filename="../helpers.cpp" line="406"/>
+        <location filename="../helpers.cpp" line="414"/>
+        <location filename="../helpers.cpp" line="451"/>
         <source>Simulator Error</source>
         <translation>Ошибка симулятора</translation>
     </message>
@@ -3547,59 +3563,59 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="448"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="612"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="622"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="632"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="642"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="652"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="662"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="672"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="742"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="761"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="772"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="782"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="807"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="619"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="629"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="639"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="649"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="659"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="669"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="679"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="739"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="749"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="768"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="779"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="789"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="814"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="449"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="613"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="623"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="633"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="643"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="653"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="663"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="673"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="733"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="743"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="752"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="762"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="773"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="783"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="680"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="769"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="815"/>
         <source>Disable Global variables</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="450"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="474"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="614"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="624"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="634"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="644"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="654"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="664"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="674"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="734"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="744"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="753"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="763"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="784"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="809"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="621"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="631"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="641"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="651"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="661"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="671"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="741"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="751"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="760"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="781"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="791"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="816"/>
         <source>Enable Lua custom scripts screen</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3619,125 +3635,125 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
         <source>FrSky Taranis X9D+</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="590"/>
         <source>Disable RAS (SWR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="574"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="581"/>
         <source>FrSky Taranis X9D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="576"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
         <source>Haptic module installed</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="595"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="602"/>
         <source>FrSky Taranis X9E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
         <source>Confirmation before radio shutdown</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="597"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="604"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="562"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="569"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="568"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="537"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="544"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="543"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="550"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="563"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="549"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
         <source>FrSky Taranis X-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="518"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="525"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="538"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="530"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="529"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="536"/>
         <source>FrSky Horus X12S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="539"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="677"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="675"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="703"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="682"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="710"/>
         <source>Support for MULTI internal module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="627"/>
         <source>Jumper T-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="637"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="701"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="708"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3747,26 +3763,26 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="777"/>
         <source>Radiomaster TX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="787"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="805"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="812"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="683"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="690"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="718"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="697"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="725"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="810"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="817"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3776,82 +3792,87 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <source>FlySky ST16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
         <source>HelloRadioSky V16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="647"/>
         <source>Jumper T-Pro V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="657"/>
         <source>Jumper T-Pro S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="667"/>
         <source>Jumper Bumblebee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
         <source>Jumper T12 MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
         <source>Jumper T14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="702"/>
         <source>Jumper T15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
         <source>Jumper T20 V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="737"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="747"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="757"/>
         <source>Radiomaster MT12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="766"/>
         <source>Radiomaster T8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="767"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
         <source>Allow bind using bind key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
         <source>Radiomaster GX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="804"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3862,12 +3883,12 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="484"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="801"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="709"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
         <source>Jumper T18</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3882,7 +3903,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="617"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4857,206 +4878,206 @@ These will be relevant for all models in the same EEPROM.</source>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="412"/>
+        <location filename="../firmwares/generalsettings.cpp" line="414"/>
         <source>Radio Settings</source>
         <translation type="unfinished">Параметры передатчика</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="414"/>
+        <location filename="../firmwares/generalsettings.cpp" line="416"/>
         <source>Hardware</source>
         <translation type="unfinished">Оборудование</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="415"/>
+        <location filename="../firmwares/generalsettings.cpp" line="417"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="430"/>
+        <location filename="../firmwares/generalsettings.cpp" line="432"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="464"/>
+        <location filename="../firmwares/generalsettings.cpp" line="466"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="469"/>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="471"/>
+        <location filename="../firmwares/generalsettings.cpp" line="483"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Switch</source>
         <translation type="unfinished">Тумблер</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="499"/>
+        <location filename="../firmwares/generalsettings.cpp" line="501"/>
         <source>None</source>
         <translation type="unfinished">Нет</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="553"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="555"/>
+        <location filename="../firmwares/generalsettings.cpp" line="557"/>
         <source>Ask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="557"/>
+        <location filename="../firmwares/generalsettings.cpp" line="559"/>
         <source>Per model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>Internal + External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="573"/>
-        <location filename="../firmwares/generalsettings.cpp" line="589"/>
+        <location filename="../firmwares/generalsettings.cpp" line="575"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Telemetry</source>
         <translation type="unfinished">Телеметрия</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="578"/>
+        <location filename="../firmwares/generalsettings.cpp" line="580"/>
         <source>Trainer</source>
         <translation type="unfinished">Тренер</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="591"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="593"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="595"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="597"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="599"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="601"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="603"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>Debug</source>
         <translation type="unfinished">Отладка</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="605"/>
+        <location filename="../firmwares/generalsettings.cpp" line="607"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="607"/>
+        <location filename="../firmwares/generalsettings.cpp" line="609"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="640"/>
+        <location filename="../firmwares/generalsettings.cpp" line="642"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="739"/>
+        <location filename="../firmwares/generalsettings.cpp" line="741"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="741"/>
+        <location filename="../firmwares/generalsettings.cpp" line="743"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="787"/>
+        <location filename="../firmwares/generalsettings.cpp" line="789"/>
         <source>Trims only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="789"/>
+        <location filename="../firmwares/generalsettings.cpp" line="791"/>
         <source>Keys only</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="791"/>
+        <location filename="../firmwares/generalsettings.cpp" line="793"/>
         <source>Switchable</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="793"/>
+        <location filename="../firmwares/generalsettings.cpp" line="795"/>
         <source>Global</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="927"/>
+        <location filename="../firmwares/generalsettings.cpp" line="929"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="931"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="933"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="935"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation type="unfinished"></translation>
     </message>
@@ -5978,32 +5999,32 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="434"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Slovak</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="435"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Spanish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Polish</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="432"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Portuguese</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="433"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Russian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="436"/>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Swedish</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6013,7 +6034,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6048,64 +6069,69 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="437"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <source>Korean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="438"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>No</source>
         <translation>Нет</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>RotEnc A</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc B</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc C</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc D</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc E</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="617"/>
+        <location filename="../generaledit/generalsetup.cpp" line="618"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15666,22 +15692,22 @@ Timestamp</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="873"/>
+        <location filename="../firmwares/generalsettings.cpp" line="875"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="875"/>
+        <location filename="../firmwares/generalsettings.cpp" line="877"/>
         <source>+= (Sum)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="877"/>
+        <location filename="../firmwares/generalsettings.cpp" line="879"/>
         <source>:= (Replace)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="886"/>
+        <location filename="../firmwares/generalsettings.cpp" line="888"/>
         <source>CH%1</source>
         <translation type="unfinished"></translation>
     </message>
@@ -17379,14 +17405,14 @@ Do you wish to continue?</source>
 <context>
     <name>YamlModelSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1288"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1287"/>
         <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
 
 Model settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1291"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1290"/>
         <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/companion/src/translations/companion_sv.ts
+++ b/companion/src/translations/companion_sv.ts
@@ -1029,274 +1029,274 @@ Felbeskrivning: %4</translation>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="422"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>Left Horizontal</source>
         <translation>Vänster horisontal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="423"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>Left Vertical</source>
         <translation>Vänster Vvrtikal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="424"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>Right Vertical</source>
         <translation>Höger vertikal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="425"/>
+        <location filename="../firmwares/boards.cpp" line="429"/>
         <source>Right Horizontal</source>
         <translation>Höger horisontal</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="426"/>
+        <location filename="../firmwares/boards.cpp" line="430"/>
         <source>Aux. 1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="427"/>
+        <location filename="../firmwares/boards.cpp" line="431"/>
         <source>Aux. 2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="443"/>
+        <location filename="../firmwares/boards.cpp" line="447"/>
         <source>LH</source>
         <translation>VH</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="444"/>
+        <location filename="../firmwares/boards.cpp" line="448"/>
         <source>LV</source>
         <translation>VV</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="449"/>
         <source>RV</source>
         <translation>HV</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
         <source>RH</source>
         <translation>HH</translation>
     </message>
     <message>
+        <location filename="../firmwares/boards.cpp" line="459"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <source>TILT_X</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="460"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <source>TILT_Y</source>
+        <translation></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="506"/>
+        <location filename="../firmwares/boards.cpp" line="516"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
+        <location filename="../firmwares/boards.cpp" line="532"/>
+        <location filename="../firmwares/boards.cpp" line="548"/>
+        <location filename="../firmwares/boards.cpp" line="555"/>
+        <source>SL1</source>
+        <translation>RG1</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="475"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <source>P4</source>
+        <translation>V4</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="517"/>
+        <location filename="../firmwares/boards.cpp" line="525"/>
+        <location filename="../firmwares/boards.cpp" line="533"/>
+        <location filename="../firmwares/boards.cpp" line="549"/>
+        <location filename="../firmwares/boards.cpp" line="556"/>
+        <source>SL2</source>
+        <translation>RG2</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="478"/>
+        <location filename="../firmwares/boards.cpp" line="557"/>
+        <source>SL3</source>
+        <translation>RG3</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="479"/>
+        <location filename="../firmwares/boards.cpp" line="558"/>
+        <source>SL4</source>
+        <translation>RG4</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <source>P5</source>
+        <translation>V5</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="907"/>
+        <location filename="../firmwares/boards.cpp" line="937"/>
+        <source>None</source>
+        <translation>Ingen</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="686"/>
+        <source>2 Positions Toggle</source>
+        <translation>2 lägen momentan</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="688"/>
+        <source>2 Positions</source>
+        <translation>2 lägen</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="690"/>
+        <source>3 Positions</source>
+        <translation>3 lägen</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="692"/>
+        <source>Function</source>
+        <translation>Funktion</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="939"/>
+        <source>Pot</source>
+        <translation>Vred</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="941"/>
+        <source>Pot with detent</source>
+        <translation>Vred med mittklick</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="943"/>
+        <source>Slider</source>
+        <translation>Reglage</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="945"/>
+        <source>Multipos Switch</source>
+        <translation>Flerlägesbrytare</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="947"/>
+        <source>Axis X</source>
+        <translation>X-axel</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="949"/>
+        <source>Axis Y</source>
+        <translation>Y-axel</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="951"/>
+        <source>Switch</source>
+        <translation>Brytare</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Flight</source>
+        <translation>Flyg</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Drive</source>
+        <translation>Kör</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="488"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="498"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
+        <location filename="../firmwares/boards.cpp" line="529"/>
+        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="553"/>
+        <source>P1</source>
+        <translation>V1</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="473"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="504"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
+        <location filename="../firmwares/boards.cpp" line="530"/>
+        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="554"/>
+        <source>P2</source>
+        <translation>V2</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="474"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="505"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
+        <location filename="../firmwares/boards.cpp" line="531"/>
+        <location filename="../firmwares/boards.cpp" line="543"/>
+        <source>P3</source>
+        <translation>V3</translation>
+    </message>
+    <message>
         <location filename="../firmwares/boards.cpp" line="455"/>
         <location filename="../firmwares/boards.cpp" line="457"/>
-        <source>TILT_X</source>
+        <source>JSx</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="456"/>
         <location filename="../firmwares/boards.cpp" line="458"/>
-        <source>TILT_Y</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="463"/>
-        <location filename="../firmwares/boards.cpp" line="472"/>
-        <location filename="../firmwares/boards.cpp" line="502"/>
-        <location filename="../firmwares/boards.cpp" line="512"/>
-        <location filename="../firmwares/boards.cpp" line="520"/>
-        <location filename="../firmwares/boards.cpp" line="528"/>
-        <location filename="../firmwares/boards.cpp" line="544"/>
-        <location filename="../firmwares/boards.cpp" line="551"/>
-        <source>SL1</source>
-        <translation>RG1</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="471"/>
-        <location filename="../firmwares/boards.cpp" line="510"/>
-        <source>P4</source>
-        <translation>V4</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="473"/>
-        <location filename="../firmwares/boards.cpp" line="503"/>
-        <location filename="../firmwares/boards.cpp" line="513"/>
-        <location filename="../firmwares/boards.cpp" line="521"/>
-        <location filename="../firmwares/boards.cpp" line="529"/>
-        <location filename="../firmwares/boards.cpp" line="545"/>
-        <location filename="../firmwares/boards.cpp" line="552"/>
-        <source>SL2</source>
-        <translation>RG2</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="474"/>
-        <location filename="../firmwares/boards.cpp" line="553"/>
-        <source>SL3</source>
-        <translation>RG3</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="475"/>
-        <location filename="../firmwares/boards.cpp" line="554"/>
-        <source>SL4</source>
-        <translation>RG4</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="511"/>
-        <source>P5</source>
-        <translation>V5</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="678"/>
-        <location filename="../firmwares/boards.cpp" line="897"/>
-        <location filename="../firmwares/boards.cpp" line="927"/>
-        <source>None</source>
-        <translation>Ingen</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="680"/>
-        <source>2 Positions Toggle</source>
-        <translation>2 lägen momentan</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="682"/>
-        <source>2 Positions</source>
-        <translation>2 lägen</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="684"/>
-        <source>3 Positions</source>
-        <translation>3 lägen</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="686"/>
-        <source>Function</source>
-        <translation>Funktion</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="929"/>
-        <source>Pot</source>
-        <translation>Vred</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="931"/>
-        <source>Pot with detent</source>
-        <translation>Vred med mittklick</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="933"/>
-        <source>Slider</source>
-        <translation>Reglage</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="935"/>
-        <source>Multipos Switch</source>
-        <translation>Flerlägesbrytare</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="937"/>
-        <source>Axis X</source>
-        <translation>X-axel</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="939"/>
-        <source>Axis Y</source>
-        <translation>Y-axel</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="941"/>
-        <source>Switch</source>
-        <translation>Brytare</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Flight</source>
-        <translation>Flyg</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Drive</source>
-        <translation>Kör</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="464"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
-        <location filename="../firmwares/boards.cpp" line="479"/>
-        <location filename="../firmwares/boards.cpp" line="484"/>
-        <location filename="../firmwares/boards.cpp" line="490"/>
-        <location filename="../firmwares/boards.cpp" line="494"/>
-        <location filename="../firmwares/boards.cpp" line="499"/>
-        <location filename="../firmwares/boards.cpp" line="507"/>
-        <location filename="../firmwares/boards.cpp" line="517"/>
-        <location filename="../firmwares/boards.cpp" line="525"/>
-        <location filename="../firmwares/boards.cpp" line="537"/>
-        <location filename="../firmwares/boards.cpp" line="549"/>
-        <source>P1</source>
-        <translation>V1</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="469"/>
-        <location filename="../firmwares/boards.cpp" line="480"/>
-        <location filename="../firmwares/boards.cpp" line="485"/>
-        <location filename="../firmwares/boards.cpp" line="495"/>
-        <location filename="../firmwares/boards.cpp" line="500"/>
-        <location filename="../firmwares/boards.cpp" line="508"/>
-        <location filename="../firmwares/boards.cpp" line="518"/>
-        <location filename="../firmwares/boards.cpp" line="526"/>
-        <location filename="../firmwares/boards.cpp" line="538"/>
-        <location filename="../firmwares/boards.cpp" line="550"/>
-        <source>P2</source>
-        <translation>V2</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="470"/>
-        <location filename="../firmwares/boards.cpp" line="486"/>
-        <location filename="../firmwares/boards.cpp" line="501"/>
-        <location filename="../firmwares/boards.cpp" line="509"/>
-        <location filename="../firmwares/boards.cpp" line="519"/>
-        <location filename="../firmwares/boards.cpp" line="527"/>
-        <location filename="../firmwares/boards.cpp" line="539"/>
-        <source>P3</source>
-        <translation>V3</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
-        <source>JSx</source>
-        <translation></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="454"/>
         <source>JSy</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="530"/>
-        <location filename="../firmwares/boards.cpp" line="540"/>
+        <location filename="../firmwares/boards.cpp" line="534"/>
+        <location filename="../firmwares/boards.cpp" line="544"/>
         <source>EXT1</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="531"/>
-        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="535"/>
+        <location filename="../firmwares/boards.cpp" line="545"/>
         <source>EXT2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="532"/>
-        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="536"/>
+        <location filename="../firmwares/boards.cpp" line="546"/>
         <source>EXT3</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="533"/>
-        <location filename="../firmwares/boards.cpp" line="543"/>
+        <location filename="../firmwares/boards.cpp" line="537"/>
+        <location filename="../firmwares/boards.cpp" line="547"/>
         <source>EXT4</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="899"/>
+        <location filename="../firmwares/boards.cpp" line="909"/>
         <source>Standard</source>
         <translation>Standard</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="901"/>
+        <location filename="../firmwares/boards.cpp" line="911"/>
         <source>Small</source>
         <translation>Liten</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="903"/>
+        <location filename="../firmwares/boards.cpp" line="913"/>
         <source>Both</source>
         <translation>Båda</translation>
     </message>
@@ -3553,39 +3553,39 @@ Tomt betyder inkludera alla. ?, * och [...] jokertecken accepteras.</translation
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="448"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="612"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="622"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="632"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="642"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="652"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="662"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="672"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="742"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="761"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="772"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="782"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="807"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="619"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="629"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="639"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="649"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="659"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="669"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="679"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="739"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="749"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="768"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="779"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="789"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="814"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation>Avaktivera helikoptermenyn och stöd för cykliska mixar</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="449"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="613"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="623"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="633"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="643"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="653"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="663"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="673"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="733"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="743"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="752"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="762"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="773"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="783"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="680"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="769"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="815"/>
         <source>Disable Global variables</source>
         <translation>Avaktivera Globala variabler</translation>
     </message>
@@ -3600,42 +3600,47 @@ Tomt betyder inkludera alla. ?, * och [...] jokertecken accepteras.</translation
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <source>FlySky ST16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
         <source>HelloRadioSky V16</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="647"/>
         <source>Jumper T-Pro V2</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="657"/>
         <source>Jumper T-Pro S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="667"/>
         <source>Jumper Bumblebee</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
         <source>Jumper T12 MAX</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
         <source>Jumper T14</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="702"/>
         <source>Jumper T15</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
         <source>Jumper T20 V2</source>
         <translation></translation>
     </message>
@@ -3647,20 +3652,20 @@ Tomt betyder inkludera alla. ?, * och [...] jokertecken accepteras.</translation
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="450"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="474"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="614"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="624"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="634"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="644"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="654"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="664"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="674"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="734"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="744"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="753"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="763"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="784"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="809"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="621"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="631"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="641"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="651"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="661"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="671"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="741"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="751"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="760"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="781"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="791"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="816"/>
         <source>Enable Lua custom scripts screen</source>
         <translation>Aktivera stöd för Lua-mixerskript</translation>
     </message>
@@ -3670,28 +3675,28 @@ Tomt betyder inkludera alla. ?, * och [...] jokertecken accepteras.</translation
         <translation>Använd SQT5 typsnitt</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="590"/>
         <source>Disable RAS (SWR)</source>
         <translation>Avaktivera RAS (SWR)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="576"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
         <source>Haptic module installed</source>
         <translation>Vibratormodul är installerad</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
         <source>Confirmation before radio shutdown</source>
         <translation>Bekräfta avstängning av radion</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="597"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="604"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation>Horusspakar installerade (hall sensor)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="539"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation>Använd endast med första versionen av DEV pcb</translation>
     </message>
@@ -3701,8 +3706,8 @@ Tomt betyder inkludera alla. ?, * och [...] jokertecken accepteras.</translation
         <translation>Tillåt icke-certifierad firmware</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="518"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="525"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="538"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation>Stöd för utbyte av intern ACCESS-modul</translation>
     </message>
@@ -3712,7 +3717,7 @@ Tomt betyder inkludera alla. ?, * och [...] jokertecken accepteras.</translation
         <translation>Aktivera stöd för AFHDS3</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="767"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
         <source>Allow bind using bind key</source>
         <translation>Tillåt parkoppling via &quot;bindknapp&quot;</translation>
     </message>
@@ -3722,13 +3727,13 @@ Tomt betyder inkludera alla. ?, * och [...] jokertecken accepteras.</translation
         <translation>Stöd för Bluetooth-modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="675"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="703"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="682"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="710"/>
         <source>Support for MULTI internal module</source>
         <translation>Stöd för intern MULTI-modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
         <source>FrSky Taranis X9D+</source>
         <translation></translation>
     </message>
@@ -3738,72 +3743,72 @@ Tomt betyder inkludera alla. ?, * och [...] jokertecken accepteras.</translation
         <translation>Aktivera stöd för AFHDS2</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="574"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="581"/>
         <source>FrSky Taranis X9D</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="595"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="602"/>
         <source>FrSky Taranis X9E</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="562"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="569"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="568"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="537"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="544"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="543"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="550"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="563"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="549"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
         <source>FrSky Taranis X-Lite</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="530"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="529"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="536"/>
         <source>FrSky Horus X12S</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="677"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="627"/>
         <source>Jumper T-Lite</source>
         <translation></translation>
     </message>
@@ -3813,77 +3818,77 @@ Tomt betyder inkludera alla. ?, * och [...] jokertecken accepteras.</translation
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="637"/>
         <source>Jumper T-Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="701"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="708"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
         <source>Jumper T20</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="757"/>
         <source>Radiomaster MT12</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="777"/>
         <source>Radiomaster TX12</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="787"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
         <source>Radiomaster GX12</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="805"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="812"/>
         <source>Radiomaster Zorro</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="683"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="690"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="718"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="697"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="725"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="810"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="817"/>
         <source>Select if internal ELRS module is installed</source>
         <translation>Välj om intern ELRS-modul är installerad</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="747"/>
         <source>Radiomaster Pocket</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="766"/>
         <source>Radiomaster T8</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="804"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation></translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="484"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="801"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation>Stöd för intern hårdvarumodd: FlySky Paladin EV Gimbals</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="709"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
         <source>Jumper T18</source>
         <translation></translation>
     </message>
@@ -3903,12 +3908,12 @@ Tomt betyder inkludera alla. ?, * och [...] jokertecken accepteras.</translation
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="617"/>
         <source>iFlight Commando8</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="737"/>
         <source>Radiomaster Boxer</source>
         <translation></translation>
     </message>
@@ -4938,206 +4943,206 @@ Dessa inställningar gäller för alla modeller.</translation>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="412"/>
+        <location filename="../firmwares/generalsettings.cpp" line="414"/>
         <source>Radio Settings</source>
         <translation>Radioinställningar</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="414"/>
+        <location filename="../firmwares/generalsettings.cpp" line="416"/>
         <source>Hardware</source>
         <translation>Hårdvara</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="415"/>
+        <location filename="../firmwares/generalsettings.cpp" line="417"/>
         <source>Internal Module</source>
         <translation>Intern modul</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="430"/>
+        <location filename="../firmwares/generalsettings.cpp" line="432"/>
         <source>Axis &amp; Pots</source>
         <translation>Axlar och vred</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Axis</source>
         <translation>Axlar</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Pot</source>
         <translation>Vred</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="464"/>
+        <location filename="../firmwares/generalsettings.cpp" line="466"/>
         <source>Switches</source>
         <translation>Brytare</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="469"/>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="471"/>
+        <location filename="../firmwares/generalsettings.cpp" line="483"/>
         <source>Flex Switch</source>
         <translation>Flexbrytare</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Function Switch</source>
         <translation>Funktionsbrytare</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Switch</source>
         <translation>Brytare</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="499"/>
+        <location filename="../firmwares/generalsettings.cpp" line="501"/>
         <source>None</source>
         <translation>Ingen</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="553"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Internal</source>
         <translation>Intern</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="555"/>
+        <location filename="../firmwares/generalsettings.cpp" line="557"/>
         <source>Ask</source>
         <translation>Fråga</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="557"/>
+        <location filename="../firmwares/generalsettings.cpp" line="559"/>
         <source>Per model</source>
         <translation>Per modell</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>Internal + External</source>
         <translation>Intern + Extern</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>External</source>
         <translation>Extern</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="573"/>
-        <location filename="../firmwares/generalsettings.cpp" line="589"/>
+        <location filename="../firmwares/generalsettings.cpp" line="575"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>OFF</source>
         <translation>AV</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Enabled</source>
         <translation>Aktiv</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Telemetry</source>
         <translation>Telemetri</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="578"/>
+        <location filename="../firmwares/generalsettings.cpp" line="580"/>
         <source>Trainer</source>
         <translation>Lärare</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="591"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>Telemetry Mirror</source>
         <translation>Speglad telemetri</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="593"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>Telemetry In</source>
         <translation>Telemetri in</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="595"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>SBUS Trainer</source>
         <translation>SBUS Lärare</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="597"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>LUA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="599"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>CLI</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="601"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>GPS</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="603"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>Debug</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="640"/>
+        <location filename="../firmwares/generalsettings.cpp" line="642"/>
         <source>mA</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="739"/>
+        <location filename="../firmwares/generalsettings.cpp" line="741"/>
         <source>Normal</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="741"/>
+        <location filename="../firmwares/generalsettings.cpp" line="743"/>
         <source>OneBit</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="787"/>
+        <location filename="../firmwares/generalsettings.cpp" line="789"/>
         <source>Trims only</source>
         <translation>Endast trimm</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="789"/>
+        <location filename="../firmwares/generalsettings.cpp" line="791"/>
         <source>Keys only</source>
         <translation>Endast knapp</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="791"/>
+        <location filename="../firmwares/generalsettings.cpp" line="793"/>
         <source>Switchable</source>
         <translation>Ändringsbar</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="793"/>
+        <location filename="../firmwares/generalsettings.cpp" line="795"/>
         <source>Global</source>
         <translation>Global</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="927"/>
+        <location filename="../firmwares/generalsettings.cpp" line="929"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation>Mode 1 (ROD HÖJ GAS SKE)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="931"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation>Mode 2 (ROD GAS HÖJ SKE)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="933"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation>Mode 3 (SKE HÖJ GAS ROD)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="935"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation>Mode 4 (SKE GAS HÖJ ROD)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="605"/>
+        <location filename="../firmwares/generalsettings.cpp" line="607"/>
         <source>SpaceMouse</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="607"/>
+        <location filename="../firmwares/generalsettings.cpp" line="609"/>
         <source>External module</source>
         <translation>Extern modul</translation>
     </message>
@@ -6077,32 +6082,32 @@ Acceptabla värden är 3 - 12 volt</translation>
         <translation>Tjeckiska</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="434"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Slovak</source>
         <translation>Slovakiska</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="435"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Spanish</source>
         <translation>Spanska</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Polish</source>
         <translation>Polska</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="432"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Portuguese</source>
         <translation>Portugisiska</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="433"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Russian</source>
         <translation>Ryska</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="436"/>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Swedish</source>
         <translation>Svenska</translation>
     </message>
@@ -6122,42 +6127,47 @@ Acceptabla värden är 3 - 12 volt</translation>
         <translation>Knappar + Kontroller</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="437"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <source>Korean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="438"/>
         <source>Ukrainian</source>
         <translation>Ukrainska</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>No</source>
         <translation>Nej</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>RotEnc A</source>
         <translation>Inm.hjul A</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc B</source>
         <translation>Inm.hjul B</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc C</source>
         <translation>Inm.hjul C</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc D</source>
         <translation>Inm.hjul D</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc E</source>
         <translation>Inm.hjul E</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="617"/>
+        <location filename="../generaledit/generalsetup.cpp" line="618"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
@@ -6166,27 +6176,27 @@ att fungera. Detta går inte att ändra från radion.
 Är du säker?</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal</source>
         <translation></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Inverted</source>
         <translation>Inverterad</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation>Vertikal inverterad, Horisontell normal</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation>Vertikal inverterad, Horisontell alternativ</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal, Edit Inverted</source>
         <translation>Normal, Redigera inverterad</translation>
     </message>
@@ -15811,22 +15821,22 @@ Tidsstämpel</translation>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="873"/>
+        <location filename="../firmwares/generalsettings.cpp" line="875"/>
         <source>OFF</source>
         <translation>AV</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="875"/>
+        <location filename="../firmwares/generalsettings.cpp" line="877"/>
         <source>+= (Sum)</source>
         <translation>+= (Summera)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="877"/>
+        <location filename="../firmwares/generalsettings.cpp" line="879"/>
         <source>:= (Replace)</source>
         <translation>:= (Ersätt)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="886"/>
+        <location filename="../firmwares/generalsettings.cpp" line="888"/>
         <source>CH%1</source>
         <translation>KN%1</translation>
     </message>
@@ -17539,7 +17549,7 @@ Vill du fortsätta?</translation>
 <context>
     <name>YamlModelSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1288"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1287"/>
         <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
 
 Model settings may be corrupted if you continue.</source>
@@ -17548,7 +17558,7 @@ Model settings may be corrupted if you continue.</source>
 Modellinställningarna kan förstöras om du fortsätter.</translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1291"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1290"/>
         <source>Read Model Settings</source>
         <translation>Läs radioinställningar</translation>
     </message>

--- a/companion/src/translations/companion_zh_CN.ts
+++ b/companion/src/translations/companion_zh_CN.ts
@@ -1024,274 +1024,274 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="422"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>Left Horizontal</source>
         <translation type="unfinished">左摇杆水平方向</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="423"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>Left Vertical</source>
         <translation type="unfinished">左摇杆垂直方向</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="424"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>Right Vertical</source>
         <translation type="unfinished">右摇杆上下方向</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="425"/>
+        <location filename="../firmwares/boards.cpp" line="429"/>
         <source>Right Horizontal</source>
         <translation type="unfinished">右摇杆水平方向</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="426"/>
+        <location filename="../firmwares/boards.cpp" line="430"/>
         <source>Aux. 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="427"/>
+        <location filename="../firmwares/boards.cpp" line="431"/>
         <source>Aux. 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="443"/>
+        <location filename="../firmwares/boards.cpp" line="447"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="444"/>
+        <location filename="../firmwares/boards.cpp" line="448"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="449"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
         <source>RH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="459"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <source>TILT_X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="460"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <source>TILT_Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="506"/>
+        <location filename="../firmwares/boards.cpp" line="516"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
+        <location filename="../firmwares/boards.cpp" line="532"/>
+        <location filename="../firmwares/boards.cpp" line="548"/>
+        <location filename="../firmwares/boards.cpp" line="555"/>
+        <source>SL1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="475"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <source>P4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="517"/>
+        <location filename="../firmwares/boards.cpp" line="525"/>
+        <location filename="../firmwares/boards.cpp" line="533"/>
+        <location filename="../firmwares/boards.cpp" line="549"/>
+        <location filename="../firmwares/boards.cpp" line="556"/>
+        <source>SL2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="478"/>
+        <location filename="../firmwares/boards.cpp" line="557"/>
+        <source>SL3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="479"/>
+        <location filename="../firmwares/boards.cpp" line="558"/>
+        <source>SL4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <source>P5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="943"/>
+        <source>Slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="945"/>
+        <source>Multipos Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="947"/>
+        <source>Axis X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="949"/>
+        <source>Axis Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="951"/>
+        <source>Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Flight</source>
+        <translation type="unfinished">飞行  [Flight]</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="488"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="498"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
+        <location filename="../firmwares/boards.cpp" line="529"/>
+        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="553"/>
+        <source>P1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="473"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="504"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
+        <location filename="../firmwares/boards.cpp" line="530"/>
+        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="554"/>
+        <source>P2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="474"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="505"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
+        <location filename="../firmwares/boards.cpp" line="531"/>
+        <location filename="../firmwares/boards.cpp" line="543"/>
+        <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="455"/>
         <location filename="../firmwares/boards.cpp" line="457"/>
-        <source>TILT_X</source>
+        <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="456"/>
         <location filename="../firmwares/boards.cpp" line="458"/>
-        <source>TILT_Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="463"/>
-        <location filename="../firmwares/boards.cpp" line="472"/>
-        <location filename="../firmwares/boards.cpp" line="502"/>
-        <location filename="../firmwares/boards.cpp" line="512"/>
-        <location filename="../firmwares/boards.cpp" line="520"/>
-        <location filename="../firmwares/boards.cpp" line="528"/>
-        <location filename="../firmwares/boards.cpp" line="544"/>
-        <location filename="../firmwares/boards.cpp" line="551"/>
-        <source>SL1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="471"/>
-        <location filename="../firmwares/boards.cpp" line="510"/>
-        <source>P4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="473"/>
-        <location filename="../firmwares/boards.cpp" line="503"/>
-        <location filename="../firmwares/boards.cpp" line="513"/>
-        <location filename="../firmwares/boards.cpp" line="521"/>
-        <location filename="../firmwares/boards.cpp" line="529"/>
-        <location filename="../firmwares/boards.cpp" line="545"/>
-        <location filename="../firmwares/boards.cpp" line="552"/>
-        <source>SL2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="474"/>
-        <location filename="../firmwares/boards.cpp" line="553"/>
-        <source>SL3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="475"/>
-        <location filename="../firmwares/boards.cpp" line="554"/>
-        <source>SL4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="511"/>
-        <source>P5</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="933"/>
-        <source>Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="935"/>
-        <source>Multipos Switch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="937"/>
-        <source>Axis X</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="939"/>
-        <source>Axis Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="941"/>
-        <source>Switch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Flight</source>
-        <translation type="unfinished">飞行  [Flight]</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Drive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="464"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
-        <location filename="../firmwares/boards.cpp" line="479"/>
-        <location filename="../firmwares/boards.cpp" line="484"/>
-        <location filename="../firmwares/boards.cpp" line="490"/>
-        <location filename="../firmwares/boards.cpp" line="494"/>
-        <location filename="../firmwares/boards.cpp" line="499"/>
-        <location filename="../firmwares/boards.cpp" line="507"/>
-        <location filename="../firmwares/boards.cpp" line="517"/>
-        <location filename="../firmwares/boards.cpp" line="525"/>
-        <location filename="../firmwares/boards.cpp" line="537"/>
-        <location filename="../firmwares/boards.cpp" line="549"/>
-        <source>P1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="469"/>
-        <location filename="../firmwares/boards.cpp" line="480"/>
-        <location filename="../firmwares/boards.cpp" line="485"/>
-        <location filename="../firmwares/boards.cpp" line="495"/>
-        <location filename="../firmwares/boards.cpp" line="500"/>
-        <location filename="../firmwares/boards.cpp" line="508"/>
-        <location filename="../firmwares/boards.cpp" line="518"/>
-        <location filename="../firmwares/boards.cpp" line="526"/>
-        <location filename="../firmwares/boards.cpp" line="538"/>
-        <location filename="../firmwares/boards.cpp" line="550"/>
-        <source>P2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="470"/>
-        <location filename="../firmwares/boards.cpp" line="486"/>
-        <location filename="../firmwares/boards.cpp" line="501"/>
-        <location filename="../firmwares/boards.cpp" line="509"/>
-        <location filename="../firmwares/boards.cpp" line="519"/>
-        <location filename="../firmwares/boards.cpp" line="527"/>
-        <location filename="../firmwares/boards.cpp" line="539"/>
-        <source>P3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
-        <source>JSx</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="454"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="530"/>
-        <location filename="../firmwares/boards.cpp" line="540"/>
+        <location filename="../firmwares/boards.cpp" line="534"/>
+        <location filename="../firmwares/boards.cpp" line="544"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="531"/>
-        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="535"/>
+        <location filename="../firmwares/boards.cpp" line="545"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="532"/>
-        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="536"/>
+        <location filename="../firmwares/boards.cpp" line="546"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="533"/>
-        <location filename="../firmwares/boards.cpp" line="543"/>
+        <location filename="../firmwares/boards.cpp" line="537"/>
+        <location filename="../firmwares/boards.cpp" line="547"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="678"/>
-        <location filename="../firmwares/boards.cpp" line="897"/>
-        <location filename="../firmwares/boards.cpp" line="927"/>
+        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="907"/>
+        <location filename="../firmwares/boards.cpp" line="937"/>
         <source>None</source>
         <translation type="unfinished">无</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="929"/>
+        <location filename="../firmwares/boards.cpp" line="939"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="931"/>
+        <location filename="../firmwares/boards.cpp" line="941"/>
         <source>Pot with detent</source>
         <translation type="unfinished">有中位旋钮</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="680"/>
+        <location filename="../firmwares/boards.cpp" line="686"/>
         <source>2 Positions Toggle</source>
         <translation type="unfinished">2位弹簧开关</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="682"/>
+        <location filename="../firmwares/boards.cpp" line="688"/>
         <source>2 Positions</source>
         <translation type="unfinished">2位开关</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="690"/>
         <source>3 Positions</source>
         <translation type="unfinished">3位开关</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="686"/>
+        <location filename="../firmwares/boards.cpp" line="692"/>
         <source>Function</source>
         <translation type="unfinished">运算方式  [Function]</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="899"/>
+        <location filename="../firmwares/boards.cpp" line="909"/>
         <source>Standard</source>
         <translation type="unfinished">标准LCD  [Standard]</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="901"/>
+        <location filename="../firmwares/boards.cpp" line="911"/>
         <source>Small</source>
         <translation type="unfinished">小</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="903"/>
+        <location filename="../firmwares/boards.cpp" line="913"/>
         <source>Both</source>
         <translation type="unfinished">两侧</translation>
     </message>
@@ -1629,34 +1629,50 @@ Error description: %4</source>
         <translation type="unfinished">模拟器现在还不支持此版固件</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="380"/>
+        <location filename="../helpers.cpp" line="388"/>
+        <source>Uknown error during Simulator startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Data Load Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Error occurred while starting simulator.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="405"/>
         <source>Error creating temporary directory for models and settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="388"/>
+        <location filename="../helpers.cpp" line="413"/>
         <source>Error writing models and settings to temporary directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="419"/>
+        <location filename="../helpers.cpp" line="444"/>
         <source>Unable to start.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="421"/>
+        <location filename="../helpers.cpp" line="446"/>
         <source>Crashed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="423"/>
+        <location filename="../helpers.cpp" line="448"/>
         <source>Exited with result code:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="381"/>
         <location filename="../helpers.cpp" line="389"/>
-        <location filename="../helpers.cpp" line="426"/>
+        <location filename="../helpers.cpp" line="406"/>
+        <location filename="../helpers.cpp" line="414"/>
+        <location filename="../helpers.cpp" line="451"/>
         <source>Simulator Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3550,59 +3566,59 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="448"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="612"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="622"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="632"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="642"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="652"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="662"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="672"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="742"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="761"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="772"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="782"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="807"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="619"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="629"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="639"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="649"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="659"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="669"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="679"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="739"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="749"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="768"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="779"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="789"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="814"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation type="unfinished">禁用直升机菜单和CCPM混控菜单</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="449"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="613"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="623"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="633"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="643"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="653"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="663"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="673"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="733"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="743"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="752"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="762"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="773"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="783"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="680"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="769"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="815"/>
         <source>Disable Global variables</source>
         <translation type="unfinished">禁用GV[Global variables]功能</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="450"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="474"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="614"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="624"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="634"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="644"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="654"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="664"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="674"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="734"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="744"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="753"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="763"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="784"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="809"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="621"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="631"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="641"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="651"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="661"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="671"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="741"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="751"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="760"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="781"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="791"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="816"/>
         <source>Enable Lua custom scripts screen</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3612,7 +3628,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished">使用 另一个 SQT5 font</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
         <source>FrSky Taranis X9D+</source>
         <translation type="unfinished">FrSky Taranis X9D+</translation>
     </message>
@@ -3627,104 +3643,104 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="590"/>
         <source>Disable RAS (SWR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="574"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="581"/>
         <source>FrSky Taranis X9D</source>
         <translation type="unfinished">FrSky Taranis X9D</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="576"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
         <source>Haptic module installed</source>
         <translation type="unfinished">振动模块已经安装</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="595"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="602"/>
         <source>FrSky Taranis X9E</source>
         <translation type="unfinished">FrSky Taranis X9E</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
         <source>Confirmation before radio shutdown</source>
         <translation type="unfinished">遥控器关机前确认</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="597"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="604"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation type="unfinished">Horus 摇杆已安装 (霍尔传感器)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="562"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="569"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="537"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="544"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="563"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="549"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
         <source>FrSky Taranis X-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="530"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="529"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="536"/>
         <source>FrSky Horus X12S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="539"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation type="unfinished">只用与 DEV pcb 版本</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="677"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="675"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="703"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="682"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="710"/>
         <source>Support for MULTI internal module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="627"/>
         <source>Jumper T-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="637"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="701"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="708"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3734,26 +3750,26 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="777"/>
         <source>Radiomaster TX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="787"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="805"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="812"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="683"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="690"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="718"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="697"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="725"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="810"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="817"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3763,82 +3779,87 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <source>FlySky ST16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
         <source>HelloRadioSky V16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="647"/>
         <source>Jumper T-Pro V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="657"/>
         <source>Jumper T-Pro S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="667"/>
         <source>Jumper Bumblebee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
         <source>Jumper T12 MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
         <source>Jumper T14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="702"/>
         <source>Jumper T15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
         <source>Jumper T20 V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="737"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="747"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="757"/>
         <source>Radiomaster MT12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="766"/>
         <source>Radiomaster T8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="767"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
         <source>Allow bind using bind key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
         <source>Radiomaster GX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="804"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3849,12 +3870,12 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="484"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="801"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="709"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
         <source>Jumper T18</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3869,7 +3890,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="617"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3894,18 +3915,18 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="568"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="543"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="550"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="518"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="525"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="538"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4952,206 +4973,206 @@ These will be relevant for all models in the same EEPROM.</source>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="412"/>
+        <location filename="../firmwares/generalsettings.cpp" line="414"/>
         <source>Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="414"/>
+        <location filename="../firmwares/generalsettings.cpp" line="416"/>
         <source>Hardware</source>
         <translation type="unfinished">硬件</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="415"/>
+        <location filename="../firmwares/generalsettings.cpp" line="417"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="430"/>
+        <location filename="../firmwares/generalsettings.cpp" line="432"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="464"/>
+        <location filename="../firmwares/generalsettings.cpp" line="466"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="469"/>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="471"/>
+        <location filename="../firmwares/generalsettings.cpp" line="483"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="499"/>
+        <location filename="../firmwares/generalsettings.cpp" line="501"/>
         <source>None</source>
         <translation type="unfinished">无</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="553"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="555"/>
+        <location filename="../firmwares/generalsettings.cpp" line="557"/>
         <source>Ask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="557"/>
+        <location filename="../firmwares/generalsettings.cpp" line="559"/>
         <source>Per model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>Internal + External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="573"/>
-        <location filename="../firmwares/generalsettings.cpp" line="589"/>
+        <location filename="../firmwares/generalsettings.cpp" line="575"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Telemetry</source>
         <translation type="unfinished">回传设置 Tele</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="578"/>
+        <location filename="../firmwares/generalsettings.cpp" line="580"/>
         <source>Trainer</source>
         <translation type="unfinished">教练功能</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="591"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="593"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="595"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished">SBUS 教练功能  [SBUS Trainer]</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="597"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="599"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="601"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="603"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>Debug</source>
         <translation type="unfinished">除错 [Debug]</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="605"/>
+        <location filename="../firmwares/generalsettings.cpp" line="607"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="607"/>
+        <location filename="../firmwares/generalsettings.cpp" line="609"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="640"/>
+        <location filename="../firmwares/generalsettings.cpp" line="642"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="739"/>
+        <location filename="../firmwares/generalsettings.cpp" line="741"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="741"/>
+        <location filename="../firmwares/generalsettings.cpp" line="743"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="787"/>
+        <location filename="../firmwares/generalsettings.cpp" line="789"/>
         <source>Trims only</source>
         <translation type="unfinished">微调</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="789"/>
+        <location filename="../firmwares/generalsettings.cpp" line="791"/>
         <source>Keys only</source>
         <translation type="unfinished">导航键</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="791"/>
+        <location filename="../firmwares/generalsettings.cpp" line="793"/>
         <source>Switchable</source>
         <translation type="unfinished">可切换</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="793"/>
+        <location filename="../firmwares/generalsettings.cpp" line="795"/>
         <source>Global</source>
         <translation type="unfinished">全局</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="927"/>
+        <location filename="../firmwares/generalsettings.cpp" line="929"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation type="unfinished">MODE1 日本手 ↕升降↔方向   ↕油门↔副翼</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="931"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation type="unfinished">MODE2 美国手 ↕油门↔方向   ↕升降↔副翼</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="933"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation type="unfinished">MODE3 中国手 ↕升降↔副翼   ↕油门↔方向</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="935"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation type="unfinished">MODE4 模式4   ↕油门↔副翼   ↕升降↔方向</translation>
     </message>
@@ -6092,32 +6113,32 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished">捷克语</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="434"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Slovak</source>
         <translation type="unfinished">慢动作  [Slow]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="435"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Spanish</source>
         <translation type="unfinished">西班牙语</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Polish</source>
         <translation type="unfinished">波兰语</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="432"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Portuguese</source>
         <translation type="unfinished">葡萄牙语</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="433"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Russian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="436"/>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Swedish</source>
         <translation type="unfinished">瑞典语</translation>
     </message>
@@ -6127,7 +6148,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished">匈牙利语</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6162,64 +6183,69 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="437"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <source>Korean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="438"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>RotEnc A</source>
         <translation type="unfinished">旋转编码器A</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc B</source>
         <translation type="unfinished">旋转编码器B</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc C</source>
         <translation type="unfinished">旋转编码器C</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc D</source>
         <translation type="unfinished">旋转编码器D</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc E</source>
         <translation type="unfinished">旋转编码器E</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="617"/>
+        <location filename="../generaledit/generalsetup.cpp" line="618"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15816,22 +15842,22 @@ Timestamp</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="873"/>
+        <location filename="../firmwares/generalsettings.cpp" line="875"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="875"/>
+        <location filename="../firmwares/generalsettings.cpp" line="877"/>
         <source>+= (Sum)</source>
         <translation type="unfinished">+=  (相加)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="877"/>
+        <location filename="../firmwares/generalsettings.cpp" line="879"/>
         <source>:= (Replace)</source>
         <translation type="unfinished">:=   (取代)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="886"/>
+        <location filename="../firmwares/generalsettings.cpp" line="888"/>
         <source>CH%1</source>
         <translation type="unfinished">通道%1</translation>
     </message>
@@ -17530,14 +17556,14 @@ Do you wish to continue?</source>
 <context>
     <name>YamlModelSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1288"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1287"/>
         <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
 
 Model settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1291"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1290"/>
         <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>

--- a/companion/src/translations/companion_zh_TW.ts
+++ b/companion/src/translations/companion_zh_TW.ts
@@ -1024,274 +1024,274 @@ Error description: %4</source>
 <context>
     <name>Boards</name>
     <message>
-        <location filename="../firmwares/boards.cpp" line="422"/>
+        <location filename="../firmwares/boards.cpp" line="426"/>
         <source>Left Horizontal</source>
         <translation type="unfinished">左搖桿水平方向</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="423"/>
+        <location filename="../firmwares/boards.cpp" line="427"/>
         <source>Left Vertical</source>
         <translation type="unfinished">左搖桿垂直方向</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="424"/>
+        <location filename="../firmwares/boards.cpp" line="428"/>
         <source>Right Vertical</source>
         <translation type="unfinished">右搖桿上下方向</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="425"/>
+        <location filename="../firmwares/boards.cpp" line="429"/>
         <source>Right Horizontal</source>
         <translation type="unfinished">右搖桿水平方向</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="426"/>
+        <location filename="../firmwares/boards.cpp" line="430"/>
         <source>Aux. 1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="427"/>
+        <location filename="../firmwares/boards.cpp" line="431"/>
         <source>Aux. 2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="443"/>
+        <location filename="../firmwares/boards.cpp" line="447"/>
         <source>LH</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="444"/>
+        <location filename="../firmwares/boards.cpp" line="448"/>
         <source>LV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="445"/>
+        <location filename="../firmwares/boards.cpp" line="449"/>
         <source>RV</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="446"/>
+        <location filename="../firmwares/boards.cpp" line="450"/>
         <source>RH</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="459"/>
+        <location filename="../firmwares/boards.cpp" line="461"/>
+        <source>TILT_X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="460"/>
+        <location filename="../firmwares/boards.cpp" line="462"/>
+        <source>TILT_Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="467"/>
+        <location filename="../firmwares/boards.cpp" line="476"/>
+        <location filename="../firmwares/boards.cpp" line="506"/>
+        <location filename="../firmwares/boards.cpp" line="516"/>
+        <location filename="../firmwares/boards.cpp" line="524"/>
+        <location filename="../firmwares/boards.cpp" line="532"/>
+        <location filename="../firmwares/boards.cpp" line="548"/>
+        <location filename="../firmwares/boards.cpp" line="555"/>
+        <source>SL1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="475"/>
+        <location filename="../firmwares/boards.cpp" line="514"/>
+        <source>P4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="477"/>
+        <location filename="../firmwares/boards.cpp" line="507"/>
+        <location filename="../firmwares/boards.cpp" line="517"/>
+        <location filename="../firmwares/boards.cpp" line="525"/>
+        <location filename="../firmwares/boards.cpp" line="533"/>
+        <location filename="../firmwares/boards.cpp" line="549"/>
+        <location filename="../firmwares/boards.cpp" line="556"/>
+        <source>SL2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="478"/>
+        <location filename="../firmwares/boards.cpp" line="557"/>
+        <source>SL3</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="479"/>
+        <location filename="../firmwares/boards.cpp" line="558"/>
+        <source>SL4</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="515"/>
+        <source>P5</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="943"/>
+        <source>Slider</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="945"/>
+        <source>Multipos Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="947"/>
+        <source>Axis X</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="949"/>
+        <source>Axis Y</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="951"/>
+        <source>Switch</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Flight</source>
+        <translation type="unfinished">飛行  [Flight]</translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="1147"/>
+        <source>Drive</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="468"/>
+        <location filename="../firmwares/boards.cpp" line="472"/>
+        <location filename="../firmwares/boards.cpp" line="483"/>
+        <location filename="../firmwares/boards.cpp" line="488"/>
+        <location filename="../firmwares/boards.cpp" line="494"/>
+        <location filename="../firmwares/boards.cpp" line="498"/>
+        <location filename="../firmwares/boards.cpp" line="503"/>
+        <location filename="../firmwares/boards.cpp" line="511"/>
+        <location filename="../firmwares/boards.cpp" line="521"/>
+        <location filename="../firmwares/boards.cpp" line="529"/>
+        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="553"/>
+        <source>P1</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="473"/>
+        <location filename="../firmwares/boards.cpp" line="484"/>
+        <location filename="../firmwares/boards.cpp" line="489"/>
+        <location filename="../firmwares/boards.cpp" line="499"/>
+        <location filename="../firmwares/boards.cpp" line="504"/>
+        <location filename="../firmwares/boards.cpp" line="512"/>
+        <location filename="../firmwares/boards.cpp" line="522"/>
+        <location filename="../firmwares/boards.cpp" line="530"/>
+        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="554"/>
+        <source>P2</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/boards.cpp" line="474"/>
+        <location filename="../firmwares/boards.cpp" line="490"/>
+        <location filename="../firmwares/boards.cpp" line="505"/>
+        <location filename="../firmwares/boards.cpp" line="513"/>
+        <location filename="../firmwares/boards.cpp" line="523"/>
+        <location filename="../firmwares/boards.cpp" line="531"/>
+        <location filename="../firmwares/boards.cpp" line="543"/>
+        <source>P3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="455"/>
         <location filename="../firmwares/boards.cpp" line="457"/>
-        <source>TILT_X</source>
+        <source>JSx</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
         <location filename="../firmwares/boards.cpp" line="456"/>
         <location filename="../firmwares/boards.cpp" line="458"/>
-        <source>TILT_Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="463"/>
-        <location filename="../firmwares/boards.cpp" line="472"/>
-        <location filename="../firmwares/boards.cpp" line="502"/>
-        <location filename="../firmwares/boards.cpp" line="512"/>
-        <location filename="../firmwares/boards.cpp" line="520"/>
-        <location filename="../firmwares/boards.cpp" line="528"/>
-        <location filename="../firmwares/boards.cpp" line="544"/>
-        <location filename="../firmwares/boards.cpp" line="551"/>
-        <source>SL1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="471"/>
-        <location filename="../firmwares/boards.cpp" line="510"/>
-        <source>P4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="473"/>
-        <location filename="../firmwares/boards.cpp" line="503"/>
-        <location filename="../firmwares/boards.cpp" line="513"/>
-        <location filename="../firmwares/boards.cpp" line="521"/>
-        <location filename="../firmwares/boards.cpp" line="529"/>
-        <location filename="../firmwares/boards.cpp" line="545"/>
-        <location filename="../firmwares/boards.cpp" line="552"/>
-        <source>SL2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="474"/>
-        <location filename="../firmwares/boards.cpp" line="553"/>
-        <source>SL3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="475"/>
-        <location filename="../firmwares/boards.cpp" line="554"/>
-        <source>SL4</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="511"/>
-        <source>P5</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="933"/>
-        <source>Slider</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="935"/>
-        <source>Multipos Switch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="937"/>
-        <source>Axis X</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="939"/>
-        <source>Axis Y</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="941"/>
-        <source>Switch</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Flight</source>
-        <translation type="unfinished">飛行  [Flight]</translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="1137"/>
-        <source>Drive</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="464"/>
-        <location filename="../firmwares/boards.cpp" line="468"/>
-        <location filename="../firmwares/boards.cpp" line="479"/>
-        <location filename="../firmwares/boards.cpp" line="484"/>
-        <location filename="../firmwares/boards.cpp" line="490"/>
-        <location filename="../firmwares/boards.cpp" line="494"/>
-        <location filename="../firmwares/boards.cpp" line="499"/>
-        <location filename="../firmwares/boards.cpp" line="507"/>
-        <location filename="../firmwares/boards.cpp" line="517"/>
-        <location filename="../firmwares/boards.cpp" line="525"/>
-        <location filename="../firmwares/boards.cpp" line="537"/>
-        <location filename="../firmwares/boards.cpp" line="549"/>
-        <source>P1</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="469"/>
-        <location filename="../firmwares/boards.cpp" line="480"/>
-        <location filename="../firmwares/boards.cpp" line="485"/>
-        <location filename="../firmwares/boards.cpp" line="495"/>
-        <location filename="../firmwares/boards.cpp" line="500"/>
-        <location filename="../firmwares/boards.cpp" line="508"/>
-        <location filename="../firmwares/boards.cpp" line="518"/>
-        <location filename="../firmwares/boards.cpp" line="526"/>
-        <location filename="../firmwares/boards.cpp" line="538"/>
-        <location filename="../firmwares/boards.cpp" line="550"/>
-        <source>P2</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="470"/>
-        <location filename="../firmwares/boards.cpp" line="486"/>
-        <location filename="../firmwares/boards.cpp" line="501"/>
-        <location filename="../firmwares/boards.cpp" line="509"/>
-        <location filename="../firmwares/boards.cpp" line="519"/>
-        <location filename="../firmwares/boards.cpp" line="527"/>
-        <location filename="../firmwares/boards.cpp" line="539"/>
-        <source>P3</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="451"/>
-        <location filename="../firmwares/boards.cpp" line="453"/>
-        <source>JSx</source>
-        <translation type="unfinished"></translation>
-    </message>
-    <message>
-        <location filename="../firmwares/boards.cpp" line="452"/>
-        <location filename="../firmwares/boards.cpp" line="454"/>
         <source>JSy</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="530"/>
-        <location filename="../firmwares/boards.cpp" line="540"/>
+        <location filename="../firmwares/boards.cpp" line="534"/>
+        <location filename="../firmwares/boards.cpp" line="544"/>
         <source>EXT1</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="531"/>
-        <location filename="../firmwares/boards.cpp" line="541"/>
+        <location filename="../firmwares/boards.cpp" line="535"/>
+        <location filename="../firmwares/boards.cpp" line="545"/>
         <source>EXT2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="532"/>
-        <location filename="../firmwares/boards.cpp" line="542"/>
+        <location filename="../firmwares/boards.cpp" line="536"/>
+        <location filename="../firmwares/boards.cpp" line="546"/>
         <source>EXT3</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="533"/>
-        <location filename="../firmwares/boards.cpp" line="543"/>
+        <location filename="../firmwares/boards.cpp" line="537"/>
+        <location filename="../firmwares/boards.cpp" line="547"/>
         <source>EXT4</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="678"/>
-        <location filename="../firmwares/boards.cpp" line="897"/>
-        <location filename="../firmwares/boards.cpp" line="927"/>
+        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="907"/>
+        <location filename="../firmwares/boards.cpp" line="937"/>
         <source>None</source>
         <translation type="unfinished">无</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="929"/>
+        <location filename="../firmwares/boards.cpp" line="939"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="931"/>
+        <location filename="../firmwares/boards.cpp" line="941"/>
         <source>Pot with detent</source>
         <translation type="unfinished">有中位旋鈕</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="680"/>
+        <location filename="../firmwares/boards.cpp" line="686"/>
         <source>2 Positions Toggle</source>
         <translation type="unfinished">2段彈簧開關</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="682"/>
+        <location filename="../firmwares/boards.cpp" line="688"/>
         <source>2 Positions</source>
         <translation type="unfinished">2段開關</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="684"/>
+        <location filename="../firmwares/boards.cpp" line="690"/>
         <source>3 Positions</source>
         <translation type="unfinished">3段開關</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="686"/>
+        <location filename="../firmwares/boards.cpp" line="692"/>
         <source>Function</source>
         <translation type="unfinished">運算方式  [Function]</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="899"/>
+        <location filename="../firmwares/boards.cpp" line="909"/>
         <source>Standard</source>
         <translation type="unfinished">標準LCD  [Standard]</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="901"/>
+        <location filename="../firmwares/boards.cpp" line="911"/>
         <source>Small</source>
         <translation type="unfinished">小</translation>
     </message>
     <message>
-        <location filename="../firmwares/boards.cpp" line="903"/>
+        <location filename="../firmwares/boards.cpp" line="913"/>
         <source>Both</source>
         <translation type="unfinished">兩側</translation>
     </message>
@@ -1629,34 +1629,50 @@ Error description: %4</source>
         <translation type="unfinished">模擬器現在還不支持此版韌體</translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="380"/>
+        <location filename="../helpers.cpp" line="388"/>
+        <source>Uknown error during Simulator startup.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Data Load Error</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="395"/>
+        <source>Error occurred while starting simulator.</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../helpers.cpp" line="405"/>
         <source>Error creating temporary directory for models and settings.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="388"/>
+        <location filename="../helpers.cpp" line="413"/>
         <source>Error writing models and settings to temporary directory.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="419"/>
+        <location filename="../helpers.cpp" line="444"/>
         <source>Unable to start.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="421"/>
+        <location filename="../helpers.cpp" line="446"/>
         <source>Crashed.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="423"/>
+        <location filename="../helpers.cpp" line="448"/>
         <source>Exited with result code:</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../helpers.cpp" line="381"/>
         <location filename="../helpers.cpp" line="389"/>
-        <location filename="../helpers.cpp" line="426"/>
+        <location filename="../helpers.cpp" line="406"/>
+        <location filename="../helpers.cpp" line="414"/>
+        <location filename="../helpers.cpp" line="451"/>
         <source>Simulator Error</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3550,59 +3566,59 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="448"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="472"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="612"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="622"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="632"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="642"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="652"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="662"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="672"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="742"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="761"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="772"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="782"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="807"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="619"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="629"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="639"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="649"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="659"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="669"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="679"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="739"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="749"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="768"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="779"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="789"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="814"/>
         <source>Disable HELI menu and cyclic mix support</source>
         <translation type="unfinished">禁用直升機菜單和CCPM混控菜單</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="449"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="473"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="613"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="623"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="633"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="643"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="653"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="663"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="673"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="733"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="743"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="752"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="762"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="773"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="783"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="680"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="769"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="815"/>
         <source>Disable Global variables</source>
         <translation type="unfinished">禁用GV[Global variables]功能</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="450"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="474"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="614"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="624"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="634"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="644"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="654"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="664"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="674"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="734"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="744"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="753"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="763"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="784"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="809"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="621"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="631"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="641"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="651"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="661"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="671"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="741"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="751"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="760"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="781"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="791"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="816"/>
         <source>Enable Lua custom scripts screen</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3612,7 +3628,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished">使用 另一個 SQT5 font</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
         <source>FrSky Taranis X9D+</source>
         <translation type="unfinished">FrSky Taranis X9D+</translation>
     </message>
@@ -3627,104 +3643,104 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="582"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="590"/>
         <source>Disable RAS (SWR)</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="589"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
         <source>FrSky Taranis X9D+ 2019</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="574"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="581"/>
         <source>FrSky Taranis X9D</source>
         <translation type="unfinished">FrSky Taranis X9D</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="576"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="583"/>
         <source>Haptic module installed</source>
         <translation type="unfinished">振動模塊已經安裝</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="595"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="602"/>
         <source>FrSky Taranis X9E</source>
         <translation type="unfinished">FrSky Taranis X9E</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="596"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
         <source>Confirmation before radio shutdown</source>
         <translation type="unfinished">遙控器關機前確認</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="597"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="604"/>
         <source>Horus gimbals installed (Hall sensors)</source>
         <translation type="unfinished">Horus 搖桿已安裝 (霍爾傳感器)</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="562"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="569"/>
         <source>FrSky Taranis X9-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="537"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="544"/>
         <source>FrSky Taranis X7 / X7S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="563"/>
         <source>FrSky Taranis X-Lite S/PRO</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="549"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="556"/>
         <source>FrSky Taranis X-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
         <source>FrSky Horus X10 / X10S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="523"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="530"/>
         <source>FrSky Horus X10 Express / X10S Express</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="529"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="536"/>
         <source>FrSky Horus X12S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="532"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="539"/>
         <source>Use ONLY with first DEV pcb version</source>
         <translation type="unfinished">只用與 DEV pcb 版本</translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="670"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="677"/>
         <source>Jumper T12 / T12 Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="675"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="703"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="682"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="710"/>
         <source>Support for MULTI internal module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="620"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="627"/>
         <source>Jumper T-Lite</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="630"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="637"/>
         <source>Jumper T-Pro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="701"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="708"/>
         <source>Jumper T16 / T16+ / T16 Pro</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3734,26 +3750,26 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="770"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="777"/>
         <source>Radiomaster TX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="780"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="787"/>
         <source>Radiomaster TX12 Mark II</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="805"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="812"/>
         <source>Radiomaster Zorro</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="683"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="690"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="718"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="697"/>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="725"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="810"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="732"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="817"/>
         <source>Select if internal ELRS module is installed</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3763,82 +3779,87 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="603"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="516"/>
+        <source>FlySky ST16</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
         <source>HelloRadioSky V16</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="640"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="647"/>
         <source>Jumper T-Pro V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="650"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="657"/>
         <source>Jumper T-Pro S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="660"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="667"/>
         <source>Jumper Bumblebee</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="681"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
         <source>Jumper T12 MAX</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="688"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
         <source>Jumper T14</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="695"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="702"/>
         <source>Jumper T15</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
         <source>Jumper T20</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="723"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
         <source>Jumper T20 V2</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="730"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="737"/>
         <source>Radiomaster Boxer</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="740"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="747"/>
         <source>Radiomaster Pocket</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="750"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="757"/>
         <source>Radiomaster MT12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="759"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="766"/>
         <source>Radiomaster T8</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="767"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="774"/>
         <source>Allow bind using bind key</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="790"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
         <source>Radiomaster GX12</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="797"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="804"/>
         <source>Radiomaster TX16S / SE / Hall / Masterfire</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3849,12 +3870,12 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="484"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="801"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="808"/>
         <source>Support hardware mod: FlySky Paladin EV Gimbals</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="709"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="716"/>
         <source>Jumper T18</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3869,7 +3890,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="610"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="617"/>
         <source>iFlight Commando8</source>
         <translation type="unfinished"></translation>
     </message>
@@ -3894,18 +3915,18 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="568"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="575"/>
         <source>FrSky Taranis X9-Lite S</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="543"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="550"/>
         <source>FrSky Taranis X7 / X7S Access</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="518"/>
-        <location filename="../firmwares/opentx/opentxinterface.cpp" line="531"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="525"/>
+        <location filename="../firmwares/opentx/opentxinterface.cpp" line="538"/>
         <source>Support for ACCESS internal module replacement</source>
         <translation type="unfinished"></translation>
     </message>
@@ -4952,206 +4973,206 @@ These will be relevant for all models in the same EEPROM.</source>
 <context>
     <name>GeneralSettings</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="412"/>
+        <location filename="../firmwares/generalsettings.cpp" line="414"/>
         <source>Radio Settings</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="414"/>
+        <location filename="../firmwares/generalsettings.cpp" line="416"/>
         <source>Hardware</source>
         <translation type="unfinished">硬件</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="415"/>
+        <location filename="../firmwares/generalsettings.cpp" line="417"/>
         <source>Internal Module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="430"/>
+        <location filename="../firmwares/generalsettings.cpp" line="432"/>
         <source>Axis &amp; Pots</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Axis</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="435"/>
+        <location filename="../firmwares/generalsettings.cpp" line="437"/>
         <source>Pot</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="464"/>
+        <location filename="../firmwares/generalsettings.cpp" line="466"/>
         <source>Switches</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="469"/>
-        <location filename="../firmwares/generalsettings.cpp" line="481"/>
+        <location filename="../firmwares/generalsettings.cpp" line="471"/>
+        <location filename="../firmwares/generalsettings.cpp" line="483"/>
         <source>Flex Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Function Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="470"/>
-        <location filename="../firmwares/generalsettings.cpp" line="482"/>
+        <location filename="../firmwares/generalsettings.cpp" line="472"/>
+        <location filename="../firmwares/generalsettings.cpp" line="484"/>
         <source>Switch</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="499"/>
+        <location filename="../firmwares/generalsettings.cpp" line="501"/>
         <source>None</source>
         <translation type="unfinished">无</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="553"/>
+        <location filename="../firmwares/generalsettings.cpp" line="555"/>
         <source>Internal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="555"/>
+        <location filename="../firmwares/generalsettings.cpp" line="557"/>
         <source>Ask</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="557"/>
+        <location filename="../firmwares/generalsettings.cpp" line="559"/>
         <source>Per model</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>Internal + External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="560"/>
+        <location filename="../firmwares/generalsettings.cpp" line="562"/>
         <source>External</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="573"/>
-        <location filename="../firmwares/generalsettings.cpp" line="589"/>
+        <location filename="../firmwares/generalsettings.cpp" line="575"/>
+        <location filename="../firmwares/generalsettings.cpp" line="591"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Enabled</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="576"/>
+        <location filename="../firmwares/generalsettings.cpp" line="578"/>
         <source>Telemetry</source>
         <translation type="unfinished">回傳設置 Tele</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="578"/>
+        <location filename="../firmwares/generalsettings.cpp" line="580"/>
         <source>Trainer</source>
         <translation type="unfinished">教練功能</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="591"/>
+        <location filename="../firmwares/generalsettings.cpp" line="593"/>
         <source>Telemetry Mirror</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="593"/>
+        <location filename="../firmwares/generalsettings.cpp" line="595"/>
         <source>Telemetry In</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="595"/>
+        <location filename="../firmwares/generalsettings.cpp" line="597"/>
         <source>SBUS Trainer</source>
         <translation type="unfinished">SBUS 教練功能  [SBUS Trainer]</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="597"/>
+        <location filename="../firmwares/generalsettings.cpp" line="599"/>
         <source>LUA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="599"/>
+        <location filename="../firmwares/generalsettings.cpp" line="601"/>
         <source>CLI</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="601"/>
+        <location filename="../firmwares/generalsettings.cpp" line="603"/>
         <source>GPS</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="603"/>
+        <location filename="../firmwares/generalsettings.cpp" line="605"/>
         <source>Debug</source>
         <translation type="unfinished">除錯 [Debug]</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="605"/>
+        <location filename="../firmwares/generalsettings.cpp" line="607"/>
         <source>SpaceMouse</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="607"/>
+        <location filename="../firmwares/generalsettings.cpp" line="609"/>
         <source>External module</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="640"/>
+        <location filename="../firmwares/generalsettings.cpp" line="642"/>
         <source>mA</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="739"/>
+        <location filename="../firmwares/generalsettings.cpp" line="741"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="741"/>
+        <location filename="../firmwares/generalsettings.cpp" line="743"/>
         <source>OneBit</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="787"/>
+        <location filename="../firmwares/generalsettings.cpp" line="789"/>
         <source>Trims only</source>
         <translation type="unfinished">微調</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="789"/>
+        <location filename="../firmwares/generalsettings.cpp" line="791"/>
         <source>Keys only</source>
         <translation type="unfinished">導航鍵</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="791"/>
+        <location filename="../firmwares/generalsettings.cpp" line="793"/>
         <source>Switchable</source>
         <translation type="unfinished">可切換</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="793"/>
+        <location filename="../firmwares/generalsettings.cpp" line="795"/>
         <source>Global</source>
         <translation type="unfinished">全局</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="927"/>
+        <location filename="../firmwares/generalsettings.cpp" line="929"/>
         <source>Mode 1 (RUD ELE THR AIL)</source>
         <translation type="unfinished">MODE1 日本手 ↕升降↔方向   ↕油門↔副翼</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="929"/>
+        <location filename="../firmwares/generalsettings.cpp" line="931"/>
         <source>Mode 2 (RUD THR ELE AIL)</source>
         <translation type="unfinished">MODE2 美國手 ↕油門↔方向 ↕升降↔副翼</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="931"/>
+        <location filename="../firmwares/generalsettings.cpp" line="933"/>
         <source>Mode 3 (AIL ELE THR RUD)</source>
         <translation type="unfinished">MODE3 中國手 ↕升降↔副翼 ↕油門↔方向</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="933"/>
+        <location filename="../firmwares/generalsettings.cpp" line="935"/>
         <source>Mode 4 (AIL THR ELE RUD)</source>
         <translation type="unfinished">MODE4 模式4 ↕油門↔副翼 ↕升降↔方向</translation>
     </message>
@@ -6092,32 +6113,32 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished">捷克語</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="434"/>
+        <location filename="../generaledit/generalsetup.cpp" line="435"/>
         <source>Slovak</source>
         <translation type="unfinished">慢動作  [Slow]</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="435"/>
+        <location filename="../generaledit/generalsetup.cpp" line="436"/>
         <source>Spanish</source>
         <translation type="unfinished">西班牙語</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <location filename="../generaledit/generalsetup.cpp" line="432"/>
         <source>Polish</source>
         <translation type="unfinished">波蘭語</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="432"/>
+        <location filename="../generaledit/generalsetup.cpp" line="433"/>
         <source>Portuguese</source>
         <translation type="unfinished">葡萄牙語</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="433"/>
+        <location filename="../generaledit/generalsetup.cpp" line="434"/>
         <source>Russian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="436"/>
+        <location filename="../generaledit/generalsetup.cpp" line="437"/>
         <source>Swedish</source>
         <translation type="unfinished">瑞典語</translation>
     </message>
@@ -6127,7 +6148,7 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished">匈牙利語</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal, Edit Inverted</source>
         <translation type="unfinished"></translation>
     </message>
@@ -6162,64 +6183,69 @@ p, li { white-space: pre-wrap; }
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="437"/>
+        <location filename="../generaledit/generalsetup.cpp" line="431"/>
+        <source>Korean</source>
+        <translation type="unfinished"></translation>
+    </message>
+    <message>
+        <location filename="../generaledit/generalsetup.cpp" line="438"/>
         <source>Ukrainian</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>No</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>RotEnc A</source>
         <translation type="unfinished">旋轉編碼器A</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc B</source>
         <translation type="unfinished">旋轉編碼器B</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc C</source>
         <translation type="unfinished">旋轉編碼器C</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc D</source>
         <translation type="unfinished">旋轉編碼器D</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="509"/>
+        <location filename="../generaledit/generalsetup.cpp" line="510"/>
         <source>Rot Enc E</source>
         <translation type="unfinished">旋轉編碼器E</translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="617"/>
+        <location filename="../generaledit/generalsetup.cpp" line="618"/>
         <source>If you enable FAI, only RSSI and RxBt sensors will keep working.
 This function cannot be disabled by the radio.
 Are you sure ?</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Inverted</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Normal</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../generaledit/generalsetup.cpp" line="636"/>
+        <location filename="../generaledit/generalsetup.cpp" line="637"/>
         <source>Vertical Inverted, Horizontal Alternate</source>
         <translation type="unfinished"></translation>
     </message>
@@ -15816,22 +15842,22 @@ Timestamp</source>
 <context>
     <name>TrainerMix</name>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="873"/>
+        <location filename="../firmwares/generalsettings.cpp" line="875"/>
         <source>OFF</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="875"/>
+        <location filename="../firmwares/generalsettings.cpp" line="877"/>
         <source>+= (Sum)</source>
         <translation type="unfinished">+=  (相加)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="877"/>
+        <location filename="../firmwares/generalsettings.cpp" line="879"/>
         <source>:= (Replace)</source>
         <translation type="unfinished">:=   (取代)</translation>
     </message>
     <message>
-        <location filename="../firmwares/generalsettings.cpp" line="886"/>
+        <location filename="../firmwares/generalsettings.cpp" line="888"/>
         <source>CH%1</source>
         <translation type="unfinished">通道%1</translation>
     </message>
@@ -17530,14 +17556,14 @@ Do you wish to continue?</source>
 <context>
     <name>YamlModelSettings</name>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1288"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1287"/>
         <source>Warning: &apos;%1&apos; has settings version %2 that is not supported by this version of Companion!
 
 Model settings may be corrupted if you continue.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1291"/>
+        <location filename="../firmwares/edgetx/yaml_modeldata.cpp" line="1290"/>
         <source>Read Model Settings</source>
         <translation type="unfinished"></translation>
     </message>


### PR DESCRIPTION
### Thank you for your continued efforts in maintaining this project. 🙇‍♂️
### Summary of Changes
- `companion_ko.ts`: Full UI translation completed
- `translations.cpp`: Registered Korean language (`ko_KR`)
- `CMakeLists.txt`: Added Korean to the list of translation files

### Additional Notes
- Successfully built and tested in a local environment
- The translation is based on the latest `en.ts` file
- If there are any missing or improvable parts, your feedback would be greatly appreciated. 🙇‍♂️

Thank you!