### PR TITLE
fix(tx15): unable to enter bootloader after #6585

### DIFF
--- a/radio/src/boards/rm-h750/board.cpp
+++ b/radio/src/boards/rm-h750/board.cpp
@@ -100,6 +100,7 @@ void boardBLEarlyInit()
   gpio_clear(AUDIO_RESET_PIN);
 
   timersInit();
+  delaysInit();
   bsp_io_init();
   usbChargerInit();
 }
@@ -141,7 +142,6 @@ void boardInit()
   delaysInit();
   timersInit();
 
-  bsp_io_init();
   usbChargerInit();
   gpio_set(LED_BLUE_GPIO);
   gpio_init(HALL_SYNC, GPIO_OUT, GPIO_PIN_SPEED_LOW);


### PR DESCRIPTION
Fix bootloader been stuck (radio not responding to power on request) since last nighttly because delays where not started.

Also removed an unnecessary call to bsp_io_init() since it is already part of later called switchInit()

ps: this issue could not been seen when using Ozone :(