### PR TITLE
fix(TX15): harden even more PCA95xx

### DIFF
--- a/radio/src/targets/tx15/bsp_io.h
+++ b/radio/src/targets/tx15/bsp_io.h
@@ -24,6 +24,7 @@
 #include "drivers/pca95xx.h"
 #include "hal/switch_driver.h"
 
+#define IO_EXPANDER_I2C_BUS    I2C_Bus_1
 
 // Port expander 2 (0x75)
 #define BSP_TR1U PCA95XX_PIN_13


### PR DESCRIPTION
Add another step in TCA95xx error management on TX15 in case a simple chip reset is not enough

While this fixes 6579 symptoms, an underlying issue likely still exist that leads to crashing I2C on SD transfer. Will be investigated later.

This closes #6579