### PR TITLE
fix(radio): USART with half-duplex and RX DMA

### DIFF
--- a/radio/src/targets/common/arm/stm32/stm32_usart_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_usart_driver.cpp
@@ -313,8 +313,10 @@ void stm32_usart_init_rx_dma(const stm32_usart_t* usart, const void* buffer, uin
   // Disable IRQ based RX
   LL_USART_DisableIT_RXNE(usart->USARTx);
 
-  // In case TX DMA is used and IDLE IRQ is not, disable the ISR completely
-  if (usart->txDMA && !LL_USART_IsEnabledIT_IDLE(usart->USARTx)) {
+  // In case TX DMA is used, IDLE IRQ is not, and not half-duplex,
+  // disable the ISR completely
+  if (usart->txDMA && !LL_USART_IsEnabledIT_IDLE(usart->USARTx) &&
+      !IS_HALF_DUPLEX(usart)) {
     NVIC_DisableIRQ(usart->IRQn);
   }
 


### PR DESCRIPTION
If we kill the IRQ, we won't be able to switch back to listening after sending (no TC ISR triggered...).
This fixes the second part of #6635. I believe this should also fix FrSky upstream telemetry (MPM and FrSky PXX1 modules).

Fixes #6635