### PR TITLE
fix(h7): do not offer flash bootloader option in SD manager

### DIFF
--- a/radio/src/gui/colorlcd/radio/radio_sdmanager.cpp
+++ b/radio/src/gui/colorlcd/radio/radio_sdmanager.cpp
@@ -370,6 +370,7 @@ void RadioSdManagerPage::fileAction(const char* path, const char* name,
       });
     }
     if (!strcasecmp(ext, FIRMWARE_EXT)) {
+//TODO: Find out why UF2FirmwareUpdate is bricking
 #if !defined(FIRMWARE_FORMAT_UF2)
       if (isBootloader(fullpath)) {
         menu->addLine(STR_FLASH_BOOTLOADER,


### PR DESCRIPTION
This removes a non working option to flash from firmware on radio with UF2. If used, it results in a nearly bricked radio (because of another issue in UF2 bootloader)