### PR TITLE
fix(adc): missing return on timeout

### DIFF
--- a/radio/src/targets/common/arm/stm32/stm32_adc.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_adc.cpp
@@ -782,6 +782,7 @@ void stm32_hal_adc_wait_completion(const stm32_adc_t* ADCs, uint8_t n_ADC,
     // busy wait
     if ((uint32_t)(timersGetUsTick() - timeout) >= SAMPLING_TIMEOUT_US) {
       _adc_timeout_error = true;
+      return;
     }
   }
 }


### PR DESCRIPTION
Discovered when @raphaelcoeffic  review #6577

Only affected main, 2.11 branch already fixed