### PR TITLE
fix: cpu_id read on H7/H5 radio

### DIFF
--- a/radio/src/targets/common/arm/stm32/cpu_id.cpp
+++ b/radio/src/targets/common/arm/stm32/cpu_id.cpp
@@ -24,14 +24,30 @@
 #if defined(SIMU)
 const uint32_t cpu_uid[3] = { 0x12345678, 0x55AA55AA, 0x87654321};
 #else
+#if defined(STM32H7)
+const uint32_t * const cpu_uid = (uint32_t *)0x1FF1E800;
+#elif defined(STM32H7RS) || defined(STM32H5)
+const uint32_t * const cpu_uid = (uint32_t *)0x08FFF800;
+#else
 const uint32_t * const cpu_uid = (uint32_t *)0x1FFF7A10;
+#endif
 #endif
 
 void getCPUUniqueID(char * s)
 {
+#if defined(STM32H7RS) || defined(STM32H5)
+  // UID is in OTP/system flash — reading with ICACHE enabled causes HardFault
+  uint32_t icache_was_enabled = HAL_ICACHE_IsEnabled();
+  if (icache_was_enabled) HAL_ICACHE_Disable();
+#endif
+
   char * tmp = strAppendUnsigned(s, cpu_uid[0], 8, 16);
   *tmp = ' ';
   tmp = strAppendUnsigned(tmp+1, cpu_uid[1], 8, 16);
   *tmp = ' ';
   strAppendUnsigned(tmp+1, cpu_uid[2], 8, 16);
+
+#if defined(STM32H7RS) || defined(STM32H5)
+  if (icache_was_enabled) HAL_ICACHE_Enable();
+#endif
 }


### PR DESCRIPTION
Fix hard fault on H7/H5 while trying to read cpu_id

No bug opened for this, found it while working on something else.
