### PR TITLE
fix(radio): propagate DEBUG everywhere needed

### DIFF
--- a/radio/src/FreeRTOSConfig.h
+++ b/radio/src/FreeRTOSConfig.h
@@ -57,7 +57,6 @@ extern uint32_t SystemCoreClock;
 #else
   #define configMAX_TASK_NAME_LEN         10
   #define configUSE_TRACE_FACILITY        1
-  //#define configCHECK_FOR_STACK_OVERFLOW  2
   #define configCHECK_FOR_STACK_OVERFLOW  0
 #endif
 

--- a/radio/src/boards/generic_stm32/CMakeLists.txt
+++ b/radio/src/boards/generic_stm32/CMakeLists.txt
@@ -40,6 +40,10 @@ add_library(minimal_board_lib OBJECT EXCLUDE_FROM_ALL ${MINIMAL_BOARD_LIB_SRC})
 add_library(board_lib OBJECT EXCLUDE_FROM_ALL ${BOARD_LIB_SRC})
 add_dependencies(board_lib minimal_board_lib)
 
+if(DEBUG)
+  target_compile_definitions(board_lib PRIVATE DEBUG)
+endif()
+
 set(FIRMWARE_SRC ${FIRMWARE_SRC}
   $<TARGET_OBJECTS:minimal_board_lib>
   $<TARGET_OBJECTS:board_lib>

--- a/radio/src/targets/common/arm/stm32/h7/CMakeLists.txt
+++ b/radio/src/targets/common/arm/stm32/h7/CMakeLists.txt
@@ -163,7 +163,11 @@ if(NOT NATIVE_BUILD)
   target_include_directories(freertos
     PUBLIC  ${RTOS_DIR}/portable/GCC/ARM_CM4F
     PRIVATE ${RTOS_DIR}/include
-    )
+  )
+
+  if(DEBUG)
+    target_compile_definitions(freertos PRIVATE DEBUG)
+  endif()
 
   include_directories(${RTOS_DIR}/portable/GCC/ARM_CM4F)
   


### PR DESCRIPTION
When compiling with `DEBUG` set, the compilation was not propagated everywhere it was needed, thus causing issues with FreeRTOS structure sizes.

This is basically due to this:
```c
#if !defined(DEBUG)
  #define configMAX_TASK_NAME_LEN         4
  #define configUSE_TRACE_FACILITY        0
  #define configCHECK_FOR_STACK_OVERFLOW  0
#else
  #define configMAX_TASK_NAME_LEN         10
  #define configUSE_TRACE_FACILITY        1
  #define configCHECK_FOR_STACK_OVERFLOW  0
#endif
```

This would cause various FreeRTOS structures to have different sizes in different source code files, thus wrecking havoc in memory.