### PR TITLE
fix(cpn): simulator crash if attempts to play bye.wav on exit

### DIFF
--- a/radio/src/edgetx.cpp
+++ b/radio/src/edgetx.cpp
@@ -1130,7 +1130,11 @@ void edgeTxClose(uint8_t shutdown)
 
   if (shutdown) {
     pulsesStop();
+#if !defined(SIMU)
+    // Audio task has been stopped so this will not play
+    // when closing the simulator
     AUDIO_BYE();
+#endif
     // TODO needed? telemetryEnd();
 #if defined(HAPTIC)
     hapticOff();


### PR DESCRIPTION
Don't play bye.wav when simulator shuts down to prevent infinite loop.
Arises from the changes to the task handling in 2.12 / 3.0.

Fixes #7084

