### PR TITLE
fix(color): main view trims and sliders may be created twice

### DIFF
--- a/radio/src/edgetx.cpp
+++ b/radio/src/edgetx.cpp
@@ -1575,7 +1575,8 @@ void edgeTxInit()
 #endif // defined(GUI)
 
 #if defined(COLORLCD)
-  LayoutFactory::loadCustomScreens();
+    LayoutFactory::deleteCustomScreens(true);
+    LayoutFactory::loadCustomScreens();
 #endif
 
 #if defined(BLUETOOTH_PROBE)


### PR DESCRIPTION
If radio / simulator is started with no models (i.e. blank SD or empty etx file), the main view may have duplicate copies of the trims and sliders loaded.

This can be seen if a widget is loaded and then switched to full screen.

Side effect of #7096

Applies to 2.12 and 3.0.
