### PR TITLE
feat(lua): allow setting and getting a switch pre start warning status

### DIFF
--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -1025,7 +1025,7 @@ Get warning state for a switch
 
 @retval nil when switch is a toggle or does not exist
 @retval number
-0 = no waning
+0 = no warning
 1 = switch up
 2 = switch middle
 3 = switch down
@@ -1067,7 +1067,7 @@ Set warning state for a switch
 @param switch (string) switch name
 
 @param state (number) state
-0 = no waning
+0 = no warning
 1 = switch up
 2 = switch middle
 3 = switch down


### PR DESCRIPTION
Allow LUA script to get or set status for switches pre flight. Typical use would be wizard where one would set a switch for "arm, gear,..) and the wizard could setup warning for that switch accordingly.

For commodity, both switch index or name can be used.