### PR TITLE
fix(firmware): radio may crash after editing a number or text field in a popup dialog

### DIFF
--- a/radio/src/gui/colorlcd/libui/keyboard_base.cpp
+++ b/radio/src/gui/colorlcd/libui/keyboard_base.cpp
@@ -102,6 +102,13 @@ Keyboard::~Keyboard()
   if (group) lv_group_del(group);
 }
 
+void Keyboard::deleteLater()
+{
+  if (!_deleted)
+    hide(false);
+  NavWindow::deleteLater();
+}
+
 void Keyboard::clearField(bool wasCancelled)
 {
   TRACE("CLEAR FIELD");

--- a/radio/src/gui/colorlcd/libui/keyboard_base.h
+++ b/radio/src/gui/colorlcd/libui/keyboard_base.h
@@ -36,6 +36,8 @@ class Keyboard : public NavWindow
  protected:
   static Keyboard *activeKeyboard;
 
+  void deleteLater() override;
+
   lv_group_t* group = nullptr;
   lv_obj_t* keyboard = nullptr;
 


### PR DESCRIPTION
Fix crash if dialog closed while editing number or text field.

To reproduce:
- open a dialog popup with a number or text field (e.g. Widget settings for Outputs widget)
- tap on the field to open the keyboard (e.g. Outputs widget, First channel)
- close the dialog by touching the screen area outside the dialog box and keyboard
- open the same dialog again
- tap on the field to edit and try to change the value

Only affects 3.0 - arises from refactoring which changed the order in which things are deleted.