### PR TITLE
fix(color): pressing a key may cause unnecessary page reload

### DIFF
--- a/radio/src/gui/colorlcd/setup_menus/pagegroup.cpp
+++ b/radio/src/gui/colorlcd/setup_menus/pagegroup.cpp
@@ -400,7 +400,7 @@ void PageGroupBase::doKeyShortcut(event_t event)
   if (pg == QM_OPEN_QUICK_MENU) {
     if (!quickMenu) openMenu();
   } else {
-    if (QuickMenu::pageIcon(pg) == icon) {
+    if (QuickMenu::subMenuIcon(pg) == icon) {
       setCurrentTab(QuickMenu::pageIndex(pg));
     } else {
       onCancel();

--- a/radio/src/gui/colorlcd/setup_menus/quick_menu.cpp
+++ b/radio/src/gui/colorlcd/setup_menus/quick_menu.cpp
@@ -366,7 +366,7 @@ void QuickMenu::openPage(QMPage page)
   }
 }
 
-EdgeTxIcon QuickMenu::pageIcon(QMPage page)
+EdgeTxIcon QuickMenu::subMenuIcon(QMPage page)
 {
   for (int i = FIRST_SEARCH_IDX; qmTopItems[i].icon != EDGETX_ICONS_COUNT; i += 1) {
     if (qmTopItems[i].pageAction == QM_ACTION) {
@@ -377,7 +377,7 @@ EdgeTxIcon QuickMenu::pageIcon(QMPage page)
       PageDef* sub = qmTopItems[i].subMenuItems;
       for (int j = 0; sub[j].icon != EDGETX_ICONS_COUNT; j += 1) {
         if (sub[j].qmPage == page) {
-          return sub[j].icon;
+          return qmTopItems[i].icon;
         }
       }
     }

--- a/radio/src/gui/colorlcd/setup_menus/quick_menu.h
+++ b/radio/src/gui/colorlcd/setup_menus/quick_menu.h
@@ -70,7 +70,7 @@ class QuickMenu : public NavWindow
   static void shutdownQuickMenu();
   static void selected();
   static void openPage(QMPage page);
-  static EdgeTxIcon pageIcon(QMPage page);
+  static EdgeTxIcon subMenuIcon(QMPage page);
   static int pageIndex(QMPage page);
   static std::vector<std::string> menuPageNames(bool forFavorites);
 


### PR DESCRIPTION
Fix key navigation in menus.

In the Model Setup page, the MDL key should not cause the menu to be deleted and reloaded. Similarly for other keys / pages.

Applies to 2.12 and 3.0.