### PR TITLE
chore: standardise STICK_DEAD_ZONE

### DIFF
--- a/radio/src/targets/pa01/CMakeLists.txt
+++ b/radio/src/targets/pa01/CMakeLists.txt
@@ -7,7 +7,7 @@ option(GHOST "Ghost TX Module" ON)
 option(MODULE_SIZE_STD "Standard size TX Module" ON)
 option(LUA_MIXER "Enable LUA mixer/model scripts support" ON)
 option(DISK_CACHE "Enable SD card disk cache" ON)
-option(STICKS_DEAD_ZONE "Enable sticks dead zone" YES)
+option(STICK_DEAD_ZONE "Enable sticks dead zone" YES)
 
 set(FIRMWARE_QSPI YES)
 set(FIRMWARE_FORMAT_UF2 YES)
@@ -79,7 +79,7 @@ add_definitions(-DRTCLOCK)
 add_definitions(-DGPS_USART_BAUDRATE=${INTERNAL_GPS_BAUDRATE})
 add_definitions(-DPWR_BUTTON_${PWR_BUTTON})
 
-if(STICKS_DEAD_ZONE)
+if(STICK_DEAD_ZONE)
   add_definitions(-DSTICK_DEAD_ZONE)
 endif()
 

--- a/radio/src/targets/pl18/CMakeLists.txt
+++ b/radio/src/targets/pl18/CMakeLists.txt
@@ -1,6 +1,6 @@
 option(DISK_CACHE "Enable SD card disk cache" ON)
 option(UNEXPECTED_SHUTDOWN "Enable the Unexpected Shutdown screen" ON)
-option(STICKS_DEAD_ZONE "Enable sticks dead zone" YES)
+option(STICK_DEAD_ZONE "Enable sticks dead zone" YES)
 option(PXX1 "PXX1 protocol support" ON)
 option(PXX2 "PXX2 protocol support" OFF)
 option(AFHDS3 "AFHDS3 TX Module" ON)
@@ -150,7 +150,7 @@ if(WIRELESS_CHARGER)
   add_definitions(-DWIRELESS_CHARGER)
 endif()
 
-if(STICKS_DEAD_ZONE)
+if(STICK_DEAD_ZONE)
   add_definitions(-DSTICK_DEAD_ZONE)
 endif()
 

--- a/radio/src/targets/st16/CMakeLists.txt
+++ b/radio/src/targets/st16/CMakeLists.txt
@@ -7,7 +7,7 @@ option(GHOST "Ghost TX Module" ON)
 option(MODULE_SIZE_STD "Standard size TX Module" ON)
 option(LUA_MIXER "Enable LUA mixer/model scripts support" ON)
 option(DISK_CACHE "Enable SD card disk cache" ON)
-option(STICKS_DEAD_ZONE "Enable sticks dead zone" YES)
+option(STICK_DEAD_ZONE "Enable sticks dead zone" YES)
 
 set(FIRMWARE_QSPI YES)
 set(FIRMWARE_FORMAT_UF2 YES)
@@ -81,7 +81,7 @@ if(INTERNAL_GPS)
   add_definitions(-DGPS_USART_BAUDRATE=${INTERNAL_GPS_BAUDRATE})
 endif()
 
-if(STICKS_DEAD_ZONE)
+if(STICK_DEAD_ZONE)
   add_definitions(-DSTICK_DEAD_ZONE)
 endif()
 

--- a/radio/src/targets/t15pro/CMakeLists.txt
+++ b/radio/src/targets/t15pro/CMakeLists.txt
@@ -27,7 +27,7 @@ set(INTERNAL_MODULE_AFHDS3 NO)
 set(ROTARY_ENCODER YES)
 set(FUNCTION_SWITCHES_WITH_RGB YES)
 
-#option(STICKS_DEAD_ZONE "Enable sticks dead zone" YES)
+#option(STICK_DEAD_ZONE "Enable sticks dead zone" YES)
 
 # IMU support
 set(IMU ON)
@@ -78,7 +78,7 @@ add_definitions(-DRTCLOCK)
 add_definitions(-DGPS_USART_BAUDRATE=${INTERNAL_GPS_BAUDRATE})
 add_definitions(-DPWR_BUTTON_${PWR_BUTTON})
 
-if(STICKS_DEAD_ZONE)
+if(STICK_DEAD_ZONE)
   add_definitions(-DSTICK_DEAD_ZONE)
 endif()
 

--- a/radio/src/targets/tx15/CMakeLists.txt
+++ b/radio/src/targets/tx15/CMakeLists.txt
@@ -34,7 +34,7 @@ if(BLUETOOTH)
   set(FLYSKY_GIMBAL OFF)
 endif()
 
-#option(STICKS_DEAD_ZONE "Enable sticks dead zone" YES)
+#option(STICK_DEAD_ZONE "Enable sticks dead zone" YES)
 
 # IMU support
 set(IMU ON)
@@ -89,7 +89,7 @@ add_definitions(-DAUDIO -DVOICE -DRTCLOCK)
 add_definitions(-DGPS_USART_BAUDRATE=${INTERNAL_GPS_BAUDRATE})
 add_definitions(-DPWR_BUTTON_${PWR_BUTTON})
 
-if(STICKS_DEAD_ZONE)
+if(STICK_DEAD_ZONE)
   add_definitions(-DSTICK_DEAD_ZONE)
 endif()
 


### PR DESCRIPTION
Align compilation option with define, because sometimes 2 ins't better than 1
