### PR TITLE
fix(sim): use QImage for color LCD rendering to fix 100% CPU (#7233)

### DIFF
--- a/companion/src/simulation/widgets/lcdwidget.cpp
+++ b/companion/src/simulation/widgets/lcdwidget.cpp
@@ -89,15 +89,9 @@ void LcdWidget::doPaint(QPainter &p)
   if (!localBuf) return;
 
   if (lcdDepth == 16) {
-    for (int x = 0; x < lcdWidth; x++) {
-      for (int y = 0; y < lcdHeight; y++) {
-        z = ((uint16_t *)localBuf)[y * lcdWidth + x];
-        rgb = qRgb(255 * ((z & 0xF800) >> 11) / 0x1F,
-                   255 * ((z & 0x07E0) >> 5) / 0x3F, 255 * (z & 0x001F) / 0x1F);
-        p.setPen(rgb);
-        p.drawPoint(x, y);
-      }
-    }
+    QImage img((const uchar*)localBuf, lcdWidth, lcdHeight,
+               lcdWidth * 2, QImage::Format_RGB16);
+    p.drawImage(0, 0, img);
     return;
   }
   if (lcdDepth == 12) {


### PR DESCRIPTION
Replace pixel-by-pixel QPainter calls (384K iterations for 800x480) with a single QImage::Format_RGB16 drawImage() call. The LCD buffer is already native RGB565 so no conversion is needed.

Fixes #7233