### PR TITLE
fix: populate switches

### DIFF
--- a/radio/src/targets/simu/sdl_simu.cpp
+++ b/radio/src/targets/simu/sdl_simu.cpp
@@ -430,9 +430,8 @@ static void draw_custom_switches()
         simuSetSwitch(i, active ? 1 : -1);
 
         ImGui::PopID();
+        n += 1;
       }
-
-      n += 1;
     }
 
     ImGui::PopStyleVar(3);


### PR DESCRIPTION
Fix missing switches on some radio on sdl simulator.

Thanks @raphaelcoeffic 
