### PR TITLE
feat(bw128): display RSSI/RQly on 4th line of telemetry screen when not used

### DIFF
--- a/radio/src/gui/128x64/view_telemetry.cpp
+++ b/radio/src/gui/128x64/view_telemetry.cpp
@@ -33,9 +33,11 @@ void displayRssiLine()
   if (TELEMETRY_STREAMING()) {
     lcdDrawSolidHorizontalLine(0, 55, 128, 0); // separator
     uint8_t rssi;
-    rssi = min((uint8_t)99, TELEMETRY_RSSI());
+    uint8_t max = 99; // TODO should be 100 for RQly
+    rssi = min(max, TELEMETRY_RSSI());
     lcdDrawNumber(LCD_W/2 -2, STATUS_BAR_Y, rssi, LEADING0 | RIGHT | SMLSIZE, 2);
-    lcdDrawText(lcdLastLeftPos,STATUS_BAR_Y, "RSSI : ", RIGHT | SMLSIZE);
+    lcdDrawText(lcdLastLeftPos,STATUS_BAR_Y, " : ", RIGHT | SMLSIZE);
+    lcdDrawText(lcdLastLeftPos,STATUS_BAR_Y, getRxStatLabels()->label, RIGHT | SMLSIZE);
     lcdDrawRect(65, 57, 38, 7);
     uint8_t v = 4*rssi/11;
     lcdDrawFilledRect(66+36-v, 58, v, 5, (rssi < g_model.rfAlarms.warning) ? DOTTED : SOLID);
@@ -108,7 +110,7 @@ bool displayNumbersTelemetryScreen(TelemetryScreenData & screen)
         fields_count++;
       }
       if (i==3) {
-        if (!TELEMETRY_STREAMING()) {
+        if (!TELEMETRY_STREAMING() || (screen.lines[i].sources[0] == 0 && screen.lines[i].sources[1] == 0)) {
           displayRssiLine();
           return fields_count;
         }

--- a/radio/src/gui/128x64/view_telemetry.cpp
+++ b/radio/src/gui/128x64/view_telemetry.cpp
@@ -36,8 +36,8 @@ void displayRssiLine()
     uint8_t max = 99; // TODO should be 100 for RQly
     rssi = min(max, TELEMETRY_RSSI());
     lcdDrawNumber(LCD_W/2 -2, STATUS_BAR_Y, rssi, LEADING0 | RIGHT | SMLSIZE, 2);
-    lcdDrawText(lcdLastLeftPos,STATUS_BAR_Y, " : ", RIGHT | SMLSIZE);
-    lcdDrawText(lcdLastLeftPos,STATUS_BAR_Y, getRxStatLabels()->label, RIGHT | SMLSIZE);
+    lcdDrawText(lcdLastLeftPos, STATUS_BAR_Y, ": ", RIGHT | SMLSIZE);
+    lcdDrawText(lcdLastLeftPos, STATUS_BAR_Y, getRxStatLabels()->label, RIGHT | SMLSIZE);
     lcdDrawRect(65, 57, 38, 7);
     uint8_t v = 4*rssi/11;
     lcdDrawFilledRect(66+36-v, 58, v, 5, (rssi < g_model.rfAlarms.warning) ? DOTTED : SOLID);

--- a/radio/src/gui/128x64/view_telemetry.cpp
+++ b/radio/src/gui/128x64/view_telemetry.cpp
@@ -32,12 +32,11 @@ void displayRssiLine()
 {
   if (TELEMETRY_STREAMING()) {
     lcdDrawSolidHorizontalLine(0, 55, 128, 0); // separator
-    uint8_t rssi;
-    uint8_t rssi_max = 99; // TODO should be 100 for RQly
-    rssi = min(rssi_max, TELEMETRY_RSSI());
+    rxStatStruct *rxStat = getRxStatLabels();
+    uint8_t rssi = min(rxStat->max, TELEMETRY_RSSI());
     lcdDrawNumber(LCD_W/2 -2, STATUS_BAR_Y, rssi, LEADING0 | RIGHT | SMLSIZE, 2);
     lcdDrawText(lcdLastLeftPos, STATUS_BAR_Y, ": ", RIGHT | SMLSIZE);
-    lcdDrawText(lcdLastLeftPos, STATUS_BAR_Y, getRxStatLabels()->label, RIGHT | SMLSIZE);
+    lcdDrawText(lcdLastLeftPos, STATUS_BAR_Y, rxStat->label, RIGHT | SMLSIZE);
     lcdDrawRect(65, 57, 38, 7);
     uint8_t v = 4*rssi/11;
     lcdDrawFilledRect(66+36-v, 58, v, 5, (rssi < g_model.rfAlarms.warning) ? DOTTED : SOLID);

--- a/radio/src/gui/128x64/view_telemetry.cpp
+++ b/radio/src/gui/128x64/view_telemetry.cpp
@@ -33,8 +33,8 @@ void displayRssiLine()
   if (TELEMETRY_STREAMING()) {
     lcdDrawSolidHorizontalLine(0, 55, 128, 0); // separator
     uint8_t rssi;
-    uint8_t max = 99; // TODO should be 100 for RQly
-    rssi = min(max, TELEMETRY_RSSI());
+    uint8_t rssi_max = 99; // TODO should be 100 for RQly
+    rssi = min(rssi_max, TELEMETRY_RSSI());
     lcdDrawNumber(LCD_W/2 -2, STATUS_BAR_Y, rssi, LEADING0 | RIGHT | SMLSIZE, 2);
     lcdDrawText(lcdLastLeftPos, STATUS_BAR_Y, ": ", RIGHT | SMLSIZE);
     lcdDrawText(lcdLastLeftPos, STATUS_BAR_Y, getRxStatLabels()->label, RIGHT | SMLSIZE);

--- a/radio/src/telemetry/telemetry.cpp
+++ b/radio/src/telemetry/telemetry.cpp
@@ -92,13 +92,14 @@ rxStatStruct *getRxStatLabels() {
   // default to RSSI/db notation
   rxStat.label = STR_RXSTAT_LABEL_RSSI;
   rxStat.unit  = STR_RXSTAT_UNIT_DBM;
+  rxStat.max   = 99;
 
   // Currently we can only display a single rx stat in settings/telemetry.
   // If both modules are used we choose the internal one
   // TODO: have to rx stat sections in settings/telemetry
   uint8_t moduleToUse = INTERNAL_MODULE;
 
-  if(g_model.moduleData[INTERNAL_MODULE].type == MODULE_TYPE_NONE && 
+  if(g_model.moduleData[INTERNAL_MODULE].type == MODULE_TYPE_NONE &&
      g_model.moduleData[EXTERNAL_MODULE].type != MODULE_TYPE_NONE) {
     moduleToUse = EXTERNAL_MODULE;
   }
@@ -115,6 +116,7 @@ rxStatStruct *getRxStatLabels() {
           multiProtocol == MODULE_SUBTYPE_MULTI_MLINK) {
         rxStat.label = STR_RXSTAT_LABEL_RQLY;
         rxStat.unit = STR_RXSTAT_UNIT_PERCENT;
+        rxStat.max = 100;
       }
     } break;
 #endif
@@ -122,6 +124,7 @@ rxStatStruct *getRxStatLabels() {
       if (g_model.moduleData[moduleToUse].subType == PPM_PROTO_TLM_MLINK) {
         rxStat.label = STR_RXSTAT_LABEL_RQLY;
         rxStat.unit = STR_RXSTAT_UNIT_PERCENT;
+        rxStat.max = 100;
       }
       break;
 
@@ -129,6 +132,7 @@ rxStatStruct *getRxStatLabels() {
     case MODULE_TYPE_GHOST:
       rxStat.label = STR_RXSTAT_LABEL_RQLY;
       rxStat.unit = STR_RXSTAT_UNIT_PERCENT;
+      rxStat.max = 100;
       break;
 
 #if defined(RADIO_NV14_FAMILY) && defined(AFHDS2)
@@ -139,6 +143,7 @@ rxStatStruct *getRxStatLabels() {
         if (NV14internalModuleFwVersion >= 0x1000E) {
           rxStat.label = STR_RXSTAT_LABEL_SIGNAL;
           rxStat.unit = STR_RXSTAT_UNIT_NOUNIT;
+          rxStat.max = 99;
         }
       }
       break;
@@ -508,7 +513,7 @@ void ModuleSyncStatus::update(uint16_t newRefreshRate, int16_t newInputLag)
 {
   if (!newRefreshRate)
     return;
-  
+
   if (newRefreshRate < MIN_REFRESH_RATE)
     newRefreshRate = newRefreshRate * (MIN_REFRESH_RATE / (newRefreshRate + 1));
   else if (newRefreshRate > MAX_REFRESH_RATE)
@@ -537,9 +542,9 @@ uint16_t ModuleSyncStatus::getAdjustedRefreshRate()
   if (lag == 0) {
     return refreshRate;
   }
-  
+
   newRefreshRate += lag;
-  
+
   if (newRefreshRate < MIN_REFRESH_RATE) {
       newRefreshRate = MIN_REFRESH_RATE;
   }
@@ -551,7 +556,7 @@ uint16_t ModuleSyncStatus::getAdjustedRefreshRate()
 #if 0
   TRACE("[SYNC] mod rate = %dus; lag = %dus",newRefreshRate,currentLag);
 #endif
-  
+
   return (uint16_t)newRefreshRate;
 }
 

--- a/radio/src/telemetry/telemetry.h
+++ b/radio/src/telemetry/telemetry.h
@@ -132,6 +132,7 @@ void frskyDSetDefault(int index, uint16_t id);
 typedef struct {
   const char *label;
   const char *unit;
+  uint8_t max;
 } rxStatStruct;
 
 rxStatStruct *getRxStatLabels();


### PR DESCRIPTION
Summary of changes:
* Display RSSI/RQly widget on 4th line of telemetry screen when it is not used.
* Use proper label per used protocol.
* Add a TODO for better value clamping.