### PR TITLE
fix(radio): radio settings may be incorrect after updating from Companion

### DIFF
--- a/radio/src/storage/sdcard_common.cpp
+++ b/radio/src/storage/sdcard_common.cpp
@@ -222,6 +222,8 @@ void storageReadAll()
 {
   TRACE("storageReadAll");
 
+  memset(&g_eeGeneral, 0, sizeof(g_eeGeneral));
+
 #if defined(STORAGE_MODELSLIST)
   // Wipe models list in case
   // it's being reloaded after USB connection

--- a/radio/src/storage/sdcard_common.h
+++ b/radio/src/storage/sdcard_common.h
@@ -63,7 +63,4 @@ bool storageReadRadioSettings(bool checks);
 const char * loadRadioSettings();
 const char * writeGeneralSettings();
 
-const char * loadRadioSettings(const char * path);
-const char * loadRadioSettings();
-
 void checkModelIdUnique(uint8_t index, uint8_t module);


### PR DESCRIPTION
Clear radio data before reading YAML.

Fixes #6552 

Required for 2.11, 2.12 and 3.0.