### PR TITLE
fix(firmware): range for V2 value may be incorrect for some logical switches

### DIFF
--- a/radio/src/dataconstants.h
+++ b/radio/src/dataconstants.h
@@ -572,6 +572,8 @@ enum MixSources {
 #define MIXSRC_FIRST_FS_SWITCH      (MIXSRC_LAST_REGULAR_SWITCH + 1)
 #endif
 
+constexpr int16_t MIXSRC_MAX_VALUE = 30000;
+
 enum SrcTypes {
   SRC_INPUT = 1 << 0,
   SRC_LUA = 1 << 1,

--- a/radio/src/edgetx.cpp
+++ b/radio/src/edgetx.cpp
@@ -585,7 +585,7 @@ getvalue_t convert16bitsTelemValue(source_t channel, ls_telemetry_value_t value)
 
 ls_telemetry_value_t maxTelemValue(source_t channel)
 {
-  return 30000;
+  return MIXSRC_MAX_VALUE;
 }
 
 void calcBacklightValue(int16_t source)
@@ -2012,7 +2012,7 @@ void getMixSrcRange(const int source, int16_t & valMin, int16_t & valMax, LcdFla
   }
 #if defined(LUA_INPUTS)
   else if (asrc >= MIXSRC_FIRST_LUA && asrc <= MIXSRC_LAST_LUA) {
-    valMax = 30000;
+    valMax = MIXSRC_MAX_VALUE;
     valMin = -valMax;
   }
 #endif
@@ -2055,7 +2055,7 @@ void getMixSrcRange(const int source, int16_t & valMin, int16_t & valMax, LcdFla
       *flags |= TIMEHOUR;
   }
   else {
-    valMax = 30000;
+    valMax = MIXSRC_MAX_VALUE;
     valMin = -valMax;
   }
 }
@@ -2075,16 +2075,20 @@ bool validateLSV2Range(LogicalSwitchData* cs, int16_t& v2_min, int16_t& v2_max, 
       // min < 0 && max >= 0
       v2_min = 0;
     }
-  } else if (cs->func == LS_FUNC_DIFFEGREATER) {
-    // delta range (min - max) .. (max - min)
-    int16_t v = v2_min - v2_max;
-    v2_max = v2_max - v2_min;
-    v2_min = v;
-  } else if (cs->func == LS_FUNC_ADIFFEGREATER) {
-    // abs delta range 0 .. (max - min)
-    v2_max = v2_max - v2_min;
-    v2_min = 0;
+  } else {
+    uint16_t v = v2_max - v2_min;
+    if (v > MIXSRC_MAX_VALUE) v = MIXSRC_MAX_VALUE;
+    if (cs->func == LS_FUNC_DIFFEGREATER) {
+      // delta range (min - max) .. (max - min)
+      v2_max = v;
+      v2_min = -v;
+    } else if (cs->func == LS_FUNC_ADIFFEGREATER) {
+      // abs delta range 0 .. (max - min)
+      v2_max = v;
+      v2_min = 0;
+    }
   }
+  TRACE(">>>>> %d %d %d",cs->func,v2_min,v2_max);
 
   bool rv = false;
 

--- a/radio/src/gui/128x64/model_telemetry_sensor.cpp
+++ b/radio/src/gui/128x64/model_telemetry_sensor.cpp
@@ -212,12 +212,12 @@ void menuModelSensor(event_t event)
         }
         else {
           if (sensor->unit == UNIT_RPMS) {
-            sensor->custom.ratio = editNumberField(STR_BLADES, 0, SENSOR_2ND_COLUMN, y, sensor->custom.ratio, 1, 30000, attr, event);
+            sensor->custom.ratio = editNumberField(STR_BLADES, 0, SENSOR_2ND_COLUMN, y, sensor->custom.ratio, 1, MIXSRC_MAX_VALUE, attr, event);
             break;
           }
           else {
             lcdDrawTextAlignedLeft(y, STR_RATIO);
-            if (attr) CHECK_INCDEC_MODELVAR(event, sensor->custom.ratio, 0, 30000);
+            if (attr) CHECK_INCDEC_MODELVAR(event, sensor->custom.ratio, 0, MIXSRC_MAX_VALUE);
             if (sensor->custom.ratio == 0) {
               lcdDrawChar(SENSOR_2ND_COLUMN, y, '-', attr);
             } else {  // Ratio + Ratio Percent
@@ -281,13 +281,13 @@ void menuModelSensor(event_t event)
         }
         else if (sensor->unit == UNIT_RPMS) {
           lcdDrawTextAlignedLeft(y, STR_MULTIPLIER);
-          if (attr) sensor->custom.offset = checkIncDec(event, sensor->custom.offset, 1, 30000, EE_MODEL|NO_INCDEC_MARKS|INCDEC_REP10);
+          if (attr) sensor->custom.offset = checkIncDec(event, sensor->custom.offset, 1, MIXSRC_MAX_VALUE, EE_MODEL|NO_INCDEC_MARKS|INCDEC_REP10);
           lcdDrawNumber(SENSOR_2ND_COLUMN, y, sensor->custom.offset, LEFT|attr);
           break;
         }
         else {
           if (sensor->prec > 0) attr |= (sensor->prec == 2 ? PREC2 : PREC1);
-          sensor->custom.offset = editNumberField(STR_OFFSET, 0, SENSOR_2ND_COLUMN, y, sensor->custom.offset, -30000, 30000, attr, event);
+          sensor->custom.offset = editNumberField(STR_OFFSET, 0, SENSOR_2ND_COLUMN, y, sensor->custom.offset, -MIXSRC_MAX_VALUE, MIXSRC_MAX_VALUE, attr, event);
           break;
         }
         // no break

--- a/radio/src/gui/212x64/model_telemetry_sensor.cpp
+++ b/radio/src/gui/212x64/model_telemetry_sensor.cpp
@@ -227,13 +227,13 @@ void menuModelSensor(event_t event)
         else {
           if (sensor->unit == UNIT_RPMS) {
             lcdDrawTextAlignedLeft(y, STR_BLADES);
-            if (attr) sensor->custom.ratio = checkIncDec(event, sensor->custom.ratio, 1, 30000, EE_MODEL|NO_INCDEC_MARKS|INCDEC_REP10);
+            if (attr) sensor->custom.ratio = checkIncDec(event, sensor->custom.ratio, 1, MIXSRC_MAX_VALUE, EE_MODEL|NO_INCDEC_MARKS|INCDEC_REP10);
             lcdDrawNumber(SENSOR_2ND_COLUMN, y, sensor->custom.ratio, LEFT|attr);
             break;
           }
           else {
             lcdDrawTextAlignedLeft(y, STR_RATIO);
-            if (attr) sensor->custom.ratio = checkIncDec(event, sensor->custom.ratio, 0, 30000, EE_MODEL|NO_INCDEC_MARKS|INCDEC_REP10);
+            if (attr) sensor->custom.ratio = checkIncDec(event, sensor->custom.ratio, 0, MIXSRC_MAX_VALUE, EE_MODEL|NO_INCDEC_MARKS|INCDEC_REP10);
             if (sensor->custom.ratio == 0) {
               lcdDrawChar(SENSOR_2ND_COLUMN, y, '-', attr);
             } else {  // Ratio + Ratio Percent
@@ -265,13 +265,13 @@ void menuModelSensor(event_t event)
         }
         else if (sensor->unit == UNIT_RPMS) {
           lcdDrawTextAlignedLeft(y, STR_MULTIPLIER);
-          if (attr) sensor->custom.offset = checkIncDec(event, sensor->custom.offset, 1, 30000, EE_MODEL|NO_INCDEC_MARKS|INCDEC_REP10);
+          if (attr) sensor->custom.offset = checkIncDec(event, sensor->custom.offset, 1, MIXSRC_MAX_VALUE, EE_MODEL|NO_INCDEC_MARKS|INCDEC_REP10);
           lcdDrawNumber(SENSOR_2ND_COLUMN, y, sensor->custom.offset, LEFT|attr);
           break;
         }
         else {
           lcdDrawTextAlignedLeft(y, STR_OFFSET);
-          if (attr) sensor->custom.offset = checkIncDec(event, sensor->custom.offset, -30000, +30000, EE_MODEL|NO_INCDEC_MARKS|INCDEC_REP10);
+          if (attr) sensor->custom.offset = checkIncDec(event, sensor->custom.offset, -MIXSRC_MAX_VALUE, +MIXSRC_MAX_VALUE, EE_MODEL|NO_INCDEC_MARKS|INCDEC_REP10);
           if (sensor->prec > 0) attr |= (sensor->prec == 2 ? PREC2 : PREC1);
           lcdDrawNumber(SENSOR_2ND_COLUMN, y, sensor->custom.offset, LEFT|attr);
           break;

--- a/radio/src/gui/colorlcd/model/model_telemetry.cpp
+++ b/radio/src/gui/colorlcd/model/model_telemetry.cpp
@@ -649,14 +649,14 @@ class SensorEditWindow : public SubPage
         });
 
     paramLines[P_BLADES] = setupLine(STR_BLADES, [=](Window* parent, coord_t x, coord_t y) {
-          new NumberEdit(parent, {x, y, NUM_EDIT_W, 0}, 1, 30000,
+          new NumberEdit(parent, {x, y, NUM_EDIT_W, 0}, 1, MIXSRC_MAX_VALUE,
                         GET_SET_DEFAULT(sensor->custom.ratio));
         });
 
     paramLines[P_RATIO] = setupLine(STR_RATIO, [=](Window* parent, coord_t x, coord_t y) {
           auto pct = new StaticText(parent, {x + NUM_EDIT_W + PAD_MEDIUM, y + PAD_MEDIUM, 0, 0}, "");
           auto num = new NumberEdit(
-              parent, {x, y, NUM_EDIT_W, 0}, 0, 30000,
+              parent, {x, y, NUM_EDIT_W, 0}, 0, MIXSRC_MAX_VALUE,
               GET_DEFAULT(sensor->custom.ratio),
               [=](int32_t value) {
                 sensor->custom.ratio = value;
@@ -692,13 +692,13 @@ class SensorEditWindow : public SubPage
         });
 
     paramLines[P_MULT] = setupLine(STR_MULTIPLIER, [=](Window* parent, coord_t x, coord_t y) {
-          new NumberEdit(parent, {x, y, NUM_EDIT_W, 0}, 1, 30000,
+          new NumberEdit(parent, {x, y, NUM_EDIT_W, 0}, 1, MIXSRC_MAX_VALUE,
                         GET_SET_DEFAULT(sensor->custom.offset));
         });
 
     paramLines[P_OFFSET] = setupLine(STR_OFFSET, [=](Window* parent, coord_t x, coord_t y) {
           new NumberEdit(
-              parent, {x, y, NUM_EDIT_W, 0}, -30000, 30000,
+              parent, {x, y, NUM_EDIT_W, 0}, -MIXSRC_MAX_VALUE, MIXSRC_MAX_VALUE,
               GET_SET_DEFAULT(sensor->custom.offset),
               (sensor->prec > 0) ? (sensor->prec == 2 ? PREC2 : PREC1) : 0);
         });


### PR DESCRIPTION
Fix logical switch V2 range to prevent overflow.

Fixes #7157

Applies to 2.11, 2.12 and 3.0