### PR TITLE
fix(color): output channel may not get focus when user taps on screen.

### DIFF
--- a/radio/src/gui/colorlcd/controls/channel_bar.cpp
+++ b/radio/src/gui/colorlcd/controls/channel_bar.cpp
@@ -35,6 +35,8 @@ ChannelBar::ChannelBar(Window* parent, const rect_t& rect, uint8_t channel,
     Window(parent, rect), channel(channel),
     getValue(std::move(getValueFunc))
 {
+  lv_obj_clear_flag(lvobj, LV_OBJ_FLAG_CLICKABLE);
+
   etx_solid_bg(lvobj, COLOR_THEME_PRIMARY2_INDEX);
 
   bar = lv_obj_create(lvobj);


### PR DESCRIPTION
Tapping in the area of the channel bar display may prevent the selected channel from getting focus, even though the menu pops up.

The channel bar is display only so make it non-clickable.
