### PR TITLE
fix(color): radio may crash if model yaml file does not contain any screen definitions

### DIFF
--- a/radio/src/datastructs_model.cpp
+++ b/radio/src/datastructs_model.cpp
@@ -197,6 +197,11 @@ void ModelData::cfsSetOffColorLuaOverride(uint8_t n, bool v) {
 static TopBarPersistentData _topbarData;
 static CustomScreenData* _screenData[MAX_CUSTOM_SCREENS];
 
+bool ModelData::hasScreenData(int screenNum)
+{
+  return _screenData[screenNum] != nullptr;
+}
+
 CustomScreenData* ModelData::getScreenData(int screenNum)
 {
   if (_screenData[screenNum] == nullptr) {

--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -835,6 +835,7 @@ PACK(struct ModelData {
   const char* getScreenLayoutId(int screenNum);
   void setScreenLayoutId(int screenNum, const char* s);
   TopBarPersistentData* getTopbarData();
+  bool hasScreenData(int screenNum);
   CustomScreenData* getScreenData(int screenNum);
   LayoutPersistentData* getScreenLayoutData(int screenNum);
   WidgetPersistentData* getWidgetData(int screenNum, int zoneNum);

--- a/radio/src/storage/storage_common.cpp
+++ b/radio/src/storage/storage_common.cpp
@@ -161,6 +161,9 @@ static void sanitizeMixerLines()
 void postModelLoad(bool alarms)
 {
 #if defined(COLORLCD)
+  if (!g_model.hasScreenData(0))
+    LayoutFactory::loadDefaultLayout();
+
   if (g_model.topbarWidgetWidth[0] == 0) {
     // Set default width for top bar widgets
     for (int i = 0; i < MAX_TOPBAR_ZONES; i += 1)


### PR DESCRIPTION
Load default screen layout if there is no screen data in model yaml file.

Fixes #6911

Required for 2.12 and 3.0.