### PR TITLE
fix(pl18): can not use trainer port

### DIFF
--- a/radio/src/targets/pl18/hal.h
+++ b/radio/src/targets/pl18/hal.h
@@ -497,8 +497,8 @@
 #define TRAINER_IN_GPIO                 GPIO_PIN(GPIOD, 12) // PD.12
 #define TRAINER_IN_TIMER_Channel        LL_TIM_CHANNEL_CH1
 
-#define TRAINER_OUT_GPIO                GPIO_PIN(GPIOD, 13) // PD.13
-#define TRAINER_OUT_TIMER_Channel       LL_TIM_CHANNEL_CH2
+#define TRAINER_OUT_GPIO                GPIO_PIN(GPIOD, 12) // PD.12
+#define TRAINER_OUT_TIMER_Channel       LL_TIM_CHANNEL_CH1
 
 #define TRAINER_TIMER                   TIM4
 #define TRAINER_TIMER_IRQn              TIM4_IRQn


### PR DESCRIPTION
fix pl18 can not use trainer port


Fixes #6710

Summary of changes:
change radio/targets/pl18/hal.h
origin
```
#define TRAINER_IN_GPIO                 GPIO_PIN(GPIOD, 12) // PD.12
#define TRAINER_IN_TIMER_Channel        LL_TIM_CHANNEL_CH1

#define TRAINER_OUT_GPIO                GPIO_PIN(GPIOD, 13) // PD.13
#define TRAINER_OUT_TIMER_Channel       LL_TIM_CHANNEL_CH2

```

fixed

```
#define TRAINER_IN_GPIO                 GPIO_PIN(GPIOD, 12) // PD.12
#define TRAINER_IN_TIMER_Channel        LL_TIM_CHANNEL_CH1

#define TRAINER_OUT_GPIO                GPIO_PIN(GPIOD, 12) // PD.12
#define TRAINER_OUT_TIMER_Channel       LL_TIM_CHANNEL_CH1
```


Tested functions:
1. Use Phoenix Simulator √
2. As Master/Jack √
3. As Salve/Jack √