### PR TITLE
fix(dsmp): improve servo refresh rates to the module

### DIFF
--- a/radio/src/pulses/dsmp.cpp
+++ b/radio/src/pulses/dsmp.cpp
@@ -257,7 +257,8 @@ static void setupPulsesLemonDSMP(uint8_t module, uint8_t*& p_buf)
     } else if (--pass0_counter == 0) {
         pass = 0;
         updateModuleStatus(flags);
-        if ((version == 1) && (-- fastSetup_count > 0)) {
+        if ((version == 1) && (fastSetup_count > 0)) {
+            fastSetup_count--;
             pass0_counter = 2;  // Keep sendint setup every 2 ch messages
         } else {
           pass0_counter = pass0_period;  // restar counter


### PR DESCRIPTION
NOTE: For 2.11.5

Fixes #6931

Summary of changes:
Small fix to reduce the number of setup messages sent after startup and increase the servo refresh rate from the TX.

The original intention was:
During the Initial 3.5 seconds of power up the module, setup messages are sent every 3 messages (66ms),
After, only needed exporadically (1 every 100 messages, about 2.2 seconds).

But had a bug that kept sending setups every 3 messages forever, and that decreases the frequency of channel refresh messages from the TX to the DSMP and in some cases, while moving the servos from one side to the other, you notice a small delay/jump in the movement. Hardly noticeable, but this fixes it.
 