### PR TITLE
fix(cpn): use correct NSIS constant for Program Files directory on 64-bit Windows

### DIFF
--- a/companion/targets/windows/companion.nsi.in
+++ b/companion/targets/windows/companion.nsi.in
@@ -19,7 +19,7 @@
   OutFile "companion-windows-@VERSION@.exe"
 
   ;Default installation folder
-  InstallDir "$PROGRAMFILES\@PROJECT_NAME@\Companion @VERSION_FAMILY@"
+  InstallDir "$PROGRAMFILES64\@PROJECT_NAME@\Companion @VERSION_FAMILY@"
 
   ;Get installation folder from registry if available
   InstallDirRegKey HKCU "Software\@PROJECT_NAME@\Companion @VERSION_FAMILY@" ""


### PR DESCRIPTION
The NSIS installer was a 32-bit PE, causing $PROGRAMFILES to resolve to "Program Files (x86)" on 64-bit Windows. Adding "Target amd64-unicode" produces a native 64-bit installer where $PROGRAMFILES correctly points to "Program Files".

Fixes #7243