### PR TITLE
fix(bw): input trim display is incorrect on some B&W radios

### DIFF
--- a/radio/src/gui/common/stdlcd/model_inputs.cpp
+++ b/radio/src/gui/common/stdlcd/model_inputs.cpp
@@ -192,7 +192,7 @@ void displayExpoLine(coord_t y, ExpoData * ed, LcdFlags attr)
     if (ed->trimSource > 0) {
       lcdDrawChar(EXPO_LINE_TRIM_POS, y, '-', attr);
     } else {
-      const char* short_label = getAnalogShortLabel(inputMappingConvertMode(-ed->trimSource - 1));
+      const char* short_label = getAnalogShortLabel(-ed->trimSource - 1);
       lcdDrawChar(EXPO_LINE_TRIM_POS, y, short_label ? short_label[0] : ' ', attr);
     }
   }


### PR DESCRIPTION
Fix value used to get channel name.

Fixes #6977 

Applies to 2.11, 2.12 and 3.0
