### PR TITLE
chore(ci): update CI configuration for firmware builds

### DIFF
--- a/.github/workflows/actions.yml
+++ b/.github/workflows/actions.yml
@@ -6,37 +6,23 @@ on:
       - 'main'
     tags:
       - v*
-    paths-ignore:
-      - '**.md'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/workflows/nightly.yml'
-      - '.github/workflows/linux_cpn.yml'
-      - '.github/workflows/macosx_cpn.yml'
-      - '.github/workflows/win-cpn-32.yml'
-      - '.github/workflows/win_cpn-64.yml'
-      - '.github/workflows/validate_fw_json.yml'
-      - 'companion/**'
-      - '.gitpod.yml'
-      - '.devcontainer/**'
-      - 'CMakeUserPresets.json'
-      - 'fw.json'
+    paths:
+      - '.github/workflows/actions.yml'
+      - 'cmake/**'
+      - 'radio/**'
+      - 'tools/build-gh.sh'
+      - '.gitmodules'
+      - 'CMakeLists.txt'
   pull_request:
     branches:
       - 'main'
-    paths-ignore:
-      - '**.md'
-      - '.github/ISSUE_TEMPLATE/**'
-      - '.github/workflows/nightly.yml'
-      - '.github/workflows/linux_cpn.yml'
-      - '.github/workflows/macosx_cpn.yml'
-      - '.github/workflows/win-cpn-32.yml'
-      - '.github/workflows/win_cpn-64.yml'
-      - '.github/workflows/validate_fw_json.yml'
-      - 'companion/**'
-      - '.gitpod.yml'
-      - '.devcontainer/**'
-      - 'CMakeUserPresets.json'
-      - 'fw.json'
+    paths:
+      - '.github/workflows/actions.yml'
+      - 'cmake/**'
+      - 'radio/**'
+      - 'tools/build-gh.sh'
+      - '.gitmodules'
+      - 'CMakeLists.txt'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/build_fw.yml
+++ b/.github/workflows/build_fw.yml
@@ -7,7 +7,7 @@ on:
     tags:
       - v*
     paths:
-      - '.github/workflows/actions.yml'
+      - '.github/workflows/build_fw.yml'
       - 'cmake/**'
       - 'radio/**'
       - 'tools/build-gh.sh'
@@ -17,7 +17,7 @@ on:
     branches:
       - 'main'
     paths:
-      - '.github/workflows/actions.yml'
+      - '.github/workflows/build_fw.yml'
       - 'cmake/**'
       - 'radio/**'
       - 'tools/build-gh.sh'

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/Edgetx/edgetx)](https://github.com/EdgeTX/edgetx/releases/latest)
 [![GitHub all releases](https://img.shields.io/github/downloads/EdgeTX/edgetx/total)](https://github.com/EdgeTX/edgetx/releases)
 [![GitHub license](https://img.shields.io/github/license/Edgetx/edgetx)](https://github.com/EdgeTX/edgetx/blob/main/LICENSE)
-[![Commit Tests](https://github.com/EdgeTX/edgetx/actions/workflows/actions.yml/badge.svg)](https://github.com/EdgeTX/edgetx/actions/workflows/actions.yml)
+[![Commit Tests](https://github.com/EdgeTX/edgetx/actions/workflows/build_fw.yml/badge.svg)](https://github.com/EdgeTX/edgetx/actions/workflows/build_fw.yml)
 [![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/edgetx/edgetx/tree/main)
 [![Conventional Commits](https://img.shields.io/badge/Conventional%20Commits-1.0.0-%23FE5196?logo=conventionalcommits&logoColor=white)](https://conventionalcommits.org)
 [![Discord](https://img.shields.io/discord/839849772864503828.svg?label=&logo=discord&logoColor=ffffff&color=7389D8&labelColor=6A7EC2)](https://discord.gg/wF9wUKnZ6H)


### PR DESCRIPTION
- Refine CI triggers by switching from paths-ignore to paths. 
- Rename the firmware build action for clarity.