### PR TITLE
fix(color): audio does not play for switch and throttle warnings

### DIFF
--- a/radio/src/gui/colorlcd/controls/switch_warn_dialog.cpp
+++ b/radio/src/gui/colorlcd/controls/switch_warn_dialog.cpp
@@ -30,11 +30,6 @@ SwitchWarnDialog::SwitchWarnDialog() :
   last_bad_switches = 0xff;
   last_bad_pots = 0x0;
   setCloseCondition(std::bind(&SwitchWarnDialog::warningInactive, this));
-}
-
-void SwitchWarnDialog::delayedInit()
-{
-  FullScreenDialog::delayedInit();
   lv_label_set_long_mode(messageLabel->getLvObj(), LV_LABEL_LONG_WRAP);
   AUDIO_ERROR_MESSAGE(AU_SWITCH_ALERT);
 }
@@ -100,11 +95,6 @@ ThrottleWarnDialog::ThrottleWarnDialog(const char* msg) :
                      STR_PRESS_ANY_KEY_TO_SKIP)
 {
   setCloseCondition(std::bind(&ThrottleWarnDialog::warningInactive, this));
-}
-
-void ThrottleWarnDialog::delayedInit()
-{
-  FullScreenDialog::delayedInit();
   lv_label_set_long_mode(messageLabel->getLvObj(), LV_LABEL_LONG_WRAP);
   AUDIO_ERROR_MESSAGE(AU_THROTTLE_ALERT);
 }

--- a/radio/src/gui/colorlcd/controls/switch_warn_dialog.h
+++ b/radio/src/gui/colorlcd/controls/switch_warn_dialog.h
@@ -40,8 +40,6 @@ class SwitchWarnDialog : public FullScreenDialog
 
   bool warningInactive();
 
-  void delayedInit() override;
-
   void checkEvents() override;
 };
 
@@ -56,6 +54,4 @@ class ThrottleWarnDialog : public FullScreenDialog
 
  protected:
   bool warningInactive();
-
-  void delayedInit() override;
 };


### PR DESCRIPTION
Missed in #6737 

Fixes #6933

Required for 2.12 and 3.0.