### PR TITLE
fix(cpn): preserve current calibration when writing models and settings to radio

### DIFF
--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1493,10 +1493,11 @@ int MdiChild::askQuestion(const QString & msg, QMessageBox::StandardButtons butt
   return QMessageBox::question(this, CPN_STR_APP_NAME, msg, buttons, defaultButton);
 }
 
-void MdiChild::writeSettings(StatusDialog * status, bool toRadio)  // write to Tx
+void MdiChild::writeSettings(StatusDialog * status, bool toRadio)
 {
   //  safeguard as the menu actions should be disabled
   int cnt = radioData.invalidModels();
+
   if (cnt) {
     QMessageBox::critical(this, tr("Write Models and Settings"), tr("Operation aborted as %1 models have significant errors that may affect model operation.").arg(cnt));
     return;
@@ -1522,8 +1523,7 @@ void MdiChild::writeSettings(StatusDialog * status, bool toRadio)  // write to T
   if (toRadio) {
     radioPath = findMassStoragePath("RADIO", true);
     qDebug() << "Searching for SD card, found" << radioPath;
-  }
-  else {
+  } else {
     radioPath = g.currentProfile().sdPath();
     if (!QFile(radioPath % "/RADIO").exists())
       radioPath.clear();
@@ -1538,8 +1538,7 @@ void MdiChild::writeSettings(StatusDialog * status, bool toRadio)  // write to T
   if (saveFile(radioPath, false)) {
     status->hide();
     QMessageBox::information(this, CPN_STR_TTL_INFO, tr("Models and settings written"));
-  }
-  else {
+  } else {
     status->hide();
     QMessageBox::critical(this, CPN_STR_TTL_ERROR, tr("Error writing models and settings!"));
   }

--- a/companion/src/storage/etx.cpp
+++ b/companion/src/storage/etx.cpp
@@ -49,7 +49,7 @@ bool EtxFormat::load(RadioData & radioData)
   return result;
 }
 
-bool EtxFormat::write(const RadioData & radioData)
+bool EtxFormat::write(RadioData & radioData)
 {
   qDebug() << "Saving to archive" << filename;
 

--- a/companion/src/storage/etx.h
+++ b/companion/src/storage/etx.h
@@ -37,7 +37,7 @@ class EtxFormat : public LabelsStorageFormat
 
     virtual QString name() { return "etx"; }
     virtual bool load(RadioData & radioData);
-    virtual bool write(const RadioData & radioData);
+    virtual bool write(RadioData & radioData);
 
   protected:
     virtual bool loadFile(QByteArray & fileData, const QString & fileName, bool optional = false);

--- a/companion/src/storage/labeled.h
+++ b/companion/src/storage/labeled.h
@@ -42,7 +42,7 @@ class LabelsStorageFormat : public StorageFormat
     }
 
     virtual bool load(RadioData & radioData);
-    virtual bool write(const RadioData & radioData);
+    virtual bool write(RadioData & radioData);
 
   protected:
     virtual bool loadFile(QByteArray & fileData, const QString & fileName, bool optional = false) = 0;
@@ -54,4 +54,5 @@ class LabelsStorageFormat : public StorageFormat
 
     bool loadChecklist(ModelData &model);
     bool writeChecklist(const ModelData & model);
+    bool loadRadioSettings(GeneralSettings & generalSettings);
 };

--- a/companion/src/storage/sdcard.cpp
+++ b/companion/src/storage/sdcard.cpp
@@ -23,7 +23,7 @@
 #include <QFile>
 #include <QDir>
 
-bool SdcardFormat::write(const RadioData & radioData)
+bool SdcardFormat::write(RadioData & radioData)
 {
   QDir dir(filename);
   dir.mkdir("RADIO");

--- a/companion/src/storage/sdcard.h
+++ b/companion/src/storage/sdcard.h
@@ -36,7 +36,7 @@ class SdcardFormat : public LabelsStorageFormat
     }
 
     virtual QString name() { return "sdcard"; }
-    virtual bool write(const RadioData & radioData);
+    virtual bool write(RadioData & radioData);
 
   protected:
     virtual bool loadFile(QByteArray & fileData, const QString & fileName, bool optional = false);

--- a/companion/src/storage/storage.h
+++ b/companion/src/storage/storage.h
@@ -51,7 +51,8 @@ class StorageFormat
     }
     virtual ~StorageFormat() {}
     virtual bool load(RadioData & radioData) = 0;
-    virtual bool write(const RadioData & radioData) = 0;
+    virtual bool load(GeneralSettings & generalSettings) { return false; }
+    virtual bool write(RadioData & radioData) = 0;
     virtual bool writeModel(const RadioData & radioData, const int modelIndex) { return false; }
 
     QString error() {
@@ -151,9 +152,14 @@ class Storage : public StorageFormat
       _warning = warning;
     }
 
-    virtual bool load(RadioData & radioData);
-    virtual bool write(const RadioData & radioData);
+    virtual bool load(RadioData & radioData) override;
+    virtual bool load(GeneralSettings & generalSettings) override;
+    virtual bool write(RadioData & radioData);
     virtual bool writeModel(const RadioData & radioData, const int modelIndex);
+
+  protected:
+    bool fileExists();
+    StorageFormat * getStorageFormat();
 };
 
 void registerStorageFactories();

--- a/companion/src/storage/yaml.h
+++ b/companion/src/storage/yaml.h
@@ -37,7 +37,7 @@ class YamlFormat : public StorageFormat
 
     virtual QString name() override { return "yml"; }
     virtual bool load(RadioData & radioData) override;
-    virtual bool write(const RadioData & radioData) override { return false; }
+    virtual bool write(RadioData & radioData) override { return false; }
     virtual bool writeModel(const RadioData & radioData, const int modelIndex) override;
 
   protected:


### PR DESCRIPTION
Summary of changes:
- read radio settings from radio before writing
- overwrite new calibration with that just read from radio
- write merged settings to radio

Reasoning:
- calibration is unique to each radio and is as at a point in time

TODO:
- move all unique hardware settings to a separate file e.g. RADIO/hardware.yml

This should probably go into 2.11.x