### PR TITLE
fix(color): source picker may show invalid switches

### DIFF
--- a/radio/src/boards/generic_stm32/switches.cpp
+++ b/radio/src/boards/generic_stm32/switches.cpp
@@ -59,7 +59,7 @@ const stm32_switch_t* boardGetSwitchDef(uint8_t idx) { return &_switch_defs[idx]
 
 uint8_t boardGetMaxSwitches() { return n_switches; }
 #if defined(FUNCTION_SWITCHES)
-bool boardIsCustomSwitch(uint8_t idx) { return _switch_defs[idx].isCustomSwitch; }
+bool boardIsCustomSwitch(uint8_t idx) { return (idx < n_switches) ? _switch_defs[idx].isCustomSwitch : false; }
 uint8_t boardGetCustomSwitchIdx(uint8_t idx) { return _switch_defs[idx].customSwitchIdx; }
 #endif
 

--- a/radio/src/targets/simu/switch_driver.cpp
+++ b/radio/src/targets/simu/switch_driver.cpp
@@ -77,7 +77,7 @@ uint8_t boardGetMaxSwitches() { return n_switches; }
 SwitchConfig boardSwitchGetDefaultConfig(uint8_t idx) { return _switch_defs[idx].defaultType; }
 
 #if defined(FUNCTION_SWITCHES)
-bool boardIsCustomSwitch(uint8_t idx) { return _switch_defs[idx].isCustomSwitch; }
+bool boardIsCustomSwitch(uint8_t idx) { return (idx < n_switches) ? _switch_defs[idx].isCustomSwitch : false; }
 uint8_t boardGetCustomSwitchIdx(uint8_t idx) { return _switch_defs[idx].customSwitchIdx; }
 #endif
 


### PR DESCRIPTION
Radios with customisable switches (e.g. T15 and TX15), the source picker popup may show invalid switches.

To reproduce:
- create a blank model
- set all customisable switches to 2POS
- edit a mix line and open the Source picker
- the switch list may show invalid values after SW6
