### PR TITLE
FLYSKY ST16 touch support

### DIFF
--- a/radio/src/targets/st16/hal.h
+++ b/radio/src/targets/st16/hal.h
@@ -486,6 +486,19 @@
 #define TOUCH_I2C_BUS                   I2C_Bus_1
 #define TOUCH_I2C_CLK_RATE              100000
 
+#define TOUCH_INT_GPIO                  GPIOI
+#define TOUCH_INT_GPIO_PIN              LL_GPIO_PIN_11   // PI.11
+#define TOUCH_RST_GPIO                  GPIOI
+#define TOUCH_RST_GPIO_PIN              LL_GPIO_PIN_3    // PI.03
+
+#define TOUCH_INT_EXTI_Line             LL_EXTI_LINE_11
+#define TOUCH_INT_EXTI_Port             LL_SYSCFG_EXTI_PORTI
+#define TOUCH_INT_EXTI_SysCfgLine       LL_SYSCFG_EXTI_LINE11
+#if !defined(USE_EXTI15_10_IRQ)
+  #define USE_EXTI15_10_IRQ
+  #define EXTI15_10_IRQ_Priority        5
+#endif
+
 #define IMU_I2C_BUS                     I2C_Bus_1
 #define IMU_I2C_ADDRESS                 0x6A
 

--- a/radio/src/targets/st16/touch_driver.cpp
+++ b/radio/src/targets/st16/touch_driver.cpp
@@ -26,6 +26,7 @@
 #include "stm32_exti_driver.h"
 
 #include "hal.h"
+#include "hal/i2c_driver.h"
 #include "timers_driver.h"
 #include "delays_driver.h"
 #include "touch_driver.h"
@@ -114,10 +115,53 @@ static void _touch_exti_isr(void)
   touchEventOccured = true;
 }
 
-static void _touch_exti_stop(void) {}
-static void _touch_exti_config(void) {}
-static void _touch_gpio_config(void) {}
-static void _touch_reset() {}
+static void _touch_exti_stop(void)
+{
+  stm32_exti_disable(TOUCH_INT_EXTI_Line);
+}
+
+static void _touch_exti_config(void)
+{
+  LL_SYSCFG_SetEXTISource(TOUCH_INT_EXTI_Port, TOUCH_INT_EXTI_SysCfgLine);
+  stm32_exti_enable(TOUCH_INT_EXTI_Line, LL_EXTI_TRIGGER_FALLING,
+                   _touch_exti_isr);
+}
+
+static void _touch_gpio_config(void)
+{
+  // Enable GPIOI clock
+  LL_AHB4_GRP1_EnableClock(LL_AHB4_GRP1_PERIPH_GPIOI);
+
+  // PI3 - TOUCH_RST: push-pull output, initially HIGH
+  LL_GPIO_InitTypeDef gpioInit;
+  LL_GPIO_StructInit(&gpioInit);
+  gpioInit.Pin = TOUCH_RST_GPIO_PIN;
+  gpioInit.Mode = LL_GPIO_MODE_OUTPUT;
+  gpioInit.Speed = LL_GPIO_SPEED_FREQ_LOW;
+  gpioInit.OutputType = LL_GPIO_OUTPUT_PUSHPULL;
+  gpioInit.Pull = LL_GPIO_PULL_NO;
+  LL_GPIO_Init(TOUCH_RST_GPIO, &gpioInit);
+  LL_GPIO_SetOutputPin(TOUCH_RST_GPIO, TOUCH_RST_GPIO_PIN);
+
+  // PI11 - TOUCH_INT: input with pull-up
+  gpioInit.Pin = TOUCH_INT_GPIO_PIN;
+  gpioInit.Mode = LL_GPIO_MODE_INPUT;
+  gpioInit.Pull = LL_GPIO_PULL_UP;
+  LL_GPIO_Init(TOUCH_INT_GPIO, &gpioInit);
+
+  // Init I2C bus
+  i2c_init(TOUCH_I2C_BUS);
+}
+
+static void _touch_reset(void)
+{
+  // Assert reset (active low)
+  LL_GPIO_ResetOutputPin(TOUCH_RST_GPIO, TOUCH_RST_GPIO_PIN);
+  delay_ms(10);
+  // Release reset
+  LL_GPIO_SetOutputPin(TOUCH_RST_GPIO, TOUCH_RST_GPIO_PIN);
+  delay_ms(300);
+}
 
 static int _i2c_read(uint8_t addr, uint32_t reg, uint8_t regSize, uint8_t* data, uint16_t len, uint32_t timeout, bool forceLong = false)
 {
@@ -177,8 +221,6 @@ static bool ft6236TouchRead(uint16_t * X, uint16_t * Y)
 
 static bool ft6236HasTouchEvent()
 {
-  touchEventOccured = true;
-  return true;
   return touchEventOccured;
 }
 
@@ -280,9 +322,8 @@ static bool cst836uTouchRead(uint16_t * X, uint16_t * Y)
 static bool cst836uHasTouchEvent()
 {
   static bool lastHasTouch = false;
-  touchEventOccured = true;
   bool ret = touchEventOccured;
-  if (ret||1) {
+  if (ret) {
     uint8_t data;
     _i2c_readMultipleRetry(TOUCH_CST836U_I2C_ADDRESS, TOUCH_CST836U_TOUCH_NUM_REG, 1, &data, sizeof(data), true);
     uint8_t hasTouch = data;


### PR DESCRIPTION
Add FT6236 touch panel initialization support for ST16. The connection lines are indicated in the picture. The rst and int of the touch screen use the communication lines of the two buttons on the back of the remote control. After installing the touch screen, clicking on the screen will cause the buttons to jump. Without installing the touch screen, these two buttons can work normally and will not be interfered with.
1) ST16 touch hardware definitions in `radio/src/targets/st16/hal.h`
- Add touch pin macros for:
  - `TOUCH_INT_GPIO` / `TOUCH_INT_GPIO_PIN` (PI11)
  - `TOUCH_RST_GPIO` / `TOUCH_RST_GPIO_PIN` (PI3)
- Add EXTI mapping macros:
  - `TOUCH_INT_EXTI_Line`
  - `TOUCH_INT_EXTI_Port`
  - `TOUCH_INT_EXTI_SysCfgLine`
- Enable `USE_EXTI15_10_IRQ` (priority 5) when not already defined.
2) ST16 touch driver implementation in `radio/src/targets/st16/touch_driver.cpp`
- Implement `_touch_gpio_config()`:
  - Configure RST pin as output
  - Configure INT pin as input with pull-up
  - Initialize touch I2C bus
- Implement `_touch_reset()` with proper reset timing.
- Implement `_touch_exti_config()` for INT falling-edge interrupt.
- Implement `_touch_exti_stop()` to disable EXTI.
3) Touch event logic fixes / 触控事件逻辑修复
- `ft6236HasTouchEvent()`:
  - Remove unconditional `true` behavior and return actual event state.
- `cst836uHasTouchEvent()`:
  - Remove forced `touchEventOccured = true`
  - Fix always-true condition (`ret||1` -> `ret`)
![1](https://github.com/user-attachments/assets/7bf9e697-7fca-4723-81f6-43da6899822b)
![2](https://github.com/user-attachments/assets/fff8cdf8-aa61-4dcb-932e-072f4bdacdd7)
<img width="981" height="918" alt="3" src="https://github.com/user-attachments/assets/7cc10745-f0dd-45fd-8b7b-e2ce5fc74d0b" />
