### PR TITLE
chore(build): cache FetchContent dependencies across build directories

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,19 @@ set(VERSION ${VERSION_MAJOR}.${VERSION_MINOR}.${VERSION_REVISION})
 option(EdgeTX_SUPERBUILD "Cross-compile EdgeTX for each toolchain" ON)
 include(ExternalProject)
 
+# Cache FetchContent downloads in a shared directory so that multiple build
+# directories (and rebuilds after a clean) reuse already-fetched dependencies.
+# Priority: -D flag > $ENV{FETCHCONTENT_BASE_DIR} > default (.cache/fetchcontent)
+if(NOT FETCHCONTENT_BASE_DIR)
+  if(DEFINED ENV{FETCHCONTENT_BASE_DIR})
+    set(FETCHCONTENT_BASE_DIR "$ENV{FETCHCONTENT_BASE_DIR}" CACHE PATH
+        "Shared cache for FetchContent downloads" FORCE)
+  else()
+    set(FETCHCONTENT_BASE_DIR "${CMAKE_SOURCE_DIR}/.cache/fetchcontent" CACHE PATH
+        "Shared cache for FetchContent downloads" FORCE)
+  endif()
+endif()
+
 if(EdgeTX_SUPERBUILD)
   include(Macros)
   CollectCommandLineArgs(CMAKE_ARGS)
@@ -53,6 +66,7 @@ if(EdgeTX_SUPERBUILD)
       -DCMAKE_TOOLCHAIN_FILE:FILEPATH=${CMAKE_SOURCE_DIR}/cmake/toolchain/native.cmake
       -DEdgeTX_SUPERBUILD:BOOL=0
       -DNATIVE_BUILD:BOOL=1
+      -DFETCHCONTENT_BASE_DIR:PATH=${FETCHCONTENT_BASE_DIR}
     INSTALL_COMMAND  ""
     EXCLUDE_FROM_ALL TRUE
     )
@@ -66,6 +80,7 @@ if(EdgeTX_SUPERBUILD)
       -DCMAKE_TOOLCHAIN_FILE:FILEPATH=${CMAKE_SOURCE_DIR}/cmake/toolchain/arm-none-eabi.cmake
       -DEdgeTX_SUPERBUILD:BOOL=0
       -DNATIVE_BUILD:BOOL=0
+      -DFETCHCONTENT_BASE_DIR:PATH=${FETCHCONTENT_BASE_DIR}
     INSTALL_COMMAND  ""
     EXCLUDE_FROM_ALL TRUE
   )
@@ -92,6 +107,7 @@ if(EdgeTX_SUPERBUILD)
       -B ${CMAKE_BINARY_DIR}/wasm
       -DEDGETX_SOURCE_DIR=${CMAKE_SOURCE_DIR}
       -DEDGETX_BUILD_TYPE=${CMAKE_BUILD_TYPE}
+      -DFETCHCONTENT_BASE_DIR=${FETCHCONTENT_BASE_DIR}
       ${CMAKE_ARGS}
     COMMAND ${CMAKE_COMMAND} --build ${CMAKE_BINARY_DIR}/wasm
   )

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -2,42 +2,46 @@
   "version": 6,
   "configurePresets": [
     {
+      "name": "default",
+      "hidden": true,
+      "cacheVariables": {
+        "FETCHCONTENT_BASE_DIR": "${sourceDir}/.cache/fetchcontent"
+      },
+      "warnings": {
+        "dev": false
+      }
+    },
+    {
       "name": "firmware",
+      "inherits": "default",
       "displayName": "Firmware",
       "binaryDir": "build/fw",
       "toolchainFile": "cmake/toolchain/arm-none-eabi.cmake",
       "cacheVariables": {
         "EdgeTX_SUPERBUILD": false,
         "NATIVE_BUILD": false
-      },
-      "warnings": {
-        "dev": false
       }
     },
     {
       "name": "companion",
+      "inherits": "default",
       "displayName": "Companion",
       "binaryDir": "build/companion",
       "toolchainFile": "cmake/toolchain/native.cmake",
       "cacheVariables": {
         "EdgeTX_SUPERBUILD": false,
         "NATIVE_BUILD": true
-      },
-      "warnings": {
-        "dev": false
       }
     },
     {
       "name": "simu",
+      "inherits": "default",
       "displayName": "SDL Simu",
       "binaryDir": "build/simu",
       "toolchainFile": "cmake/toolchain/native.cmake",
       "cacheVariables": {
         "EdgeTX_SUPERBUILD": false,
         "NATIVE_BUILD": true
-      },
-      "warnings": {
-        "dev": false
       }
     }
   ],

--- a/cmake/FetchGtest.cmake
+++ b/cmake/FetchGtest.cmake
@@ -5,7 +5,9 @@ include(FetchContent)
 FetchContent_Declare(
   googletest
   GIT_REPOSITORY https://github.com/google/googletest
-  GIT_TAG        f8d7d77c06936315286eb55f8de22cd23c188571 # v1.14.0
+  GIT_TAG        v1.14.0  # f8d7d77c06936315286eb55f8de22cd23c188571
+  GIT_SHALLOW    TRUE
+  UPDATE_DISCONNECTED TRUE
 )
 
 # For Windows: Prevent overriding the parent project's compiler/linker settings

--- a/cmake/FetchImgui.cmake
+++ b/cmake/FetchImgui.cmake
@@ -4,10 +4,8 @@ include(FetchContent)
 
 FetchContent_Declare(
   imgui
-  GIT_REPOSITORY https://github.com/ocornut/imgui
-  GIT_TAG        dbb5eeaadffb6a3ba6a60de1290312e5802dba5a # v1.91.8
-  GIT_SHALLOW    TRUE
-  UPDATE_DISCONNECTED TRUE
+  URL      https://github.com/ocornut/imgui/archive/refs/tags/v1.92.6.tar.gz
+  DOWNLOAD_EXTRACT_TIMESTAMP true
 )
 
 FetchContent_MakeAvailable(imgui)

--- a/cmake/FetchMaxLibQt.cmake
+++ b/cmake/FetchMaxLibQt.cmake
@@ -4,8 +4,8 @@ include(FetchContent)
 
 FetchContent_Declare(
   maxLibQt
-  GIT_REPOSITORY https://github.com/edgetx/maxLibQt
-  GIT_TAG        7e433da60d3f2e975d46afc91804a88029cd1b78
+  URL      https://github.com/edgetx/maxLibQt/archive/7e433da60d3f2e975d46afc91804a88029cd1b78.tar.gz
+  DOWNLOAD_EXTRACT_TIMESTAMP true
 )
 
 FetchContent_MakeAvailable(maxLibQt)

--- a/cmake/FetchMiniz.cmake
+++ b/cmake/FetchMiniz.cmake
@@ -4,8 +4,8 @@ include(FetchContent)
 
 FetchContent_Declare(
   miniz
-  GIT_REPOSITORY https://github.com/richgel999/miniz
-  GIT_TAG        89d7a5f6c3ce8893ea042b0a9d2a2d9975589ac9
+  URL      https://github.com/richgel999/miniz/archive/89d7a5f6c3ce8893ea042b0a9d2a2d9975589ac9.tar.gz
+  DOWNLOAD_EXTRACT_TIMESTAMP true
 )
 
 FetchContent_MakeAvailable(miniz)

--- a/cmake/FetchWamr.cmake
+++ b/cmake/FetchWamr.cmake
@@ -23,6 +23,7 @@ FetchContent_Declare(
   GIT_REPOSITORY https://github.com/bytecodealliance/wasm-micro-runtime
   GIT_TAG        WAMR-2.4.4
   GIT_SHALLOW    TRUE
+  UPDATE_DISCONNECTED TRUE
 )
 
 # Populate separately so we can patch before building

--- a/cmake/FetchYamlCpp.cmake
+++ b/cmake/FetchYamlCpp.cmake
@@ -4,8 +4,8 @@ include(FetchContent)
 
 FetchContent_Declare(
   yaml-cpp
-  GIT_REPOSITORY https://github.com/jbeder/yaml-cpp
-  GIT_TAG        28f93bdec6387d42332220afa9558060c8016795
+  URL      https://github.com/jbeder/yaml-cpp/archive/28f93bdec6387d42332220afa9558060c8016795.tar.gz
+  DOWNLOAD_EXTRACT_TIMESTAMP true
 )
 
 FetchContent_MakeAvailable(yaml-cpp)

--- a/tools/build-wasm-modules.sh
+++ b/tools/build-wasm-modules.sh
@@ -81,7 +81,7 @@ file(WRITE "\${CMAKE_CURRENT_BINARY_DIR}/wasi_sdk_path.txt" "\${WASI_SDK_PATH}")
 CMAKEOF
 
     if ! cmake -S "$fetch_dir" -B "$fetch_dir/build" \
-        -DFETCHCONTENT_BASE_DIR="$PWD/_deps" 2>&1; then
+        -DFETCHCONTENT_BASE_DIR="$SRCDIR/.cache/fetchcontent" 2>&1; then
         echo "❌ Failed to fetch WASI SDK"
         return 1
     fi


### PR DESCRIPTION
- Share downloaded dependencies via `.cache/fetchcontent` so that multiple build directories and clean rebuilds reuse already-fetched sources. 
- Switch yaml-cpp, maxLibQt, miniz, and imgui to tarball URLs to avoid downloading full git history. 
- Add `GIT_SHALLOW` and `UPDATE_DISCONNECTED` to remaining git-based deps (googletest, WAMR). 
- Upgrade imgui to v1.92.6. 
- Support overriding cache location via `FETCHCONTENT_BASE_DIR` env var.

---

Some minimimal documentation:

- `FetchContent` downloads are now cached in a shared directory so multiple build directories and clean rebuilds can reuse the same fetched dependency sources.
- Default cache location: `.cache/fetchcontent` at the source root.
- Override order:
  1. `-D FETCHCONTENT_BASE_DIR=...`
  2. `FETCHCONTENT_BASE_DIR` environment variable
  3. default: `${sourceDir}/.cache/fetchcontent`
- This is now propagated into the different build presets / sub-builds so firmware, companion, simu, and wasm-related fetches can share the same cache.
- If a contributor suspects stale dependency contents, removing `.cache/fetchcontent` and re-running CMake should force a clean refetch.

Follow-up TODOs:
- consider caching `.cache/fetchcontent` in CI as well
- consider adding `URL_HASH` for tarball-based dependencies for stronger integrity