### PR TITLE
fix: review Jumper VREF values

### DIFF
--- a/radio/src/targets/horus/hal.h
+++ b/radio/src/targets/horus/hal.h
@@ -546,9 +546,9 @@
   #define ADC_DMA_STREAM_IRQHandler     DMA2_Stream0_IRQHandler
 
   // VBat divider is /4 on F42x and F43x devices
-  #if defined(RADIO_TX16S) || defined(RADIO_T15) || defined(RADIO_F16) || defined(RADIO_V16)
+  #if defined(RADIO_TX16S) || defined(RADIO_T15) || defined(RADIO_F16) || defined(RADIO_V16) || defined(RADIO_T18)
     #define ADC_VREF_PREC2              330
-  #elif defined(RADIO_T16) || defined(RADIO_T18)
+  #elif defined(RADIO_T16)
     #define ADC_VREF_PREC2              300
   #else
     #define ADC_VREF_PREC2              250

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -1519,7 +1519,7 @@
   #define ADC_CHANNEL_POT1              LL_ADC_CHANNEL_8  // ADC12_IN8
   #define ADC_CHANNEL_POT2              LL_ADC_CHANNEL_9  // ADC12_IN9
   #define ADC_CHANNEL_BATT              LL_ADC_CHANNEL_10
-  #define ADC_VREF_PREC2                330
+  #define ADC_VREF_PREC2                300
 #elif defined(RADIO_TPROS)
   #define HARDWARE_POT1
   #define HARDWARE_POT2
@@ -1582,7 +1582,7 @@
   #define ADC_CHANNEL_POT1              LL_ADC_CHANNEL_6
   #define ADC_CHANNEL_POT2              LL_ADC_CHANNEL_8
   #define ADC_CHANNEL_BATT              LL_ADC_CHANNEL_10
-  #define ADC_VREF_PREC2                330
+  #define ADC_VREF_PREC2                300
 #elif defined(RADIO_BUMBLEBEE)
   #define ADC_MAIN                      ADC3
   #define ADC_DMA                       DMA2
@@ -1645,11 +1645,7 @@
   #define ADC_EXT                       ADC1
   #define ADC_EXT_CHANNELS              { ADC_CHANNEL_RTC_BATT }
   #define ADC_EXT_SAMPTIME              LL_ADC_SAMPLINGTIME_56CYCLES
-#if defined(RADIO_T20V2)
   #define ADC_VREF_PREC2                300
-#else
-  #define ADC_VREF_PREC2                330
-#endif
 #elif defined(RADIO_MT12)
   #define ADC_GPIO_PIN_STICK_TH         LL_GPIO_PIN_0  // PA.00
   #define ADC_GPIO_PIN_STICK_ST         LL_GPIO_PIN_1  // PA.01


### PR DESCRIPTION
After another report of bat issue on RCG (this time on T14), I asked Jumper to provide a complete list of VREF per radio, which they kindly supplied.

![image](https://github.com/user-attachments/assets/72ec28f8-7338-4316-8239-38f190182e3e)

If your Chinese is as non existent as mine, the strange thing means Bumblebee !

This is aligning our code to the list they supplied

Needed for 2.11 too
