### PR TITLE
fix(h7): no LTO for system_clock.c

### DIFF
--- a/radio/src/targets/common/arm/stm32/h7/CMakeLists.txt
+++ b/radio/src/targets/common/arm/stm32/h7/CMakeLists.txt
@@ -8,12 +8,12 @@ include_directories(${CMSIS_DIR}/Include)
 
 if(CPU_TYPE STREQUAL STM32H7RS)
   include_directories(${CMSIS_DIR}/Device/ST/STM32H7RS/Include)
-  set(CMSIS_SRC
+  set(CMSIS_SRC ${CMSIS_SRC}
     targets/common/arm/stm32/h7/system_stm32h7rsxx.c
   )
 else()
   include_directories(${CMSIS_DIR}/Device/ST/STM32H7xx/Include)
-  set(CMSIS_SRC
+  set(CMSIS_SRC ${CMSIS_SRC}
     targets/common/arm/stm32/h7/system_stm32h7xx.c
   )
 endif()

--- a/radio/src/targets/st16/CMakeLists.txt
+++ b/radio/src/targets/st16/CMakeLists.txt
@@ -135,7 +135,6 @@ set(BOARD_COMMON_SRC
 # Bootloader board library
 add_library(board_bl OBJECT EXCLUDE_FROM_ALL
   ${BOARD_COMMON_SRC}
-  ${TARGET_SRC_DIR}/system_clock.c
   ${TARGET_SRC_DIR}/sdram_driver.cpp
   ${RADIO_SRC_DIR}/gui/colorlcd/boot_menu.cpp
   targets/common/arm/stm32/stm32_qspi.cpp
@@ -143,6 +142,8 @@ add_library(board_bl OBJECT EXCLUDE_FROM_ALL
 )
 add_dependencies(board_bl minimal_board_lib)
 set(BOOTLOADER_SRC ${BOOTLOADER_SRC} $<TARGET_OBJECTS:board_bl>)
+
+set(CMSIS_SRC ${TARGET_SRC_DIR}/system_clock.c)
 
 # Firmware board library
 add_library(board OBJECT EXCLUDE_FROM_ALL

--- a/radio/src/targets/stm32h7s78-dk/CMakeLists.txt
+++ b/radio/src/targets/stm32h7s78-dk/CMakeLists.txt
@@ -86,11 +86,12 @@ set(BOARD_COMMON_SRC
 # Bootloader board library
 add_library(board_bl OBJECT EXCLUDE_FROM_ALL
   ${BOARD_COMMON_SRC}
-  ${TARGET_SRC_DIR}/system_clock.c
   ${TARGET_SRC_DIR}/extram_driver.cpp
   ${RADIO_SRC_DIR}/gui/colorlcd/boot_menu.cpp
 )
 set(BOOTLOADER_SRC ${BOOTLOADER_SRC} $<TARGET_OBJECTS:board_bl>)
+
+set(CMSIS_SRC ${TARGET_SRC_DIR}/system_clock.c)
 
 # Firmware board library
 add_library(board OBJECT EXCLUDE_FROM_ALL

--- a/radio/src/targets/tx15/CMakeLists.txt
+++ b/radio/src/targets/tx15/CMakeLists.txt
@@ -137,7 +137,6 @@ set(BOARD_COMMON_SRC
 # Bootloader board library
 add_library(board_bl OBJECT EXCLUDE_FROM_ALL
   ${BOARD_COMMON_SRC}
-  ${TARGET_SRC_DIR}/system_clock.c
   ${TARGET_SRC_DIR}/sdram_driver.cpp
   ${TARGET_SRC_DIR}/usb_charger_driver.cpp
   ${RADIO_SRC_DIR}/gui/colorlcd/boot_menu.cpp
@@ -146,6 +145,8 @@ add_library(board_bl OBJECT EXCLUDE_FROM_ALL
 )
 add_dependencies(board_bl minimal_board_lib)
 set(BOOTLOADER_SRC ${BOOTLOADER_SRC} $<TARGET_OBJECTS:board_bl>)
+
+set(CMSIS_SRC ${TARGET_SRC_DIR}/system_clock.c)
 
 # Firmware board library
 add_library(board OBJECT EXCLUDE_FROM_ALL


### PR DESCRIPTION
This interacts otherwise badly with `BOOTSTRAP`, such that some inline functions used inside `SystemClock_Config` are called with an address located in RAM (agressive LTO behaviour) instead of being inlined in place.

Fixes boot crash introduced in #6541.