### PR TITLE
fix(color): widget zone size may be incorrect on startup.

### DIFF
--- a/radio/src/gui/colorlcd/mainview/layout_factory_impl.cpp
+++ b/radio/src/gui/colorlcd/mainview/layout_factory_impl.cpp
@@ -34,6 +34,7 @@ Layout::Layout(Window* parent, const LayoutFactory* factory,
     zoneCount(zoneCount),
     zoneMap(zoneMap)
 {
+  show(true);
 }
 
 void Layout::setTrimsVisible(bool visible)

--- a/radio/src/gui/colorlcd/mainview/view_main_decoration.cpp
+++ b/radio/src/gui/colorlcd/mainview/view_main_decoration.cpp
@@ -44,7 +44,7 @@ ViewMainDecoration::ViewMainDecoration(Window* parent, bool showTrims, bool show
   if (showTrims)
     createTrims(w_ml, w_mr, w_bl, w_br);
   if (showFM)
-  createFlightMode(w_bc);
+    createFlightMode(w_bc);
   if (showSliders)
     createSliders(w_ml, w_mr, w_bl, w_bc, w_br);
 }


### PR DESCRIPTION
The initial zone size passed to a widgets 'create' function may be wrong on startup.
