### PR TITLE
fix(color): widgets may move or resize when trims are disabled in flight modes

### DIFF
--- a/radio/src/gui/colorlcd/mainview/view_main_decoration.cpp
+++ b/radio/src/gui/colorlcd/mainview/view_main_decoration.cpp
@@ -31,7 +31,7 @@
 #include "hal/adc_driver.h"
 
 ViewMainDecoration::ViewMainDecoration(Window* parent, bool showTrims, bool showSliders, bool showFM) :
-  parent(parent)
+  parent(parent), showTrims(showTrims), showSliders(showSliders), showFM(showFM)
 {
   w_ml = layoutBox(parent, LV_ALIGN_LEFT_MID, LV_FLEX_FLOW_ROW_REVERSE);
   w_mr = layoutBox(parent, LV_ALIGN_RIGHT_MID, LV_FLEX_FLOW_ROW);
@@ -41,11 +41,11 @@ ViewMainDecoration::ViewMainDecoration(Window* parent, bool showTrims, bool show
   w_bc = layoutBox(parent, LV_ALIGN_BOTTOM_MID, LV_FLEX_FLOW_COLUMN);
   lv_obj_set_flex_align(w_bc->getLvObj(), LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_SPACE_AROUND);
 
-  if (showTrims)
+  if (this->showTrims)
     createTrims(w_ml, w_mr, w_bl, w_br);
-  if (showFM)
+  if (this->showFM)
     createFlightMode(w_bc);
-  if (showSliders)
+  if (this->showSliders)
     createSliders(w_ml, w_mr, w_bl, w_bc, w_br);
 }
 
@@ -68,6 +68,7 @@ Window* ViewMainDecoration::layoutBox(Window* parent, lv_align_t align,
 
 void ViewMainDecoration::setSlidersVisible(bool visible)
 {
+  showSliders = visible;
   for (int i=0; i < SLIDERS_MAX; i++) {
     if (sliders[i]) {
       sliders[i]->show(visible);
@@ -77,6 +78,7 @@ void ViewMainDecoration::setSlidersVisible(bool visible)
 
 void ViewMainDecoration::setTrimsVisible(bool visible)
 {
+  showTrims = visible;
   for (int i=0; i < TRIMS_MAX; i++) {
     if (trims[i]) {
       trims[i]->setVisible(visible);
@@ -86,27 +88,55 @@ void ViewMainDecoration::setTrimsVisible(bool visible)
 
 void ViewMainDecoration::setFlightModeVisible(bool visible)
 {
+  showFM = visible;
   if (flightMode)
     flightMode->show(visible);
 }
 
+// Check if trim may be visible in one or more flight modes
+static bool canTrimShow(int idx)
+{
+  idx = inputMappingConvertMode(idx);
+  for (int i = 0; i < MAX_FLIGHT_MODES; i += 1) {
+    if (i == 0 || g_model.flightModeData[i].swtch != SWITCH_NONE) {
+      trim_t v = getRawTrimValue(i, idx);
+      if (v.mode != TRIM_MODE_NONE && v.mode != TRIM_MODE_3POS)
+        return true;
+    }
+  }
+  return false;
+}
+
 rect_t ViewMainDecoration::getMainZone() const
 {
-  // update layout first
-  lv_obj_update_layout(parent->getLvObj());
+  coord_t x = 0, w = LCD_W, h = LCD_H;
 
-  auto x_left = lv_obj_get_x2(w_ml->getLvObj());
-  auto x_right = lv_obj_get_x(w_mr->getLvObj());
-
-  lv_coord_t bottom = LCD_H;
-  Window* boxes[] = { w_bl, w_bc, w_br };
-
-  for ( auto box : boxes ) {
-    auto y = lv_obj_get_y(box->getLvObj());
-    if (y < bottom) bottom = y;
+  if (showSliders) {
+    x += MainViewSlider::SLIDER_BAR_SIZE;
+    w -= 2 * MainViewSlider::SLIDER_BAR_SIZE;
+    h -= MainViewSlider::SLIDER_BAR_SIZE;
   }
 
-  return rect_t{ x_left, 0, x_right - x_left, bottom};
+  if (showTrims) {
+    if (canTrimShow(TRIMS_LV)) {
+      x += MainViewSlider::SLIDER_BAR_SIZE;
+      w -= MainViewSlider::SLIDER_BAR_SIZE;
+    }
+    if (canTrimShow(TRIMS_RV)) {
+      w -= MainViewSlider::SLIDER_BAR_SIZE;
+    }
+    if (showFM) {
+      h -= EdgeTxStyles::STD_FONT_HEIGHT;
+    } else {
+      if (canTrimShow(TRIMS_LH) || canTrimShow(TRIMS_RH)) {
+        h -= MainViewSlider::SLIDER_BAR_SIZE;
+      }
+    }
+  } else if (showFM) {
+    h -= EdgeTxStyles::STD_FONT_HEIGHT;
+  }
+
+  return rect_t{x, 0, w, h};
 }
 
 void ViewMainDecoration::createSliders(Window* ml, Window* mr, Window* bl, Window* bc, Window* br)

--- a/radio/src/gui/colorlcd/mainview/view_main_decoration.h
+++ b/radio/src/gui/colorlcd/mainview/view_main_decoration.h
@@ -27,53 +27,56 @@ class MainViewTrim;
 
 class ViewMainDecoration
 {
-  public:
-    ViewMainDecoration(Window* parent, bool showTrims = true, bool showSliders = true, bool showFM = true);
+ public:
+  ViewMainDecoration(Window* parent, bool showTrims = true, bool showSliders = true, bool showFM = true);
 
-    // Set decoration visibility
-    void setTrimsVisible(bool visible);
-    void setSlidersVisible(bool visible);
-    void setFlightModeVisible(bool visible);
+  // Set decoration visibility
+  void setTrimsVisible(bool visible);
+  void setSlidersVisible(bool visible);
+  void setFlightModeVisible(bool visible);
 
-    // Get the available space in the middle of the screen
-    // (without decoration)
-    rect_t getMainZone() const;
+  // Get the available space in the middle of the screen
+  // (without decoration)
+  rect_t getMainZone() const;
 
-  protected:
+ protected:
+  bool showTrims;
+  bool showSliders;
+  bool showFM;
 
-    enum {
-      SLIDERS_POT1 = 0,
-      SLIDERS_POT2,
-      SLIDERS_POT3,
-      SLIDERS_REAR_LEFT,
-      SLIDERS_EXT1,
-      SLIDERS_REAR_RIGHT,
-      SLIDERS_EXT2,
-      SLIDERS_MAX
-    };
-  
-    enum {
-      TRIMS_LH = 0,
-      TRIMS_LV,
-      TRIMS_RV,
-      TRIMS_RH,
-      TRIMS_MAX
-    };
+  enum {
+    SLIDERS_POT1 = 0,
+    SLIDERS_POT2,
+    SLIDERS_POT3,
+    SLIDERS_REAR_LEFT,
+    SLIDERS_EXT1,
+    SLIDERS_REAR_RIGHT,
+    SLIDERS_EXT2,
+    SLIDERS_MAX
+  };
 
-    Window* parent;
-    Window* w_ml;
-    Window* w_mr;
-    Window* w_bl;
-    Window* w_bc;
-    Window* w_br;
-  
-    Window* sliders[SLIDERS_MAX] = { 0 };
-    MainViewTrim* trims[TRIMS_MAX] = { 0 };
-    Window* flightMode = nullptr;
+  enum {
+    TRIMS_LH = 0,
+    TRIMS_LV,
+    TRIMS_RV,
+    TRIMS_RH,
+    TRIMS_MAX
+  };
 
-    Window* layoutBox(Window* parent, lv_align_t align, lv_flex_flow_t flow);
+  Window* parent;
+  Window* w_ml;
+  Window* w_mr;
+  Window* w_bl;
+  Window* w_bc;
+  Window* w_br;
 
-    void createSliders(Window* ml, Window* mr, Window* bl, Window* bc, Window* br);
-    void createTrims(Window* ml, Window* mr, Window* bl, Window* br);
-    void createFlightMode(Window* bc);
+  Window* sliders[SLIDERS_MAX] = { 0 };
+  MainViewTrim* trims[TRIMS_MAX] = { 0 };
+  Window* flightMode = nullptr;
+
+  Window* layoutBox(Window* parent, lv_align_t align, lv_flex_flow_t flow);
+
+  void createSliders(Window* ml, Window* mr, Window* bl, Window* bc, Window* br);
+  void createTrims(Window* ml, Window* mr, Window* bl, Window* br);
+  void createFlightMode(Window* bc);
 };

--- a/radio/src/gui/colorlcd/widgets/outputs.cpp
+++ b/radio/src/gui/colorlcd/widgets/outputs.cpp
@@ -207,14 +207,16 @@ class OutputsWidget : public Widget
     if (chan != firstChan) { firstChan= chan; changed = true; }
 
     // Get size
-    uint8_t n = height() / ChannelValue::ROW_HEIGHT;
+    if (width() != lastWidth) { lastWidth = width(); changed = true; }
+    if (height() != lastHeight) { lastHeight = height(); changed = true; }
+    uint8_t n = lastHeight / ChannelValue::ROW_HEIGHT;
     if (n != rows) { rows = n; changed = true; }
-    n = (width() > COLS_MIN_W) ? 2 : 1;
+    n = (lastWidth > COLS_MIN_W) ? 2 : 1;
     if (n != cols) { cols = n; changed = true; }
 
     if (changed) {
       clear();
-      coord_t colWidth = width() / cols;
+      coord_t colWidth = lastWidth / cols;
       uint8_t chan = firstChan;
       for (uint8_t c = 0; c < cols && chan <= MAX_OUTPUT_CHANNELS; c += 1) {
         for (uint8_t r = 0; r < rows && chan <= MAX_OUTPUT_CHANNELS;
@@ -228,8 +230,8 @@ class OutputsWidget : public Widget
   static const ZoneOption options[];
 
  protected:
-  // Last time we refreshed the window
-  uint32_t lastRefresh = 0;
+  coord_t lastWidth = -1;
+  coord_t lastHeight = -1;
   uint8_t firstChan = 255;
   uint8_t cols = 0;
   uint8_t rows = 0;


### PR DESCRIPTION
Restore widget zone sizing from 2.10 when trims are disabled/enabled in flight modes.

I have made one additional enhancement where, if a trim is disabled in ALL flight modes, then the space used by the trim may be used for widgets. E.G. if the left vertical trim is disabled in all FM then widgets will use this space.

Also fIxes the outputs widget layout where it may not update correctly when the zone size changes.

Fixes: #6745 
