### PR TITLE
fix(color): widgets may not update correctly when flight mode changes

### DIFF
--- a/radio/src/gui/colorlcd/mainview/layout_factory_impl.cpp
+++ b/radio/src/gui/colorlcd/mainview/layout_factory_impl.cpp
@@ -21,6 +21,7 @@
 
 #include "layout_factory_impl.h"
 
+#include "edgetx.h"
 #include "sliders.h"
 #include "trims.h"
 #include "view_main.h"
@@ -92,6 +93,15 @@ rect_t Layout::getZone(unsigned int index) const
   if (isMirrored()) xo = z.w - xo - w;
 
   return {z.x + xo, z.y + yo, w, h};
+}
+
+void Layout::checkEvents()
+{
+  Window::checkEvents();
+  if (lastFM != mixerCurrentFlightMode) {
+    lastFM = mixerCurrentFlightMode;
+    updateZones();
+  }
 }
 
 const ZoneOption defaultZoneOptions[] = {LAYOUT_COMMON_OPTIONS,

--- a/radio/src/gui/colorlcd/mainview/layout_factory_impl.h
+++ b/radio/src/gui/colorlcd/mainview/layout_factory_impl.h
@@ -113,6 +113,7 @@ class Layout: public LayoutBase
     std::unique_ptr<ViewMainDecoration> decoration;
     uint8_t zoneCount;
     uint8_t* zoneMap = nullptr;
+    uint8_t lastFM = 0;
 
     // Last time we refreshed the window
     uint32_t lastRefresh = 0;
@@ -122,6 +123,8 @@ class Layout: public LayoutBase
 
     unsigned int getZonesCount() const override { return zoneCount; }
     rect_t getZone(unsigned int index) const override;
+
+    void checkEvents() override;
 };
 
 template<class T>


### PR DESCRIPTION
If a flight mode change alters which trims and/or sliders are visible, the widget zones changes may not get updated correctly.

Fixes #6630
