### PR TITLE
fix(radio): disable gyro in USB storage mode

### DIFF
--- a/radio/src/gyro.cpp
+++ b/radio/src/gyro.cpp
@@ -24,6 +24,7 @@
 #include "debug.h"
 #define _USE_MATH_DEFINES
 #include <math.h>
+#include "hal/usb_driver.h"
 
 #define ACC_LSB_VALUE	0.000488  // 0.488 mg/LSB
 
@@ -47,7 +48,7 @@ void Gyro::wakeup()
   static tmr10ms_t gyroWakeupTime = 0;
 
   tmr10ms_t now = get_tmr10ms();
-  if (errors >= 100 || now < gyroWakeupTime)
+  if (errors >= 100 || now < gyroWakeupTime || usbPluggedInStorageMode())
     return;
 
   gyroWakeupTime = now + 1; /* 10ms default */

--- a/radio/src/hal/CMakeLists.txt
+++ b/radio/src/hal/CMakeLists.txt
@@ -11,6 +11,7 @@ set(SRC ${SRC}
   hal/module_port.cpp
   hal/adc_driver.cpp
   hal/switch_driver.cpp
+  hal/usb_driver.cpp
 )
 
 if(FUNCTION_SWITCHES)

--- a/radio/src/hal/usb_driver.cpp
+++ b/radio/src/hal/usb_driver.cpp
@@ -1,0 +1,37 @@
+/*
+* Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "usb_driver.h"
+
+bool usbPluggedInStorageMode()
+{
+  return usbPlugged() && getSelectedUsbMode() == USB_MASS_STORAGE_MODE;
+}
+
+bool usbPluggedInJoystickMode()
+{
+  return usbPlugged() && getSelectedUsbMode() == USB_JOYSTICK_MODE;
+}
+
+bool usbPluggedInVCPMode()
+{
+  return usbPlugged() && getSelectedUsbMode() == USB_SERIAL_MODE;
+}

--- a/radio/src/hal/usb_driver.h
+++ b/radio/src/hal/usb_driver.h
@@ -50,6 +50,9 @@ void usbInit();
 void usbStart();
 void usbStop();
 bool usbStarted();
+bool usbPluggedInStorageMode();
+bool usbPluggedInJoystickMode();
+bool usbPluggedInVCPMode();
 
 EXTERN_C(int getSelectedUsbMode());
 void setSelectedUsbMode(int mode);


### PR DESCRIPTION
During debugging, I often see gyro reads errors message when in storage mode. This simply disables it when in storage mode.

Would be nice for 2.12 too