### PR TITLE
Fixed the issue of connecting the USB charging vibration motor after shutting down

### DIFF
--- a/radio/src/targets/pa01/board.cpp
+++ b/radio/src/targets/pa01/board.cpp
@@ -18,7 +18,7 @@
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
  */
- 
+
 #include "stm32_adc.h"
 #include "stm32_gpio.h"
 #include "stm32_i2c_driver.h"
@@ -140,7 +140,7 @@ bool pwrPressedDebounced()
     debouncedState = state;
   else
     lastState = state;
-  
+
   return debouncedState;
 }
 
@@ -173,7 +173,7 @@ void boardInit()
 
   adcInit(&_adc_driver);
   getADC();
-  
+
   flysky_gimbal_init();
   usbInit();
   rgbChargeInit(); // RTOS was not running, timer_create will prevent the ADC from reading.
@@ -190,11 +190,12 @@ void boardInit()
   uint32_t now = 0;
 
   pwrOn();
+  hapticInit();
 
   // Init debounce
   pwrPressedDebounced();
   pwrPressedDebounced();
-  
+
   // Handle charging state if charger is active
   if (isChargerActive()) {
     static uint32_t adc_sample_time = 0; // Hardware ADC sample tick
@@ -237,7 +238,7 @@ void boardInit()
       }
     }
   }
-  
+
   // Second stage: Detect secondary long-press sequence
   while (1)
   {
@@ -299,7 +300,7 @@ void boardInit()
         rotaryEncoderCheck();
         rotenc_t value = rotaryEncoderGetValue();
         if (value != lastEncoderValue) {
-          lastEncoderValue = value;     
+          lastEncoderValue = value;
           press_end_touch = timersGetMsTick();
         }
         press_start = 0;
@@ -310,7 +311,7 @@ void boardInit()
     }
     battery_charge_end();
   }
-#endif  
+#endif
 #endif
 
   rgbLedInit();
@@ -318,7 +319,6 @@ void boardInit()
   keysInit();
   switchInit();
   audioInit();
-  hapticInit();
 
 #if defined(RTCLOCK)
   rtcInit(); // RTC must be initialized before rambackupRestore() is called
@@ -355,7 +355,7 @@ void boardOff()
 //    RTC->BKP0R = SHUTDOWN_REQUEST;
   pwrOff();
 
-  // We reach here only in forced power situations, such as hw-debugging with external power  
+  // We reach here only in forced power situations, such as hw-debugging with external power
   // Enter STM32 stop mode / deep-sleep
   // Code snippet from ST Nucleo PWR_EnterStopMode example
 #define PDMode             0x00000000U
@@ -369,7 +369,7 @@ void boardOff()
 
 /* Set SLEEPDEEP bit of Cortex System Control Register */
   SET_BIT(SCB->SCR, ((uint32_t)SCB_SCR_SLEEPDEEP_Msk));
-  
+
   // To avoid HardFault at return address, end in an endless loop
   while (1) {
 
@@ -388,7 +388,7 @@ int usbPlugged()
     debouncedState = state;
   else
     lastState = state;
-  
+
   return debouncedState;
 }
 */


### PR DESCRIPTION
Fixes # When the device is turned off and charging, there is a voltage of about 0.6V across the vibration motor.

Summary of changes:
1.Move the initialization of the motor control pins before the charge detection。
