### PR TITLE
fix(cpn): typos and punctuation in German translations

### DIFF
--- a/companion/src/translations/companion_de.ts
+++ b/companion/src/translations/companion_de.ts
@@ -238,7 +238,7 @@ Mode 3:
   Rechter Knüppel:  Gas, Seite
 
 Mode 4:
-  Linker Knüpple:  Gas, Quer
+  Linker Knüppel:  Gas, Quer
   Rechter Knüppel:  Höhe, Seite
 
 </translation>
@@ -302,7 +302,7 @@ Mode 4:
     <message>
         <location filename="../apppreferencesdialog.ui" line="97"/>
         <source>Radio Settings</source>
-        <translation type="unfinished">Sender Grunfeinstellungen</translation>
+        <translation type="unfinished">Sender Grundeinstellungen</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.ui" line="147"/>
@@ -859,7 +859,7 @@ Mode 4:
     <message>
         <location filename="../apppreferencesdialog.cpp" line="371"/>
         <source>AVAILABLE: Radio settings of unknown age</source>
-        <translation>Verüfgbar: Sender-Einstellungen mit unklarem Alter</translation>
+        <translation>Verfügbar: Sender-Einstellungen mit unklarem Alter</translation>
     </message>
     <message>
         <location filename="../apppreferencesdialog.cpp" line="373"/>
@@ -1927,7 +1927,7 @@ Do you want to import settings from a file?</source>
     <message>
         <location filename="../shared/curvedialog.cpp" line="187"/>
         <source>Single Expo</source>
-        <translation type="unfinished">Enfache Expo</translation>
+        <translation type="unfinished">Einfache Expo</translation>
     </message>
     <message>
         <location filename="../shared/curvedialog.cpp" line="188"/>
@@ -3542,7 +3542,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="453"/>
         <source>Use alternative SQT5 font</source>
-        <translation>Alternative SQT5 Schrift verw</translation>
+        <translation>Alternative SQT5 Schrift verwenden</translation>
     </message>
     <message>
         <location filename="../firmwares/opentx/opentxinterface.cpp" line="613"/>
@@ -4171,7 +4171,7 @@ Blank means include all. ?, *, and [...] wildcards accepted.</source>
     <message>
         <location filename="../flash/flashfirmwaredialog.ui" line="207"/>
         <source>Use firmware start screen</source>
-        <translation>Verwende den Firmware Startscrenn</translation>
+        <translation>Verwende den Firmware Startscreen</translation>
     </message>
     <message>
         <location filename="../flash/flashfirmwaredialog.ui" line="214"/>
@@ -4752,7 +4752,7 @@ Incompatability - File: &apos;%2&apos; Profile: &apos;%3&apos;</source>
     <message>
         <location filename="../generaledit/generaledit.ui" line="20"/>
         <source>Radio Settings</source>
-        <translation type="unfinished">Sender Grunfeinstellungen</translation>
+        <translation type="unfinished">Sender Grundeinstellungen</translation>
     </message>
     <message>
         <location filename="../generaledit/generaledit.ui" line="49"/>
@@ -4994,7 +4994,7 @@ Are you sure?</source>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="328"/>
         <source>Radio Settings</source>
-        <translation>Sender Grunfeinstellungen</translation>
+        <translation>Sender Grundeinstellungen</translation>
     </message>
     <message>
         <location filename="../firmwares/generalsettings.cpp" line="330"/>
@@ -7430,7 +7430,7 @@ Sind Sie sicher?</translation>
         <source>The column containing GPS coordinates must be named &quot;GPS&quot;.
 
 The columns for altitude &quot;GAlt&quot; and for speed &quot;GSpd&quot; are optional</source>
-        <translation>Die Spalten mit GPS-Koordianten müssen &quot;GPS&quot;. heisen
+        <translation>Die Spalten mit GPS-Koordinaten müssen &quot;GPS&quot; heißen
 
 Die Spalten für Höhe &quot;GAlt&quot; und für Geschwindigkeit &quot;GSpd&quot; sind optional</translation>
     </message>
@@ -8218,7 +8218,7 @@ Do you wish to continue?</source>
     <message>
         <location filename="../mainwindow.cpp" line="826"/>
         <source>Edit the splash image of your Radio</source>
-        <translation>Editiere das Starthbild für den Sender</translation>
+        <translation>Editiere das Startbild für den Sender</translation>
     </message>
     <message>
         <location filename="../mainwindow.cpp" line="556"/>
@@ -8350,7 +8350,7 @@ Do you wish to continue?</source>
     <message>
         <location filename="../mdichild.cpp" line="1223"/>
         <source>Editing model %1: </source>
-        <translation>Modell %1 bearbeiten :</translation>
+        <translation>Modell %1 bearbeiten:</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="357"/>
@@ -8406,7 +8406,7 @@ Do you wish to continue?</source>
     <message>
         <location filename="../mdichild.cpp" line="1042"/>
         <source>Do you want to overwrite radio general settings?</source>
-        <translation>Wollen sie wirklich die Sender Grundeinstellungen überschreiben?</translation>
+        <translation>Wollen Sie wirklich die Sender Grundeinstellungen überschreiben?</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1446"/>
@@ -8451,7 +8451,7 @@ Do you wish to continue?</source>
     <message>
         <location filename="../mdichild.cpp" line="1565"/>
         <source>Unable to find file %1!</source>
-        <translation>Kann die Datei %1 nicht finden !</translation>
+        <translation>Kann die Datei %1 nicht finden!</translation>
     </message>
     <message>
         <location filename="../mdichild.cpp" line="1346"/>
@@ -9378,7 +9378,7 @@ p, li { white-space: pre-wrap; }
     <message>
         <location filename="../modeledit/mixes.cpp" line="559"/>
         <source>Really clear all the mixes?</source>
-        <translation>Wirklich alle Mischer löschen ?</translation>
+        <translation>Wirklich alle Mischer löschen?</translation>
     </message>
 </context>
 <context>
@@ -12396,7 +12396,7 @@ r</translation>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="177"/>
         <source>Multiplier</source>
-        <translation type="unfinished">Muliplikator</translation>
+        <translation type="unfinished">Multiplikator</translation>
     </message>
     <message>
         <location filename="../firmwares/sensordata.cpp" line="182"/>
@@ -13375,7 +13375,7 @@ ebenfalls umgekehrt.
     <message>
         <location filename="../simulator.cpp" line="132"/>
         <source>type</source>
-        <translation>Tayp</translation>
+        <translation>Typ</translation>
     </message>
     <message>
         <location filename="../simulator.cpp" line="138"/>
@@ -17681,7 +17681,7 @@ Process now?</source>
     <message>
         <location filename="../wizard/wizarddialog.cpp" line="98"/>
         <source>Air brakes are used to reduce the speed of advanced sail planes.&lt;br&gt;They are very uncommon on other types of planes.</source>
-        <translation>Störklappen werden eingesetzt um den Widerstand zu erhöhen und damit den Gleitwinkel  bei Seglern zu verschlechtern.&lt;br&gt;Für ander Arten von Flugzeugen sind sie eher ungewöhnlich.</translation>
+        <translation>Störklappen werden eingesetzt um den Widerstand zu erhöhen und damit den Gleitwinkel bei Seglern zu verschlechtern.&lt;br&gt;Für andere Arten von Flugzeugen sind sie eher ungewöhnlich.</translation>
     </message>
     <message>
         <location filename="../wizard/wizarddialog.cpp" line="102"/>


### PR DESCRIPTION
Fixes #7118

Summary of changes:
Fixed some German translation mistakes for companion. 
