### PR TITLE
fix(color): switch picker for Lua scripts may show incorrect switch names

### DIFF
--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -438,7 +438,7 @@ static bool switchIsAvailable(int swtch, bool invert)
 static bool isSwitchSwitchAvailable(int swtch, bool invert) {
   // Check normal switch
   if (swtch < MAX_SWITCHES * 3) {
-    div_t swinfo = switchInfo(swtch);
+    div_t swinfo = switchInfo(swtch + SWSRC_FIRST_SWITCH);
     if (swinfo.quot >= switchGetMaxSwitches() + switchGetMaxFctSwitches()) {
       return false;
     }
@@ -458,7 +458,7 @@ static bool isSwitchSwitchAvailable(int swtch, bool invert) {
   }
 
   // Multipos switch
-  int index = (swtch - SWSRC_FIRST_MULTIPOS_SWITCH) / XPOTS_MULTIPOS_COUNT;
+  int index = (swtch + SWSRC_FIRST_SWITCH - SWSRC_FIRST_MULTIPOS_SWITCH) / XPOTS_MULTIPOS_COUNT;
   return (index < adcGetMaxInputs(ADC_INPUT_FLEX)) ? IS_POT_MULTIPOS(index) : false;
 }
 


### PR DESCRIPTION
Fixes #6387 

Fix switch offsets.
