### PR TITLE
chore(color): leave compressed bitmap data in flash memory

### DIFF
--- a/radio/src/fonts/lvgl/lrg/lv_font_cn_L.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_cn_L.c
@@ -8614,11 +8614,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x18,0x08,0x3e,0x00,0x14,0x89,0x13,0x06,0x50,0xf0,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 621, .type = 3, .unicode_list = 4976, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_cn_L = {
+const etxLz4Font lv_font_cn_L __FLASH = {
 .uncomp_size = 297624,
 .comp_size = 137758,
 .line_height = 33,

--- a/radio/src/fonts/lvgl/lrg/lv_font_cn_XS.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_cn_XS.c
@@ -4248,11 +4248,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 621, .type = 3, .unicode_list = 4976, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_cn_XS = {
+const etxLz4Font lv_font_cn_XS __FLASH = {
 .uncomp_size = 96398,
 .comp_size = 67890,
 .line_height = 18,

--- a/radio/src/fonts/lvgl/lrg/lv_font_cn_XXS.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_cn_XXS.c
@@ -2534,11 +2534,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0x02,0xc0,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 621, .type = 3, .unicode_list = 4976, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_cn_XXS = {
+const etxLz4Font lv_font_cn_XXS __FLASH = {
 .uncomp_size = 49419,
 .comp_size = 40468,
 .line_height = 13,

--- a/radio/src/fonts/lvgl/lrg/lv_font_cn_bold_STD.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_cn_bold_STD.c
@@ -5874,11 +5874,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x02,0x0b,0x00,0xa0,0x06,0xa0,0x00,0x00,0x00,0x03,0xff,0x80,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 621, .type = 3, .unicode_list = 4976, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_cn_bold_STD = {
+const etxLz4Font lv_font_cn_bold_STD __FLASH = {
 .uncomp_size = 147605,
 .comp_size = 93918,
 .line_height = 23,

--- a/radio/src/fonts/lvgl/lrg/lv_font_cn_bold_XL.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_cn_bold_XL.c
@@ -11984,11 +11984,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x59,0x09,0x07,0x7e,0x00,0x27,0x1c,0x40,0x15,0x00,0x50,0x50,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 621, .type = 3, .unicode_list = 4976, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_cn_bold_XL = {
+const etxLz4Font lv_font_cn_bold_XL __FLASH = {
 .uncomp_size = 544774,
 .comp_size = 191680,
 .line_height = 45,

--- a/radio/src/fonts/lvgl/lrg/lv_font_en_L.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_en_L.c
@@ -1409,14 +1409,14 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x02,0x00,0xc0,0x11,0x00,0x13,0x1f,0x13,0x14,0x22,0x14,0x22,0x14,0x22,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 32, .range_length = 95, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 136, .range_length = 15, .glyph_id_start = 96, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 176, .range_length = 1, .glyph_id_start = 111, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 192, .range_length = 192, .glyph_id_start = 112, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_en_L = {
+const etxLz4Font lv_font_en_L __FLASH = {
 .uncomp_size = 69586,
 .comp_size = 22479,
 .line_height = 42,

--- a/radio/src/fonts/lvgl/lrg/lv_font_en_XS.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_en_XS.c
@@ -1135,7 +1135,7 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x26,0x50,0x00,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 32, .range_length = 95, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 128, .range_length = 4, .glyph_id_start = 96, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 136, .range_length = 15, .glyph_id_start = 100, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
@@ -1144,7 +1144,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 8226, .range_length = 55425, .glyph_id_start = 308, .list_length = 62, .type = 3, .unicode_list = 2960, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_en_XS = {
+const etxLz4Font lv_font_en_XS __FLASH = {
 .uncomp_size = 34875,
 .comp_size = 18087,
 .line_height = 23,

--- a/radio/src/fonts/lvgl/lrg/lv_font_en_XXS.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_en_XXS.c
@@ -752,7 +752,7 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x1f,0x00,0x74,0x01,0x26,0x50,0x00,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 32, .range_length = 95, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 128, .range_length = 4, .glyph_id_start = 96, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 136, .range_length = 15, .glyph_id_start = 100, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
@@ -761,7 +761,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 8226, .range_length = 55425, .glyph_id_start = 308, .list_length = 62, .type = 3, .unicode_list = 2960, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_en_XXS = {
+const etxLz4Font lv_font_en_XXS __FLASH = {
 .uncomp_size = 19827,
 .comp_size = 11963,
 .line_height = 17,

--- a/radio/src/fonts/lvgl/lrg/lv_font_en_bold_STD.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_en_bold_STD.c
@@ -1430,7 +1430,7 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x26,0x50,0x00,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 32, .range_length = 95, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 128, .range_length = 4, .glyph_id_start = 96, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 136, .range_length = 15, .glyph_id_start = 100, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
@@ -1439,7 +1439,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 8226, .range_length = 55425, .glyph_id_start = 308, .list_length = 62, .type = 3, .unicode_list = 2960, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_en_bold_STD = {
+const etxLz4Font lv_font_en_bold_STD __FLASH = {
 .uncomp_size = 50388,
 .comp_size = 22807,
 .line_height = 27,

--- a/radio/src/fonts/lvgl/lrg/lv_font_en_bold_XL.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_en_bold_XL.c
@@ -1733,13 +1733,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x14,0x22,0x14,0x22,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 32, .range_length = 95, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 176, .range_length = 1, .glyph_id_start = 96, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 192, .range_length = 192, .glyph_id_start = 97, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_en_bold_XL = {
+const etxLz4Font lv_font_en_bold_XL __FLASH = {
 .uncomp_size = 114986,
 .comp_size = 27653,
 .line_height = 55,

--- a/radio/src/fonts/lvgl/lrg/lv_font_en_bold_XXL.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_en_bold_XXL.c
@@ -1576,12 +1576,12 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 32, .range_length = 95, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 176, .range_length = 1, .glyph_id_start = 96, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_en_bold_XXL = {
+const etxLz4Font lv_font_en_bold_XXL __FLASH = {
 .uncomp_size = 114327,
 .comp_size = 25137,
 .line_height = 93,

--- a/radio/src/fonts/lvgl/lrg/lv_font_he_L.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_he_L.c
@@ -161,12 +161,12 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0x6f,0xd0,0x00,0x03,0xff,0x10,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1488, .range_length = 27, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1524, .range_length = 1, .glyph_id_start = 28, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_he_L = {
+const etxLz4Font lv_font_he_L __FLASH = {
 .uncomp_size = 4752,
 .comp_size = 2504,
 .line_height = 34,

--- a/radio/src/fonts/lvgl/lrg/lv_font_he_XS.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_he_XS.c
@@ -85,12 +85,12 @@ static const uint8_t lz4FontData[] __FLASH = {
 0xf4,0x00,0x9f,0x00,0xae,0x00,0x0c,0xa0,0x0d,0x90,0x00,0xf4,0x01,0xf3,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1488, .range_length = 27, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1524, .range_length = 1, .glyph_id_start = 28, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_he_XS = {
+const etxLz4Font lv_font_he_XS __FLASH = {
 .uncomp_size = 1657,
 .comp_size = 1295,
 .line_height = 19,

--- a/radio/src/fonts/lvgl/lrg/lv_font_he_XXS.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_he_XXS.c
@@ -52,12 +52,12 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x10,0x00,0xc5,0x07,0x22,0x70,0x2f,0x18,0xa0,0x6a,0x0c,0x40,0x94,0x0d,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1488, .range_length = 27, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1524, .range_length = 1, .glyph_id_start = 28, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_he_XXS = {
+const etxLz4Font lv_font_he_XXS __FLASH = {
 .uncomp_size = 873,
 .comp_size = 767,
 .line_height = 12,

--- a/radio/src/fonts/lvgl/lrg/lv_font_he_bold_STD.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_he_bold_STD.c
@@ -114,12 +114,12 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x5f,0xc0,0x09,0xf9,0x00,0x9f,0x60,0x0c,0xf3,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1488, .range_length = 27, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1524, .range_length = 1, .glyph_id_start = 28, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_he_bold_STD = {
+const etxLz4Font lv_font_he_bold_STD __FLASH = {
 .uncomp_size = 2472,
 .comp_size = 1754,
 .line_height = 22,

--- a/radio/src/fonts/lvgl/lrg/lv_font_he_bold_XL.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_he_bold_XL.c
@@ -227,12 +227,12 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x10,0xa0,0x96,0x02,0x80,0xa0,0x00,0x00,0xaf,0xff,0x40,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1488, .range_length = 27, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1524, .range_length = 1, .glyph_id_start = 28, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_he_bold_XL = {
+const etxLz4Font lv_font_he_bold_XL __FLASH = {
 .uncomp_size = 9024,
 .comp_size = 3565,
 .line_height = 45,

--- a/radio/src/fonts/lvgl/lrg/lv_font_jp_L.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_jp_L.c
@@ -5007,14 +5007,14 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 147, .glyph_id_start = 1, .list_length = 45, .type = 3, .unicode_list = 3200, .glyph_id_ofs_list = 0 },
 { .range_start = 12449, .range_length = 49, .glyph_id_start = 46, .list_length = 49, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 3290 },
 { .range_start = 12499, .range_length = 27, .glyph_id_start = 89, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 12527, .range_length = 27114, .glyph_id_start = 116, .list_length = 284, .type = 3, .unicode_list = 3339, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_jp_L = {
+const etxLz4Font lv_font_jp_L __FLASH = {
 .uncomp_size = 185634,
 .comp_size = 80034,
 .line_height = 33,

--- a/radio/src/fonts/lvgl/lrg/lv_font_jp_XS.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_jp_XS.c
@@ -2572,14 +2572,14 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x50,0x00,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 147, .glyph_id_start = 1, .list_length = 45, .type = 3, .unicode_list = 3200, .glyph_id_ofs_list = 0 },
 { .range_start = 12449, .range_length = 49, .glyph_id_start = 46, .list_length = 49, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 3290 },
 { .range_start = 12499, .range_length = 27, .glyph_id_start = 89, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 12527, .range_length = 27114, .glyph_id_start = 116, .list_length = 284, .type = 3, .unicode_list = 3339, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_jp_XS = {
+const etxLz4Font lv_font_jp_XS __FLASH = {
 .uncomp_size = 65521,
 .comp_size = 41078,
 .line_height = 18,

--- a/radio/src/fonts/lvgl/lrg/lv_font_jp_XXS.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_jp_XXS.c
@@ -1572,14 +1572,14 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x02,0x50,0x00,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 147, .glyph_id_start = 1, .list_length = 45, .type = 3, .unicode_list = 3200, .glyph_id_ofs_list = 0 },
 { .range_start = 12449, .range_length = 49, .glyph_id_start = 46, .list_length = 49, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 3290 },
 { .range_start = 12499, .range_length = 27, .glyph_id_start = 89, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 12527, .range_length = 27114, .glyph_id_start = 116, .list_length = 284, .type = 3, .unicode_list = 3339, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_jp_XXS = {
+const etxLz4Font lv_font_jp_XXS __FLASH = {
 .uncomp_size = 37385,
 .comp_size = 25079,
 .line_height = 13,

--- a/radio/src/fonts/lvgl/lrg/lv_font_jp_bold_STD.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_jp_bold_STD.c
@@ -3512,14 +3512,14 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x50,0x00,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 147, .glyph_id_start = 1, .list_length = 45, .type = 3, .unicode_list = 3200, .glyph_id_ofs_list = 0 },
 { .range_start = 12449, .range_length = 49, .glyph_id_start = 46, .list_length = 49, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 3290 },
 { .range_start = 12499, .range_length = 27, .glyph_id_start = 89, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 12527, .range_length = 27114, .glyph_id_start = 116, .list_length = 284, .type = 3, .unicode_list = 3339, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_jp_bold_STD = {
+const etxLz4Font lv_font_jp_bold_STD __FLASH = {
 .uncomp_size = 96349,
 .comp_size = 56118,
 .line_height = 23,

--- a/radio/src/fonts/lvgl/lrg/lv_font_jp_bold_XL.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_jp_bold_XL.c
@@ -7000,14 +7000,14 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 147, .glyph_id_start = 1, .list_length = 45, .type = 3, .unicode_list = 3200, .glyph_id_ofs_list = 0 },
 { .range_start = 12449, .range_length = 49, .glyph_id_start = 46, .list_length = 49, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 3290 },
 { .range_start = 12499, .range_length = 27, .glyph_id_start = 89, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 12527, .range_length = 27114, .glyph_id_start = 116, .list_length = 284, .type = 3, .unicode_list = 3339, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_jp_bold_XL = {
+const etxLz4Font lv_font_jp_bold_XL __FLASH = {
 .uncomp_size = 335050,
 .comp_size = 111922,
 .line_height = 44,

--- a/radio/src/fonts/lvgl/lrg/lv_font_ko_L.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_ko_L.c
@@ -4142,11 +4142,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 44032, .range_length = 11145, .glyph_id_start = 1, .list_length = 446, .type = 3, .unicode_list = 3576, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ko_L = {
+const etxLz4Font lv_font_ko_L __FLASH = {
 .uncomp_size = 165478,
 .comp_size = 66195,
 .line_height = 34,

--- a/radio/src/fonts/lvgl/lrg/lv_font_ko_XS.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_ko_XS.c
@@ -2069,11 +2069,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x80,0xe0,0x00,0x00,0x00,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 44032, .range_length = 11145, .glyph_id_start = 1, .list_length = 446, .type = 3, .unicode_list = 3576, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ko_XS = {
+const etxLz4Font lv_font_ko_XS __FLASH = {
 .uncomp_size = 54844,
 .comp_size = 33033,
 .line_height = 19,

--- a/radio/src/fonts/lvgl/lrg/lv_font_ko_XXS.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_ko_XXS.c
@@ -1180,11 +1180,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0x40,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 44032, .range_length = 11145, .glyph_id_start = 1, .list_length = 446, .type = 3, .unicode_list = 3576, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ko_XXS = {
+const etxLz4Font lv_font_ko_XXS __FLASH = {
 .uncomp_size = 28283,
 .comp_size = 18802,
 .line_height = 13,

--- a/radio/src/fonts/lvgl/lrg/lv_font_ko_bold_STD.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_ko_bold_STD.c
@@ -2757,11 +2757,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0xbc,0x10,0x3c,0x93,0x55,0x0f,0xde,0x22,0x07,0x50,0x00,0x00,0x00,0x00,0x9a,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 44032, .range_length = 11145, .glyph_id_start = 1, .list_length = 446, .type = 3, .unicode_list = 3576, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ko_bold_STD = {
+const etxLz4Font lv_font_ko_bold_STD __FLASH = {
 .uncomp_size = 79760,
 .comp_size = 44047,
 .line_height = 23,

--- a/radio/src/fonts/lvgl/lrg/lv_font_ko_bold_XL.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_ko_bold_XL.c
@@ -6031,11 +6031,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0x00,0x01,0xab,0x30,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 44032, .range_length = 11145, .glyph_id_start = 1, .list_length = 446, .type = 3, .unicode_list = 3576, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ko_bold_XL = {
+const etxLz4Font lv_font_ko_bold_XL __FLASH = {
 .uncomp_size = 292878,
 .comp_size = 96421,
 .line_height = 45,

--- a/radio/src/fonts/lvgl/lrg/lv_font_ru_L.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_ru_L.c
@@ -468,13 +468,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x1b,0x27,0x28,0x28,0x29,0x19,0x2a,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1067, .range_length = 37, .glyph_id_start = 27, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1105, .range_length = 1, .glyph_id_start = 64, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ru_L = {
+const etxLz4Font lv_font_ru_L __FLASH = {
 .uncomp_size = 16272,
 .comp_size = 7416,
 .line_height = 37,

--- a/radio/src/fonts/lvgl/lrg/lv_font_ru_XS.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_ru_XS.c
@@ -276,13 +276,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x28,0x28,0x29,0x19,0x2a,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1067, .range_length = 37, .glyph_id_start = 27, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1105, .range_length = 1, .glyph_id_start = 64, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ru_XS = {
+const etxLz4Font lv_font_ru_XS __FLASH = {
 .uncomp_size = 6931,
 .comp_size = 4342,
 .line_height = 21,

--- a/radio/src/fonts/lvgl/lrg/lv_font_ru_XXS.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_ru_XXS.c
@@ -187,13 +187,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x14,0x1b,0x27,0x28,0x28,0x29,0x19,0x2a,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1067, .range_length = 37, .glyph_id_start = 27, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1105, .range_length = 1, .glyph_id_start = 64, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ru_XXS = {
+const etxLz4Font lv_font_ru_XXS __FLASH = {
 .uncomp_size = 4747,
 .comp_size = 2921,
 .line_height = 15,

--- a/radio/src/fonts/lvgl/lrg/lv_font_ru_bold_STD.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_ru_bold_STD.c
@@ -338,13 +338,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x27,0x28,0x29,0x2a,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1067, .range_length = 37, .glyph_id_start = 27, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1105, .range_length = 1, .glyph_id_start = 64, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ru_bold_STD = {
+const etxLz4Font lv_font_ru_bold_STD __FLASH = {
 .uncomp_size = 9267,
 .comp_size = 5333,
 .line_height = 25,

--- a/radio/src/fonts/lvgl/lrg/lv_font_ru_bold_XL.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_ru_bold_XL.c
@@ -611,13 +611,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x25,0x14,0x1e,0x26,0x27,0x27,0x28,0x29,0x2a,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1067, .range_length = 37, .glyph_id_start = 27, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1105, .range_length = 1, .glyph_id_start = 64, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ru_bold_XL = {
+const etxLz4Font lv_font_ru_bold_XL __FLASH = {
 .uncomp_size = 28827,
 .comp_size = 9706,
 .line_height = 50,

--- a/radio/src/fonts/lvgl/lrg/lv_font_tw_L.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_tw_L.c
@@ -9564,11 +9564,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x14,0x89,0x5a,0x09,0x50,0xf0,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 645, .type = 3, .unicode_list = 5168, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_tw_L = {
+const etxLz4Font lv_font_tw_L __FLASH = {
 .uncomp_size = 311130,
 .comp_size = 152954,
 .line_height = 33,

--- a/radio/src/fonts/lvgl/lrg/lv_font_tw_XS.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_tw_XS.c
@@ -4627,11 +4627,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0x23,0x3e,0xd0,0x09,0x00,0x80,0x5b,0x10,0x00,0x00,0x04,0xf0,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 645, .type = 3, .unicode_list = 5168, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_tw_XS = {
+const etxLz4Font lv_font_tw_XS __FLASH = {
 .uncomp_size = 100678,
 .comp_size = 73967,
 .line_height = 18,

--- a/radio/src/fonts/lvgl/lrg/lv_font_tw_XXS.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_tw_XXS.c
@@ -2711,11 +2711,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0xc0,0xce,0x8a,0x90,0x02,0xc0,0x00,0x03,0xb1,0x00,0x02,0xc0,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 645, .type = 3, .unicode_list = 5168, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_tw_XXS = {
+const etxLz4Font lv_font_tw_XXS __FLASH = {
 .uncomp_size = 51577,
 .comp_size = 43309,
 .line_height = 13,

--- a/radio/src/fonts/lvgl/lrg/lv_font_tw_bold_STD.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_tw_bold_STD.c
@@ -6416,11 +6416,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 645, .type = 3, .unicode_list = 5168, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_tw_bold_STD = {
+const etxLz4Font lv_font_tw_bold_STD __FLASH = {
 .uncomp_size = 153720,
 .comp_size = 102578,
 .line_height = 23,

--- a/radio/src/fonts/lvgl/lrg/lv_font_tw_bold_XL.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_tw_bold_XL.c
@@ -13254,11 +13254,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 645, .type = 3, .unicode_list = 5168, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_tw_bold_XL = {
+const etxLz4Font lv_font_tw_bold_XL __FLASH = {
 .uncomp_size = 567710,
 .comp_size = 211986,
 .line_height = 45,

--- a/radio/src/fonts/lvgl/lrg/lv_font_ua_L.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_ua_L.c
@@ -452,13 +452,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x23,0x24,0x13,0x25,0x13,0x1a,0x26,0x18,0x27,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1028, .range_length = 4, .glyph_id_start = 1, .list_length = 4, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 520 },
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 4, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1068, .range_length = 44, .glyph_id_start = 30, .list_length = 44, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 524 },
 };
 
-const etxLz4Font lv_font_ua_L = {
+const etxLz4Font lv_font_ua_L __FLASH = {
 .uncomp_size = 15573,
 .comp_size = 7164,
 .line_height = 37,

--- a/radio/src/fonts/lvgl/lrg/lv_font_ua_XS.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_ua_XS.c
@@ -265,13 +265,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x26,0x18,0x27,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1028, .range_length = 4, .glyph_id_start = 1, .list_length = 4, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 520 },
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 4, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1068, .range_length = 44, .glyph_id_start = 30, .list_length = 44, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 524 },
 };
 
-const etxLz4Font lv_font_ua_XS = {
+const etxLz4Font lv_font_ua_XS __FLASH = {
 .uncomp_size = 6571,
 .comp_size = 4166,
 .line_height = 21,

--- a/radio/src/fonts/lvgl/lrg/lv_font_ua_XXS.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_ua_XXS.c
@@ -181,13 +181,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1028, .range_length = 4, .glyph_id_start = 1, .list_length = 4, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 520 },
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 4, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1068, .range_length = 44, .glyph_id_start = 30, .list_length = 44, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 524 },
 };
 
-const etxLz4Font lv_font_ua_XXS = {
+const etxLz4Font lv_font_ua_XXS __FLASH = {
 .uncomp_size = 4470,
 .comp_size = 2818,
 .line_height = 15,

--- a/radio/src/fonts/lvgl/lrg/lv_font_ua_bold_STD.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_ua_bold_STD.c
@@ -327,13 +327,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x24,0x13,0x1d,0x25,0x26,0x27,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1028, .range_length = 4, .glyph_id_start = 1, .list_length = 4, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 520 },
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 4, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1068, .range_length = 44, .glyph_id_start = 30, .list_length = 44, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 524 },
 };
 
-const etxLz4Font lv_font_ua_bold_STD = {
+const etxLz4Font lv_font_ua_bold_STD __FLASH = {
 .uncomp_size = 8871,
 .comp_size = 5161,
 .line_height = 25,

--- a/radio/src/fonts/lvgl/lrg/lv_font_ua_bold_XL.c
+++ b/radio/src/fonts/lvgl/lrg/lv_font_ua_bold_XL.c
@@ -593,13 +593,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x22,0x23,0x13,0x24,0x13,0x1d,0x25,0x26,0x27,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1028, .range_length = 4, .glyph_id_start = 1, .list_length = 4, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 520 },
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 4, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1068, .range_length = 44, .glyph_id_start = 30, .list_length = 44, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 524 },
 };
 
-const etxLz4Font lv_font_ua_bold_XL = {
+const etxLz4Font lv_font_ua_bold_XL __FLASH = {
 .uncomp_size = 27745,
 .comp_size = 9420,
 .line_height = 50,

--- a/radio/src/fonts/lvgl/lz4_font.cpp
+++ b/radio/src/fonts/lvgl/lz4_font.cpp
@@ -221,7 +221,7 @@ int main(int argc, char* argv[])
 
   // Cmaps
   if (dsc->cmap_num > 0) {
-    fprintf(fp, "static const etxFontCmap cmaps[] = {\n");
+    fprintf(fp, "static const etxFontCmap cmaps[] __FLASH = {\n");
     for (int i = 0; i < dsc->cmap_num; i += 1) {
       fprintf(fp,
               "{ .range_start = %d, .range_length = %d, .glyph_id_start = %d, "
@@ -243,7 +243,7 @@ int main(int argc, char* argv[])
   if (dsc->kern_classes) size += sizeof(lv_font_fmt_txt_kern_classes_t);
 
   // Custom font structure
-  fprintf(fp, "const etxLz4Font %s = {\n", argv[1]+4);
+  fprintf(fp, "const etxLz4Font %s __FLASH = {\n", argv[1]+4);
   fprintf(fp, ".uncomp_size = %d,\n", uncomp_size);
   fprintf(fp, ".comp_size = %d,\n", comp_size);
   fprintf(fp, ".line_height = %d,\n", etx_font.line_height);

--- a/radio/src/fonts/lvgl/sml/lv_font_cn_L.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_cn_L.c
@@ -4633,11 +4633,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x24,0x04,0xee,0xd3,0x43,0x90,0x4c,0x10,0x00,0x00,0x00,0xba,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 621, .type = 3, .unicode_list = 4976, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_cn_L = {
+const etxLz4Font lv_font_cn_L __FLASH = {
 .uncomp_size = 107014,
 .comp_size = 74063,
 .line_height = 19,

--- a/radio/src/fonts/lvgl/sml/lv_font_cn_XS.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_cn_XS.c
@@ -1955,11 +1955,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x36,0x10,0xa1,0x05,0x00,0x90,0xc0,0x00,0xa1,0x00,0x09,0x40,0x00,0xa1,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 621, .type = 3, .unicode_list = 4976, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_cn_XS = {
+const etxLz4Font lv_font_cn_XS __FLASH = {
 .uncomp_size = 36503,
 .comp_size = 31215,
 .line_height = 11,

--- a/radio/src/fonts/lvgl/sml/lv_font_cn_XXS.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_cn_XXS.c
@@ -1445,11 +1445,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x70,0x19,0xa3,0x1c,0x22,0x80,0x04,0x50,0x09,0x00,0x0a,0x00,0x09,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 621, .type = 3, .unicode_list = 4976, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_cn_XXS = {
+const etxLz4Font lv_font_cn_XXS __FLASH = {
 .uncomp_size = 26632,
 .comp_size = 23054,
 .line_height = 10,

--- a/radio/src/fonts/lvgl/sml/lv_font_cn_bold_STD.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_cn_bold_STD.c
@@ -3045,11 +3045,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 621, .type = 3, .unicode_list = 4976, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_cn_bold_STD = {
+const etxLz4Font lv_font_cn_bold_STD __FLASH = {
 .uncomp_size = 58550,
 .comp_size = 48641,
 .line_height = 14,

--- a/radio/src/fonts/lvgl/sml/lv_font_cn_bold_XL.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_cn_bold_XL.c
@@ -6797,11 +6797,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x4f,0xfc,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 621, .type = 3, .unicode_list = 4976, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_cn_bold_XL = {
+const etxLz4Font lv_font_cn_bold_XL __FLASH = {
 .uncomp_size = 187676,
 .comp_size = 108677,
 .line_height = 25,

--- a/radio/src/fonts/lvgl/sml/lv_font_en_L.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_en_L.c
@@ -826,14 +826,14 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x13,0x14,0x22,0x14,0x22,0x14,0x22,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 32, .range_length = 95, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 136, .range_length = 15, .glyph_id_start = 96, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 176, .range_length = 1, .glyph_id_start = 111, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 192, .range_length = 192, .glyph_id_start = 112, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_en_L = {
+const etxLz4Font lv_font_en_L __FLASH = {
 .uncomp_size = 26379,
 .comp_size = 13144,
 .line_height = 23,

--- a/radio/src/fonts/lvgl/sml/lv_font_en_XS.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_en_XS.c
@@ -630,7 +630,7 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 32, .range_length = 95, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 128, .range_length = 4, .glyph_id_start = 96, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 136, .range_length = 15, .glyph_id_start = 100, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
@@ -639,7 +639,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 8226, .range_length = 55425, .glyph_id_start = 308, .list_length = 62, .type = 3, .unicode_list = 2960, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_en_XS = {
+const etxLz4Font lv_font_en_XS __FLASH = {
 .uncomp_size = 15758,
 .comp_size = 10004,
 .line_height = 14,

--- a/radio/src/fonts/lvgl/sml/lv_font_en_XXS.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_en_XXS.c
@@ -472,7 +472,7 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x1f,0x00,0x74,0x01,0x26,0x50,0x00,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 32, .range_length = 95, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 128, .range_length = 4, .glyph_id_start = 96, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 136, .range_length = 15, .glyph_id_start = 100, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
@@ -481,7 +481,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 8226, .range_length = 55425, .glyph_id_start = 308, .list_length = 62, .type = 3, .unicode_list = 2960, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_en_XXS = {
+const etxLz4Font lv_font_en_XXS __FLASH = {
 .uncomp_size = 11393,
 .comp_size = 7483,
 .line_height = 10,

--- a/radio/src/fonts/lvgl/sml/lv_font_en_bold_STD.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_en_bold_STD.c
@@ -855,7 +855,7 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x02,0x00,0x1f,0x00,0x74,0x01,0x26,0x50,0x00,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 32, .range_length = 95, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 128, .range_length = 4, .glyph_id_start = 96, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 136, .range_length = 15, .glyph_id_start = 100, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
@@ -864,7 +864,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 8226, .range_length = 55425, .glyph_id_start = 308, .list_length = 62, .type = 3, .unicode_list = 2960, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_en_bold_STD = {
+const etxLz4Font lv_font_en_bold_STD __FLASH = {
 .uncomp_size = 21874,
 .comp_size = 13613,
 .line_height = 17,

--- a/radio/src/fonts/lvgl/sml/lv_font_en_bold_XL.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_en_bold_XL.c
@@ -1024,13 +1024,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x1f,0x13,0x14,0x22,0x14,0x22,0x14,0x22,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 32, .range_length = 95, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 176, .range_length = 1, .glyph_id_start = 96, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 192, .range_length = 192, .glyph_id_start = 97, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_en_bold_XL = {
+const etxLz4Font lv_font_en_bold_XL __FLASH = {
 .uncomp_size = 42476,
 .comp_size = 16313,
 .line_height = 33,

--- a/radio/src/fonts/lvgl/sml/lv_font_en_bold_XXL.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_en_bold_XXL.c
@@ -908,12 +908,12 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0x23,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 32, .range_length = 95, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 176, .range_length = 1, .glyph_id_start = 96, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_en_bold_XXL = {
+const etxLz4Font lv_font_en_bold_XXL __FLASH = {
 .uncomp_size = 39292,
 .comp_size = 14452,
 .line_height = 54,

--- a/radio/src/fonts/lvgl/sml/lv_font_he_L.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_he_L.c
@@ -89,12 +89,12 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x5f,0x40,0xbc,0x00,0x8e,0x00,0xe7,0x00,0xc9,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1488, .range_length = 27, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1524, .range_length = 1, .glyph_id_start = 28, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_he_L = {
+const etxLz4Font lv_font_he_L __FLASH = {
 .uncomp_size = 1757,
 .comp_size = 1354,
 .line_height = 20,

--- a/radio/src/fonts/lvgl/sml/lv_font_he_XS.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_he_XS.c
@@ -43,12 +43,12 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0xc1,0x6a,0x3d,0x09,0x46,0x70,0xb0,0xa1,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1488, .range_length = 27, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1524, .range_length = 1, .glyph_id_start = 28, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_he_XS = {
+const etxLz4Font lv_font_he_XS __FLASH = {
 .uncomp_size = 706,
 .comp_size = 618,
 .line_height = 11,

--- a/radio/src/fonts/lvgl/sml/lv_font_he_XXS.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_he_XXS.c
@@ -36,12 +36,12 @@ static const uint8_t lz4FontData[] __FLASH = {
 0xb1,0xa0,0x08,0x44,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1488, .range_length = 27, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1524, .range_length = 1, .glyph_id_start = 28, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_he_XXS = {
+const etxLz4Font lv_font_he_XXS __FLASH = {
 .uncomp_size = 552,
 .comp_size = 501,
 .line_height = 8,

--- a/radio/src/fonts/lvgl/sml/lv_font_he_bold_STD.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_he_bold_STD.c
@@ -63,12 +63,12 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x17,0xe0,0x8a,0x0b,0x80,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1488, .range_length = 27, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1524, .range_length = 1, .glyph_id_start = 28, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_he_bold_STD = {
+const etxLz4Font lv_font_he_bold_STD __FLASH = {
 .uncomp_size = 1057,
 .comp_size = 933,
 .line_height = 14,

--- a/radio/src/fonts/lvgl/sml/lv_font_he_bold_XL.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_he_bold_XL.c
@@ -125,12 +125,12 @@ static const uint8_t lz4FontData[] __FLASH = {
 0xf2,0x00,0x0f,0xf5,0x00,0x9f,0xd0,0x00,0x4f,0xf0,0x00,0xdf,0x70,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1488, .range_length = 27, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1524, .range_length = 1, .glyph_id_start = 28, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_he_bold_XL = {
+const etxLz4Font lv_font_he_bold_XL __FLASH = {
 .uncomp_size = 3121,
 .comp_size = 1934,
 .line_height = 26,

--- a/radio/src/fonts/lvgl/sml/lv_font_jp_L.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_jp_L.c
@@ -2789,14 +2789,14 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0x00,0x52,0x53,0x8a,0x01,0xff,0x02,0x50,0x00,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 147, .glyph_id_start = 1, .list_length = 45, .type = 3, .unicode_list = 3200, .glyph_id_ofs_list = 0 },
 { .range_start = 12449, .range_length = 49, .glyph_id_start = 46, .list_length = 49, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 3290 },
 { .range_start = 12499, .range_length = 27, .glyph_id_start = 89, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 12527, .range_length = 27114, .glyph_id_start = 116, .list_length = 284, .type = 3, .unicode_list = 3339, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_jp_L = {
+const etxLz4Font lv_font_jp_L __FLASH = {
 .uncomp_size = 71690,
 .comp_size = 44558,
 .line_height = 19,

--- a/radio/src/fonts/lvgl/sml/lv_font_jp_XS.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_jp_XS.c
@@ -1242,14 +1242,14 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x53,0x8a,0x01,0xff,0x02,0x50,0x00,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 147, .glyph_id_start = 1, .list_length = 45, .type = 3, .unicode_list = 3200, .glyph_id_ofs_list = 0 },
 { .range_start = 12449, .range_length = 49, .glyph_id_start = 46, .list_length = 49, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 3290 },
 { .range_start = 12499, .range_length = 27, .glyph_id_start = 89, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 12527, .range_length = 27114, .glyph_id_start = 116, .list_length = 284, .type = 3, .unicode_list = 3339, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_jp_XS = {
+const etxLz4Font lv_font_jp_XS __FLASH = {
 .uncomp_size = 29774,
 .comp_size = 19803,
 .line_height = 11,

--- a/radio/src/fonts/lvgl/sml/lv_font_jp_XXS.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_jp_XXS.c
@@ -935,14 +935,14 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 147, .glyph_id_start = 1, .list_length = 45, .type = 3, .unicode_list = 3200, .glyph_id_ofs_list = 0 },
 { .range_start = 12449, .range_length = 49, .glyph_id_start = 46, .list_length = 49, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 3290 },
 { .range_start = 12499, .range_length = 27, .glyph_id_start = 89, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 12527, .range_length = 27114, .glyph_id_start = 116, .list_length = 284, .type = 3, .unicode_list = 3339, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_jp_XXS = {
+const etxLz4Font lv_font_jp_XXS __FLASH = {
 .uncomp_size = 23810,
 .comp_size = 14882,
 .line_height = 10,

--- a/radio/src/fonts/lvgl/sml/lv_font_jp_bold_STD.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_jp_bold_STD.c
@@ -1893,14 +1893,14 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x52,0x53,0x8a,0x01,0xff,0x02,0x50,0x00,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 147, .glyph_id_start = 1, .list_length = 45, .type = 3, .unicode_list = 3200, .glyph_id_ofs_list = 0 },
 { .range_start = 12449, .range_length = 49, .glyph_id_start = 46, .list_length = 49, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 3290 },
 { .range_start = 12499, .range_length = 27, .glyph_id_start = 89, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 12527, .range_length = 27114, .glyph_id_start = 116, .list_length = 284, .type = 3, .unicode_list = 3339, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_jp_bold_STD = {
+const etxLz4Font lv_font_jp_bold_STD __FLASH = {
 .uncomp_size = 43059,
 .comp_size = 30220,
 .line_height = 14,

--- a/radio/src/fonts/lvgl/sml/lv_font_jp_bold_XL.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_jp_bold_XL.c
@@ -4022,14 +4022,14 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 147, .glyph_id_start = 1, .list_length = 45, .type = 3, .unicode_list = 3200, .glyph_id_ofs_list = 0 },
 { .range_start = 12449, .range_length = 49, .glyph_id_start = 46, .list_length = 49, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 3290 },
 { .range_start = 12499, .range_length = 27, .glyph_id_start = 89, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 12527, .range_length = 27114, .glyph_id_start = 116, .list_length = 284, .type = 3, .unicode_list = 3339, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_jp_bold_XL = {
+const etxLz4Font lv_font_jp_bold_XL __FLASH = {
 .uncomp_size = 120370,
 .comp_size = 64277,
 .line_height = 25,

--- a/radio/src/fonts/lvgl/sml/lv_font_ko_L.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_ko_L.c
@@ -2242,11 +2242,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0xc5,0x14,0x3e,0x80,0x0a,0x50,0x00,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 44032, .range_length = 11145, .glyph_id_start = 1, .list_length = 446, .type = 3, .unicode_list = 3576, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ko_L = {
+const etxLz4Font lv_font_ko_L __FLASH = {
 .uncomp_size = 60456,
 .comp_size = 35803,
 .line_height = 20,

--- a/radio/src/fonts/lvgl/sml/lv_font_ko_XS.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_ko_XS.c
@@ -987,11 +987,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x90,0x05,0x20,0x09,0x00,0x00,0x00,0x90,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 44032, .range_length = 11145, .glyph_id_start = 1, .list_length = 446, .type = 3, .unicode_list = 3576, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ko_XS = {
+const etxLz4Font lv_font_ko_XS __FLASH = {
 .uncomp_size = 21571,
 .comp_size = 15723,
 .line_height = 11,

--- a/radio/src/fonts/lvgl/sml/lv_font_ko_XXS.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_ko_XXS.c
@@ -729,11 +729,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x16,0x00,0x00,0x15,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 44032, .range_length = 11145, .glyph_id_start = 1, .list_length = 446, .type = 3, .unicode_list = 3576, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ko_XXS = {
+const etxLz4Font lv_font_ko_XXS __FLASH = {
 .uncomp_size = 16404,
 .comp_size = 11588,
 .line_height = 9,

--- a/radio/src/fonts/lvgl/sml/lv_font_ko_bold_STD.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_ko_bold_STD.c
@@ -1497,11 +1497,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x40,0x2f,0x00,0x36,0x10,0x0f,0x80,0x00,0x00,0x2f,0x00,0x00,0x00,0x01,0x90,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 44032, .range_length = 11145, .glyph_id_start = 1, .list_length = 446, .type = 3, .unicode_list = 3576, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ko_bold_STD = {
+const etxLz4Font lv_font_ko_bold_STD __FLASH = {
 .uncomp_size = 32610,
 .comp_size = 23887,
 .line_height = 14,

--- a/radio/src/fonts/lvgl/sml/lv_font_ko_bold_XL.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_ko_bold_XL.c
@@ -3191,11 +3191,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0x00,0x00,0x03,0x30,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 44032, .range_length = 11145, .glyph_id_start = 1, .list_length = 446, .type = 3, .unicode_list = 3576, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ko_bold_XL = {
+const etxLz4Font lv_font_ko_bold_XL __FLASH = {
 .uncomp_size = 101127,
 .comp_size = 50981,
 .line_height = 26,

--- a/radio/src/fonts/lvgl/sml/lv_font_ru_L.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_ru_L.c
@@ -284,13 +284,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x25,0x14,0x26,0x14,0x1b,0x27,0x28,0x28,0x29,0x19,0x2a,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1067, .range_length = 37, .glyph_id_start = 27, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1105, .range_length = 1, .glyph_id_start = 64, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ru_L = {
+const etxLz4Font lv_font_ru_L __FLASH = {
 .uncomp_size = 7168,
 .comp_size = 4476,
 .line_height = 21,

--- a/radio/src/fonts/lvgl/sml/lv_font_ru_XS.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_ru_XS.c
@@ -167,13 +167,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x2a,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1067, .range_length = 37, .glyph_id_start = 27, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1105, .range_length = 1, .glyph_id_start = 64, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ru_XS = {
+const etxLz4Font lv_font_ru_XS __FLASH = {
 .uncomp_size = 4171,
 .comp_size = 2594,
 .line_height = 12,

--- a/radio/src/fonts/lvgl/sml/lv_font_ru_XXS.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_ru_XXS.c
@@ -131,13 +131,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x21,0x22,0x23,0x24,0x25,0x14,0x26,0x14,0x1b,0x27,0x28,0x28,0x29,0x19,0x2a,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1067, .range_length = 37, .glyph_id_start = 27, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1105, .range_length = 1, .glyph_id_start = 64, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ru_XXS = {
+const etxLz4Font lv_font_ru_XXS __FLASH = {
 .uncomp_size = 3436,
 .comp_size = 2032,
 .line_height = 9,

--- a/radio/src/fonts/lvgl/sml/lv_font_ru_bold_STD.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_ru_bold_STD.c
@@ -209,13 +209,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x27,0x27,0x28,0x29,0x2a,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1067, .range_length = 37, .glyph_id_start = 27, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1105, .range_length = 1, .glyph_id_start = 64, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ru_bold_STD = {
+const etxLz4Font lv_font_ru_bold_STD __FLASH = {
 .uncomp_size = 5064,
 .comp_size = 3270,
 .line_height = 15,

--- a/radio/src/fonts/lvgl/sml/lv_font_ru_bold_XL.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_ru_bold_XL.c
@@ -382,13 +382,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x1e,0x26,0x27,0x27,0x28,0x29,0x2a,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1067, .range_length = 37, .glyph_id_start = 27, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1105, .range_length = 1, .glyph_id_start = 64, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ru_bold_XL = {
+const etxLz4Font lv_font_ru_bold_XL __FLASH = {
 .uncomp_size = 11504,
 .comp_size = 6040,
 .line_height = 29,

--- a/radio/src/fonts/lvgl/sml/lv_font_tw_L.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_tw_L.c
@@ -5062,11 +5062,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x10,0x00,0x00,0x00,0xba,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 645, .type = 3, .unicode_list = 5168, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_tw_L = {
+const etxLz4Font lv_font_tw_L __FLASH = {
 .uncomp_size = 111720,
 .comp_size = 80920,
 .line_height = 19,

--- a/radio/src/fonts/lvgl/sml/lv_font_tw_XS.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_tw_XS.c
@@ -2081,11 +2081,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0xa1,0x00,0x09,0x40,0x00,0xa1,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 645, .type = 3, .unicode_list = 5168, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_tw_XS = {
+const etxLz4Font lv_font_tw_XS __FLASH = {
 .uncomp_size = 38111,
 .comp_size = 33224,
 .line_height = 11,

--- a/radio/src/fonts/lvgl/sml/lv_font_tw_XXS.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_tw_XXS.c
@@ -1516,11 +1516,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x09,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 645, .type = 3, .unicode_list = 5168, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_tw_XXS = {
+const etxLz4Font lv_font_tw_XXS __FLASH = {
 .uncomp_size = 27793,
 .comp_size = 24178,
 .line_height = 10,

--- a/radio/src/fonts/lvgl/sml/lv_font_tw_bold_STD.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_tw_bold_STD.c
@@ -3232,11 +3232,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0xbe,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 645, .type = 3, .unicode_list = 5168, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_tw_bold_STD = {
+const etxLz4Font lv_font_tw_bold_STD __FLASH = {
 .uncomp_size = 60847,
 .comp_size = 51635,
 .line_height = 14,

--- a/radio/src/fonts/lvgl/sml/lv_font_tw_bold_XL.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_tw_bold_XL.c
@@ -7432,11 +7432,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0xb0,0x0b,0x70,0x00,0x00,0x00,0x00,0x4f,0xfc,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 645, .type = 3, .unicode_list = 5168, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_tw_bold_XL = {
+const etxLz4Font lv_font_tw_bold_XL __FLASH = {
 .uncomp_size = 195448,
 .comp_size = 118845,
 .line_height = 25,

--- a/radio/src/fonts/lvgl/sml/lv_font_ua_L.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_ua_L.c
@@ -274,13 +274,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x21,0x22,0x23,0x24,0x13,0x25,0x13,0x1a,0x26,0x18,0x27,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1028, .range_length = 4, .glyph_id_start = 1, .list_length = 4, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 520 },
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 4, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1068, .range_length = 44, .glyph_id_start = 30, .list_length = 44, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 524 },
 };
 
-const etxLz4Font lv_font_ua_L = {
+const etxLz4Font lv_font_ua_L __FLASH = {
 .uncomp_size = 6811,
 .comp_size = 4318,
 .line_height = 21,

--- a/radio/src/fonts/lvgl/sml/lv_font_ua_XS.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_ua_XS.c
@@ -160,13 +160,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x21,0x22,0x23,0x24,0x13,0x25,0x13,0x1a,0x26,0x18,0x27,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1028, .range_length = 4, .glyph_id_start = 1, .list_length = 4, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 520 },
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 4, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1068, .range_length = 44, .glyph_id_start = 30, .list_length = 44, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 524 },
 };
 
-const etxLz4Font lv_font_ua_XS = {
+const etxLz4Font lv_font_ua_XS __FLASH = {
 .uncomp_size = 3911,
 .comp_size = 2494,
 .line_height = 12,

--- a/radio/src/fonts/lvgl/sml/lv_font_ua_XXS.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_ua_XXS.c
@@ -127,13 +127,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1028, .range_length = 4, .glyph_id_start = 1, .list_length = 4, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 520 },
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 4, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1068, .range_length = 44, .glyph_id_start = 30, .list_length = 44, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 524 },
 };
 
-const etxLz4Font lv_font_ua_XXS = {
+const etxLz4Font lv_font_ua_XXS __FLASH = {
 .uncomp_size = 3206,
 .comp_size = 1954,
 .line_height = 9,

--- a/radio/src/fonts/lvgl/sml/lv_font_ua_bold_STD.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_ua_bold_STD.c
@@ -203,13 +203,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x13,0x1d,0x25,0x26,0x27,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1028, .range_length = 4, .glyph_id_start = 1, .list_length = 4, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 520 },
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 4, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1068, .range_length = 44, .glyph_id_start = 30, .list_length = 44, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 524 },
 };
 
-const etxLz4Font lv_font_ua_bold_STD = {
+const etxLz4Font lv_font_ua_bold_STD __FLASH = {
 .uncomp_size = 4824,
 .comp_size = 3176,
 .line_height = 15,

--- a/radio/src/fonts/lvgl/sml/lv_font_ua_bold_XL.c
+++ b/radio/src/fonts/lvgl/sml/lv_font_ua_bold_XL.c
@@ -370,13 +370,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x27,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1028, .range_length = 4, .glyph_id_start = 1, .list_length = 4, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 520 },
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 4, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1068, .range_length = 44, .glyph_id_start = 30, .list_length = 44, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 524 },
 };
 
-const etxLz4Font lv_font_ua_bold_XL = {
+const etxLz4Font lv_font_ua_bold_XL __FLASH = {
 .uncomp_size = 11036,
 .comp_size = 5844,
 .line_height = 29,

--- a/radio/src/fonts/lvgl/std/lv_font_cn_L.c
+++ b/radio/src/fonts/lvgl/std/lv_font_cn_L.c
@@ -5992,11 +5992,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0xe2,0x59,0x14,0x00,0x67,0xc4,0x80,0x00,0x00,0x00,0x07,0xf4,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 621, .type = 3, .unicode_list = 4976, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_cn_L = {
+const etxLz4Font lv_font_cn_L __FLASH = {
 .uncomp_size = 165149,
 .comp_size = 95807,
 .line_height = 24,

--- a/radio/src/fonts/lvgl/std/lv_font_cn_XS.c
+++ b/radio/src/fonts/lvgl/std/lv_font_cn_XS.c
@@ -2832,11 +2832,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x70,0x00,0x01,0xc2,0x00,0x00,0x77,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 621, .type = 3, .unicode_list = 4976, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_cn_XS = {
+const etxLz4Font lv_font_cn_XS __FLASH = {
 .uncomp_size = 55839,
 .comp_size = 45241,
 .line_height = 14,

--- a/radio/src/fonts/lvgl/std/lv_font_cn_XXS.c
+++ b/radio/src/fonts/lvgl/std/lv_font_cn_XXS.c
@@ -1739,11 +1739,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x50,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 621, .type = 3, .unicode_list = 4976, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_cn_XXS = {
+const etxLz4Font lv_font_cn_XXS __FLASH = {
 .uncomp_size = 32097,
 .comp_size = 27746,
 .line_height = 11,

--- a/radio/src/fonts/lvgl/std/lv_font_cn_bold_STD.c
+++ b/radio/src/fonts/lvgl/std/lv_font_cn_bold_STD.c
@@ -3940,11 +3940,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0xcf,0x20,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 621, .type = 3, .unicode_list = 4976, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_cn_bold_STD = {
+const etxLz4Font lv_font_cn_bold_STD __FLASH = {
 .uncomp_size = 82282,
 .comp_size = 62963,
 .line_height = 17,

--- a/radio/src/fonts/lvgl/std/lv_font_cn_bold_XL.c
+++ b/radio/src/fonts/lvgl/std/lv_font_cn_bold_XL.c
@@ -8753,11 +8753,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x3e,0x00,0x23,0x4c,0x30,0x73,0x00,0x50,0xf5,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 621, .type = 3, .unicode_list = 4976, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_cn_bold_XL = {
+const etxLz4Font lv_font_cn_bold_XL __FLASH = {
 .uncomp_size = 297809,
 .comp_size = 139981,
 .line_height = 32,

--- a/radio/src/fonts/lvgl/std/lv_font_en_L.c
+++ b/radio/src/fonts/lvgl/std/lv_font_en_L.c
@@ -1055,14 +1055,14 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x13,0x1f,0x13,0x14,0x22,0x14,0x22,0x14,0x22,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 32, .range_length = 95, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 136, .range_length = 15, .glyph_id_start = 96, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 176, .range_length = 1, .glyph_id_start = 111, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 192, .range_length = 192, .glyph_id_start = 112, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_en_L = {
+const etxLz4Font lv_font_en_L __FLASH = {
 .uncomp_size = 39145,
 .comp_size = 16810,
 .line_height = 29,

--- a/radio/src/fonts/lvgl/std/lv_font_en_XS.c
+++ b/radio/src/fonts/lvgl/std/lv_font_en_XS.c
@@ -817,7 +817,7 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 32, .range_length = 95, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 128, .range_length = 4, .glyph_id_start = 96, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 136, .range_length = 15, .glyph_id_start = 100, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
@@ -826,7 +826,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 8226, .range_length = 55425, .glyph_id_start = 308, .list_length = 62, .type = 3, .unicode_list = 2960, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_en_XS = {
+const etxLz4Font lv_font_en_XS __FLASH = {
 .uncomp_size = 21311,
 .comp_size = 12997,
 .line_height = 17,

--- a/radio/src/fonts/lvgl/std/lv_font_en_XXS.c
+++ b/radio/src/fonts/lvgl/std/lv_font_en_XXS.c
@@ -560,7 +560,7 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x26,0x50,0x00,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 32, .range_length = 95, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 128, .range_length = 4, .glyph_id_start = 96, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 136, .range_length = 15, .glyph_id_start = 100, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
@@ -569,7 +569,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 8226, .range_length = 55425, .glyph_id_start = 308, .list_length = 62, .type = 3, .unicode_list = 2960, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_en_XXS = {
+const etxLz4Font lv_font_en_XXS __FLASH = {
 .uncomp_size = 13836,
 .comp_size = 8887,
 .line_height = 12,

--- a/radio/src/fonts/lvgl/std/lv_font_en_bold_STD.c
+++ b/radio/src/fonts/lvgl/std/lv_font_en_bold_STD.c
@@ -995,7 +995,7 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x13,0x14,0x22,0x02,0x00,0x1f,0x00,0x74,0x01,0x26,0x50,0x00,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 32, .range_length = 95, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 128, .range_length = 4, .glyph_id_start = 96, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 136, .range_length = 15, .glyph_id_start = 100, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
@@ -1004,7 +1004,7 @@ static const etxFontCmap cmaps[] = {
 { .range_start = 8226, .range_length = 55425, .glyph_id_start = 308, .list_length = 62, .type = 3, .unicode_list = 2960, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_en_bold_STD = {
+const etxLz4Font lv_font_en_bold_STD __FLASH = {
 .uncomp_size = 29867,
 .comp_size = 15856,
 .line_height = 20,

--- a/radio/src/fonts/lvgl/std/lv_font_en_bold_XL.c
+++ b/radio/src/fonts/lvgl/std/lv_font_en_bold_XL.c
@@ -1207,13 +1207,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0x13,0x1f,0x13,0x14,0x22,0x14,0x22,0x14,0x22,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 32, .range_length = 95, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 176, .range_length = 1, .glyph_id_start = 96, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 192, .range_length = 192, .glyph_id_start = 97, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_en_bold_XL = {
+const etxLz4Font lv_font_en_bold_XL __FLASH = {
 .uncomp_size = 61864,
 .comp_size = 19243,
 .line_height = 40,

--- a/radio/src/fonts/lvgl/std/lv_font_en_bold_XXL.c
+++ b/radio/src/fonts/lvgl/std/lv_font_en_bold_XXL.c
@@ -1147,12 +1147,12 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x1b,0x1c,0x1d,0x1e,0x1f,0x20,0x21,0x1f,0x22,0x00,0x00,0x23,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 32, .range_length = 95, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 176, .range_length = 1, .glyph_id_start = 96, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_en_bold_XXL = {
+const etxLz4Font lv_font_en_bold_XXL __FLASH = {
 .uncomp_size = 63081,
 .comp_size = 18286,
 .line_height = 69,

--- a/radio/src/fonts/lvgl/std/lv_font_he_L.c
+++ b/radio/src/fonts/lvgl/std/lv_font_he_L.c
@@ -114,12 +114,12 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x06,0xf4,0x00,0x2f,0x80,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1488, .range_length = 27, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1524, .range_length = 1, .glyph_id_start = 28, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_he_L = {
+const etxLz4Font lv_font_he_L __FLASH = {
 .uncomp_size = 2633,
 .comp_size = 1750,
 .line_height = 25,

--- a/radio/src/fonts/lvgl/std/lv_font_he_XS.c
+++ b/radio/src/fonts/lvgl/std/lv_font_he_XS.c
@@ -59,12 +59,12 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x86,0x0b,0x40,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1488, .range_length = 27, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1524, .range_length = 1, .glyph_id_start = 28, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_he_XS = {
+const etxLz4Font lv_font_he_XS __FLASH = {
 .uncomp_size = 993,
 .comp_size = 867,
 .line_height = 13,

--- a/radio/src/fonts/lvgl/std/lv_font_he_XXS.c
+++ b/radio/src/fonts/lvgl/std/lv_font_he_XXS.c
@@ -39,12 +39,12 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1488, .range_length = 27, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1524, .range_length = 1, .glyph_id_start = 28, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_he_XXS = {
+const etxLz4Font lv_font_he_XXS __FLASH = {
 .uncomp_size = 603,
 .comp_size = 545,
 .line_height = 10,

--- a/radio/src/fonts/lvgl/std/lv_font_he_bold_STD.c
+++ b/radio/src/fonts/lvgl/std/lv_font_he_bold_STD.c
@@ -82,12 +82,12 @@ static const uint8_t lz4FontData[] __FLASH = {
 0xf0,0x4f,0x70,0x0f,0xa0,0x8f,0x20,0x3f,0x40,0xbc,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1488, .range_length = 27, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1524, .range_length = 1, .glyph_id_start = 28, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_he_bold_STD = {
+const etxLz4Font lv_font_he_bold_STD __FLASH = {
 .uncomp_size = 1489,
 .comp_size = 1243,
 .line_height = 17,

--- a/radio/src/fonts/lvgl/std/lv_font_he_bold_XL.c
+++ b/radio/src/fonts/lvgl/std/lv_font_he_bold_XL.c
@@ -165,12 +165,12 @@ static const uint8_t lz4FontData[] __FLASH = {
 0xf1,0x00,0x5f,0xfb,0x00,0x05,0xff,0xb0,0x00,0x8f,0xf5,0x00,0x08,0xff,0x50,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1488, .range_length = 27, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1524, .range_length = 1, .glyph_id_start = 28, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_he_bold_XL = {
+const etxLz4Font lv_font_he_bold_XL __FLASH = {
 .uncomp_size = 4821,
 .comp_size = 2576,
 .line_height = 32,

--- a/radio/src/fonts/lvgl/std/lv_font_jp_L.c
+++ b/radio/src/fonts/lvgl/std/lv_font_jp_L.c
@@ -3556,14 +3556,14 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0x52,0x53,0x8a,0x01,0xff,0x02,0x50,0x00,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 147, .glyph_id_start = 1, .list_length = 45, .type = 3, .unicode_list = 3200, .glyph_id_ofs_list = 0 },
 { .range_start = 12449, .range_length = 49, .glyph_id_start = 46, .list_length = 49, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 3290 },
 { .range_start = 12499, .range_length = 27, .glyph_id_start = 89, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 12527, .range_length = 27114, .glyph_id_start = 116, .list_length = 284, .type = 3, .unicode_list = 3339, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_jp_L = {
+const etxLz4Font lv_font_jp_L __FLASH = {
 .uncomp_size = 106436,
 .comp_size = 56829,
 .line_height = 24,

--- a/radio/src/fonts/lvgl/std/lv_font_jp_XS.c
+++ b/radio/src/fonts/lvgl/std/lv_font_jp_XS.c
@@ -1759,14 +1759,14 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x50,0x00,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 147, .glyph_id_start = 1, .list_length = 45, .type = 3, .unicode_list = 3200, .glyph_id_ofs_list = 0 },
 { .range_start = 12449, .range_length = 49, .glyph_id_start = 46, .list_length = 49, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 3290 },
 { .range_start = 12499, .range_length = 27, .glyph_id_start = 89, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 12527, .range_length = 27114, .glyph_id_start = 116, .list_length = 284, .type = 3, .unicode_list = 3339, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_jp_XS = {
+const etxLz4Font lv_font_jp_XS __FLASH = {
 .uncomp_size = 41248,
 .comp_size = 28070,
 .line_height = 14,

--- a/radio/src/fonts/lvgl/std/lv_font_jp_XXS.c
+++ b/radio/src/fonts/lvgl/std/lv_font_jp_XXS.c
@@ -1104,14 +1104,14 @@ static const uint8_t lz4FontData[] __FLASH = {
 0xff,0x02,0x50,0x00,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 147, .glyph_id_start = 1, .list_length = 45, .type = 3, .unicode_list = 3200, .glyph_id_ofs_list = 0 },
 { .range_start = 12449, .range_length = 49, .glyph_id_start = 46, .list_length = 49, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 3290 },
 { .range_start = 12499, .range_length = 27, .glyph_id_start = 89, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 12527, .range_length = 27114, .glyph_id_start = 116, .list_length = 284, .type = 3, .unicode_list = 3339, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_jp_XXS = {
+const etxLz4Font lv_font_jp_XXS __FLASH = {
 .uncomp_size = 27010,
 .comp_size = 17592,
 .line_height = 11,

--- a/radio/src/fonts/lvgl/std/lv_font_jp_bold_STD.c
+++ b/radio/src/fonts/lvgl/std/lv_font_jp_bold_STD.c
@@ -2400,14 +2400,14 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 147, .glyph_id_start = 1, .list_length = 45, .type = 3, .unicode_list = 3200, .glyph_id_ofs_list = 0 },
 { .range_start = 12449, .range_length = 49, .glyph_id_start = 46, .list_length = 49, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 3290 },
 { .range_start = 12499, .range_length = 27, .glyph_id_start = 89, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 12527, .range_length = 27114, .glyph_id_start = 116, .list_length = 284, .type = 3, .unicode_list = 3339, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_jp_bold_STD = {
+const etxLz4Font lv_font_jp_bold_STD __FLASH = {
 .uncomp_size = 57348,
 .comp_size = 38323,
 .line_height = 17,

--- a/radio/src/fonts/lvgl/std/lv_font_jp_bold_XL.c
+++ b/radio/src/fonts/lvgl/std/lv_font_jp_bold_XL.c
@@ -5131,14 +5131,14 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x4f,0x00,0x00,0x52,0x53,0x8a,0x01,0xff,0x02,0x50,0x00,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 147, .glyph_id_start = 1, .list_length = 45, .type = 3, .unicode_list = 3200, .glyph_id_ofs_list = 0 },
 { .range_start = 12449, .range_length = 49, .glyph_id_start = 46, .list_length = 49, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 3290 },
 { .range_start = 12499, .range_length = 27, .glyph_id_start = 89, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 12527, .range_length = 27114, .glyph_id_start = 116, .list_length = 284, .type = 3, .unicode_list = 3339, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_jp_bold_XL = {
+const etxLz4Font lv_font_jp_bold_XL __FLASH = {
 .uncomp_size = 186826,
 .comp_size = 82031,
 .line_height = 32,

--- a/radio/src/fonts/lvgl/std/lv_font_ko_L.c
+++ b/radio/src/fonts/lvgl/std/lv_font_ko_L.c
@@ -2862,11 +2862,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0xf9,0x0f,0x2b,0x05,0xf1,0x0e,0x03,0x0a,0x11,0x00,0x50,0x00,0x00,0x00,0x02,0xd0,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 44032, .range_length = 11145, .glyph_id_start = 1, .list_length = 446, .type = 3, .unicode_list = 3576, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ko_L = {
+const etxLz4Font lv_font_ko_L __FLASH = {
 .uncomp_size = 92036,
 .comp_size = 45728,
 .line_height = 25,

--- a/radio/src/fonts/lvgl/std/lv_font_ko_XS.c
+++ b/radio/src/fonts/lvgl/std/lv_font_ko_XS.c
@@ -1328,11 +1328,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0xb0,0x02,0x40,0x00,0x0b,0x00,0x00,0x00,0x00,0xb0,0x00,0x00,0x00,0x05,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 44032, .range_length = 11145, .glyph_id_start = 1, .list_length = 446, .type = 3, .unicode_list = 3576, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ko_XS = {
+const etxLz4Font lv_font_ko_XS __FLASH = {
 .uncomp_size = 31445,
 .comp_size = 21183,
 .line_height = 14,

--- a/radio/src/fonts/lvgl/std/lv_font_ko_XXS.c
+++ b/radio/src/fonts/lvgl/std/lv_font_ko_XXS.c
@@ -836,11 +836,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0x08,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 44032, .range_length = 11145, .glyph_id_start = 1, .list_length = 446, .type = 3, .unicode_list = 3576, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ko_XXS = {
+const etxLz4Font lv_font_ko_XXS __FLASH = {
 .uncomp_size = 18546,
 .comp_size = 13301,
 .line_height = 10,

--- a/radio/src/fonts/lvgl/std/lv_font_ko_bold_STD.c
+++ b/radio/src/fonts/lvgl/std/lv_font_ko_bold_STD.c
@@ -1957,11 +1957,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x80,0x45,0x60,0xe0,0x00,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 44032, .range_length = 11145, .glyph_id_start = 1, .list_length = 446, .type = 3, .unicode_list = 3576, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ko_bold_STD = {
+const etxLz4Font lv_font_ko_bold_STD __FLASH = {
 .uncomp_size = 46351,
 .comp_size = 31241,
 .line_height = 17,

--- a/radio/src/fonts/lvgl/std/lv_font_ko_bold_XL.c
+++ b/radio/src/fonts/lvgl/std/lv_font_ko_bold_XL.c
@@ -4272,11 +4272,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x50,0x00,0x00,0x00,0x00,0x10,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 44032, .range_length = 11145, .glyph_id_start = 1, .list_length = 446, .type = 3, .unicode_list = 3576, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ko_bold_XL = {
+const etxLz4Font lv_font_ko_bold_XL __FLASH = {
 .uncomp_size = 160147,
 .comp_size = 68278,
 .line_height = 33,

--- a/radio/src/fonts/lvgl/std/lv_font_ru_L.c
+++ b/radio/src/fonts/lvgl/std/lv_font_ru_L.c
@@ -360,13 +360,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x29,0x19,0x2a,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1067, .range_length = 37, .glyph_id_start = 27, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1105, .range_length = 1, .glyph_id_start = 64, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ru_L = {
+const etxLz4Font lv_font_ru_L __FLASH = {
 .uncomp_size = 10051,
 .comp_size = 5684,
 .line_height = 27,

--- a/radio/src/fonts/lvgl/std/lv_font_ru_XS.c
+++ b/radio/src/fonts/lvgl/std/lv_font_ru_XS.c
@@ -198,13 +198,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x1b,0x27,0x28,0x28,0x29,0x19,0x2a,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1067, .range_length = 37, .glyph_id_start = 27, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1105, .range_length = 1, .glyph_id_start = 64, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ru_XS = {
+const etxLz4Font lv_font_ru_XS __FLASH = {
 .uncomp_size = 4847,
 .comp_size = 3096,
 .line_height = 15,

--- a/radio/src/fonts/lvgl/std/lv_font_ru_XXS.c
+++ b/radio/src/fonts/lvgl/std/lv_font_ru_XXS.c
@@ -147,13 +147,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x19,0x2a,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1067, .range_length = 37, .glyph_id_start = 27, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1105, .range_length = 1, .glyph_id_start = 64, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ru_XXS = {
+const etxLz4Font lv_font_ru_XXS __FLASH = {
 .uncomp_size = 3733,
 .comp_size = 2275,
 .line_height = 11,

--- a/radio/src/fonts/lvgl/std/lv_font_ru_bold_STD.c
+++ b/radio/src/fonts/lvgl/std/lv_font_ru_bold_STD.c
@@ -256,13 +256,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x22,0x23,0x24,0x14,0x25,0x14,0x1e,0x26,0x27,0x27,0x28,0x29,0x2a,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1067, .range_length = 37, .glyph_id_start = 27, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1105, .range_length = 1, .glyph_id_start = 64, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ru_bold_STD = {
+const etxLz4Font lv_font_ru_bold_STD __FLASH = {
 .uncomp_size = 6348,
 .comp_size = 4030,
 .line_height = 18,

--- a/radio/src/fonts/lvgl/std/lv_font_ru_bold_XL.c
+++ b/radio/src/fonts/lvgl/std/lv_font_ru_bold_XL.c
@@ -464,13 +464,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x23,0x24,0x14,0x25,0x14,0x1e,0x26,0x27,0x27,0x28,0x29,0x2a,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 1, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1067, .range_length = 37, .glyph_id_start = 27, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1105, .range_length = 1, .glyph_id_start = 64, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_ru_bold_XL = {
+const etxLz4Font lv_font_ru_bold_XL __FLASH = {
 .uncomp_size = 16236,
 .comp_size = 7357,
 .line_height = 36,

--- a/radio/src/fonts/lvgl/std/lv_font_tw_L.c
+++ b/radio/src/fonts/lvgl/std/lv_font_tw_L.c
@@ -6659,11 +6659,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,0x07,0xf4,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 645, .type = 3, .unicode_list = 5168, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_tw_L = {
+const etxLz4Font lv_font_tw_L __FLASH = {
 .uncomp_size = 172843,
 .comp_size = 106470,
 .line_height = 24,

--- a/radio/src/fonts/lvgl/std/lv_font_tw_XS.c
+++ b/radio/src/fonts/lvgl/std/lv_font_tw_XS.c
@@ -3038,11 +3038,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x77,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 645, .type = 3, .unicode_list = 5168, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_tw_XS = {
+const etxLz4Font lv_font_tw_XS __FLASH = {
 .uncomp_size = 58211,
 .comp_size = 48531,
 .line_height = 14,

--- a/radio/src/fonts/lvgl/std/lv_font_tw_XXS.c
+++ b/radio/src/fonts/lvgl/std/lv_font_tw_XXS.c
@@ -1833,11 +1833,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 645, .type = 3, .unicode_list = 5168, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_tw_XXS = {
+const etxLz4Font lv_font_tw_XXS __FLASH = {
 .uncomp_size = 33472,
 .comp_size = 29249,
 .line_height = 11,

--- a/radio/src/fonts/lvgl/std/lv_font_tw_bold_STD.c
+++ b/radio/src/fonts/lvgl/std/lv_font_tw_bold_STD.c
@@ -4233,11 +4233,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x70,0x5b,0x10,0x00,0x00,0xcf,0x20,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 645, .type = 3, .unicode_list = 5168, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_tw_bold_STD = {
+const etxLz4Font lv_font_tw_bold_STD __FLASH = {
 .uncomp_size = 85704,
 .comp_size = 67656,
 .line_height = 17,

--- a/radio/src/fonts/lvgl/std/lv_font_tw_bold_XL.c
+++ b/radio/src/fonts/lvgl/std/lv_font_tw_bold_XL.c
@@ -9633,11 +9633,11 @@ static const uint8_t lz4FontData[] __FLASH = {
 0xf1,0x07,0x3e,0x00,0x23,0x4c,0x30,0x73,0x00,0x50,0xf5,0x00,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 12289, .range_length = 28496, .glyph_id_start = 1, .list_length = 645, .type = 3, .unicode_list = 5168, .glyph_id_ofs_list = 0 },
 };
 
-const etxLz4Font lv_font_tw_bold_XL = {
+const etxLz4Font lv_font_tw_bold_XL __FLASH = {
 .uncomp_size = 310730,
 .comp_size = 154063,
 .line_height = 32,

--- a/radio/src/fonts/lvgl/std/lv_font_ua_L.c
+++ b/radio/src/fonts/lvgl/std/lv_font_ua_L.c
@@ -346,13 +346,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x26,0x18,0x27,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1028, .range_length = 4, .glyph_id_start = 1, .list_length = 4, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 520 },
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 4, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1068, .range_length = 44, .glyph_id_start = 30, .list_length = 44, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 524 },
 };
 
-const etxLz4Font lv_font_ua_L = {
+const etxLz4Font lv_font_ua_L __FLASH = {
 .uncomp_size = 9573,
 .comp_size = 5462,
 .line_height = 27,

--- a/radio/src/fonts/lvgl/std/lv_font_ua_XS.c
+++ b/radio/src/fonts/lvgl/std/lv_font_ua_XS.c
@@ -191,13 +191,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x1a,0x26,0x18,0x27,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1028, .range_length = 4, .glyph_id_start = 1, .list_length = 4, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 520 },
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 4, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1068, .range_length = 44, .glyph_id_start = 30, .list_length = 44, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 524 },
 };
 
-const etxLz4Font lv_font_ua_XS = {
+const etxLz4Font lv_font_ua_XS __FLASH = {
 .uncomp_size = 4571,
 .comp_size = 2983,
 .line_height = 15,

--- a/radio/src/fonts/lvgl/std/lv_font_ua_XXS.c
+++ b/radio/src/fonts/lvgl/std/lv_font_ua_XXS.c
@@ -141,13 +141,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x1f,0x20,0x21,0x22,0x23,0x24,0x13,0x25,0x13,0x1a,0x26,0x18,0x27,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1028, .range_length = 4, .glyph_id_start = 1, .list_length = 4, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 520 },
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 4, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1068, .range_length = 44, .glyph_id_start = 30, .list_length = 44, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 524 },
 };
 
-const etxLz4Font lv_font_ua_XXS = {
+const etxLz4Font lv_font_ua_XXS __FLASH = {
 .uncomp_size = 3494,
 .comp_size = 2192,
 .line_height = 11,

--- a/radio/src/fonts/lvgl/std/lv_font_ua_bold_STD.c
+++ b/radio/src/fonts/lvgl/std/lv_font_ua_bold_STD.c
@@ -246,13 +246,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x13,0x24,0x13,0x1d,0x25,0x26,0x27,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1028, .range_length = 4, .glyph_id_start = 1, .list_length = 4, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 520 },
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 4, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1068, .range_length = 44, .glyph_id_start = 30, .list_length = 44, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 524 },
 };
 
-const etxLz4Font lv_font_ua_bold_STD = {
+const etxLz4Font lv_font_ua_bold_STD __FLASH = {
 .uncomp_size = 6055,
 .comp_size = 3866,
 .line_height = 18,

--- a/radio/src/fonts/lvgl/std/lv_font_ua_bold_XL.c
+++ b/radio/src/fonts/lvgl/std/lv_font_ua_bold_XL.c
@@ -452,13 +452,13 @@ static const uint8_t lz4FontData[] __FLASH = {
 0x20,0x21,0x22,0x23,0x13,0x24,0x13,0x1d,0x25,0x26,0x27,0x00,0x00,0x00,
 };
 
-static const etxFontCmap cmaps[] = {
+static const etxFontCmap cmaps[] __FLASH = {
 { .range_start = 1028, .range_length = 4, .glyph_id_start = 1, .list_length = 4, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 520 },
 { .range_start = 1040, .range_length = 26, .glyph_id_start = 4, .list_length = 0, .type = 2, .unicode_list = 0, .glyph_id_ofs_list = 0 },
 { .range_start = 1068, .range_length = 44, .glyph_id_start = 30, .list_length = 44, .type = 0, .unicode_list = 0, .glyph_id_ofs_list = 524 },
 };
 
-const etxLz4Font lv_font_ua_bold_XL = {
+const etxLz4Font lv_font_ua_bold_XL __FLASH = {
 .uncomp_size = 15559,
 .comp_size = 7166,
 .line_height = 36,

--- a/radio/src/gui/colorlcd/bitmaps.cpp
+++ b/radio/src/gui/colorlcd/bitmaps.cpp
@@ -69,314 +69,314 @@ MaskBitmap* _decompressed_mask(const uint8_t* lz4_compressed)
   return raw;
 }
 
-static const uint8_t mask_menu_favs[] = {
+static const uint8_t mask_menu_favs[] __FLASH = {
 #include "mask_menu_favs.lbm"
 };
 
-static const uint8_t mask_menu_model[] = {
+static const uint8_t mask_menu_model[] __FLASH = {
 #include "mask_menu_model.lbm"
 };
-static const uint8_t mask_menu_notes[] = {
+static const uint8_t mask_menu_notes[] __FLASH = {
 #include "mask_menu_notes.lbm"
 };
-static const uint8_t mask_menu_radio[] = {
+static const uint8_t mask_menu_radio[] __FLASH = {
 #include "mask_menu_radio.lbm"
 };
-static const uint8_t mask_menu_stats[] = {
+static const uint8_t mask_menu_stats[] __FLASH = {
 #include "mask_menu_stats.lbm"
 };
-static const uint8_t mask_menu_theme[] = {
+static const uint8_t mask_menu_theme[] __FLASH = {
 #include "mask_menu_theme.lbm"
 };
-static const uint8_t mask_model_curves[] = {
+static const uint8_t mask_model_curves[] __FLASH = {
 #include "mask_model_curves.lbm"
 };
-static const uint8_t mask_model_flight_modes[] = {
+static const uint8_t mask_model_flight_modes[] __FLASH = {
 #include "mask_model_flight_modes.lbm"
 };
-static const uint8_t mask_model_gvars[] = {
+static const uint8_t mask_model_gvars[] __FLASH = {
 #include "mask_model_gvars.lbm"
 };
-static const uint8_t mask_model_heli[] = {
+static const uint8_t mask_model_heli[] __FLASH = {
 #include "mask_model_heli.lbm"
 };
-static const uint8_t mask_model_inputs[] = {
+static const uint8_t mask_model_inputs[] __FLASH = {
 #include "mask_model_inputs.lbm"
 };
-static const uint8_t mask_model_logical_switches[] = {
+static const uint8_t mask_model_logical_switches[] __FLASH = {
 #include "mask_model_logical_switches.lbm"
 };
-static const uint8_t mask_model_lua_scripts[] = {
+static const uint8_t mask_model_lua_scripts[] __FLASH = {
 #include "mask_model_lua_scripts.lbm"
 };
-static const uint8_t mask_model_mixer[] = {
+static const uint8_t mask_model_mixer[] __FLASH = {
 #include "mask_model_mixer.lbm"
 };
-static const uint8_t mask_model_outputs[] = {
+static const uint8_t mask_model_outputs[] __FLASH = {
 #include "mask_model_outputs.lbm"
 };
-static const uint8_t mask_model_setup[] = {
+static const uint8_t mask_model_setup[] __FLASH = {
 #include "mask_model_setup.lbm"
 };
-static const uint8_t mask_model_special_functions[] = {
+static const uint8_t mask_model_special_functions[] __FLASH = {
 #include "mask_model_special_functions.lbm"
 };
-static const uint8_t mask_model_telemetry[] = {
+static const uint8_t mask_model_telemetry[] __FLASH = {
 #include "mask_model_telemetry.lbm"
 };
-static const uint8_t mask_model_usb[] = {
+static const uint8_t mask_model_usb[] __FLASH = {
 #include "mask_model_usb.lbm"
 };
-static const uint8_t mask_menu_model_select[] = {
+static const uint8_t mask_menu_model_select[] __FLASH = {
 #include "mask_menu_model_select.lbm"  //TODO: someone may want to make proper icon
 };
-static const uint8_t mask_monitor[] = {
+static const uint8_t mask_monitor[] __FLASH = {
 #include "mask_monitor.lbm"
 };
-static const uint8_t mask_monitor_logsw[] = {
+static const uint8_t mask_monitor_logsw[] __FLASH = {
 #include "mask_monitor_logsw.lbm"
 };
-static const uint8_t mask_edgetx[] = {
+static const uint8_t mask_edgetx[] __FLASH = {
 #include "mask_edgetx.lbm"
 };
-static const uint8_t mask_radio_calibration[] = {
+static const uint8_t mask_radio_calibration[] __FLASH = {
 #include "mask_radio_calibration.lbm"
 };
-static const uint8_t mask_radio_global_functions[] = {
+static const uint8_t mask_radio_global_functions[] __FLASH = {
 #include "mask_radio_global_functions.lbm"
 };
-static const uint8_t mask_radio_hardware[] = {
+static const uint8_t mask_radio_hardware[] __FLASH = {
 #include "mask_radio_hardware.lbm"
 };
-static const uint8_t mask_radio_sd_browser[] = {
+static const uint8_t mask_radio_sd_browser[] __FLASH = {
 #include "mask_radio_sd_browser.lbm"
 };
-static const uint8_t mask_radio_setup[] = {
+static const uint8_t mask_radio_setup[] __FLASH = {
 #include "mask_radio_setup.lbm"
 };
-static const uint8_t mask_radio_tools[] = {
+static const uint8_t mask_radio_tools[] __FLASH = {
 #include "mask_radio_tools.lbm"
 };
-static const uint8_t mask_radio_edit_theme[] = {
+static const uint8_t mask_radio_edit_theme[] __FLASH = {
 #include "mask_radio_edit_theme.lbm"
 };
-static const uint8_t mask_radio_trainer[] = {
+static const uint8_t mask_radio_trainer[] __FLASH = {
 #include "mask_radio_trainer.lbm"
 };
-static const uint8_t mask_radio_version[] = {
+static const uint8_t mask_radio_version[] __FLASH = {
 #include "mask_radio_version.lbm"
 };
-static const uint8_t mask_stats_analogs[] = {
+static const uint8_t mask_stats_analogs[] __FLASH = {
 #include "mask_stats_analogs.lbm"
 };
-static const uint8_t mask_stats_debug[] = {
+static const uint8_t mask_stats_debug[] __FLASH = {
 #include "mask_stats_debug.lbm"
 };
-static const uint8_t mask_stats_timers[] = {
+static const uint8_t mask_stats_timers[] __FLASH = {
 #include "mask_stats_timers.lbm"
 };
-static const uint8_t mask_theme_add_view[] = {
+static const uint8_t mask_theme_add_view[] __FLASH = {
 #include "mask_theme_add_view.lbm"
 };
-static const uint8_t mask_theme_setup[] = {
+static const uint8_t mask_theme_setup[] __FLASH = {
 #include "mask_theme_setup.lbm"
 };
-static const uint8_t mask_theme_view1[] = {
+static const uint8_t mask_theme_view1[] __FLASH = {
 #include "mask_theme_view1.lbm"
 };
-static const uint8_t mask_theme_view2[] = {
+static const uint8_t mask_theme_view2[] __FLASH = {
 #include "mask_theme_view2.lbm"
 };
-static const uint8_t mask_theme_view3[] = {
+static const uint8_t mask_theme_view3[] __FLASH = {
 #include "mask_theme_view3.lbm"
 };
-static const uint8_t mask_theme_view4[] = {
+static const uint8_t mask_theme_view4[] __FLASH = {
 #include "mask_theme_view4.lbm"
 };
-static const uint8_t mask_theme_view5[] = {
+static const uint8_t mask_theme_view5[] __FLASH = {
 #include "mask_theme_view5.lbm"
 };
-static const uint8_t mask_theme_view6[] = {
+static const uint8_t mask_theme_view6[] __FLASH = {
 #include "mask_theme_view6.lbm"
 };
-static const uint8_t mask_theme_view7[] = {
+static const uint8_t mask_theme_view7[] __FLASH = {
 #include "mask_theme_view7.lbm"
 };
-static const uint8_t mask_theme_view8[] = {
+static const uint8_t mask_theme_view8[] __FLASH = {
 #include "mask_theme_view8.lbm"
 };
-static const uint8_t mask_theme_view9[] = {
+static const uint8_t mask_theme_view9[] __FLASH = {
 #include "mask_theme_view9.lbm"
 };
-static const uint8_t mask_theme_view10[] = {
+static const uint8_t mask_theme_view10[] __FLASH = {
 #include "mask_theme_view10.lbm"
 };
 
-static const uint8_t mask_chan_locked[] = {
+static const uint8_t mask_chan_locked[] __FLASH = {
 #include "mask_monitor_lockch.lbm"
 };
-static const uint8_t mask_chan_inverted[] = {
+static const uint8_t mask_chan_inverted[] __FLASH = {
 #include "mask_monitor_inver.lbm"
 };
 
-static const uint8_t mask_shutdown_circle0[] = {
+static const uint8_t mask_shutdown_circle0[] __FLASH = {
 #include "mask_shutdown_circle0.lbm"
 };
-static const uint8_t mask_shutdown_circle1[] = {
+static const uint8_t mask_shutdown_circle1[] __FLASH = {
 #include "mask_shutdown_circle1.lbm"
 };
-static const uint8_t mask_shutdown_circle2[] = {
+static const uint8_t mask_shutdown_circle2[] __FLASH = {
 #include "mask_shutdown_circle2.lbm"
 };
-static const uint8_t mask_shutdown_circle3[] = {
+static const uint8_t mask_shutdown_circle3[] __FLASH = {
 #include "mask_shutdown_circle3.lbm"
 };
 
-static const uint8_t mask_shutdown[] = {
+static const uint8_t mask_shutdown[] __FLASH = {
 #include "mask_shutdown.lbm"
 };
 
-const uint8_t mask_topleft_bg[] = {
+const uint8_t mask_topleft_bg[] __FLASH = {
 #include "mask_topleft.lbm"
 };
-const uint8_t mask_topright_bg[] = {
+const uint8_t mask_topright_bg[] __FLASH = {
 #include "mask_topright.lbm"
 };
 
-const uint8_t mask_currentmenu_bg[] = {
+const uint8_t mask_currentmenu_bg[] __FLASH = {
 #include "mask_currentmenu_bg.lbm"
 };
-const uint8_t mask_currentmenu_shadow[] = {
+const uint8_t mask_currentmenu_shadow[] __FLASH = {
 #include "mask_currentmenu_shadow.lbm"
 };
-const uint8_t mask_currentmenu_dot[] = {
+const uint8_t mask_currentmenu_dot[] __FLASH = {
 #include "mask_currentmenu_dot.lbm"
 };
 
-static const uint8_t mask_dot[] = {
+static const uint8_t mask_dot[] __FLASH = {
 #include "mask_dot.lbm"
 };
 
-static const uint8_t mask_topmenu_usb[] = {
+static const uint8_t mask_topmenu_usb[] __FLASH = {
 #include "mask_topmenu_usb.lbm"
 };
-static const uint8_t mask_topmenu_vol0[] = {
+static const uint8_t mask_topmenu_vol0[] __FLASH = {
 #include "mask_volume_0.lbm"
 };
-static const uint8_t mask_topmenu_vol1[] = {
+static const uint8_t mask_topmenu_vol1[] __FLASH = {
 #include "mask_volume_1.lbm"
 };
-static const uint8_t mask_topmenu_vol2[] = {
+static const uint8_t mask_topmenu_vol2[] __FLASH = {
 #include "mask_volume_2.lbm"
 };
-static const uint8_t mask_topmenu_vol3[] = {
+static const uint8_t mask_topmenu_vol3[] __FLASH = {
 #include "mask_volume_3.lbm"
 };
-static const uint8_t mask_topmenu_vol4[] = {
+static const uint8_t mask_topmenu_vol4[] __FLASH = {
 #include "mask_volume_4.lbm"
 };
-static const uint8_t mask_topmenu_vol_scale[] = {
+static const uint8_t mask_topmenu_vol_scale[] __FLASH = {
 #include "mask_volume_scale.lbm"
 };
-static const uint8_t mask_topmenu_txbatt[] = {
+static const uint8_t mask_topmenu_txbatt[] __FLASH = {
 #include "mask_txbat.lbm"
 };
 #if defined(USB_CHARGER)
-static const uint8_t mask_topmenu_txbatt_charging[] = {
+static const uint8_t mask_topmenu_txbatt_charging[] __FLASH = {
 #include "mask_txbat_charging.lbm"
 };
 #endif
 #if defined(INTERNAL_MODULE_PXX1) && defined(EXTERNAL_ANTENNA)
-static const uint8_t mask_topmenu_antenna[] = {
+static const uint8_t mask_topmenu_antenna[] __FLASH = {
 #include "mask_antenna.lbm"
 };
 #endif
 #if defined(INTERNAL_GPS)
-static const uint8_t mask_topmenu_gps[] = {
+static const uint8_t mask_topmenu_gps[] __FLASH = {
 #include "mask_topmenu_gps_18.lbm"
 };
 #endif
 
-static const uint8_t mask_error[] = {
+static const uint8_t mask_error[] __FLASH = {
 #include "mask_error.lbm"
 };
-static const uint8_t mask_busy[] = {
+static const uint8_t mask_busy[] __FLASH = {
 #include "mask_busy.lbm"
 };
 
-static const uint8_t mask_usb_plugged[] = {
+static const uint8_t mask_usb_plugged[] __FLASH = {
 #include "mask_usb_symbol.lbm"
 };
 
-static const uint8_t mask_timer[] = {
+static const uint8_t mask_timer[] __FLASH = {
 #include "mask_timer.lbm"
 };
-static const uint8_t mask_timer_bg[] = {
+static const uint8_t mask_timer_bg[] __FLASH = {
 #include "mask_timer_bg.lbm"
 };
 
-static const uint8_t mask_textline_curve[] = {
+static const uint8_t mask_textline_curve[] __FLASH = {
 #include "mask_textline_curve.lbm"
 };
-static const uint8_t mask_textline_fm[] = {
+static const uint8_t mask_textline_fm[] __FLASH = {
 #include "mask_textline_fm.lbm"
 };
 
-static const uint8_t mask_mplex_add[] = {
+static const uint8_t mask_mplex_add[] __FLASH = {
 #include "mask_mplex_add.lbm"
 };
-static const uint8_t mask_mplex_multi[] = {
+static const uint8_t mask_mplex_multi[] __FLASH = {
 #include "mask_mplex_multi.lbm"
 };
-static const uint8_t mask_mplex_replace[] = {
+static const uint8_t mask_mplex_replace[] __FLASH = {
 #include "mask_mplex_replace.lbm"
 };
 
-const uint8_t mask_round_title_left[]{
+const uint8_t mask_round_title_left[] __FLASH = {
 #include "mask_round_title_left.lbm"
 };
-const uint8_t mask_round_title_right[]{
+const uint8_t mask_round_title_right[] __FLASH = {
 #include "mask_round_title_right.lbm"
 };
 
-static const uint8_t mask_model_grid_large[] = {
+static const uint8_t mask_model_grid_large[] __FLASH = {
 #include "mask_model_grid_large.lbm"
 };
-static const uint8_t mask_model_grid_small[] = {
+static const uint8_t mask_model_grid_small[] __FLASH = {
 #include "mask_model_grid_small.lbm"
 };
-static const uint8_t mask_model_list_one[] = {
+static const uint8_t mask_model_list_one[] __FLASH = {
 #include "mask_model_list_one.lbm"
 };
-static const uint8_t mask_model_list_two[] = {
+static const uint8_t mask_model_list_two[] __FLASH = {
 #include "mask_model_list_two.lbm"
 };
 
-static const uint8_t mask_trim[] = {
+static const uint8_t mask_trim[] __FLASH = {
 #include "mask_trim.lbm"
 };
-static const uint8_t mask_trim_shadow[] = {
+static const uint8_t mask_trim_shadow[] __FLASH = {
 #include "mask_trim_shadow.lbm"
 };
 
-static const uint8_t mask_tools_apps[] = {
+static const uint8_t mask_tools_apps[] __FLASH = {
 #include "mask_tools_apps.lbm"
 };
-static const uint8_t mask_tools_reset[] = {
+static const uint8_t mask_tools_reset[] __FLASH = {
 #include "mask_tools_reset.lbm"
 };
 
-static const uint8_t mask_btn_close[] = {
+static const uint8_t mask_btn_close[] __FLASH = {
 #include "mask_btn_close.lbm"
 };
-static const uint8_t mask_btn_next[] = {
+static const uint8_t mask_btn_next[] __FLASH = {
 #include "mask_btn_next.lbm"
 };
-static const uint8_t mask_btn_prev[] = {
+static const uint8_t mask_btn_prev[] __FLASH = {
 #include "mask_btn_prev.lbm"
 };
 
-static const uint8_t mask_top_logo[] = {
+static const uint8_t mask_top_logo[] __FLASH = {
 #include "mask_top_logo.lbm"
 };
 
@@ -390,7 +390,7 @@ struct _BuiltinIcon {
   }
 
 // Note: Order must match EdgeTxIcon enum
-static const _BuiltinIcon _builtinIcons[EDGETX_ICONS_COUNT] = {
+static const _BuiltinIcon _builtinIcons[EDGETX_ICONS_COUNT] __FLASH = {
     BI(ICON_EDGETX, mask_edgetx),
     BI(ICON_QM_FAVORITES, mask_menu_favs),
     BI(ICON_RADIO, mask_menu_radio),

--- a/radio/src/gui/colorlcd/radio/radio_calibration.cpp
+++ b/radio/src/gui/colorlcd/radio/radio_calibration.cpp
@@ -31,10 +31,10 @@
 
 uint8_t menuCalibrationState;
 
-static const uint8_t stick_pointer[] = {
+static const uint8_t stick_pointer[] __FLASH = {
 #include "alpha_stick_pointer.lbm"
 };
-static const uint8_t stick_background[] = {
+static const uint8_t stick_background[] __FLASH = {
 #include "alpha_stick_background.lbm"
 };
 

--- a/radio/src/gui/colorlcd/startup_shutdown.cpp
+++ b/radio/src/gui/colorlcd/startup_shutdown.cpp
@@ -41,7 +41,7 @@ const std::string nam_str = strip_leading_hyphen("" VERSION_SUFFIX);
 const std::string git_str = "(" GIT_STR ")";
 #endif
 
-const uint8_t __bmp_splash_logo[]{
+const uint8_t __bmp_splash_logo[] __FLASH = {
 #include "splash_logo.lbm"
 };
 


### PR DESCRIPTION
Don't copy compressed bitmap data to SDRAM on H7 radios.
The compressed bitmap is only used to create the uncompressed bitmap, so there is no need to copy it to SDRAM.

Applies to 2.12 and 3.0.