### PR TITLE
fix: firmware size in UF2 bootloader after flashing

### DIFF
--- a/radio/src/drivers/uf2_ghostfat.cpp
+++ b/radio/src/drivers/uf2_ghostfat.cpp
@@ -217,9 +217,11 @@ static FAT_BootBlock const BootBlock = {
 };
 
 static uf2_fat_write_state_t _uf2_write_state;
+static uint32_t _flash_sz;
 
 void uf2_fat_reset_state()
 {
+  _flash_sz = 0;
   memset(&_uf2_write_state, 0, sizeof(_uf2_write_state));
 }
 
@@ -248,8 +250,7 @@ static inline bool is_firmware_valid(firmware_description_t const* fw_desc)
 // get current.uf2 flash size in bytes, round up to 256 bytes
 static uint32_t current_flash_size(void)
 {
-  static uint32_t flash_sz = 0;
-  uint32_t result = flash_sz; // presumes atomic 32-bit read/write and static result
+  uint32_t result = _flash_sz; // presumes atomic 32-bit read/write and static result
 
   // only need to compute once
   if ( result == 0 ) {
@@ -262,10 +263,10 @@ static uint32_t current_flash_size(void)
     } else {
       result = UF2_MAX_FW_SIZE;
     }
-    flash_sz = result; // presumes atomic 32-bit read/write and static result
+    _flash_sz = result; // presumes atomic 32-bit read/write and static result
   }
 
-  return flash_sz;
+  return _flash_sz;
 }
 
 static void padded_memcpy (char *dst, char const *src, int len)
@@ -373,12 +374,12 @@ void uf2_fat_read_block(uint32_t block_no, uint8_t *data)
                 writeUF2FirmwareVersion(bl);
             } else {
                 if (sectionIdx < BOOTLOADER_SIZE / 256) {
-                    addr = 0x08000000 + sectionIdx * 256;
+                    addr = BOOTLOADER_ADDRESS + sectionIdx * 256;
                 } else {
                     sectionIdx -= BOOTLOADER_SIZE / 256 + 1;
                     addr = FIRMWARE_ADDRESS + sectionIdx * 256;
                 }
-            
+
                 bl->targetAddr = addr;
                 bl->payloadSize = 256;
                 memcpy(bl->data, (void *)addr, bl->payloadSize);


### PR DESCRIPTION
After flashing UF2 firmware, the bootloader would still use the old firmware size.
Beware that your OS might cache the FAT entry for `CURRENT.UF2`, so that you might have to unmount/mount if you want to see the new size. Hopefully it will however try to refresh the FAT entries after copying a file onto the UF2 drive.