### PR TITLE
fix(boxer): default hardware switches

### DIFF
--- a/radio/util/hw_defs/switch_config.py
+++ b/radio/util/hw_defs/switch_config.py
@@ -5,13 +5,11 @@ SWITCH_CONFIG = {
         # left side
         "SA": {"default": "2POS",   "display": [0, 0]},
         "SB": {"default": "3POS",   "display": [0, 1]},
-        "SE": {"default": "3POS",   "display": [0, 2]},
-        "SG": {"default": "2POS",   "display": [0, 3]},
+        "SE": {"default": "2POS",   "display": [0, 2]},
         # right side
         "SC": {"default": "3POS",   "display": [1, 0]},
         "SD": {"default": "2POS",   "display": [1, 1]},
         "SF": {"default": "TOGGLE", "display": [1, 2]},
-        "SH": {"default": "2POS", "display": [1, 3]},
     },
     "gx12": {
         # left side


### PR DESCRIPTION
From RADIOMASTER web site
SE - latching so default should be 2POS
SG & SH - do not exist