### PR TITLE
fix(cpn): simulator screen size is wrong for some color radios.

### DIFF
--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -405,10 +405,10 @@ int Boards::getCapability(Board::Type board, Board::Capability capability)
     case LcdWidth:
       if (IS_RADIOMASTER_TX16SMK3(board))
         return 800;
-      else if (IS_FAMILY_HORUS_OR_T16(board) || IS_RADIOMASTER_TX15(board) || IS_FAMILY_PL18(board) || IS_FLYSKY_ST16(board))
-        return 480;
       else if (IS_FLYSKY_NV14(board) || IS_FLYSKY_EL18(board) || IS_FLYSKY_PA01(board))
         return 320;
+      else if (IS_FAMILY_HORUS_OR_T16(board) || IS_RADIOMASTER_TX15(board) || IS_FAMILY_PL18(board) || IS_FLYSKY_ST16(board))
+        return 480;
       else if (IS_TARANIS(board) && !IS_TARANIS_SMALL(board))
         return 212;
       else


### PR DESCRIPTION
Wrong size for 480x320 radios and PA01.

Broken in #7017 & #7016

Applies to 2.12 and 3.0.