### PR TITLE
fix(cpn): failure to load radio.yml file if quick menu favorites configured

### DIFF
--- a/companion/src/firmwares/edgetx/yaml_generalsettings.cpp
+++ b/companion/src/firmwares/edgetx/yaml_generalsettings.cpp
@@ -719,7 +719,8 @@ bool convert<GeneralSettings>::decode(const Node& node, GeneralSettings& rhs)
   }
   if (node["qmFavorites"]) {
     for (int i = 0; i < MAX_QMFAVOURITES; i += 1)
-      node["qmFavorites"][std::to_string(i)]["shortcut"] >> QMPageLut >> rhs.qmFavorites[i];
+      if (node["qmFavorites"][std::to_string(i)])
+        node["qmFavorites"][std::to_string(i)]["shortcut"] >> QMPageLut >> rhs.qmFavorites[i];
   }
 
   //  override critical settings after import


### PR DESCRIPTION
Fix reading of radio.yml if quick menu favorites are set.

Required for 2.12 and 3.0.