### PR TITLE
fix(x7): incorrect GPIO for SPort power pin

### DIFF
--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -2408,7 +2408,7 @@
   #define SPORT_UPDATE_PWR_GPIO         GPIO_PIN(GPIOB, 3) // PB.03
 #elif defined(RADIO_X7)
   #define SPORT_MAX_BAUDRATE            250000 // < 400000
-  #define SPORT_UPDATE_PWR_GPIO         GPIO_PIN(GPIOB, 3) // PB.02
+  #define SPORT_UPDATE_PWR_GPIO         GPIO_PIN(GPIOB, 2) // PB.02
 #elif defined(PCBX9LITE)
   #define SPORT_MAX_BAUDRATE            250000 // not tested
   #define SPORT_UPDATE_PWR_GPIO         GPIO_PIN(GPIOE, 15) // PE.15


### PR DESCRIPTION
Broken in #5023, with thanks to @bug400 for spotting it

Fixes #6884

Summary of changes:
- corrects what is most likely a copy/paste incorrect GPIO pin definition

Confirmed as working by issue raiser => https://github.com/EdgeTX/edgetx/issues/6884#issuecomment-3697715094