### PR TITLE
fix(color): model notes button visibility in quick menu may be incorrect

### DIFF
--- a/radio/src/gui/colorlcd/setup_menus/quick_menu.cpp
+++ b/radio/src/gui/colorlcd/setup_menus/quick_menu.cpp
@@ -264,16 +264,14 @@ QuickMenu::QuickMenu() :
 #endif
 
   for (int i = 0; qmTopItems[i].icon != EDGETX_ICONS_COUNT; i += 1) {
-    if ((qmTopItems[i].enabled == nullptr) || qmTopItems[i].enabled()) {
-      if (qmTopItems[i].pageAction == QM_ACTION) {
-        mainMenu->addButton(qmTopItems[i].icon, STR_VAL(qmTopItems[i].qmTitle), qmTopItems[i].action);
+    if (qmTopItems[i].pageAction == QM_ACTION) {
+      mainMenu->addButton(qmTopItems[i].icon, STR_VAL(qmTopItems[i].qmTitle), qmTopItems[i].action, qmTopItems[i].enabled);
 #if VERSION_MAJOR > 2
-      } else {
-        auto sub = new QuickSubMenu(box, this, qmTopItems[i].icon, STR_VAL(qmTopItems[i].qmTitle), STR_VAL(qmTopItems[i].title), qmTopItems[i].subMenuItems);
-        sub->addButton();
-        subMenus.emplace_back(sub);
+    } else {
+      auto sub = new QuickSubMenu(box, this, qmTopItems[i].icon, STR_VAL(qmTopItems[i].qmTitle), STR_VAL(qmTopItems[i].title), qmTopItems[i].subMenuItems);
+      sub->addButton();
+      subMenus.emplace_back(sub);
 #endif
-      }
     }
   }
 }


### PR DESCRIPTION
Fix model notes in quick menu.

Fixes #7001

Applies to 2.12 only.