### PR TITLE
chore: cleanup pwrOn()

### DIFF
--- a/radio/src/edgetx.cpp
+++ b/radio/src/edgetx.cpp
@@ -1415,10 +1415,7 @@ void edgeTxInit()
 #endif
 
 #if defined(STARTUP_ANIMATION)
-  if (WAS_RESET_BY_WATCHDOG_OR_SOFTWARE()) {
-    pwrOn();
-  }
-  else {
+  if (!WAS_RESET_BY_WATCHDOG_OR_SOFTWARE()) {
     runStartupAnimation();
   }
 #else // defined(STARTUP_ANIMATION)

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -250,12 +250,6 @@ void boardInit()
   DBGMCU->APB2FZ = 0x00070003;
 #endif
 
-#if defined(PWR_BUTTON_PRESS)
-  if (WAS_RESET_BY_WATCHDOG_OR_SOFTWARE()) {
-    pwrOn();
-  }
-#endif
-
 #if defined(TOPLCD_GPIO)
   toplcdInit();
 #endif


### PR DESCRIPTION
Cleanup EM pwrOn() handling as it now handled as part of pwrResetHandler()

I do not have the following radio to test but this likely applies to:
PA01 : pa01/board.cpp line 260
PL18 : pl18/board.cpp line 249
ST16: st16/board.cpp line 220

@richardclli could you have a look at those Flysky radios and update PR accordingly ?

NB: cli command trigger_watchdog_reset can be used to test ;)