### PR TITLE
fix(sim): flex switches may be set incorrectly on startup

### DIFF
--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -388,6 +388,7 @@ void lcdSetInvert(bool invert)
 
 void boardInit()
 {
+  switchInit();
 }
 
 uint32_t pwrCheck() { return simu_shutdown ? e_power_off : e_power_on; }


### PR DESCRIPTION
Flex switches are not initialised in the simulator so they may show incorrectly in radio hardware settings.

To reproduce:
- create a blank document in companion for the TX16S
- run the simulator
- navigate to the Radio -> Hardware -> Switches view and scroll down to the flex switches.
- flex switches will all be set to S1

![screenshot_tx16s_25-06-23_17-23-46](https://github.com/user-attachments/assets/f8d33aec-e65f-4c91-b484-97da3ce8d402)
