### PR TITLE
fix(hw_defs): improve template error reporting in code generator

### DIFF
--- a/radio/util/hw_defs/generator.py
+++ b/radio/util/hw_defs/generator.py
@@ -26,21 +26,18 @@ def eprint(*args, **kwargs):
 
 
 def is_ext_input(input):
-    if input.get("type") != "FLEX":
+    if str(getattr(input, "type", "")) != "FLEX":
         return False
 
-    name = input.get("name")
-    if name and name.startswith("EXT"):
-        return True
-
-    return False
+    name = str(getattr(input, "name", ""))
+    return name.startswith("EXT")
 
 
 def generate_from_template(json_filename, template_filename, target):
     with open(json_filename) as json_file:
         raw_data = json_file.read()
 
-        # Validate and normalize using Pydantic model
+        # Validate using Pydantic model
         try:
             hw_def = HardwareDefinition.from_json(raw_data)
         except pydantic.ValidationError as e:
@@ -50,21 +47,13 @@ def generate_from_template(json_filename, template_filename, target):
                 eprint(f"  {loc}: {err['msg']}")
             sys.exit(1)
 
-        # Re-serialize with defaults filled in by Pydantic
+        # Load remaining fields not yet in the Pydantic model
         root_obj = json.loads(raw_data)
-        root_obj["adc_inputs"] = hw_def.adc_inputs.model_dump(mode="json")
-        root_obj["switches"] = [s.model_dump(mode="json") for s in hw_def.switches]
-        root_obj["keys"] = [k.model_dump(mode="json") for k in hw_def.keys]
 
-        adc_inputs = root_obj["adc_inputs"]
-        adc_index = json_index.build_adc_index(adc_inputs)
-        adc_gpios = json_index.build_adc_gpio_port_index(adc_inputs)
-
-        switches = root_obj["switches"]
-        switch_gpios = json_index.build_switch_gpio_port_index(switches)
-
-        keys = root_obj["keys"]
-        key_gpios = json_index.build_key_gpio_port_index(keys)
+        adc_index = json_index.build_adc_index(hw_def.adc_inputs)
+        adc_gpios = json_index.build_adc_gpio_port_index(hw_def.adc_inputs)
+        switch_gpios = json_index.build_switch_gpio_port_index(hw_def.switches)
+        key_gpios = json_index.build_key_gpio_port_index(hw_def.keys)
 
         trims = root_obj.get("trims")
         trim_gpios = json_index.build_trim_gpio_port_index(trims)
@@ -87,7 +76,10 @@ def generate_from_template(json_filename, template_filename, target):
         key_index = list([str(i) for i in KeyEnum])
 
         context = dict(
-            root_obj,
+            adc_inputs=hw_def.adc_inputs,
+            switches=hw_def.switches,
+            keys=hw_def.keys,
+            trims=trims,
             adc_index=adc_index,
             adc_gpios=adc_gpios,
             switch_gpios=switch_gpios,

--- a/radio/util/hw_defs/json_index.py
+++ b/radio/util/hw_defs/json_index.py
@@ -1,12 +1,11 @@
 #
-# These methods are used to build helper indexes on JSON structures
+# These methods are used to build helper indexes on data structures
 #
 def build_adc_index(adc_inputs):
     i = 0
     index = {}
-    for adc_input in adc_inputs["inputs"]:
-        name = adc_input["name"]
-        index[name] = i
+    for adc_input in adc_inputs.inputs:
+        index[str(adc_input.name)] = i
         i = i + 1
 
     return index
@@ -22,11 +21,11 @@ def append_to_index(d, key, val):
 def build_adc_gpio_port_index(adc_inputs):
     i = 0
     gpios = {}
-    for adc_input in adc_inputs["inputs"]:
-        if adc_input["adc"] == "SPI":
+    for adc_input in adc_inputs.inputs:
+        if str(adc_input.adc) == "SPI":
             continue
 
-        gpio = adc_input.get("gpio")
+        gpio = getattr(adc_input, "gpio", None)
         if gpio is None:
             i = i + 1
             continue
@@ -34,7 +33,7 @@ def build_adc_gpio_port_index(adc_inputs):
         if gpio not in gpios:
             gpios[gpio] = []
 
-        pin = {"pin": adc_input["pin"], "idx": i}
+        pin = {"pin": adc_input.pin, "idx": i}
 
         gpios[gpio].append(pin)
         i = i + 1
@@ -45,22 +44,22 @@ def build_adc_gpio_port_index(adc_inputs):
 def build_switch_gpio_port_index(switches):
     gpios = {}
     for switch in switches:
-        sw_type = switch["type"]
+        sw_type = str(switch.type)
 
         if sw_type == "2POS" or sw_type == "FSWITCH":
-            gpio = switch.get("gpio")
-            pin = switch.get("pin")
+            gpio = switch.gpio
+            pin = switch.pin
             if gpio is not None and pin is not None:
                 append_to_index(gpios, gpio, pin)
 
         elif sw_type == "3POS":
-            gpio_high = switch.get("gpio_high")
-            pin_high = switch.get("pin_high")
+            gpio_high = switch.gpio_high
+            pin_high = switch.pin_high
             if gpio_high is not None and pin_high is not None:
                 append_to_index(gpios, gpio_high, pin_high)
 
-            gpio_low = switch.get("gpio_low")
-            pin_low = switch.get("pin_low")
+            gpio_low = switch.gpio_low
+            pin_low = switch.pin_low
             if gpio_low is not None and pin_low is not None:
                 append_to_index(gpios, gpio_low, pin_low)
 
@@ -88,6 +87,6 @@ def build_trim_gpio_port_index(trims):
 def build_key_gpio_port_index(keys):
     gpios = {}
     for key in keys:
-        append_to_index(gpios, key["gpio"], key["pin"])
+        append_to_index(gpios, key.gpio, key.pin)
 
     return gpios

--- a/radio/util/hw_defs/models.py
+++ b/radio/util/hw_defs/models.py
@@ -26,6 +26,11 @@ class ADC(BaseModel):
     dma_stream: Optional[str] = None
     dma_stream_irq: Optional[str] = None
     dma_stream_irq_handler: Optional[str] = None
+    # SPI ADC fields
+    gpio_pin_sck: Optional[str] = None
+    gpio_pin_miso: Optional[str] = None
+    gpio_pin_mosi: Optional[str] = None
+    gpio_pin_cs: Optional[str] = None
 
 
 StickEnum = StrEnum(
@@ -101,6 +106,7 @@ class StickInput(BaseModel):
     pin: Optional[str] = None
     channel: Optional[Union[str, int]] = None
     inverted: Optional[bool] = False
+    pwm_channel: Optional[int] = None
 
 
 class FlexInput(BaseModel):
@@ -111,7 +117,7 @@ class FlexInput(BaseModel):
     pin: Optional[str] = None
     channel: Optional[Union[str, int]] = None
     inverted: Optional[bool] = False
-    default: Optional[FlexType] = FlexType.NONE
+    default: Optional[FlexType] = None
     label: Optional[str] = None
     short_label: Optional[str] = None
 

--- a/radio/util/hw_defs/stm32_pwm_inputs.jinja
+++ b/radio/util/hw_defs/stm32_pwm_inputs.jinja
@@ -3,7 +3,7 @@
 //   This file has been generated from the target's JSON hardware description
 //
 
-{% set pwm_inputs = adc_inputs.inputs | selectattr('pwm_channel', 'defined') | list %}
+{% set pwm_inputs = adc_inputs.inputs | selectattr('type', '==', 'STICK') | selectattr('pwm_channel', 'ne', none) | list %}
 static const stick_pwm_input_t _PWM_inputs[] = {
 {% for input in pwm_inputs %}
   {


### PR DESCRIPTION
Use FileSystemLoader so Jinja2 tracebacks show actual template filenames, StrictUndefined to catch missing data early, and wrap render errors with context (JSON file, target, None-valued keys).

Add validation test missed in #6437