### PR TITLE
fix(afhds3): modify RF power related issues

### DIFF
--- a/radio/src/gui/colorlcd/module/afhds3_settings.cpp
+++ b/radio/src/gui/colorlcd/module/afhds3_settings.cpp
@@ -93,10 +93,14 @@ AFHDS3Settings::AFHDS3Settings(Window* parent, const FlexGridLayout& g,
   #if defined(RADIO_PL18U) || defined(PCBPA01)
     hasPowerOption = true;
     maxPower = AFHDS3_POWER_500;
+  #if  defined(PCBPA01)
+    md->afhds3.rfPower = afhds3::get_current_rfpower_level(moduleIdx);
+  #endif
   #endif
   } else if (moduleIdx == EXTERNAL_MODULE) {
     hasPowerOption = true;
     maxPower = AFHDS3_FRM303_POWER_MAX;
+    md->afhds3.rfPower = afhds3::get_current_rfpower_level(moduleIdx);
   }
 
   if (hasPowerOption) {

--- a/radio/src/pulses/afhds3.h
+++ b/radio/src/pulses/afhds3.h
@@ -69,7 +69,7 @@ typedef PulsesData ExtmoduleData;
 #if defined(INTERNAL_MODULE_AFHDS3)
 typedef SerialData IntmoduleData;
 #endif
-
+uint8_t get_current_rfpower_level( uint8_t module );
 extern etx_proto_driver_t ProtoDriver;
 
 void getStatusString(uint8_t module, char* buffer);

--- a/radio/src/pulses/afhds3_transport.h
+++ b/radio/src/pulses/afhds3_transport.h
@@ -48,6 +48,7 @@ enum COMMAND : uint8_t {
   TELEMETRY_DATA = 0x09,
   SEND_COMMAND = 0x0C,
   COMMAND_RESULT = 0x0D,
+  MODULE_RFPOWER = 0x13, //PA01 Internal RF module only
   MODULE_VERSION = 0x20,
   MODEL_ID = 0x2F,
   VIRTUAL_FAILSAFE = 0x99,  // virtual command used to trigger failsafe

--- a/radio/src/telemetry/flysky_ibus.cpp
+++ b/radio/src/telemetry/flysky_ibus.cpp
@@ -202,6 +202,8 @@ const FlySkySensor flySkySensors[] = {
 };
 // clang-format on
 
+uint16_t  sns_RFCurrentPower;
+
 int32_t getALT(uint32_t value);
 inline int setFlyskyTelemetryValue( int16_t type, uint8_t instance, int32_t value, uint32_t unit, uint32_t prec)
 {
@@ -240,6 +242,7 @@ void processFlySkyAFHDS3Sensor(const uint8_t * packet, uint8_t len )
       uint8_t data2[] = { (uint8_t)(SENSOR_TYPE_RF_MODULE_VOL>>8), (uint8_t)SENSOR_TYPE_RF_MODULE_VOL, id, packet[4], packet[5] };
       uint8_t data3[] = { (uint8_t)(SENSOR_TYPE_RF_MODULE_POWER>>8), (uint8_t)SENSOR_TYPE_RF_MODULE_POWER, id, packet[8], packet[9] };
 //      uint8_t data4[] = { (uint8_t)(SENSOR_TYPE_RF_MODULE_RAW>>8), (uint8_t)SENSOR_TYPE_RF_MODULE_RAW, id, packet[6] & 0x07};
+      sns_RFCurrentPower = (packet[9]<<8)+packet[8];
 
       processFlySkyAFHDS3Sensor(data1, 1 );
       processFlySkyAFHDS3Sensor(data2, 2 );


### PR DESCRIPTION
1.The RF module power can be modified even when the RX is not connected.
2.Fixed the issue of inconsistency between the displayed power of the RADIO and the actual power of the RF module.

