### PR TITLE
chore: cleanup GVAR code.

### DIFF
--- a/radio/src/curves.cpp
+++ b/radio/src/curves.cpp
@@ -435,12 +435,12 @@ char *getCurveRefString(char *dest, size_t len, const CurveRef& curve)
     switch (curve.type) {
       case CURVE_REF_DIFF:
         *(s++) = 'D'; if (--len == 0) return dest;
-        getValueOrSrcVarString(s, len, curve.value, -100, 100, 0, "%");
+        getValueOrSrcVarString(s, len, curve.value, 0, "%");
         return dest;
 
       case CURVE_REF_EXPO:
         *(s++) = 'E'; if (--len == 0) return dest;
-        getValueOrSrcVarString(s, len, curve.value, -100, 100, 0, "%");
+        getValueOrSrcVarString(s, len, curve.value, 0, "%");
         return dest;
 
       case CURVE_REF_FUNC:

--- a/radio/src/dataconstants.h
+++ b/radio/src/dataconstants.h
@@ -25,7 +25,7 @@
 
 #include "board.h"
 #include "storage/yaml/yaml_defs.h"
-
+#include "gvars.h"
 
 #if defined(EXPORT)
   #define LUA_EXPORT(...)              LEXP(__VA_ARGS__)
@@ -387,15 +387,6 @@ enum PotsWarnMode {
   POTS_WARN_MANUAL,
   POTS_WARN_AUTO
 };
-
-#define LEN_GVAR_NAME                3
-#define GVAR_MAX                     1024
-#define GVAR_MIN                     -GVAR_MAX
-
-// we reserve the space inside the range of values, like offset, weight, etc.
-#define RESERVE_RANGE_FOR_GVARS      10
-
-#define MAX_GVARS                    9
 
 // Maximum number analog inputs by type
 #define MAX_STICKS        4

--- a/radio/src/gui/128x64/model_outputs.cpp
+++ b/radio/src/gui/128x64/model_outputs.cpp
@@ -90,7 +90,7 @@ int32_t gvValDisplay(int32_t val)
 int32_t gvValEdit(const char* title, int32_t val, int32_t offset, int min, int max, coord_t y, uint8_t attr, event_t event, bool active, LcdFlags flags)
 {
   lcdDrawText(0, y, title, flags);
-  if (GV_IS_GV_VALUE(val, -GV_RANGELARGE, GV_RANGELARGE) || (attr && event == EVT_KEY_LONG(KEY_ENTER))) {
+  if (GV_IS_GV_VALUE(val) || (attr && event == EVT_KEY_LONG(KEY_ENTER))) {
     if (event == EVT_KEY_LONG(KEY_ENTER))
       killEvents(event);
     return GVAR_MENU_ITEM(LIMITS_ONE_2ND_COLUMN, y, val, -LIMIT_EXT_MAX, LIMIT_EXT_MAX, attr|PREC1|flags, 0, event);
@@ -275,7 +275,7 @@ void menuModelLimits(event_t event)
       switch (j) {
         case ITEM_OUTPUTS_OFFSET:
 #if defined(GVARS)
-          if (GV_IS_GV_VALUE(ld->offset, -GV_RANGELARGE, GV_RANGELARGE)) {
+          if (GV_IS_GV_VALUE(ld->offset)) {
             drawGVarName(LIMITS_OFFSET_POS, y, ld->offset, attr|PREC1|RIGHT);
             break;
           }
@@ -285,7 +285,7 @@ void menuModelLimits(event_t event)
 
         case ITEM_OUTPUTS_MIN:
 #if defined(GVARS)
-          if (GV_IS_GV_VALUE(ld->min, -GV_RANGELARGE, GV_RANGELARGE)) {
+          if (GV_IS_GV_VALUE(ld->min)) {
             drawGVarName(limitsMinPos, y, ld->min, attr|PREC1|RIGHT);
             break;
           }
@@ -300,7 +300,7 @@ void menuModelLimits(event_t event)
 
         case ITEM_OUTPUTS_MAX:
 #if defined(GVARS)
-          if (GV_IS_GV_VALUE(ld->max, -GV_RANGELARGE, GV_RANGELARGE)) {
+          if (GV_IS_GV_VALUE(ld->max)) {
             drawGVarName(LIMITS_MAX_POS, y, ld->max, attr|PREC1|RIGHT);
             break;
           }

--- a/radio/src/gui/128x64/widgets.cpp
+++ b/radio/src/gui/128x64/widgets.cpp
@@ -199,7 +199,6 @@ void drawGVarValue(coord_t x, coord_t y, uint8_t gvar, gvar_t value, LcdFlags fl
 
 int16_t editGVarFieldValue(coord_t x, coord_t y, int16_t value, int16_t min, int16_t max, LcdFlags attr, uint8_t editflags, event_t event)
 {
-  uint16_t delta = GV_GET_GV1_VALUE(min, max);
   bool invers = (attr & INVERS);
 
   // TRACE("editGVarFieldValue(val=%d min=%d max=%d)", value, min, max);
@@ -208,24 +207,19 @@ int16_t editGVarFieldValue(coord_t x, coord_t y, int16_t value, int16_t min, int
     killEvents(event);
     s_editMode = !s_editMode;
     if (attr & PREC1)
-      value = (GV_IS_GV_VALUE(value, min, max) ? GET_GVAR(value, min, max, mixerCurrentFlightMode)*10 : delta);
+      value = (GV_IS_GV_VALUE(value) ? GET_GVAR(value, min, max, mixerCurrentFlightMode)*10 : GV_VALUE_FROM_INDEX(0));
     else
-      value = (GV_IS_GV_VALUE(value, min, max) ? GET_GVAR(value, min, max, mixerCurrentFlightMode) : delta);
+      value = (GV_IS_GV_VALUE(value) ? GET_GVAR(value, min, max, mixerCurrentFlightMode) : GV_VALUE_FROM_INDEX(0));
     storageDirty(EE_MODEL);
   }
 
-  if (GV_IS_GV_VALUE(value, min, max)) {
+  if (GV_IS_GV_VALUE(value)) {
     attr &= ~PREC1;
-    int8_t idx = (int16_t)GV_INDEX_CALC_DELTA(value, delta);
+    int8_t idx = (int16_t)GV_INDEX_FROM_VALUE(value);
     if (invers) {
       CHECK_INCDEC_MODELVAR(event, idx, -MAX_GVARS, MAX_GVARS-1);
     }
-    if (idx < 0) {
-      value = (int16_t)GV_CALC_VALUE_IDX_NEG(idx, delta);
-    }
-    else {
-      value = (int16_t)GV_CALC_VALUE_IDX_POS(idx, delta);
-    }
+    value = (int16_t)GV_VALUE_FROM_INDEX(idx);
     drawGVarName(x, y, idx, attr);
   }
   else {

--- a/radio/src/gui/212x64/model_outputs.cpp
+++ b/radio/src/gui/212x64/model_outputs.cpp
@@ -161,7 +161,7 @@ void menuModelLimits(event_t event)
           break;
 
         case ITEM_LIMITS_OFFSET:
-          if (GV_IS_GV_VALUE(ld->offset, -1000, 1000) || (attr && event == EVT_KEY_LONG(KEY_ENTER))) {
+          if (GV_IS_GV_VALUE(ld->offset) || (attr && event == EVT_KEY_LONG(KEY_ENTER))) {
             if (event == EVT_KEY_LONG(KEY_ENTER))
               killEvents(event);
             ld->offset = GVAR_MENU_ITEM(LIMITS_OFFSET_POS, y, ld->offset, -1000, 1000, RIGHT|attr|PREC1, 0, event);
@@ -184,7 +184,7 @@ void menuModelLimits(event_t event)
           break;
 
         case ITEM_LIMITS_MIN:
-          if (GV_IS_GV_VALUE(ld->min, -GV_RANGELARGE, GV_RANGELARGE) || (attr && event == EVT_KEY_LONG(KEY_ENTER))) {
+          if (GV_IS_GV_VALUE(ld->min) || (attr && event == EVT_KEY_LONG(KEY_ENTER))) {
             if (event == EVT_KEY_LONG(KEY_ENTER))
               killEvents(event);
             ld->min = GVAR_MENU_ITEM(LIMITS_MIN_POS, y, ld->min, -LIMIT_EXT_MAX, LIMIT_EXT_MAX, attr|PREC1|RIGHT, 0, event);
@@ -195,7 +195,7 @@ void menuModelLimits(event_t event)
           break;
 
         case ITEM_LIMITS_MAX:
-          if (GV_IS_GV_VALUE(ld->max, -GV_RANGELARGE, GV_RANGELARGE) || (attr && event == EVT_KEY_LONG(KEY_ENTER))) {
+          if (GV_IS_GV_VALUE(ld->max) || (attr && event == EVT_KEY_LONG(KEY_ENTER))) {
             if (event == EVT_KEY_LONG(KEY_ENTER))
               killEvents(event);
             ld->max = GVAR_MENU_ITEM(LIMITS_MAX_POS, y, ld->max, -LIMIT_EXT_MAX, LIMIT_EXT_MAX, attr|PREC1|RIGHT, 0, event);

--- a/radio/src/gui/212x64/widgets.cpp
+++ b/radio/src/gui/212x64/widgets.cpp
@@ -157,7 +157,6 @@ void drawGVarValue(coord_t x, coord_t y, uint8_t gvar, gvar_t value, LcdFlags fl
 
 int16_t editGVarFieldValue(coord_t x, coord_t y, int16_t value, int16_t min, int16_t max, LcdFlags attr, uint8_t editflags, event_t event)
 {
-  uint16_t delta = GV_GET_GV1_VALUE(min, max);
   bool invers = (attr & INVERS);
 
   // TRACE("editGVarFieldValue(val=%d min=%d max=%d)", value, min, max);
@@ -166,26 +165,21 @@ int16_t editGVarFieldValue(coord_t x, coord_t y, int16_t value, int16_t min, int
     killEvents(event);
     s_editMode = !s_editMode;
     if (attr & PREC1) {
-      value = (GV_IS_GV_VALUE(value, min, max) ? GET_GVAR(value, min, max, mixerCurrentFlightMode)*10 : delta);
+      value = (GV_IS_GV_VALUE(value) ? GET_GVAR(value, min, max, mixerCurrentFlightMode)*10 : GV_VALUE_FROM_INDEX(0));
     }
     else {
-      value = (GV_IS_GV_VALUE(value, min, max) ? GET_GVAR(value, min, max, mixerCurrentFlightMode) : delta);
+      value = (GV_IS_GV_VALUE(value) ? GET_GVAR(value, min, max, mixerCurrentFlightMode) : GV_VALUE_FROM_INDEX(0));
     }
     storageDirty(EE_MODEL);
   }
 
-  if (GV_IS_GV_VALUE(value, min, max)) {
+  if (GV_IS_GV_VALUE(value)) {
     attr &= ~PREC1;
-    int8_t idx = (int16_t)GV_INDEX_CALC_DELTA(value, delta);
+    int8_t idx = (int16_t)GV_INDEX_FROM_VALUE(value);
     if (invers) {
       CHECK_INCDEC_MODELVAR(event, idx, -MAX_GVARS, MAX_GVARS-1);
     }
-    if (idx < 0) {
-      value = (int16_t)GV_CALC_VALUE_IDX_NEG(idx, delta);
-    }
-    else {
-      value = (int16_t)GV_CALC_VALUE_IDX_POS(idx, delta);
-    }
+    value = (int16_t)GV_VALUE_FROM_INDEX(idx);
     drawGVarName(x, y, idx, attr);
   }
   else {

--- a/radio/src/gui/colorlcd/controls/channel_bar.cpp
+++ b/radio/src/gui/colorlcd/controls/channel_bar.cpp
@@ -158,7 +158,7 @@ void OutputChannelBar::drawLimitLines(bool forced)
     int32_t ldMin;
     int32_t ldMax;
 
-    if (GV_IS_GV_VALUE(ld->min, -CHANNELS_LIMIT, 0)) {
+    if (GV_IS_GV_VALUE(ld->min)) {
       ldMin =
           GET_GVAR_PREC1(ld->min, -CHANNELS_LIMIT, 0, mixerCurrentFlightMode) +
           LIMIT_STD_MAX;
@@ -170,7 +170,7 @@ void OutputChannelBar::drawLimitLines(bool forced)
       limMin = ldMin;
     }
 
-    if (GV_IS_GV_VALUE(ld->max, 0, CHANNELS_LIMIT)) {
+    if (GV_IS_GV_VALUE(ld->max)) {
       ldMax =
           GET_GVAR_PREC1(ld->max, 0, CHANNELS_LIMIT, mixerCurrentFlightMode) -
           LIMIT_STD_MAX;

--- a/radio/src/gui/colorlcd/controls/gvar_numberedit.cpp
+++ b/radio/src/gui/colorlcd/controls/gvar_numberedit.cpp
@@ -40,15 +40,10 @@ GVarNumberEdit::GVarNumberEdit(Window* parent, int32_t vmin,
   gvar_field = new Choice(
       this, {0, 0, EdgeTxStyles::EDIT_FLD_WIDTH_NARROW, 0}, -MAX_GVARS, MAX_GVARS - 1,
       [=]() {
-        uint16_t gvar1 = GV_GET_GV1_VALUE(vmin, vmax);
-        return GV_INDEX_CALC_DELTA(getValue(), gvar1);
+        return GV_INDEX_FROM_VALUE(getValue());
       },
       [=](int idx) {
-        uint16_t gvar1 = GV_GET_GV1_VALUE(vmin, vmax);
-        if (idx < 0)
-          setValue(GV_CALC_VALUE_IDX_NEG(idx, gvar1));
-        else
-          setValue(GV_CALC_VALUE_IDX_POS(idx, gvar1));
+        setValue(GV_VALUE_FROM_INDEX(idx));
       });
   gvar_field->setTextHandler(
       [=](int32_t value) { return getGVarString(value); });
@@ -63,9 +58,9 @@ GVarNumberEdit::GVarNumberEdit(Window* parent, int32_t vmin,
   if (modelGVEnabled()) {
     m_gvBtn = new TextButton(this, {EdgeTxStyles::EDIT_FLD_WIDTH_NARROW + PAD_TINY, 0, GV_BTN_W, 0}, STR_GV, [=]() {
       switchGVarMode();
-      return GV_IS_GV_VALUE(getValue(), vmin, vmax);
+      return GV_IS_GV_VALUE(getValue());
     });
-    m_gvBtn->check(GV_IS_GV_VALUE(getValue(), vmin, vmax));
+    m_gvBtn->check(GV_IS_GV_VALUE(getValue()));
   }
 #endif
 
@@ -79,13 +74,13 @@ void GVarNumberEdit::switchGVarMode()
   if (modelGVEnabled()) {
     int32_t value = getValue();
     setValue(
-        GV_IS_GV_VALUE(value, vmin, vmax)
+        GV_IS_GV_VALUE(value)
             ? ((textFlags & PREC1)
                    ? GET_GVAR_PREC1(value, vmin, vmax, mixerCurrentFlightMode)
                    : GET_GVAR(value, vmin, vmax, mixerCurrentFlightMode))
-            : GV_GET_GV1_VALUE(vmin, vmax));
+            : GV_VALUE_FROM_INDEX(0));
 
-    m_gvBtn->check(GV_IS_GV_VALUE(value, vmin, vmax));
+    m_gvBtn->check(GV_IS_GV_VALUE(value));
 
     // update field type based on value
     update();
@@ -115,7 +110,7 @@ void GVarNumberEdit::update()
   num_field->hide();
   
   int32_t value = getValue();
-  if (GV_IS_GV_VALUE(value, vmin, vmax)) {
+  if (GV_IS_GV_VALUE(value)) {
     // GVAR mode
     act_field = gvar_field;
     num_field->setSetValueHandler(nullptr);

--- a/radio/src/gui/colorlcd/libui/list_line_button.cpp
+++ b/radio/src/gui/colorlcd/libui/list_line_button.cpp
@@ -84,7 +84,7 @@ void InputMixButtonBase::setWeight(gvar_t value, gvar_t min, gvar_t max)
   }
 
   char s[32];
-  getValueOrSrcVarString(s, sizeof(s), value, min, max, 0, "%");
+  getValueOrSrcVarString(s, sizeof(s), value, 0, "%");
   if (getTextWidth(s, 0, FONT(STD)) > WGT_W)
     lv_obj_add_state(weight, LV_STATE_USER_1);
   else

--- a/radio/src/gui/colorlcd/model/model_outputs.cpp
+++ b/radio/src/gui/colorlcd/model/model_outputs.cpp
@@ -148,16 +148,15 @@ class OutputLineButton : public ListLineButton
     }
 
     char s[32];
-    getValueOrGVarString(s, sizeof(s), output->min, -GV_RANGELARGE, 0, PREC1,
+    getValueOrGVarString(s, sizeof(s), output->min, PREC1,
                          nullptr, -LIMITS_MIN_MAX_OFFSET, true);
     lv_label_set_text(min, s);
 
-    getValueOrGVarString(s, sizeof(s), output->max, 0, GV_RANGELARGE, PREC1,
+    getValueOrGVarString(s, sizeof(s), output->max, PREC1,
                          nullptr, +LIMITS_MIN_MAX_OFFSET, true);
     lv_label_set_text(max, s);
 
-    getValueOrGVarString(s, sizeof(s), output->offset, -LIMIT_STD_MAX,
-                         +LIMIT_STD_MAX, PREC1, nullptr, 0, true);
+    getValueOrGVarString(s, sizeof(s), output->offset, PREC1, nullptr, 0, true);
     lv_label_set_text(offset, s);
 
     lv_label_set_text_fmt(center, "%d%s", PPM_CENTER + output->ppmCenter,

--- a/radio/src/gvars.cpp
+++ b/radio/src/gvars.cpp
@@ -72,8 +72,8 @@ void setGVarValue(uint8_t gv, int16_t value, int8_t fm)
 
 int16_t getGVarFieldValue(int16_t val, int16_t min, int16_t max, int8_t fm)
 {
-  if (GV_IS_GV_VALUE(val, min, max)) {
-    int8_t gv = GV_INDEX_CALCULATION(val, max);
+  if (GV_IS_GV_VALUE(val)) {
+    int8_t gv = GV_INDEX_FROM_VALUE(val);
     val = getGVarValue(gv, fm);
   }
   return limit(min, val, max);
@@ -81,8 +81,8 @@ int16_t getGVarFieldValue(int16_t val, int16_t min, int16_t max, int8_t fm)
 
 int32_t getGVarFieldValuePrec1(int16_t val, int16_t min, int16_t max, int8_t fm)
 {
-  if (GV_IS_GV_VALUE(val, min, max)) {
-    int8_t gv = GV_INDEX_CALCULATION(val, max);
+  if (GV_IS_GV_VALUE(val)) {
+    int8_t gv = GV_INDEX_FROM_VALUE(val);
     val = getGVarValuePrec1(gv, fm);
   }
   else {

--- a/radio/src/gvars.h
+++ b/radio/src/gvars.h
@@ -21,6 +21,12 @@
 
 #pragma once
 
+#define LEN_GVAR_NAME                3
+#define GVAR_MAX                     1024
+#define GVAR_MIN                     -GVAR_MAX
+
+#define MAX_GVARS                    9
+
 // GVars have one value per flight mode
 #define GVAR_VALUE(gv, fm)           g_model.flightModeData[fm].gvars[gv]
 
@@ -42,21 +48,16 @@
   #define GET_GVAR_PREC1(x, ...)       (x*10)
 #endif
 
-#define GV_GET_GV1_VALUE(vmin, vmax)        ((vmax<=GV_RANGESMALL && vmin>=GV_RANGESMALL_NEG) ? GV1_SMALL : GV1_LARGE)
-#define GV_INDEX_CALCULATION(x,max)  ((max<=GV_RANGESMALL && min>=GV_RANGESMALL_NEG) ? (uint8_t) x-GV1_SMALL : ((x&(GV1_LARGE*2-1))-GV1_LARGE))
-#define GV_IS_GV_VALUE(x,min,max)    ((max>GV1_SMALL || min<-GV1_SMALL) ? (x>GV_RANGELARGE || x<GV_RANGELARGE_NEG) : (x>max) || (x<min))
+// we reserve the space inside the range of values, like offset, weight, etc.
+#define GV_RANGE_MAX                1024
+#define GV_RANGE_POS                (GV_RANGE_MAX - 1 - MAX_GVARS)
+#define GV_RANGE_NEG                (-GV_RANGE_MAX + MAX_GVARS)
 
-#define GV_INDEX_CALC_DELTA(x,delta)   ((x&(delta*2-1)) - delta)
+#define GV_IS_GV_VALUE(x)           (x > GV_RANGE_POS || x < GV_RANGE_NEG)
+#define GV_INDEX_FROM_VALUE(x)      ((x & (GV_RANGE_MAX * 2 - 1)) - GV_RANGE_MAX)
+#define GV_VALUE_FROM_INDEX(idx)    ((idx < 0) ? GV_RANGE_MAX + idx : -GV_RANGE_MAX + idx)
 
-#define GV_CALC_VALUE_IDX_POS(idx,delta) (-delta+idx)
-#define GV_CALC_VALUE_IDX_NEG(idx,delta) (delta+idx)
-
-#define GV_RANGESMALL                  (GV1_SMALL - (RESERVE_RANGE_FOR_GVARS+1))
-#define GV_RANGESMALL_NEG              (-GV1_SMALL + (RESERVE_RANGE_FOR_GVARS+1))
-#define GV_RANGELARGE                  (GV1_LARGE - (RESERVE_RANGE_FOR_GVARS+1))
-#define GV_RANGELARGE_NEG              (-GV1_LARGE + (RESERVE_RANGE_FOR_GVARS+1))
-
-// the define GV1_LARGE marks the highest bit value used for this variables
+// the define GV_RANGE_MAX marks the highest bit value used for this variables
 // because this would give too big numbers for ARM, we limit it further for
 // offset and weight
 constexpr int32_t MIX_WEIGHT_MAX = 500;

--- a/radio/src/myeeprom.h
+++ b/radio/src/myeeprom.h
@@ -133,17 +133,17 @@ enum CurveRefType {
 #define LIMIT_STD_MAX       (LIMIT_STD_PERCENT*10)
 #define PPM_CENTER_MAX      500
 #define LIMIT_MAX(lim)                                            \
-  (GV_IS_GV_VALUE(lim->max, -GV_RANGELARGE, GV_RANGELARGE)        \
+  (GV_IS_GV_VALUE(lim->max)                                       \
        ? GET_GVAR_PREC1(lim->max, -LIMIT_EXT_MAX, +LIMIT_EXT_MAX, \
                         mixerCurrentFlightMode)                   \
        : lim->max + LIMIT_STD_MAX)
 #define LIMIT_MIN(lim)                                            \
-  (GV_IS_GV_VALUE(lim->min, -GV_RANGELARGE, GV_RANGELARGE)        \
+  (GV_IS_GV_VALUE(lim->min)                                       \
        ? GET_GVAR_PREC1(lim->min, -LIMIT_EXT_MAX, +LIMIT_EXT_MAX, \
                         mixerCurrentFlightMode)                   \
        : lim->min - LIMIT_STD_MAX)
 #define LIMIT_OFS(lim)                                               \
-  (GV_IS_GV_VALUE(lim->offset, -LIMIT_STD_MAX, LIMIT_STD_MAX)        \
+  (GV_IS_GV_VALUE(lim->offset)                                       \
        ? GET_GVAR_PREC1(lim->offset, -LIMIT_STD_MAX, +LIMIT_STD_MAX, \
                         mixerCurrentFlightMode)                      \
        : lim->offset)
@@ -168,9 +168,6 @@ enum TrainerMultiplex {
   TRAINER_REPL = 2,
 };
 
-#define GV1_SMALL       128
-#define GV1_LARGE       1024
-#define GV_RANGE_OFFSET 500
 #define DELAY_MAX       250 /* 25 seconds */
 #define SLOW_MAX        250 /* 25 seconds */
 

--- a/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
@@ -65,27 +65,20 @@ static bool w_board(void* user, uint8_t* data, uint32_t bitoffs,
 
 static uint32_t in_read_weight(const YamlNode* node, const char* val, uint8_t val_len)
 {
-  int gvar = (node->size > 8 ? GV1_LARGE : GV1_SMALL);
-  
-  if ((val_len == 4)
-      && (val[0] == '-')
-      && (val[1] == 'G')
-      && (val[2] == 'V')
-      && (val[3] >= '1')
-      && (val[3] <= '9')) {
-
-    TRACE("%.*s -> %i\n", val_len, val, gvar - (val[3] - '0'));
-    return gvar - (val[3] - '0');  // -GVx => 128 - x
-  }
-
-  if ((val_len == 3)
-      && (val[0] == 'G')
-      && (val[1] == 'V')
-      && (val[2] >= '1')
-      && (val[2] <= '9')) {
-
-    TRACE("%.*s -> %i\n", val_len, val, -gvar + (val[2] - '1'));
-    return -gvar + (val[2] - '1');  //  GVx => -128 + (x-1)
+  if ((strncmp(val, "GV", 2) == 0) || (strncmp(val, "-GV", 3) == 0)) {
+    bool neg = false;
+    int ofst = 2;
+    if (val[0] == '-') {
+      neg = true;
+      ofst = 3;
+    }
+    int32_t idx = yaml_str2int(val + ofst, val_len - ofst);
+    // Convert to range -MAX_GVARS .. MAX_GVARS - 1
+    if (neg)
+      idx = -idx;
+    else
+      idx = idx - 1;
+    return GV_VALUE_FROM_INDEX(idx);
   }
 
   return (uint32_t)yaml_str2int(val, val_len);
@@ -94,15 +87,21 @@ static uint32_t in_read_weight(const YamlNode* node, const char* val, uint8_t va
 bool in_write_weight(const YamlNode* node, uint32_t val, yaml_writer_func wf,
                      void* opaque)
 {
-  int32_t sval = yaml_to_signed(val, node->size <= 11 ? node->size : 11);
-  int32_t gvar = (node->size > 8 ? GV1_LARGE : GV1_SMALL);
+  int32_t sval = yaml_to_signed(val, node->size);
 
-  if (sval >= gvar - 10 && sval <= gvar) {
-    char n = gvar - sval + '0';
-    return wf(opaque, "-GV", 3) && wf(opaque, &n, 1);
-  } else if (sval <= -gvar + 10 && sval >= -gvar) {
-    char n = val - gvar + '1';
-    return wf(opaque, "GV", 2) && wf(opaque, &n, 1);
+  if (GV_IS_GV_VALUE(sval)) {
+    char s[8] = "";
+    int ofst = 0;
+    char idx = GV_INDEX_FROM_VALUE(sval);
+    if (idx < 0) {
+      s[0] = '-';
+      ofst = 1;
+      idx = -idx;
+    } else {
+      idx = idx + 1;
+    }
+    strAppendStringWithIndex(s + ofst, "GV", idx);
+    return wf(opaque, s, strlen(s));
   }
 
   char* s = yaml_signed2str(sval);

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -362,12 +362,12 @@ char *getGVarString(char *dest, int idx)
 }
 
 #if defined(LIBOPENUI)
-char *getValueOrGVarString(char *dest, size_t len, gvar_t value, gvar_t vmin,
-                           gvar_t vmax, LcdFlags flags, const char *suffix,
+char *getValueOrGVarString(char *dest, size_t len, gvar_t value,
+                           LcdFlags flags, const char *suffix,
                            gvar_t offset, bool usePPMUnit)
 {
-  if (GV_IS_GV_VALUE(value, vmin, vmax)) {
-    int index = GV_INDEX_CALC_DELTA(value, GV_GET_GV1_VALUE(vmin, vmax));
+  if (GV_IS_GV_VALUE(value)) {
+    int index = GV_INDEX_FROM_VALUE(value);
     return getGVarString(dest, index);
   }
 
@@ -378,8 +378,8 @@ char *getValueOrGVarString(char *dest, size_t len, gvar_t value, gvar_t vmin,
   return dest;
 }
 
-char *getValueOrSrcVarString(char *dest, size_t len, gvar_t value, gvar_t vmin,
-                           gvar_t vmax, LcdFlags flags, const char *suffix,
+char *getValueOrSrcVarString(char *dest, size_t len, gvar_t value,
+                           LcdFlags flags, const char *suffix,
                            gvar_t offset, bool usePPMUnit)
 {
   SourceNumVal v;

--- a/radio/src/strhelpers.h
+++ b/radio/src/strhelpers.h
@@ -117,11 +117,9 @@ char *getCurveString(char *dest, int idx);
 char *getCurveString(int idx);
 char *getGVarString(char *dest, int idx);
 char *getGVarString(int idx);
-char *getValueOrGVarString(char *dest, size_t len, gvar_t value, gvar_t vmin,
-                           gvar_t vmax, LcdFlags flags = 0,
+char *getValueOrGVarString(char *dest, size_t len, gvar_t value, LcdFlags flags = 0,
                            const char *suffix = nullptr, gvar_t offset = 0, bool usePPMUnit = false);
-char *getValueOrSrcVarString(char *dest, size_t len, gvar_t value, gvar_t vmin,
-                             gvar_t vmax, LcdFlags flags = 0,
+char *getValueOrSrcVarString(char *dest, size_t len, gvar_t value, LcdFlags flags = 0,
                              const char *suffix = nullptr, gvar_t offset = 0, bool usePPMUnit = false);
 const char *getSwitchWarnSymbol(uint8_t pos);
 const char *getSwitchPositionSymbol(uint8_t pos);


### PR DESCRIPTION
Remove legacy GV stuff that is no longer required.
Remove hardwired limits on number of GV's (YAML read/write).
Rename some things for readability.

Note:
This PR is to cleanup the existing code to make way for increasing the number of GV's.
It does not address UI layout issues that would likely result from longer GV names (GV10, etc).
