### PR TITLE
fix(color): full screen dialog may crash

### DIFF
--- a/radio/src/gui/colorlcd/libui/fullscreen_dialog.cpp
+++ b/radio/src/gui/colorlcd/libui/fullscreen_dialog.cpp
@@ -49,11 +49,6 @@ FullScreenDialog::FullScreenDialog(
 
   bringToTop();
 
-  delayLoad();
-}
-
-void FullScreenDialog::delayedInit()
-{
   build();
 }
 
@@ -165,9 +160,9 @@ void FullScreenDialog::deleteLater(bool detach, bool trash)
   }
 }
 
-void FullScreenDialog::setMessage(std::string text)
+void FullScreenDialog::setMessage(const char* text)
 {
-  messageLabel->setText(text);
+  if (messageLabel) messageLabel->setText(text);
 }
 
 static void run_ui_manually()

--- a/radio/src/gui/colorlcd/libui/fullscreen_dialog.h
+++ b/radio/src/gui/colorlcd/libui/fullscreen_dialog.h
@@ -39,7 +39,7 @@ class FullScreenDialog : public Window
   }
 #endif
 
-  void setMessage(std::string text);
+  void setMessage(const char* text);
 
   void onEvent(event_t event) override;
   void onCancel() override;
@@ -83,9 +83,7 @@ class FullScreenDialog : public Window
   bool running = false;
   std::function<bool(void)> closeCondition;
   std::function<void(void)> confirmHandler;
-  StaticText* messageLabel;
+  StaticText* messageLabel = nullptr;
 
   void build();
-
-  void delayedInit() override;
 };


### PR DESCRIPTION
Fix potential crash in full screen dialog.

Can happen when trying to flash multi protocol module.
