### PR TITLE
fix(lua): prevent drawGauge fill bar overlapping its outline

### DIFF
--- a/radio/src/lua/api_stdlcd.cpp
+++ b/radio/src/lua/api_stdlcd.cpp
@@ -513,8 +513,8 @@ static int luaLcdDrawGauge(lua_State *L)
 #else
   lcdDrawRect(x, y, w, h, 0xff, flags);
 #endif
-  uint8_t len = limit((uint8_t)1, uint8_t((w-2)*num/den), uint8_t(w-2));
-  lcdDrawSolidFilledRect(x+1, y+1, len, h-2, flags);
+  uint8_t len = limit((uint8_t)0, uint8_t(((w-2)*num + den/2) / den), uint8_t(w-2));
+  if (len > 0) lcdDrawSolidFilledRect(x+1, y+1, len, h-2, flags);
   return 0;
 }
 


### PR DESCRIPTION
Summary of changes:
Fix a visual bug for the Lua Gauge element.

The Gauge will be drawn as a rectangle outline and a filled rectangle filling. The width of the filling rectangle didn't take the outline width into consideration resulting in a two pixel overdraw at 100%.
This change subtracts the online pixels so it fits inside the outline.