### PR TITLE
fix(libsimu): move Menu wrapper methods to fix Windows build

### DIFF
--- a/radio/src/gui/colorlcd/libui/menu.cpp
+++ b/radio/src/gui/colorlcd/libui/menu.cpp
@@ -400,12 +400,24 @@ void Menu::addLine(const MaskBitmap* icon_mask, const std::string& text,
   updatePosition();
 }
 
+void Menu::addLine(const std::string &text, std::function<void()> onPress,
+                  std::function<bool()> isChecked)
+{
+  addLine(nullptr, text, onPress, isChecked);
+}
+
 void Menu::addLineBuffered(const MaskBitmap* icon_mask, const std::string& text,
                            std::function<void()> onPress,
                            std::function<bool()> isChecked)
 {
   content->addLine(icon_mask, text, std::move(onPress), std::move(isChecked),
                    false);
+}
+
+void Menu::addLineBuffered(const std::string &text, std::function<void()> onPress,
+                           std::function<bool()> isChecked)
+{
+  addLineBuffered(nullptr, text, onPress, isChecked);
 }
 
 void Menu::updateLines()

--- a/radio/src/gui/colorlcd/libui/menu.h
+++ b/radio/src/gui/colorlcd/libui/menu.h
@@ -49,20 +49,14 @@ class Menu : public ModalWindow
                std::function<bool()> isChecked = nullptr);
 
   void addLine(const std::string &text, std::function<void()> onPress,
-               std::function<bool()> isChecked = nullptr)
-  {
-    addLine(nullptr, text, onPress, isChecked);
-  }
+               std::function<bool()> isChecked = nullptr);
 
   void addLineBuffered(const MaskBitmap *icon_mask, const std::string &text,
                        std::function<void()> onPress,
                        std::function<bool()> isChecked = nullptr);
 
   void addLineBuffered(const std::string &text, std::function<void()> onPress,
-                       std::function<bool()> isChecked = nullptr)
-  {
-    addLineBuffered(nullptr, text, onPress, isChecked);
-  }
+                       std::function<bool()> isChecked = nullptr);
 
   void updateLines();
 


### PR DESCRIPTION
Fixes compile error/failure when building libsim on Windows due to being broken by #6989 changes whereby inline wrapper methods were calling the non-inline methods across compilation unit boundaries on Windows.

