### PR TITLE
feat: allow CRSF cells or volt array for frame 0x0E

### DIFF
--- a/radio/src/telemetry/crossfire.h
+++ b/radio/src/telemetry/crossfire.h
@@ -39,6 +39,7 @@
 #define CF_RPM_ID                      0x0C
 #define TEMP_ID                        0x0D
 #define CELLS_ID                       0x0E
+#define VOLT_ARRAY_ID                  0xFE  // Pseudo sensor out of 0x0E frame
 #define LINK_ID                        0x14
 #define CHANNELS_ID                    0x16
 #define LINK_RX_ID                     0x1C
@@ -102,6 +103,7 @@ enum CrossfireSensorIndexes {
   CF_RPM_INDEX,
   TEMP_INDEX,
   CELLS_INDEX,
+  VOLT_ARRAY_INDEX,
   UNKNOWN_INDEX,
 };
 

--- a/radio/src/translations/untranslated.h
+++ b/radio/src/translations/untranslated.h
@@ -116,6 +116,7 @@
 #define STR_SENSOR_A2                        "A2"
 #define STR_SENSOR_A3                        "A3"
 #define STR_SENSOR_A4                        "A4"
+#define STR_SENSOR_VOLT                      "Volt"
 #define STR_SENSOR_BATT                      "RxBt"
 #define STR_SENSOR_ALT                       "Alt"
 #define STR_SENSOR_TEMP                      "Temp"


### PR DESCRIPTION
This supports upcoming change in CRSF protocol: https://github.com/tbs-fpv/tbs-crsf-spec/pull/23

Likely needed in 2.11 please
