### PR TITLE
feat(cpn): add NB4P firmware registration and board family support

### DIFF
--- a/companion/src/firmwares/boards.h
+++ b/companion/src/firmwares/boards.h
@@ -698,6 +698,11 @@ inline bool IS_FLYSKY_PL18U(Board::Type board)
   return (board == Board::BOARD_FLYSKY_PL18U);
 }
 
+inline bool IS_FLYSKY_NB4P(Board::Type board)
+{
+  return (board == Board::BOARD_FLYSKY_NB4P);
+}
+
 inline bool IS_FLYSKY_ST16(Board::Type board)
 {
   return (board == Board::BOARD_FLYSKY_ST16);
@@ -705,7 +710,7 @@ inline bool IS_FLYSKY_ST16(Board::Type board)
 
 inline bool IS_FAMILY_PL18(Board::Type board)
 {
-  return IS_FLYSKY_PL18(board) || IS_FLYSKY_PL18EV(board) || IS_FLYSKY_PL18U(board);
+  return IS_FLYSKY_PL18(board) || IS_FLYSKY_PL18EV(board) || IS_FLYSKY_PL18U(board) || IS_FLYSKY_NB4P(board);
 }
 
 inline bool IS_TARANIS_XLITE(Board::Type board)

--- a/companion/src/firmwares/opentx/opentxinterface.cpp
+++ b/companion/src/firmwares/opentx/opentxinterface.cpp
@@ -526,6 +526,12 @@ void registerOpenTxFirmwares()
   addOpenTxRfOptions(firmware, FLEX + AFHDS3);
   registerOpenTxFirmware(firmware);
 
+  /* FlySky NB4+ board */
+  firmware = new OpenTxFirmware(FIRMWAREID("nb4p"), Firmware::tr("FlySky NB4+"), BOARD_FLYSKY_NB4P);
+  addOpenTxFrskyOptions(firmware);
+  addOpenTxRfOptions(firmware, FLEX + AFHDS3);
+  registerOpenTxFirmware(firmware);
+
   /* FlySky ST16 board */
   firmware = new OpenTxFirmware(FIRMWAREID("st16"), Firmware::tr("FlySky ST16"), BOARD_FLYSKY_ST16);
   addOpenTxFrskyOptions(firmware);


### PR DESCRIPTION

## Overview
This PR adds FlySky NB4+ support to EdgeTX Companion, enabling firmware selection and configuration for this board.

## Changes
- **boards.h**: Added `IS_FLYSKY_NB4P()` macro and extended `IS_FAMILY_PL18()` to include NB4P
- **opentxinterface.cpp**: Registered NB4P firmware with RF options (FLEX + AFHDS3)

## Technical Notes
- **FourCC**: Intentionally left shared with PL18 family for legacy compatibility. Board differentiation will rely on YAML capabilities going forward.
- **Bluetooth**: Not included (hardware does not support it).
- **AFHDS2A**: Not included (not documented for NB4+).
- **Simulator UI**: Deferred to separate PR; generic UI suffices for now.

## Related
Follows up on merged PR adding `BOARD_FLYSKY_NB4P` board definition (#6659).