### PR TITLE
chore(GX12): remove compiler warning

### DIFF
--- a/radio/src/targets/taranis/gx12/bsp_io.cpp
+++ b/radio/src/targets/taranis/gx12/bsp_io.cpp
@@ -127,9 +127,6 @@ struct bsp_io_sw_def {
   uint32_t pin_low;
 };
 
-static constexpr uint32_t RGB_OFFSET = (1 << 16); // first after bspio pins
-static uint16_t soft2POSLogicalState = 0xFFFF;
-
 static SwitchHwPos _get_switch_pos(uint8_t idx)
 {
   SwitchHwPos pos = SWITCH_HW_UP;


### PR DESCRIPTION
Remove unused code and avoid a compiler warning. Thanks Philmoz for noticing this one