### PR TITLE
feat(gx12): add safety timer for port expander

### DIFF
--- a/radio/src/boards/generic_stm32/rgb_leds.cpp
+++ b/radio/src/boards/generic_stm32/rgb_leds.cpp
@@ -78,7 +78,7 @@ static void _refresh_cb(timer_handle_t* timer)
   ws2812_update(&_led_timer);
 }
 
-void rgbLedStart()
+static void rgbLedStart()
 {
   if (!timer_is_created(&_refresh_timer)) {
     timer_create(&_refresh_timer, _refresh_cb, "rgbled",
@@ -111,6 +111,7 @@ void rgbLedInit()
 {
   ws2812_init(&_led_timer, _led_colors, LED_STRIP_LENGTH, WS2812_GRB);
   rgbLedClearAll();
+  rgbLedStart();
 }
 
 // Make sure the timer channel is supported

--- a/radio/src/boards/generic_stm32/rgb_leds.h
+++ b/radio/src/boards/generic_stm32/rgb_leds.h
@@ -24,7 +24,6 @@
 #include <stdint.h>
 
 void rgbLedInit();
-void rgbLedStart();
 void rgbLedStop();
 
 void rgbSetLedColor(uint8_t led, uint8_t r, uint8_t g, uint8_t b);

--- a/radio/src/edgetx.cpp
+++ b/radio/src/edgetx.cpp
@@ -1559,10 +1559,6 @@ void edgeTxInit()
 
   resetBacklightTimeout();
 
-#if defined(LED_STRIP_GPIO) && !defined(SIMU)
-  rgbLedStart();
-#endif
-
   pulsesStart();
   WDG_ENABLE(WDG_DURATION);
 }

--- a/radio/src/os/timer.h
+++ b/radio/src/os/timer.h
@@ -43,3 +43,4 @@ int timer_start(timer_handle_t* h);
 int timer_stop(timer_handle_t* h);
 
 int timer_set_period(timer_handle_t* h, unsigned period);
+static inline int timer_reset(timer_handle_t* h) { return timer_start(h); }

--- a/radio/src/os/timer_pthread.cpp
+++ b/radio/src/os/timer_pthread.cpp
@@ -133,6 +133,7 @@ void timer_queue::main_loop() {
 
 void timer_queue::process_cmds()
 {
+  int added = 0;
   while (!_cmds.empty()) {
     timer_req_t req = _cmds.back();
     _cmds.pop_back();
@@ -150,6 +151,7 @@ void timer_queue::process_cmds()
         t->active = true;
         if (pos == _timers.end()) {
           _timers.emplace_back(t);
+          added++;
         }
         break;
 
@@ -164,6 +166,7 @@ void timer_queue::process_cmds()
       }
     }
   }
+  if (added) sort_timers();
 }
 
 void timer_queue::trigger_timers() {
@@ -182,10 +185,7 @@ void timer_queue::trigger_timers() {
       break;
     }
   }
-
-  if (triggered) {
-    sort_timers();
-  }
+  if (triggered) sort_timers();
 }
 
 void timer_queue::async_calls() {

--- a/radio/src/targets/common/arm/stm32/timers_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/timers_driver.cpp
@@ -26,8 +26,6 @@
 #include "hal.h"
 #include "hal/watchdog_driver.h"
 
-#include "FreeRTOSConfig.h"
-
 static volatile uint32_t _ms_ticks;
 
 static void _init_1ms_timer()
@@ -45,7 +43,7 @@ static void _init_1ms_timer()
   MS_TIMER->DIER = TIM_DIER_UIE;
 
   NVIC_EnableIRQ(MS_TIMER_IRQn);
-  NVIC_SetPriority(MS_TIMER_IRQn, configLIBRARY_MAX_SYSCALL_INTERRUPT_PRIORITY);
+  NVIC_SetPriority(MS_TIMER_IRQn, 4);
 }
 
 void timersInit()

--- a/radio/src/tasks.cpp
+++ b/radio/src/tasks.cpp
@@ -127,7 +127,7 @@ static void _timer_10ms_cb(timer_handle_t* h)
   per10ms();
 }
 
-void timer10msStart()
+static void timer10msStart()
 {
   if (!timer_is_created(&_timer10ms)) {
     timer_create(&_timer10ms, _timer_10ms_cb, "10ms", 10, true);


### PR DESCRIPTION
This PR adds a safety timer that will force polling the I2C port expander present in GX12 at least every 100ms.