### PR TITLE
fix(scripts): remove i386 dependencies and fix aqt location in setup_buildenv_ubuntu24.04.sh

### DIFF
--- a/tools/setup_buildenv_ubuntu24.04.sh
+++ b/tools/setup_buildenv_ubuntu24.04.sh
@@ -83,7 +83,7 @@ if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
 fi
 
 echo "=== Step $((STEP++)): Installing Qt ==="
-.local/bin/aqt install-qt --outputdir qt linux desktop 6.9.0 linux_gcc_64 -m qtmultimedia qtserialport
+/usr/local/bin/aqt install-qt --outputdir qt linux desktop 6.9.0 linux_gcc_64 -m qtmultimedia qtserialport
 if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
   echo "Step finished. Please press Enter to continue or Ctrl+C to stop."
   read


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Make setup_buildenv_ubuntu24.04.sh not fail on Ubuntu 24.04.1 LTS.

Fixes #7035

Summary of changes:
- removed i386 dependencies;
- fixed path to `aqt`.