### PR TITLE
fix(gx12): some customisable switches (SA/SD) set to NONE when updating

### DIFF
--- a/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_funcs.cpp
@@ -2745,7 +2745,7 @@ static const struct YamlNode struct_cfsGroupOn[] {
   YAML_END,
 };
 
-#if NUM_FUNCTIION_SWITCHES > 6
+#if NUM_FUNCTIONS_SWITCHES > 6
 #define NUM_CFS_FOR_CONVERSION  6
 #else
 #define NUM_CFS_FOR_CONVERSION  NUM_FUNCTIONS_SWITCHES


### PR DESCRIPTION
Fix typo preventing correct conversion from 2.11 for GX12.

Applies to 2.12 and 3.0.