### PR TITLE
chore(elrs): allow future use of unused bits in the "Arming status byte"

### DIFF
--- a/radio/src/pulses/crossfire.cpp
+++ b/radio/src/pulses/crossfire.cpp
@@ -97,9 +97,9 @@ uint8_t createCrossfireChannelsFrame(uint8_t moduleIdx, uint8_t * frame, int16_t
 {
   //
   // sends channel data and also communicates status information in status byte:
-  // - arming mode Switch or CH5
-  // - arming status in Switch mode
-  // - crsf errors
+  // - arming status in Switch mode (bit 0)
+  // - arming mode Switch or CH5 (bit 1)
+  // - bits 2-7 spare
   //
   uint8_t * buf = frame;
   *buf++ = MODULE_ADDRESS;

--- a/radio/src/pulses/crossfire.cpp
+++ b/radio/src/pulses/crossfire.cpp
@@ -96,20 +96,20 @@ uint8_t createCrossfireModelIDFrame(uint8_t moduleIdx, uint8_t * frame)
 uint8_t createCrossfireChannelsFrame(uint8_t moduleIdx, uint8_t * frame, int16_t * pulses)
 {
   //
-  // sends channel data and also communicates commanded armed status in arming mode Switch.
-  // frame len 24 -> arming mode CH5: module will use channel 5
-  // frame len 25 -> arming mode Switch: send commanded armed status in extra byte after channel data
-  // 
-  ModuleData *md = &g_model.moduleData[moduleIdx];
-
-  uint8_t armingMode = md->crsf.crsfArmingMode; // 0 = Channel mode, 1 = Switch mode
-  uint8_t lenAdjust = (armingMode == ARMING_MODE_SWITCH) ? 1 : 0;
-
+  // sends channel data and also communicates status information in status byte:
+  // - arming mode Switch or CH5
+  // - arming status in Switch mode
+  // - crsf errors
+  //
   uint8_t * buf = frame;
   *buf++ = MODULE_ADDRESS;
-  *buf++ = 24 + lenAdjust;      // 1(ID) + 22(channel data) + (+1 extra byte if Switch mode) + 1(CRC)
+  *buf++ = 25;                  // 1(ID) + 22(channel data) + 1(extra status byte) + 1(CRC)
   uint8_t * crc_start = buf;
   *buf++ = CHANNELS_ID;
+
+  //
+  // assemble channel data
+  //
   uint32_t bits = 0;
   uint8_t bitsavailable = 0;
   for (int i=0; i<CROSSFIRE_CHANNELS_COUNT; i++) {
@@ -122,14 +122,33 @@ uint8_t createCrossfireChannelsFrame(uint8_t moduleIdx, uint8_t * frame, int16_t
       bitsavailable -= 8;
     }
   }
-  
-  if (armingMode == ARMING_MODE_SWITCH) {
+
+  //
+  // assemble status byte
+  //
+  ModuleData *md = &g_model.moduleData[moduleIdx];
+
+  if (md->crsf.crsfArmingMode == ARMING_MODE_SWITCH) {
     swsrc_t sw =  md->crsf.crsfArmingTrigger;
 
-    *buf++ = (sw != SWSRC_NONE) && getSwitch(sw, 0);  // commanded armed status in Switch mode
+    *buf = (sw != SWSRC_NONE) && getSwitch(sw, 0);  // commanded armed status in Switch mode
+  } else {
+    *buf = 0x02;                                    // flag arming mode CH5
   }
+
+  extern bool crsfErrorFlag;
+  if(crsfErrorFlag) {
+    *buf |= 0x04;                                   // flag crsf error
+    crsfErrorFlag = false;
+  }
+
+  buf++;
   
-  *buf++ = crc8(crc_start, 23 + lenAdjust);
+  //
+  // add crc
+  //
+  *buf++ = crc8(crc_start, 24);
+
   return buf - frame;
 }
 
@@ -452,5 +471,4 @@ const etx_proto_driver_t CrossfireDriver = {
   .processData = nullptr,
   .processFrame = crossfireProcessFrame,
   .onConfigChange = nullptr,
-  .txCompleted = modulePortSerialTxCompleted,
 };

--- a/radio/src/pulses/crossfire.cpp
+++ b/radio/src/pulses/crossfire.cpp
@@ -136,11 +136,13 @@ uint8_t createCrossfireChannelsFrame(uint8_t moduleIdx, uint8_t * frame, int16_t
     *buf = 0x02;                                    // flag arming mode CH5
   }
 
-  extern bool crsfErrorFlag;
-  if(crsfErrorFlag) {
-    *buf |= 0x04;                                   // flag crsf error
-    crsfErrorFlag = false;
-  }
+  // Example: flag crsf errors to ELRS in bit 2 for resending linkstats
+  //
+  //extern bool crsfErrorFlag;
+  //if(crsfErrorFlag) {
+  //  *buf |= 0x04;                                   // flag crsf error
+  //  crsfErrorFlag = false;
+  //}
 
   buf++;
   

--- a/radio/src/pulses/crossfire.cpp
+++ b/radio/src/pulses/crossfire.cpp
@@ -473,4 +473,5 @@ const etx_proto_driver_t CrossfireDriver = {
   .processData = nullptr,
   .processFrame = crossfireProcessFrame,
   .onConfigChange = nullptr,
+  .txCompleted = modulePortSerialTxCompleted,
 };

--- a/radio/src/pulses/crossfire.cpp
+++ b/radio/src/pulses/crossfire.cpp
@@ -136,14 +136,6 @@ uint8_t createCrossfireChannelsFrame(uint8_t moduleIdx, uint8_t * frame, int16_t
     *buf = 0x02;                                    // flag arming mode CH5
   }
 
-  // Example: flag crsf errors to ELRS in bit 2 for resending linkstats
-  //
-  //extern bool crsfErrorFlag;
-  //if(crsfErrorFlag) {
-  //  *buf |= 0x04;                                   // flag crsf error
-  //  crsfErrorFlag = false;
-  //}
-
   buf++;
   
   //

--- a/radio/src/pulses/crossfire.cpp
+++ b/radio/src/pulses/crossfire.cpp
@@ -96,20 +96,20 @@ uint8_t createCrossfireModelIDFrame(uint8_t moduleIdx, uint8_t * frame)
 uint8_t createCrossfireChannelsFrame(uint8_t moduleIdx, uint8_t * frame, int16_t * pulses)
 {
   //
-  // sends channel data and also communicates commanded armed status in arming mode Switch.
-  // frame len 24 -> arming mode CH5: module will use channel 5
-  // frame len 25 -> arming mode Switch: send commanded armed status in extra byte after channel data
-  // 
-  ModuleData *md = &g_model.moduleData[moduleIdx];
-
-  uint8_t armingMode = md->crsf.crsfArmingMode; // 0 = Channel mode, 1 = Switch mode
-  uint8_t lenAdjust = (armingMode == ARMING_MODE_SWITCH) ? 1 : 0;
-
+  // sends channel data and also communicates status information in status byte:
+  // - arming mode Switch or CH5
+  // - arming status in Switch mode
+  // - crsf errors
+  //
   uint8_t * buf = frame;
   *buf++ = MODULE_ADDRESS;
-  *buf++ = 24 + lenAdjust;      // 1(ID) + 22(channel data) + (+1 extra byte if Switch mode) + 1(CRC)
+  *buf++ = 25;                  // 1(ID) + 22(channel data) + 1(extra status byte) + 1(CRC)
   uint8_t * crc_start = buf;
   *buf++ = CHANNELS_ID;
+
+  //
+  // assemble channel data
+  //
   uint32_t bits = 0;
   uint8_t bitsavailable = 0;
   for (int i=0; i<CROSSFIRE_CHANNELS_COUNT; i++) {
@@ -122,14 +122,33 @@ uint8_t createCrossfireChannelsFrame(uint8_t moduleIdx, uint8_t * frame, int16_t
       bitsavailable -= 8;
     }
   }
-  
-  if (armingMode == ARMING_MODE_SWITCH) {
+
+  //
+  // assemble status byte
+  //
+  ModuleData *md = &g_model.moduleData[moduleIdx];
+
+  if (md->crsf.crsfArmingMode == ARMING_MODE_SWITCH) {
     swsrc_t sw =  md->crsf.crsfArmingTrigger;
 
-    *buf++ = (sw != SWSRC_NONE) && getSwitch(sw, 0);  // commanded armed status in Switch mode
+    *buf = (sw != SWSRC_NONE) && getSwitch(sw, 0);  // commanded armed status in Switch mode
+  } else {
+    *buf = 0x02;                                    // flag arming mode CH5
   }
+
+  extern bool crsfErrorFlag;
+  if(crsfErrorFlag) {
+    *buf |= 0x04;                                   // flag crsf error
+    crsfErrorFlag = false;
+  }
+
+  buf++;
   
-  *buf++ = crc8(crc_start, 23 + lenAdjust);
+  //
+  // add crc
+  //
+  *buf++ = crc8(crc_start, 24);
+
   return buf - frame;
 }
 
@@ -467,5 +486,4 @@ const etx_proto_driver_t CrossfireDriver = {
   .processData = nullptr,
   .processFrame = crossfireProcessFrame,
   .onConfigChange = nullptr,
-  .txCompleted = modulePortSerialTxCompleted,
 };

--- a/radio/src/pulses/crossfire.cpp
+++ b/radio/src/pulses/crossfire.cpp
@@ -488,4 +488,5 @@ const etx_proto_driver_t CrossfireDriver = {
   .processData = nullptr,
   .processFrame = crossfireProcessFrame,
   .onConfigChange = nullptr,
+  .txCompleted = modulePortSerialTxCompleted,
 };

--- a/radio/src/tests/crossfire.cpp
+++ b/radio/src/tests/crossfire.cpp
@@ -22,12 +22,20 @@
 #include "gtest/gtest.h"
 #include "gtests.h"
 #include "telemetry/telemetry.h"
+#include "telemetry/crossfire.h"
+#include "crc.h"
 
 #if defined(CROSSFIRE)
 
 uint8_t createCrossfireChannelsFrame(uint8_t moduleIdx, uint8_t * frame, int16_t * pulses);
+
+// Spec-defined part of the frame (0x16 RC Channels Packed): sync byte, type,
+// 16 x 11-bit channel packing. Expected bytes computed independently, not
+// derived from createCrossfireChannelsFrame() itself.
 TEST(Crossfire, createCrossfireChannelsFrame)
 {
+  MODEL_RESET();
+
   int16_t pulsesStart[MAX_TRAINER_CHANNELS];
   uint8_t crossfire[CROSSFIRE_FRAME_MAXLEN];
 
@@ -38,7 +46,71 @@ TEST(Crossfire, createCrossfireChannelsFrame)
 
   createCrossfireChannelsFrame(EXTERNAL_MODULE, crossfire, pulsesStart);
 
-  // TODO check
+  ASSERT_EQ(crossfire[0], MODULE_ADDRESS);
+  ASSERT_EQ(crossfire[2], CHANNELS_ID);
+
+  const uint8_t expectedChannelData[22] = {
+    0xAD, 0xA0, 0x88, 0x5E, 0xC0, 0x73, 0xA4, 0x56, 0x51, 0x4C, 0x6F,
+    0xE0, 0x33, 0x22, 0x2B, 0x27, 0x9A, 0x57, 0xF0, 0x1A, 0x99, 0xD5
+  };
+  ASSERT_EQ(memcmp(&crossfire[3], expectedChannelData, sizeof(expectedChannelData)), 0);
+}
+
+// Status byte after the 0x16 payload is an ExpressLRS extension, not TBS CRSF
+// spec (semantics per ExpressLRS's TXModuleEndpoint.cpp / crsf_protocol.h).
+// Frame is always 25 bytes (1 ID + 22 channel data + 1 status + 1 CRC);
+// bit 0 = commanded armed status (Switch mode only), bit 1 = arming mode is CH5.
+TEST(Crossfire, ExpressLRSArmingExtension_CH5Mode)
+{
+  MODEL_RESET();
+
+  int16_t pulsesStart[MAX_TRAINER_CHANNELS];
+  uint8_t crossfire[CROSSFIRE_FRAME_MAXLEN];
+
+  memset(crossfire, 0, sizeof(crossfire));
+  for (int i=0; i<MAX_TRAINER_CHANNELS; i++) {
+    pulsesStart[i] = -1024 + (2048 / MAX_TRAINER_CHANNELS) * i;
+  }
+
+  g_model.moduleData[EXTERNAL_MODULE].crsf.crsfArmingMode = ARMING_MODE_CH5;
+
+  uint8_t len = createCrossfireChannelsFrame(EXTERNAL_MODULE, crossfire, pulsesStart);
+
+  ASSERT_EQ(len, 27);
+  ASSERT_EQ(crossfire[0], MODULE_ADDRESS);
+  ASSERT_EQ(crossfire[1], 25);
+  ASSERT_EQ(crossfire[2], CHANNELS_ID);
+  ASSERT_EQ(crossfire[25], 0x02); // bit 1: arming mode CH5
+
+  uint8_t crc = crc8(&crossfire[2], 24);
+  ASSERT_EQ(crossfire[26], crc);
+}
+
+TEST(Crossfire, ExpressLRSArmingExtension_SwitchMode)
+{
+  MODEL_RESET();
+
+  int16_t pulsesStart[MAX_TRAINER_CHANNELS];
+  uint8_t crossfire[CROSSFIRE_FRAME_MAXLEN];
+
+  memset(crossfire, 0, sizeof(crossfire));
+  for (int i=0; i<MAX_TRAINER_CHANNELS; i++) {
+    pulsesStart[i] = -1024 + (2048 / MAX_TRAINER_CHANNELS) * i;
+  }
+
+  g_model.moduleData[EXTERNAL_MODULE].crsf.crsfArmingMode = ARMING_MODE_SWITCH;
+  g_model.moduleData[EXTERNAL_MODULE].crsf.crsfArmingTrigger = SWSRC_NONE;
+
+  uint8_t len = createCrossfireChannelsFrame(EXTERNAL_MODULE, crossfire, pulsesStart);
+
+  ASSERT_EQ(len, 27);
+  ASSERT_EQ(crossfire[0], MODULE_ADDRESS);
+  ASSERT_EQ(crossfire[1], 25);
+  ASSERT_EQ(crossfire[2], CHANNELS_ID);
+  ASSERT_EQ(crossfire[25], 0); // SWSRC_NONE -> not armed, bit 1 clear (Switch mode)
+
+  uint8_t crc = crc8(&crossfire[2], 24);
+  ASSERT_EQ(crossfire[26], crc);
 }
 
 TEST(Crossfire, crc8)


### PR DESCRIPTION
This PR allows future use of the currently unused status bits in the byte we use to communicate the commanded arming status to ExpressLRS modules if we ever have a need for them. The changes are fully backward compatible with the existing V2.11 and V2.12 implementation for communicating the commanded arming status to ExpressLRS modules. It is also compatible with modules using ExpressLRS V3 firmware. 

Summary of changes:
- sends status byte with every CRSF 0x16 RC Channels packet. Note: the TBS CRSF V3 specification allows sending extra fields. [CRSF V3 Frame Details](https://github.com/tbs-fpv/tbs-crsf-spec/blob/main/crsf.md#frame-details):  "_size may be bigger than expected frame of given type. This should not be a reason to count the frame invalid. Frame receiver should just ignore extra fields._". ExpressLRS pre-V4 firmware ignores the field and will use CH5 Arming.
- determines arming method and status using bit 0 and 1 of the status byte

<img width="545" height="77" alt="image" src="https://github.com/user-attachments/assets/75f9d997-775d-4fbc-9080-3af19b00f2a0" />

- makes status byte bits 2 to 7 available for future use

This complements the changes made to V4 in https://github.com/ExpressLRS/ExpressLRS/pull/3470 and is fully backwards compatible to the existing implementation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Crossfire CHANNELS frame structure to use a consistent fixed-length payload with dedicated status byte
  * Improved arming status reporting in Crossfire protocol to properly reflect armed state based on configuration

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EdgeTX/edgetx/pull/7022?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->