### PR TITLE
fix(cpn): preserve current calibration when writing models and settings to radio

### DIFF
--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -1499,10 +1499,11 @@ int MdiChild::askQuestion(const QString & msg, QMessageBox::StandardButtons butt
   return QMessageBox::question(this, CPN_STR_APP_NAME, msg, buttons, defaultButton);
 }
 
-void MdiChild::writeSettings(StatusDialog * status, bool toRadio)  // write to Tx
+void MdiChild::writeSettings(StatusDialog * status, bool toRadio)
 {
   //  safeguard as the menu actions should be disabled
   int cnt = radioData.invalidModels();
+
   if (cnt) {
     QMessageBox::critical(this, tr("Write Models and Settings"), tr("Operation aborted as %1 models have significant errors that may affect model operation.").arg(cnt));
     return;
@@ -1529,8 +1530,7 @@ void MdiChild::writeSettings(StatusDialog * status, bool toRadio)  // write to T
   if (toRadio) {
     radioPath = findMassstoragePath("RADIO", true);
     qDebug() << "Searching for SD card, found" << radioPath;
-  }
-  else {
+  } else {
     radioPath = g.currentProfile().sdPath();
     if (!QFile(radioPath % "/RADIO").exists())
       radioPath.clear();
@@ -1545,8 +1545,7 @@ void MdiChild::writeSettings(StatusDialog * status, bool toRadio)  // write to T
   if (saveFile(radioPath, false)) {
     status->hide();
     QMessageBox::information(this, CPN_STR_TTL_INFO, tr("Models and settings written"));
-  }
-  else {
+  } else {
     status->hide();
     QMessageBox::critical(this, CPN_STR_TTL_ERROR, tr("Error writing models and settings!"));
   }

--- a/companion/src/storage/etx.cpp
+++ b/companion/src/storage/etx.cpp
@@ -49,7 +49,7 @@ bool EtxFormat::load(RadioData & radioData)
   return result;
 }
 
-bool EtxFormat::write(const RadioData & radioData)
+bool EtxFormat::write(RadioData & radioData)
 {
   qDebug() << "Saving to archive" << filename;
 

--- a/companion/src/storage/etx.h
+++ b/companion/src/storage/etx.h
@@ -37,7 +37,7 @@ class EtxFormat : public LabelsStorageFormat
 
     virtual QString name() { return "etx"; }
     virtual bool load(RadioData & radioData);
-    virtual bool write(const RadioData & radioData);
+    virtual bool write(RadioData & radioData);
 
   protected:
     virtual bool loadFile(QByteArray & fileData, const QString & fileName);

--- a/companion/src/storage/labeled.cpp
+++ b/companion/src/storage/labeled.cpp
@@ -57,21 +57,8 @@ bool LabelsStorageFormat::load(RadioData & radioData)
       qDebug() << tr("Found %1").arg(filename);
   }
 
-  QByteArray radioSettingsBuffer;
-  if (!loadFile(radioSettingsBuffer, "RADIO/radio.yml")) {
-    setError(tr("Cannot extract RADIO/radio.yml"));
+  if (!loadRadioSettings(radioData.generalSettings))
     return false;
-  }
-
-  try {
-    if (!loadRadioSettingsFromYaml(radioData.generalSettings, radioSettingsBuffer)) {
-      setError(tr("Cannot load RADIO/radio.yml"));
-      return false;
-    }
-  } catch(const std::runtime_error& e) {
-    setError(tr("Cannot load RADIO/radio.yml") + ":\n" + QString(e.what()));
-    return false;
-  }
 
   board = (Board::Type)radioData.generalSettings.variant;
 
@@ -184,8 +171,34 @@ bool LabelsStorageFormat::load(RadioData & radioData)
   return true;
 }
 
-bool LabelsStorageFormat::write(const RadioData & radioData)
+bool LabelsStorageFormat::write(RadioData & radioData)
 {
+  // TODO
+  // move all unique radio settings to a separate file eg RADIO/hardware.yml.
+  // These settings/values should never be transferred to another radio.
+  // Also some are at a point in time eg calibration and
+  // therefore not restored to the radio from say an etx file
+
+  // may not exist on a new sd card or path
+  if (QFile(filename + "/RADIO/radio.yml").exists()) {
+    GeneralSettings gsCur;
+
+    if (loadRadioSettings(gsCur)) {
+      GeneralSettings & gsNew = radioData.generalSettings;
+      gsNew.txCurrentCalibration = gsCur.txCurrentCalibration;
+      gsNew.txVoltageCalibration = gsCur.txVoltageCalibration;
+
+      for (int i = 0; i < CPN_MAX_INPUTS; i++) {
+        gsNew.inputConfig[i].calib = gsCur.inputConfig[i].calib;
+      }
+
+      qDebug() << "Hardware specific settings preserved";
+    } else {
+      setError("Error reading current settings from radio");
+      return false;
+    }
+  }
+
   QByteArray radioSettingsBuffer;
   if (!writeRadioSettingsToYaml(radioData.generalSettings, radioSettingsBuffer))
     return false;
@@ -241,6 +254,31 @@ bool LabelsStorageFormat::write(const RadioData & radioData)
     QByteArray labelsListBuffer;
     if (!writeLabelsListToYaml(radioData, labelsListBuffer) || !writeFile(labelsListBuffer, "MODELS/labels.yml"))
       return false;
+  }
+
+  return true;
+}
+
+bool LabelsStorageFormat::loadRadioSettings(GeneralSettings & generalSettings)
+{
+  QByteArray radioSettingsBuffer;
+
+  const QString file("RADIO/radio.yml");
+  const QString filePath(QDir::toNativeSeparators(filename + "/" + file));
+
+  if (!loadFile(radioSettingsBuffer, file)) {
+    setError(tr("Cannot extract %1").arg(filePath));
+    return false;
+  }
+
+  try {
+    if (!loadRadioSettingsFromYaml(generalSettings, radioSettingsBuffer)) {
+      setError(tr("Cannot load %1").arg(filePath));
+      return false;
+    }
+  } catch(const std::runtime_error& e) {
+    setError(tr("Cannot load %1").arg(filePath) + ":\n" + QString(e.what()));
+    return false;
   }
 
   return true;

--- a/companion/src/storage/labeled.h
+++ b/companion/src/storage/labeled.h
@@ -42,7 +42,7 @@ class LabelsStorageFormat : public StorageFormat
     }
 
     virtual bool load(RadioData & radioData);
-    virtual bool write(const RadioData & radioData);
+    virtual bool write(RadioData & radioData);
 
   protected:
     virtual bool loadFile(QByteArray & fileData, const QString & fileName) = 0;
@@ -51,4 +51,6 @@ class LabelsStorageFormat : public StorageFormat
     virtual bool deleteFile(const QString & fileName) = 0;
 
     StorageType probeFormat();
+
+    bool loadRadioSettings(GeneralSettings & generalSettings);
 };

--- a/companion/src/storage/sdcard.cpp
+++ b/companion/src/storage/sdcard.cpp
@@ -23,7 +23,7 @@
 #include <QFile>
 #include <QDir>
 
-bool SdcardFormat::write(const RadioData & radioData)
+bool SdcardFormat::write(RadioData & radioData)
 {
   QDir dir(filename);
   dir.mkdir("RADIO");

--- a/companion/src/storage/sdcard.h
+++ b/companion/src/storage/sdcard.h
@@ -36,7 +36,7 @@ class SdcardFormat : public LabelsStorageFormat
     }
 
     virtual QString name() { return "sdcard"; }
-    virtual bool write(const RadioData & radioData);
+    virtual bool write(RadioData & radioData);
 
   protected:
     virtual bool loadFile(QByteArray & fileData, const QString & fileName);

--- a/companion/src/storage/storage.h
+++ b/companion/src/storage/storage.h
@@ -51,7 +51,8 @@ class StorageFormat
     }
     virtual ~StorageFormat() {}
     virtual bool load(RadioData & radioData) = 0;
-    virtual bool write(const RadioData & radioData) = 0;
+    virtual bool load(GeneralSettings & generalSettings) { return false; }
+    virtual bool write(RadioData & radioData) = 0;
     virtual bool writeModel(const RadioData & radioData, const int modelIndex) { return false; }
 
     QString error() {
@@ -151,9 +152,14 @@ class Storage : public StorageFormat
       _warning = warning;
     }
 
-    virtual bool load(RadioData & radioData);
-    virtual bool write(const RadioData & radioData);
+    virtual bool load(RadioData & radioData) override;
+    virtual bool load(GeneralSettings & generalSettings) override;
+    virtual bool write(RadioData & radioData);
     virtual bool writeModel(const RadioData & radioData, const int modelIndex);
+
+  protected:
+    bool fileExists();
+    StorageFormat * getStorageFormat();
 };
 
 void registerStorageFactories();

--- a/companion/src/storage/yaml.h
+++ b/companion/src/storage/yaml.h
@@ -37,7 +37,7 @@ class YamlFormat : public StorageFormat
 
     virtual QString name() override { return "yml"; }
     virtual bool load(RadioData & radioData) override;
-    virtual bool write(const RadioData & radioData) override { return false; }
+    virtual bool write(RadioData & radioData) override { return false; }
     virtual bool writeModel(const RadioData & radioData, const int modelIndex) override;
 
   protected:


### PR DESCRIPTION
2.11 version of #6722

Putting up the PR as I suspect I screwed up during the cherry-pick or it run afoul of some other main only change... as when I tested on Linux in an environment with no prior saved calibration data, it didn't see any inputs at all...

<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

