### PR TITLE
fix(radio): temporary fix to restore EM capability.

### DIFF
--- a/radio/src/boards/jumper-h750/board.cpp
+++ b/radio/src/boards/jumper-h750/board.cpp
@@ -95,6 +95,8 @@ void EXTERNAL_MODULE_OFF()
 
 void boardBLEarlyInit()
 {
+  pwrOn();
+
   timersInit();
   usbChargerInit();
 }

--- a/radio/src/boards/rm-h750/board.cpp
+++ b/radio/src/boards/rm-h750/board.cpp
@@ -95,6 +95,8 @@ void EXTERNAL_MODULE_OFF()
 
 void boardBLEarlyInit()
 {
+  pwrOn();
+
   // TAS2505 requires reset pin to be low on power on
   gpio_init(AUDIO_RESET_PIN, GPIO_OUT, GPIO_PIN_SPEED_LOW);
   gpio_clear(AUDIO_RESET_PIN);

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -63,6 +63,11 @@ void boardBLEarlyInit()
 {
   videoSwitchInit();
 }
+#else
+void boardBLEarlyInit()
+{
+  pwrOn();
+}
 #endif
 
 extern "C" void SDRAM_Init();


### PR DESCRIPTION
This restores EM capabilities to colorlcd radios on main branch, but this also brings a likely undesirable behavior where a rapid press of power button is enough to turn radio on, and will need to be addressed later, but I think EM fix cannot wait