### PR TITLE
fix(scripts): qt version and formatting

### DIFF
--- a/tools/msys2_fetch_and_build_all.sh
+++ b/tools/msys2_fetch_and_build_all.sh
@@ -209,8 +209,8 @@ if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
 fi
 
 echo "=== Step $((STEP++)): Running CMake for ${RADIO_TYPE} as an example ==="
-cmake -G "MSYS Makefiles" -Wno-dev -DCMAKE_PREFIX_PATH=$HOME/6.8.2/mingw_64 -DSDL2_LIBRARY_PATH=/mingw64/bin/ ${BUILD_OPTIONS} -DCMAKE_BUILD_TYPE=Release ../
-check_command $? "cmake -G MSYS Makefiles -Wno-dev -DCMAKE_PREFIX_PATH=$HOME/6.8.2/mingw_64 -DSDL2_LIBRARY_PATH=/mingw64/bin/ ${BUILD_OPTIONS} -DCMAKE_BUILD_TYPE=Release ../"
+cmake -G "MSYS Makefiles" -Wno-dev -DCMAKE_PREFIX_PATH=$HOME/6.9.0/mingw_64 -DSDL2_LIBRARY_PATH=/mingw64/bin/ ${BUILD_OPTIONS} -DCMAKE_BUILD_TYPE=Release ../
+check_command $? "cmake -G MSYS Makefiles -Wno-dev -DCMAKE_PREFIX_PATH=$HOME/6.9.0/mingw_64 -DSDL2_LIBRARY_PATH=/mingw64/bin/ ${BUILD_OPTIONS} -DCMAKE_BUILD_TYPE=Release ../"
 if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
   echo "Step finished. Please check the output above and press Enter to continue or Ctrl+C to stop."
   read

--- a/tools/setup_buildenv_ubuntu22.04.sh
+++ b/tools/setup_buildenv_ubuntu22.04.sh
@@ -87,7 +87,7 @@ sudo python3 -m pip install \
     lxml \
     lz4 \
     aqtinstall \
-	  pyelftools
+    pyelftools
 if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
   echo "Step finished. Please check the output above and press Enter to continue or Ctrl+C to stop."
   read

--- a/tools/setup_buildenv_ubuntu22.04.sh
+++ b/tools/setup_buildenv_ubuntu22.04.sh
@@ -42,16 +42,61 @@ if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
 fi
 
 echo "=== Step $((STEP++)): Installing packages ==="
-sudo apt-get -y install build-essential cmake gcc git lib32ncurses-dev lib32z1 libsdl2-dev qtbase5-dev qt5-qmake qtmultimedia5-dev qttools5-dev qttools5-dev-tools qtcreator libqt5svg5-dev libqt5serialport5-dev software-properties-common wget zip python3-pip-whl python3-pil libgtest-dev python3-pip python3-tk python3-setuptools clang python3-clang libusb-1.0-0-dev stlink-tools openocd npm pv libncurses5:i386 libpython2.7:i386 libclang-dev python-is-python3
+sudo apt-get -y install \
+    build-essential \
+    cmake \
+    gcc \
+    git \
+    lib32ncurses-dev \
+    lib32z1 \
+    libsdl2-dev \
+    software-properties-common \
+    wget \
+    zip \
+    python3-pip-whl \
+    python3-pil \
+    libgtest-dev \
+    python3-pip \
+    python3-tk \
+    python3-setuptools \
+    clang \
+    python3-clang \
+    libusb-1.0-0-dev \
+    stlink-tools \
+    openocd \
+    npm \
+    pv \
+    libncurses5:i386 \
+    libpython2.7:i386 \
+    libclang-dev \
+    python-is-python3 \
+    openssl
 if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
   echo "Step finished. Please check the output above and press Enter to continue or Ctrl+C to stop."
   read
 fi
 
 echo "=== Step $((STEP++)): Installing Python packages ==="
-sudo python3 -m pip install filelock asciitree jinja2 pillow==7.2.0 clang==14.0.0 future lxml lz4
+sudo python3 -m pip install \
+    filelock \
+    asciitree \
+    jinja2 \
+    pillow==7.2.0 \
+    clang==14.0.0 \
+    future \
+    lxml \
+    lz4 \
+    aqtinstall \
+	  pyelftools
 if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
   echo "Step finished. Please check the output above and press Enter to continue or Ctrl+C to stop."
+  read
+fi
+
+echo "=== Step $((STEP++)): Installing Qt ==="
+./aqt install-qt --outputdir qt linux desktop 6.9.0 linux_gcc_64 -m qtmultimedia qtserialport
+if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
+  echo "Step finished. Please press Enter to continue or Ctrl+C to stop."
   read
 fi
 
@@ -114,7 +159,7 @@ fi
 
 echo "=== Step $((STEP++)): Building and Installing USB DFU host utility ==="
 cd dfu-util-0.11/
-./configure 
+./configure
 make
 sudo make install
 cd ..

--- a/tools/setup_buildenv_ubuntu24.04.sh
+++ b/tools/setup_buildenv_ubuntu24.04.sh
@@ -42,7 +42,36 @@ if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
 fi
 
 echo "=== Step $((STEP++)): Installing packages ==="
-sudo apt-get -y install build-essential cmake gcc git lib32ncurses-dev lib32z1 libfox-1.6-dev libsdl2-dev software-properties-common wget zip python3-pip-whl python3-pil libgtest-dev python3-pip python3-tk python3-setuptools clang python3-clang libusb-1.0-0-dev stlink-tools openocd npm pv libncurses5:i386 libpython2.7:i386 libclang-dev python-is-python3
+sudo apt-get -y install \
+    build-essential \
+    cmake \
+    gcc \
+    git \
+    lib32ncurses-dev \
+    lib32z1 \
+    libfox-1.6-dev \
+    libsdl2-dev \
+    software-properties-common \
+    wget \
+    zip \
+    python3-pip-whl \
+    python3-pil \
+    libgtest-dev \
+    python3-pip \
+    python3-tk \
+    python3-setuptools \
+    clang \
+    python3-clang \
+    libusb-1.0-0-dev \
+    stlink-tools \
+    openocd \
+    npm \
+    pv \
+    libncurses5:i386 \
+    libpython2.7:i386 \
+    libclang-dev \
+    python-is-python3 \
+    openssl
 if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
   echo "Step finished. Please check the output above and press Enter to continue or Ctrl+C to stop."
   read
@@ -62,14 +91,14 @@ python3 -m pip install --break-system-package \
     lxml \
     lz4 \
     aqtinstall \
-	pyelftools
+	  pyelftools
 if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
   echo "Step finished. Please check the output above and press Enter to continue or Ctrl+C to stop."
   read
 fi
 
 echo "=== Step $((STEP++)): Installing Qt ==="
-./aqt install-qt --outputdir qt linux desktop 6.8.2 linux_gcc_64 -m qtmultimedia qtserialport
+./aqt install-qt --outputdir qt linux desktop 6.9.0 linux_gcc_64 -m qtmultimedia qtserialport
 if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
   echo "Step finished. Please press Enter to continue or Ctrl+C to stop."
   read

--- a/tools/setup_buildenv_ubuntu24.04.sh
+++ b/tools/setup_buildenv_ubuntu24.04.sh
@@ -91,7 +91,7 @@ python3 -m pip install --break-system-package \
     lxml \
     lz4 \
     aqtinstall \
-	  pyelftools
+    pyelftools
 if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
   echo "Step finished. Please check the output above and press Enter to continue or Ctrl+C to stop."
   read


### PR DESCRIPTION
Summary of changes:
- update Qt version to 6.9.0
- use same method to install Qt
- formatting to make it easier to identify packages installed

Comment: 
- packages installed has not been cleaned up so scripts can be more easily regressed for 2.11. 
- Really need set for 2.11 and 3.0 and rationalise across build chains to reduce maintenance i.e. too many scripts to be updated for a single change e.g. add extra package.