### PR TITLE
Allow doubletap of a main screen widget to fullscreen it

### DIFF
--- a/radio/src/lua/lua_widget.cpp
+++ b/radio/src/lua/lua_widget.cpp
@@ -274,12 +274,31 @@ LuaWidget::~LuaWidget()
 
 void LuaWidget::onClicked()
 {
-  if (!fullscreen) {
-    ButtonBase::onClicked();
+  if (fullscreen) {
+    LuaScriptManager::onClickedEvent();
     return;
   }
 
-  LuaScriptManager::onClickedEvent();
+  // DoubleClick to enter fullscreen mode
+  constexpr uint32_t DOUBLETAP_TIMEOUT_MS = 500;
+
+  uint32_t now = time_get_ms();
+  if (now - tapLastMs > DOUBLETAP_TIMEOUT_MS) {
+    tapCount = 0;
+  }
+  tapLastMs = now;
+  ++tapCount;
+
+  if (tapCount < 2) {
+    Widget::onClicked();
+  } else {
+    onDoubleClicked();
+  }
+}
+
+void LuaWidget::onDoubleClicked()
+{
+  setFullscreen(true);
 }
 
 void LuaWidget::onCancel()

--- a/radio/src/lua/lua_widget.h
+++ b/radio/src/lua/lua_widget.h
@@ -149,9 +149,12 @@ class LuaWidget : public Widget, public LuaScriptManager
   int optionsDataRef;
   char* errorMessage;
   bool refreshed = false;
+  uint32_t tapLastMs = 0;
+  uint32_t tapCount = 0;
 
   // Window interface
   void onClicked() override;
+  void onDoubleClicked();
   void onCancel() override;
   void checkEvents() override;
   void onEvent(event_t event) override;


### PR DESCRIPTION
Adds a doubleclick handler for lua widgets on colorlcd to make them fullscreen. We've waited too long!

Widgets are awesome, all being right there on the main screen, strutting their stuff. Interacting with them is not allowed, of course, because it is all to easy to tap them accidentally. However, the tap and hold, long press, select Fullscreen from the menu is not exactly a quick interaction. This PR adds the ability to doubletap to jump right into fullscreen of a widget, rather than feeling like "digging into the menus" to access this behavior.

I feel like this is needed, now that the SYS button starts a menu journey rather than going to the tools menu. Launching the ExpressLRS script has changed from (Click, Tap) to (Click, Tap, Tap, Tap) with each tap requiring the user comprehend a new set of options presented to them. Widget doubletaps can allow quick access to fullscreen apps that used to be tools scripts and allow more natural interactions instead with what the user wants right up front from the main screen instead of feeling like everything is a buried configuration option.

Note that LVGL 9.4 adds this event type directly (`LV_EVENT_DOUBLE_CLICKED`), so this is currently emulated with EdgeTX code until that makes its way into EdgeTX. The timeout I've chosen is generous, but it might need to be even more generous, as I find that taps aren't accurately caught if you tap the screen quickly.

EDIT: Also tagging #4371 (which resulted in the awesome App Mode type widget) as related

Resolves #2629