### PR TITLE
fix(color): preview may not work when editing customisable switch colors in radio setup.

### DIFF
--- a/radio/src/gui/colorlcd/model/function_switches.cpp
+++ b/radio/src/gui/colorlcd/model/function_switches.cpp
@@ -136,6 +136,7 @@ class FunctionSwitch : public Window
           g_model.cfsOffColor(switchIndex).setColor(newValue);
 
           offValue = g_model.cfsOffColor(switchIndex);
+          setFSEditOverride(-1, 0);
           SET_DIRTY();
         },
         [=](int newValue) { previewColor(newValue); }, ETX_RGB888);
@@ -154,6 +155,7 @@ class FunctionSwitch : public Window
           g_model.cfsOnColor(switchIndex).setColor(newValue);
 
           onValue = g_model.cfsOnColor(switchIndex);
+          setFSEditOverride(-1, 0);
           SET_DIRTY();
         },
         [=](int newValue) { previewColor(newValue); }, ETX_RGB888);
@@ -240,11 +242,7 @@ class FunctionSwitch : public Window
   {
     // Convert color index to RGB
     newValue = color32ToRGB(newValue);
-    if (g_model.cfsState(switchIndex)) {
-      g_model.cfsOnColor(switchIndex).setColor(newValue);
-    } else {
-      g_model.cfsOffColor(switchIndex).setColor(newValue);
-    }
+    setFSEditOverride(switchIndex, newValue);
   }
 #endif
 

--- a/radio/src/gui/colorlcd/radio/radio_cfs.cpp
+++ b/radio/src/gui/colorlcd/radio/radio_cfs.cpp
@@ -106,6 +106,7 @@ class RadioFunctionSwitch : public Window
           g_eeGeneral.switchOffColor(switchIndex).setColor(newValue);
 
           offValue = g_eeGeneral.switchOffColor(switchIndex);
+          setFSEditOverride(-1, 0);
           SET_DIRTY();
         },
         [=](int newValue) { previewColor(newValue); }, ETX_RGB888);
@@ -124,6 +125,7 @@ class RadioFunctionSwitch : public Window
           g_eeGeneral.switchOnColor(switchIndex).setColor(newValue);
 
           onValue = g_eeGeneral.switchOnColor(switchIndex);
+          setFSEditOverride(-1, 0);
           SET_DIRTY();
         },
         [=](int newValue) { previewColor(newValue); }, ETX_RGB888);
@@ -209,11 +211,7 @@ class RadioFunctionSwitch : public Window
   {
     // Convert color index to RGB
     newValue = color32ToRGB(newValue);
-    if (g_model.cfsState(switchIndex)) {
-        g_eeGeneral.switchOnColor(switchIndex).setColor(newValue);
-    } else {
-        g_eeGeneral.switchOffColor(switchIndex).setColor(newValue);
-    }
+    setFSEditOverride(switchIndex, newValue);
   }
 #endif
 

--- a/radio/src/hal/rgbleds.cpp
+++ b/radio/src/hal/rgbleds.cpp
@@ -27,6 +27,14 @@
 #if defined(FUNCTION_SWITCHES_RGB_LEDS)
 static bool hasLedOverride[NUM_FUNCTIONS_SWITCHES] = { false };
 static RGBLedColor ledOverride[NUM_FUNCTIONS_SWITCHES];
+static int cfsEditOverride = -1;
+static uint32_t cfsEditColor;
+
+void setFSEditOverride(int index, uint32_t color)
+{
+  cfsEditOverride = index;
+  cfsEditColor = color;
+}
 
 void setFSLedOverride(uint8_t index, bool state, uint8_t r, uint8_t g, uint8_t b)
 {
@@ -38,21 +46,31 @@ void setFSLedOverride(uint8_t index, bool state, uint8_t r, uint8_t g, uint8_t b
 
 void setFSLedOFF(uint8_t index) {
   if (g_model.getSwitchType(index) != SWITCH_NONE) {
-    uint8_t cfsIdx = switchGetCustomSwitchIdx(index);
-    if (hasLedOverride[cfsIdx] && g_model.getSwitchOffColorLuaOverride(index))
-      fsLedRGB(cfsIdx, ledOverride[cfsIdx].getColor());
-    else
-      fsLedRGB(cfsIdx, g_model.getSwitchOffColor(index).getColor());
+    if (cfsEditOverride >= 0) {
+      uint8_t cfsIdx = switchGetCustomSwitchIdx(cfsEditOverride);
+      fsLedRGB(cfsIdx, cfsEditColor);
+    } else {
+      uint8_t cfsIdx = switchGetCustomSwitchIdx(index);
+      if (hasLedOverride[cfsIdx] && g_model.getSwitchOffColorLuaOverride(index))
+        fsLedRGB(cfsIdx, ledOverride[cfsIdx].getColor());
+      else
+        fsLedRGB(cfsIdx, g_model.getSwitchOffColor(index).getColor());
+    }
   }
 }
 
 void setFSLedON(uint8_t index) {
   if (g_model.getSwitchType(index) != SWITCH_NONE) {
-    uint8_t cfsIdx = switchGetCustomSwitchIdx(index);
-    if (hasLedOverride[cfsIdx] && g_model.getSwitchOnColorLuaOverride(index))
-      fsLedRGB(cfsIdx, ledOverride[cfsIdx].getColor());
-    else
-      fsLedRGB(cfsIdx, g_model.getSwitchOnColor(index).getColor());
+    if (cfsEditOverride >= 0) {
+      uint8_t cfsIdx = switchGetCustomSwitchIdx(cfsEditOverride);
+      fsLedRGB(cfsIdx, cfsEditColor);
+    } else {
+      uint8_t cfsIdx = switchGetCustomSwitchIdx(index);
+      if (hasLedOverride[cfsIdx] && g_model.getSwitchOnColorLuaOverride(index))
+        fsLedRGB(cfsIdx, ledOverride[cfsIdx].getColor());
+      else
+        fsLedRGB(cfsIdx, g_model.getSwitchOnColor(index).getColor());
+    }
   }
 }
 

--- a/radio/src/hal/rgbleds.h
+++ b/radio/src/hal/rgbleds.h
@@ -25,6 +25,7 @@
 //                                    "Off",  "White",    "Red",  "Green", "Yellow", "Orange",   "Blue",   "Pink"
 constexpr uint32_t colorTable[] = {0x000000, 0xFFFFFF, 0xFF0000, 0x00FF00, 0xFFFF00, 0xFF4000, 0x0000FF, 0xFF00FF};
 
+void setFSEditOverride(int index, uint32_t color);
 void setFSLedOverride(uint8_t index, bool state, uint8_t r, uint8_t g, uint8_t b);
 void setFSLedOFF(uint8_t index);
 void setFSLedON(uint8_t index);


### PR DESCRIPTION
When editing a customisable switch color in the model setup the LED shows the color preview as it is changed.
However the preview does not work in the radio setup unless the switch type is set to Global.

This PR fixes the preview so it works consistently in all cases.
