### PR TITLE
fix(cpn): remove magic numbers and align values with firmware

### DIFF
--- a/companion/src/constants.h
+++ b/companion/src/constants.h
@@ -44,8 +44,10 @@
 #define CPN_MAX_SWITCHES_STD           20
 #define CPN_MAX_SWITCHES               (CPN_MAX_SWITCHES_STD + CPN_MAX_SWITCHES_FLEX + CPN_MAX_SWITCHES_FUNCTION)
 #define CPN_MAX_SENSORS                99
-#define CPN_MAX_SCRIPTS                9
-#define CPN_MAX_SCRIPT_INPUTS          10
+#define CPN_MAX_SCRIPTS                9  // Max for Color LCD
+#define CPN_LEN_SCRIPT_FILENAME        6
+#define CPN_LEN_SCRIPT_NAME            6
+#define CPN_MAX_SCRIPT_INPUTS          6
 #define CPN_MAX_SCRIPT_OUTPUTS         6
 #define CPN_MAX_SPACEMOUSE             6
 #define CPN_MAX_INPUTS                 32 // v2.10 replaces CPN_MAX_ANALOGS - the value is abitary as radio ADC refactor is still a WIP

--- a/companion/src/firmwares/modeldata.h
+++ b/companion/src/firmwares/modeldata.h
@@ -67,8 +67,8 @@ class RSSIAlarmData {
 class ScriptData {
   public:
     ScriptData() { clear(); }
-    char    filename[10+1];
-    char    name[10+1];
+    char    filename[CPN_LEN_SCRIPT_FILENAME+1];
+    char    name[CPN_LEN_SCRIPT_NAME+1];
     int     inputs[CPN_MAX_SCRIPT_INPUTS];
     void clear() { memset(reinterpret_cast<void *>(this), 0, sizeof(ScriptData)); }
 };


### PR DESCRIPTION
Fix values in Companion to match firmware. Remove magic numbers.

Applies to 2.11, 2.12 and 3.0.