### PR TITLE
fix(color): file picker may not work in Lua scripts

### DIFF
--- a/radio/src/gui/colorlcd/libui/filechoice.cpp
+++ b/radio/src/gui/colorlcd/libui/filechoice.cpp
@@ -92,8 +92,8 @@ class FileChoiceMenuToolbar : public MenuToolbar
  protected:
 };
 
-FileChoice::FileChoice(Window *parent, const rect_t &rect, std::string folder,
-                       const char *extension, int maxlen,
+FileChoice::FileChoice(Window *parent, const rect_t &rect, const std::string folder,
+                       const std::string extension, int maxlen,
                        std::function<std::string()> getValue,
                        std::function<void(std::string)> setValue,
                        bool stripExtension, const char *title) :
@@ -101,7 +101,7 @@ FileChoice::FileChoice(Window *parent, const rect_t &rect, std::string folder,
         parent, rect, 0, 0, [=]() { return selectedIdx; },
         [=](int val) { setValue(getString(val)); selectedIdx = val; }, title, CHOICE_TYPE_FOLDER),
     folder(std::move(folder)),
-    extension(extension),
+    extension(std::move(extension)),
     maxlen(maxlen),
     getValue(std::move(getValue)),
     stripExtension(stripExtension)
@@ -113,9 +113,9 @@ std::string FileChoice::getLabelText() { return getValue(); }
 
 void FileChoice::loadFiles()
 {
-  if (loaded) return;
+  if (filesLoaded) return;
 
-  loaded = true;
+  filesLoaded = true;
 
   FILINFO fno;
   DIR dir;
@@ -137,7 +137,7 @@ void FileChoice::loadFiles()
 
       fnExt = getFileExtension(fno.fname, 0, 0, &fnLen, &extLen);
 
-      if (extension && (!fnExt || !isExtensionMatching(fnExt, extension)))
+      if (!extension.empty() && (!fnExt || !isExtensionMatching(fnExt, extension.c_str())))
         continue;  // wrong extension
 
       if (stripExtension) fnLen -= extLen;

--- a/radio/src/gui/colorlcd/libui/filechoice.h
+++ b/radio/src/gui/colorlcd/libui/filechoice.h
@@ -24,8 +24,8 @@
 class FileChoice : public Choice
 {
 public:
-  FileChoice(Window* parent, const rect_t& rect, std::string folder,
-             const char* extension, int maxlen,
+  FileChoice(Window* parent, const rect_t& rect, const std::string folder,
+             const std::string extension, int maxlen,
              std::function<std::string()> getValue,
              std::function<void(std::string)> setValue,
              bool stripExtension = false,
@@ -36,12 +36,13 @@ public:
 #endif
 
 protected:
+  bool filesLoaded = false;
   int fileCount = 0;
   int selectedIdx = -1;
   Menu* menu = nullptr;
   std::string getLabelText() override;
   std::string folder;
-  const char* extension;
+  std::string extension;
   int maxlen;
   std::function<std::string()> getValue;
   bool stripExtension;

--- a/radio/src/gui/colorlcd/mainview/widget_settings.cpp
+++ b/radio/src/gui/colorlcd/mainview/widget_settings.cpp
@@ -198,7 +198,7 @@ WidgetSettings::WidgetSettings(Widget* w) :
         break;
 
       case WidgetOption::File:
-        new FileChoice(line, rect_t{}, opt->fileSelectPath, nullptr, FF_MAX_LFN,
+        new FileChoice(line, rect_t{}, opt->fileSelectPath, "", FF_MAX_LFN,
                         [=]() {
                           return widgetData->getString(optIdx);
                         },

--- a/radio/src/lua/lua_lvgl_widget.cpp
+++ b/radio/src/lua/lua_lvgl_widget.cpp
@@ -2690,7 +2690,7 @@ void LvglWidgetFilePicker::build(lua_State *L)
   if (h == LV_SIZE_CONTENT) h = 0;
   auto c = new FileChoice(
       lvglManager->getCurrentParent(), {x, y, w, h},
-      folder.c_str(), extension.c_str(), maxLen,
+      folder, extension, maxLen,
       [=]() { return pcallGetStringVal(L, getFunction); },
       [=](std::string val) { pcallSetStringVal(L, setFunction, val.c_str()); },
       hideExtension, title.txt.c_str());


### PR DESCRIPTION
Fix file picker to work correctly in Lua scripts.

Also needs to be applied to 2.12 and 3.0.