### PR TITLE
fix(color): model may not be saved when curve 'smooth' property is changed.

### DIFF
--- a/radio/src/gui/colorlcd/model/curveedit.cpp
+++ b/radio/src/gui/colorlcd/model/curveedit.cpp
@@ -328,6 +328,7 @@ void CurveEditWindow::buildBody(Window* window)
       new TextButton(iLine, rect_t{0, 0, EdgeTxStyles::EDIT_FLD_WIDTH_NARROW, 0}, STR_SMOOTH, [=]() {
         g_model.curves[index].smooth = !g_model.curves[index].smooth;
         Messaging::send(Messaging::CURVE_EDIT);
+        SET_DIRTY();
         return g_model.curves[index].smooth;
       });
   smooth->check(g_model.curves[index].smooth);


### PR DESCRIPTION
Mark model as dirty when smooth property is changed.

Applies to 2.11, 2.12 and 3.0.
