### PR TITLE
chore: fix flash size for TX15.

### DIFF
--- a/radio/src/boards/rm-h750/board.h
+++ b/radio/src/boards/rm-h750/board.h
@@ -30,6 +30,7 @@
 #include "hal/serial_port.h"
 #include "hal/watchdog_driver.h"
 
+#define FLASHSIZE                       0x1000000
 #define BOOTLOADER_SIZE                 0x10000
 #define BOOTLOADER_ADDRESS              0x08000000
 #define FIRMWARE_ADDRESS                0x90000000


### PR DESCRIPTION
Also applies to other new RadioMaster radios.