### PR TITLE
feat(cpn): update application display name for MacOS

### DIFF
--- a/companion/src/CMakeLists.txt
+++ b/companion/src/CMakeLists.txt
@@ -428,9 +428,11 @@ elseif(WIN32)
 elseif(APPLE)
   # Qt + Cmake + Mac is poorly documented. A lot of this is guesswork
   # and trial and error. Do not hesitate to fix it for the better
+  set(COMPANION_DISPLAY_NAME "EdgeTX Companion")
   set_target_properties(${COMPANION_NAME} PROPERTIES
       MACOSX_RPATH TRUE
       MACOSX_BUNDLE TRUE
+      MACOSX_BUNDLE_BUNDLE_NAME "${COMPANION_DISPLAY_NAME}"
       MACOSX_BUNDLE_INFO_PLIST ${COMPANION_TARGETS_DIR}/MacOSXBundleInfo.plist.in
 
       INSTALL_RPATH "@executable_path/../Frameworks"
@@ -440,7 +442,7 @@ elseif(APPLE)
   # This the name that the user will see in the generated DMG and what the application
   # will be called under /Applications. We include the version string to make installing
   # different versions side-by-side
-  set(COMPANION_OSX_APP_BUNDLE_NAME "EdgeTX Companion ${VERSION_FAMILY}")
+  set(COMPANION_OSX_APP_BUNDLE_NAME "${COMPANION_DISPLAY_NAME} ${VERSION_FAMILY}")
   set(MACOSX_BUNDLE_GUI_IDENTIFIER "org.edgetx.companion")
 
   set(companion_app_dir "companion.app")
@@ -587,7 +589,7 @@ else()
   else()
     set(LINUXDEPLOY_ARCH "x86_64")
   endif()
-  
+
   set(LINUXDEPLOY_APPIMAGE "linuxdeploy-${LINUXDEPLOY_ARCH}.AppImage")
   set(LINUXDEPLOY_PLUGIN_QT "linuxdeploy-plugin-qt-${LINUXDEPLOY_ARCH}.AppImage")
   set(LINUXDEPLOY_URL "https://github.com/linuxdeploy/linuxdeploy/releases/download/continuous")


### PR DESCRIPTION
Summary of changes:
- changes the name reported/displayed for companion on MacOS from `companion` to `EdgeTX Companion`
- note: this only alters the menu bar display name - the dock display name is/remains "EdgeTX Companion {VER}"

Before (main):
<img width="315" height="130" alt="image" src="https://github.com/user-attachments/assets/99f8ee60-1c90-490c-b051-8423c490e4d2" />

Before (2.11):
<img width="315" height="130" alt="image" src="https://github.com/user-attachments/assets/76d37614-f489-42a9-a97b-b9a6cf80e622" />

After:
<img width="315" height="130" alt="image" src="https://github.com/user-attachments/assets/d9ea7935-cfe4-4863-9d27-4dd31eeed9b0" />


