### PR TITLE
fix(radio): prevent starting another USART send when one is already in progress

### DIFF
--- a/radio/src/targets/common/arm/stm32/stm32_usart_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_usart_driver.cpp
@@ -558,6 +558,12 @@ void stm32_usart_send_byte(const stm32_usart_t* usart, uint8_t byte)
 
 void stm32_usart_send_buffer(const stm32_usart_t* usart, const uint8_t * data, uint32_t size)
 {
+
+  if (!stm32_usart_tx_completed(usart)) {
+    // Transmission is already in progress, abort
+    return;
+  }
+
   _half_duplex_output(usart);
 
   if (usart->txDMA) {


### PR DESCRIPTION
When 2 module are in use, the internal drives mixer scheduling. In case of ELRS, this could drive mixer runs as low as 1ms

Issue #6609 happens because a MPM frame takes about 3ms to be sent. In current code send is restarted before the frame is even finished when internal elrs rate is set above 250hz, resulting in a continuous flow of meaningless bytes

Before
<img width="1960" height="1192" alt="image" src="https://github.com/user-attachments/assets/68ed8ce0-cf88-415b-8b62-420d5e9c0f76" />

After
<img width="2114" height="1214" alt="image" src="https://github.com/user-attachments/assets/8cbd731a-ced4-443a-9574-5beb8ad245ba" />

This prevent serial sent to be done if one is still in progress, which makes sense for any serial transmission 

This fixes #6609, fixes #3054