### PR TITLE
fix(color): quick menu may crash after using USB SD mode

### DIFF
--- a/radio/src/gui/colorlcd/mainview/view_main.cpp
+++ b/radio/src/gui/colorlcd/mainview/view_main.cpp
@@ -102,6 +102,7 @@ ViewMain::~ViewMain() { _instance = nullptr; }
 void ViewMain::deleteLater(bool detach, bool trash)
 {
   Layer::pop(this);
+  QuickMenu::shutdownQuickMenu();
   Window::deleteLater(detach, trash);
 }
 

--- a/radio/src/gui/colorlcd/setup_menus/quick_menu.cpp
+++ b/radio/src/gui/colorlcd/setup_menus/quick_menu.cpp
@@ -174,6 +174,11 @@ QuickMenu* QuickMenu::openQuickMenu(std::function<void()> cancelHandler,
   return instance;
 }
 
+void QuickMenu::shutdownQuickMenu()
+{
+  if (instance) instance->deleteLater();
+}
+
 QuickMenu::QuickMenu() :
     NavWindow(MainWindow::instance(), {0, 0, LCD_W, LCD_H})
 {
@@ -245,6 +250,7 @@ void QuickMenu::deleteLater(bool detach, bool trash)
   if (_deleted) return;
 
   instance = nullptr;
+
   Window::deleteLater(detach, trash);
 }
 

--- a/radio/src/gui/colorlcd/setup_menus/quick_menu.h
+++ b/radio/src/gui/colorlcd/setup_menus/quick_menu.h
@@ -93,6 +93,7 @@ class QuickMenu : public NavWindow
   static QuickMenu* openQuickMenu(std::function<void()> cancelHandler,
             std::function<void(bool close)> selectHandler = nullptr,
             PageGroupBase* pageGroup = nullptr, SubMenu curPage = NONE);
+  static void shutdownQuickMenu();
 
   void onCancel() override;
   void onSelect(bool close);
@@ -149,7 +150,7 @@ class QuickMenu : public NavWindow
 
   void focusMainMenu();
 
-  void deleteLater(bool detach, bool trash) override;
+  void deleteLater(bool detach = true, bool trash = true) override;
 };
 
 class QuickSubMenu


### PR DESCRIPTION
Quick menu not cleaned up correctly when UI was closed on entering USB SD mode.

Fixes #6658
