### PR TITLE
chore(cpn): remove SKY9X/9XRPRO

### DIFF
--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -32,15 +32,11 @@
 //  External access is only via getEEpromSize() and getFlashSize()
 
 #define EESIZE_TARANIS                 (32*1024)
-#define EESIZE_SKY9X                   (128*4096)
-#define EESIZE_9XRPRO                  (128*4096)
-#define EESIZE_MAX                     EESIZE_9XRPRO
+#define EESIZE_MAX                     EESIZE_TARANIS
 
 // getFlashSize() (and these macros) is only used by radiointerface::getDfuArgs (perhaps can find a better way?)
 
 #define FSIZE_TARANIS                  (512*1024)
-#define FSIZE_SKY9X                    (256*1024)
-#define FSIZE_9XRPRO                   (512*1024)
 #define FSIZE_HORUS                    (2048*1024)
 #define FSIZE_MAX                      FSIZE_HORUS
 
@@ -121,10 +117,6 @@ uint32_t Boards::getFourCC(Type board)
       return 0x3C78746F;
     case BOARD_TARANIS_X9LITES:
       return 0x3E78746F;
-    case BOARD_SKY9X:
-    case BOARD_AR9X:
-    case BOARD_9XRPRO:
-      return 0x3278746F;
     case BOARD_BETAFPV_LR3PRO:
       return 0x4578746F;
     case BOARD_IFLIGHT_COMMANDO8:
@@ -173,11 +165,6 @@ uint32_t Boards::getFourCC(Type board)
 int Boards::getEEpromSize(Board::Type board)
 {
   switch (board) {
-    case BOARD_SKY9X:
-      return EESIZE_SKY9X;
-    case BOARD_9XRPRO:
-    case BOARD_AR9X:
-      return EESIZE_9XRPRO;
     case BOARD_TARANIS_XLITES:
     case BOARD_TARANIS_XLITE:
     case BOARD_TARANIS_X7:
@@ -237,11 +224,6 @@ int Boards::getEEpromSize(Board::Type board)
 int Boards::getFlashSize(Type board)
 {
   switch (board) {
-    case BOARD_SKY9X:
-      return FSIZE_SKY9X;
-    case BOARD_9XRPRO:
-    case BOARD_AR9X:
-      return FSIZE_9XRPRO;
     case BOARD_TARANIS_XLITES:
     case BOARD_TARANIS_XLITE:
     case BOARD_TARANIS_X7:
@@ -604,12 +586,6 @@ QString Boards::getBoardName(Board::Type board)
       return "Taranis X9-Lite";
     case BOARD_TARANIS_X9LITES:
       return "Taranis X9-Lite S";
-    case BOARD_SKY9X:
-      return "Sky9x";
-    case BOARD_9XRPRO:
-      return "9XR-PRO";
-    case BOARD_AR9X:
-      return "AR9X";
     case BOARD_HORUS_X12S:
       return "Horus X12S";
     case BOARD_X10:

--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -36,9 +36,10 @@
 
 // getFlashSize() (and these macros) is only used by radiointerface::getDfuArgs (perhaps can find a better way?)
 
-#define FSIZE_TARANIS                  (512*1024)
-#define FSIZE_HORUS                    (2048*1024)
-#define FSIZE_MAX                      FSIZE_HORUS
+#define FSIZE_512KB                    (512*1024)
+#define FSIZE_1MB                      (1024*1024)
+#define FSIZE_2MB                      (2048*1024)
+#define FSIZE_MAX                      FSIZE_2MB
 
 // pre v2.10
 static const StringTagMappingTable legacyTrimSourcesLut = {
@@ -237,26 +238,27 @@ int Boards::getFlashSize(Type board)
     case BOARD_BETAFPV_LR3PRO:
     case BOARD_IFLIGHT_COMMANDO8:
     case BOARD_JUMPER_T12:
-    case BOARD_JUMPER_T12MAX:
-    case BOARD_JUMPER_T14:
     case BOARD_JUMPER_T20:
-    case BOARD_JUMPER_T20V2:
     case BOARD_JUMPER_TLITE:
     case BOARD_JUMPER_TLITE_F4:
     case BOARD_JUMPER_TPRO:
     case BOARD_JUMPER_TPROV2:
-    case BOARD_JUMPER_TPROS:
-    case BOARD_JUMPER_BUMBLEBEE:
     case BOARD_RADIOMASTER_TX12:
     case BOARD_RADIOMASTER_TX12_MK2:
     case BOARD_RADIOMASTER_ZORRO:
-    case BOARD_RADIOMASTER_BOXER:
     case BOARD_RADIOMASTER_T8:
     case BOARD_RADIOMASTER_POCKET:
-    case BOARD_RADIOMASTER_MT12:
-    case BOARD_RADIOMASTER_GX12:
+      return FSIZE_512KB;
     case BOARD_HELLORADIOSKY_V14:
-      return FSIZE_TARANIS;
+    case BOARD_JUMPER_BUMBLEBEE:
+    case BOARD_JUMPER_T12MAX:
+    case BOARD_JUMPER_T14:
+    case BOARD_JUMPER_T20V2:
+    case BOARD_JUMPER_TPROS:
+    case BOARD_RADIOMASTER_GX12:
+    case BOARD_RADIOMASTER_BOXER:
+    case BOARD_RADIOMASTER_MT12:
+      return FSIZE_1MB;
     case BOARD_HORUS_X12S:
     case BOARD_X10:
     case BOARD_X10_EXPRESS:
@@ -272,7 +274,7 @@ int Boards::getFlashSize(Type board)
     case BOARD_FLYSKY_ST16:
     case BOARD_FATFISH_F16:
     case BOARD_HELLORADIOSKY_V16:
-      return FSIZE_HORUS;
+      return FSIZE_2MB;
     case BOARD_UNKNOWN:
       return FSIZE_MAX;
     default:

--- a/companion/src/firmwares/boards.h
+++ b/companion/src/firmwares/boards.h
@@ -45,9 +45,6 @@ namespace Board {
   enum Type
   {
     BOARD_UNKNOWN = -1,
-    BOARD_SKY9X,
-    BOARD_9XRPRO,
-    BOARD_AR9X,
     BOARD_TARANIS_X7,
     BOARD_TARANIS_X7_ACCESS,
     BOARD_TARANIS_X9D,
@@ -479,16 +476,6 @@ class Boards
 // temporary aliases for transition period, use Boards class instead.
 #define getBoardCapability(b__, c__)   Boards::getCapability(b__, c__)
 
-inline bool IS_SKY9X(Board::Type board)
-{
-  return board == Board::BOARD_SKY9X || board == Board::BOARD_9XRPRO || board == Board::BOARD_AR9X;
-}
-
-inline bool IS_9XRPRO(Board::Type board)
-{
-  return board == Board::BOARD_9XRPRO;
-}
-
 inline bool IS_BETAFPV_LR3PRO(Board::Type board)
 {
   return board == Board::BOARD_BETAFPV_LR3PRO;
@@ -790,7 +777,7 @@ inline bool IS_STM32(Board::Type board)
 
 inline bool IS_ARM(Board::Type board)
 {
-  return IS_STM32(board) || IS_SKY9X(board);
+  return IS_STM32(board);
 }
 
 inline bool HAS_LARGE_LCD(Board::Type board)

--- a/companion/src/firmwares/moduledata.cpp
+++ b/companion/src/firmwares/moduledata.cpp
@@ -148,37 +148,6 @@ bool ModuleData::isAvailable(PulsesProtocol proto, int port)
         return false;
     }
   }
-  else if (IS_SKY9X(board)) {
-    switch (port) {
-      case 0:
-        switch (proto) {
-          case PULSES_PPM:
-          case PULSES_PXX_XJT_X16:
-          case PULSES_PXX_XJT_D8:
-          case PULSES_PXX_XJT_LR12:
-          case PULSES_PXX_R9M:
-          case PULSES_LP45:
-          case PULSES_DSM2:
-          case PULSES_DSMX:
-          case PULSES_SBUS:
-          case PULSES_MULTIMODULE:
-            return true;
-          default:
-            return false;
-        }
-        break;
-      case 1:
-        switch (proto) {
-          case PULSES_PPM:
-            return true;
-          default:
-            return false;
-        }
-        break;
-      default:
-        return false;
-    }
-  }
   else {
     switch (proto) {
       case PULSES_PPM:
@@ -626,37 +595,6 @@ bool ModuleData::isProtocolAvailable(int moduleidx, unsigned int protocol, Gener
             return false;
         }
 
-      default:
-        return false;
-    }
-  }
-  else if (IS_SKY9X(board)) {
-    switch (moduleidx) {
-      case 0:
-        switch (protocol) {
-          case PULSES_PPM:
-          case PULSES_PXX_XJT_X16:
-          case PULSES_PXX_XJT_D8:
-          case PULSES_PXX_XJT_LR12:
-          case PULSES_PXX_R9M:
-          case PULSES_LP45:
-          case PULSES_DSM2:
-          case PULSES_DSMX:
-          case PULSES_SBUS:
-          case PULSES_MULTIMODULE:
-            return true;
-          default:
-            return false;
-        }
-        break;
-      case 1:
-        switch (protocol) {
-          case PULSES_PPM:
-            return true;
-          default:
-            return false;
-        }
-        break;
       default:
         return false;
     }

--- a/companion/src/firmwares/opentx/opentxinterface.cpp
+++ b/companion/src/firmwares/opentx/opentxinterface.cpp
@@ -216,8 +216,6 @@ int OpenTxFirmware::getCapability(::Capability capability)
       return (IS_HORUS_OR_TARANIS(board) ? 500 : (id.contains("ppmca") ? 125 : 0));
     case SYMLimits:
       return 1;
-    case OptrexDisplay:
-      return (board == BOARD_SKY9X ? true : false);
     case HasVario:
       return Boards::isAir(board);
     case HasVarioSink:
@@ -234,8 +232,6 @@ int OpenTxFirmware::getCapability(::Capability capability)
       return IS_TARANIS_XLITE(board) && !id.contains("stdr9m");
     case HasPPMStart:
       return true;
-    case HastxCurrentCalibration:
-      return (IS_SKY9X(board) ? true : false);
     case HasVolume:
       return true;
     case HasBrightness:

--- a/companion/src/modeledit/setup_module.cpp
+++ b/companion/src/modeledit/setup_module.cpp
@@ -367,9 +367,6 @@ void ModulePanel::update()
         break;
       case PULSES_PPM:
         mask |= MASK_SUBTYPES | MASK_PPM_FIELDS | MASK_SBUSPPM_FIELDS| MASK_CHANNELS_RANGE| MASK_CHANNELS_COUNT;
-        if (IS_9XRPRO(board)) {
-          mask |= MASK_OPEN_DRAIN;
-        }
         break;
       case PULSES_SBUS:
         module.channelsCount = 16;

--- a/companion/src/radiointerface.cpp
+++ b/companion/src/radiointerface.cpp
@@ -105,9 +105,6 @@ QStringList getWriteFirmwareArgs(const QString & filename)
   if (IS_STM32(board)) {
     return getDfuArgs("-D", filename);
   }
-  else if (board == Board::BOARD_SKY9X) {
-    return getSambaArgs(QString("send_file {Flash} \"") + filename + "\" 0x400000 0\n" + "FLASH::ScriptGPNMV 2\n");
-  }
   else {
     return getSambaArgs(QString("send_file {Flash} \"") + filename + "\" 0x400000 0\n" + "FLASH::ScriptGPNMV 2\n");
   }
@@ -118,9 +115,6 @@ QStringList getReadFirmwareArgs(const QString & filename)
   Board::Type board = getCurrentBoard();
   if (IS_STM32(board)) {
     return getDfuArgs("-U", filename);
-  }
-  else if (board == Board::BOARD_SKY9X) {
-    return getSambaArgs(QString("receive_file {Flash} \"") + filename + "\" 0x400000 0x40000 0\n");
   }
   else {
     return getSambaArgs(QString("receive_file {Flash} \"") + filename + "\" 0x400000 0x80000 0\n");


### PR DESCRIPTION
Summary of changes:
 - rip out 9XRPRO / SKY9X / AR9X remnants
 - `FSIZE_` corrections (was in #6409, move here as not strictly necessary there)

WiP, some more optimisation / refactoring of some now otherwise redundant functions might still happen... ie. (IS_ARM() needs to go, `getReadFirmwareArgs()` / `getWriteFirmwareArgs()` can probably be flattened... etc. 

@elecpower Any reason not to rip these out now (as in for 3.0, not necessarily right this instant :hand_over_mouth:)?