### PR TITLE
chore(color): use static memory buffer for LVGL

### DIFF
--- a/radio/src/gui/colorlcd/lcd.cpp
+++ b/radio/src/gui/colorlcd/lcd.cpp
@@ -30,6 +30,16 @@
 #include "dma2d.h"
 #endif
 
+#if LV_MEM_CUSTOM == 0
+char LVGL_MEM_BUFFER[LV_MEM_SIZE] __SDRAM __ALIGNED(16);
+
+char* get_lvgl_mem(int nbytes)
+{
+  UNUSED(nbytes);
+  return LVGL_MEM_BUFFER;
+}
+#endif
+
 pixel_t LCD_FIRST_FRAME_BUFFER[DISPLAY_BUFFER_SIZE] __SDRAM;
 pixel_t LCD_SECOND_FRAME_BUFFER[DISPLAY_BUFFER_SIZE] __SDRAM;
 

--- a/radio/src/gui/colorlcd/lv_conf.h
+++ b/radio/src/gui/colorlcd/lv_conf.h
@@ -69,14 +69,8 @@
     #if LV_MEM_ADR == 0
         //#define LV_MEM_POOL_INCLUDE your_alloc_library  /* Uncomment if using an external allocator*/
         //#define LV_MEM_POOL_ALLOC   your_alloc          /* Uncomment if using an external allocator*/
-        #if defined(SIMU)
-            // 'sbrk' does not exist on Windows :(
-            #define LV_MEM_POOL_INCLUDE <stdlib.h>
-            #define LV_MEM_POOL_ALLOC malloc
-        #else
-            #define LV_MEM_POOL_INCLUDE <unistd.h>
-            #define LV_MEM_POOL_ALLOC sbrk
-        #endif
+        extern char* get_lvgl_mem(int);
+        #define LV_MEM_POOL_ALLOC get_lvgl_mem
     #endif
 
 #else       /*LV_MEM_CUSTOM*/


### PR DESCRIPTION
Compile time static allocation of lvgl memory buffer.

Applies to 2.12 and 3.0.