### PR TITLE
fix(bw): cannot select 'inc/dec' mode for Adjust SF on some radios

### DIFF
--- a/radio/src/gui/128x64/model_special_functions.cpp
+++ b/radio/src/gui/128x64/model_special_functions.cpp
@@ -460,7 +460,8 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
               s_editMode = !s_editMode;
               active = true;
               CFN_GVAR_MODE(cfn) += 1;
-              CFN_GVAR_MODE(cfn) &= 0x03;
+              if (CFN_GVAR_MODE(cfn) > FUNC_ADJUST_GVAR_INCDEC)
+                CFN_GVAR_MODE(cfn) = FUNC_ADJUST_GVAR_CONSTANT;
               val_displayed = 0;
             }
 #endif


### PR DESCRIPTION
Fix value range check.

Fixes #6488

