### PR TITLE
fix(lua): event handling may not work when using the Lua 'page' object

### DIFF
--- a/radio/src/lua/lua_lvgl_widget.cpp
+++ b/radio/src/lua/lua_lvgl_widget.cpp
@@ -2349,6 +2349,7 @@ class WidgetPage : public NavWindow, public LuaEventHandler
   {
     if (prevBtn) prevBtn->enable(prevActive());
     if (nextBtn) nextBtn->enable(nextActive());
+    NavWindow::checkEvents();
   }
 };
 


### PR DESCRIPTION
Fix event handling for child objects inside a 'page' object.

Required for 2.11, 2.12 and 3.0.