### PR TITLE
fix(color): channel bars overlap close button on mix and output edit pages

### DIFF
--- a/radio/src/gui/colorlcd/model/mixer_edit.cpp
+++ b/radio/src/gui/colorlcd/model/mixer_edit.cpp
@@ -32,6 +32,7 @@
 #include "sourcechoice.h"
 #include "switchchoice.h"
 #include "curveedit.h"
+#include "pagegroup.h"
 
 #define SET_DIRTY() storageDirty(EE_MODEL)
 
@@ -70,7 +71,7 @@ void MixEditWindow::buildHeader(Window *window)
 
   new MixerEditStatusBar(
       window,
-      {window->getRect().w - MIX_STATUS_BAR_WIDTH - MIX_RIGHT_MARGIN, 0,
+      {window->getRect().w - MIX_STATUS_BAR_WIDTH - PageGroup::PAGE_TOP_BAR_H, 0,
        MIX_STATUS_BAR_WIDTH, EdgeTxStyles::MENU_HEADER_HEIGHT},
       channel);
 }

--- a/radio/src/gui/colorlcd/model/mixer_edit.h
+++ b/radio/src/gui/colorlcd/model/mixer_edit.h
@@ -31,7 +31,6 @@ class MixEditWindow : public Page
   MixEditWindow(int8_t channel, uint8_t index);
 
   static LAYOUT_SIZE_SCALED(MIX_STATUS_BAR_WIDTH, 250, 180)
-  static LAYOUT_SIZE(MIX_RIGHT_MARGIN, 0, 3)
 
  protected:
   uint8_t channel;

--- a/radio/src/gui/colorlcd/model/output_edit.cpp
+++ b/radio/src/gui/colorlcd/model/output_edit.cpp
@@ -27,6 +27,7 @@
 #include "gvar_numberedit.h"
 #include "edgetx.h"
 #include "etx_lv_theme.h"
+#include "pagegroup.h"
 
 #define SET_DIRTY() storageDirty(EE_MODEL)
 
@@ -95,8 +96,7 @@ void OutputEditWindow::buildHeader(Window *window)
 {
   statusBar = new OutputEditStatusBar(
       window,
-      {window->getRect().w - OUTPUT_EDIT_STATUS_BAR_WIDTH -
-           OUTPUT_EDIT_RIGHT_MARGIN,
+      {window->getRect().w - OUTPUT_EDIT_STATUS_BAR_WIDTH - PageGroup::PAGE_TOP_BAR_H,
        0, OUTPUT_EDIT_STATUS_BAR_WIDTH, EdgeTxStyles::MENU_HEADER_HEIGHT},
       channel);
 }

--- a/radio/src/gui/colorlcd/model/output_edit.h
+++ b/radio/src/gui/colorlcd/model/output_edit.h
@@ -37,7 +37,6 @@ class OutputEditWindow : public Page
   explicit OutputEditWindow(uint8_t channel);
 
   static LAYOUT_SIZE_SCALED(OUTPUT_EDIT_STATUS_BAR_WIDTH, 250, 180)
-  static LAYOUT_SIZE(OUTPUT_EDIT_RIGHT_MARGIN, 0, 3)
 
  protected:
   uint8_t channel;


### PR DESCRIPTION
Missed in 3.0 UI changes.
