### PR TITLE
fix: make sure debug build bootloader always handles USB

### DIFF
--- a/radio/src/targets/common/arm/stm32/usb_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/usb_driver.cpp
@@ -84,7 +84,7 @@ void setSelectedUsbMode(int mode)
 #if defined(USB_GPIO_VBUS)
 int usbPlugged()
 {
-#if defined(DEBUG_DISABLE_USB)
+#if defined(DEBUG_DISABLE_USB) && !defined(BOOT)
   return false;
 #endif
 


### PR DESCRIPTION
This is a developper and partners related change that ensure bootloader stays fully functional (especially on H7) when debug builds are shared for testing. No end user impacts

For 2.12 also please