### PR TITLE
chore(ci): always upload build logs for CPN runs

### DIFF
--- a/.github/workflows/linux_cpn.yml
+++ b/.github/workflows/linux_cpn.yml
@@ -43,16 +43,40 @@ jobs:
         working-directory: ${{github.workspace}}
         shell: bash
         run: |
-          mkdir output && \
-          tools/build-companion.sh "$(pwd)" "$(pwd)/output/"
+          mkdir output && mkdir logs && \
+          tools/build-companion.sh "$(pwd)" "$(pwd)/output/" 2>&1 | tee logs/build-main.log
+
+      - name: Collect build logs
+        if: always()
+        shell: bash
+        run: |
+          # Create logs directory if it doesn't exist
+          mkdir -p logs
+          
+          # Copy all build logs from the build directory
+          if [ -d "build" ]; then
+            find build -name "*.log" -type f -exec cp {} logs/ \; 2>/dev/null || true
+            find build -name "CMakeOutput.log" -type f -exec cp {} logs/ \; 2>/dev/null || true
+            find build -name "CMakeError.log" -type f -exec cp {} logs/ \; 2>/dev/null || true
+          fi
 
       - name: Compose release filename
+        if: always()
         # https://stackoverflow.com/questions/58033366/how-to-get-current-branch-within-github-actions
         run: echo "artifact_name=edgetx-cpn-linux-${GITHUB_REF##*/}" >> $GITHUB_ENV
 
       - name: Archive production artifacts
+        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: "${{ env.artifact_name }}"
           path:  ${{github.workspace}}/output
           retention-days: 15
+
+      - name: Archive build logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: "${{ env.artifact_name }}-logs"
+          path: ${{github.workspace}}/logs
+          retention-days: 30

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -76,16 +76,40 @@ jobs:
         working-directory: ${{github.workspace}}
         shell: bash
         run: |
-          mkdir output && \
-          tools/build-companion.sh "$(pwd)" "$(pwd)/output/"
+          mkdir output && mkdir logs && \
+          tools/build-companion.sh "$(pwd)" "$(pwd)/output/" 2>&1 | tee logs/build-main.log
+
+      - name: Collect build logs
+        if: always()
+        shell: bash
+        run: |
+          # Create logs directory if it doesn't exist
+          mkdir -p logs
+          
+          # Copy all build logs from the build directory
+          if [ -d "build" ]; then
+            find build -name "*.log" -type f -exec cp {} logs/ \; 2>/dev/null || true
+            find build -name "CMakeOutput.log" -type f -exec cp {} logs/ \; 2>/dev/null || true
+            find build -name "CMakeError.log" -type f -exec cp {} logs/ \; 2>/dev/null || true
+          fi
 
       - name: Compose release filename
+        if: always()
         # https://stackoverflow.com/questions/58033366/how-to-get-current-branch-within-github-actions
         run: echo "artifact_name=edgetx-cpn-osx-${GITHUB_REF##*/}" >> $GITHUB_ENV
 
       - name: Archive production artifacts
+        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: "${{ env.artifact_name }}"
           path:  ${{github.workspace}}/output
           retention-days: 15
+
+      - name: Archive build logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: "${{ env.artifact_name }}-logs"
+          path: ${{github.workspace}}/logs
+          retention-days: 30

--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -76,17 +76,41 @@ jobs:
 
       - name: Build
         run: |
-          mkdir output && \
+          mkdir output && mkdir logs && \
           CMAKE_PREFIX_PATH="$QT_ROOT_DIR;$SDL2_ROOT" \
-          tools/build-companion.sh "$(pwd)" "$(pwd)/output/"
+          tools/build-companion.sh "$(pwd)" "$(pwd)/output/" 2>&1 | tee logs/build-main.log
+
+      - name: Collect build logs
+        if: always()
+        shell: bash
+        run: |
+          # Create logs directory if it doesn't exist
+          mkdir -p logs
+          
+          # Copy all build logs from the build directory
+          if [ -d "build" ]; then
+            find build -name "*.log" -type f -exec cp {} logs/ \; 2>/dev/null || true
+            find build -name "CMakeOutput.log" -type f -exec cp {} logs/ \; 2>/dev/null || true
+            find build -name "CMakeError.log" -type f -exec cp {} logs/ \; 2>/dev/null || true
+          fi
 
       - name: Compose release filename
+        if: always()
         # https://stackoverflow.com/questions/58033366/how-to-get-current-branch-within-github-actions
         run: echo "artifact_name=edgetx-cpn-win64-${GITHUB_REF##*/}" >> $GITHUB_ENV
 
       - name: Archive production artifacts
+        if: success()
         uses: actions/upload-artifact@v4
         with:
           name: "${{ env.artifact_name }}"
           path:  ${{github.workspace}}/output
           retention-days: 15
+
+      - name: Archive build logs
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: "${{ env.artifact_name }}-logs"
+          path: ${{github.workspace}}/logs
+          retention-days: 30

--- a/tools/build-companion.sh
+++ b/tools/build-companion.sh
@@ -14,6 +14,9 @@ if [[ -z ${OUTDIR} ]]; then
   OUTDIR="$(pwd)/output"
 fi
 
+# Create a master log file for the entire build process
+MASTER_LOG="build-summary.log"
+
 QUIET_FLAGS=""
 if [[ "$CMAKE_GENERATOR" == "Ninja" ]]; then
     QUIET_FLAGS="-- --quiet"
@@ -58,11 +61,20 @@ output_error_log() {
 
     if [[ -f "$log_file" ]]; then
         echo "------------------------------------------"
-        echo " Full error output from $log_file:"
+        echo " Full error output from $log_file ($context):"
         echo "------------------------------------------"
         cat "$log_file"
+        echo "------------------------------------------"
+        
+        # Also append to master log for aggregation
+        {
+            echo "=== Error from $log_file ($context) ==="
+            cat "$log_file"
+            echo "=== End of $log_file ==="
+        } >> "$MASTER_LOG"
     else
         echo "⚠️ Warning: Log file $log_file not found for $context"
+        echo "⚠️ Warning: Log file $log_file not found for $context" >> "$MASTER_LOG"
     fi
 }
 


### PR DESCRIPTION
Enhance the CI process by ensuring that build logs are collected and uploaded for all Companion workflow runs. A master log file now aggregates error outputs for easier review.

What could possibly go wrong? 