### PR TITLE
fix(color): navigation buttons are not place correctly in Lua 'page'.

### DIFF
--- a/radio/src/lua/lua_lvgl_widget.cpp
+++ b/radio/src/lua/lua_lvgl_widget.cpp
@@ -2302,13 +2302,13 @@ class WidgetPage : public NavWindow, public LuaEventHandler
   {
 #if defined(HARDWARE_TOUCH)
     if (showPrev) {
-      prevBtn = new IconButton(this, ICON_BTN_PREV, LCD_W - PageGroup::PAGE_GROUP_BACK_BTN_W * 3, PAD_MEDIUM, [=]() {
+      prevBtn = new IconButton(this, ICON_BTN_PREV, LCD_W - PageGroup::PAGE_GROUP_TOP_BAR_H * 3, PAD_MEDIUM, [=]() {
         prevAction();
         return 0;
       });
     }
     if (showNext) {
-      nextBtn = new IconButton(this, ICON_BTN_NEXT, LCD_W - PageGroup::PAGE_GROUP_BACK_BTN_W * 2, PAD_MEDIUM, [=]() {
+      nextBtn = new IconButton(this, ICON_BTN_NEXT, LCD_W - PageGroup::PAGE_GROUP_TOP_BAR_H * 2, PAD_MEDIUM, [=]() {
         nextAction();
         return 0;
       });


### PR DESCRIPTION
Fix nav button positions for 2.12.

Not required for 3.0.
