### PR TITLE
fix(bw): enable LTO for `board_bl` to prevent bootloader overflow

### DIFF
--- a/radio/src/bootloader/CMakeLists.txt
+++ b/radio/src/bootloader/CMakeLists.txt
@@ -52,6 +52,7 @@ if(NOT NO_LTO)
   target_compile_options(stm32_drivers PRIVATE -flto)
   target_compile_options(stm32_drivers_w_dbg_fw PRIVATE -flto)
   target_compile_options(stm32_drivers_w_dbg_bl PRIVATE -flto)
+  target_compile_options(board_bl PRIVATE -flto)
 endif()
 
 add_executable(bootloader EXCLUDE_FROM_ALL ${BOOTLOADER_SRC})


### PR DESCRIPTION
Otherwise most B&W targets would not compile with `-DDEBUG=RTT`.