### PR TITLE
fix(color): back button may not be visible on Lua script 'page'

### DIFF
--- a/radio/src/gui/colorlcd/setup_menus/pagegroup.h
+++ b/radio/src/gui/colorlcd/setup_menus/pagegroup.h
@@ -232,10 +232,12 @@ class PageGroup : public PageGroupBase
   static LAYOUT_VAL_SCALED(PAGE_GROUP_TOP_BAR_H, 48)
   static constexpr coord_t PAGE_GROUP_ALT_TITLE_H = EdgeTxStyles::STD_FONT_HEIGHT;
   static constexpr coord_t PAGE_GROUP_BACK_BTN_W = 0;
+  static LAYOUT_VAL_SCALED(PAGE_GROUP_BACK_BTN_XO, 45)
 #else
   static LAYOUT_VAL_SCALED(PAGE_GROUP_TOP_BAR_H, 45)
   static constexpr coord_t PAGE_GROUP_ALT_TITLE_H = 0;
   static constexpr coord_t PAGE_GROUP_BACK_BTN_W = PAGE_GROUP_TOP_BAR_H;
+  static constexpr coord_t PAGE_GROUP_BACK_BTN_XO = PAGE_GROUP_TOP_BAR_H;
 #endif
   static constexpr coord_t PAGE_GROUP_BODY_Y = PAGE_GROUP_TOP_BAR_H + PAGE_GROUP_ALT_TITLE_H;
 

--- a/radio/src/gui/colorlcd/themes/theme_manager.cpp
+++ b/radio/src/gui/colorlcd/themes/theme_manager.cpp
@@ -573,7 +573,7 @@ HeaderIcon::HeaderIcon(Window* parent, const char* iconFile, std::function<void(
 }
 
 HeaderBackIcon::HeaderBackIcon(Window* parent, std::function<void()> action) :
-  StaticIcon(parent, LCD_W - PageGroup::PAGE_GROUP_BACK_BTN_W, 0, ICON_TOPRIGHT_BG, COLOR_THEME_FOCUS_INDEX),
+  StaticIcon(parent, LCD_W - PageGroup::PAGE_GROUP_BACK_BTN_XO, 0, ICON_TOPRIGHT_BG, COLOR_THEME_FOCUS_INDEX),
   action(std::move(action))
 {
   (new StaticIcon(this, 0, 0, ICON_BTN_CLOSE, COLOR_THEME_PRIMARY2_INDEX))->center(width() + PAD_MEDIUM, height());

--- a/radio/src/lua/lua_lvgl_widget.cpp
+++ b/radio/src/lua/lua_lvgl_widget.cpp
@@ -2302,13 +2302,13 @@ class WidgetPage : public NavWindow, public LuaEventHandler
   {
 #if defined(HARDWARE_TOUCH)
     if (showPrev) {
-      prevBtn = new IconButton(this, ICON_BTN_PREV, LCD_W - PageGroup::PAGE_GROUP_BACK_BTN_W * 3, PAD_MEDIUM, [=]() {
+      prevBtn = new IconButton(this, ICON_BTN_PREV, LCD_W - PageGroup::PAGE_GROUP_BACK_BTN_XO * 3, PAD_MEDIUM, [=]() {
         prevAction();
         return 0;
       });
     }
     if (showNext) {
-      nextBtn = new IconButton(this, ICON_BTN_NEXT, LCD_W - PageGroup::PAGE_GROUP_BACK_BTN_W * 2, PAD_MEDIUM, [=]() {
+      nextBtn = new IconButton(this, ICON_BTN_NEXT, LCD_W - PageGroup::PAGE_GROUP_BACK_BTN_XO * 2, PAD_MEDIUM, [=]() {
         nextAction();
         return 0;
       });


### PR DESCRIPTION
Fix position of back button for Lua script 'page'.

Required for 2.12; but should be applied to 3.0 as well to keep code consistent.