### PR TITLE
fix(pa01): occasional Read/Write Failures on SD Card​

### DIFF
--- a/radio/src/targets/common/arm/stm32/diskio_sdio.cpp
+++ b/radio/src/targets/common/arm/stm32/diskio_sdio.cpp
@@ -138,8 +138,11 @@ struct {
 #endif
 
 #define BLOCK_SIZE FF_MAX_SS
-#define SD_TIMEOUT 300 /* 300ms */
-
+#if defined(RADIO_PA01)
+  #define SD_TIMEOUT 1000 /* 1000ms */
+#else
+  #define SD_TIMEOUT 300 /* 300ms */
+#endif
 #if defined(STM32F4)
 extern uint32_t _sram;
 extern uint32_t _heap_start;


### PR DESCRIPTION
There's a chance the system won't read RADIO data during startup. Troubleshooting revealed that the timeout was too short.
