### PR TITLE
fix(color): radio yaml file may not be parsed correctly on H7 radios.

### DIFF
--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -1072,7 +1072,9 @@ PACK(struct RadioData {
   NOBACKUP(uint8_t  rotEncMode:3);
 
 #if defined(STM32F2) || defined(STM32F4)
-  NOBACKUP(int8_t   uartSampleMode:2); // See UartSampleModes
+  NOBACKUP(int8_t uartSampleMode:2); // See UartSampleModes
+#else
+  NOBACKUP(uint8_t uartSampleModeSpare:2 SKIP);
 #endif
 
 #if defined(STICK_DEAD_ZONE)

--- a/radio/src/storage/yaml/yaml_datastructs_pa01.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_pa01.cpp
@@ -406,6 +406,7 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_STRING("ownerRegistrationID", 8),
   YAML_CUSTOM("rotEncDirection",r_rotEncDirection,nullptr),
   YAML_UNSIGNED( "rotEncMode", 3 ),
+  YAML_PADDING( 2 ),
   YAML_UNSIGNED( "stickDeadZone", 3 ),
   YAML_SIGNED( "imuMax", 8 ),
   YAML_SIGNED( "imuOffset", 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_st16.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_st16.cpp
@@ -406,6 +406,7 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_STRING("ownerRegistrationID", 8),
   YAML_CUSTOM("rotEncDirection",r_rotEncDirection,nullptr),
   YAML_UNSIGNED( "rotEncMode", 3 ),
+  YAML_PADDING( 2 ),
   YAML_UNSIGNED( "stickDeadZone", 3 ),
   YAML_SIGNED( "imuMax", 8 ),
   YAML_SIGNED( "imuOffset", 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_t15pro.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t15pro.cpp
@@ -406,6 +406,7 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_STRING("ownerRegistrationID", 8),
   YAML_CUSTOM("rotEncDirection",r_rotEncDirection,nullptr),
   YAML_UNSIGNED( "rotEncMode", 3 ),
+  YAML_PADDING( 2 ),
   YAML_UNSIGNED( "stickDeadZone", 3 ),
   YAML_SIGNED( "imuMax", 8 ),
   YAML_SIGNED( "imuOffset", 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_tx15.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tx15.cpp
@@ -406,6 +406,7 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_STRING("ownerRegistrationID", 8),
   YAML_CUSTOM("rotEncDirection",r_rotEncDirection,nullptr),
   YAML_UNSIGNED( "rotEncMode", 3 ),
+  YAML_PADDING( 2 ),
   YAML_UNSIGNED( "stickDeadZone", 3 ),
   YAML_SIGNED( "imuMax", 8 ),
   YAML_SIGNED( "imuOffset", 8 ),


### PR DESCRIPTION
Fix structure alignment for YAML parsing on H7 radios.
