### PR TITLE
fix(color): widget size and position may not be correct when switched to full screen.

### DIFF
--- a/radio/src/gui/colorlcd/mainview/layout_factory_impl.cpp
+++ b/radio/src/gui/colorlcd/mainview/layout_factory_impl.cpp
@@ -101,6 +101,9 @@ void Layout::checkEvents()
   rect_t z = getMainZone();
   if (z.x != lastMainZone.x || z.y != lastMainZone.y || z.w != lastMainZone.w || z.h != lastMainZone.h) {
     lastMainZone = z;
+    for (int i = 0; i < MAX_LAYOUT_ZONES; i++)
+      if (widgets[i] && widgets[i]->isFullscreen())
+        return;
     updateZones();
   }
 }


### PR DESCRIPTION
Broken in #6639 
