### PR TITLE
fix: crossfire temperature sensor unit

### DIFF
--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -66,7 +66,7 @@ const CrossfireSensor crossfireSensors[] = {
   CS(BARO_ALT_ID,    0, STR_SENSOR_ALT,           UNIT_METERS,            2),
   CS(AIRSPEED_ID,    0, STR_SENSOR_ASPD,          UNIT_KMH,               1),
   CS(CF_RPM_ID,      0, STR_SENSOR_RPM,           UNIT_RPMS,              0),
-  CS(TEMP_ID,        0, STR_SENSOR_TEMP,          UNIT_DEGREE,            1),
+  CS(TEMP_ID,        0, STR_SENSOR_TEMP,          UNIT_CELSIUS,           1),
   CS(CELLS_ID,       0, STR_SENSOR_CELLS,         UNIT_CELLS,             2),
   CS(VOLT_ARRAY_ID,  0, STR_SENSOR_VOLT,          UNIT_VOLTS,             2),
   CS(0,              0, "UNKNOWN",                UNIT_RAW,               0),


### PR DESCRIPTION
As reported on Discord, the wrong types of degree was used for CRSF temperature sensors,