### PR TITLE
fix(firmware): potential crash when using multi protocol module.

### DIFF
--- a/radio/src/MultiProtoDefs.h
+++ b/radio/src/MultiProtoDefs.h
@@ -163,7 +163,6 @@ enum ModuleSubtypeMulti {
 //
 // Common list of Multi protocol names. Needs to match enum ModuleSubtypeMulti
 //
-#define MAX_MPM_NAME_LEN 8  // Update if a protocol with a longer name is added !!!
 #define KNOWN_PROTO_NAMES \
   "FlySky","Hubsan","FrSky D","Hisky","V2x2","DSM","Devo","YD717","KN","SymaX",\
   "SLT","CX10","CG023","Bayang","FrSky X","ESky","MT99XX","MJXq","Shenqi","FY326",\

--- a/radio/src/io/multi_protolist.cpp
+++ b/radio/src/io/multi_protolist.cpp
@@ -162,9 +162,7 @@ std::string MultiRfProtocols::getProtoLabel(unsigned int proto) const
     if (status.protocolName[0] && status.isValid()) {
       return std::string(status.protocolName);
     } else if (proto <= MODULE_SUBTYPE_MULTI_LAST) {
-      char tmp[8];
-      getStringAtIndex(tmp, STR_MULTI_PROTOCOLS, proto);
-      return std::string(tmp);
+      return getStringAtIndex(STR_MULTI_PROTOCOLS, proto);
     }
   } else {
     int idx = getIndex(proto);
@@ -322,8 +320,7 @@ void MultiRfProtocols::fillBuiltinProtos()
 
     if (pdef->protocol == MM_RF_CUSTOM_SELECTED) break;  // skip custom proto
 
-    char tmp[MAX_MPM_NAME_LEN + 2];
-    rfProto.label = getStringAtIndex(tmp, STR_MULTI_PROTOCOLS, pdef->protocol);
+    rfProto.label = getStringAtIndex(STR_MULTI_PROTOCOLS, pdef->protocol);
     rfProto.flags =
         (pdef->failsafe ? 0x01 : 0) | (pdef->disable_ch_mapping ? 0x02 : 0);
 

--- a/radio/src/strhelpers.cpp
+++ b/radio/src/strhelpers.cpp
@@ -120,6 +120,11 @@ char *strcat_zchar(char *dest, const char *name, uint8_t size,
 #endif
 
 #if !defined(BOOT)
+std::string getStringAtIndex(const char *const *s, int idx)
+{
+  return std::string(s[idx]);
+}
+
 char *getStringAtIndex(char *dest, const char *const *s, int idx)
 {
   strcpy(dest, s[idx]);

--- a/radio/src/strhelpers.h
+++ b/radio/src/strhelpers.h
@@ -106,6 +106,7 @@ void formatNumberAsString(char *buffer, const uint8_t buffer_size, int32_t val,
 
 #if !defined(BOOT)
 char *getStringAtIndex(char *dest, const char *const *s, int idx);
+std::string getStringAtIndex(const char *const *s, int idx);
 char *strAppendStringWithIndex(char *dest, const char *s, int idx);
 #define LEN_TIMER_STRING 10  // "-00:00:00"
 char *getTimerString(char *dest, int32_t tme,


### PR DESCRIPTION
Fix stack overflow.

PR #6515 added a longer protocol name.

Fixes #7038 

Applies to 2.12 and 3.0.
