### PR TITLE
fix(radio): input value may not return to 0 when using the 'x<0' or 'x>0' side options

### DIFF
--- a/radio/src/mixer.cpp
+++ b/radio/src/mixer.cpp
@@ -231,6 +231,8 @@ void applyExpos(int16_t * anas, uint8_t mode, int16_t ovwrIdx, int16_t ovwrValue
           virtualInputsTrims[cur_chn] = -1;
         // if (srcRaw < 0) v = -v;
         anas[cur_chn] = v;
+      } else {
+        anas[ed->chn] = 0;
       }
     }
   }


### PR DESCRIPTION
Ensure correct input value when using 'side' option.

In addition to the scenario  described in #6663, the problem can also occur if the source for the input is moved quickly past the 0 (center) point.

Fixes #6663
