### PR TITLE
fix(color): number edit control does not size properly when width set to a percentage

### DIFF
--- a/radio/src/gui/colorlcd/libui/numberedit.cpp
+++ b/radio/src/gui/colorlcd/libui/numberedit.cpp
@@ -214,11 +214,15 @@ NumberEdit::NumberEdit(Window* parent, const rect_t& rect, int vmin, int vmax,
     vmin(vmin),
     vmax(vmax)
 {
-  if (rect.w == 0) setWidth(EdgeTxStyles::EDIT_FLD_WIDTH);
+  if (rect.w == 0 || rect.w == LV_SIZE_CONTENT) setWidth(EdgeTxStyles::EDIT_FLD_WIDTH);
 
   setTextFlag(textFlags);
 
-  lv_obj_set_width(label, width() - PAD_MEDIUM * 2 - 2);
+  padLeft(PAD_MEDIUM);
+  padRight(PAD_SMALL);
+
+  lv_obj_set_width(label, LV_PCT(100));
+
   if (textFlags & CENTERED)
     etx_obj_add_style(label, styles->text_align_center, LV_PART_MAIN);
   else


### PR DESCRIPTION
Fixed to make it easier to do layouts in Lua scripts.

Required in 2.11, 2.12 and 3.0.
