### PR TITLE
fix(color): shortcut override and quick menu favorites not saved to YAML files

### DIFF
--- a/radio/src/storage/yaml/yaml_datastructs_f16.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_f16.cpp
@@ -447,8 +447,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "modelQuickSelect", 1 ),
   YAML_PADDING( 5 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
-  YAML_PADDING( 48 ),
-  YAML_PADDING( 96 ),
+  YAML_ARRAY("keyShortcuts", 8, 6, struct_QuickMenuPage, NULL),
+  YAML_ARRAY("qmFavorites", 8, 12, struct_QuickMenuPage, NULL),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_nb4p.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_nb4p.cpp
@@ -438,8 +438,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "modelQuickSelect", 1 ),
   YAML_PADDING( 5 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
-  YAML_PADDING( 48 ),
-  YAML_PADDING( 96 ),
+  YAML_ARRAY("keyShortcuts", 8, 6, struct_QuickMenuPage, NULL),
+  YAML_ARRAY("qmFavorites", 8, 12, struct_QuickMenuPage, NULL),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
@@ -445,8 +445,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "modelQuickSelect", 1 ),
   YAML_PADDING( 5 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
-  YAML_PADDING( 48 ),
-  YAML_PADDING( 96 ),
+  YAML_ARRAY("keyShortcuts", 8, 6, struct_QuickMenuPage, NULL),
+  YAML_ARRAY("qmFavorites", 8, 12, struct_QuickMenuPage, NULL),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_pa01.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_pa01.cpp
@@ -470,8 +470,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "modelQuickSelect", 1 ),
   YAML_PADDING( 5 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
-  YAML_PADDING( 48 ),
-  YAML_PADDING( 96 ),
+  YAML_ARRAY("keyShortcuts", 8, 6, struct_QuickMenuPage, NULL),
+  YAML_ARRAY("qmFavorites", 8, 12, struct_QuickMenuPage, NULL),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_pl18.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_pl18.cpp
@@ -445,8 +445,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "modelQuickSelect", 1 ),
   YAML_PADDING( 5 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
-  YAML_PADDING( 48 ),
-  YAML_PADDING( 96 ),
+  YAML_ARRAY("keyShortcuts", 8, 6, struct_QuickMenuPage, NULL),
+  YAML_ARRAY("qmFavorites", 8, 12, struct_QuickMenuPage, NULL),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_pl18u.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_pl18u.cpp
@@ -438,8 +438,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "modelQuickSelect", 1 ),
   YAML_PADDING( 5 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
-  YAML_PADDING( 48 ),
-  YAML_PADDING( 96 ),
+  YAML_ARRAY("keyShortcuts", 8, 6, struct_QuickMenuPage, NULL),
+  YAML_ARRAY("qmFavorites", 8, 12, struct_QuickMenuPage, NULL),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_st16.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_st16.cpp
@@ -470,8 +470,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "modelQuickSelect", 1 ),
   YAML_PADDING( 5 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
-  YAML_PADDING( 48 ),
-  YAML_PADDING( 96 ),
+  YAML_ARRAY("keyShortcuts", 8, 6, struct_QuickMenuPage, NULL),
+  YAML_ARRAY("qmFavorites", 8, 12, struct_QuickMenuPage, NULL),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_t15.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t15.cpp
@@ -455,8 +455,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "modelQuickSelect", 1 ),
   YAML_PADDING( 5 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
-  YAML_PADDING( 48 ),
-  YAML_PADDING( 96 ),
+  YAML_ARRAY("keyShortcuts", 8, 6, struct_QuickMenuPage, NULL),
+  YAML_ARRAY("qmFavorites", 8, 12, struct_QuickMenuPage, NULL),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_t15pro.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t15pro.cpp
@@ -470,8 +470,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "modelQuickSelect", 1 ),
   YAML_PADDING( 5 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
-  YAML_PADDING( 48 ),
-  YAML_PADDING( 96 ),
+  YAML_ARRAY("keyShortcuts", 8, 6, struct_QuickMenuPage, NULL),
+  YAML_ARRAY("qmFavorites", 8, 12, struct_QuickMenuPage, NULL),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_tx15.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tx15.cpp
@@ -470,8 +470,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "modelQuickSelect", 1 ),
   YAML_PADDING( 5 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
-  YAML_PADDING( 48 ),
-  YAML_PADDING( 96 ),
+  YAML_ARRAY("keyShortcuts", 8, 6, struct_QuickMenuPage, NULL),
+  YAML_ARRAY("qmFavorites", 8, 12, struct_QuickMenuPage, NULL),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {

--- a/radio/src/storage/yaml/yaml_datastructs_x10.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x10.cpp
@@ -446,8 +446,8 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_UNSIGNED( "modelQuickSelect", 1 ),
   YAML_PADDING( 5 ),
   YAML_UNSIGNED( "pwrOffIfInactive", 8 ),
-  YAML_PADDING( 48 ),
-  YAML_PADDING( 96 ),
+  YAML_ARRAY("keyShortcuts", 8, 6, struct_QuickMenuPage, NULL),
+  YAML_ARRAY("qmFavorites", 8, 12, struct_QuickMenuPage, NULL),
   YAML_END
 };
 static const struct YamlNode struct_unsigned_8[] = {


### PR DESCRIPTION
Fix yaml parser definitions for 3.0 UI version (keyboard shortcuts and favorites missing).
