### PR TITLE
fix(h7): init rambackup clock so EM process operates correctly

### DIFF
--- a/radio/src/targets/common/arm/stm32/rtc_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/rtc_driver.cpp
@@ -67,6 +67,10 @@ void rtcInit()
   __HAL_RCC_PWR_CLK_ENABLE();
 #endif
 
+#if defined(STM32H7) || defined(STM32H7RS)
+  __HAL_RCC_BKPRAM_CLK_ENABLE();
+#endif
+
   HAL_PWR_EnableBkUpAccess();
 #if defined(LSE_DRIVE_STRENGTH)
   __HAL_RCC_LSE_CONFIG(RCC_LSE_OFF);


### PR DESCRIPTION
ramBackup was not working on H750 radios, which prevented the EM process to reload radio and model data, resulting in a restart, but with no data loaded (therefore useless)

Needed in 2.11, 2.12