### PR TITLE
feat(color): quick menu key shortcut changes

### DIFF
--- a/radio/src/gui/colorlcd/mainview/view_main.cpp
+++ b/radio/src/gui/colorlcd/mainview/view_main.cpp
@@ -252,7 +252,7 @@ void ViewMain::onLongPressSYS()
 {
   if (viewMainMenu) viewMainMenu->closeMenu();
   // Radio setup
-  PageGroup::RadioMenu();
+  PageGroup::ToolsMenu();
 }
 void ViewMain::onPressMDL()
 {

--- a/radio/src/gui/colorlcd/model/model_select.cpp
+++ b/radio/src/gui/colorlcd/model/model_select.cpp
@@ -551,7 +551,7 @@ void ModelLabelsWindow::onLongPressSYS()
 {
   onCancel();
   // Radio setup
-  PageGroup::RadioMenu();
+  PageGroup::ToolsMenu();
 }
 void ModelLabelsWindow::onPressMDL()
 {

--- a/radio/src/gui/colorlcd/setup_menus/pagegroup.cpp
+++ b/radio/src/gui/colorlcd/setup_menus/pagegroup.cpp
@@ -267,7 +267,7 @@ void PageGroupBase::onLongPressSYS()
     setCurrentTab(0);
   } else {
     onCancel();
-    PageGroup::RadioMenu();
+    PageGroup::ToolsMenu();
   }
 }
 
@@ -355,7 +355,7 @@ void PageGroup::openMenu()
 }
 
 PageGroup* PageGroup::ScreenMenu() { return new PageGroup(ICON_THEME, STR_MAIN_MENU_SCREEN_SETTINGS, screensMenuItems); }
-PageGroup* PageGroup::RadioMenu() { return new PageGroup(ICON_RADIO, STR_MAIN_MENU_RADIO_SETTINGS, radioMenuItems); }
+PageGroup* PageGroup::ToolsMenu() { return new PageGroup(ICON_RADIO_TOOLS, STR_QM_TOOLS, toolsMenuItems); }
 PageGroup* PageGroup::ModelMenu() { return new PageGroup(ICON_MODEL, STR_MAIN_MENU_MODEL_SETTINGS, modelMenuItems); }
 
 //-----------------------------------------------------------------------------

--- a/radio/src/gui/colorlcd/setup_menus/pagegroup.h
+++ b/radio/src/gui/colorlcd/setup_menus/pagegroup.h
@@ -197,7 +197,7 @@ class PageGroup : public PageGroupBase
   bool isPageGroup() override { return true; }
 
   static PageGroup* ScreenMenu();
-  static PageGroup* RadioMenu();
+  static PageGroup* ToolsMenu();
   static PageGroup* ModelMenu();
 
   static LAYOUT_VAL_SCALED(PAGE_TOP_BAR_H, 45)

--- a/radio/src/gui/colorlcd/setup_menus/quick_menu.cpp
+++ b/radio/src/gui/colorlcd/setup_menus/quick_menu.cpp
@@ -338,10 +338,10 @@ void QuickMenu::enableSubMenu()
 
 #if defined(HARDWARE_KEYS)
 void QuickMenu::onPressSYS() { closeMenu(); }
-// void QuickMenu::onLongPressSYS() { subMenus[1]->onPress(0); }
-// void QuickMenu::onPressMDL() { subMenus[0]->onPress(0); }
-// void QuickMenu::onLongPressMDL() { onSelect(true); new ModelLabelsWindow(); }
-// void QuickMenu::onPressTELE() { subMenus[2]->onPress(ScreenSetupPage::FIRST_SCREEN_OFFSET); }
-// void QuickMenu::onLongPressTELE() { onSelect(true); new ChannelsViewMenu(); }
-// void QuickMenu::onLongPressRTN() { onCancel(); }
+void QuickMenu::onLongPressSYS() { subMenus[3]->onPress(0); }
+void QuickMenu::onPressMDL() { subMenus[0]->onPress(0); }
+void QuickMenu::onLongPressMDL() { onSelect(true); new ModelLabelsWindow(); }
+void QuickMenu::onPressTELE() { subMenus[2]->onPress(ScreenSetupPage::FIRST_SCREEN_OFFSET); }
+void QuickMenu::onLongPressTELE() { onSelect(true); new ChannelsViewMenu(); }
+void QuickMenu::onLongPressRTN() { closeMenu(); }
 #endif

--- a/radio/src/gui/colorlcd/setup_menus/quick_menu.h
+++ b/radio/src/gui/colorlcd/setup_menus/quick_menu.h
@@ -111,12 +111,12 @@ class QuickMenu : public NavWindow
 
 #if defined(HARDWARE_KEYS)
   void onPressSYS() override;
-  // void onLongPressSYS() override;
-  // void onPressMDL() override;
-  // void onLongPressMDL() override;
-  // void onPressTELE() override;
-  // void onLongPressTELE() override;
-  // void onLongPressRTN() override;
+  void onLongPressSYS() override;
+  void onPressMDL() override;
+  void onLongPressMDL() override;
+  void onPressTELE() override;
+  void onLongPressTELE() override;
+  void onLongPressRTN() override;
 #endif
 
   static constexpr int QM_MAIN_BTNS = 6;


### PR DESCRIPTION
Changes from feedback and after using it:
- Long press SYS opens Apps page (used more often than Radio Setup)
- Enable other key shortcuts when quick menu is open (MDL, PAGE and TELE key shortcuts remain active all the time)
- Long press RTN closes quick menu

