### PR TITLE
fix(cmake): honor parallel limits for custom targets

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,51 +80,56 @@ if(EdgeTX_SUPERBUILD)
     EXCLUDE_FROM_ALL TRUE
   )
 
+  if(DEFINED CMAKE_BUILD_PARALLEL_LEVEL)
+    set(PARALLEL_FLAG --parallel ${CMAKE_BUILD_PARALLEL_LEVEL})
+  else()
+    set(PARALLEL_FLAG --parallel)
+  endif()
+
   add_custom_target(configure
     DEPENDS native-configure arm-none-eabi-configure)
 
   add_custom_target(libsimulator
-    COMMAND ${CMAKE_COMMAND} --build native --target libsimulator --parallel
+    COMMAND ${CMAKE_COMMAND} --build native --target libsimulator ${PARALLEL_FLAG}
     DEPENDS native-configure
   )
 
   add_custom_target(simulator
-    COMMAND ${CMAKE_COMMAND} --build native --target simulator --parallel
+    COMMAND ${CMAKE_COMMAND} --build native --target simulator ${PARALLEL_FLAG}
     DEPENDS native-configure
   )
 
   add_custom_target(simu
-    COMMAND ${CMAKE_COMMAND} --build native --target simu --parallel
-    DEPENDS native-configure
+    COMMAND ${CMAKE_COMMAND} --build native --target simu ${PARALLEL_FLAG}
   )
 
   add_custom_target(companion
-    COMMAND ${CMAKE_COMMAND} --build native --target companion --parallel
+    COMMAND ${CMAKE_COMMAND} --build native --target companion ${PARALLEL_FLAG}
     DEPENDS native-configure
   )
 
   add_custom_target(gtests-radio
-    COMMAND ${CMAKE_COMMAND} --build native --target gtests-radio --parallel
+    COMMAND ${CMAKE_COMMAND} --build native --target gtests-radio ${PARALLEL_FLAG}
     DEPENDS native-configure
   )
 
   add_custom_target(tests-radio
-    COMMAND ${CMAKE_COMMAND} --build native --target tests-radio --parallel
+    COMMAND ${CMAKE_COMMAND} --build native --target tests-radio ${PARALLEL_FLAG}
     DEPENDS native-configure
   )
 
   add_custom_target(bootloader
-    COMMAND ${CMAKE_COMMAND} --build arm-none-eabi --target bootloader --parallel
+    COMMAND ${CMAKE_COMMAND} --build arm-none-eabi --target bootloader ${PARALLEL_FLAG}
     DEPENDS arm-none-eabi-configure
   )
 
   add_custom_target(firmware
-    COMMAND ${CMAKE_COMMAND} --build arm-none-eabi --target firmware --parallel
+    COMMAND ${CMAKE_COMMAND} --build arm-none-eabi --target firmware ${PARALLEL_FLAG}
     DEPENDS arm-none-eabi-configure
   )
 
   add_custom_target(firmware-size
-    COMMAND ${CMAKE_COMMAND} --build arm-none-eabi --target firmware-size --parallel
+    COMMAND ${CMAKE_COMMAND} --build arm-none-eabi --target firmware-size ${PARALLEL_FLAG}
     DEPENDS arm-none-eabi-configure
   )
 


### PR DESCRIPTION
Summary of changes:
- Makes it so the parallel build option isn't completely overridden when using the custom CMake targets. Needed in order to build things like Companion with only 16GB of ram (if you don't want the build to either fail or completely lock your device up). Really, @raphaelcoeffic ? REALLY?!?! :rofl: 

To set, use `-DCMAKE_BUILD_PARALLEL_LEVEL=<num-parallel-tasks>` in your initial CMake line

In a nutshell

- CMAKE_BUILD_PARALLEL_LEVEL env var propagates to the inner cmake correctly
- GNU make's jobserver conflict (-j0 forced in submake) overrides it, making limiting cores impossible with the make generator
- Alternative is to use  -GNinja — solves the problem cleanly, no workarounds needed, and to boot should be a lot faster

Control over parallel settings was broken by #6455
