### PR TITLE
fix(color): subtrim value on Outputs page not updated when copying all trims to sub trims

### DIFF
--- a/radio/src/gui/colorlcd/model/model_outputs.cpp
+++ b/radio/src/gui/colorlcd/model/model_outputs.cpp
@@ -228,6 +228,8 @@ void ModelOutputsPage::build(Window* window)
         STR_TRIMS2OFFSETS, STR_ADD_ALL_TRIMS_TO_SUBTRIMS,
         [=] {
           moveTrimsToOffsets();
+          for (int i = 0; i < outputButtons.size(); i += 1)
+            outputButtons[i]->refresh();
         });
     return 0;
   });
@@ -240,6 +242,8 @@ void ModelOutputsPage::build(Window* window)
     auto btn = new OutputLineButton(window, ch);
     lv_obj_set_pos(btn->getLvObj(), TRIMB_X, TRIMB_Y + (ch * (OutputLineButton::CH_LINE_H + PAD_TINY)));
     btn->setWidth(TRIMB_W);
+
+    outputButtons.emplace_back(btn);
 
     LimitData* output = limitAddress(ch);
     btn->setPressHandler([=]() -> uint8_t {

--- a/radio/src/gui/colorlcd/model/model_outputs.h
+++ b/radio/src/gui/colorlcd/model/model_outputs.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <vector>
+
 #include "pagegroup.h"
 
 class OutputLineButton;
@@ -49,5 +51,7 @@ class ModelOutputsPage : public PageGroupItem
   static constexpr coord_t TRIMB_W = LCD_W - PAD_SMALL * 2;
 
  protected:
+  std::vector<OutputLineButton*> outputButtons;
+
   void editOutput(uint8_t channel, OutputLineButton* btn);
 };


### PR DESCRIPTION
Update output list after using the 'Add all trims to subtrims' button.

Applies to 2.11, 2.12 and 3.0.
