### PR TITLE
fix: ensure ws2812 DMA transfer is completed before disabling channel

### DIFF
--- a/radio/src/targets/common/arm/stm32/stm32_ws2812.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_ws2812.cpp
@@ -139,6 +139,12 @@ static void _update_dma_buffer(const stm32_pulse_timer_t* tim, uint8_t tc)
     LL_DMA_DisableIT_TC(tim->DMAx, tim->DMA_Stream);
     LL_DMA_DisableIT_HT(tim->DMAx, tim->DMA_Stream);
     LL_DMA_DisableStream(tim->DMAx, tim->DMA_Stream);
+
+    uint32_t timeout = 1000;
+    while (LL_DMA_IsEnabledStream(tim->DMAx, tim->DMA_Stream) && timeout--) 	{
+      __NOP();  // Wait
+    }
+
     LL_TIM_CC_DisableChannel(tim->TIMx, tim->TIM_Channel);
   }
   WS2812_DBG_LOW;


### PR DESCRIPTION
During testing of their new upcoming radio, Radiomaster did notice that when left very extended periods of time (12hours+), the RGB leds might stop working. While nearly impossible to catch the issue while it is happening, they have found that making this change seem to prevent this issue from happening.

For 2.12 also please