### PR TITLE
fix(color): typo in bm800_masks path for 800x480

### DIFF
--- a/radio/src/bitmaps/800x480/CMakeLists.txt
+++ b/radio/src/bitmaps/800x480/CMakeLists.txt
@@ -3,7 +3,7 @@ set(BITMAP_LZ4_ARGS ${BITMAP_SIZE_ARGS} --lz4)
 set(MASK_LZ4_ARGS ${BITMAP_SIZE_ARGS} --lz4)
 
 add_bitmaps_target(bm800_bmps "${RADIO_SRC_DIR}/bitmaps/800x480/bmp_*.png" "4/4/4/4" "${BITMAP_LZ4_ARGS}")
-add_bitmaps_target(bm800_masks "${RADIO_SRC_DIR}/bitmaps/800x480/os/mask_*.png" 8bits "${MASK_LZ4_ARGS}")
+add_bitmaps_target(bm800_masks "${RADIO_SRC_DIR}/bitmaps/800x480/mask_*.png" 8bits "${MASK_LZ4_ARGS}")
 
 add_custom_target(bm800_bitmaps)
 


### PR DESCRIPTION
#6781 was broken for 800x480 radios