### PR TITLE
fix(color): widget background function is called when a one time script is running

### DIFF
--- a/radio/src/gui/colorlcd/libui/mainwindow.cpp
+++ b/radio/src/gui/colorlcd/libui/mainwindow.cpp
@@ -64,7 +64,8 @@ void MainWindow::run()
   auto start = timersGetMsTick();
 #endif
 
-  ViewMain::refreshWidgets();
+  if (widgetRefreshEnable)
+    ViewMain::refreshWidgets();
 
   auto opaque = Window::firstOpaque();
   if (opaque) {

--- a/radio/src/gui/colorlcd/libui/mainwindow.h
+++ b/radio/src/gui/colorlcd/libui/mainwindow.h
@@ -51,9 +51,12 @@ class MainWindow: public Window
 
   void shutdown();
 
+  void enableWidgetRefresh(bool state) { widgetRefreshEnable = state; }
+
  protected:
   lv_obj_t* background = nullptr;
   const BitmapBuffer *backgroundBitmap = nullptr;
+  bool widgetRefreshEnable = true;
 
   static MainWindow * _instance;
 

--- a/radio/src/gui/colorlcd/standalone_lua.cpp
+++ b/radio/src/gui/colorlcd/standalone_lua.cpp
@@ -136,6 +136,8 @@ StandaloneLuaWindow::StandaloneLuaWindow(bool useLvgl, int initFn, int runFn) :
 
   pushLayer(true);
 
+  MainWindow::instance()->enableWidgetRefresh(false);
+
   if (useLvglLayout()) {
     padAll(PAD_ZERO);
     etx_scrollbar(lvobj);
@@ -205,8 +207,6 @@ void StandaloneLuaWindow::deleteLater()
 
   luaScriptManager = nullptr;
 
-  Window::deleteLater();
-
   _instance = nullptr;
 
 #if defined(USE_HATS_AS_KEYS)
@@ -216,6 +216,8 @@ void StandaloneLuaWindow::deleteLater()
   luaState = prevLuaState;
 
   luaEmptyEventBuffer();
+
+  MainWindow::instance()->enableWidgetRefresh(true);
 
   Window::deleteLater();
 }


### PR DESCRIPTION
Don't call widget background function when stand alone script running (2.11 behaviour).

Fixes #7023

Applies to 2.12 and 3.0.
