### PR TITLE
chore(cpn): new profile language from operating system

### DIFF
--- a/companion/src/apppreferencesdialog.cpp
+++ b/companion/src/apppreferencesdialog.cpp
@@ -807,8 +807,12 @@ void AppPreferencesDialog::populateFirmwareOptions(const Firmware * firmware)
 {
   const Firmware * baseFw = firmware->getFirmwareBase();
   QStringList currVariant = Firmware::getCurrentVariant()->getId().split('-');
-  const QString currLang = ui->langCombo->count() ? ui->langCombo->currentText() : currVariant.last();
+  QString fwLang = Firmware::getCurrentVariant()->getLanguage();
 
+  if (fwLang.isEmpty()) // try to detect os language
+    fwLang = QLocale::languageToString(QLocale().language()).split("_").first();
+
+  const QString currLang = ui->langCombo->count() ? ui->langCombo->currentText() : fwLang;
   updateLock = true;
 
   ui->langCombo->clear();


### PR DESCRIPTION
Summary of changes:
- for a new radio profile try to detect the language from operating system
- depending on the operating system and/or its configuration this may result in the default 'C' language
- as we do not use ISO language codes there may not be a match especially for those languages with a 3 character code
- should there be no match to our predefined language list the the first entry i.e. 'en' will be selected (current behaviour)
