### PR TITLE
fix(color): Lua scripts do not see selected language when using ALL_LANGS build

### DIFF
--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1758,7 +1758,15 @@ static int luaGetGeneralSettings(lua_State * L)
   lua_pushtablenumber(L, "battMin", (90+g_eeGeneral.vBatMin) * 0.1f);
   lua_pushtablenumber(L, "battMax", (120+g_eeGeneral.vBatMax) * 0.1f);
   lua_pushtableinteger(L, "imperial", g_eeGeneral.imperial);
+#if defined(ALL_LANGS)
+  char l[3];
+  l[0] = toupper(g_eeGeneral.ttsLanguage[0]);
+  l[1] = toupper(g_eeGeneral.ttsLanguage[1]);
+  l[2] = 0;
+  lua_pushtablestring(L, "language", l);
+#else
   lua_pushtablestring(L, "language", TRANSLATIONS);
+#endif
   lua_pushtablestring(L, "voice", currentLanguagePack->id);
   lua_pushtableinteger(L, "gtimer", g_eeGeneral.globalTimer);
   return 1;

--- a/radio/src/lua/lua_widget_factory.cpp
+++ b/radio/src/lua/lua_widget_factory.cpp
@@ -110,7 +110,14 @@ void LuaWidgetFactory::translateOptions(WidgetOption * options)
   // No translations provided
   if (!translateFunction) return;
 
-  auto lang = TRANSLATIONS;
+#if defined(ALL_LANGS)
+  char lang[3];
+  lang[0] = toupper(g_eeGeneral.ttsLanguage[0]);
+  lang[1] = toupper(g_eeGeneral.ttsLanguage[1]);
+  lang[2] = 0;
+#else
+  char* lang = TRANSLATIONS;
+#endif
 
   auto option = options;
   while (option && option->name != nullptr) {


### PR DESCRIPTION
Use selected language for Lua when ALL_LANGS build option is set.

Required for 2.12 and 3.0.