### PR TITLE
fix: align DMA buffers to 32bytes on H7

### DIFF
--- a/radio/src/targets/common/arm/stm32/h7/memory_sections.h
+++ b/radio/src/targets/common/arm/stm32/h7/memory_sections.h
@@ -24,7 +24,7 @@
 #define __INIT_HOOK    __attribute__((section(".init_hook")))
 
 #define __CCMRAM       __attribute__((section(".ccm"), aligned(4)))
-#define __DMA          __attribute__((section(".ram"), aligned(4)))
+#define __DMA          __attribute__((section(".ram"), aligned(32)))
 #define __DMA_NO_CACHE __attribute__((section(".dram"), aligned(4)))
 #define __IRAM         __attribute__((section(".iram")))
 #define __SDRAM        __attribute__((section(".sdram"), aligned(4)))


### PR DESCRIPTION
Align DMA buffers to 32bytes on H7

Fixes #6509

Thanks Radiomaster for spotting that one.