### PR TITLE
feat(color): use PAGE keys to cycle through top level quick menu items

### DIFF
--- a/radio/src/gui/colorlcd/setup_menus/quick_menu.cpp
+++ b/radio/src/gui/colorlcd/setup_menus/quick_menu.cpp
@@ -37,11 +37,7 @@ ButtonBase* QuickSubMenu::addButton()
 {
   menuButton = quickMenu->getTopMenu()->addButton(icon, title,
                       [=]() -> uint8_t {
-                        if (!subMenu) buildSubMenu();
-                        quickMenu->getTopMenu()->setCurrent(menuButton);
-                        quickMenu->getTopMenu()->setDisabled(false);
-                        quickMenu->getTopMenu()->clearFocus();
-                        enableSubMenu();
+                        activate();
                         return 0;
                       });
 
@@ -65,6 +61,13 @@ bool QuickSubMenu::isSubMenu(QuickMenu::SubMenu n)
 {
   for (int i = 0; items[i].icon < EDGETX_ICONS_COUNT; i += 1)
     if (items[i].subMenu == n) return true;
+  return false;
+}
+
+bool QuickSubMenu::isSubMenu(ButtonBase* b)
+{
+  for (int i = 0; items[i].icon < EDGETX_ICONS_COUNT; i += 1)
+    if (menuButton == b) return true;
   return false;
 }
 
@@ -96,6 +99,15 @@ void QuickSubMenu::setCurrent(QuickMenu::SubMenu n)
   quickMenu->getTopMenu()->setCurrent(menuButton);
   quickMenu->getTopMenu()->setDisabled(false);
   subMenu->setCurrent(getIndex(n));
+  enableSubMenu();
+}
+
+void QuickSubMenu::activate()
+{
+  if (!subMenu) buildSubMenu();
+  quickMenu->getTopMenu()->setCurrent(menuButton);
+  quickMenu->getTopMenu()->setDisabled(false);
+  quickMenu->getTopMenu()->clearFocus();
   enableSubMenu();
 }
 
@@ -344,4 +356,31 @@ void QuickMenu::onLongPressMDL() { onSelect(true); new ModelLabelsWindow(); }
 void QuickMenu::onPressTELE() { subMenus[2]->onPress(ScreenSetupPage::FIRST_SCREEN_OFFSET); }
 void QuickMenu::onLongPressTELE() { onSelect(true); new ChannelsViewMenu(); }
 void QuickMenu::onLongPressRTN() { closeMenu(); }
+
+void QuickMenu::afterPG()
+{
+  auto b = mainMenu->getFocusedButton();
+  if (b) {
+    for(auto sub : subMenus) {
+      if (sub->isSubMenu(b)) {
+        sub->activate();
+        return;
+      }
+    }
+    focusMainMenu();
+    curPage = QuickMenu::NONE;
+  }
+}
+
+void QuickMenu::onPressPGDN()
+{
+  mainMenu->nextEntry();
+  afterPG();
+}
+
+void QuickMenu::onPressPGUP()
+{
+  mainMenu->prevEntry();
+  afterPG();
+}
 #endif

--- a/radio/src/gui/colorlcd/setup_menus/quick_menu.h
+++ b/radio/src/gui/colorlcd/setup_menus/quick_menu.h
@@ -117,6 +117,9 @@ class QuickMenu : public NavWindow
   void onPressTELE() override;
   void onLongPressTELE() override;
   void onLongPressRTN() override;
+  void onPressPGDN() override;
+  void onPressPGUP() override;
+  void afterPG();
 #endif
 
   static constexpr int QM_MAIN_BTNS = 6;
@@ -164,12 +167,14 @@ class QuickSubMenu
   {}
 
   bool isSubMenu(QuickMenu::SubMenu n);
+  bool isSubMenu(ButtonBase* b);
   int getIndex(QuickMenu::SubMenu n);
 
   ButtonBase* addButton();
   void enableSubMenu();
   void setDisabled(bool all);
   void setCurrent(QuickMenu::SubMenu n);
+  void activate();
   void buildSubMenu();
   uint8_t onPress(int n);
   void onSelect(bool close);

--- a/radio/src/gui/colorlcd/setup_menus/quick_menu_group.cpp
+++ b/radio/src/gui/colorlcd/setup_menus/quick_menu_group.cpp
@@ -232,3 +232,28 @@ void QuickMenuGroup::doLayout(int cols)
     }
   }
 }
+
+void QuickMenuGroup::nextEntry()
+{
+  if (group)
+    lv_group_focus_next(group);
+}
+
+void QuickMenuGroup::prevEntry()
+{
+  if (group)
+    lv_group_focus_prev(group);
+}
+
+ButtonBase* QuickMenuGroup::getFocusedButton()
+{
+  if (group) {
+    lv_obj_t* b = lv_group_get_focused(group);
+    if (b) {
+      for (size_t i = 0; i < btns.size(); i += 1)
+        if (btns[i]->getLvObj() == b)
+          return btns[i];
+    }
+  }
+  return nullptr;
+}

--- a/radio/src/gui/colorlcd/setup_menus/quick_menu_group.h
+++ b/radio/src/gui/colorlcd/setup_menus/quick_menu_group.h
@@ -50,6 +50,9 @@ class QuickMenuGroup : public Window
   void setCurrent(ButtonBase* b);
   void setCurrent(int b) { setCurrent(btns[b]); }
   void doLayout(int cols);
+  void nextEntry();
+  void prevEntry();
+  ButtonBase* getFocusedButton();
 
 #if PORTRAIT
   static LAYOUT_VAL_SCALED(QM_BUTTON_WIDTH, 72)


### PR DESCRIPTION
Suggested by a few of people.

When a sub menu group is selected with the PAGE keys it is also activated so the sub menu immediately active.