### PR TITLE
ci: tweak headings for the release notes, fix labels and scopes

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -105,20 +105,44 @@ jobs:
             {
               "categories": [
                 {
+                  "title": "## 🖥️ Black & White Radio Changes",
+                  "labels": ["scope:bw"]
+                },
+                {
+                  "title": "## 🎨 Color Radio Changes",
+                  "labels": ["scope:color"]
+                },
+                {
+                  "title": "## 🎮 Firmware (All Radios Generally)",
+                  "labels": ["scope:firmware", "scope:fw"]
+                },
+                {
+                  "title": "## 💻 Companion Software Changes",
+                  "labels": ["scope:cpn", "companion"]
+                },
+                {
                   "title": "## 🚀 Features",
-                  "labels": ["feat", "feature"]
+                  "labels": ["feat", "enhancement ✨"]
                 },
                 {
                   "title": "## 🐛 Fixes",
-                  "labels": ["fix", "bugfix"]
+                  "labels": ["fix", "bugfix", "bug 🪲", "bug/regression ↩️"]
+                },
+                {
+                  "title": "## 🧹 Chores",
+                  "labels": ["chore", "house keeping 🧹"]
+                },
+                {
+                  "title": "## 🔧 CI/CD",
+                  "labels": ["ci", "ci/cd 🔧"]
                 },
                 {
                   "title": "## 🧪 Tests",
-                  "labels": ["test"]
+                  "labels": ["scope:test", "test", "unit tests 🧪"]
                 },
                 {
                   "title": "## 📝 Documentation",
-                  "labels": ["docs"]
+                  "labels": ["scope:docs", "docs", "documentation 📝"]
                 },
                 {
                   "title": "## 🔨 Refactoring",
@@ -138,8 +162,12 @@ jobs:
               "empty_template": "- No changes",
               "label_extractor": [
                 {
-                  "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\(.+\\))?(!)?:",
+                  "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([^)]+\\))?(!)?:",
                   "target": "$1"
+                },
+                {
+                  "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)\\(([^)]+)\\)",
+                  "target": "scope:$2"
                 }
               ]
             }

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -194,20 +194,44 @@ jobs:
             {
               "categories": [
                 {
+                  "title": "## 🖥️ Black & White Radio Changes",
+                  "labels": ["scope:bw"]
+                },
+                {
+                  "title": "## 🎨 Color Radio Changes",
+                  "labels": ["scope:color"]
+                },
+                {
+                  "title": "## 🎮 Firmware (All Radios Generally)",
+                  "labels": ["scope:firmware", "scope:fw"]
+                },
+                {
+                  "title": "## 💻 Companion Software Changes",
+                  "labels": ["scope:cpn", "companion"]
+                },
+                {
                   "title": "## 🚀 Features",
-                  "labels": ["feat", "feature"]
+                  "labels": ["feat", "enhancement ✨"]
                 },
                 {
                   "title": "## 🐛 Fixes",
-                  "labels": ["fix", "bugfix"]
+                  "labels": ["fix", "bugfix", "bug 🪲", "bug/regression ↩️"]
+                },
+                {
+                  "title": "## 🧹 Chores",
+                  "labels": ["chore", "house keeping 🧹"]
+                },
+                {
+                  "title": "## 🔧 CI/CD",
+                  "labels": ["ci", "ci/cd 🔧"]
                 },
                 {
                   "title": "## 🧪 Tests",
-                  "labels": ["test"]
+                  "labels": ["scope:test", "test", "unit tests 🧪"]
                 },
                 {
                   "title": "## 📝 Documentation",
-                  "labels": ["docs"]
+                  "labels": ["scope:docs", "docs", "documentation 📝"]
                 },
                 {
                   "title": "## 🔨 Refactoring",
@@ -227,8 +251,12 @@ jobs:
               "empty_template": "- No changes",
               "label_extractor": [
                 {
-                  "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\(.+\\))?(!)?:",
+                  "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([^)]+\\))?(!)?:",
                   "target": "$1"
+                },
+                {
+                  "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)\\(([^)]+)\\)",
+                  "target": "scope:$2"
                 }
               ],
               "max_pull_requests": 1000,


### PR DESCRIPTION
Summary of changes:
 - add scopes for B&W, Colour, Firmware and Companion
 - fix labels matching so they match the labels we use
