### PR TITLE
fix(cpn): mode strings for surface radios

### DIFF
--- a/companion/src/modelprinter.cpp
+++ b/companion/src/modelprinter.cpp
@@ -475,16 +475,23 @@ QString ModelPrinter::printFlightModes(unsigned int flightModes)
   int numFlightModes = firmware->getCapability(FlightModes);
   if (numFlightModes && flightModes) {
     if (flightModes == (unsigned int)(1 << numFlightModes) - 1) {
-      return tr("Disabled in all flight modes");
-    }
-    else {
+      return (Boards::getCapability(getCurrentBoard(), Board::Air)
+                  ? tr("Disabled in all flight modes")
+                  : tr("Disabled in all drive modes"));
+    } else {
       QStringList list;
       for (int i = 0; i < numFlightModes; i++) {
         if (!(flightModes & (1 << i))) {
           list << printFlightModeName(i);
         }
       }
-      return (list.size() > 1 ? tr("Flight modes") : tr("Flight mode")) + QString("(%1)").arg(list.join(", "));
+      if (Boards::getCapability(getCurrentBoard(), Board::Air)) {
+        return (list.size() > 1 ? tr("Flight modes") : tr("Flight mode")) +
+               QString("(%1)").arg(list.join(", "));
+      } else {
+        return (list.size() > 1 ? tr("Drive modes") : tr("Drive mode")) +
+               QString("(%1)").arg(list.join(", "));
+      };
     }
   }
   else

--- a/companion/src/multimodelprinter.cpp
+++ b/companion/src/multimodelprinter.cpp
@@ -424,13 +424,20 @@ QString MultiModelPrinter::printHeliSetup()
 
 QString MultiModelPrinter::printFlightModes()
 {
-  QString str = printTitle(tr("Flight modes"));
+  QString str = printTitle(Boards::getCapability(getCurrentBoard(), Board::Air)
+                               ? tr("Flight modes")
+                               : tr("Drive modes"));
   // Trims
   {
     MultiColumns columns(modelPrinterMap.size());
     columns.appendSectionTableStart();
-    QStringList hd = QStringList() << tr("Flight mode") << tr("Switch") << tr("F.In") << tr("F.Out");
-    for (int i = 0; i < getBoardCapability(getCurrentBoard(), Board::NumTrims); i++) {
+    QStringList hd = QStringList()
+                     << (Boards::getCapability(getCurrentBoard(), Board::Air)
+                             ? tr("Flight mode")
+                             : tr("Drive mode"))
+                     << tr("Switch") << tr("F.In") << tr("F.Out");
+    for (int i = 0; i < getBoardCapability(getCurrentBoard(), Board::NumTrims);
+         i++) {
       hd << RawSource(SOURCE_TYPE_TRIM, i + 1).toString();
     }
     columns.appendRowHeader(hd);
@@ -502,7 +509,10 @@ QString MultiModelPrinter::printFlightModes()
       columns.appendRowEnd();
     }
 
-    columns.appendRowHeader(QStringList() << tr("Flight mode"));
+    columns.appendRowHeader(
+        QStringList() << (Boards::getCapability(getCurrentBoard(), Board::Air)
+                              ? tr("Flight mode")
+                              : tr("Drive mode")));
 
     for (int i = 0; i < firmware->getCapability(FlightModes); i++) {
       columns.appendRowStart();


### PR DESCRIPTION
Fix drive mode strings for surface radios in companion

Before: 
<img width="761" height="304" alt="Screenshot from 2025-08-10 20-39-16" src="https://github.com/user-attachments/assets/8e2d9d49-8e7c-40e6-af60-4f1fcdf06f09" />

After:
<img width="761" height="304" alt="Screenshot from 2025-08-11 00-32-39" src="https://github.com/user-attachments/assets/2a5da436-390a-4db3-86be-732a4ce6c4dd" />
