### PR TITLE
fix(radio): early init hooks

### DIFF
--- a/radio/src/boards/jumper-h750/board.cpp
+++ b/radio/src/boards/jumper-h750/board.cpp
@@ -95,8 +95,6 @@ void EXTERNAL_MODULE_OFF()
 
 void boardBLEarlyInit()
 {
-  pwrOn();
-
   timersInit();
   usbChargerInit();
 }

--- a/radio/src/boards/rm-h750/board.cpp
+++ b/radio/src/boards/rm-h750/board.cpp
@@ -95,8 +95,6 @@ void EXTERNAL_MODULE_OFF()
 
 void boardBLEarlyInit()
 {
-  pwrOn();
-
   // TAS2505 requires reset pin to be low on power on
   gpio_init(AUDIO_RESET_PIN, GPIO_OUT, GPIO_PIN_SPEED_LOW);
   gpio_clear(AUDIO_RESET_PIN);

--- a/radio/src/targets/common/arm/stm32/f4/memory_sections.h
+++ b/radio/src/targets/common/arm/stm32/f4/memory_sections.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#define __INIT_HOOK    __attribute__((section(".init_hook")))
+#define __INIT_HOOK    __attribute__((section(".init_hook"), used))
 
 #define __CCMRAM       __attribute__((section(".ccm"), aligned(4)))
 #define __DMA          __attribute__((section(".ram"), aligned(4)))

--- a/radio/src/targets/common/arm/stm32/h7/memory_sections.h
+++ b/radio/src/targets/common/arm/stm32/h7/memory_sections.h
@@ -21,7 +21,7 @@
 
 #pragma once
 
-#define __INIT_HOOK    __attribute__((section(".init_hook")))
+#define __INIT_HOOK    __attribute__((section(".init_hook"), used))
 
 #define __CCMRAM       __attribute__((section(".ccm"), aligned(4)))
 #define __DMA          __attribute__((section(".ram"), aligned(32)))

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -63,11 +63,6 @@ void boardBLEarlyInit()
 {
   videoSwitchInit();
 }
-#else
-void boardBLEarlyInit()
-{
-  pwrOn();
-}
 #endif
 
 extern "C" void SDRAM_Init();


### PR DESCRIPTION
Since #6541 `pwr_driver.cpp` is included in LTO (`board_bl`), which causes `_pwr_init_hook` to be evicted by the linker. This removed `pwrResetHandler` from the early init and thus broke EM fast reboot and power initialisation.

This PR marks all `__INIT_HOOK` symbols as **used**, which fixes the observed issues:
- `_pwr_init_hook` is present again in the bootloader's `__init_hook_array`
- should fix PL18 init as well (backlight hack; see `backlightLowInit`)