### PR TITLE
fix(v16): I2C conflicts in sensors reading

### DIFF
--- a/radio/src/targets/horus/tp_gt911.cpp
+++ b/radio/src/targets/horus/tp_gt911.cpp
@@ -644,11 +644,30 @@ static const char *event2str(uint8_t ev)
 }
 #endif
 
+#if defined(CSD203_SENSOR)
+  extern bool IICReadStatusFlag;
+#endif
+
 struct TouchState touchPanelRead()
 {
   uint8_t state = 0;
 
   if (!touchEventOccured) return internalTouchState;
+#if defined(CSD203_SENSOR)
+  for(int a=0;a<6;a++)
+  {//IIC bus preemption
+    if(IICReadStatusFlag==false) 
+    {
+      IICReadStatusFlag=true;
+      break;
+    } 
+    else if(a>6)
+    {
+      return internalTouchState;
+    }
+    delay_us(10);
+  }
+#endif  
 
   touchEventOccured = false;
 
@@ -659,6 +678,9 @@ struct TouchState touchPanelRead()
       touchGT911hiccups++;
       TRACE("GT911 I2C read XY error");
       if (!I2C_ReInit()) TRACE("I2C B1 ReInit failed");
+    #if defined(CSD203_SENSOR)
+      IICReadStatusFlag=false;
+    #endif  
       return internalTouchState;
     }
 
@@ -684,6 +706,9 @@ struct TouchState touchPanelRead()
         touchGT911hiccups++;
         TRACE("GT911 I2C data read error");
         if (!I2C_ReInit()) TRACE("I2C B1 ReInit failed");
+      #if defined(CSD203_SENSOR)
+        IICReadStatusFlag=false;
+      #endif  
         return internalTouchState;
       }
         
@@ -734,6 +759,9 @@ struct TouchState touchPanelRead()
   }
 
   TRACE("touch event = %s", event2str(internalTouchState.event));
+#if defined(CSD203_SENSOR)
+  IICReadStatusFlag=false;
+#endif
   return internalTouchState;
 }
 

--- a/radio/src/targets/horus/tp_gt911.cpp
+++ b/radio/src/targets/horus/tp_gt911.cpp
@@ -656,13 +656,11 @@ struct TouchState touchPanelRead()
 #if defined(CSD203_SENSOR)
   for(int a=0;a<6;a++)
   {//IIC bus preemption
-    if(IICReadStatusFlag==false) 
-    {
+    if(IICReadStatusFlag==false){
       IICReadStatusFlag=true;
       break;
     } 
-    else if(a>6)
-    {
+    else if(a>6){
       return internalTouchState;
     }
     delay_us(10);


### PR DESCRIPTION
<!-- 
The current of V16 and the IIC used by the gyroscope and the touch TP911 are on the same IIC bus, so there may be conflicts in reading and writing.
-->

Fixes #
fix v16 iic sensorread conflict

