### PR TITLE
refactor: convert simufatfs to C++17

### DIFF
--- a/radio/src/lib_file.cpp
+++ b/radio/src/lib_file.cpp
@@ -109,7 +109,7 @@ FRESULT sdReadDir(DIR * dir, FILINFO * fno, bool & firstTime)
   return res;
 }
 
-#if !defined(BOOT) && (!defined(SIMU) || defined(SIMU_DISKIO))
+#if !defined(BOOT)
 
 // Replace FatFS implementation of f_puts and f_printf
 

--- a/radio/src/targets/simu/simpgmspace.h
+++ b/radio/src/targets/simu/simpgmspace.h
@@ -30,6 +30,8 @@
 #include <stddef.h>
 #include <errno.h>
 
+#include <string>
+
 #define __disable_irq()
 #define __enable_irq()
 
@@ -52,15 +54,10 @@ void stopEepromThread();
 
 void simuMain();
 
-#if !defined(SKIP_FATFS_DECLARATION) && !defined(SIMU_DISKIO)
-  #define SIMU_USE_SDCARD
-#endif
+void simuFatfsSetPaths(const char * sdPath, const char * settingsPath);
 
-#if defined(SIMU_USE_SDCARD)
-  void simuFatfsSetPaths(const char * sdPath, const char * settingsPath);
-#else
-  #define simuFatfsSetPaths(...)
-#endif
+std::string simuFatfsGetCurrentPath();
+std::string simuFatfsGetRealPath(const std::string &p);
 
 #if defined(TRACE_SIMPGMSPACE)
   #undef TRACE_SIMPGMSPACE

--- a/radio/src/tests/gtests.cpp
+++ b/radio/src/tests/gtests.cpp
@@ -24,7 +24,7 @@
 #include <unistd.h>
 #include <memory>
 #include "gtests.h"
-#include "hal/adc_driver.h"
+#include "location.h"
 
 using ::testing::TestEventListener;
 using ::testing::EmptyTestEventListener;
@@ -141,12 +141,10 @@ const char * nchar2string(const char * string, int size)
   return _stringResult;
 }
 
-extern const etx_hal_adc_driver_t simu_adc_driver;
-
 int main(int argc, char **argv)
 {
   simuInit();
-  adcInit(&simu_adc_driver);
+  simuFatfsSetPaths(TESTS_PATH, nullptr);
 
 #if !defined(COLORLCD)
   menuLevel = 0;

--- a/radio/src/tests/lcd.cpp
+++ b/radio/src/tests/lcd.cpp
@@ -24,11 +24,13 @@
 #include <assert.h>
 #include <gtest/gtest.h>
 
-#include "edgetx.h"
-#include "location.h"
-#include "targets/simu/simulcd.h"
-
 #if !defined(COLORLCD)
+#include "simpgmspace.h"
+#include "simulcd.h"
+
+#include "common/stdlcd/draw_functions.h"
+#include "dataconstants.h"
+#include "debug.h"
 
 #define STB_IMAGE_IMPLEMENTATION
 #include "stb/stb_image.h"
@@ -48,7 +50,7 @@ static uint8_t _get_pixel(int x, int y)
 
   if (BPP == 1) {
     if (simuLcdBuf[x + (y / 8) * LCD_W] & (1 << (y % 8))) {
-      return 0; // TODO
+      return 0;
     }
     return 161;
   }
@@ -56,7 +58,7 @@ static uint8_t _get_pixel(int x, int y)
   if (BPP == 4) {
     pixel_t p = simuLcdBuf[y / 2 * LCD_W + x];
     uint8_t z = (y & 1) ? (p >> 4) : (p & 0x0F);
-    return 161 - ((uint16_t)z * 161) / 15; // TODO
+    return 161 - ((uint16_t)z * 161) / 15;
   }
 }
 
@@ -67,7 +69,7 @@ static uint8_t _get_ref_pixel(const uint8_t* data, int x, int y, int bpp)
 
 static void dumpImage(const std::string& filename)
 {
-  std::string fullpath = TESTS_PATH "/images/color/failed_" + filename;
+  std::string fullpath = simuFatfsGetRealPath("images/bw/failed_" + filename);
 
   TRACE("dumping image '%s'", fullpath.c_str());
 
@@ -99,7 +101,7 @@ bool checkScreenshot(const char* test)
   filename += 'x' + std::to_string(LCD_H);
   filename += ".png";
 
-  std::string fullpath = TESTS_PATH "/images/bw/" + filename;
+  std::string fullpath = simuFatfsGetRealPath("images/bw/" + filename);
 
   // Read data
   int32_t w, h, bpp;
@@ -350,7 +352,7 @@ TEST(Lcd, BMPWrapping)
 {
   lcdClear();
   uint8_t bitmap[2+40*40/2];
-  lcdLoadBitmap(bitmap, TESTS_PATH "/images/bw/plane.bmp", 40, 40);
+  lcdLoadBitmap(bitmap, "images/bw/plane.bmp", 40, 40);
   lcdDrawBitmap(200, 0, bitmap);
   lcdDrawBitmap(200, 60, bitmap);
   lcdDrawBitmap(240, 60, bitmap);     // x too big
@@ -419,31 +421,31 @@ TEST(Lcd, lcdDrawBitmapLoadAndDisplay)
   // Test proper BMP files, they should display correctly
   {
     TestBuffer<1000>  bitmap(BITMAP_BUFFER_SIZE(7, 32));
-    EXPECT_TRUE(lcdLoadBitmap(bitmap.buffer(), TESTS_PATH "/images/bw/4b_7x32.bmp", 7, 32) != NULL);
+    EXPECT_TRUE(lcdLoadBitmap(bitmap.buffer(), "images/bw/4b_7x32.bmp", 7, 32) != NULL);
     bitmap.leakCheck();
     lcdDrawBitmap(10, 2, bitmap.buffer());
   }
   {
     TestBuffer<1000>  bitmap(BITMAP_BUFFER_SIZE(6, 32));
-    EXPECT_TRUE(lcdLoadBitmap(bitmap.buffer(), TESTS_PATH "/images/bw/1b_6x32.bmp", 6, 32) != NULL);
+    EXPECT_TRUE(lcdLoadBitmap(bitmap.buffer(), "images/bw/1b_6x32.bmp", 6, 32) != NULL);
     bitmap.leakCheck();
     lcdDrawBitmap(20, 2, bitmap.buffer());
   }
   {
     TestBuffer<1000>  bitmap(BITMAP_BUFFER_SIZE(31, 31));
-    EXPECT_TRUE(lcdLoadBitmap(bitmap.buffer(), TESTS_PATH "/images/bw/4b_31x31.bmp", 31, 31) != NULL);
+    EXPECT_TRUE(lcdLoadBitmap(bitmap.buffer(), "images/bw/4b_31x31.bmp", 31, 31) != NULL);
     bitmap.leakCheck();
     lcdDrawBitmap(30, 2, bitmap.buffer());
   }
   {
     TestBuffer<1000>  bitmap(BITMAP_BUFFER_SIZE(39, 32));
-    EXPECT_TRUE(lcdLoadBitmap(bitmap.buffer(), TESTS_PATH "/images/bw/1b_39x32.bmp", 39, 32) != NULL);
+    EXPECT_TRUE(lcdLoadBitmap(bitmap.buffer(), "images/bw/1b_39x32.bmp", 39, 32) != NULL);
     bitmap.leakCheck();
     lcdDrawBitmap(70, 2, bitmap.buffer());
   }
   {
     TestBuffer<1000>  bitmap(BITMAP_BUFFER_SIZE(20, 20));
-    EXPECT_TRUE(lcdLoadBitmap(bitmap.buffer(), TESTS_PATH "/images/bw/4b_20x20.bmp", 20, 20) != NULL);
+    EXPECT_TRUE(lcdLoadBitmap(bitmap.buffer(), "images/bw/4b_20x20.bmp", 20, 20) != NULL);
     bitmap.leakCheck();
     lcdDrawBitmap(120, 2, bitmap.buffer());
   }
@@ -457,7 +459,7 @@ TEST(Lcd, lcdDrawBitmapLoadAndDisplay)
   }
   {
     TestBuffer<1000>  bitmap(BITMAP_BUFFER_SIZE(10, 10));
-    EXPECT_TRUE(lcdLoadBitmap(bitmap.buffer(), TESTS_PATH "/images/bw/1b_39x32.bmp", 10, 10) == NULL) << "to small buffer";
+    EXPECT_TRUE(lcdLoadBitmap(bitmap.buffer(), "images/bw/1b_39x32.bmp", 10, 10) == NULL) << "to small buffer";
     bitmap.leakCheck();
   }
 }

--- a/radio/src/tests/lcd_480x272.cpp
+++ b/radio/src/tests/lcd_480x272.cpp
@@ -22,11 +22,9 @@
 #include <gtest/gtest.h>
 #include <math.h>
 
-#include "location.h"
-#include "edgetx.h"
-
 #if defined(COLORLCD)
 
+#include "simpgmspace.h"
 #include "bitmaps.h"
 
 #define STB_IMAGE_WRITE_IMPLEMENTATION
@@ -47,8 +45,7 @@ void convert_RGB565_to_RGB888(uint8_t* dst, const BitmapBuffer* src, coord_t w,
 
 void dumpImage(const std::string& filename, const BitmapBuffer* dc)
 {
-  std::string fullpath = TESTS_PATH "/images/color/failed_" + filename;
-
+  std::string fullpath = simuFatfsGetRealPath("images/color/failed_" + filename);
   TRACE("dumping image '%s'", fullpath.c_str());
 
   // allocate enough for 3 channels
@@ -72,7 +69,7 @@ bool checkScreenshot_colorlcd(const BitmapBuffer* dc, const char* test)
   filename += 'x' + std::to_string(LCD_H);
   filename += ".png";
 
-  std::string fullpath = TESTS_PATH "/images/color/" + filename;
+  std::string fullpath = "images/color/" + filename;
 
   std::unique_ptr<BitmapBuffer> testPict(
       BitmapBuffer::loadBitmap(fullpath.c_str()));
@@ -265,8 +262,7 @@ TEST(Lcd_colorlcd, bitmap)
   dc.clear(COLOR_THEME_SECONDARY3);
 
   dc.setClippingRect(100, 400, 50, 200);
-  std::unique_ptr<BitmapBuffer> bmp(
-      BitmapBuffer::loadBitmap(TESTS_PATH "/images/color/edgetx.png"));
+  std::unique_ptr<BitmapBuffer> bmp(BitmapBuffer::loadBitmap("images/color/edgetx.png"));
   dc.drawBitmap(0, 0, bmp.get());
   dc.drawBitmap(320, 0, bmp.get());
   dc.drawBitmap(0, 150, bmp.get());


### PR DESCRIPTION
Summary of changes:
- removed usage of POSIX headers in `simufatfs.cpp`
- use only plain C++17 to improve portability

This PR contains some of the changes already submitted in #6452 and will be rebased once that PR is merged.