### PR TITLE
fix(cpn): custom switches in switch and function lists

### DIFF
--- a/companion/src/firmwares/customfunctiondata.cpp
+++ b/companion/src/firmwares/customfunctiondata.cpp
@@ -254,7 +254,8 @@ bool CustomFunctionData::isFuncAvailable(const int index, const ModelData * mode
         ((index == FuncDisableAudioAmp && !Boards::getCapability(fw->getBoard(), Board::HasAudioMuteGPIO))) ||
         ((index == FuncRGBLed && !(Boards::getCapability(fw->getBoard(), Board::HasBlingLEDS) || Boards::getCapability(fw->getBoard(), Board::FunctionSwitchColors)))) ||
         ((index == FuncLCDtoVideo && !IS_FATFISH_F16(fw->getBoard()))) ||
-        ((index >= FuncPushCustomSwitch1 && index <= FuncPushCustomSwitchLast) && !Boards::getCapability(fw->getBoard(), Board::FunctionSwitches))
+        ((index >= FuncPushCustomSwitch1 && index <= FuncPushCustomSwitchLast) &&
+          !Boards::isSwitchFunc(Boards::getSwitchIndexForCFSOffset(index - FuncPushCustomSwitch1)))
         );
   return !ret;
 }

--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -545,7 +545,7 @@ bool ModelData::isFunctionSwitchPositionAvailable(int swIndex, int swPos, const 
   if (fs == Board::SWITCH_GLOBAL)
     return gs->switchConfig[swIndex].type != Board::SWITCH_NOT_AVAILABLE;
 
-  return true;
+  return fs != Board::SWITCH_NOT_AVAILABLE;
 }
 
 bool ModelData::isFunctionSwitchSourceAllowed(int index) const


### PR DESCRIPTION
Fixes #7094

Summary of changes:
- exclude physical switches from Push Custom Switch xxx in SF action lists (7094)
- exclude Custom Switches configured as NONE in model from switch lists (found during testing)

Required for 2.12 and 3.0