### PR TITLE
feat(color): increase RAM allocation to LVGL for Lua scripts with many images

### DIFF
--- a/radio/src/gui/colorlcd/lv_conf.h
+++ b/radio/src/gui/colorlcd/lv_conf.h
@@ -57,7 +57,11 @@
 #endif
 #if LV_MEM_CUSTOM == 0
     /*Size of the memory available for `lv_mem_alloc()` in bytes (>= 2kB)*/
-    #define LV_MEM_SIZE (1024U * 1024U)          /*[bytes]*/
+    #if defined(SIMU)
+        #define LV_MEM_SIZE (4 * 1024U * 1024U)      /*[bytes]*/
+    #else
+        #define LV_MEM_SIZE (2 * 1024U * 1024U)      /*[bytes]*/
+    #endif
 
     /*Set an address for the memory pool instead of allocating it as a normal array. Can be in external SRAM too.*/
     #define LV_MEM_ADR 0     /*0: unused*/


### PR DESCRIPTION
As there is plenty of RAM available on color radios, this PR increases the memory allocation to LVGL.
Mainly for Lua scripts that want to use images.