### PR TITLE
chore: optional env variable to limit the number of jobs in build-gh.sh

### DIFF
--- a/tools/build-gh.sh
+++ b/tools/build-gh.sh
@@ -81,8 +81,8 @@ do
     fi
 
     cmake ${BUILD_OPTIONS} "${SRCDIR}"
-    cmake --build . --target arm-none-eabi-configure --parallel
-    cmake --build arm-none-eabi --target ${FIRMARE_TARGET} --parallel
+    cmake --build . --target arm-none-eabi-configure --parallel ${MAX_JOBS}
+    cmake --build arm-none-eabi --target ${FIRMARE_TARGET} --parallel ${MAX_JOBS}
 
     rm -f CMakeCache.txt arm-none-eabi/CMakeCache.txt
 


### PR DESCRIPTION
This is necessary for cloudbuild where `build-gh.sh`. Might be useful for GH Actions as well, it case we run into resource limitations issues.