### PR TITLE
fix(color): string passed to the Lua 'set' function of textEdit control may not be terminated

### DIFF
--- a/radio/src/lua/lua_lvgl_widget.cpp
+++ b/radio/src/lua/lua_lvgl_widget.cpp
@@ -1911,7 +1911,8 @@ void LvglWidgetTextEdit::build(lua_State *L)
                             int t = lua_gettop(L);
                             PROTECT_LUA()
                             {
-                              if (!pcallFuncWithString(L, setFunction, 0, value)) {
+                              std::string s(value, maxLen); // Ensure string is terminated
+                              if (!pcallFuncWithString(L, setFunction, 0, s.c_str())) {
                                 lvglManager->luaShowError();
                               }
                             }


### PR DESCRIPTION
Reported on [discord by KKKhc](https://discord.com/channels/839849772864503828/839895574244229152/1378372041417166959).
