### PR TITLE
fix(gx12): customisable switch startup/shutdown led animation

### DIFF
--- a/radio/src/gui/128x64/startup_shutdown.cpp
+++ b/radio/src/gui/128x64/startup_shutdown.cpp
@@ -33,6 +33,8 @@ const unsigned char bmp_sleep[]  = {
 
 #if defined(RADIO_FAMILY_T20)
 constexpr uint8_t steps = NUM_FUNCTIONS_SWITCHES/2;
+#elif defined(RADIO_GX12)
+constexpr uint8_t steps = NUM_FUNCTIONS_SWITCHES - 2; //Exclude SA and SD
 #elif defined(FUNCTION_SWITCHES)
 constexpr uint8_t steps = NUM_FUNCTIONS_SWITCHES;
 #endif
@@ -95,6 +97,13 @@ void drawShutdownAnimation(uint32_t duration, uint32_t totalDuration,
       steps);
 
   for (uint8_t j = 0; j < steps; j++) {
+#if defined(FUNCTION_SWITCHES_RGB_LEDS)
+    fsLedRGB(j, 0);
+    if (steps - index2 > j) {
+        fsLedRGB(j, 0xFFFFFF);
+    }
+    rgbLedColorApply();
+#else
     setFSLedOFF(j);
 #if defined(RADIO_FAMILY_T20)
     setFSLedOFF(j + steps);
@@ -105,6 +114,7 @@ void drawShutdownAnimation(uint32_t duration, uint32_t totalDuration,
       setFSLedON(j + steps);
 #endif
     }
+#endif
   }
 #endif
 


### PR DESCRIPTION
Fixes RGB led animation for GX12