### PR TITLE
fix(lua): modules linkage

### DIFF
--- a/radio/src/lua/api_colorlcd.cpp
+++ b/radio/src/lua/api_colorlcd.cpp
@@ -1414,6 +1414,7 @@ static int luaLcdExitFullScreen(lua_State *L)
   return 0;
 }
 
+extern "C" {
 LROT_BEGIN(colorlib, NULL, 0)
   // Colors gui/colorlcd/colors.h
   LROT_NUMENTRY( COLOR_THEME_PRIMARY1, COLOR2FLAGS(COLOR_THEME_PRIMARY1_INDEX) )
@@ -1502,9 +1503,8 @@ LROT_BEGIN(bitmaplib, NULL, 0)
   LROT_FUNCENTRY( toMask, luaBitmapTo8bitMask )
 LROT_END(bitmaplib, NULL, 0)
 
-extern "C" {
-  LUALIB_API int luaopen_bitmap(lua_State * L) {
-    luaL_rometatable( L, BITMAP_METATABLE,  LROT_TABLEREF(bitmap_mt));
-    return 0;
-  }
+LUALIB_API int luaopen_bitmap(lua_State * L) {
+  luaL_rometatable( L, BITMAP_METATABLE,  LROT_TABLEREF(bitmap_mt));
+  return 0;
+}
 }

--- a/radio/src/lua/api_colorlcd_lvgl.cpp
+++ b/radio/src/lua/api_colorlcd_lvgl.cpp
@@ -337,6 +337,7 @@ static int luaLvglGetScrollPos(lua_State *L)
   return 0;
 }
 
+extern "C" {
 // lvgl functions
 LROT_BEGIN(lvgllib, NULL, 0)
   LROT_FUNCENTRY(clear, luaLvglClear)
@@ -481,7 +482,6 @@ LROT_BEGIN(lvgl_mt, NULL, LROT_MASK_GC_INDEX)
   LROT_FUNCENTRY(getScrollPos, luaLvglGetScrollPos)
 LROT_END(lvgl_mt, NULL, LROT_MASK_GC_INDEX)
 
-extern "C" {
 LUALIB_API int luaopen_lvgl(lua_State *L)
 {
   luaL_rometatable(L, LVGL_SIMPLEMETATABLE, LROT_TABLEREF(lvgl_base_mt));

--- a/radio/src/lua/api_filesystem.cpp
+++ b/radio/src/lua/api_filesystem.cpp
@@ -248,6 +248,7 @@ static int luaRename(lua_State * L)
   return 1;
 }
 
+extern "C" {
 LROT_BEGIN(dir_handle, NULL, LROT_MASK_GC)
   LROT_FUNCENTRY( __gc, dir_gc )
 LROT_END(dir_handle, NULL, LROT_MASK_GC)
@@ -261,9 +262,8 @@ LROT_BEGIN(etxdir, NULL, 0)
   LROT_FUNCENTRY( rename, luaRename )
 LROT_END(etxdir, NULL, 0)
 
-extern "C" {
-  LUAMOD_API int luaopen_etxdir(lua_State* L) {
-    luaL_rometatable( L, DIR_METATABLE,  LROT_TABLEREF(dir_handle));
-    return 0;
-  }
+LUAMOD_API int luaopen_etxdir(lua_State* L) {
+  luaL_rometatable( L, DIR_METATABLE,  LROT_TABLEREF(dir_handle));
+  return 0;
+}
 }

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -2916,6 +2916,7 @@ static int luaGetStickMode(lua_State* const L)
   { "EVT_"#xxx"_LONG",  LRO_NUMVAL(EVT_KEY_LONG(yyy)) },        \
   { "EVT_"#xxx"_REPT",  LRO_NUMVAL(EVT_KEY_REPT(yyy)) },
 
+extern "C" {
 LROT_BEGIN(etxlib, NULL, 0)
   LROT_FUNCENTRY( getTime, luaGetTime )
   LROT_FUNCENTRY( getDateTime, luaGetDateTime )
@@ -3225,3 +3226,4 @@ LROT_BEGIN(etxstr, NULL, 0)
   LROT_LUDENTRY( CHAR_LS, STR_CHAR_LS )
   LROT_LUDENTRY( CHAR_CURVE, STR_CHAR_CURVE )
 LROT_END(etxstr, NULL, 0)
+}

--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -1863,6 +1863,7 @@ static int luaModelSetSwashRing(lua_State *L)
 }
 #endif // HELI
 
+extern "C" {
 LROT_BEGIN(modellib, NULL, 0)
   LROT_FUNCENTRY( getInfo, luaModelGetInfo )
   LROT_FUNCENTRY( setInfo, luaModelSetInfo )
@@ -1906,3 +1907,4 @@ LROT_BEGIN(modellib, NULL, 0)
   LROT_FUNCENTRY( setSwashRing, luaModelSetSwashRing )
 #endif
 LROT_END(modellib, NULL, 0)
+}

--- a/radio/src/lua/api_stdlcd.cpp
+++ b/radio/src/lua/api_stdlcd.cpp
@@ -623,6 +623,7 @@ static int luaLcdDrawCombobox(lua_State *L)
   return 0;
 }
 
+extern "C" {
 LROT_BEGIN(lcdlib, NULL, 0)
   LROT_FUNCENTRY( refresh, luaLcdRefresh )
   LROT_FUNCENTRY( clear, luaLcdClear )
@@ -649,8 +650,7 @@ LROT_END(lcdlib, NULL, 0)
 LROT_BEGIN(bitmaplib, NULL, 0)
 LROT_END(bitmaplib, NULL, 0)
 
-extern "C" {
-  LUALIB_API int luaopen_bitmap(lua_State * L) {
-    return 0;
-  }
+LUALIB_API int luaopen_bitmap(lua_State * L) {
+  return 0;
+}
 }


### PR DESCRIPTION
LUA modules read-only tables are used from `linit.c`, which requires C linkage rather than C++.