### PR TITLE
fix(pa01): SDIO file access stability

### DIFF
--- a/radio/src/targets/pa01/hal.h
+++ b/radio/src/targets/pa01/hal.h
@@ -296,8 +296,6 @@
 #define QSPI_QE_BIT                     (1 << 6)
 
 // Storage
-#define STORAGE_USE_SDIO
-
 /*
  * SDIO pins:
  *  - SDMMC1_D0-D3 (PC.08-11)
@@ -305,7 +303,8 @@
  *  - SDMMC1_CMD   (PD.02)
  */
 #define SD_SDIO                        SDMMC1
-#define SD_SDIO_TRANSFER_CLK_DIV       SDMMC_HSPEED_CLK_DIV
+#define SD_SDIO_TRANSFER_CLK_DIV       SDMMC_NSPEED_CLK_DIV  // 25MHz
+#define STORAGE_USE_SDIO
 
 // Audio
 #define AUDIO_MUTE_GPIO               GPIO_PIN(GPIOE, 4) // PE.04


### PR DESCRIPTION
PA01 has SDIO clock to high that affects filesystem stability.
