### PR TITLE
feat: support BT and serial gimbal on TX15

### DIFF
--- a/radio/src/targets/tx15/CMakeLists.txt
+++ b/radio/src/targets/tx15/CMakeLists.txt
@@ -7,6 +7,8 @@ option(GHOST "Ghost TX Module" ON)
 option(MODULE_SIZE_STD "Standard size TX Module" ON)
 option(LUA_MIXER "Enable LUA mixer/model scripts support" ON)
 option(DISK_CACHE "Enable SD card disk cache" ON)
+option(BLUETOOTH "FrSky BT module support" ON)
+option(FLYSKY_GIMBAL "Serial gimbal support" OFF)
 
 set(FIRMWARE_QSPI YES)
 set(FIRMWARE_FORMAT_UF2 YES)
@@ -26,6 +28,11 @@ set(HARDWARE_EXTERNAL_MODULE YES)
 set(INTERNAL_MODULE_AFHDS3 NO)
 set(ROTARY_ENCODER YES)
 set(FUNCTION_SWITCHES_WITH_RGB YES)
+
+# BT and serial gimbal share same UART
+if(FLYSKY_GIMBAL)
+  set(BLUETOOTH OFF)
+endif()
 
 #option(STICKS_DEAD_ZONE "Enable sticks dead zone" YES)
 
@@ -137,6 +144,12 @@ set(BOARD_COMMON_SRC
   targets/common/arm/stm32/watchdog_driver.cpp
   drivers/pca95xx.cpp
 )
+
+if(BLUETOOTH)
+  set(BOARD_COMMON_SRC ${BOARD_COMMON_SRC}
+    targets/common/arm/stm32/bluetooth_driver.cpp
+  )
+endif()
 
 # Bootloader board library
 add_library(board_bl OBJECT EXCLUDE_FROM_ALL

--- a/radio/src/targets/tx15/hal.h
+++ b/radio/src/targets/tx15/hal.h
@@ -384,15 +384,25 @@ TIM17:	ROTARY_ENCODER_TIMER
 #define HAPTIC_TIMER_MODE               TIM_CCMR1_OC2M_1 | TIM_CCMR1_OC2M_2 | TIM_CCMR1_OC2PE
 #define HAPTIC_TIMER_COMPARE_VALUE      HAPTIC_GPIO_TIMER->CCR2
 
-// Flysky Hall Stick
+#if defined(BLUETOOTH)
+// Bluetooth
+#define STORAGE_BLUETOOTH
+#define BT_USART                        UART4
+#define BT_USART_IRQn                   UART4_IRQn
+#define BT_TX_GPIO                      GPIO_PIN(GPIOB, 9)
+#define BT_RX_GPIO                      GPIO_PIN(GPIOB, 8)
+#endif
+
+#if defined(FLYSKY_GIMBAL)
+// FlySky Hall Sticks
 #define FLYSKY_HALL_SERIAL_USART                 UART4
 #define FLYSKY_HALL_SERIAL_TX_GPIO               GPIO_PIN(GPIOB, 9)
 #define FLYSKY_HALL_SERIAL_RX_GPIO               GPIO_PIN(GPIOB, 8)
 #define FLYSKY_HALL_SERIAL_USART_IRQn            UART4_IRQn
-
 #define FLYSKY_HALL_SERIAL_DMA                   DMA1
 #define FLYSKY_HALL_DMA_Stream_RX                LL_DMA_STREAM_2
 #define FLYSKY_HALL_DMA_Channel                  LL_DMAMUX1_REQ_UART4_RX
+#endif
 
 // LED Strip
 #define LED_STRIP_LENGTH                  26  // 6POS + 2 rings of 10


### PR DESCRIPTION
This adds a compile choice to enable BT (default) or serial gimbal to TX15

This is completely untested since I don't have either BT module or serial gimbals

@elecpower I don't think there is a companion impact for the serial gimbals, but I would think BT might