### PR TITLE
fix(cpn): update components checkbox spacing

### DIFF
--- a/companion/src/apppreferencesdialog.cpp
+++ b/companion/src/apppreferencesdialog.cpp
@@ -493,6 +493,7 @@ void AppPreferencesDialog::initSettings()
     grid->addWidget(lblName[i], row, col++);
 
     chkCheckForUpdate[i] = new QCheckBox();
+    chkCheckForUpdate[i]->setStyleSheet("spacing: 10px"); // workaround Qt 6.9.0 Qt::AlignHCenter causes text to overlap checkbox rhs
     grid->addWidget(chkCheckForUpdate[i], row, col++);
     grid->setAlignment(chkCheckForUpdate[i], Qt::AlignHCenter);
 


### PR DESCRIPTION
Workaround to stop cropping of checkboxes due to centre alignment