### PR TITLE
fix(radio): microsecond timer

### DIFF
--- a/radio/src/targets/common/arm/stm32/timers_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/timers_driver.cpp
@@ -43,7 +43,7 @@ static void _init_1ms_timer()
   MS_TIMER->DIER = TIM_DIER_UIE;
 
   NVIC_EnableIRQ(MS_TIMER_IRQn);
-  NVIC_SetPriority(MS_TIMER_IRQn, 4);
+  NVIC_SetPriority(MS_TIMER_IRQn, 0);
 }
 
 void timersInit()
@@ -84,6 +84,9 @@ static inline void _interrupt_1ms()
 
   ++pre_scale;
   ++_ms_ticks;
+
+  __DSB();
+  __ISB();
 
   // 5ms loop
   if(pre_scale == 5 || pre_scale == 10) {


### PR DESCRIPTION
Summary of changes:
- Fix `timersGetUsTick()`: strict memory ordering is now enforced on `_ms_ticks`.
- Re-enable hardware oversampling on ADC3 (where supported).

In #6484, hardware oversampling was disabled on ADC3 to work-around strange timeout issues observed. It turns out the ADC was not timing out: the timer itself was faulty. During first tests, it also fixed some strange issues where a higher mixer runtime was measured without clear explanation. Again, it turns out that the time base itself was at fault.
