### PR TITLE
fix(sim): restore switch positions after simulator startup

### DIFF
--- a/companion/src/simulation/simulatorwidget.cpp
+++ b/companion/src/simulation/simulatorwidget.cpp
@@ -422,7 +422,6 @@ void SimulatorWidget::start()
   emit simulatorInit();  // init simulator default I/O values
 
   setupRadioWidgets();
-  restoreRadioWidgetsState();
 
   bool tests = !(flags & SIMULATOR_FLAGS_NOTX);
   if (!startupData.isEmpty()) {
@@ -457,6 +456,7 @@ void SimulatorWidget::stop()
 
 void SimulatorWidget::onSimulatorStarted()
 {
+  restoreRadioWidgetsState();
   m_heartbeatTimer.start();
   m_timer.start();
 }


### PR DESCRIPTION
boardInit() resets all switch states during simuMain(), which is called by simulatorStart. Moving restoreRadioWidgetsState() from start() to onSimulatorStarted() ensures saved switch positions are applied after the firmware has fully initialized, keeping UI and backend in sync.

Fixes #7259 and #7246