### PR TITLE
feat: add 'unplug USB' message to trigger_watchdog_reset

### DIFF
--- a/radio/src/cli.cpp
+++ b/radio/src/cli.cpp
@@ -1738,6 +1738,9 @@ int cliCrypt(const char ** argv)
 
 int cliTriggerEM(const char** argv)
 {
+  // Wait USB unplug since that could interfere
+  cliSerialPrint("Please unplug USB");
+  while (usbPlugged()) {}
   // Prevent task switching
   vTaskSuspendAll();
   // Trigger watchdog


### PR DESCRIPTION
When testing EM from CLI, the USB plugged for cli could interfere depending on radio hardware and/or firmware options. This asks the tester to unplug USB, then trigger the EM reset.

for 2.12 as well please