### PR TITLE
fix(color): settings for 'Outputs' widget incorrect with older models

### DIFF
--- a/radio/src/gui/colorlcd/mainview/widget.cpp
+++ b/radio/src/gui/colorlcd/mainview/widget.cpp
@@ -377,6 +377,7 @@ Widget* WidgetFactory::create(Window* parent, const rect_t& rect,
     parseOptionDefaults();
   }
   if (options) {
+    checkOptions(screenNum, zoneNum);
     int i = 0;
     for (const WidgetOption* option = options; option->name; option++, i++) {
       TRACE("WidgetFactory::create() setting option '%s'", option->name);

--- a/radio/src/gui/colorlcd/mainview/widget.h
+++ b/radio/src/gui/colorlcd/mainview/widget.h
@@ -156,6 +156,7 @@ class WidgetFactory
 
   const WidgetOption* getDefaultOptions() const { return options; }
   virtual const void parseOptionDefaults() const {}
+  virtual const void checkOptions(int screenNum, int zoneNum) const {}
 
   const char* getDisplayName() const
   {


### PR DESCRIPTION
Fix options loaded from model yaml file for outputs widget.

The 'Last channel' option added in #7098 causes the option values to be loaded into the wrong slots when loading a previously saved model file.
