### PR TITLE
fix(telemetry): don't override protocol defined distance and precision definitions

### DIFF
--- a/radio/src/telemetry/telemetry_sensors.cpp
+++ b/radio/src/telemetry/telemetry_sensors.cpp
@@ -617,10 +617,6 @@ void TelemetrySensor::init(const char * label, uint8_t unit, uint8_t prec)
   memclear(this->label, TELEM_LABEL_LEN);
   strncpy(this->label, label, TELEM_LABEL_LEN);
   this->unit = unit;
-  if (prec > 1 && (IS_DISTANCE_UNIT(unit) || IS_SPEED_UNIT(unit))) {
-    // 2 digits precision is not needed here
-    prec = 1;
-  }
   this->prec = prec;
   // Log sensors by default
   this->logs = true;


### PR DESCRIPTION
CRSF VSpd is defined with cm/s resolution (PREC2) but after sensor discovery is listed as PREC1 (dm/s). 

EdgeTX overrides precision definitions to PREC1 for all distance and speed units if a precision > 1 was defined. If definitions made in the protocol decoder are wrong they should be corrected there but there shouldn't be a general override of protocol decoder settings.