### PR TITLE
ci: use hybrid changelog mode to support direct commits

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -101,6 +101,7 @@ jobs:
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v4
         with:
+          mode: "HYBRID"
           configurationJson: |
             {
               "categories": [
@@ -159,6 +160,7 @@ jobs:
               ],
               "template": "#{{CHANGELOG}}",
               "pr_template": "- #{{TITLE}} (##{{NUMBER}})",
+              "commit_template": "- #{{TITLE}} (#{{MERGE_SHA}})",
               "empty_template": "- No changes",
               "label_extractor": [
                 {

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -190,6 +190,7 @@ jobs:
         id: build_changelog
         uses: mikepenz/release-changelog-builder-action@v4
         with:
+          mode: "HYBRID"
           configurationJson: |
             {
               "categories": [
@@ -248,6 +249,7 @@ jobs:
               ],
               "template": "#{{CHANGELOG}}\n\n## Thank you to the following contributors who made this release possible!\n#{{CONTRIBUTORS}}",
               "pr_template": "- #{{TITLE}} (##{{NUMBER}})",
+              "commit_template": "- #{{TITLE}} (#{{MERGE_SHA}})",
               "empty_template": "- No changes",
               "label_extractor": [
                 {


### PR DESCRIPTION
Summary of changes:
 - switch changelog generator over to hybrid mode, so that it will work with direct commits as well as PRs (i.e. for version branches)
