### PR TITLE
fix(gx12): custom function switch LED state may be incorrect

### DIFF
--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -718,6 +718,7 @@ static void menuModelCFSOne(event_t event)
             fsLedRGB(switchGetCustomSwitchIdx(swIndex), 0);
 #endif
           } else if (config == SWITCH_TOGGLE) {
+            setFSLogicalState(swIndex, 0);
             g_model.cfsSetStart(swIndex, FS_START_PREVIOUS);  // Toggle switches do not have startup position
           }
         }

--- a/radio/src/gui/common/stdlcd/radio_hardware.cpp
+++ b/radio/src/gui/common/stdlcd/radio_hardware.cpp
@@ -198,6 +198,7 @@ static void menuRadioCFSOne(event_t event)
               fsLedRGB(switchGetCustomSwitchIdx(swIndex), 0);
 #endif
           } else if (config == SWITCH_TOGGLE) {
+            setFSLogicalState(swIndex, 0);
             g_eeGeneral.switchSetStart(swIndex, FS_START_PREVIOUS);  // Toggle switches do not have startup position
           }
         }


### PR DESCRIPTION
Fix GX12 function switch LED state.

To reproduce:
- Change a function switch type to 2POS, with no group selected
- Press the function switch to turn the LED on
- Change the type to Toggle

The LED remains on when the switch is not pressed and turns off when pressed (inverted).
