### PR TITLE
feat(color): allow LVGL Lua objects to remain fixed in place within scrolling containers

### DIFF
--- a/radio/src/lua/lua_lvgl_widget.cpp
+++ b/radio/src/lua/lua_lvgl_widget.cpp
@@ -654,6 +654,8 @@ void LvglWidgetObjectBase::parseParam(lua_State *L, const char *key)
     getSizeFunction = ::getRef(L, LUA_REGISTRYINDEX);
   } else if (!strcmp(key, "pos")) {
     getPosFunction = ::getRef(L, LUA_REGISTRYINDEX);
+  } else if (!strcmp(key, "floating")) {
+    floating = getLuaBool(L);
   }
 }
 
@@ -746,6 +748,7 @@ void LvglWidgetObjectBase::refresh()
   setSize(w, h);
   setColor(color.flags);
   setOpacity(opacity.value);
+  setFloating(floating);
 }
 
 void LvglWidgetObjectBase::create(lua_State *L, int index)
@@ -775,6 +778,17 @@ void LvglSimpleWidgetObject::setSize(coord_t w, coord_t h)
   this->w = w;
   this->h = h;
   if (lvobj) lv_obj_set_size(lvobj, w, h);
+}
+
+void LvglSimpleWidgetObject::setFloating(bool isFloating)
+{
+  floating = isFloating;
+  if (lvobj) {
+    if (floating)
+      lv_obj_add_flag(lvobj, LV_OBJ_FLAG_FLOATING);
+    else
+      lv_obj_clear_flag(lvobj, LV_OBJ_FLAG_FLOATING);
+  }
 }
 
 void LvglSimpleWidgetObject::show()
@@ -867,6 +881,7 @@ void LvglWidgetLabel::build(lua_State *L)
   setOpacity(opacity.value);
   setFont(font.flags);
   setAlign(align.flags);
+  setFloating(floating);
 }
 
 //-----------------------------------------------------------------------------
@@ -922,6 +937,7 @@ void LvglWidgetLineBase::refresh()
 {
   setColor(color.flags);
   setOpacity(opacity.value);
+  setFloating(floating);
   setLine();
   lv_obj_set_style_line_rounded(lvobj, rounded, LV_PART_MAIN);
   if (dashGap > 0 && dashWidth > 0) {
@@ -1112,6 +1128,7 @@ void LvglWidgetLine::build(lua_State *L)
     setLine();
     setColor(color.flags);
     setOpacity(opacity.value);
+    setFloating(floating);
   }
 }
 
@@ -1399,8 +1416,9 @@ void LvglWidgetTriangle::build(lua_State *L)
     setPos(x, y);
     LvglSimpleWidgetObject::setSize(w,h);
 
-    // Set color
+    // Set properties
     setColor(color.flags);
+    setFloating(floating);
   }
 }
 
@@ -1466,6 +1484,17 @@ void LvglWidgetObject::setSize(coord_t w, coord_t h)
   this->w = w;
   this->h = h;
   if (window) window->setSize(w, h);
+}
+
+void LvglWidgetObject::setFloating(bool isFloating)
+{
+  floating = isFloating;
+  if (window) {
+    if (floating)
+      lv_obj_add_flag(window->getLvObj(), LV_OBJ_FLAG_FLOATING);
+    else
+      lv_obj_clear_flag(window->getLvObj(), LV_OBJ_FLAG_FLOATING);
+  }
 }
 
 bool LvglWidgetObject::setFlex()
@@ -1602,6 +1631,7 @@ void LvglWidgetBox::build(lua_State *L)
   setPosAndSize();
   setColor(color.flags);
   setOpacity(opacity.value);
+  setFloating(floating);
 }
 
 //-----------------------------------------------------------------------------
@@ -1944,6 +1974,7 @@ void LvglWidgetArc::build(lua_State *L)
   setBgColor(bgColor.flags);
   setOpacity(opacity.value);
   setBgOpacity(bgOpacity.value);
+  setFloating(floating);
 }
 
 //-----------------------------------------------------------------------------
@@ -1991,6 +2022,7 @@ void LvglWidgetImage::build(lua_State *L)
 {
   window = new StaticImage(lvglManager->getCurrentParent(), {x, y, w, h},
                            filename.chars(), fillFrame);
+  setFloating(floating);
 }
 
 //-----------------------------------------------------------------------------
@@ -2009,6 +2041,7 @@ void LvglWidgetQRCode::parseParam(lua_State *L, const char *key)
 void LvglWidgetQRCode::build(lua_State *L)
 {
   window = new QRCode(lvglManager->getCurrentParent(), x, y, w, data, colorToRGB(color.flags), colorToRGB(bgColor));
+  setFloating(floating);
 }
 
 //-----------------------------------------------------------------------------

--- a/radio/src/lua/lua_lvgl_widget.h
+++ b/radio/src/lua/lua_lvgl_widget.h
@@ -264,6 +264,7 @@ class LvglWidgetObjectBase
   virtual void setOpacity(uint8_t newOpa) {}
   virtual void setPos(coord_t x, coord_t y) {}
   virtual void setSize(coord_t w, coord_t h) {}
+  virtual void setFloating(bool isFloating) {}
 
   void create(lua_State *L, int index);
   void update(lua_State *L);
@@ -286,6 +287,7 @@ class LvglWidgetObjectBase
   int getPosFunction = LUA_REFNIL;
   LvglParamFuncOrValue color = { .function = LUA_REFNIL, .flags = COLOR2FLAGS(COLOR_THEME_SECONDARY1_INDEX)};
   LvglParamFuncOrValue opacity = { .function = LUA_REFNIL, .value = LV_OPA_COVER};
+  bool floating = false;
 
   virtual void build(lua_State *L);
   virtual void refresh();
@@ -322,6 +324,7 @@ class LvglSimpleWidgetObject : public LvglWidgetObjectBase
 
   void setPos(coord_t x, coord_t y) override;
   void setSize(coord_t w, coord_t h) override;
+  void setFloating(bool isFloating) override;
 
   Window *getWindow() const override { return nullptr; }
 
@@ -482,6 +485,7 @@ class LvglWidgetObject : public LvglWidgetObjectBase
 
   void setPos(coord_t x, coord_t y) override;
   void setSize(coord_t w, coord_t h) override;
+  void setFloating(bool isFloating) override;
 
   bool callRefs(lua_State *L) override;
   void clearRefs(lua_State *L) override;


### PR DESCRIPTION
Add 'floating' option to Lua objects so they remain fixed on screen when underlying container is scrolled.

Applies to 2.11, 2.12 and 3.0.