### PR TITLE
fix(cpn): simulator colours

### DIFF
--- a/companion/src/simulation/simulatormainwindow.cpp
+++ b/companion/src/simulation/simulatormainwindow.cpp
@@ -134,7 +134,7 @@ SimulatorMainWindow::SimulatorMainWindow(QWidget *parent, const QString & simula
 
   restoreUiState();
 
-  setStyleSheet(SimulatorStyle::styleSheet());
+  //setStyleSheet(SimulatorStyle::styleSheet());
 
   connect(ui->actionShowKeymap, &QAction::triggered, this, &SimulatorMainWindow::showHelp);
   connect(ui->actionAbout, &QAction::triggered, this, &SimulatorMainWindow::showAbout);


### PR DESCRIPTION
Qt 6.9 has changed ui colour inheritance

Summary of changes:
