### PR TITLE
fix(radio): value calculation when GV used as source in weight/offset changed from 2.10

### DIFF
--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -63,7 +63,8 @@ int32_t getSourceNumFieldValue(int16_t val, int16_t min, int16_t max)
     result = getValue(v.value);
     if (abs(v.value) >= MIXSRC_FIRST_GVAR && v.value <= MIXSRC_LAST_GVAR) {
       // Mimic behviour of GET_GVAR_PREC1
-      result = result * 10;
+      if (g_model.gvars[abs(v.value) - MIXSRC_FIRST_GVAR].prec == 0)
+        result = result * 10;
     } else {
       result = calcRESXto1000(result);
     }


### PR DESCRIPTION
After the change to allow any source for weight/offset, the GV value calculation logic did not quite mimic the 2.10 behaviour.

Fixes: #6239 
