### PR TITLE
fix(color): color picker UI issue with fixed color set

### DIFF
--- a/radio/src/gui/colorlcd/controls/color_editor.cpp
+++ b/radio/src/gui/colorlcd/controls/color_editor.cpp
@@ -449,7 +449,7 @@ class FixedColorType : public ColorType
     });
   }
 
-  static LAYOUT_VAL_SCALED(BTN_W, 44)
+  static LAYOUT_VAL_SCALED(BTN_W, 42)
 };
 
 /////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Fix color picker layout for fixed color set.

Before:
<img width="480" height="320" alt="screenshot_tx15_25-10-23_17-55-41" src="https://github.com/user-attachments/assets/50dd9625-8d72-4978-83cf-f9a54f5b39af" />

After:
<img width="480" height="320" alt="screenshot_tx15_25-10-23_17-54-51" src="https://github.com/user-attachments/assets/1ec4a6c2-1b75-4161-b6a8-72e43968b15e" />
