### PR TITLE
fix(bw): spectrum analyser corrupts menu display after closing

### DIFF
--- a/radio/src/gui/common/stdlcd/radio_spectrum_analyser.cpp
+++ b/radio/src/gui/common/stdlcd/radio_spectrum_analyser.cpp
@@ -43,6 +43,7 @@ void menuRadioSpectrumAnalyser(event_t event)
   });
 
   if (menuEvent) {
+    moduleState[g_moduleIdx].mode = MODULE_MODE_NORMAL;
     lcdDrawCenteredText(LCD_H/2, STR_STOPPING);
     lcdRefresh();
 #if defined(PXX2)


### PR DESCRIPTION
Turn off data collection when exiting spectrum analyser.

Note: this is untested as I don't have suitable hardware for testing; but seems the most likely cause for the reported issue (the affected menus and the spectrum analyser share a memory buffer).

Fixes #6380 
