### PR TITLE
fix: display of mixer max time

### DIFF
--- a/radio/src/edgetx.h
+++ b/radio/src/edgetx.h
@@ -312,7 +312,7 @@ bool setTrimValue(uint8_t phase, uint8_t idx, int trim);
 
 void flightReset(uint8_t check=true);
 
-#define DURATION_MS_PREC2(x) ((x)/20)
+#define DURATION_MS_PREC2(x) ((x)/10)
 
 #if defined(THRTRACE)
   #if defined(COLORLCD)


### PR DESCRIPTION
Historically, the duration of mixer run was recorded using a 2 MHz timer, but this has changes and is now using timersGetUsTick(), but the display computation was not changed, resulting to a display value divided by 2 compared to real running time..

Needed for 2.11 and 2.12 also