### PR TITLE
fix(t20v2): incorrect default transmitter battery calibration

### DIFF
--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -1645,7 +1645,11 @@
   #define ADC_EXT                       ADC1
   #define ADC_EXT_CHANNELS              { ADC_CHANNEL_RTC_BATT }
   #define ADC_EXT_SAMPTIME              LL_ADC_SAMPLINGTIME_56CYCLES
+#if defined(RADIO_T20V2)
+  #define ADC_VREF_PREC2                300
+#else
   #define ADC_VREF_PREC2                330
+#endif
 #elif defined(RADIO_MT12)
   #define ADC_GPIO_PIN_STICK_TH         LL_GPIO_PIN_0  // PA.00
   #define ADC_GPIO_PIN_STICK_ST         LL_GPIO_PIN_1  // PA.01


### PR DESCRIPTION
T20v2 does have a 3,0V Ref, but was set at 3,3V. Because of that Vbat measurement where too high. With this fix, I'm at 0,03v difference between (uncalibrated) display and voltmeter.

This change will likely affect stick calibration, so I leave you to decide if it should be brought into 2.11 codeline or not. 