### PR TITLE
fix(color): rotary encoder may not work in setup menus (2.11 version)

### DIFF
--- a/radio/src/gui/colorlcd/libui/fullscreen_dialog.cpp
+++ b/radio/src/gui/colorlcd/libui/fullscreen_dialog.cpp
@@ -156,11 +156,9 @@ void FullScreenDialog::deleteLater(bool detach, bool trash)
   if (running) {
     running = false;
   } else {
-    Layer::pop(this);
     Window::deleteLater(detach, trash);
+    Layer::pop(this);
   }
-  // Window* p = Layer::back();
-  // if (p) p->show();
 }
 
 void FullScreenDialog::setMessage(std::string text)

--- a/radio/src/gui/colorlcd/libui/layer.cpp
+++ b/radio/src/gui/colorlcd/libui/layer.cpp
@@ -23,7 +23,7 @@ std::list<Layer> Layer::stack;
 Layer::Layer(Window* w, lv_group_t* g) : window(w), group(g) {}
 Layer::~Layer() { lv_group_del(group); }
 
-static void _assign_lv_group(lv_group_t* g)
+void _assign_lv_group(lv_group_t* g)
 {
   lv_group_set_default(g);
 

--- a/radio/src/gui/colorlcd/libui/mainwindow.cpp
+++ b/radio/src/gui/colorlcd/libui/mainwindow.cpp
@@ -85,7 +85,10 @@ void MainWindow::shutdown()
   LayoutFactory::deleteCustomScreens();
 
   // clear layer stack first
-  for (Window* w = Layer::back(); w; w = Layer::back()) w->deleteLater();
+  for (Window* w = Layer::back(); w; w = Layer::back()) {
+    w->deleteLater();
+    Layer::pop(w);
+  }
 
   children.clear();
   clear();

--- a/radio/src/gui/colorlcd/libui/menu.cpp
+++ b/radio/src/gui/colorlcd/libui/menu.cpp
@@ -70,8 +70,6 @@ class MenuBody : public TableField
   {
     // Allow encoder acceleration
     lv_obj_add_flag(lvobj, LV_OBJ_FLAG_ENCODER_ACCEL);
-    // Add scroll bar if needed
-    etx_scrollbar(lvobj);
 
     setColumnWidth(0, rect.w);
 

--- a/radio/src/gui/colorlcd/libui/modal_window.cpp
+++ b/radio/src/gui/colorlcd/libui/modal_window.cpp
@@ -57,8 +57,8 @@ ModalWindow::ModalWindow(bool closeWhenClickOutside) :
 void ModalWindow::deleteLater(bool detach, bool trash)
 {
   if (_deleted) return;
-  Layer::pop(this);
   Window::deleteLater(detach, trash);
+  Layer::pop(this);
 }
 
 void ModalWindow::onClicked()

--- a/radio/src/gui/colorlcd/libui/page.cpp
+++ b/radio/src/gui/colorlcd/libui/page.cpp
@@ -96,10 +96,10 @@ Page::Page(EdgeTxIcon icon, PaddingSize padding, bool pauseRefresh) :
 
 void Page::deleteLater(bool detach, bool trash)
 {
+  NavWindow::deleteLater(detach, trash);
+
   Layer::pop(this);
   Layer::back()->show();
-
-  NavWindow::deleteLater(detach, trash);
 }
 
 void Page::onCancel() { deleteLater(); }

--- a/radio/src/gui/colorlcd/libui/table.cpp
+++ b/radio/src/gui/colorlcd/libui/table.cpp
@@ -176,7 +176,6 @@ TableField::TableField(Window* parent, const rect_t& rect) :
 {
   setWindowFlag(OPAQUE);
 
-  etx_scrollbar(lvobj);
   lv_table_set_col_cnt(lvobj, 1);
 }
 
@@ -305,32 +304,40 @@ bool TableField::onLongPress()
   return true;
 }
 
+extern void _assign_lv_group(lv_group_t* g);
+
 void TableField::setAutoEdit()
 {
+  if (autoedit) return;
+
   autoedit = true;
-  lv_group_t* g = (lv_group_t*)lv_obj_get_group(lvobj);
-  if (g) {
-    setFocusHandler([=](bool focus) {
-      if (focus) {
-        lv_group_set_focus_cb(g, TableField::force_editing);
-      } else {
-        lv_group_set_focus_cb(g, nullptr);
-      }
-    });
-    lv_group_set_editing(g, true);
-  }
+
+  oldGroup = lv_group_get_default();
+  group = lv_group_create();
+  lv_group_add_obj(group, lvobj);
+  _assign_lv_group(group);
+
+  lv_group_set_editing(group, true);
+
+  setFocusHandler([=](bool focus) {
+    if (focus) {
+      lv_group_set_focus_cb(group, TableField::force_editing);
+    } else {
+      lv_group_set_focus_cb(group, nullptr);
+    }
+  });
 }
 
 void TableField::deleteLater(bool detach, bool trash)
 {
   if (!deleted()) {
     if (autoedit) {
-      lv_group_t* g = (lv_group_t*)lv_obj_get_group(lvobj);
-      if (g) {
-        lv_group_set_focus_cb(g, nullptr);
-        lv_group_set_editing(g, false);
-      }
-      Window::deleteLater(detach, trash);
+      lv_group_del(group);
+      if (oldGroup)
+        _assign_lv_group(oldGroup);
+      else
+        lv_group_set_default(nullptr);
     }
+    Window::deleteLater(detach, trash);
   }
 }

--- a/radio/src/gui/colorlcd/libui/table.h
+++ b/radio/src/gui/colorlcd/libui/table.h
@@ -60,6 +60,8 @@ class TableField : public Window
  protected:
   bool autoedit = false;
   std::function<void()> longPressHandler = nullptr;
+  lv_group_t* group = nullptr;
+  lv_group_t* oldGroup = nullptr;
 
   void onEvent(event_t event) override;
   bool onLongPress() override;

--- a/radio/src/gui/colorlcd/libui/tabsgroup.cpp
+++ b/radio/src/gui/colorlcd/libui/tabsgroup.cpp
@@ -327,10 +327,10 @@ void TabsGroup::deleteLater(bool detach, bool trash)
 {
   if (_deleted) return;
 
+  Window::deleteLater(detach, trash);
+
   Layer::pop(this);
   Layer::back()->show();
-
-  Window::deleteLater(detach, trash);
 }
 
 void TabsGroup::addTab(PageTab* page)

--- a/radio/src/gui/colorlcd/mainview/topbar.cpp
+++ b/radio/src/gui/colorlcd/mainview/topbar.cpp
@@ -66,10 +66,10 @@ void SetupTopBarWidgetsPage::onCancel() { deleteLater(); }
 
 void SetupTopBarWidgetsPage::deleteLater(bool detach, bool trash)
 {
-  Layer::pop(this);
-
   // and continue async deletion...
   Window::deleteLater(detach, trash);
+
+  Layer::pop(this);
 
   // restore screen setting tab on top
   new ScreenMenu(0);

--- a/radio/src/gui/colorlcd/mainview/view_main.cpp
+++ b/radio/src/gui/colorlcd/mainview/view_main.cpp
@@ -103,8 +103,8 @@ ViewMain::~ViewMain() { _instance = nullptr; }
 
 void ViewMain::deleteLater(bool detach, bool trash)
 {
-  Layer::pop(this);
   NavWindow::deleteLater(detach, trash);
+  Layer::pop(this);
 }
 
 void ViewMain::addMainView(WidgetsContainer* view, uint32_t viewId)

--- a/radio/src/gui/colorlcd/mainview/view_main_menu.cpp
+++ b/radio/src/gui/colorlcd/mainview/view_main_menu.cpp
@@ -154,8 +154,8 @@ ViewMainMenu::ViewMainMenu(Window* parent, std::function<void()> closeHandler) :
 void ViewMainMenu::deleteLater(bool detach, bool trash)
 {
   if (closeHandler) closeHandler();
-  Layer::pop(this);
   Window::deleteLater(detach, trash);
+  Layer::pop(this);
 }
 
 void ViewMainMenu::onClicked() { deleteLater(); }

--- a/radio/src/gui/colorlcd/mainview/widgets_setup.cpp
+++ b/radio/src/gui/colorlcd/mainview/widgets_setup.cpp
@@ -155,6 +155,8 @@ void SetupWidgetsPage::onCancel() { deleteLater(); }
 
 void SetupWidgetsPage::deleteLater(bool detach, bool trash)
 {
+  Window::deleteLater(detach, trash);
+
   // restore screen setting tab on top
   Layer::pop(this);
 
@@ -165,7 +167,6 @@ void SetupWidgetsPage::deleteLater(bool detach, bool trash)
     viewMain->setCurrentMainView(savedView);
     viewMain->showTopBarEdgeTxButton();
   }
-  Window::deleteLater(detach, trash);
   new ScreenMenu(customScreenIdx + 1);
 
   storageDirty(EE_MODEL);

--- a/radio/src/gui/colorlcd/standalone_lua.cpp
+++ b/radio/src/gui/colorlcd/standalone_lua.cpp
@@ -215,6 +215,8 @@ void StandaloneLuaWindow::deleteLater(bool detach, bool trash)
 
   luaScriptManager = nullptr;
 
+  Window::deleteLater(detach, trash);
+
   Layer::pop(this);
   Layer::back()->show();
 
@@ -233,8 +235,6 @@ void StandaloneLuaWindow::deleteLater(bool detach, bool trash)
   luaState = prevLuaState;
 
   luaEmptyEventBuffer();
-
-  Window::deleteLater(detach, trash);
 }
 
 void StandaloneLuaWindow::checkEvents()


### PR DESCRIPTION
Fix rotary encoder not working after deleting a TableField.
The memory leak fix in PR #6794 exposed an issue with the way groups were handled in the TableField class.

To reproduce:
- press SYS to open TOOLS
- press PAGE twice to RADIO SETUP

The rotary encoder will not navigate around the page.

2.11 version of #6801