### PR TITLE
fix(pa01,st16): should use ADC3 for reading RTC battery

### DIFF
--- a/radio/src/targets/pa01/hal.h
+++ b/radio/src/targets/pa01/hal.h
@@ -184,7 +184,7 @@
 
 #define ADC_EXT                         ADC3
 #define ADC_EXT_CHANNELS                                                \
-  { ADC_CHANNEL_SWC, ADC_CHANNEL_SWD }
+  { ADC_CHANNEL_SWC, ADC_CHANNEL_SWD, ADC_CHANNEL_RTC_BAT }
 
 #define ADC_EXT_DMA                     DMA2
 #define ADC_EXT_DMA_CHANNEL             LL_DMAMUX1_REQ_ADC3

--- a/radio/src/targets/st16/hal.h
+++ b/radio/src/targets/st16/hal.h
@@ -208,10 +208,10 @@
 #define ADC_SAMPTIME                    LL_ADC_SAMPLINGTIME_8CYCLES_5
 
 #define ADC_EXT                         ADC3
-#define ADC_EXT_CHANNELS                                                \
-  {                                                                     \
-    ADC_CHANNEL_SWA, ADC_CHANNEL_SWB, ADC_CHANNEL_SWC, ADC_CHANNEL_SWD, \
-        ADC_CHANNEL_SWE, ADC_CHANNEL_SWF, ADC_CHANNEL_BATT              \
+#define ADC_EXT_CHANNELS                                                    \
+  {                                                                         \
+    ADC_CHANNEL_SWA, ADC_CHANNEL_SWB, ADC_CHANNEL_SWC, ADC_CHANNEL_SWD,     \
+    ADC_CHANNEL_SWE, ADC_CHANNEL_SWF, ADC_CHANNEL_BATT, ADC_CHANNEL_RTC_BAT \
   }
 
 #define ADC_EXT_DMA                     DMA2


### PR DESCRIPTION
Fixed RTC voltage reading problem in PA01 and ST16.
