### PR TITLE
chore: temporarily pin github actions image versions

### DIFF
--- a/.github/workflows/build_fw.yml
+++ b/.github/workflows/build_fw.yml
@@ -28,7 +28,7 @@ on:
 jobs:
   test:
     name: Run tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-20250929.60.1
     strategy:
       matrix:
         target:
@@ -78,7 +78,7 @@ jobs:
   build:
     name: Run builds
     needs: test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-20250929.60.1
     strategy:
       matrix:
         target:

--- a/.github/workflows/linux_cpn.yml
+++ b/.github/workflows/linux_cpn.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-20250929.60.1
     container:
       image: ghcr.io/edgetx/edgetx-dev:latest
       volumes:

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -32,7 +32,7 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: macos-13
+    runs-on: macos-13-20250908.1476
 
     steps:
       - name: Select XCode version

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -12,7 +12,7 @@ concurrency:
 jobs:
   build:
     name: Build firmware
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04-20250929.60.1
     strategy:
       matrix:
         target:

--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -37,7 +37,7 @@ jobs:
     # well on Windows or Mac.  You can convert this to a matrix build if you need
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
-    runs-on: windows-2022
+    runs-on: windows-2022-20250929.55.1
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
Checking if it is actually the recent actions image updates that broke something...