### PR TITLE
fix(radio): potential crash if too many telemetry sensors discovered

### DIFF
--- a/radio/src/gui/128x64/model_telemetry.cpp
+++ b/radio/src/gui/128x64/model_telemetry.cpp
@@ -214,7 +214,7 @@ void menuModelTelemetry(event_t event)
             pushMenu(menuModelSensor);
           }
           else {
-            allowNewSensors = 0;
+            allowNewSensors = false;
             POPUP_WARNING(STR_TELEMETRYFULL);
           }
         }

--- a/radio/src/gui/212x64/model_telemetry.cpp
+++ b/radio/src/gui/212x64/model_telemetry.cpp
@@ -218,7 +218,7 @@ void menuModelTelemetry(event_t event)
             pushMenu(menuModelSensor);
           }
           else {
-            allowNewSensors = 0;
+            allowNewSensors = false;
             POPUP_WARNING(STR_TELEMETRYFULL);
           }
         }

--- a/radio/src/gui/colorlcd/model/model_telemetry.cpp
+++ b/radio/src/gui/colorlcd/model/model_telemetry.cpp
@@ -773,7 +773,14 @@ void ModelTelemetryPage::checkEvents()
 {
   int _lastKnownIndex = availableTelemetryIndex();
 
-  if (lastKnownIndex >= 0 && lastKnownIndex != _lastKnownIndex) {
+  if (_lastKnownIndex < 0) {
+    if (discover->checked()) {
+      rebuild(window);
+      discover->setText(STR_DISCOVER_SENSORS);
+      discover->check(false);
+      POPUP_WARNING(STR_TELEMETRYFULL);
+    }
+  } else if (lastKnownIndex != _lastKnownIndex) {
     rebuild(window);
     lastKnownIndex = _lastKnownIndex;
   }
@@ -784,7 +791,8 @@ void ModelTelemetryPage::checkEvents()
 void ModelTelemetryPage::rebuild(Window* window, int8_t focusSensorIndex)
 {
   buildSensorList(focusSensorIndex);
-  lastKnownIndex = availableTelemetryIndex();
+  if (availableTelemetryIndex() >= 0)
+    lastKnownIndex = availableTelemetryIndex();
 }
 
 void ModelTelemetryPage::editSensor(Window* window, uint8_t index)
@@ -822,7 +830,7 @@ void ModelTelemetryPage::buildSensorList(int8_t focusSensorIndex)
             SET_DIRTY();
             rebuild(window, newIndex);
           } else {
-            new FullScreenDialog(WARNING_TYPE_ALERT, "", STR_TELEMETRYFULL);
+            POPUP_WARNING(STR_TELEMETRYFULL);
           }
         });
         menu->addLine(STR_DELETE, [=]() {
@@ -904,7 +912,7 @@ void ModelTelemetryPage::build(Window* window)
         if (idx >= 0)
           editSensor(window, idx);
         else
-          new FullScreenDialog(WARNING_TYPE_ALERT, "", STR_TELEMETRYFULL);
+          POPUP_WARNING(STR_TELEMETRYFULL);
         return 0;
       });
   lv_obj_set_grid_cell(b->getLvObj(), LV_GRID_ALIGN_STRETCH, 1, 1,

--- a/radio/src/gui/colorlcd/model/model_telemetry.cpp
+++ b/radio/src/gui/colorlcd/model/model_telemetry.cpp
@@ -775,31 +775,24 @@ void ModelTelemetryPage::checkEvents()
 
   if (_lastKnownIndex < 0) {
     if (discover->checked()) {
-      rebuild(window);
+      buildSensorList(-1);
       discover->setText(STR_DISCOVER_SENSORS);
       discover->check(false);
       POPUP_WARNING(STR_TELEMETRYFULL);
     }
   } else if (lastKnownIndex != _lastKnownIndex) {
-    rebuild(window);
+    buildSensorList(-1);
     lastKnownIndex = _lastKnownIndex;
   }
 
   PageTab::checkEvents();
 }
 
-void ModelTelemetryPage::rebuild(Window* window, int8_t focusSensorIndex)
-{
-  buildSensorList(focusSensorIndex);
-  if (availableTelemetryIndex() >= 0)
-    lastKnownIndex = availableTelemetryIndex();
-}
-
-void ModelTelemetryPage::editSensor(Window* window, uint8_t index)
+void ModelTelemetryPage::editSensor(uint8_t index)
 {
   lastKnownIndex = -1;
   Window* editWindow = new SensorEditWindow(index);
-  editWindow->setCloseHandler([=]() { rebuild(window, index); });
+  editWindow->setCloseHandler([=]() { buildSensorList(index); });
 }
 
 void ModelTelemetryPage::buildSensorList(int8_t focusSensorIndex)
@@ -817,7 +810,7 @@ void ModelTelemetryPage::buildSensorList(int8_t focusSensorIndex)
 
       button->setPressHandler([=]() -> uint8_t {
         Menu* menu = new Menu();
-        menu->addLine(STR_EDIT, [=]() { editSensor(window, idx); });
+        menu->addLine(STR_EDIT, [=]() { editSensor(idx); });
         menu->addLine(STR_COPY, [=]() {
           auto newIndex = availableTelemetryIndex();
           if (newIndex >= 0) {
@@ -828,7 +821,7 @@ void ModelTelemetryPage::buildSensorList(int8_t focusSensorIndex)
             TelemetryItem& newItem = telemetryItems[newIndex];
             newItem = sourceItem;
             SET_DIRTY();
-            rebuild(window, newIndex);
+            buildSensorList(newIndex);
           } else {
             POPUP_WARNING(STR_TELEMETRYFULL);
           }
@@ -837,17 +830,17 @@ void ModelTelemetryPage::buildSensorList(int8_t focusSensorIndex)
           delTelemetryIndex(idx);  // calls setDirty internally
           for (uint8_t i = idx + 1; i < MAX_TELEMETRY_SENSORS; i += 1) {
             if (g_model.telemetrySensors[i].isAvailable()) {
-              rebuild(window, i);
+              buildSensorList(i);
               return;
             }
           }
           for (int8_t i = idx - 1; i >= 0; i -= 1) {
             if (g_model.telemetrySensors[i].isAvailable()) {
-              rebuild(window, i);
+              buildSensorList(i);
               return;
             }
           }
-          rebuild(window, -1);
+          buildSensorList(-1);
         });
         return 0;
       });
@@ -867,6 +860,11 @@ void ModelTelemetryPage::buildSensorList(int8_t focusSensorIndex)
 
   uint8_t sensorsCount = getTelemetrySensorsCount();
   deleteAll->show(sensorsCount > 0);
+
+  if (availableTelemetryIndex() >= 0)
+    lastKnownIndex = availableTelemetryIndex();
+  else
+    lastKnownIndex = MAX_TELEMETRY_SENSORS;
 }
 
 void ModelTelemetryPage::build(Window* window)
@@ -874,8 +872,6 @@ void ModelTelemetryPage::build(Window* window)
   window->padAll(PAD_TINY);
   window->padBottom(PAD_LARGE);
   window->setFlexLayout(LV_FLEX_FLOW_COLUMN, PAD_ZERO);
-
-  this->window = window;
 
   // Sensors
   new Subtitle(window, STR_TELEMETRY_SENSORS);
@@ -910,7 +906,7 @@ void ModelTelemetryPage::build(Window* window)
       new TextButton(line, rect_t{}, STR_TELEMETRY_NEWSENSOR, [=]() -> uint8_t {
         int idx = availableTelemetryIndex();
         if (idx >= 0)
-          editSensor(window, idx);
+          editSensor(idx);
         else
           POPUP_WARNING(STR_TELEMETRYFULL);
         return 0;

--- a/radio/src/gui/colorlcd/model/model_telemetry.h
+++ b/radio/src/gui/colorlcd/model/model_telemetry.h
@@ -37,14 +37,12 @@ class ModelTelemetryPage : public PageTab
 
  protected:
   int lastKnownIndex = 0;
-  Window* window = nullptr;
   Window* sensorWindow = nullptr;
   TextButton* discover = nullptr;
   TextButton* deleteAll = nullptr;
 
   void checkEvents() override;
 
-  void editSensor(Window* window, uint8_t index);
-  void rebuild(Window* window, int8_t focusSensorIndex = -1);
+  void editSensor(uint8_t index);
   void buildSensorList(int8_t focusSensorIndex = -1);
 };

--- a/radio/src/telemetry/telemetry_sensors.cpp
+++ b/radio/src/telemetry/telemetry_sensors.cpp
@@ -56,7 +56,7 @@
 #endif
 
 TelemetryItem telemetryItems[MAX_TELEMETRY_SENSORS];
-uint8_t allowNewSensors;
+bool allowNewSensors;
 
 bool isFaiForbidden(source_t idx)
 {
@@ -597,7 +597,11 @@ int setTelemetryValue(TelemetryProtocol protocol, uint16_t id, uint8_t subId,
     return index;
   }
   else {
+    allowNewSensors = false;
+#if !defined(COLORLCD)
+    // Not safe on color LCD - handled in telemetry page instead
     POPUP_WARNING(STR_TELEMETRYFULL);
+#endif
     return -1;
   }
 }

--- a/radio/src/telemetry/telemetry_sensors.h
+++ b/radio/src/telemetry/telemetry_sensors.h
@@ -130,5 +130,5 @@ class TelemetryItem
 };
 
 extern TelemetryItem telemetryItems[MAX_TELEMETRY_SENSORS];
-extern uint8_t allowNewSensors;
+extern bool allowNewSensors;
 bool isFaiForbidden(source_t idx);


### PR DESCRIPTION
Radio does not stop trying to add new sensors and gets very confused.

Also changed the popup warnings for color radios to be consistent (changed full screen warning to message popup).

This fixes #6286
