### PR TITLE
fix(radio): wider PWM gimbal boundaries

### DIFF
--- a/radio/src/targets/common/arm/stm32/sticks_pwm_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/sticks_pwm_driver.cpp
@@ -40,8 +40,8 @@
 #define PWM_MAX_PERIOD 5000
 
 // sensor uses a duty cycle [5%; 95%]
-#define PWM_MIN_PULSE   80
-#define PWM_MAX_PULSE 3820
+#define PWM_MIN_PULSE   40
+#define PWM_MAX_PULSE 4000
 
 #define PWM_PRESCALER_FREQ 1038000
 


### PR DESCRIPTION
It seems that the boundaries chosen for PWM gimbal signal were a bit too tight for some radios. This should be better now.

**Please note:** this PR is based on upcoming v2.11.3 to allow users to test with a safe firmware.

Fixes #6404