### PR TITLE
refactor(radio): move per10ms() to a software timer

### DIFF
--- a/radio/src/bootloader/boot_dfu.cpp
+++ b/radio/src/bootloader/boot_dfu.cpp
@@ -23,9 +23,14 @@
 
 #include "boot.h"
 #include "hal/usb_driver.h"
-#include "lcd.h"
 
-extern volatile uint8_t tenms;
+#include "lcd.h"
+#include "timers_driver.h"
+
+#define FRAME_INTERVAL_MS 20
+
+// make linker happy
+void per5ms() {}
 
 void bootloaderDFU()
 {
@@ -34,8 +39,12 @@ void bootloaderDFU()
 
   bootloaderDrawDFUScreen();
 
+  uint32_t next_frame = timersGetMsTick();
+
   for (;;) {
-    if (tenms) {
+    if (timersGetMsTick() - next_frame >= FRAME_INTERVAL_MS) {
+      next_frame += FRAME_INTERVAL_MS;
+
       if (!usbPlugged()) break;
       bootloaderDrawDFUScreen();
       lcdRefresh();

--- a/radio/src/bootloader/boot_uf2.cpp
+++ b/radio/src/bootloader/boot_uf2.cpp
@@ -30,19 +30,11 @@
 
 #include "board.h"
 #include "lcd.h"
+#include "timers_driver.h"
+
+#define FRAME_INTERVAL_MS 20
 
 extern uf2_fat_write_state_t _uf2_write_state;
-
-volatile tmr10ms_t g_tmr10ms;
-volatile uint8_t tenms = 1;
-
-void per5ms() {} // make linker happy
-
-void per10ms()
-{
-  tenms |= 1u; // 10 mS has passed
-  g_tmr10ms++;
-}
 
 void bootloaderUF2()
 {
@@ -52,10 +44,12 @@ void bootloaderUF2()
   storageInit();
   disk_initialize(0);
 
+  uint32_t next_frame = timersGetMsTick();
+
   for (;;) {
 
-    if (tenms) {
-      tenms = 0;
+    if (timersGetMsTick() - next_frame >= FRAME_INTERVAL_MS) {
+      next_frame += FRAME_INTERVAL_MS;
 
       keysPollingCycle();
       event_t event = getEvent();

--- a/radio/src/targets/common/arm/stm32/timers_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/timers_driver.cpp
@@ -100,8 +100,6 @@ static inline void _interrupt_1ms()
       watchdogTimeout -= 1;
       WDG_RESET();  // Retrigger hardware watchdog
     }
-
-    per10ms();
   }
 }
 


### PR DESCRIPTION
This helps reducing the pressure on the timer queue.

2.11 version of #5966 which was merged into 3.0 as part of #5840