### PR TITLE
fix(firmware): default customizable switches to be like classic 6POS

### DIFF
--- a/radio/src/model_init.cpp
+++ b/radio/src/model_init.cpp
@@ -106,9 +106,12 @@ void initCustomSwitches()
   for (int i = 0; i < switchGetMaxSwitches(); i += 1) {
     if (switchIsCustomSwitch(i)) {
       uint8_t idx = switchGetCustomSwitchIdx(i);
-      g_model.customSwitches[idx].type = SWITCH_GLOBAL;
-      g_model.customSwitches[idx].group = 0;
-      g_model.customSwitches[idx].start = FS_START_PREVIOUS;
+      g_model.customSwitches[idx].type = SWITCH_2POS;
+      g_model.customSwitches[idx].group = 1;
+      if (idx == 0)
+        g_model.customSwitches[idx].start = FS_START_ON;
+      else
+        g_model.customSwitches[idx].start = FS_START_OFF;
       g_model.customSwitches[idx].state = 0;
       g_model.customSwitches[idx].name[0] = 0;
 #if defined(FUNCTION_SWITCHES_RGB_LEDS)

--- a/radio/src/model_init.cpp
+++ b/radio/src/model_init.cpp
@@ -120,6 +120,7 @@ void initCustomSwitches()
 #endif
     }
   }
+  g_model.cfsSetGroupAlwaysOn(1, true);
 }
 #endif
 


### PR DESCRIPTION
As a side consequence of switch refactor, default for customizable switches default was changed from '6pos like' to individual non grouped custom switches. Drone pilot are therefore missing the 'GR1' channel to map their flight mode settings. 

This restores it to previous "well known" default settings (This applies only to future models created from defaults).
