### PR TITLE
chore(radio): remove some H7 build warnings

### DIFF
--- a/radio/src/boards/generic_stm32/module_ports.cpp
+++ b/radio/src/boards/generic_stm32/module_ports.cpp
@@ -277,6 +277,7 @@ static const stm32_pulse_timer_t trainerModuleTimer = {
 #define TELEMETRY_USART_IRQ_PRIORITY 0
 #define TELEMETRY_DMA_IRQ_PRIORITY   0
 
+#if !defined(STM32H7) && !defined(STM32H7RS)
 static void _set_sport_input(uint8_t enable)
 {
 #if defined(TELEMETRY_DIR_GPIO)
@@ -289,6 +290,7 @@ static void _set_sport_input(uint8_t enable)
   (void)enable;
 #endif
 }
+#endif
 
 #if defined(TELEMETRY_USART)
 static const stm32_usart_t sportUSART = {
@@ -309,7 +311,7 @@ static const stm32_usart_t sportUSART = {
   .rxDMA_Stream = 0,
   .rxDMA_Channel = 0,
 #endif
-#if defined(STM32H7) || (STM32H7RS)
+#if defined(STM32H7) || defined(STM32H7RS)
   .set_input = nullptr,
 #else
   .set_input = _set_sport_input,

--- a/radio/src/gyro.cpp
+++ b/radio/src/gyro.cpp
@@ -34,11 +34,13 @@
 
 Gyro gyro;
 
+#if !defined(IMU_ICM4207C)
 static float deg2RESX(float deg)
 {
   // [-90 : 90] -> [-RESX : RESX]
   return (deg * float(RESX)) / 90.0;
 }
+#endif
 
 void Gyro::wakeup()
 {

--- a/radio/src/targets/common/arm/stm32/stm32_exti_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_exti_driver.cpp
@@ -337,13 +337,6 @@ _DEFINE_CUSTOM_EXTI_IRQ_HANDLER(CUSTOM_EXTI_IRQ_NAME, CUSTOM_EXTI_IRQ_LINE, CUST
 
 #pragma GCC diagnostic pop // re-enable all warnings
 
-static bool _custom_has_handler(stm32_exti_handler_t* _handlers, uint8_t len)
-{
-  for (uint8_t i = 0; i < len; i++)
-    if (_handlers[i]) return true;
-  return false;
-}
-
 void stm32_exti_custom_enable(uint32_t line, uint8_t trigger, stm32_exti_handler_t cb)
 {
 #if defined(LL_APB2_GRP1_PERIPH_EXTI)


### PR DESCRIPTION
Clean up some build warnings for H7 based radios, remove duplicate function (`_custom_has_handler` is functionally identical to `_has_handler`).