### PR TITLE
chore: Update German 🇩🇪 radio translations

### DIFF
--- a/radio/src/translations/i18n/de.h
+++ b/radio/src/translations/i18n/de.h
@@ -715,7 +715,6 @@
 #define TR_CURRENT_CALIB               "Strom abgl."
 #define TR_VOLTAGE                     TR("Spg", "Spannungsquelle")  //9XR-Pro
 #define TR_SELECT_MODEL                "Modell auswählen"
-#define TR_MANAGE_MODELS               TR_BW_COL("MODELL MANAGER", "Modell Manager")
 #define TR_MODELS                      "Modelle"
 #define TR_SELECT_MODE                 "Wähle Mode"
 #define TR_CREATE_MODEL                TR("Neues Modell" , "Neues Modell erstellen")


### PR DESCRIPTION
Summary of changes:
I have tried to stick with the current names wherever possible for the quick menu updates. There is also a whitespace cleanup; if that is unwanted, I can revert that commit. Since I have no BW radio, I am not able to test things, but I have tried to have the same length as en.h is using. 