### PR TITLE
fix(cpn): missing NSIS for windows-2025 runner

### DIFF
--- a/.github/actions/build_companion/action.yml
+++ b/.github/actions/build_companion/action.yml
@@ -45,7 +45,7 @@ runs:
 
     - name: Install NSIS
       if: runner.os == 'Windows'
-      uses: repolevedavaj/install-nsis@v1.1.0
+      uses: repolevedavaj/install-nsis@v1.2.1
       with:
         nsis-version: '3.11'
 

--- a/.github/actions/build_companion/action.yml
+++ b/.github/actions/build_companion/action.yml
@@ -43,6 +43,12 @@ runs:
       shell: pwsh
       run: ${{ github.action_path }}/setup-msvc.ps1
 
+    - name: Install NSIS
+      if: runner.os == 'Windows'
+      uses: repolevedavaj/install-nsis@v1.1.0
+      with:
+        nsis-version: '3.11'
+
     - name: Build
       shell: bash
       env:

--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -94,7 +94,9 @@ jobs:
     name: Linux Companion
     runs-on: ubuntu-latest
     needs: modules
-    if: inputs.target == 'all' || inputs.target == 'linux' || inputs.target == ''
+    if: |
+      (inputs.target == 'all' || inputs.target == 'linux' || inputs.target == '') &&
+      (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci: skip-cpn-linux'))
 
     container:
       image: ghcr.io/edgetx/edgetx-dev:latest
@@ -127,7 +129,9 @@ jobs:
     name: macOS Companion
     runs-on: macos-15
     needs: modules
-    if: inputs.target == 'all' || inputs.target == 'macos' || inputs.target == ''
+    if: |
+      (inputs.target == 'all' || inputs.target == 'macos' || inputs.target == '') &&
+      (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci: skip-cpn-macos'))
 
     env:
       CMAKE_OSX_ARCHITECTURES: 'x86_64;arm64'
@@ -156,7 +160,9 @@ jobs:
     name: Windows Companion
     runs-on: windows-latest
     needs: modules
-    if: inputs.target == 'all' || inputs.target == 'windows' || inputs.target == ''
+    if: |
+      (inputs.target == 'all' || inputs.target == 'windows' || inputs.target == '') &&
+      (github.event_name != 'pull_request' || !contains(github.event.pull_request.labels.*.name, 'ci: skip-cpn-win'))
 
     env:
       CMAKE_GENERATOR: 'Ninja'

--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -154,7 +154,7 @@ jobs:
 
   build-win64:
     name: Windows Companion
-    runs-on: windows-2022
+    runs-on: windows-latest
     needs: modules
     if: inputs.target == 'all' || inputs.target == 'windows' || inputs.target == ''
 

--- a/tools/build-companion.sh
+++ b/tools/build-companion.sh
@@ -70,7 +70,7 @@ get_platform_config() {
             PACKAGE_EMOJI="🐧"
             ;;
         *)
-            PACKAGE_TARGET="installer"
+            PACKAGE_TARGET="install"
             PACKAGE_FILES="companion/*.exe"
             PACKAGE_NAME="Windows installer"
             PACKAGE_EMOJI="🪟"

--- a/tools/build-companion.sh
+++ b/tools/build-companion.sh
@@ -70,7 +70,7 @@ get_platform_config() {
             PACKAGE_EMOJI="🐧"
             ;;
         *)
-            PACKAGE_TARGET="install"
+            PACKAGE_TARGET="installer"
             PACKAGE_FILES="companion/*.exe"
             PACKAGE_NAME="Windows installer"
             PACKAGE_EMOJI="🪟"

--- a/tools/build-companion.sh
+++ b/tools/build-companion.sh
@@ -125,7 +125,13 @@ else
         echo "    📄 Copied: $(basename "$PACKAGE_FILE")"
     else
         echo "    ❌ Failed to copy package files to output directory"
+        echo "    📁 Directory Contents:"
+        echo "    ----------------------"
         ls -la native/ || echo "native/ directory not found"
+        echo "Looking for files matching: $PACKAGE_FILES"
+        find native/ -name "$PACKAGE_FILES" 2>/dev/null || echo "No matching files found"
+        echo "All .exe files under native/:"
+        find native/ -iname "*.exe" 2>/dev/null || echo "No .exe files found"
         error_status=1
     fi
 fi

--- a/tools/build-companion.sh
+++ b/tools/build-companion.sh
@@ -126,12 +126,6 @@ else
     else
         echo "    ❌ Failed to copy package files to output directory"
         ls -la native/ || echo "native/ directory not found"
-        if [ "$PACKAGE_TARGET" == "installer" ]; then
-            echo "Contents of companion/ directory:"
-            ls -la companion/ || echo "companion/ directory not found"
-        fi
-        echo "Looking for files matching: $PACKAGE_FILES"
-        find native/ -name "$PACKAGE_FILES" 2>/dev/null || echo "No matching files found"
         error_status=1
     fi
 fi

--- a/tools/build-companion.sh
+++ b/tools/build-companion.sh
@@ -118,7 +118,7 @@ elif ! cmake_build_parallel native --target ${PACKAGE_TARGET} >> "$LOG_FILE" 2>&
     cat "$LOG_FILE"
     error_status=1
 else
-    PACKAGE_FILE=$(find native/ -name "${PACKAGE_FILES}" -type f | head -n1)
+    PACKAGE_FILE=$(find native/ -path "native/${PACKAGE_FILES}" -type f | head -n1)
     if [ -n "$PACKAGE_FILE" ] && cp "$PACKAGE_FILE" "${OUTDIR}" 2>/dev/null; then
         echo "    ✅ Build completed successfully!"
         echo "    📁 Package saved to: ${OUTDIR}"
@@ -129,9 +129,7 @@ else
         echo "    ----------------------"
         ls -la native/ || echo "native/ directory not found"
         echo "Looking for files matching: $PACKAGE_FILES"
-        find native/ -name "$PACKAGE_FILES" 2>/dev/null || echo "No matching files found"
-        echo "All .exe files under native/:"
-        find native/ -iname "*.exe" 2>/dev/null || echo "No .exe files found"
+        find native/ -path "native/${PACKAGE_FILES}" 2>/dev/null || echo "No matching files found"
         error_status=1
     fi
 fi

--- a/tools/build-companion.sh
+++ b/tools/build-companion.sh
@@ -117,13 +117,17 @@ elif ! cmake_build_parallel native --target ${PACKAGE_TARGET} >> "$LOG_FILE" 2>&
     echo "    ❌ Packaging failed"
     cat "$LOG_FILE"
     error_status=1
-elif cp "native/${PACKAGE_FILES}" "${OUTDIR}" 2>/dev/null; then
-    echo "    ✅ Build completed successfully!"
-    echo "    📁 Package saved to: ${OUTDIR}"
 else
-    echo "    ❌ Failed to copy package files to output directory"
-    ls -la native/ || echo "native/ directory not found"
-    error_status=1
+    PACKAGE_FILE=$(find native/ -name "${PACKAGE_FILES}" -type f | head -n1)
+    if [ -n "$PACKAGE_FILE" ] && cp "$PACKAGE_FILE" "${OUTDIR}" 2>/dev/null; then
+        echo "    ✅ Build completed successfully!"
+        echo "    📁 Package saved to: ${OUTDIR}"
+        echo "    📄 Copied: $(basename "$PACKAGE_FILE")"
+    else
+        echo "    ❌ Failed to copy package files to output directory"
+        ls -la native/ || echo "native/ directory not found"
+        error_status=1
+    fi
 fi
 
 if [[ -n "$GITHUB_ACTIONS" ]]; then

--- a/tools/build-companion.sh
+++ b/tools/build-companion.sh
@@ -126,6 +126,12 @@ else
     else
         echo "    ❌ Failed to copy package files to output directory"
         ls -la native/ || echo "native/ directory not found"
+        if [ "$PACKAGE_TARGET" == "installer" ]; then
+            echo "Contents of companion/ directory:"
+            ls -la companion/ || echo "companion/ directory not found"
+        fi
+        echo "Looking for files matching: $PACKAGE_FILES"
+        find native/ -name "$PACKAGE_FILES" 2>/dev/null || echo "No matching files found"
         error_status=1
     fi
 fi

--- a/tools/build-companion.sh
+++ b/tools/build-companion.sh
@@ -52,10 +52,11 @@ if [[ -z ${EDGETX_VERSION_SUFFIX} ]]; then
   fi
 fi
 
-rm -rf build && mkdir build && cd build
+rm -rf build && mkdir build && cd build || exit
 
 get_platform_config() {
-    local platform=$(uname)
+    local platform
+    platform=$(uname)
     case "$platform" in
         "Darwin")
             PACKAGE_TARGET="package"
@@ -116,7 +117,7 @@ elif ! cmake_build_parallel native --target ${PACKAGE_TARGET} >> "$LOG_FILE" 2>&
     echo "    ❌ Packaging failed"
     cat "$LOG_FILE"
     error_status=1
-elif cp native/$PACKAGE_FILES "${OUTDIR}" 2>/dev/null; then
+elif cp "native/${PACKAGE_FILES}" "${OUTDIR}" 2>/dev/null; then
     echo "    ✅ Build completed successfully!"
     echo "    📁 Package saved to: ${OUTDIR}"
 else


### PR DESCRIPTION
Test to see if this is the reason win64 broke - I fully expect it to fail as this makes no sense - but the build system can tell me that itself. 🤣 

This confirms what I suspected... the 2025 image removed NSIS as a default package: actions/runner-images/issues/11754

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Windows companion application packaging by ensuring the required installer tooling is available during builds.
  * Improved artifact detection and error reporting when companion packages cannot be created or copied.
* **Chores**
  * Updated platform build workflows to support the latest Windows build environment.
  * Added controls to selectively skip Linux, macOS, or Windows companion builds when needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->