### PR TITLE
fix(cpn): length of widget option strings

### DIFF
--- a/companion/src/firmwares/customisation_data.h
+++ b/companion/src/firmwares/customisation_data.h
@@ -33,7 +33,7 @@
 
 constexpr int MAX_CUSTOM_SCREENS      {10};
 constexpr int MAX_THEME_OPTIONS       {5};
-constexpr int LEN_ZONE_OPTION_STRING  {8};
+constexpr int LEN_ZONE_OPTION_STRING  {12};
 constexpr int MAX_LAYOUT_ZONES        {10};
 constexpr int MAX_LAYOUT_OPTIONS      {10};
 constexpr int WIDGET_NAME_LEN         {20};


### PR DESCRIPTION

Fixes #6328

Missed in #5605

Summary of changes:
- resync LEN_ZONE_OPTION_STRING value so widget option strings aren't truncated
- verified all other constants are in sync with firmware values
