### PR TITLE
fix(color): radio may crash when using key shortcuts

### DIFF
--- a/radio/src/gui/colorlcd/setup_menus/quick_menu.cpp
+++ b/radio/src/gui/colorlcd/setup_menus/quick_menu.cpp
@@ -509,6 +509,7 @@ void QuickMenu::onSelect(bool close)
 {
   closeMenu();
   if (selectHandler) selectHandler(close);
+  selectHandler = nullptr;
 }
 
 void QuickMenu::closeMenu()
@@ -516,6 +517,7 @@ void QuickMenu::closeMenu()
   Layer::pop(this);
   hide();
   if (cancelHandler) cancelHandler();
+  cancelHandler = nullptr;
 }
 
 void QuickMenu::onCancel()


### PR DESCRIPTION
Fix potential crash when using key shortcuts to navigate to menu pages.

Applies to 2.12 and 3.0.