### PR TITLE
chore: see if doubling cmake parallel building makes things explode

### DIFF
--- a/.github/workflows/build_fw.yml
+++ b/.github/workflows/build_fw.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Test ${{ matrix.target }}
         env:
           FLAVOR: ${{ matrix.target }}
-          CMAKE_BUILD_PARALLEL_LEVEL: 4
+          CMAKE_BUILD_PARALLEL_LEVEL: 8
         run: |
           echo "Running commit tests"
           ./tools/commit-tests.sh

--- a/.github/workflows/linux_cpn.yml
+++ b/.github/workflows/linux_cpn.yml
@@ -46,7 +46,7 @@ jobs:
         working-directory: ${{github.workspace}}
         shell: bash
         env:
-          CMAKE_BUILD_PARALLEL_LEVEL: 4
+          CMAKE_BUILD_PARALLEL_LEVEL: 8
         run: |
           mkdir output && mkdir logs && \
           tools/build-companion.sh "$(pwd)" "$(pwd)/output/" 2>&1 | tee logs/build-main.log

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -74,7 +74,7 @@ jobs:
         working-directory: ${{github.workspace}}
         shell: bash
         env:
-          CMAKE_BUILD_PARALLEL_LEVEL: 3
+          CMAKE_BUILD_PARALLEL_LEVEL: 6
         run: |
           mkdir output && mkdir logs && \
           tools/build-companion.sh "$(pwd)" "$(pwd)/output/" 2>&1 | tee logs/build-main.log

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -51,7 +51,7 @@ jobs:
         env:
           FLAVOR: ${{ matrix.target }}
           EDGETX_VERSION_SUFFIX: nightly
-          CMAKE_BUILD_PARALLEL_LEVEL: 4
+          CMAKE_BUILD_PARALLEL_LEVEL: 8
         run: ./tools/build-gh.sh
 
       - name: Package firmware ${{ matrix.target }}

--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -75,7 +75,7 @@ jobs:
 
       - name: Build
         env:
-          CMAKE_BUILD_PARALLEL_LEVEL: 4
+          CMAKE_BUILD_PARALLEL_LEVEL: 8
         run: |
           mkdir output && mkdir logs && \
           CMAKE_PREFIX_PATH="$QT_ROOT_DIR;$SDL2_ROOT" \


### PR DESCRIPTION
Simply double number of parallel build tasks for all CI runs, to see how GitHub runner copes