### PR TITLE
fix(pa01): battery charge animations not being shown

### DIFF
--- a/radio/src/targets/common/arm/stm32/stm32_i2c_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_i2c_driver.cpp
@@ -35,7 +35,7 @@
 struct stm32_i2c_device {
   I2C_HandleTypeDef handle;
   const stm32_i2c_hw_def_t* hw_def;
-#if !defined(BOOT)
+#if !defined(BOOT) && !defined(RADIO_PA01)
   mutex_handle_t mutex;
 #endif
 };
@@ -54,7 +54,7 @@ static I2C_HandleTypeDef* i2c_get_handle(uint8_t bus)
   return &_i2c_devs[bus].handle;
 }
 
-#if !defined(BOOT)
+#if !defined(BOOT) && !defined(RADIO_PA01)
 #define I2CMutex(bus) MutexLock mutexLock = MutexLock::MakeInstance(&i2c_get_device(bus)->mutex)
 #else
 #define I2CMutex(bus)
@@ -525,7 +525,7 @@ int stm32_i2c_init(uint8_t bus, uint32_t clock_rate, const stm32_i2c_hw_def_t* h
   }
 #endif
 
-#if !defined(BOOT)
+#if !defined(BOOT) && !defined(RADIO_PA01)
   mutex_create(&dev->mutex);
 #endif
   return 1;


### PR DESCRIPTION
As originally stated in #6790,

> Note: this disables the I2C bus mutex as the PA01 needs I2C in the bootloader, and the current mutex code is not compatible with the bootloader. A better fix is needed; but this at least makes the radio operational again.