### PR TITLE
fix(bw): main view switch display may be incorrect

### DIFF
--- a/radio/src/gui/128x64/view_main.cpp
+++ b/radio/src/gui/128x64/view_main.cpp
@@ -519,12 +519,15 @@ void menuMainView(event_t event)
         // Switches
         // -> 2 columns: one for each side
         // -> 4 slots on each side
-        uint8_t switches = switchGetMaxSwitches();
+        uint8_t maxSwitch = 0;
+        for (uint8_t n = 0; n < switchGetMaxSwitches(); n += 1)
+            if (SWITCH_EXISTS(n) && !switchIsFlex(n))
+              maxSwitch = n + 1;
 
-        if (switches < 7) {
-          for (int i = 0; i < switches; ++i) {
-            if (SWITCH_EXISTS(i) && !switchIsFlex(i)) {
-              auto switch_display = switchGetDisplayPosition(i);
+        for (int i = 0; i < maxSwitch; ++i) {
+          if (SWITCH_EXISTS(i) && !switchIsFlex(i)) {
+            auto switch_display = switchGetDisplayPosition(i);
+            if (maxSwitch < 7) {
               coord_t x = switch_display.col == 0 ? 3 * FW + 3 : 18 * FW + 1;
               coord_t y = 33 + switch_display.row * FH;
               getvalue_t val = getValue(MIXSRC_FIRST_SWITCH + i);
@@ -534,14 +537,9 @@ void menuMainView(event_t event)
                               : ((val == 0) ? 3 * i + 2 : 3 * i + 3));
               drawSwitch(x, y, sw, CENTERED, false);
             }
-          }
-        }
-        else {
-          for (int i = 0; i < switches; ++i) {
-            if (SWITCH_EXISTS(i) && !switchIsFlex(i)) {
-              auto switch_display = switchGetDisplayPosition(i);
+            else {
               coord_t x = (switch_display.col == 0 ? 8 : 96) + switch_display.row * 5;
-              if (switches < 9) x += 3;
+              if (maxSwitch < 9) x += (switch_display.col == 0 ? 2 : 3);
               drawSmallSwitch(x, 5 * FH + 1, 4, i);
             }
           }


### PR DESCRIPTION
PR #6077 was not quite right and messed up the switch display on the X7S.

Hopefully this will be better.

Tested on X7S, GX12, TLite and T20V2. Also tested that #6073 is still fixed.
