### PR TITLE
feat(color,lua): enhancements and fixes to the Lua API's

### DIFF
--- a/radio/src/gui/colorlcd/libui/choice.cpp
+++ b/radio/src/gui/colorlcd/libui/choice.cpp
@@ -226,7 +226,7 @@ void Choice::openMenu()
 {
   setEditMode(true);  // this needs to be done first before menu is created.
 
-  auto menu = new Menu();
+  auto menu = new Menu(false, popupWidth);
   if (menuTitle) menu->setTitle(menuTitle);
 
   fillMenu(menu);

--- a/radio/src/gui/colorlcd/libui/choice.h
+++ b/radio/src/gui/colorlcd/libui/choice.h
@@ -54,10 +54,13 @@ class ChoiceBase : public FormField
 
   const char* getTitle() const { return menuTitle; }
 
+  void setPopupWidth(coord_t w) { popupWidth = w; }
+
   static LAYOUT_VAL_SCALED(ICON_W, 18)
 
  protected:
   lv_obj_t *label;
+  coord_t popupWidth = 0;
   int vmin = 0;
   int vmax = 0;
   const char *menuTitle = nullptr;

--- a/radio/src/gui/colorlcd/libui/menu.cpp
+++ b/radio/src/gui/colorlcd/libui/menu.cpp
@@ -305,13 +305,15 @@ static lv_obj_t* menu_content_create(lv_obj_t* parent)
 class MenuWindowContent : public Window
 {
  public:
-  explicit MenuWindowContent(Menu* parent) :
+  explicit MenuWindowContent(Menu* parent, coord_t popupWidth) :
       Window(parent, rect_t{}, menu_content_create)
   {
     setWindowFlag(OPAQUE);
 
+    coord_t w = (popupWidth > MENUS_WIDTH) ? popupWidth : MENUS_WIDTH;
+
     lv_obj_center(lvobj);
-    setFlexLayout(LV_FLEX_FLOW_COLUMN, PAD_ZERO, MENUS_WIDTH, LV_SIZE_CONTENT);
+    setFlexLayout(LV_FLEX_FLOW_COLUMN, PAD_ZERO, w, LV_SIZE_CONTENT);
 
     header = new StaticText(this, {0, 0, LV_PCT(100), 0}, "", 
                             COLOR_THEME_PRIMARY2_INDEX);
@@ -319,7 +321,7 @@ class MenuWindowContent : public Window
     header->padAll(PAD_SMALL);
     header->hide();
 
-    body = new MenuBody(this, rect_t{0, 0, MENUS_WIDTH, LV_SIZE_CONTENT});
+    body = new MenuBody(this, rect_t{0, 0, w, LV_SIZE_CONTENT});
     lv_obj_set_style_max_height(body->getLvObj(), LCD_H * 0.8, LV_PART_MAIN);
   }
 
@@ -357,10 +359,10 @@ class MenuWindowContent : public Window
 
 //-----------------------------------------------------------------------------
 
-Menu::Menu(bool multiple) :
+Menu::Menu(bool multiple, coord_t popupWidth) :
     ModalWindow(true),
     multiple(multiple),
-    content(new MenuWindowContent(this))
+    content(new MenuWindowContent(this, popupWidth))
 {
 }
 

--- a/radio/src/gui/colorlcd/libui/menu.h
+++ b/radio/src/gui/colorlcd/libui/menu.h
@@ -29,7 +29,7 @@ class Menu : public ModalWindow
   friend class MenuBody;
 
  public:
-  explicit Menu(bool multiple = false);
+  explicit Menu(bool multiple = false, coord_t popupWidth = 0);
 
 #if defined(DEBUG_WINDOWS)
   std::string getName() const override { return "Menu"; }

--- a/radio/src/gui/colorlcd/libui/window.cpp
+++ b/radio/src/gui/colorlcd/libui/window.cpp
@@ -59,15 +59,20 @@ void Window::eventHandler(lv_event_t *e)
 
   switch (code) {
     case LV_EVENT_SCROLL: {
+      lv_coord_t scroll_x = lv_obj_get_scroll_x(target);
+      lv_coord_t scroll_y = lv_obj_get_scroll_y(target);
+      if (scrollHandler) scrollHandler(scroll_x, scroll_y);
+
       // exclude pointer based scrolling (only focus scrolling)
-      if (!lv_obj_is_scrolling(target)) {
+      if (!lv_obj_is_scrolling(target) && !noForcedScroll) {
         lv_point_t *p = (lv_point_t *)lv_event_get_param(e);
         lv_coord_t scroll_bottom = lv_obj_get_scroll_bottom(target);
 
-        lv_coord_t scroll_y = lv_obj_get_scroll_y(target);
         TRACE("SCROLL[x=%d;y=%d;top=%d;bottom=%d]", p->x, p->y, scroll_y,
               scroll_bottom);
 
+        // Force scroll to top or bottom when near either edge.
+        // Only applies when using rotary encoder or keys.
         if (scroll_y <= 45 && p->y > 0) {
           lv_obj_scroll_by(target, 0, scroll_y, LV_ANIM_OFF);
         } else if (scroll_bottom <= 16 && p->y < 0) {

--- a/radio/src/gui/colorlcd/libui/window.h
+++ b/radio/src/gui/colorlcd/libui/window.h
@@ -75,6 +75,9 @@ class Window
   typedef std::function<void(bool)> FocusHandler;
   void setFocusHandler(FocusHandler h) { focusHandler = std::move(h); }
 
+  typedef std::function<void(coord_t, coord_t)> ScrollHandler;
+  void setScrollHandler(ScrollHandler h) { scrollHandler = std::move(h); }
+
   virtual void clear();
   virtual void deleteLater(bool detach = true, bool trash = true);
 
@@ -182,6 +185,8 @@ class Window
   virtual void enable(bool enabled = true);
   void disable() { enable(false); }
 
+  void disableForcedScroll() { noForcedScroll = true; }
+
  protected:
   static std::list<Window *> trash;
 
@@ -194,12 +199,14 @@ class Window
 
   WindowFlags windowFlags = 0;
   LcdFlags textFlags = 0;
+  bool noForcedScroll = false;
 
   bool _deleted = false;
   static bool _longPressed;
 
-  std::function<void()> closeHandler;
-  std::function<void(bool)> focusHandler;
+  CloseHandler closeHandler;
+  FocusHandler focusHandler;
+  std::function<void(coord_t, coord_t)> scrollHandler;
 
   void deleteChildren();
 

--- a/radio/src/lua/api_colorlcd_lvgl.cpp
+++ b/radio/src/lua/api_colorlcd_lvgl.cpp
@@ -433,7 +433,6 @@ LROT_BEGIN(lvgl_base_mt, NULL, LROT_MASK_GC_INDEX)
   LROT_FUNCENTRY(set, luaLvglSet)
   LROT_FUNCENTRY(show, luaLvglShow)
   LROT_FUNCENTRY(hide, luaLvglHide)
-  LROT_FUNCENTRY(getScrollPos, luaLvglGetScrollPos)
 LROT_END(lvgl_base_mt, NULL, LROT_MASK_GC_INDEX)
 
 // Metatable for complex objects

--- a/radio/src/lua/lua_lvgl_widget.cpp
+++ b/radio/src/lua/lua_lvgl_widget.cpp
@@ -2299,6 +2299,8 @@ void LvglWidgetChoice::parseParam(lua_State *L, const char *key)
   if (parseValuesParam(L, key)) return;
   if (!strcmp(key, "filter")) {
     filterFunction = luaL_ref(L, LUA_REGISTRYINDEX);
+  } else if (!strcmp(key, "popupWidth")) {
+    popupWidth = luaL_checkinteger(L, -1);
   } else {
     LvglWidgetPicker::parseParam(L, key);
   }
@@ -2317,6 +2319,8 @@ void LvglWidgetChoice::build(lua_State *L)
       lvglManager->getCurrentParent(), {x, y, w, h}, values, 0, values.size() - 1,
       [=]() { return pcallGetIntVal(L, getFunction) - 1; },
       [=](int val) { pcallSetIntVal(L, setFunction, val + 1); }, title.c_str());
+
+  c->setPopupWidth(popupWidth);
 
   if (filterFunction != LUA_REFNIL)
     c->setAvailableHandler([=](int n) {

--- a/radio/src/lua/lua_lvgl_widget.cpp
+++ b/radio/src/lua/lua_lvgl_widget.cpp
@@ -901,7 +901,7 @@ uint32_t LvglWidgetLine::getPts(lua_State* L)
     }
     for (size_t i = 0; i < ptCnt; i += 1)
       getPt(L, i);
-    return hash(pts, sizeof(ptCnt * sizeof(lv_point_t)));
+    return hash(pts, ptCnt * sizeof(lv_point_t));
   } else {
     ptCnt = 0;
     return -1;

--- a/radio/src/lua/lua_lvgl_widget.cpp
+++ b/radio/src/lua/lua_lvgl_widget.cpp
@@ -191,6 +191,10 @@ bool LvglValuesParam::parseValuesParam(lua_State *L, const char *key)
 
 bool LvglScrollableParams::parseScrollableParam(lua_State *L, const char *key)
 {
+  if (!strcmp(key, "scrollBar")) {
+    showScrollBar = lua_toboolean(L, -1);
+    return true;
+  }
   if (!strcmp(key, "scrollDir")) {
     scrollDir = (lv_dir_t)luaL_checkunsigned(L, -1);
     return true;
@@ -1400,7 +1404,8 @@ void LvglWidgetBox::build(lua_State *L)
     lv_obj_clear_flag(window->getLvObj(), LV_OBJ_FLAG_CLICKABLE);
   } else {
     lv_obj_set_scroll_dir(window->getLvObj(), scrollDir);
-    etx_scrollbar(window->getLvObj());
+    if (showScrollBar)
+      etx_scrollbar(window->getLvObj());
   }
   if (setFlex())
     lv_obj_set_flex_align(window->getLvObj(), LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_SPACE_AROUND);
@@ -2070,7 +2075,8 @@ class WidgetPage : public NavWindow, public LuaEventHandler
 {
  public:
   WidgetPage(Window *parent, std::function<void()> backAction,
-             std::string title, std::string subtitle, std::string iconFile, lv_dir_t scrollDir) :
+             std::string title, std::string subtitle, std::string iconFile,
+             lv_dir_t scrollDir, bool showScrollBar) :
       NavWindow(parent, {0, 0, LCD_W, LCD_H}), backAction(std::move(backAction))
   {
     if (iconFile.empty())
@@ -2089,7 +2095,8 @@ class WidgetPage : public NavWindow, public LuaEventHandler
     lv_obj_set_style_max_height(body->getLvObj(), LCD_H - EdgeTxStyles::MENU_HEADER_HEIGHT,
                                 LV_PART_MAIN);
     lv_obj_set_scroll_dir(body->getLvObj(), scrollDir);
-    etx_scrollbar(body->getLvObj());
+    if (showScrollBar)
+      etx_scrollbar(body->getLvObj());
 
 #if defined(HARDWARE_TOUCH)
     addBackButton();
@@ -2162,7 +2169,7 @@ void LvglWidgetPage::build(lua_State *L)
 {
   auto page = new WidgetPage(
       lvglManager->getCurrentParent(),
-      [=]() { pcallSimpleFunc(L, backActionFunction); }, title, subtitle, iconFile, scrollDir);
+      [=]() { pcallSimpleFunc(L, backActionFunction); }, title, subtitle, iconFile, scrollDir, showScrollBar);
 
   window = page->getBody();
   window->disableForcedScroll();

--- a/radio/src/lua/lua_lvgl_widget.h
+++ b/radio/src/lua/lua_lvgl_widget.h
@@ -151,6 +151,19 @@ class LvglValuesParam
   bool parseValuesParam(lua_State *L, const char *key);
 };
 
+class LvglScrollableParams
+{
+ public:
+  LvglScrollableParams() {}
+
+ protected:
+  lv_dir_t scrollDir = LV_DIR_ALL;
+  int scrollToFunction = LUA_REFNIL;
+  int scrolledFunction = LUA_REFNIL;
+
+  bool parseScrollableParam(lua_State *L, const char *key);
+};
+
 //-----------------------------------------------------------------------------
 
 class LvglWidgetObjectBase
@@ -414,7 +427,7 @@ class LvglWidgetObject : public LvglWidgetObjectBase
 
 //-----------------------------------------------------------------------------
 
-class LvglWidgetBox : public LvglWidgetObject
+class LvglWidgetBox : public LvglWidgetObject, public LvglScrollableParams
 {
  public:
   LvglWidgetBox() : LvglWidgetObject() {}
@@ -422,9 +435,10 @@ class LvglWidgetBox : public LvglWidgetObject
   coord_t getScrollX() override;
   coord_t getScrollY() override;
 
- protected:
-  lv_dir_t scrollDir = LV_DIR_ALL;
+  bool callRefs(lua_State *L) override;
+  void clearRefs(lua_State *L) override;
 
+ protected:
   void build(lua_State *L) override;
   void parseParam(lua_State *L, const char *key) override;
 };
@@ -751,11 +765,12 @@ class LvglWidgetVerticalSlider : public LvglWidgetSliderBase
 
 //-----------------------------------------------------------------------------
 
-class LvglWidgetPage : public LvglWidgetObject, public LvglTitleParam
+class LvglWidgetPage : public LvglWidgetObject, public LvglTitleParam, public LvglScrollableParams
 {
  public:
   LvglWidgetPage() : LvglWidgetObject() {}
 
+  bool callRefs(lua_State *L) override;
   void clearRefs(lua_State *L) override;
 
   coord_t getScrollX() override;
@@ -764,7 +779,6 @@ class LvglWidgetPage : public LvglWidgetObject, public LvglTitleParam
  protected:
   std::string subtitle;
   std::string iconFile;
-  lv_dir_t scrollDir = LV_DIR_ALL;
 
   int backActionFunction = LUA_REFNIL;
 

--- a/radio/src/lua/lua_lvgl_widget.h
+++ b/radio/src/lua/lua_lvgl_widget.h
@@ -860,6 +860,7 @@ class LvglWidgetChoice : public LvglWidgetPicker, public LvglTitleParam, public 
 
  protected:
   int filterFunction = LUA_REFNIL;
+  coord_t popupWidth = 0;
 
   void build(lua_State *L) override;
   void parseParam(lua_State *L, const char *key) override;

--- a/radio/src/lua/lua_lvgl_widget.h
+++ b/radio/src/lua/lua_lvgl_widget.h
@@ -157,6 +157,7 @@ class LvglScrollableParams
   LvglScrollableParams() {}
 
  protected:
+  bool showScrollBar = true;
   lv_dir_t scrollDir = LV_DIR_ALL;
   int scrollToFunction = LUA_REFNIL;
   int scrolledFunction = LUA_REFNIL;


### PR DESCRIPTION
Fixes #6350

Summary of changes:
- Fix 'line' drawing.
- Add 'popupWidth' property to 'choice' object to allow script to control the width of the popup window.
- Add 'scrollBar' property to the 'box' and 'page' objects to allow turning off the scroll bars (boolean, set to false to disable scroll bars).
- Add 'scrollTo' function to the 'box' and 'page' objects to allow Lua script to set scroll position of the container.
- Add 'scrolled' function to the 'box' and 'page' objects to send the scroll position to the script code when the container is scrolled. Alternative to the 'getScrollPos' global function.
