### PR TITLE
fix(sim): wrong background color for B&W simulator

### DIFF
--- a/companion/src/simulation/simulateduiwidgetGeneric.cpp
+++ b/companion/src/simulation/simulateduiwidgetGeneric.cpp
@@ -43,7 +43,7 @@ SimulatedUIWidgetGeneric::SimulatedUIWidgetGeneric(SimulatorInterface *simulator
     m_backlightColors << QColor(247, 242, 159);   //  yellow
   }
   else
-    m_backlightColors << QColor(47, 123, 227);
+    m_backlightColors << QColor(198, 208, 199);
 
   if (Boards::getCapability(board, Board::LcdOLED)) {
     ui->lcd->setBgDefaultColor(QColor(0, 0, 0));        //  black

--- a/companion/src/simulation/widgets/lcdwidget.h
+++ b/companion/src/simulation/widgets/lcdwidget.h
@@ -47,7 +47,7 @@ class LcdWidget : public QWidget
       QWidget(parent),
       localBuf(NULL),
       lightEnable(false),
-      bgDefaultColor(QColor(198, 208, 199)),
+      bgDefaultColor(QColor(148, 156, 149)),
       fgDefaultColor(QColor(0, 0, 0))
   {
   }


### PR DESCRIPTION
Fix color for simulator on B&W radios. Broken in PR #6233.
