### PR TITLE
feat(color): reduce lag in scrolling main view when using model info widget

### DIFF
--- a/radio/src/gui/colorlcd/libui/static.cpp
+++ b/radio/src/gui/colorlcd/libui/static.cpp
@@ -301,6 +301,14 @@ void StaticBitmap::setSource(const char *filename)
   }
 }
 
+void StaticBitmap::clearSource()
+{
+  if (img) delete img;
+  img = nullptr;
+  if (canvas) lv_obj_del(canvas);
+  canvas = nullptr;
+}
+
 StaticBitmap::~StaticBitmap()
 {
   if (img) delete img;

--- a/radio/src/gui/colorlcd/libui/static.h
+++ b/radio/src/gui/colorlcd/libui/static.h
@@ -178,6 +178,7 @@ class StaticBitmap : public Window
 #endif
 
   void setSource(const char *filename);
+  void clearSource();
   bool hasImage() const;
 
  protected:

--- a/radio/src/gui/colorlcd/mainview/topbar_impl.cpp
+++ b/radio/src/gui/colorlcd/mainview/topbar_impl.cpp
@@ -73,30 +73,24 @@ rect_t TopBar::getZone(unsigned int index) const
 
 void TopBar::setVisible(float visible) // 0.0 -> 1.0
 {
+  coord_t y = 0;
   if (visible == 0.0) {
-    setTop(-(int)EdgeTxStyles::MENU_HEADER_HEIGHT);
+    y = -EdgeTxStyles::MENU_HEADER_HEIGHT;
+  } else if (visible > 0.0 && visible < 1.0){
+    y = -(float)EdgeTxStyles::MENU_HEADER_HEIGHT * (1.0 - visible);
   }
-  else if (visible == 1.0) {
-    setTop(0);
-  }
-  else if (visible > 0.0 && visible < 1.0){
-    float top = - (float)EdgeTxStyles::MENU_HEADER_HEIGHT * (1.0 - visible);
-    setTop((coord_t)top);
-  }
+  if (y != top()) setTop(y);
 }
 
 void TopBar::setEdgeTxButtonVisible(float visible) // 0.0 -> 1.0
 {
+  coord_t y = 0;
   if (visible == 0.0) {
-    headerIcon->setTop(-(int)EdgeTxStyles::MENU_HEADER_HEIGHT);
+    y = -EdgeTxStyles::MENU_HEADER_HEIGHT;
+  } else if (visible > 0.0 && visible < 1.0){
+    y = -(float)EdgeTxStyles::MENU_HEADER_HEIGHT * (1.0 - visible);
   }
-  else if (visible == 1.0) {
-    headerIcon->setTop(0);
-  }
-  else if (visible > 0.0 && visible < 1.0){
-    float top = - (float)EdgeTxStyles::MENU_HEADER_HEIGHT * (1.0 - visible);
-    headerIcon->setTop((coord_t)top);
-  }
+  if (y != headerIcon->top()) headerIcon->setTop(y);
 }
 
 coord_t TopBar::getVisibleHeight(float visible) const // 0.0 -> 1.0

--- a/radio/src/gui/colorlcd/mainview/view_main.cpp
+++ b/radio/src/gui/colorlcd/mainview/view_main.cpp
@@ -52,17 +52,26 @@ static void saveViewId(unsigned view)
   }
 }
 
+static void tile_view_scroll_begin(lv_event_t * e)
+{
+	lv_anim_t* a = (lv_anim_t*)lv_event_get_param(e);
+	if (a) a->time = 0;
+}
+
 static void tile_view_scroll(lv_event_t* e)
 {
-  // (void)e;
   auto viewMain = ViewMain::instance();
   if (viewMain) {
-    if (lv_event_get_code(e) == LV_EVENT_SCROLL_END) {
-      auto view = viewMain->getCurrentMainView();
-      saveViewId(view);
-    } else {
-      viewMain->updateTopbarVisibility();
-    }
+    viewMain->updateTopbarVisibility();
+  }
+}
+
+static void tile_view_scroll_end(lv_event_t* e)
+{
+  auto viewMain = ViewMain::instance();
+  if (viewMain) {
+    auto view = viewMain->getCurrentMainView();
+    saveViewId(view);
   }
 }
 
@@ -81,8 +90,9 @@ ViewMain::ViewMain() :
 
   lv_obj_add_flag(tile_view, LV_OBJ_FLAG_EVENT_BUBBLE);
   lv_obj_set_user_data(tile_view, this);
+  lv_obj_add_event_cb(tile_view, tile_view_scroll_begin, LV_EVENT_SCROLL_BEGIN, NULL);
   lv_obj_add_event_cb(tile_view, tile_view_scroll, LV_EVENT_SCROLL, nullptr);
-  lv_obj_add_event_cb(tile_view, tile_view_scroll, LV_EVENT_SCROLL_END,
+  lv_obj_add_event_cb(tile_view, tile_view_scroll_end, LV_EVENT_SCROLL_END,
                       nullptr);
 
   // create last to be on top

--- a/radio/src/gui/colorlcd/widgets/modelbmp.cpp
+++ b/radio/src/gui/colorlcd/widgets/modelbmp.cpp
@@ -43,7 +43,7 @@ class ModelBitmapWidget : public Widget
     label = new StaticText(this, rect_t{}, s);
     label->hide();
 
-    image = new StaticImage(this, rect_t{0, 0, width(), height()});
+    image = new StaticBitmap(this, rect_t{0, 0, width(), height()});
     image->hide();
 
     update();
@@ -95,24 +95,28 @@ class ModelBitmapWidget : public Widget
     else
       lv_obj_clear_state(lvobj, ETX_STATE_BG_FILL);
 
-    if (!image->hasImage() || deps_hash != getHash()) {
+    coord_t w = width();
+    coord_t h = height() - (isLarge ? LARGE_IMG_H : 0);
+    bool sizeChg = (w != image->width()) || (h != image->height());
+
+    if (sizeChg)
+      image->setRect({0, isLarge ? LARGE_IMG_H : 0, w, h});
+
+    if (!image->hasImage() || deps_hash != getHash() || sizeChg) {
       if (g_model.header.bitmap[0]) {
         char filename[LEN_BITMAP_NAME + 1];
         strAppend(filename, g_model.header.bitmap, LEN_BITMAP_NAME);
         std::string fullpath =
             std::string(BITMAPS_PATH PATH_SEPARATOR) + filename;
 
-        image->setSource(fullpath);
+        image->setSource(fullpath.c_str());
       } else {
         image->clearSource();
       }
       deps_hash = getHash();
     }
 
-    image->setRect(
-        {0, isLarge ? LARGE_IMG_H : 0, width(), height() - (isLarge ? LARGE_IMG_H : 0)});
     image->show(image->hasImage());
-    image->setZoom();
 
     label->show(isLarge || !image->hasImage());
   }
@@ -123,7 +127,7 @@ class ModelBitmapWidget : public Widget
   bool isLarge = false;
   uint32_t deps_hash = 0;
   StaticText* label = nullptr;
-  StaticImage* image = nullptr;
+  StaticBitmap* image = nullptr;
 
   uint32_t getHash() { return hash(g_model.header.bitmap, LEN_BITMAP_NAME); }
 

--- a/radio/src/gui/colorlcd/widgets/modelbmp.cpp
+++ b/radio/src/gui/colorlcd/widgets/modelbmp.cpp
@@ -38,15 +38,13 @@ class ModelBitmapWidget : public Widget
     etx_obj_add_style(lvobj, styles->bg_opacity_cover,
                       LV_PART_MAIN | ETX_STATE_BG_FILL);
 
-    char s[LEN_MODEL_NAME + 1];
-    strAppend(s, g_model.header.name, LEN_MODEL_NAME);
-    label = new StaticText(this, rect_t{}, s);
+    label = new StaticText(this, rect_t{}, "");
     label->hide();
 
-    image = new StaticBitmap(this, rect_t{0, 0, width(), height()});
+    image = new StaticBitmap(this, {0, 0, width(), height()});
     image->hide();
 
-    update();
+    checkEvents();
   }
 
   void checkEvents() override
@@ -55,8 +53,6 @@ class ModelBitmapWidget : public Widget
 
     if (getHash() != deps_hash) {
       update();
-      // Force bitmap redraw
-      invalidate();
     }
 
     char s[LEN_MODEL_NAME + 1];


### PR DESCRIPTION
Use StaticBitmap instead of StaticImage for model info widget.

Does not look as nice (no anti aliasing); but is faster and does not slow down the left/right scrolling of the main view as much.
