### PR TITLE
fix(color): default popup width is not scaled to LCD size

### DIFF
--- a/radio/src/gui/colorlcd/libui/menu.cpp
+++ b/radio/src/gui/colorlcd/libui/menu.cpp
@@ -351,7 +351,7 @@ class MenuWindowContent : public Window
     body->addLine(icon_mask, text, onPress, isChecked, update);
   }
 
-  static constexpr coord_t MENUS_WIDTH = 200;
+  static LAYOUT_VAL_SCALED(MENUS_WIDTH, 200)
 
  protected:
   StaticText* header = nullptr;


### PR DESCRIPTION
Scale default popup width to LCD size.