### PR TITLE
chore: remove Qt and SDL2 from radio unit tests

### DIFF
--- a/cmake/NativeTargets.cmake
+++ b/cmake/NativeTargets.cmake
@@ -46,7 +46,6 @@ endif()
 
 # Windows-specific includes and libs shared by sub-projects
 if(WIN32)
-  list(APPEND WIN_INCLUDE_DIRS "${RADIO_SRC_DIR}/thirdparty/windows/dirent")
   # TODO: is that still necessary?
   set(CMAKE_C_USE_RESPONSE_FILE_FOR_INCLUDES OFF)
   set(CMAKE_C_USE_RESPONSE_FILE_FOR_LIBRARIES OFF)

--- a/companion/src/CMakeLists.txt
+++ b/companion/src/CMakeLists.txt
@@ -60,7 +60,6 @@ if(WARNINGS_AS_ERRORS)
 endif()
 
 if(WIN32)
-  include_directories(SYSTEM ${WIN_INCLUDE_DIRS})
   if(NOT WIN_USE_CONSOLE)
     set(WIN_EXECUTABLE_TYPE WIN32)  # GUI (WinMain) app
   endif()
@@ -187,8 +186,7 @@ target_link_libraries(common
   Qt::Widgets
   Qt::SerialPort
   ${SDL2_LIBRARIES}
-  ${WIN_LINK_LIBRARIES}
-  )
+)
 
 set(CPN_COMMON_LIB common)
 

--- a/companion/src/tests/CMakeLists.txt
+++ b/companion/src/tests/CMakeLists.txt
@@ -14,11 +14,6 @@ if(Qt6Widgets_FOUND)
 
   include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
-  if(WIN32)
-    target_include_directories(gtests-companion-lib PUBLIC ${WIN_INCLUDE_DIRS})
-    target_link_libraries(gtests-companion-lib PRIVATE ${WIN_LINK_LIBRARIES})
-  endif(WIN32)
-
   file(GLOB TEST_SRC_FILES ${TESTS_PATH}/*.cpp)
 
   set(CMAKE_C_FLAGS_DEBUG "${CMAKE_C_FLAGS_DEBUG} -O0")

--- a/radio/src/audio.cpp
+++ b/radio/src/audio.cpp
@@ -35,10 +35,6 @@
 #include "model_audio.h"
 #include "hal/audio_driver.h"
 
-#if defined(SIMU) && !defined(SIMU_AUDIO)
-void audioConsumeCurrentBuffer() {}
-#endif
-
 extern mutex_handle_t audioMutex;
 
 // Only first quadrant values - other quadrants calulated taking advantage of symmetry in sine wave.

--- a/radio/src/targets/simu/CMakeLists.txt
+++ b/radio/src/targets/simu/CMakeLists.txt
@@ -5,13 +5,12 @@ if(NOT SIMU_TARGET)
   return()
 endif()
 
-target_compile_options(radiolib_native PUBLIC -DSIMU)
-
 set(SIMU_DRIVERS
   simpgmspace.cpp
   simufatfs.cpp
   simudisk.cpp
   simulcd.cpp
+  audio_driver.cpp
   switch_driver.cpp
   adc_driver.cpp
   module_drivers.cpp
@@ -40,7 +39,6 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 if(SDL2_FOUND)
   include_directories(${SDL2_INCLUDE_DIRS})
   target_compile_options(radiolib_native PUBLIC -DSIMU_AUDIO)
-  list(APPEND SIMU_DRIVERS simuaudio.cpp)
   if(TARGET SDL2::SDL2)
     set(SDL2_LIBRARIES SDL2::SDL2)
   endif()
@@ -97,20 +95,24 @@ if(Qt6Widgets_FOUND)
   qt_wrap_cpp(SIMULATOR_SRC
     ${COMPANION_SRC_DIRECTORY}/simulation/simulatorinterface.h
     opentxsimulator.h
-    )
+  )
   list(APPEND SIMULATOR_SRC ${SIMU_SRC} opentxsimulator.cpp)
+
   add_library(${SIMULATOR_TARGET} SHARED ${SIMULATOR_SRC})
+  if(SDL2_FOUND)
+    target_sources(${SIMULATOR_TARGET} PRIVATE simuaudio.cpp)
+  else()
+    target_sources(${SIMULATOR_TARGET} PRIVATE no_audio.cpp)
+  endif()
 
   target_compile_options(${SIMULATOR_TARGET} PRIVATE ${SIMU_SRC_OPTIONS})
   target_compile_definitions(${SIMULATOR_TARGET} PUBLIC ${APP_COMMON_DEFINES})
   target_link_libraries(${SIMULATOR_TARGET} ${SDL2_LIBRARIES} Qt::Core Qt::SerialPort)
 
   # Remove debug symbols on release builds
-  if(NOT CLANG)
-    if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
-      add_custom_command(TARGET ${SIMULATOR_TARGET} POST_BUILD
-        COMMAND ${CMAKE_STRIP} $<TARGET_FILE:${SIMULATOR_TARGET}>)
-    endif()
+  if("${CMAKE_BUILD_TYPE}" STREQUAL "Release")
+    add_custom_command(TARGET ${SIMULATOR_TARGET} POST_BUILD
+      COMMAND ${CMAKE_STRIP} -x $<TARGET_FILE:${SIMULATOR_TARGET}>)
   endif()
 
   add_custom_command(
@@ -118,7 +120,7 @@ if(Qt6Widgets_FOUND)
     COMMAND ${CMAKE_COMMAND} -E make_directory ${CMAKE_BINARY_DIR}/plugins/
     COMMAND ${CMAKE_COMMAND} -E copy
             $<TARGET_FILE:${SIMULATOR_TARGET}> ${CMAKE_BINARY_DIR}/plugins/
-    )
+  )
 
   # Introduced at 2.5 - TODO replace with a code change
   # When compiled shared simulators using libopenui and Companion have classes named MainWindow
@@ -171,6 +173,7 @@ set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${WARNING_FLAGS}")
 add_executable(simu
   EXCLUDE_FROM_ALL
   ${SIMU_SRC}
+  simuaudio.cpp
   display.cpp
   widgets.cpp
   knobs.cpp

--- a/radio/src/targets/simu/CMakeLists.txt
+++ b/radio/src/targets/simu/CMakeLists.txt
@@ -152,13 +152,6 @@ if(Qt6Widgets_FOUND)
   add_custom_target(all-simu-libs COMMAND ${all_libs_cmd} USES_TERMINAL WORKING_DIRECTORY ${CMAKE_BINARY_DIR})
 endif()
 
-if(WIN32)
-  include_directories(SYSTEM ${WIN_INCLUDE_DIRS})
-  if(Qt6Widgets_FOUND)
-    target_link_libraries(${SIMULATOR_TARGET} PRIVATE ${WIN_LINK_LIBRARIES})
-  endif()
-endif(WIN32)
-
 if(MINGW)
   # struct packing breaks on MinGW w/out -mno-ms-bitfields: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=52991 & http://stackoverflow.com/questions/24015852/struct-packing-and-alignment-with-mingw
   set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mno-ms-bitfields")

--- a/radio/src/targets/simu/no_audio.cpp
+++ b/radio/src/targets/simu/no_audio.cpp
@@ -19,11 +19,8 @@
  * GNU General Public License for more details.
  */
 
-#pragma once
+#include "simuaudio.h"
 
-#include <stdint.h>
-
-bool simuAudioInit();
-void simuAudioDeInit();
-void simuQueueAudio(const uint8_t* data, uint32_t len);
-int simuAudioGetVolume();
+bool simuAudioInit() { return false; }
+void simuAudioDeInit() {}
+void simuQueueAudio(const uint8_t*, uint32_t) {}

--- a/radio/src/targets/simu/simpgmspace.cpp
+++ b/radio/src/targets/simu/simpgmspace.cpp
@@ -22,10 +22,6 @@
 #include "board.h"
 #define SIMPGMSPC_USE_QT    0
 
-#if defined(SIMU_AUDIO)
-  #include <SDL.h>
-#endif
-
 #include "edgetx.h"
 #include "simulcd.h"
 

--- a/radio/src/targets/simu/simpgmspace.h
+++ b/radio/src/targets/simu/simpgmspace.h
@@ -48,14 +48,6 @@ void simuStop();
 bool simuIsRunning();
 void startEepromThread(const char * filename = "eeprom.bin");
 void stopEepromThread();
-
-#if defined(SIMU_AUDIO)
-  int startAudio(int volumeGain = 10);
-  void stopAudio();
-#else
-  #define startAudio(dummy) (-1)
-  #define stopAudio()
-#endif
 #endif
 
 void simuMain();

--- a/radio/src/tests/CMakeLists.txt
+++ b/radio/src/tests/CMakeLists.txt
@@ -1,49 +1,36 @@
 
-if(Qt6Widgets_FOUND)
-  add_library(gtests-radio-lib STATIC EXCLUDE_FROM_ALL
-    ${googletest_SOURCE_DIR}/googletest/src/gtest-all.cc
-  )
-  target_include_directories(gtests-radio-lib PRIVATE
-    ${googletest_SOURCE_DIR}/googletest
-  )
+add_library(gtests-radio-lib STATIC EXCLUDE_FROM_ALL
+  ${googletest_SOURCE_DIR}/googletest/src/gtest-all.cc
+)
+target_include_directories(gtests-radio-lib PRIVATE
+  ${googletest_SOURCE_DIR}/googletest
+)
 
-  set(TESTS_PATH ${RADIO_SRC_DIR}/tests)
-  set(TESTS_BUILD_PATH ${CMAKE_CURRENT_BINARY_DIR})
-  configure_file(${RADIO_SRC_DIR}/tests/location.h.in ${CMAKE_CURRENT_BINARY_DIR}/location.h @ONLY)
-  include_directories(${CMAKE_CURRENT_BINARY_DIR})
-  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS_DEBUG} -O0 -fsanitize=address")
-  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_DEBUG} -O0 ${WARNING_FLAGS} -fsanitize=address")
+set(TESTS_PATH ${RADIO_SRC_DIR}/tests)
+set(TESTS_BUILD_PATH ${CMAKE_CURRENT_BINARY_DIR})
+configure_file(${RADIO_SRC_DIR}/tests/location.h.in ${CMAKE_CURRENT_BINARY_DIR}/location.h @ONLY)
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
-  if(WIN32)
-    target_include_directories(gtests-radio-lib PUBLIC ${WIN_INCLUDE_DIRS})
-    target_link_libraries(gtests-radio-lib PRIVATE ${WIN_LINK_LIBRARIES})
-  endif(WIN32)
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS_DEBUG} -O0 -fsanitize=address")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_DEBUG} -O0 ${WARNING_FLAGS} -fsanitize=address")
 
-  if(SDL2_FOUND)
-    target_include_directories(gtests-radio-lib PUBLIC ${SDL2_INCLUDE_DIR})
-    target_link_libraries(gtests-radio-lib PRIVATE ${SDL2_LIBRARIES})
-  endif()
+if(WIN32)
+  target_include_directories(gtests-radio-lib PUBLIC ${WIN_INCLUDE_DIRS})
+  target_link_libraries(gtests-radio-lib PRIVATE ${WIN_LINK_LIBRARIES})
+endif(WIN32)
 
+file(GLOB TEST_SRC_FILES ${RADIO_SRC_DIR}/tests/*.cpp
+  CONFIGURE_DEPENDS "${RADIO_SRC_DIR}/tests/*.cpp")
 
-  file(GLOB TEST_SRC_FILES ${RADIO_SRC_DIR}/tests/*.cpp
-    CONFIGURE_DEPENDS "${RADIO_SRC_DIR}/tests/*.cpp")
+set(TEST_SRC_FILES ${TEST_SRC_FILES}
+  ${CMAKE_CURRENT_SOURCE_DIR}/location.h
+  ${SIMU_SRC}
+)
 
-  set(TEST_SRC_FILES ${TEST_SRC_FILES}
-    ${CMAKE_CURRENT_SOURCE_DIR}/location.h
-    ${SIMU_SRC}
-    )
+add_executable(gtests-radio EXCLUDE_FROM_ALL
+  ${TEST_SRC_FILES}
+)
+target_compile_options(gtests-radio PRIVATE ${SIMU_SRC_OPTIONS})
 
-  if(MINGW)
-    # struct packing breaks on MinGW w/out -mno-ms-bitfields: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=52991 & http://stackoverflow.com/questions/24015852/struct-packing-and-alignment-with-mingw
-    set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -mno-ms-bitfields")
-  endif()
-
-  add_executable(gtests-radio EXCLUDE_FROM_ALL
-    ${TEST_SRC_FILES}
-    )
-  target_compile_options(gtests-radio PRIVATE ${SIMU_SRC_OPTIONS})
-
-  add_dependencies(gtests-radio gtests-radio-lib)
-  target_link_libraries(gtests-radio gtests-radio-lib Qt::Core Qt::Widgets)
-  message(STATUS "Added optional gtests target")
-endif()
+target_link_libraries(gtests-radio gtests-radio-lib)
+message(STATUS "Added optional gtests target")

--- a/radio/src/tests/CMakeLists.txt
+++ b/radio/src/tests/CMakeLists.txt
@@ -14,11 +14,6 @@ include_directories(${CMAKE_CURRENT_BINARY_DIR})
 set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS_DEBUG} -O0 -fsanitize=address")
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_DEBUG} -O0 ${WARNING_FLAGS} -fsanitize=address")
 
-if(WIN32)
-  target_include_directories(gtests-radio-lib PUBLIC ${WIN_INCLUDE_DIRS})
-  target_link_libraries(gtests-radio-lib PRIVATE ${WIN_LINK_LIBRARIES})
-endif(WIN32)
-
 file(GLOB TEST_SRC_FILES ${RADIO_SRC_DIR}/tests/*.cpp
   CONFIGURE_DEPENDS "${RADIO_SRC_DIR}/tests/*.cpp")
 

--- a/radio/src/tests/gtests.cpp
+++ b/radio/src/tests/gtests.cpp
@@ -19,7 +19,6 @@
  * GNU General Public License for more details.
  */
 
-#include <QApplication>
 #include <stdio.h>
 #include <stdlib.h>
 #include <unistd.h>
@@ -144,7 +143,6 @@ extern const etx_hal_adc_driver_t simu_adc_driver;
 
 int main(int argc, char **argv)
 {
-  QCoreApplication app(argc, argv);
   simuInit();
   adcInit(&simu_adc_driver);
 

--- a/radio/src/tests/gtests.cpp
+++ b/radio/src/tests/gtests.cpp
@@ -127,6 +127,8 @@ uint16_t simu_get_analog(uint8_t idx)
   return 0;
 }
 
+void simuQueueAudio(const uint8_t*, uint32_t) {}
+
 static char _stringResult[200];
 
 const char * nchar2string(const char * string, int size)

--- a/radio/src/tests/gtests.h
+++ b/radio/src/tests/gtests.h
@@ -21,11 +21,9 @@
 
 #pragma once
 
-#include <QtCore/QString>
 #include <math.h>
 #include <gtest/gtest.h>
 
-#define SWAP_DEFINED
 #include "edgetx.h"
 #include "model_init.h"
 #include "switches.h"

--- a/radio/src/tests/lcd_480x272.cpp
+++ b/radio/src/tests/lcd_480x272.cpp
@@ -22,7 +22,6 @@
 #include <gtest/gtest.h>
 #include <math.h>
 
-#define SWAP_DEFINED
 #include "location.h"
 #include "edgetx.h"
 
@@ -53,12 +52,13 @@ void dumpImage(const std::string& filename, const BitmapBuffer* dc)
   TRACE("dumping image '%s'", fullpath.c_str());
 
   // allocate enough for 3 channels
-  auto pixels = dc->width() * dc->height();
+  std::vector<uint8_t> img;
   auto stride = dc->width() * 3;
-  uint8_t* img = (uint8_t*)malloc(pixels * 3);
-  convert_RGB565_to_RGB888(img, dc, dc->width(), dc->height());
-  stbi_write_png(fullpath.c_str(), dc->width(), dc->height(), 3, img, stride);
-  free(img);
+  auto pixel_bytes = stride * dc->height();
+  img.resize(pixel_bytes);
+
+  convert_RGB565_to_RGB888(img.data(), dc, dc->width(), dc->height());
+  stbi_write_png(fullpath.c_str(), dc->width(), dc->height(), 3, img.data(), stride);
 }
 
 bool checkScreenshot_colorlcd(const BitmapBuffer* dc, const char* test)

--- a/radio/src/tests/lua.cpp
+++ b/radio/src/tests/lua.cpp
@@ -24,7 +24,6 @@
 
 #if defined(LUA)
 
-#define SWAP_DEFINED
 #include "edgetx.h"
 #include "lua/lua_states.h"
 


### PR DESCRIPTION
Summary of changes:
- replaced Qt in unit test image comparison with `stb_image.h` 
- removed SDL2 dependency from radio unit tests