### PR TITLE
feat(color): handle long press enter for pre-flight switch checks

### DIFF
--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -1206,17 +1206,7 @@ void menuModelSetup(event_t event)
                 if (menuHorizontalPosition < 0 ||
                     menuHorizontalPosition >= switchWarningsCount) {
                   START_NO_HIGHLIGHT();
-                  getMovedSwitch();
-                  // Mask switches enabled for warnings
-                  swarnstate_t sw_mask = 0;
-                  for(uint8_t i = 0; i < switchGetMaxSwitches(); i++) {
-                    if (SWITCH_WARNING_ALLOWED(i))
-                      if (g_model.switchWarning & (0x07 << (3 * i)))
-                        sw_mask |= (0x07 << (3 * i));
-                  }
-                  g_model.switchWarning = switches_states & sw_mask;
-                  AUDIO_WARNING1();
-                  storageDirty(EE_MODEL);
+                  setAllPreflightSwitchStates();
                 }
                 break;
             }

--- a/radio/src/gui/212x64/model_setup.cpp
+++ b/radio/src/gui/212x64/model_setup.cpp
@@ -879,17 +879,7 @@ void menuModelSetup(event_t event)
               killEvents(event);
               if (menuHorizontalPosition < 0) {
                 START_NO_HIGHLIGHT();
-                getMovedSwitch();
-                // Mask switches enabled for warnings
-                swarnstate_t sw_mask = 0;
-                for(uint8_t i = 0; i < switchGetMaxSwitches(); i++) {
-                  if (SWITCH_WARNING_ALLOWED(i))
-                    if (g_model.switchWarning & (0x07 << (3 * i)))
-                      sw_mask |= (0x07 << (3 * i));
-                }
-                g_model.switchWarning = switches_states & sw_mask;
-                AUDIO_WARNING1();
-                storageDirty(EE_MODEL);
+                setAllPreflightSwitchStates();
               }
               break;
           }

--- a/radio/src/gui/colorlcd/libui/button_matrix.cpp
+++ b/radio/src/gui/colorlcd/libui/button_matrix.cpp
@@ -26,11 +26,12 @@ static void btnmatrix_constructor(const lv_obj_class_t* class_p, lv_obj_t* obj)
 {
   etx_obj_add_style(obj, styles->rounded, LV_PART_MAIN);
   etx_obj_add_style(obj, styles->bg_opacity_20,
-                    LV_PART_MAIN | LV_STATE_FOCUSED);
+                    LV_PART_MAIN | LV_STATE_EDITED);
 
-  etx_bg_color(obj, COLOR_THEME_FOCUS_INDEX, LV_PART_MAIN | LV_STATE_FOCUSED);
+  etx_solid_bg(obj, COLOR_THEME_FOCUS_INDEX, LV_PART_MAIN | LV_STATE_FOCUSED);
 
   etx_std_style(obj, LV_PART_ITEMS, PAD_LARGE);
+  etx_remove_border_color(obj, LV_PART_ITEMS | LV_STATE_FOCUSED);
 
   etx_obj_add_style(obj, styles->border_color[COLOR_THEME_FOCUS_INDEX],
                     LV_PART_ITEMS | LV_STATE_EDITED);

--- a/radio/src/gui/colorlcd/libui/button_matrix.cpp
+++ b/radio/src/gui/colorlcd/libui/button_matrix.cpp
@@ -82,7 +82,7 @@ ButtonMatrix::ButtonMatrix(Window* parent, const rect_t& r) :
   lv_obj_add_flag(lvobj, LV_OBJ_FLAG_SCROLL_ON_FOCUS);
   lv_obj_clear_flag(lvobj, LV_OBJ_FLAG_CLICK_FOCUSABLE);
 
-  lv_obj_add_event_cb(lvobj, btn_matrix_event, LV_EVENT_ALL, this);
+  lv_obj_add_event_cb(lvobj, btn_matrix_event, LV_EVENT_VALUE_CHANGED, this);
 }
 
 ButtonMatrix::~ButtonMatrix() { deallocate(); }

--- a/radio/src/gui/colorlcd/model/preflight_checks.cpp
+++ b/radio/src/gui/colorlcd/model/preflight_checks.cpp
@@ -47,13 +47,7 @@ class SwitchWarnMatrix : public ButtonMatrix
 
     initBtnMap(min((int)btn_cnt, SW_BTNS), btn_cnt);
 
-    uint8_t btn_id = 0;
-    for (uint8_t i = 0; i < MAX_SWITCHES; i++) {
-      if (SWITCH_WARNING_ALLOWED(i)) {
-        setTextAndState(btn_id);
-        btn_id++;
-      }
-    }
+    setAllState();
 
     update();
 
@@ -65,8 +59,13 @@ class SwitchWarnMatrix : public ButtonMatrix
     padAll(PAD_SMALL);
   }
 
-  void onPress(uint8_t btn_id)
+  void onPress(uint8_t btn_id) override
   {
+    if (longPress) {
+      longPress = false;
+      return;
+    }
+
     if (btn_id >= MAX_SWITCHES) return;
     auto sw = sw_idx[btn_id];
 
@@ -83,7 +82,7 @@ class SwitchWarnMatrix : public ButtonMatrix
     setTextAndState(btn_id);
   }
 
-  bool isActive(uint8_t btn_id)
+  bool isActive(uint8_t btn_id) override
   {
     if (btn_id >= MAX_SWITCHES) return false;
     return bfGet(g_model.switchWarning, 3 * sw_idx[btn_id], 3) != 0;
@@ -105,6 +104,26 @@ class SwitchWarnMatrix : public ButtonMatrix
 
  private:
   uint8_t sw_idx[MAX_SWITCHES];
+  bool longPress = false;
+
+  void setAllState()
+  {
+    uint8_t btn_id = 0;
+    for (uint8_t i = 0; i < MAX_SWITCHES; i++) {
+      if (SWITCH_WARNING_ALLOWED(i)) {
+        setTextAndState(btn_id);
+        btn_id++;
+      }
+    }
+  }
+
+  bool onLongPress() override
+  {
+    longPress = true;
+    setAllPreflightSwitchStates();
+    setAllState();
+    return true;
+  }
 };
 
 class PotWarnMatrix : public ButtonMatrix

--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -1213,3 +1213,18 @@ void logicalSwitchesCopyState(uint8_t src, uint8_t dst)
 {
   lswFm[dst] = lswFm[src];
 }
+
+void setAllPreflightSwitchStates()
+{
+  getMovedSwitch();
+  // Mask switches enabled for warnings
+  swarnstate_t sw_mask = 0;
+  for(uint8_t i = 0; i < switchGetMaxSwitches(); i++) {
+    if (SWITCH_WARNING_ALLOWED(i))
+      if (g_model.switchWarning & (0x07 << (3 * i)))
+        sw_mask |= (0x07 << (3 * i));
+  }
+  g_model.switchWarning = switches_states & sw_mask;
+  AUDIO_WARNING1();
+  storageDirty(EE_MODEL);
+}

--- a/radio/src/switches.h
+++ b/radio/src/switches.h
@@ -111,3 +111,5 @@ void fsLedRGB(uint8_t, uint32_t color);
 uint32_t fsGetLedRGB(uint8_t index);
 uint8_t getRGBColorIndex(uint32_t color);
 #endif
+
+void setAllPreflightSwitchStates();


### PR DESCRIPTION
Add the same functionality that is available on B&W radios - a long press of the enter key when editing the pre-flight switch settings will use the current switch positions.

Marked for 3.0; but could be included in 2.11.2 if desired.

Fixes #6265 

Also improves the UI for the button matrix to differentiate the focus VS editing states.
This is most noticeable when using the rotary encoder rather than touch screen.

Not focused or edited (same as current UI):
![screenshot_tx16s_25-05-20_09-00-58](https://github.com/user-attachments/assets/060d0bc9-b14b-41fe-adfd-67b405890a65)

Focussed but not editing:
![screenshot_tx16s_25-05-20_09-01-00](https://github.com/user-attachments/assets/2164c936-441e-4094-a4ea-2e31f33c99b5)

Editing:
![screenshot_tx16s_25-05-20_09-03-23](https://github.com/user-attachments/assets/3873a978-e7c0-4212-bb80-c71ec16eb1ca)
