### PR TITLE
fix: custom function switch initialisation should only add SW1-SW6 to group 1

### DIFF
--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -223,12 +223,19 @@ void ModelData::setDefaultFunctionSwitches(int functionSwitchCount)
     return;
 
   for (int i = 0; i < functionSwitchCount; i++) {
-    customSwitches[i].type = Board::SWITCH_2POS;
-    customSwitches[i].group = 1;
-    if (i == 0)
-      customSwitches[i].start = ModelData::FUNC_SWITCH_START_ON;
-    else
-      customSwitches[i].start = ModelData::FUNC_SWITCH_START_OFF;
+    auto nm = Boards::getSwitchName(Boards::getSwitchIndexForCFS(i,getCurrentFirmware()->getBoard()));
+    if (nm.startsWith("SW")) {
+      customSwitches[i].type = Board::SWITCH_2POS;
+      customSwitches[i].group = 1;
+      if (nm.startsWith("SW1"))
+        customSwitches[i].start = ModelData::FUNC_SWITCH_START_ON;
+      else
+        customSwitches[i].start = ModelData::FUNC_SWITCH_START_OFF;
+    } else {
+      customSwitches[i].type = Board::SWITCH_GLOBAL;
+      customSwitches[i].group = 0;
+      customSwitches[i].start = ModelData::FUNC_SWITCH_START_PREVIOUS;
+    }
     customSwitches[i].state = 0;
     customSwitches[i].name[0] = 0;
     customSwitches[i].onColor.setColor(255, 255, 255);

--- a/radio/src/model_init.cpp
+++ b/radio/src/model_init.cpp
@@ -106,12 +106,18 @@ void initCustomSwitches()
   for (int i = 0; i < switchGetMaxSwitches(); i += 1) {
     if (switchIsCustomSwitch(i)) {
       uint8_t idx = switchGetCustomSwitchIdx(i);
-      g_model.customSwitches[idx].type = SWITCH_2POS;
-      g_model.customSwitches[idx].group = 1;
-      if (idx == 0)
-        g_model.customSwitches[idx].start = FS_START_ON;
-      else
-        g_model.customSwitches[idx].start = FS_START_OFF;
+      if (strncmp(switchGetDefaultName(i), "SW", 2) == 0) {
+        g_model.customSwitches[idx].type = SWITCH_2POS;
+        g_model.customSwitches[idx].group = 1;
+        if (strncmp(switchGetDefaultName(i), "SW1", 3) == 0)
+          g_model.customSwitches[idx].start = FS_START_ON;
+        else
+          g_model.customSwitches[idx].start = FS_START_OFF;
+      } else {
+        g_model.customSwitches[idx].type = SWITCH_GLOBAL;
+        g_model.customSwitches[idx].group = 0;
+        g_model.customSwitches[idx].start = FS_START_PREVIOUS;
+      }
       g_model.customSwitches[idx].state = 0;
       g_model.customSwitches[idx].name[0] = 0;
 #if defined(FUNCTION_SWITCHES_RGB_LEDS)


### PR DESCRIPTION
The changes to the custom function switch initialisation in PR's #6604 and #6607 did not consider the SA & SD switches on the GX12. As a result these were included in group 1 when they should have been set to GLOBAL.

Fix CFS initialisation for GX12.
