### PR TITLE
fix: pushCS should not be a GF 

### DIFF
--- a/companion/src/firmwares/boardjson.cpp
+++ b/companion/src/firmwares/boardjson.cpp
@@ -437,27 +437,61 @@ int BoardJson::getNumericSuffix(const std::string str)
   return -1;
 }
 
-const int BoardJson::getSwitchIndex(const QString val, Board::LookupValueType lvt) const
+const int BoardJson::getCFSIndexForSwitch(int offset) const
 {
-  return getSwitchIndex(m_switches, val, lvt);
+  return getCFSIndexForSwitch(m_switches, offset);
 }
 
-const int BoardJson::getCFSIndexForSwitch(int sw) const
+// static
+int BoardJson::getCFSIndexForSwitch(const SwitchesTable * switches, int sw)
 {
-  if (sw < (int)m_switches->size() && m_switches->at(sw).isCustomSwitch)
-    return m_switches->at(sw).customSwitchIdx;
+  if (sw < (int)switches->size() && switches->at(sw).isCustomSwitch)
+    return switches->at(sw).customSwitchIdx;
 
   return -1;
 }
 
-const int BoardJson::getSwitchIndexForCFS(int cfsIdx) const
+const int BoardJson::getSwitchIndexForCFS(int offset) const
 {
-  for (int i = 0; i < (int)m_switches->size(); i++) {
-    if (m_switches->at(i).isCustomSwitch && m_switches->at(i).customSwitchIdx == cfsIdx)
+  return getSwitchIndexForCFS(m_switches, offset);
+}
+
+// static
+int BoardJson::getSwitchIndexForCFS(const SwitchesTable * switches, int cfsIdx)
+{
+  for (int i = 0; i < (int)switches->size(); i++) {
+    if (switches->at(i).isCustomSwitch && switches->at(i).customSwitchIdx == cfsIdx)
       return i;
   }
 
   return -1;
+}
+
+const int BoardJson::getSwitchIndexForCFSOffset(int offset) const
+{
+  return getSwitchIndexForCFSOffset(m_switches, offset);
+}
+
+// static
+int BoardJson::getSwitchIndexForCFSOffset(const SwitchesTable * switches, const int offset)
+{
+  int cnt = 0;
+
+  for (int i = 0; i < (int)switches->size(); i++) {
+    if (switches->at(i).isCustomSwitch) {
+      if (cnt == offset)
+        return i;
+      else
+        cnt++;
+    }
+  }
+
+  return -1;
+}
+
+const int BoardJson::getSwitchIndex(const QString val, Board::LookupValueType lvt) const
+{
+  return getSwitchIndex(m_switches, val, lvt);
 }
 
 // static

--- a/companion/src/firmwares/boardjson.cpp
+++ b/companion/src/firmwares/boardjson.cpp
@@ -467,6 +467,28 @@ int BoardJson::getSwitchIndexForCFS(const SwitchesTable * switches, int cfsIdx)
   return -1;
 }
 
+const int BoardJson::getCFSOffsetForCFSIndex(int index) const
+{
+  return getCFSOffsetForCFSIndex(m_switches, index);
+}
+
+// static
+int BoardJson::getCFSOffsetForCFSIndex(const SwitchesTable * switches, const int index)
+{
+  int cnt = 0;
+
+  for (int i = 0; i < (int)switches->size(); i++) {
+    if (switches->at(i).isCustomSwitch) {
+      if (switches->at(i).customSwitchIdx == index)
+        return cnt;
+      else
+        cnt++;
+    }
+  }
+
+  return -1;
+}
+
 const int BoardJson::getSwitchIndexForCFSOffset(int offset) const
 {
   return getSwitchIndexForCFSOffset(m_switches, offset);

--- a/companion/src/firmwares/boardjson.h
+++ b/companion/src/firmwares/boardjson.h
@@ -141,6 +141,7 @@ class BoardJson
     const int getSwitchIndex(const QString val, Board::LookupValueType lvt) const;
     const int getCFSIndexForSwitch(int sw) const;
     const int getSwitchIndexForCFS(int customSwitchIdx) const;
+    const int getSwitchIndexForCFSOffset(int offset) const;
     const Board::SwitchInfo getSwitchInfo(int index) const;
     const QString getSwitchName(int index) const;
     const QString getSwitchTag(int index) const;
@@ -207,6 +208,9 @@ private:
     static Board::KeyInfo getKeyInfo(const KeysTable * keys, int index);
 
     static int getSwitchIndex(const SwitchesTable * switches, QString val, Board::LookupValueType lvt);
+    static int getCFSIndexForSwitch(const SwitchesTable * switches, int sw);
+    static int getSwitchIndexForCFS(const SwitchesTable * switches, int customSwitchIdx);
+    static int getSwitchIndexForCFSOffset(const SwitchesTable * switches, int offset);
     static Board::SwitchInfo getSwitchInfo(const SwitchesTable * switches, int index);
     static QString getSwitchName(const SwitchesTable * switches, int index);
     static QString getSwitchTag(const SwitchesTable * switches, int index);

--- a/companion/src/firmwares/boardjson.h
+++ b/companion/src/firmwares/boardjson.h
@@ -142,6 +142,7 @@ class BoardJson
     const int getCFSIndexForSwitch(int sw) const;
     const int getSwitchIndexForCFS(int customSwitchIdx) const;
     const int getSwitchIndexForCFSOffset(int offset) const;
+    const int getCFSOffsetForCFSIndex(int index) const;
     const Board::SwitchInfo getSwitchInfo(int index) const;
     const QString getSwitchName(int index) const;
     const QString getSwitchTag(int index) const;
@@ -211,6 +212,7 @@ private:
     static int getCFSIndexForSwitch(const SwitchesTable * switches, int sw);
     static int getSwitchIndexForCFS(const SwitchesTable * switches, int customSwitchIdx);
     static int getSwitchIndexForCFSOffset(const SwitchesTable * switches, int offset);
+    static int getCFSOffsetForCFSIndex(const SwitchesTable * switches, int index);
     static Board::SwitchInfo getSwitchInfo(const SwitchesTable * switches, int index);
     static QString getSwitchName(const SwitchesTable * switches, int index);
     static QString getSwitchTag(const SwitchesTable * switches, int index);

--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -1087,6 +1087,11 @@ int Boards::getSwitchIndexForCFSOffset(int offset, Board::Type board)
   return getBoardJson(board)->getSwitchIndexForCFSOffset(offset);
 }
 
+int Boards::getCFSOffsetForCFSIndex(int index, Board::Type board)
+{
+  return getBoardJson(board)->getCFSOffsetForCFSIndex(index);
+}
+
 QString Boards::getSwitchName(int index, Board::Type board)
 {
   return getBoardJson(board)->getSwitchName(index);

--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -1081,7 +1081,12 @@ int Boards::getSwitchIndexForCFS(int cfsIdx, Board::Type board)
 {
   return getBoardJson(board)->getSwitchIndexForCFS(cfsIdx);
 }
-    
+
+int Boards::getSwitchIndexForCFSOffset(int offset, Board::Type board)
+{
+  return getBoardJson(board)->getSwitchIndexForCFSOffset(offset);
+}
+
 QString Boards::getSwitchName(int index, Board::Type board)
 {
   return getBoardJson(board)->getSwitchName(index);

--- a/companion/src/firmwares/boards.h
+++ b/companion/src/firmwares/boards.h
@@ -432,6 +432,7 @@ class Boards
     static int getSwitchIndex(QString val, Board::LookupValueType lvt, Board::Type board = Board::BOARD_UNKNOWN);
     static int getCFSIndexForSwitch(int swIdx, Board::Type board = Board::BOARD_UNKNOWN);
     static int getSwitchIndexForCFS(int cfsIdx, Board::Type board = Board::BOARD_UNKNOWN);
+    static int getSwitchIndexForCFSOffset(int offset, Board::Type board = Board::BOARD_UNKNOWN);
     static QString getSwitchName(int index, Board::Type board = Board::BOARD_UNKNOWN);
     static QString getSwitchTag(int index, Board::Type board = Board::BOARD_UNKNOWN);
     static int getSwitchTagNum(int index, Board::Type board = Board::BOARD_UNKNOWN);

--- a/companion/src/firmwares/boards.h
+++ b/companion/src/firmwares/boards.h
@@ -433,6 +433,7 @@ class Boards
     static int getCFSIndexForSwitch(int swIdx, Board::Type board = Board::BOARD_UNKNOWN);
     static int getSwitchIndexForCFS(int cfsIdx, Board::Type board = Board::BOARD_UNKNOWN);
     static int getSwitchIndexForCFSOffset(int offset, Board::Type board = Board::BOARD_UNKNOWN);
+    static int getCFSOffsetForCFSIndex(int index, Board::Type board = Board::BOARD_UNKNOWN);
     static QString getSwitchName(int index, Board::Type board = Board::BOARD_UNKNOWN);
     static QString getSwitchTag(int index, Board::Type board = Board::BOARD_UNKNOWN);
     static int getSwitchTagNum(int index, Board::Type board = Board::BOARD_UNKNOWN);

--- a/companion/src/firmwares/customfunctiondata.cpp
+++ b/companion/src/firmwares/customfunctiondata.cpp
@@ -133,7 +133,7 @@ QString CustomFunctionData::funcToString(const AssignFunc func, const ModelData 
   else if (func == FuncLCDtoVideo)
     return tr("LCD to Video");
   else if (func >= FuncPushCustomSwitch1 && func <= FuncPushCustomSwitchLast && Boards::getCapability(getCurrentBoard(), Board::FunctionSwitches)) {
-    const int idx = Boards::getSwitchTypeOffset(Board::SWITCH_FUNC) + func - FuncPushCustomSwitch1 + 1;
+    const int idx = Boards::getSwitchIndexForCFSOffset(func - FuncPushCustomSwitch1) + 1;
     return tr("Push Custom Switch %1").arg(RawSource(SOURCE_TYPE_SWITCH, idx).toString(model));
   }
   else {

--- a/companion/src/firmwares/customfunctiondata.cpp
+++ b/companion/src/firmwares/customfunctiondata.cpp
@@ -279,7 +279,8 @@ int CustomFunctionData::funcContext(const int index)
 
   if ((index >= FuncOverrideCH1 && index <= FuncOverrideCHLast) ||
       (index >= FuncRangeCheckInternalModule && index <= FuncBindExternalModule) ||
-      (index >= FuncAdjustGV1 && index <= FuncAdjustGVLast))
+      (index >= FuncAdjustGV1 && index <= FuncAdjustGVLast) ||
+      (index >= FuncPushCustomSwitch1 && index <= FuncPushCustomSwitchLast))
     ret &= ~GlobalFunctionsContext;
 
   return ret;

--- a/companion/src/firmwares/edgetx/yaml_customfunctiondata.cpp
+++ b/companion/src/firmwares/edgetx/yaml_customfunctiondata.cpp
@@ -223,11 +223,12 @@ Node convert<CustomFunctionData>::encode(const CustomFunctionData& rhs)
   case FuncSetScreen:
     def += std::to_string(rhs.param);
     break;
-  case FuncPushCustomSwitch1:
-    def += std::to_string(p1);
+  case FuncPushCustomSwitch1: {
+    int idx = Boards::getCFSIndexForSwitch(Boards::getSwitchIndexForCFSOffset(p1));
+    def += std::to_string(idx);
     def += ",";
     def += std::to_string(rhs.param);
-    break;
+  } break;
   default:
     add_comma = false;
     break;
@@ -393,7 +394,8 @@ bool convert<CustomFunctionData>::decode(const Node& node,
   case FuncPushCustomSwitch1: {
     int sw = 0;
     def >> sw;
-    rhs.func = (AssignFunc)((int)rhs.func + sw);
+    int offset = Boards::getCFSOffsetForCFSIndex(sw);
+    rhs.func = (AssignFunc)((int)rhs.func + offset);
     def.ignore();
     int param = 0;
     def >> param;

--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -678,6 +678,12 @@ bool isAssignableFunctionAvailable(int function, bool modelFunctions)
     case FUNC_TEST:
       return false;
 #endif
+    case FUNC_PUSH_CUST_SWITCH:
+#if defined(FUNCTION_SWITCHES) || defined(CFN_ONLY)
+      return modelFunctions;
+#else
+      return false;
+#endif
     default:
       return true;
   }

--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -678,12 +678,11 @@ bool isAssignableFunctionAvailable(int function, bool modelFunctions)
     case FUNC_TEST:
       return false;
 #endif
-    case FUNC_PUSH_CUST_SWITCH:
 #if defined(FUNCTION_SWITCHES) || defined(CFN_ONLY)
+    case FUNC_PUSH_CUST_SWITCH:
       return modelFunctions;
-#else
-      return false;
 #endif
+
     default:
       return true;
   }


### PR DESCRIPTION
PushCS cannot be available in global SF since we cannot know if target CS exists in the model.

@elecpower maybe it need a Companion mirror change too ?
