### PR TITLE
fix(bw): radio_spectrum_analyser screen glitch on exit

### DIFF
--- a/radio/src/gui/common/stdlcd/radio_spectrum_analyser.cpp
+++ b/radio/src/gui/common/stdlcd/radio_spectrum_analyser.cpp
@@ -58,6 +58,7 @@ void menuRadioSpectrumAnalyser(event_t event)
     if (TELEMETRY_STREAMING()) {
       lcdDrawCenteredText(LCD_H/2, STR_TURN_OFF_RECEIVER);
       if (event == EVT_KEY_BREAK(KEY_EXIT)) {
+        killEvents(event);
         popMenu();
       }
       return;


### PR DESCRIPTION
Summary of changes:
Just calls killEvents to prevent screen garbage when exiting