### PR TITLE
fix(color): telemetry sensor settings may not be saved to model YAML file

### DIFF
--- a/radio/src/gui/colorlcd/model/model_telemetry.cpp
+++ b/radio/src/gui/colorlcd/model/model_telemetry.cpp
@@ -346,6 +346,7 @@ class SensorSourceChoice : public SourceChoice
                      *source = newValue == MIXSRC_NONE
                                    ? 0
                                    : (newValue - MIXSRC_FIRST_TELEM) / 3 + 1;
+                     SET_DIRTY();
                    })
   {
     setAvailableHandler([=](int16_t value) {
@@ -663,6 +664,7 @@ class SensorEditWindow : public SubPage
                 if (sensor->custom.ratio != 0)
                   s = formatNumberAsString((sensor->custom.ratio * 1000) / 255, PREC1, 0, "", "%");
                 pct->setText(s);
+                SET_DIRTY();
               },
               PREC1);
           num->setZeroText("-");


### PR DESCRIPTION
Mark model as dirty when sensor fields are changed.

Reported in Discord => https://discord.com/channels/839849772864503828/1476038631264223405/1476038631264223405

Applies to 2.11, 2.12 and 3.0.