### PR TITLE
chore: sync action for mfg repos

### DIFF
--- a/.github/workflows/sync_repos.yml
+++ b/.github/workflows/sync_repos.yml
@@ -1,0 +1,50 @@
+name: Sync from EdgeTX upstream
+
+on:
+  schedule:
+    - cron: '0 2 * * 1' # Weekly on Monday at 2 AM UTC
+  workflow_dispatch: # Manual trigger option
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.SYNC_PAT }}
+      
+      - name: Configure git
+        run: |
+          git config user.name "EdgeTX Sync Bot"
+          git config user.email "sync-bot@edgetx.org"
+      
+      - name: Sync branches from upstream (hard reset)
+        env:
+          BRANCHES: "main 2.11" # Add/modify branches here as needed
+        run: |
+          git remote add upstream https://github.com/EdgeTX/edgetx.git
+          git fetch upstream
+          
+          for branch in $BRANCHES; do
+            echo "=== Syncing branch: $branch ==="
+            
+            # Check if upstream has this branch
+            if ! git ls-remote --heads upstream | grep -q "refs/heads/$branch"; then
+              echo "⚠️  Branch $branch does not exist in upstream, skipping..."
+              continue
+            fi
+            
+            # Hard reset to upstream (creates exact copy with same SHA)
+            git checkout -B $branch upstream/$branch
+            
+            # Force push to origin
+            git push origin $branch --force
+            
+            echo "✓ Branch $branch synced (SHA: $(git rev-parse HEAD))"
+          done
+          
+          echo ""
+          echo "=== Sync Complete ==="
+          echo "All specified branches are now exact copies of upstream"


### PR DESCRIPTION
Summary of changes:
- cron triggered action that will automatically sync all enabled private mfg repos once a week
- has a manual trigger option if occasionally needed sooner

Before the inevitable "it should be run more frequently"... I'll just leave this (last month's private repo usage) here... please insert credit card. 

<img width="917" height="168" alt="image" src="https://github.com/user-attachments/assets/bb02b676-e4b4-4135-ada0-fa20ab4427e1" />



