### PR TITLE
fix(pxx1): upstream telemetry buffer alignment

### DIFF
--- a/radio/src/pulses/pxx1.cpp
+++ b/radio/src/pulses/pxx1.cpp
@@ -275,7 +275,11 @@ static void pxx1SportSensorPolling(void* param)
       b != outputTelemetryBuffer.sport.physicalId)
     return;
 
-  drv->sendBuffer(ctx, outputTelemetryBuffer.data + 1,
+  // fix alignement for DMA
+  memmove(outputTelemetryBuffer.data, outputTelemetryBuffer.data + 1,
+          outputTelemetryBuffer.size - 1);
+
+  drv->sendBuffer(ctx, outputTelemetryBuffer.data,
                   outputTelemetryBuffer.size - 1);
 
   outputTelemetryBuffer.reset();


### PR DESCRIPTION
Fixes #6618, fixes #6219

Summary of changes:
- shift the output telemetry buffer by 1 byte to fix alignment when sent using DMA.
