### PR TITLE
fix(f4): re-enable pre-fetch, instruction and data cache

### DIFF
--- a/radio/src/targets/common/arm/stm32/f4/system_clock.c
+++ b/radio/src/targets/common/arm/stm32/f4/system_clock.c
@@ -58,6 +58,11 @@ void SystemClock_Config(void)
   /* Set FLASH latency */
   LL_FLASH_SetLatency(LL_FLASH_LATENCY_5);
 
+  /* Setup pre-fetch + caches */
+  LL_FLASH_EnablePrefetch();
+  LL_FLASH_EnableInstCache();
+  LL_FLASH_EnableDataCache();
+
   /* Enable PWR clock */
   LL_APB1_GRP1_EnableClock(LL_APB1_GRP1_PERIPH_PWR);
 


### PR DESCRIPTION
This was disabled by mistake in #6183.

Fixes #6816.