### PR TITLE
fix(color): widgets may not use all available space on some radios

### DIFF
--- a/radio/src/gui/colorlcd/mainview/view_main_decoration.h
+++ b/radio/src/gui/colorlcd/mainview/view_main_decoration.h
@@ -72,6 +72,8 @@ class ViewMainDecoration
   Window* sliders[SLIDERS_MAX] = { 0 };
   MainViewTrim* trims[TRIMS_MAX] = { 0 };
   Window* flightMode = nullptr;
+  bool hasVerticalSliders = false;
+  bool has6POS = false;
 
   Window* layoutBox(Window* parent, lv_align_t align, lv_flex_flow_t flow);
 


### PR DESCRIPTION
Changes:
- for radios with 2 (or less) sliders the width that would be used by the vertical sliders is allocated to widgets
- for radios that do not use the bottom center slider area (i.e. 6POS), the height available for widgets is increased

Marked for 2.12 / 3.0; but could be applied to 2.11 if desired.

Before:
<img width="480" height="320" alt="screenshot_tx15_26-01-11_12-02-51" src="https://github.com/user-attachments/assets/a245a6eb-6fa4-488d-ba19-683358608c43" />

After:
<img width="480" height="320" alt="screenshot_tx15_26-01-11_12-04-02" src="https://github.com/user-attachments/assets/6329137d-7c25-4a22-8f2a-5068c73e8c54" />
