### PR TITLE
fix(bootloader): resolve undefined BIDI references for Hebrew builds

### DIFF
--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -146,10 +146,11 @@ endforeach()
 
 set(RTL_LANGUAGES HE)
 if(TRANSLATIONS IN_LIST RTL_LANGUAGES)
-  add_definitions(-DTRANSLATION_IS_RTL=1)
+  set(TRANSLATION_IS_RTL 1)
 else()
-  add_definitions(-DTRANSLATION_IS_RTL=0)
+  set(TRANSLATION_IS_RTL 0)
 endif()
+add_definitions(-DTRANSLATION_IS_RTL=${TRANSLATION_IS_RTL})
 
 set(SRC ${SRC} debug.cpp)
 

--- a/radio/src/bootloader/CMakeLists.txt
+++ b/radio/src/bootloader/CMakeLists.txt
@@ -60,6 +60,12 @@ add_dependencies(bootloader ${BITMAPS_TARGET})
 target_compile_definitions(bootloader PUBLIC BOOT)
 target_compile_definitions(board_bl PUBLIC BOOT)
 
+# Force include BIDI functions for LVGL compatibility 
+# (needed because bootloader uses LVGL components that call BIDI functions)
+target_sources(bootloader PRIVATE 
+  ${RADIO_SRC_DIR}/thirdparty/lvgl/src/misc/lv_bidi.c
+)
+
 if(ARCH STREQUAL ARM)
   target_link_libraries(bootloader PUBLIC cmsis)
 endif()

--- a/radio/src/bootloader/CMakeLists.txt
+++ b/radio/src/bootloader/CMakeLists.txt
@@ -60,12 +60,6 @@ add_dependencies(bootloader ${BITMAPS_TARGET})
 target_compile_definitions(bootloader PUBLIC BOOT)
 target_compile_definitions(board_bl PUBLIC BOOT)
 
-# Force include BIDI functions for LVGL compatibility 
-# (needed because bootloader uses LVGL components that call BIDI functions)
-target_sources(bootloader PRIVATE 
-  ${RADIO_SRC_DIR}/thirdparty/lvgl/src/misc/lv_bidi.c
-)
-
 if(ARCH STREQUAL ARM)
   target_link_libraries(bootloader PUBLIC cmsis)
 endif()

--- a/radio/src/gui/colorlcd/CMakeListsLVGL.txt
+++ b/radio/src/gui/colorlcd/CMakeListsLVGL.txt
@@ -32,7 +32,6 @@ set(LVGL_SOURCES_MINIMAL
   hal/lv_hal_tick.c
 
   misc/lv_area.c
-  misc/lv_bidi.c
   misc/lv_color.c
   misc/lv_gc.c
   misc/lv_ll.c
@@ -40,6 +39,11 @@ set(LVGL_SOURCES_MINIMAL
   misc/lv_txt.c
   misc/lv_utils.c
 )
+
+# Add BIDI support for RTL languages (needed for bootloader LVGL draw functions)
+if(TRANSLATION_IS_RTL)
+  list(APPEND LVGL_SOURCES_MINIMAL misc/lv_bidi.c)
+endif()
 
 set(LVGL_SOURCES
   ${LVGL_SOURCES_MINIMAL}

--- a/radio/src/gui/colorlcd/CMakeListsLVGL.txt
+++ b/radio/src/gui/colorlcd/CMakeListsLVGL.txt
@@ -32,6 +32,7 @@ set(LVGL_SOURCES_MINIMAL
   hal/lv_hal_tick.c
 
   misc/lv_area.c
+  misc/lv_bidi.c
   misc/lv_color.c
   misc/lv_gc.c
   misc/lv_ll.c


### PR DESCRIPTION
The bootloader was failing to link when building Hebrew firmware due to undefined references to LVGL BIDI functions (lv_bidi_calculate_align, _lv_bidi_process_paragraph, _lv_bidi_get_logical_pos).

This occurred because:
- bootloader includes lv_draw_label.c which calls BIDI functions when TRANSLATION_IS_RTL set
- BIDI source (lv_bidi.c) not included in LVGL_SOURCES_MINIMAL
- TRANSLATION_IS_RTL conditional compilation worked for main firmware but not bootloader because it uses the larger LVGL_SOURCES list

FLAVOR=tx16s EXTRA_OPTIONS="-DTRANSLATIONS=HE" tools/build-gh.sh

```
[ 28%] Built target board_lib
lto-wrapper: warning: using serial compilation of 2 LTRANS jobs
lto-wrapper: note: see the '-flto' option documentation for more information
/opt/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi/bin/../lib/gcc/arm-none-eabi/14.2.1/../../../../arm-none-eabi/bin/ld: CMakeFiles/bootloader.dir/__/thirdparty/lvgl/src/draw/lv_draw_label.c.obj: in function `lv_draw_label':
/workspaces/edgetx/radio/src/thirdparty/lvgl/src/draw/lv_draw_label.c:107:(.text.lv_draw_label+0x76): undefined reference to `lv_bidi_calculate_align'
/opt/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi/bin/../lib/gcc/arm-none-eabi/14.2.1/../../../../arm-none-eabi/bin/ld: /workspaces/edgetx/radio/src/thirdparty/lvgl/src/draw/lv_draw_label.c:223:(.text.lv_draw_label+0x2c0): undefined reference to `_lv_bidi_process_paragraph'
/opt/arm-gnu-toolchain-14.2.rel1-x86_64-arm-none-eabi/bin/../lib/gcc/arm-none-eabi/14.2.1/../../../../arm-none-eabi/bin/ld: /workspaces/edgetx/radio/src/thirdparty/lvgl/src/draw/lv_draw_label.c:234:(.text.lv_draw_label+0x304): undefined reference to `_lv_bidi_get_logical_pos'
collect2: error: ld returned 1 exit status
gmake[3]: *** [radio/src/bootloader/CMakeFiles/bootloader.dir/build.make:1146: radio/src/bootloader/bootloader.elf] Error 1
gmake[2]: *** [CMakeFiles/Makefile2:1332: radio/src/bootloader/CMakeFiles/bootloader.dir/all] Error 2
gmake[1]: *** [CMakeFiles/Makefile2:904: radio/src/CMakeFiles/firmware-size.dir/rule] Error 2
gmake: *** [Makefile:384: firmware-size] Error 2
```
