### PR TITLE
fix(color): potential crash when configuring external module if trainer mode set to Master/SBUS

### DIFF
--- a/radio/src/gui/colorlcd/module/module_setup.cpp
+++ b/radio/src/gui/colorlcd/module/module_setup.cpp
@@ -750,6 +750,7 @@ ModulePage::ModulePage(uint8_t moduleIdx) : Page(ICON_MODEL_SETUP)
                  MODULE_TYPE_COUNT - 1, GET_DEFAULT(md->type));
 
   moduleChoice->setAvailableHandler([=](int8_t moduleType) {
+    if (moduleType == MODULE_TYPE_NONE) return true;
     return moduleIdx == INTERNAL_MODULE ? isInternalModuleAvailable(moduleType)
                                         : isExternalModuleAvailable(moduleType);
   });


### PR DESCRIPTION
Fix potential crash when selecting external module type, if trainer mode is set to Master/SBUS.
