### PR TITLE
fix(firmware): add timeout to shutdown bye audio wait loop

### DIFF
--- a/radio/src/edgetx.cpp
+++ b/radio/src/edgetx.cpp
@@ -20,6 +20,7 @@
  */
 
 #include "os/sleep.h"
+#include "os/time.h"
 #if !defined(SIMU)
 #include "stm32_ws2812.h"
 #include "boards/generic_stm32/rgb_leds.h"
@@ -1167,7 +1168,12 @@ void edgeTxClose(uint8_t shutdown)
 
   storageCheck(true);
 
+  uint32_t bye_start = time_get_ms();
   while (IS_PLAYING(ID_PLAY_PROMPT_BASE + AU_BYE)) {
+    if (time_get_ms() - bye_start > 5000/*5s*/) {
+      TRACE("shutdown: bye audio timeout");
+      break;
+    }
     sleep_ms(10);
   }
 


### PR DESCRIPTION
Prevents shutdown hang when SD card is failing. The IS_PLAYING loop had no timeout, so a blocked audio task (e.g. waiting on FatFs mutex during slow SD I/O) could stall shutdown past the watchdog window.

Related to #7227.