### PR TITLE
feat(radio): add the ability to trigger EM from CLI

### DIFF
--- a/radio/src/boards/jumper-h750/board.cpp
+++ b/radio/src/boards/jumper-h750/board.cpp
@@ -156,7 +156,7 @@ void boardInit()
 
 #if !defined(DEBUG_SEGGER_RTT)
   // This is needed to prevent radio from starting when usb is plugged to charge
-  if (usbPlugged()) {
+  if (!UNEXPECTED_SHUTDOWN() && usbPlugged()) {
     while (usbPlugged() && !pwrPressed()) {
       delay_ms(1000);
     }

--- a/radio/src/cli.cpp
+++ b/radio/src/cli.cpp
@@ -1736,6 +1736,14 @@ int cliCrypt(const char ** argv)
 }
 #endif
 
+int cliTriggerEM(const char** argv)
+{
+  // Prevent task switching
+  vTaskSuspendAll();
+  // Trigger watchdog
+  while(1);
+}
+
 #if defined(TP_GT911)
 // from tp_gt911.cpp
 extern uint8_t tp_gt911_cfgVer;
@@ -1811,6 +1819,7 @@ const CliCommand cliCommands[] = {
 #if defined(TP_GT911)
   { "reset_gt911", cliResetGT911, ""},
 #endif
+  { "trigger_wathdog_reset", cliTriggerEM, ""},
   { nullptr, nullptr, nullptr }  /* sentinel */
 };
 


### PR DESCRIPTION
EM reset triggered by hardware watchdog are a key part of EdgeTx safety, but currently, the only way to test it is to produce a specific debug firmware, effectively severely reducing our, and EdgeTx partners, ability to test it easily.

This add a CLI instruction "trigger_wathdog_reset" that cannot be launch by mistake, yet is still easy to trigger when really desired, even on release firmware.

While testing it, i found an issue on T15 pro.. proof if any was needed that this PR is useful :), so fixing it as part of this PR