### PR TITLE
fix(simulator): radio profile sd path

### DIFF
--- a/companion/src/simulator.cpp
+++ b/companion/src/simulator.cpp
@@ -180,6 +180,8 @@ CommandLineParseResult cliOptions(SimulatorOptions * simOptions, int * profileId
     }
 
     *simOptions = g.profile[pId].simulatorOptions();
+    // refresh just in case the path has been changed. Note: can be overridden via CLI or startup ui
+    simOptions->sdPath = g.profile[pId].sdPath();
     cliOptsFound = true;
   }
 


### PR DESCRIPTION
Fixes #6362

Summary of changes:
When starting the simulator use the radio profile sd path instead of the last run saved value.
Note: the profile sd path can be overridden via cli or startup ui.