### PR TITLE
fix(build): move AddHardwareDefTarget after all add_definitions

### DIFF
--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -117,10 +117,6 @@ add_definitions(-D${RADIO_NAME})
 set(${RADIO_NAME} YES)
 
 set(HW_DESC_JSON ${FLAVOUR}.json)
-AddHardwareDefTarget(${HW_DESC_JSON})
-
-# enable generating JSON definition separately for debugging
-add_custom_target(hardware_defs DEPENDS ${HW_DESC_JSON}.h)
 
 include(hal/CMakeLists.txt)
 
@@ -147,6 +143,11 @@ endif()
 if(ARCH STREQUAL ARM)
   include(targets/common/arm/CMakeLists.txt)
 endif()
+
+# Generate hardware definitions from hal.h
+# Must be after all add_definitions() so the preprocessor sees all flags
+AddHardwareDefTarget(${HW_DESC_JSON})
+add_custom_target(hardware_defs DEPENDS ${HW_DESC_JSON}.h)
 
 include_directories(targets/${TARGET_DIR} ${THIRDPARTY_DIR})
 


### PR DESCRIPTION
AddHardwareDefTarget captures COMPILE_DEFINITIONS at call time to pass to the preprocessor. It was called before options, CPU, and platform CMake files had added their -D flags, so the generated hardware definitions were missing STM32F4, HARDWARE_EXTERNAL_MODULE, INTERNAL_MODULE_SERIAL, RGBLEDS, SSD1309_LCD, etc.

Move the call to after all includes so the preprocessor sees the complete set of flags.

Since this is not used anymore in `main`, this is really only useful for verification of defines when extracting single boards/radios from huge `hal.h` define spaghetti.