### PR TITLE
fix(color): top level quick menu items are not dimmed when sub menu selected.

### DIFF
--- a/radio/src/gui/colorlcd/setup_menus/quick_menu_group.cpp
+++ b/radio/src/gui/colorlcd/setup_menus/quick_menu_group.cpp
@@ -24,6 +24,7 @@
 #include "bitmaps.h"
 #include "button.h"
 #include "static.h"
+#include "quick_menu_def.h"
 
 static void etx_quick_button_constructor(const lv_obj_class_t* class_p,
                                          lv_obj_t* obj)


### PR DESCRIPTION
Fix for quick menu top level not showing dimmed state.