### PR TITLE
fix(t8): abs() usage issue in setBindProtocolSelection

### DIFF
--- a/radio/src/targets/taranis/bind_button_driver.cpp
+++ b/radio/src/targets/taranis/bind_button_driver.cpp
@@ -28,7 +28,7 @@ bool setBindProtocolSelection()
   int16_t yPos = calibratedAnalogs[ADC_MAIN_LV];
 
   // Center: D8
-  if (abs(xPos < 50 && abs(yPos) < 50)) {
+  if (abs(xPos) < 50 && abs(yPos) < 50) {
     g_model.moduleData[INTERNAL_MODULE].multi.rfProtocol = MODULE_SUBTYPE_MULTI_FRSKY;
     g_model.moduleData[INTERNAL_MODULE].subType = MULTI_FRSKYD_SUBTYPE_D8;
     storageDirty(EE_MODEL);


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes #6432

Summary of changes:
- taranis-button-drv : fix abs() usage issue in setBindProtocolSelection