### PR TITLE
fix(color): battery voltage value not updating on Radio Hardware page

### DIFF
--- a/radio/src/gui/colorlcd/radio/radio_hardware.cpp
+++ b/radio/src/gui/colorlcd/radio/radio_hardware.cpp
@@ -86,7 +86,7 @@ class BatCalEdit : public NumberEdit
   {
     if (getBatteryVoltage() != lastBatVolts) {
       lastBatVolts = getBatteryVoltage();
-      invalidate();
+      update();
     }
   }
 };

--- a/radio/src/gui/colorlcd/radio/radio_hardware.cpp
+++ b/radio/src/gui/colorlcd/radio/radio_hardware.cpp
@@ -86,7 +86,7 @@ class BatCalEdit : public NumberEdit
   {
     if (getBatteryVoltage() != lastBatVolts) {
       lastBatVolts = getBatteryVoltage();
-      update();
+      setValue(g_eeGeneral.txVoltageCalibration);
     }
   }
 };


### PR DESCRIPTION
Fix refresh of the value in the 'Battery calibration' field on Radio Hardware page.

The value would update if you tap on the field to edit it; but would not refresh if the hardware value changed.
