### PR TITLE
fix(taranis): restore volume cli for I2C audio targets

### DIFF
--- a/radio/src/cli.cpp
+++ b/radio/src/cli.cpp
@@ -1540,6 +1540,11 @@ int cliDisplay(const char ** argv)
     gettime(&utm);
     cliSerialPrint("rtc = %4d-%02d-%02d %02d:%02d:%02d.%02d0", utm.tm_year+TM_YEAR_BASE, utm.tm_mon+1, utm.tm_mday, utm.tm_hour, utm.tm_min, utm.tm_sec, g_ms100);
   }
+#if defined(VOLUME_I2C_ADDRESS)
+  else if (!strcmp(argv[1], "volume")) {
+    cliSerialPrint("volume = %d", getVolume());
+  }
+#endif
   else if (!strcmp(argv[1], "uid")) {
     char str[LEN_CPU_UID+1];
     getCPUUniqueID(str);

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -883,6 +883,9 @@
 #if !defined(SOFTWARE_VOLUME)
   #define VOLUME_I2C_ADDRESS            0x2E
   #define VOLUME_I2C_BUS                I2C_Bus_1
+
+  #include <stdint.h>
+  int32_t getVolume();
 #endif
 
 #define I2C_B1_CLK_RATE                 400000

--- a/radio/src/targets/taranis/volume_i2c.cpp
+++ b/radio/src/targets/taranis/volume_i2c.cpp
@@ -33,15 +33,6 @@ static const uint8_t volumeScale[VOLUME_LEVEL_MAX + 1] = {
     64, 82, 96, 105, 112, 117, 120, 122, 124, 125, 126, 127,
 };
 
-static int32_t read_i2c_volume()
-{
-  uint8_t value = 0;
-  if (i2c_read(VOLUME_I2C_BUS, VOLUME_I2C_ADDRESS, 0, 1, &value, 1) < 0)
-    return -1;
-
-  return value;
-}
-
 static void write_i2c_volume(uint8_t volume)
 {
   i2c_init(VOLUME_I2C_BUS);

--- a/radio/src/targets/taranis/volume_i2c.cpp
+++ b/radio/src/targets/taranis/volume_i2c.cpp
@@ -33,6 +33,15 @@ static const uint8_t volumeScale[VOLUME_LEVEL_MAX + 1] = {
     64, 82, 96, 105, 112, 117, 120, 122, 124, 125, 126, 127,
 };
 
+static int32_t read_i2c_volume()
+{
+  uint8_t value = 0;
+  if (i2c_read(VOLUME_I2C_BUS, VOLUME_I2C_ADDRESS, 0, 1, &value, 1) < 0)
+    return -1;
+
+  return value;
+}
+
 static void write_i2c_volume(uint8_t volume)
 {
   i2c_init(VOLUME_I2C_BUS);
@@ -46,6 +55,11 @@ void audioSetVolume(uint8_t volume)
   }
 
   write_i2c_volume(volumeScale[volume]);
+}
+
+int32_t getVolume()
+{
+  return read_i2c_volume();
 }
 
 #endif


### PR DESCRIPTION
Summary of changes:

`read_i2c_volume` static function is defined but not used in targets/taranis/volume_i2c.cpp.

This one generates the next warning on build.

```
edgetx/radio/src/targets/taranis/volume_i2c.cpp:36:16: warning: 'int32_t read_i2c_volume()' defined but not used [-Wunused-function]
   36 | static int32_t read_i2c_volume()
```