### PR TITLE
chore: beautify MutexLock, add example code and prevent wrong usage

### DIFF
--- a/radio/src/targets/common/arm/stm32/stm32_i2c_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_i2c_driver.cpp
@@ -55,7 +55,7 @@ static I2C_HandleTypeDef* i2c_get_handle(uint8_t bus)
 }
 
 #if !defined(BOOT)
-#define I2CMutex(bus) MutexLock mutexLock(&i2c_get_device(bus)->mutex)
+#define I2CMutex(bus) MutexLock mutexLock = MutexLock::MakeInstance(&i2c_get_device(bus)->mutex)
 #else
 #define I2CMutex(bus)
 #endif


### PR DESCRIPTION
Summary of changes:
The new MutexLock class has one very specific use case. This PR clarifies the use case, adds example code and prevents missuse by making it (almost) impossible to create it hte wrong way or copy it to someone else.
