### PR TITLE
fix(radio): unaligned access in Ghost tool

### DIFF
--- a/radio/src/pulses/ghost.cpp
+++ b/radio/src/pulses/ghost.cpp
@@ -44,6 +44,7 @@ static uint8_t getGhostModuleAddr()
 static uint8_t createGhostMenuControlFrame(uint8_t * frame, int16_t * pulses)
 {
   uint8_t * buf = frame;
+  memset(buf, 0, GHST_UL_RC_CHANS_SIZE + 2);
 
   *buf++ = getGhostModuleAddr();            // addr
   *buf++ = GHST_UL_RC_CHANS_SIZE;           // length
@@ -53,9 +54,9 @@ static uint8_t createGhostMenuControlFrame(uint8_t * frame, int16_t * pulses)
   // payload
   *buf++ = reusableBuffer.ghostMenu.buttonAction; // Joystick states, Up, Down, Left, Right, Press
   *buf++ = reusableBuffer.ghostMenu.menuAction;   // menu control, open, close, etc.
-  for (uint8_t i = 0; i < 8; i++) {
-    *buf++ = 0;   // padding to make this the same size as the pulses packet
-  }
+
+  // skip padding
+  buf += 8;
 
   // crc
   *buf++ = crc8(crc_start, GHST_UL_RC_CHANS_SIZE - 1);


### PR DESCRIPTION
The loop gets optimised easily to a 2x 32bit write access, which obviously trigger an alignment exception due to the offset. Clearing the packet upfront makes it fully aligned.

Fixes #6635 
