### PR TITLE
chore(ci): bump checkout action version

### DIFF
--- a/.github/workflows/build_fw.yml
+++ b/.github/workflows/build_fw.yml
@@ -62,7 +62,7 @@ jobs:
         - ${{ github.workspace }}:/src
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
           # fetch-depth: 0 # https://github.com/actions/checkout#Fetch-all-history-for-all-tags-and-branches
@@ -114,7 +114,7 @@ jobs:
         - ${{ github.workspace }}:/src
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 

--- a/.github/workflows/linux_cpn.yml
+++ b/.github/workflows/linux_cpn.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
       - '[0-9]+.[0-9]+'
     tags:
-      - v*  
+      - v*
     paths: &trigger-paths
       - '.github/workflows/linux_cpn.yml'
       - 'companion/**'
@@ -37,7 +37,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -56,7 +56,7 @@ jobs:
         run: |
           # Create logs directory if it doesn't exist
           mkdir -p logs
-          
+
           # Copy all build logs from the build directory
           if [ -d "build" ]; then
             find build -name "*.log" -type f -exec cp {} logs/ \; 2>/dev/null || true

--- a/.github/workflows/macosx_cpn.yml
+++ b/.github/workflows/macosx_cpn.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
       - '[0-9]+.[0-9]+'
     tags:
-      - v*  
+      - v*
     paths: &trigger-paths
       - '.github/workflows/macosx_cpn.yml'
       - 'companion/**'
@@ -38,7 +38,7 @@ jobs:
           xcode-version: '16.0'
 
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -84,7 +84,7 @@ jobs:
         run: |
           # Create logs directory if it doesn't exist
           mkdir -p logs
-          
+
           # Copy all build logs from the build directory
           if [ -d "build" ]; then
             find build -name "*.log" -type f -exec cp {} logs/ \; 2>/dev/null || true

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -45,7 +45,7 @@ jobs:
         - ${{ github.workspace }}:/src
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -76,7 +76,7 @@ jobs:
       contents: write
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0  # Need full history for changelog
 

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -19,7 +19,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0

--- a/.github/workflows/sync_repos.yml
+++ b/.github/workflows/sync_repos.yml
@@ -10,41 +10,41 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           token: ${{ secrets.SYNC_PAT }}
-      
+
       - name: Configure git
         run: |
           git config user.name "EdgeTX Sync Bot"
           git config user.email "sync-bot@edgetx.org"
-      
+
       - name: Sync branches from upstream (hard reset)
         env:
           BRANCHES: "main 2.11" # Add/modify branches here as needed
         run: |
           git remote add upstream https://github.com/EdgeTX/edgetx.git
           git fetch upstream
-          
+
           for branch in $BRANCHES; do
             echo "=== Syncing branch: $branch ==="
-            
+
             # Check if upstream has this branch
             if ! git ls-remote --heads upstream | grep -q "refs/heads/$branch"; then
               echo "⚠️  Branch $branch does not exist in upstream, skipping..."
               continue
             fi
-            
+
             # Hard reset to upstream (creates exact copy with same SHA)
             git checkout -B $branch upstream/$branch
-            
+
             # Force push to origin
             git push origin $branch --force
-            
+
             echo "✓ Branch $branch synced (SHA: $(git rev-parse HEAD))"
           done
-          
+
           echo ""
           echo "=== Sync Complete ==="
           echo "All specified branches are now exact copies of upstream"

--- a/.github/workflows/win_cpn-64.yml
+++ b/.github/workflows/win_cpn-64.yml
@@ -6,7 +6,7 @@ on:
       - 'main'
       - '[0-9]+.[0-9]+'
     tags:
-      - v*  
+      - v*
     paths: &trigger-paths
       - '.github/workflows/win_cpn-64.yml'
       - 'companion/**'
@@ -42,7 +42,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           submodules: recursive
 
@@ -86,7 +86,7 @@ jobs:
         run: |
           # Create logs directory if it doesn't exist
           mkdir -p logs
-          
+
           # Copy all build logs from the build directory
           if [ -d "build" ]; then
             find build -name "*.log" -type f -exec cp {} logs/ \; 2>/dev/null || true


### PR DESCRIPTION
NodeJS v20 is being depreciated, meaning we should be now using NodeJS v24 based actions.

