### PR TITLE
fix(radio): clear buffers on telemetry start

### DIFF
--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -75,6 +75,11 @@ static rxStatStruct rxStat;
 
 telemetry_buffer _telemetry_rx_buffer[NUM_MODULES];
 
+static void clearTelemetryRxBuffers()
+{
+  memset(_telemetry_rx_buffer, 0, sizeof(_telemetry_rx_buffer));
+}
+
 uint8_t* getTelemetryRxBuffer(uint8_t moduleIdx)
 {
   return _telemetry_rx_buffer[moduleIdx].buffer;
@@ -185,6 +190,7 @@ void telemetryStart()
     timer_create(&telemetryTimer, telemetryTimerCb, "Telem", 2, true);
   }
 
+  clearTelemetryRxBuffers();
   timer_start(&telemetryTimer);
 }
 


### PR DESCRIPTION
While investigating #6400, it has been noticed that the telemetry buffers are not cleared on model change.
Looking more on the code, it seems these buffers were never cleared. This PR fixes exactly this.