### PR TITLE
chore(ci): bump to MacOS 14 for Companion builds

### DIFF
--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -27,7 +27,7 @@ env:
 
 jobs:
   build:
-    runs-on: macos-15
+    runs-on: macos-15-intel
     if: |
       github.event_name != 'pull_request' ||
       !contains(github.event.pull_request.labels.*.name, 'ci: skip-cpn-macos')


### PR DESCRIPTION
Per the "two latest releases" GitHub policy and actions/runner-images#13046, macOS 13 Ventura is no longer available as of the 8th of December, 2025.

The macos-15-intel image will be available until August, 2027, after which point Apple Silicon support will be the only supported option. c.f. https://github.com/actions/runner-images/issues/13045

