### PR TITLE
fix(ci): incorrect configuration tag for changelog generator

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -163,10 +163,12 @@ jobs:
               "label_extractor": [
                 {
                   "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([^)]+\\))?(!)?:",
+                  "on_property": "title",
                   "target": "$1"
                 },
                 {
                   "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)\\(([^)]+)\\)",
+                  "on_property": "title",
                   "target": "scope:$2"
                 }
               ]

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -252,10 +252,12 @@ jobs:
               "label_extractor": [
                 {
                   "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)(\\([^)]+\\))?(!)?:",
+                  "on_property": "title",
                   "target": "$1"
                 },
                 {
                   "pattern": "^(build|chore|ci|docs|feat|fix|perf|refactor|revert|style|test)\\(([^)]+)\\)",
+                  "on_property": "title",
                   "target": "scope:$2"
                 }
               ],


### PR DESCRIPTION
Summary of changes:
 - was using wrong configuration tag for release notes / changelog generator
 - label extractor by default targets PR body, not title
