### PR TITLE
fix(x10): build failure due to ledGreen not always existing

### DIFF
--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -242,7 +242,9 @@ void boardInit()
 #if !defined(POWER_LED_BLUE)
   ledBlue();
 #else
+  #if defined(LED_GREEN_GPIO)
   ledGreen();
+  #endif
 #endif
 }
 #endif

--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -194,7 +194,7 @@ void ledInit();
 void ledOff();
 void ledRed();
 void ledBlue();
-#if defined(PCBX10)
+#if defined(LED_GREEN_GPIO)
   void ledGreen();
 #endif
 


### PR DESCRIPTION
Ensure that the `ledGreen` function is only declared and called when `LED_GREEN_GPIO` is defined, preventing build failures when it is not available.