### PR TITLE
fix(gx12): switch warning screen not detecting switch movement

### DIFF
--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -32,6 +32,10 @@
 #include "inactivity_timer.h"
 #include "tasks/mixer_task.h"
 
+#if defined(RADIO_GX12)
+#include "targets/taranis/gx12/bsp_io.h"
+#endif
+
 #define CS_LAST_VALUE_INIT -32768
 
 #if defined(COLORLCD)
@@ -913,7 +917,9 @@ void checkSwitches()
 #endif
 
   while (true) {
-
+#if defined(RADIO_GX12)
+    _poll_switches();
+#endif
     if (!isSwitchWarningRequired(bad_pots))
       break;
 


### PR DESCRIPTION
Fix GX12 startup switches check after #7105 