### PR TITLE
fix(color): label at the top & bottom of the page of Lua scripts may not be visible when scrolling

### DIFF
--- a/radio/src/gui/colorlcd/libui/window.cpp
+++ b/radio/src/gui/colorlcd/libui/window.cpp
@@ -173,13 +173,10 @@ void Window::eventHandler(lv_event_t *e)
 
   switch (code) {
     case LV_EVENT_SCROLL: {
-      lv_coord_t scroll_x = lv_obj_get_scroll_x(target);
-      lv_coord_t scroll_y = lv_obj_get_scroll_y(target);
-      if (scrollHandler) scrollHandler(scroll_x, scroll_y);
-
       // exclude pointer based scrolling (only focus scrolling)
       if (!lv_obj_is_scrolling(target) && ((windowFlags & NO_FORCED_SCROLL) == 0)) {
         lv_point_t *p = (lv_point_t *)lv_event_get_param(e);
+        lv_coord_t scroll_y = lv_obj_get_scroll_y(target);
         lv_coord_t scroll_bottom = lv_obj_get_scroll_bottom(target);
 
         TRACE("SCROLL[x=%d;y=%d;top=%d;bottom=%d]", p->x, p->y, scroll_y,
@@ -187,12 +184,17 @@ void Window::eventHandler(lv_event_t *e)
 
         // Force scroll to top or bottom when near either edge.
         // Only applies when using rotary encoder or keys.
-        if (scroll_y <= 45 && p->y > 0) {
+        if (scroll_y <= EdgeTxStyles::UI_ELEMENT_HEIGHT * 2 && p->y > 0) {
           lv_obj_scroll_by(target, 0, scroll_y, LV_ANIM_OFF);
-        } else if (scroll_bottom <= 16 && p->y < 0) {
+        } else if (scroll_bottom <= EdgeTxStyles::UI_ELEMENT_HEIGHT * 2 && p->y < 0) {
           lv_obj_scroll_by(target, 0, -scroll_bottom, LV_ANIM_OFF);
         }
       }
+
+      lv_coord_t scroll_x = lv_obj_get_scroll_x(target);
+      lv_coord_t scroll_y = lv_obj_get_scroll_y(target);
+      if (scrollHandler) scrollHandler(scroll_x, scroll_y);
+
     } break;
     case LV_EVENT_CLICKED:
       if (!_longPressed) {

--- a/radio/src/lua/lua_lvgl_widget.cpp
+++ b/radio/src/lua/lua_lvgl_widget.cpp
@@ -2472,7 +2472,6 @@ void LvglWidgetPage::build(lua_State *L)
       showBackButton, prevActionFunction != LUA_REFNIL, nextActionFunction != LUA_REFNIL);
 
   window = page->getBody();
-  window->setWindowFlag(NO_FORCED_SCROLL);
   window->setScrollHandler([=](coord_t x, coord_t y) { pcallFuncWith2Int(L, scrolledFunction, 0, x, y); });
   if (setFlex()) {
     lv_flex_align_t align1 = (align.flags & RIGHT) ? LV_FLEX_ALIGN_END : (align.flags & CENTERED) ? LV_FLEX_ALIGN_CENTER : LV_FLEX_ALIGN_START;


### PR DESCRIPTION
Allow up to 2 lines of label/text at the top and bottom of the Lua 'page' to be forced into view when scrolling with the rotary encoder.

Applies to 2.11, 2.12 and 3.0.

