### PR TITLE
fix(cpn): show correct icon on Linux when using Gnome

### DIFF
--- a/companion/targets/linux/companion.desktop.in
+++ b/companion/targets/linux/companion.desktop.in
@@ -6,5 +6,6 @@ Comment=The Ultimate Transmitter Companion
 Icon=@COMPANION_NAME@
 Exec=@COMPANION_NAME@
 Terminal=false
+StartupWMClass=EdgeTX Companion
 StartupNotify=false
 Categories=Utility;


### PR DESCRIPTION
Fixes #
Gnome Desktop Environment requires the StartupWMClass. If its not present it will not show the application icon in the taskbar or task switcher. It will show a default icon instead then.

See screenshot here. Companion is the Icon on the very right:
.
<img width="1300" height="822" alt="Bildschirmfoto vom 2025-11-28 21-03-05" src="https://github.com/user-attachments/assets/34f15b21-a4a4-4148-b93d-3a49f547131e" />

This is with the StartupWMClass:
<img width="1300" height="822" alt="Bildschirmfoto vom 2025-11-28 21-10-01" src="https://github.com/user-attachments/assets/94f53d97-77f1-4971-acb7-5c5f3d4f605a" />


