### PR TITLE
fix(crsf): assign GPS Alt unique name rather than share Baro Alt

### DIFF
--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -64,7 +64,7 @@ const CrossfireSensor crossfireSensors[] = {
   CS(GPS_ID,         0, STR_DEF(STR_SENSOR_GPS),           UNIT_GPS_LONGITUDE,     0),
   CS(GPS_ID,         2, STR_DEF(STR_SENSOR_GSPD),          UNIT_KMH,               1),
   CS(GPS_ID,         3, STR_DEF(STR_SENSOR_HDG),           UNIT_DEGREE,            2),
-  CS(GPS_ID,         4, STR_DEF(STR_SENSOR_ALT),           UNIT_METERS,            0),
+  CS(GPS_ID,         4, STR_DEF(STR_SENSOR_GPSALT),        UNIT_METERS,            0),
   CS(GPS_ID,         5, STR_DEF(STR_SENSOR_SATELLITES),    UNIT_RAW,               0),
   CS(ATTITUDE_ID,    0, STR_DEF(STR_SENSOR_PITCH),         UNIT_RADIANS,           3),
   CS(ATTITUDE_ID,    1, STR_DEF(STR_SENSOR_ROLL),          UNIT_RADIANS,           3),


### PR DESCRIPTION
With the release of Betaflight 2025.12, CRSF now transmits two different altitude values:
- GPS altitude in the GPS frame (0x02)
- Barometric altitude (and vertical speed) in the new frame (0x09)


Currently, both of these values are displayed as "Alt" in EdgeTX, which makes it impossible to distinguish between them, even though they represent different data sources and have different characteristics (barometric altitude is in `cm` or `dm` while GPS altitude is only in `m`).

With this PR, the telemetry data related to the GPS altitude is displayed as "GAlt" while the barometric altitude is displayed as "Alt"

Fixes #5852 

Summary of changes:
- Change ALT to GPSALT 

Tested on a RM Pocket
![20260115_134813](https://github.com/user-attachments/assets/db18e34a-229e-4121-b80e-3e81cfdd8841)
