### PR TITLE
fix(v14): SA/SD LED init

### DIFF
--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -110,6 +110,21 @@ uint16_t getSixPosAnalogValue(uint16_t adcValue)
 }
 #endif
 
+#if defined(SALED_PWR_GPIO)
+void SALEDpwrInit()
+{
+  gpio_init(SALED_PWR_GPIO, GPIO_OUT, GPIO_PIN_SPEED_LOW);
+  SALED_PWR_ON();
+}
+#endif
+#if defined(SDLED_PWR_GPIO)
+void SDLEDpwrInit()
+{
+  gpio_init(SDLED_PWR_GPIO, GPIO_OUT, GPIO_PIN_SPEED_LOW);
+  SDLED_PWR_ON();
+}
+#endif
+
 void boardInit()
 {
   LL_APB2_GRP1_EnableClock(LL_APB2_GRP1_PERIPH_SYSCFG);
@@ -201,6 +216,13 @@ void boardInit()
 
   keysInit();
   switchInit();
+
+#if defined(SALED_PWR_GPIO)
+  SALEDpwrInit();
+#endif
+#if defined(SDLED_PWR_GPIO)
+  SDLEDpwrInit();
+#endif
 
 #if defined(ROTARY_ENCODER_NAVIGATION)
   rotaryEncoderInit();

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -2049,6 +2049,19 @@
 #endif
 #endif
 
+// voice
+#if defined(RADIO_V12) || defined(RADIO_V14)
+  #define VoiceAI_PWR_GPIO              GPIO_PIN(GPIOD, 14) // PD.14
+  #define VoiceAI_PWR_OFF()             gpio_clear(VoiceAI_PWR_GPIO)
+  #define VoiceAI_PWR_ON()              gpio_set(VoiceAI_PWR_GPIO)
+#endif
+#if defined(RADIO_V14)
+  #define SALED_PWR_GPIO                   GPIO_PIN(GPIOC, 13) // PD.14
+  #define SALED_PWR_ON()                   gpio_set(SALED_PWR_GPIO)
+  #define SDLED_PWR_GPIO                   GPIO_PIN(GPIOE, 8) // PD.14
+  #define SDLED_PWR_ON()                   gpio_set(SDLED_PWR_GPIO)
+#endif
+
 // Internal Module
 #if defined(PCBXLITE)
 #define EXTERNAL_ANTENNA

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -2049,12 +2049,7 @@
 #endif
 #endif
 
-// voice
-#if defined(RADIO_V12) || defined(RADIO_V14)
-  #define VoiceAI_PWR_GPIO              GPIO_PIN(GPIOD, 14) // PD.14
-  #define VoiceAI_PWR_OFF()             gpio_clear(VoiceAI_PWR_GPIO)
-  #define VoiceAI_PWR_ON()              gpio_set(VoiceAI_PWR_GPIO)
-#endif
+// Switches with LEDs
 #if defined(RADIO_V14)
   #define SALED_PWR_GPIO                   GPIO_PIN(GPIOC, 13) // PD.14
   #define SALED_PWR_ON()                   gpio_set(SALED_PWR_GPIO)


### PR DESCRIPTION
The SA and SD of V14 are switches with LED lights. Special processing is required during initialization, otherwise the parallel LED will affect the voltage status of the GPIO pin.

Fixes #
V14 SA SD initialization configuration