### PR TITLE
feat(color): extend Lua API to allow changes to choice values, widget settings title

### DIFF
--- a/radio/src/gui/colorlcd/libui/choice.cpp
+++ b/radio/src/gui/colorlcd/libui/choice.cpp
@@ -150,6 +150,7 @@ void Choice::addValue(const char* value)
 
 void Choice::setValues(std::vector<std::string> values)
 {
+  this->values.clear();
   this->values = std::move(values);
   currentValue = INT_MAX; // Force update
   update();

--- a/radio/src/lua/lua_lvgl_widget.cpp
+++ b/radio/src/lua/lua_lvgl_widget.cpp
@@ -243,6 +243,7 @@ bool LvglThicknessParam::parseThicknessParam(lua_State *L, const char *key)
 bool LvglValuesParam::parseValuesParam(lua_State *L, const char *key)
 {
   if (!strcmp(key, "values")) {
+    values.clear();
     luaL_checktype(L, -1, LUA_TTABLE);
     for (lua_pushnil(L); lua_next(L, -2); lua_pop(L, 1)) {
       values.push_back(lua_tostring(L, -1));
@@ -1579,6 +1580,24 @@ void LvglWidgetSetting::parseParam(lua_State *L, const char *key)
   LvglWidgetObject::parseParam(L, key);
 }
 
+void LvglWidgetSetting::setTitle(const char* s)
+{
+  if (label && title.changedText(s))
+    lv_label_set_text(label, title.txt.c_str());
+}
+
+bool LvglWidgetSetting::callRefs(lua_State *L)
+{
+  if (!LvglWidgetObject::callRefs(L)) return false;
+
+  if (isVisible()) {
+    if (!pcallUpdateStringVal(L, title.function, [=](const char* s) { setTitle(s); }))
+      return false;
+  }
+
+  return true;
+}
+
 void LvglWidgetSetting::clearRefs(lua_State *L)
 {
   clearTitleRefs(L);
@@ -1590,10 +1609,10 @@ void LvglWidgetSetting::build(lua_State *L)
   window =
       new Window(lvglManager->getCurrentParent(), {x, y, w, h}, lv_obj_create);
   window->padAll(PAD_OUTLINE);
-  auto lbl = etx_label_create(window->getLvObj());
-  lv_obj_align(lbl, LV_ALIGN_LEFT_MID, 0, 0);
-  etx_txt_color(lbl, COLOR_THEME_PRIMARY1_INDEX);
-  lv_label_set_text(lbl, title.txt.c_str());
+  label = etx_label_create(window->getLvObj());
+  lv_obj_align(label, LV_ALIGN_LEFT_MID, 0, 0);
+  etx_txt_color(label, COLOR_THEME_PRIMARY1_INDEX);
+  lv_label_set_text(label, title.txt.c_str());
 }
 
 //-----------------------------------------------------------------------------
@@ -2694,7 +2713,7 @@ void LvglWidgetChoice::clearRefs(lua_State *L)
 
 void LvglWidgetChoice::build(lua_State *L)
 {
-  if (h == LV_SIZE_CONTENT) h = 0;
+  if (h == LV_SIZE_CONTENT) h = EdgeTxStyles::UI_ELEMENT_HEIGHT;
   auto c = new Choice(
       lvglManager->getCurrentParent(), {x, y, w, h}, values, 0, values.size() - 1,
       [=]() { return pcallGetIntVal(L, getFunction) - 1; },
@@ -2724,6 +2743,14 @@ void LvglWidgetChoice::build(lua_State *L)
     });
 
   window = c;
+}
+
+void LvglWidgetChoice::refresh()
+{
+  LvglWidgetPicker::refresh();
+  Choice* c = (Choice*)window;
+  c->setValues(values);
+  c->setMax(values.size() - 1);
 }
 
 //-----------------------------------------------------------------------------

--- a/radio/src/lua/lua_lvgl_widget.h
+++ b/radio/src/lua/lua_lvgl_widget.h
@@ -532,9 +532,13 @@ class LvglWidgetSetting : public LvglWidgetObject, public LvglTitleParam
  public:
   LvglWidgetSetting() : LvglWidgetObject() {}
 
+  void setTitle(const char* s);
+
+  bool callRefs(lua_State *L) override;
   void clearRefs(lua_State *L) override;
 
  protected:
+  lv_obj_t* label = nullptr;
 
   void build(lua_State *L) override;
   void parseParam(lua_State *L, const char *key) override;
@@ -973,6 +977,7 @@ class LvglWidgetChoice : public LvglWidgetPicker, public LvglTitleParam, public 
 
   void build(lua_State *L) override;
   void parseParam(lua_State *L, const char *key) override;
+  void refresh() override;
 };
 
 //-----------------------------------------------------------------------------


### PR DESCRIPTION
Changes:
- Allow 'choice' values property to be changed.
- Allow 'setting' title property to be changed.

The 'setting' title property can be set to a function to allow dynamic updates.
The 'choice' values property can be updated using the 'set' function.
The 'choice' values property cannot be assigned to a function due to the potential performance impact.

Applies to 2.11, 2.12 and 3.0.