### PR TITLE
fix(uf2): prevent being unable to flash when corrupted firmware present

### DIFF
--- a/radio/src/drivers/uf2_ghostfat.cpp
+++ b/radio/src/drivers/uf2_ghostfat.cpp
@@ -223,11 +223,12 @@ static FAT_BootBlock const BootBlock = {
     .ReservedSectors      = RESERVED_SECTORS,
     .FATCopies            = 2,
     .RootDirectoryEntries = (ROOT_DIR_SECTORS * DIRENTRIES_PER_SECTOR),
-    .TotalSectors16       = NUM_FAT_BLOCKS - 2,
+    .TotalSectors16       = 0,
     .MediaDescriptor      = 0xF8,
     .SectorsPerFAT        = SECTORS_PER_FAT,
     .SectorsPerTrack      = 1,
     .Heads                = 1,
+    .TotalSectors32       = NUM_FAT_BLOCKS - 2,
     .PhysicalDriveNum     = 0x80, // to match MediaDescriptor of 0xF8
     .ExtendedBootSig      = 0x29,
     .VolumeSerialNumber   = 0x00000000,
@@ -284,6 +285,9 @@ static uint32_t current_flash_size(void)
     if (is_firmware_valid(fw_desc)) {
       // round up to 256 bytes
       result = (fw_desc->length + BOOTLOADER_SIZE + 255U) & (~255U);
+      // Sometime corrupted firmware return very large size, leave not enough space to flash a fix
+      if (result >= UF2_MAX_FW_SIZE)
+        result = UF2_MAX_FW_SIZE;
     } else {
       result = UF2_MAX_FW_SIZE;
     }

--- a/radio/src/drivers/uf2_ghostfat.h
+++ b/radio/src/drivers/uf2_ghostfat.h
@@ -23,7 +23,7 @@
 
 #include <stdint.h>
 
-#define UF2_NUM_BLOCKS 32768 // at least 16MB
+#define UF2_NUM_BLOCKS 65536 // at least 32MB
 #define UF2_INVALID_NUM_BLOCKS 0xFFFFFFFF
 
 typedef struct {


### PR DESCRIPTION
This fixes UF2:

- a bootloader design flaw where volume size does not allow to store 2 x max firmware size, therefore preventing a new firmware to be flashed is current firmware size is max firmware size. Size is now 33MB

- a bug where current firmware size can report larger than max firmware size if a corrupted firmware is present

This fixes #6765 