### PR TITLE
fix(lua): curve value incorrect in model.getInput and model.insertInput API calls

### DIFF
--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -85,7 +85,7 @@ inline uint16_t makeSourceNumVal(int16_t val, bool isSource = false)
 
 PACK(struct CurveRef {
   uint16_t type:5;
-  int16_t  value:11 CUST(r_sourceNumVal,w_sourceNumVal);
+  uint16_t value:11 CUST(r_sourceNumVal,w_sourceNumVal);
 });
 
 PACK(struct MixData {

--- a/radio/src/gui/common/stdlcd/model_curves.cpp
+++ b/radio/src/gui/common/stdlcd/model_curves.cpp
@@ -147,7 +147,7 @@ void editCurveRef(coord_t x, coord_t y, CurveRef & curve, event_t event, LcdFlag
       drawCurveName(x, y, v.value, flags);
       if (active && menuHorizontalPosition == 1) {
         if (event == EVT_KEY_LONG(KEY_ENTER) && v.value != 0) {
-          s_currIdxSubMenu = abs(curve.value) - 1;
+          s_currIdxSubMenu = abs(v.value) - 1;
           pushMenu(menuModelCurveOne);
         }
         else {

--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -680,18 +680,10 @@ static int luaModelInsertInput(lua_State *L)
         expo->mode = luaL_checkinteger(L, -1);
       }
       else if (!strcmp(key, "weight")) {
-        int val = luaL_checkinteger(L, -1);
-        SourceNumVal v;
-        v.isSource = (abs(val) >= 1024);
-        v.value = val;
-        expo->weight = v.rawValue;
+        expo->weight = luaL_checkunsigned(L, -1);
       }
       else if (!strcmp(key, "offset")) {
-        int val = luaL_checkinteger(L, -1);
-        SourceNumVal v;
-        v.isSource = (abs(val) >= 1024);
-        v.value = val;
-        expo->offset = v.rawValue;
+        expo->offset = luaL_checkunsigned(L, -1);
       }
       else if (!strcmp(key, "switch")) {
         expo->swtch = luaL_checkinteger(L, -1);
@@ -700,11 +692,7 @@ static int luaModelInsertInput(lua_State *L)
         expo->curve.type = luaL_checkinteger(L, -1);
       }
       else if (!strcmp(key, "curveValue")) {
-        int val = luaL_checkinteger(L, -1);
-        SourceNumVal v;
-        v.isSource = (abs(val) >= 1024);
-        v.value = val;
-        expo->curve.value = v.rawValue;
+        expo->curve.value = luaL_checkunsigned(L, -1);
       }
       else if (!strcmp(key, "trimSource")) {
         expo->trimSource = - luaL_checkinteger(L, -1);


### PR DESCRIPTION
Incorrect data type for curve reference value.

Fixes #6356 

Fixes issue with the Lua API call (see issue 6356).

Also fixes an issue for a long press of the ENTER key on a custom curve name in inputs or mixes.
If the selected curve is negative (e..g -CV3), it will open the wrong curve on the radio and crash on the simulator.
