### PR TITLE
fix(sport):  XJT module incorrect processing Telemetry Push/Pop data - 2.11

### DIFF
--- a/radio/src/telemetry/frsky.cpp
+++ b/radio/src/telemetry/frsky.cpp
@@ -78,7 +78,7 @@ static inline bool pushFrskyTelemetryData(bool is_sport, uint8_t data,
 
   } // switch
 
-  if (is_sport && len >= FRSKY_SPORT_PACKET_SIZE) {
+  if (is_sport && *len >= FRSKY_SPORT_PACKET_SIZE) {
     // end of frame detected
     dataState = STATE_DATA_IDLE;
     return true;


### PR DESCRIPTION
NOTE: For 2.11 Branch
Fixes #6720
Fixes #6219

Summary of changes:
Sport telemetry not processed correctly for Telemetry Push/Pop data.
Confusion between pointer and value.