### PR TITLE
fix(lua): memory leak when re-loading Lua scripts

### DIFF
--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -1377,6 +1377,13 @@ void luaInit()
 
   if (luaState != INTERPRETER_PANIC) {
     if (mainState) {
+      if (lsScripts) {
+        for (int i = 0; i < luaScriptsCount; i += 1)
+          luaFree(lsScripts, scriptInternalData[i]);
+        lua_settop(lsScripts, 0);
+        lua_gc(lsScripts, LUA_GCCOLLECT, 0);
+        lsScripts = nullptr;
+      }
       lua_settop(mainState, 0);
       lua_gc(mainState, LUA_GCCOLLECT, 0);
 


### PR DESCRIPTION
After exiting a stand alone script on B&W radios, Lua memory is not completely released.
Can also happen on all radios when switching models.

Bug in PR #6337.

Fixes #6370
