### PR TITLE
fix(bw): cannot select channel for override Special Function

### DIFF
--- a/radio/src/gui/128x64/model_special_functions.cpp
+++ b/radio/src/gui/128x64/model_special_functions.cpp
@@ -257,7 +257,6 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
               lcdDrawText(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, STR_CHANS, attr);
             else
               drawSource(MODEL_SPECIAL_FUNC_3RD_COLUMN, y, MIXSRC_FIRST_STICK + param - 1, attr);
-            if (active) CHECK_INCDEC_MODELVAR_ZERO(event, CFN_CH_INDEX(cfn), maxParam);
           }
 #if defined(GVARS)
           else if (func == FUNC_ADJUST_GVAR) {
@@ -265,6 +264,7 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
             maxParam = MAX_GVARS - 1;
             drawStringWithIndex(lcdNextPos + 2, y, STR_GV, CFN_GVAR_INDEX(cfn)+1, attr);
             if (active) CFN_GVAR_INDEX(cfn) = checkIncDec(event, CFN_GVAR_INDEX(cfn), 0, maxParam, eeFlags);
+            break;
           }
 #endif // GVARS
           else if (func == FUNC_SET_TIMER) {
@@ -277,17 +277,20 @@ void menuSpecialFunctions(event_t event, CustomFunctionData * functions, CustomF
               if (attr)
                 repeatLastCursorHorMove(event);
             }
+            break;
           }
 #if defined(FUNCTION_SWITCHES)
           else if (func == FUNC_PUSH_CUST_SWITCH) {
             uint8_t sw = switchGetSwitchFromCustomIdx(CFN_CS_INDEX(cfn));
             lcdDrawText(lcdNextPos + 5, y, switchGetDefaultName(sw), attr);
             if (active) CFN_CS_INDEX(cfn) = switchGetCustomSwitchIdx(checkIncDec(event, sw, 0, switchGetMaxSwitches() - 1, eeFlags, switchIsCustomSwitch));
+            break;
           }
 #endif          
           else if (attr) {
             repeatLastCursorHorMove(event);
           }
+          if (active) CHECK_INCDEC_MODELVAR_ZERO(event, CFN_CH_INDEX(cfn), maxParam);
           break;
         }
 


### PR DESCRIPTION
Fix B&W override special function - broken in #6095 

Fixes #7050 

Applies to 2.12 and 3.0.