### PR TITLE
feat(lua): add 'edited' callback to 'numberEdit' control for LVGL Lua scripts

### DIFF
--- a/radio/src/gui/colorlcd/libui/numberedit.cpp
+++ b/radio/src/gui/colorlcd/libui/numberedit.cpp
@@ -243,6 +243,7 @@ void NumberEdit::openEdit()
         lv_obj_get_width(lvobj), lv_obj_get_height(lvobj)});
     edit->setChangeHandler([=]() {
       update();
+      if (onEdited) onEdited(currentValue);
       if (edit->hasFocus())
         lv_group_focus_obj(lvobj);
       edit->hide();

--- a/radio/src/gui/colorlcd/libui/numberedit.h
+++ b/radio/src/gui/colorlcd/libui/numberedit.h
@@ -89,6 +89,11 @@ class NumberEdit : public TextButton
     _getValue = std::move(handler);
   }
 
+  void setOnEditedHandler(std::function<void(int)> handler)
+  {
+    onEdited = std::move(handler);
+  }
+
   int32_t getValue() const { return _getValue != nullptr ? _getValue() : 0; }
 
  protected:
@@ -97,6 +102,7 @@ class NumberEdit : public TextButton
   NumberArea* edit = nullptr;
   std::function<int()> _getValue;
   std::function<void(int)> _setValue;
+  std::function<void(int)> onEdited;
   int vdefault = 0;
   int vmin;
   int vmax;

--- a/radio/src/lua/lua_lvgl_widget.cpp
+++ b/radio/src/lua/lua_lvgl_widget.cpp
@@ -165,6 +165,7 @@ bool LvglMinMaxParams::parseMinMaxParam(lua_State *L, const char *key)
   }
   if (!strcmp(key, "max")) {
     max = luaL_checkinteger(L, -1);
+    return true;
   }
   return false;
 }
@@ -2159,10 +2160,13 @@ void LvglWidgetTextEdit::build(lua_State *L)
 void LvglWidgetNumberEdit::parseParam(lua_State *L, const char *key)
 {
   if (parseMinMaxParam(L, key)) return;
+  if (parseGetSetParam(L, key)) return;
 
   if (!strcmp(key, "display")) {
     dispFunction = luaL_ref(L, LUA_REGISTRYINDEX);
-  } else if (!parseGetSetParam(L, key)) {
+  } else if (!strcmp(key, "edited")) {
+    editedFunction = luaL_ref(L, LUA_REGISTRYINDEX);
+  } else {
     LvglWidgetObject::parseParam(L, key);
   }
 }
@@ -2170,6 +2174,7 @@ void LvglWidgetNumberEdit::parseParam(lua_State *L, const char *key)
 void LvglWidgetNumberEdit::clearRefs(lua_State *L)
 {
   clearRef(L, dispFunction);
+  clearRef(L, editedFunction);
   clearGetSetRefs(L);
   LvglWidgetObject::clearRefs(L);
 }
@@ -2200,6 +2205,11 @@ void LvglWidgetNumberEdit::build(lua_State *L)
       UNPROTECT_LUA();
       lua_settop(L, t);
       return s;
+    });
+  }
+  if (editedFunction != LUA_REFNIL) {
+    ((NumberEdit*)window)->setOnEditedHandler([=]( int val) {
+      pcallSetIntVal(L, editedFunction, val);
     });
   }
 }

--- a/radio/src/lua/lua_lvgl_widget.h
+++ b/radio/src/lua/lua_lvgl_widget.h
@@ -802,6 +802,7 @@ class LvglWidgetNumberEdit : public LvglWidgetObject, public LvglGetSetParams, p
 
  protected:
   int dispFunction = LUA_REFNIL;
+  int editedFunction = LUA_REFNIL;
 
   void build(lua_State *L) override;
   void parseParam(lua_State *L, const char *key) override;


### PR DESCRIPTION
Currently the 'set' callback is called for every incremental change to a numberEdit control.
As requested by the ELRS team, this PR add a new 'edited' callback function that is only called after the user has finished editing the value.

Applies to 2.11, 2.12 and 3.0.
