### PR TITLE
feat(radio): allow Lua tools to be contained entirely within a folder

### DIFF
--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -1416,7 +1416,7 @@ bool readToolName(char * toolName, const char * filename)
   UINT count;
 
   if (f_open(&file, filename, FA_READ) != FR_OK) {
-    return "Error opening file";
+    return false;
   }
 
   FRESULT res = f_read(&file, &buffer, sizeof(buffer), &count);


### PR DESCRIPTION
Extends the logic of searching for Lua tool scripts to allow a tool to live entirely within a subfolder of SCRIPTS/TOOLS.

Currently every tool needs a .lua file in the SCRIPTS/TOOLS folder, and many are shipped with additional scripts an assets that live in another folder.

With this PR the entire tool can be stored within a subfolder under SCRIPT/TOOLS.

Instead of ignoring subfolders when scanning for tools, it checks if there is a main.lua inside the folder. If this file exists then it is used as the tool startup script (and is scanned for the tool name).

If the main.lua file contains the script name (using the TNS|script name|TNE pattern) then it is used as the tool name.
If main.lua does not contain a script name then the folder name is used as the script name.
