### PR TITLE
fix(cpn): cannot select correct script file for 'Lua Script' SF/GF

### DIFF
--- a/companion/src/modeledit/customfunctions.cpp
+++ b/companion/src/modeledit/customfunctions.cpp
@@ -98,12 +98,12 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
   }
 
   if (IS_STM32(firmware->getBoard())) {
-    scriptsSet = getFilesSet(g.profile[g.id()].sdPath() + "/SCRIPTS/RGBLED", QStringList() << "*.lua", firmware->getCapability(VoicesMaxLength));
+    scriptsSetRGB = getFilesSet(g.profile[g.id()].sdPath() + "/SCRIPTS/RGBLED", QStringList() << "*.lua", firmware->getCapability(VoicesMaxLength));
     for (int i = 0; i < fswCapability; i++) {
       if (functions[i].func == FuncRGBLed) {
         QString temp = functions[i].paramarm;
         if (!temp.isEmpty()) {
-          scriptsSet.insert(temp);
+          scriptsSetRGB.insert(temp);
         }
       }
     }
@@ -557,7 +557,7 @@ void CustomFunctionsPanel::refreshCustomFunction(int i, bool changed)
         Helpers::getFileComboBoxValue(fswtchParamArmT[i], cfn.paramarm, 8);
         cfn.repeatParam = fswtchRepeat[i]->currentData().toInt();
       }
-      Helpers::populateFileComboBox(fswtchParamArmT[i], scriptsSet, cfn.paramarm);
+      Helpers::populateFileComboBox(fswtchParamArmT[i], func == FuncPlayScript ? scriptsSet : scriptsSetRGB, cfn.paramarm);
       fswtchRepeat[i]->setModel(tabModelFactory->getItemModel(repeatLuaId));
       fswtchRepeat[i]->setCurrentIndex(fswtchRepeat[i]->findData(cfn.repeatParam));
     }

--- a/companion/src/modeledit/customfunctions.h
+++ b/companion/src/modeledit/customfunctions.h
@@ -96,6 +96,7 @@ class CustomFunctionsPanel : public GenericPanel
 
     QSet<QString> tracksSet;
     QSet<QString> scriptsSet;
+    QSet<QString> scriptsSetRGB;
     int mediaPlayerCurrent;
     QComboBox * fswtchSwtch[CPN_MAX_SPECIAL_FUNCTIONS];
     QComboBox * fswtchFunc[CPN_MAX_SPECIAL_FUNCTIONS];


### PR DESCRIPTION
When creating a 'Lua Script' SF/GF in Companion model edit, the file selection drop down shows the 'RGB Led' files instead of the Lua script function files.

Applies to 2.11, 2.12 and 3.0
