### PR TITLE
fix(color): text input field may not display correctly when value is erased.

### DIFF
--- a/radio/src/gui/colorlcd/libui/textedit.cpp
+++ b/radio/src/gui/colorlcd/libui/textedit.cpp
@@ -156,8 +156,7 @@ void TextEdit::openEdit()
                           lv_obj_get_width(lvobj), lv_obj_get_height(lvobj)},
                         text, length);
     edit->setChangeHandler([=]() {
-      std::string s(text, length);
-      setText(s);
+      update();
       if (updateHandler) updateHandler();
       lv_group_focus_obj(lvobj);
       edit->hide();


### PR DESCRIPTION
Ensure display show '---' when text field value is erased.

To reproduce:
- edit text field (e.g. axis name), set a non-blank value, leave edit mode (close keyboard)
- edit field again, erase all characters - field shows as '---'
- leave edit mode - field shows as blank instead of '---'
