### PR TITLE
fix(lua): model.setCurve function may fail when creating a curve with 17 points.

### DIFF
--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -1282,10 +1282,11 @@ static int luaModelSetCurve(lua_State *L)
     }
   }
   // Check how many points are set
-  uint8_t numPoints=0;
-  do {
-    numPoints++;
-  } while (yPoints[numPoints]!=-127 && numPoints < MAX_POINTS_PER_CURVE);
+  int numPoints = 0;
+  for (numPoints = 0; numPoints < MAX_POINTS_PER_CURVE; numPoints += 1) {
+    if (yPoints[numPoints] == -127)
+      break;
+  }
   newCurveHeader.points = numPoints - 5;
 
   if (numPoints < MIN_POINTS_PER_CURVE || numPoints > MAX_POINTS_PER_CURVE) {


### PR DESCRIPTION
Fixes #6399 

Replace the code that calculate the number of points in the curve to work around what looks like a compiler optimisation bug.

In the previous code (below), the 'numPoints < MAX_POINTS_PER_CURVE' test gets optimised away so the loop falls off the end of the array and gets the number of points wrong.
```C
  uint8_t numPoints=0;
  do {
    numPoints++;
  } while (yPoints[numPoints]!=-127 && numPoints < MAX_POINTS_PER_CURVE);
```