### PR TITLE
fix(color): simulator may crash or freeze when RF module is set to MPM

### DIFF
--- a/radio/src/definitions.h
+++ b/radio/src/definitions.h
@@ -31,10 +31,12 @@
 typedef const char* STR_TYP;
 #define STR_DEF(x) x
 #define STR_VAL(x) x
+#define STR_SAFE_VAL(x) x
 #else
 typedef const char* (*STR_TYP)();
 #define STR_DEF(x) x##_FN
 #define STR_VAL(x) x()
+#define STR_SAFE_VAL(x) (x ? x() : nullptr)
 #endif
 
 #if !defined(M_PI)

--- a/radio/src/gui/colorlcd/module/module_setup.cpp
+++ b/radio/src/gui/colorlcd/module/module_setup.cpp
@@ -32,6 +32,7 @@
 #include "ppm_settings.h"
 #include "storage/modelslist.h"
 #include "etx_lv_theme.h"
+#include "os/sleep.h"
 
 #if defined(INTERNAL_MODULE_PXX1) && defined(EXTERNAL_ANTENNA)
 #include "pxx1_settings.h"
@@ -611,9 +612,10 @@ class ModuleSubTypeChoice : public Choice
       MultiModuleStatus& status = getMultiModuleStatus(moduleIdx);
       status.invalidate();
 
-      uint32_t startUpdate = lv_tick_get();
-      while (!status.isValid() && (lv_tick_elaps(startUpdate) < 250))
-        ;
+      uint32_t startUpdate = time_get_ms();
+      while (!status.isValid() && (time_get_ms() - startUpdate < 250))
+        sleep_ms(1);
+
       SET_DIRTY();
 #endif
     }

--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -1261,7 +1261,7 @@ const char * getMultiOptionTitleStatic(uint8_t moduleIdx)
 {
   const uint8_t multi_proto = g_model.moduleData[moduleIdx].multi.rfProtocol;
   const mm_protocol_definition * pdef = getMultiProtocolDefinition(multi_proto);
-  return STR_VAL(pdef->optionsstr);
+  return STR_SAFE_VAL(pdef->optionsstr);
 }
 
 const char * getMultiOptionTitle(uint8_t moduleIdx)
@@ -1272,7 +1272,7 @@ const char * getMultiOptionTitle(uint8_t moduleIdx)
     if (status.optionDisp >= getMaxMultiOptions()) {
       status.optionDisp = 1; // Unknown options are defaulted to type 1 (basic option)
     }
-    return STR_VAL(mm_options_strings::options[status.optionDisp]);
+    return STR_SAFE_VAL(mm_options_strings::options[status.optionDisp]);
   }
 
   return getMultiOptionTitleStatic(moduleIdx);


### PR DESCRIPTION
Fix simulator crash when internal module is MPM (broken in #6510).
Fix simulator freeze when changing MPM protocol (broken in #5840).

Fixes #6953
