### PR TITLE
fix(color): button text for some choice values may be incorrect

### DIFF
--- a/radio/src/gui/colorlcd/libui/choice.h
+++ b/radio/src/gui/colorlcd/libui/choice.h
@@ -42,6 +42,7 @@ class ChoiceBase : public FormField
   void setTextHandler(std::function<std::string(int)> handler)
   {
     textHandler = std::move(handler);
+    currentValue = INT_MAX; // Force update
     update();
   }
 


### PR DESCRIPTION
Ensure button updates when text handler set.
Fixes bug introduced in #6294 

Reported by gismo2004 [on discord](https://discord.com/channels/839849772864503828/839895574244229152/1377522492318679071).
To reproduce, open input editor, or mix editor. Source value may show a number instead of the source name.
