### PR TITLE
chore(color): improve TRACE error messages for image file handling.

### DIFF
--- a/radio/src/gui/colorlcd/libui/static.cpp
+++ b/radio/src/gui/colorlcd/libui/static.cpp
@@ -22,6 +22,7 @@
 #include "lz4/lz4.h"
 #include "sdcard.h"
 #include "etx_lv_theme.h"
+#include "stb/stb_image.h"
 
 //-----------------------------------------------------------------------------
 
@@ -238,7 +239,7 @@ void StaticImage::setSource(std::string filename)
     lv_img_set_src(image, fullpath.c_str());
     if (!hasImage()) {
       // Failed to load
-      TRACE_ERROR("could not load image '%s'", filename.c_str());
+      TRACE_ERROR("could not load image '%s' - %s\n", filename.c_str(), stbi_failure_reason());
       clearSource();
     }
     setZoom();


### PR DESCRIPTION
Mainly for Lua script development in the simulator.

Applies to 2.11, 2.12 and 3.0.