### PR TITLE
fix(simu): restarting timer_queue

### DIFF
--- a/radio/src/os/task_pthread.cpp
+++ b/radio/src/os/task_pthread.cpp
@@ -80,7 +80,8 @@ void task_shutdown_all()
     pthread_join(task, nullptr);
   }
 
-  timer_queue::instance().stop();
+  timer_queue::destroy();
+  _stop_tasks = false;
 }
 
 struct run_context {

--- a/radio/src/os/timer_pthread.h
+++ b/radio/src/os/timer_pthread.h
@@ -41,5 +41,5 @@ struct timer_handle_t {
   std::atomic_bool active;
 };
 
-#define TIMER_INITIALIZER {}
+#define TIMER_INITIALIZER {0}
 

--- a/radio/src/os/timer_pthread_impl.h
+++ b/radio/src/os/timer_pthread_impl.h
@@ -31,7 +31,7 @@ struct timer_req_t {
 class timer_queue {
 
   std::unique_ptr<std::thread> _thread;
-  bool _running;
+  bool _running = false;
 
   std::deque<timer_req_t> _cmds;
   std::mutex _cmds_mutex;

--- a/radio/src/os/timer_pthread_impl.h
+++ b/radio/src/os/timer_pthread_impl.h
@@ -54,18 +54,19 @@ class timer_queue {
   void async_calls();
   void process_cmds();
   void send_cmd(timer_req_t&& req);
+  void stop();
 
 public:
   timer_queue(timer_queue const &) = delete;
   void operator=(timer_queue const &) = delete;
 
   static timer_queue &instance();
+  static void destroy();
 
   static void create_timer(timer_handle_t *timer, timer_func_t func, const char *name,
                            unsigned period, bool repeat);
 
   void start();
-  void stop();
 
   void start_timer(timer_handle_t *timer);
   void stop_timer(timer_handle_t *timer);


### PR DESCRIPTION
As it seems, the `timer_queue` class wasn't made to allow for restart. This PR fixes it.

Fixes #6218 