### PR TITLE
feat(radio): add LTO option for complete firmware to reduce X9D+2019

### DIFF
--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -672,6 +672,12 @@ endif()
 
 set(LINKER_SCRIPT firmware.ld)
 
+if(USE_FW_LTO)
+  message("-- Use LTO to compile firmware")
+  target_compile_options(firmware PRIVATE -flto)
+  target_link_options(firmware PRIVATE -Wl,-u,SystemCoreClockUpdate)
+endif()
+
 target_link_options(firmware PRIVATE
   -lm -T${LINKER_DIR}/${LINKER_SCRIPT}
   -Wl,-Map=firmware.map,--cref,--no-warn-mismatch,--gc-sections

--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -262,14 +262,14 @@ enum MenuModelSetupItems {
   ITEM_MODEL_SETUP_LINES_COUNT
 };
 
-PACK(struct ExpandState {
+PACK(struct ModelSetupExpandState {
   uint8_t preflight:1;
   uint8_t throttle:1;
   uint8_t viewOpt:1;
   uint8_t functionSwitches:1;
 });
 
-static struct ExpandState expandState;
+static struct ModelSetupExpandState expandState;
 
 static uint8_t PREFLIGHT_ROW(uint8_t value) { return expandState.preflight ? value : HIDDEN_ROW; }
 

--- a/radio/src/gui/128x64/model_telemetry.cpp
+++ b/radio/src/gui/128x64/model_telemetry.cpp
@@ -42,11 +42,11 @@ enum MenuModelTelemetryFrskyItems {
   ITEM_TELEMETRY_MAX
 };
 
-PACK(struct ExpandState {
+PACK(struct TelemetryExpandState {
   uint8_t sensors:1;
 });
 
-struct ExpandState telemExpandState;
+struct TelemetryExpandState telemExpandState;
 
 uint8_t SENSOR_ROW(uint8_t value)
 {

--- a/radio/src/gui/128x64/radio_setup.cpp
+++ b/radio/src/gui/128x64/radio_setup.cpp
@@ -128,13 +128,13 @@ enum {
   ITEM_RADIO_SETUP_MAX
 };
 
-PACK(struct ExpandState {
+PACK(struct RadioSetupExpandState {
   uint8_t sound:1;
   uint8_t alarms:1;
   uint8_t viewOpt:1;
 });
 
-static struct ExpandState expandState;
+static struct RadioSetupExpandState expandState;
 
 static uint8_t SOUND_ROW(uint8_t value) { return expandState.sound ? value : HIDDEN_ROW; }
 static uint8_t SOUND_WARNING_ROW(uint8_t value) { return expandState.sound && isFunctionActive(FUNCTION_VOLUME) ? value : HIDDEN_ROW; }

--- a/radio/src/gui/212x64/model_setup.cpp
+++ b/radio/src/gui/212x64/model_setup.cpp
@@ -207,13 +207,13 @@ enum MenuModelSetupItems {
 #define MODEL_SETUP_3RD_COLUMN        (MODEL_SETUP_2ND_COLUMN+6*FW)
 #define MODEL_SETUP_SET_FAILSAFE_OFS  10*FW-2
 
-PACK(struct ExpandState {
+PACK(struct ModelSetupExpandState {
   uint8_t preflight:1;
   uint8_t throttle:1;
   uint8_t viewOpt:1;
 });
 
-static struct ExpandState expandState;
+static struct ModelSetupExpandState expandState;
 
 static uint8_t PREFLIGHT_ROW(uint8_t value) { return expandState.preflight ? value : HIDDEN_ROW; }
 

--- a/radio/src/gui/212x64/model_telemetry.cpp
+++ b/radio/src/gui/212x64/model_telemetry.cpp
@@ -42,11 +42,11 @@ enum MenuModelTelemetryFrskyItems {
   ITEM_TELEMETRY_MAX
 };
 
-PACK(struct ExpandState {
+PACK(struct TelemetryExpandState {
   uint8_t sensors:1;
 });
 
-struct ExpandState telemExpandState;
+struct TelemetryExpandState telemExpandState;
 
 uint8_t SENSOR_ROW(uint8_t value)
 {

--- a/radio/src/gui/212x64/radio_setup.cpp
+++ b/radio/src/gui/212x64/radio_setup.cpp
@@ -127,13 +127,13 @@ enum MenuRadioSetupItems {
   ITEM_RADIO_SETUP_MAX
 };
 
-PACK(struct ExpandState {
+PACK(struct RadioSetupExpandState {
   uint8_t sound:1;
   uint8_t alarms:1;
   uint8_t viewOpt:1;
 });
 
-static struct ExpandState expandState;
+static struct RadioSetupExpandState expandState;
 
 static uint8_t SOUND_ROW(uint8_t value) { return expandState.sound ? value : HIDDEN_ROW; }
 static uint8_t SOUND_WARNING_ROW(uint8_t value) { return expandState.sound && isFunctionActive(FUNCTION_VOLUME) ? value : HIDDEN_ROW; }

--- a/radio/src/sdcard.cpp
+++ b/radio/src/sdcard.cpp
@@ -447,8 +447,8 @@ uint32_t sdGetSize()
 
 uint32_t sdGetFreeSectors()
 {
-  DWORD nofree;
-  FATFS * fat;
+  DWORD nofree = 0;
+  FATFS * fat = nullptr;
   if (f_getfree("", &nofree, &fat) != FR_OK) {
     return 0;
   }

--- a/radio/src/targets/common/arm/stm32/system_init.c
+++ b/radio/src/targets/common/arm/stm32/system_init.c
@@ -39,7 +39,7 @@
 #endif
 
 #define NAKED __attribute__((naked))
-#define BOOTSTRAP __attribute__((section(".bootstrap")))
+#define BOOTSTRAP __attribute__((section(".bootstrap"), used))
 
 // Linker script symbols
 extern uint32_t _sisr_vector;
@@ -170,7 +170,7 @@ NAKED BOOTSTRAP void naked_copy()
   );
 }
 
-void init_hooks()
+__attribute__((used)) void init_hooks()
 {
   extern uint32_t __init_hook_array_start;
   extern uint32_t __init_hook_array_end;

--- a/tools/build-common.sh
+++ b/tools/build-common.sh
@@ -87,7 +87,7 @@ get_target_build_options() {
             BUILD_OPTIONS+="-DPCB=X9D+"
             ;;
         x9dp2019)
-            BUILD_OPTIONS+="-DPCB=X9D+ -DPCBREV=2019"
+            BUILD_OPTIONS+="-DPCB=X9D+ -DPCBREV=2019 -DUSE_FW_LTO=y"
             ;;
         x9e)
             BUILD_OPTIONS+="-DPCB=X9E"


### PR DESCRIPTION
This aims at reducing the pain for the *always overflowing* X9D+2019. This frees ~20KB FLASH.