### PR TITLE
fix(pa01,st16): should use ADC3 for reading RTC battery - v2.11

### DIFF
--- a/radio/src/targets/pa01/hal.h
+++ b/radio/src/targets/pa01/hal.h
@@ -172,7 +172,7 @@
 
 #define ADC_EXT                         ADC3
 #define ADC_EXT_CHANNELS                                                \
-  { ADC_CHANNEL_SWC, ADC_CHANNEL_SWD }
+  { ADC_CHANNEL_SWC, ADC_CHANNEL_SWD, ADC_CHANNEL_RTC_BAT }
 
 #define ADC_EXT_DMA                     DMA2
 #define ADC_EXT_DMA_CHANNEL             LL_DMAMUX1_REQ_ADC3
@@ -181,7 +181,7 @@
 #define ADC_EXT_DMA_STREAM_IRQHandler   DMA2_Stream0_IRQHandler
 #define ADC_EXT_SAMPTIME                LL_ADC_SAMPLINGTIME_8CYCLES_5
 
-#define ADC_VREF_PREC2                  329
+#define ADC_VREF_PREC2                  660
 
 #define ADC_DIRECTION {       \
     0,0,0,0, /* gimbals */    \

--- a/radio/src/targets/st16/hal.h
+++ b/radio/src/targets/st16/hal.h
@@ -190,10 +190,10 @@
 #define ADC_SAMPTIME                    LL_ADC_SAMPLINGTIME_8CYCLES_5
 
 #define ADC_EXT                         ADC3
-#define ADC_EXT_CHANNELS                                                \
-  {                                                                     \
-    ADC_CHANNEL_SWA, ADC_CHANNEL_SWB, ADC_CHANNEL_SWC, ADC_CHANNEL_SWD, \
-        ADC_CHANNEL_SWE, ADC_CHANNEL_SWF, ADC_CHANNEL_BATT              \
+#define ADC_EXT_CHANNELS                                                    \
+  {                                                                         \
+    ADC_CHANNEL_SWA, ADC_CHANNEL_SWB, ADC_CHANNEL_SWC, ADC_CHANNEL_SWD,     \
+    ADC_CHANNEL_SWE, ADC_CHANNEL_SWF, ADC_CHANNEL_BATT, ADC_CHANNEL_RTC_BAT \
   }
 
 #define ADC_EXT_DMA                     DMA2
@@ -203,7 +203,7 @@
 #define ADC_EXT_DMA_STREAM_IRQHandler   DMA2_Stream0_IRQHandler
 #define ADC_EXT_SAMPTIME                LL_ADC_SAMPLINGTIME_8CYCLES_5
 
-#define ADC_VREF_PREC2                  329
+#define ADC_VREF_PREC2                  660
 
 #define ADC_DIRECTION {       \
     0,0,0,0, /* gimbals */    \


### PR DESCRIPTION
Fixed RTC voltage reading problem in PA01 and ST16.
