### PR TITLE
fix(color): Lua LVGL line color not set correctly when 'pts' property is a function

### DIFF
--- a/radio/src/lua/lua_lvgl_widget.cpp
+++ b/radio/src/lua/lua_lvgl_widget.cpp
@@ -800,10 +800,15 @@ bool LvglWidgetLine::callRefs(lua_State *L)
   int t = lua_gettop(L);
   if (getPointsFunction != LUA_REFNIL) {
     if (pcallFunc(L, getPointsFunction, 1)) {
+      bool firstPts = (pts == nullptr);
       uint32_t h = getPts(L);
       if (h != ptsHash) {
         ptsHash = h;
         setLine();
+      }
+      if (firstPts) {
+        setColor(color.flags);
+        setOpacity(opacity.value);
       }
       lua_settop(L, t);
     } else {


### PR DESCRIPTION
Reported by @offer-shmuely on Discord.

Sample test script:
```Lua
local function init()
    lvgl.clear();
    lvgl.line({
        pts={{10,10},{320,240}},
        color=RED,
        thickness=5,
    })
    lvgl.line({
        pts=function() return {{50,10},{320,240}} end,
        color=BLUE,
        thickness=5,
    })
end
local function run(event, touchState)
  return 0
end
return {init = init, run = run, useLvgl=true}
```
