### PR TITLE
refactor(driver): move Flysky gimbal sync into board-level ADC callbacks

### DIFF
--- a/radio/src/boards/generic_stm32/analog_inputs.cpp
+++ b/radio/src/boards/generic_stm32/analog_inputs.cpp
@@ -68,6 +68,9 @@ static void adc_deinit()
 
 static bool adc_start_read()
 {
+#if defined(FLYSKY_GIMBAL)
+  flysky_gimbal_start_read();
+#endif
   bool success = stm32_hal_adc_start_read(_ADC_adc, n_ADC, _ADC_inputs, n_inputs);
 #if defined(USE_ADS79XX)
   if (n_ADC_spi > 0) {
@@ -85,6 +88,9 @@ static void adc_wait_completion()
   if (n_ADC_spi > 0) ads79xx_adc_wait_completion(&_ADC_spi[0], _ADC_inputs);
 #endif
   stm32_hal_adc_wait_completion(_ADC_adc, n_ADC, _ADC_inputs, n_inputs);
+#if defined(FLYSKY_GIMBAL)
+  flysky_gimbal_wait_completion();
+#endif
 }
 
 const etx_hal_adc_driver_t _adc_driver = {

--- a/radio/src/hal/adc_driver.cpp
+++ b/radio/src/hal/adc_driver.cpp
@@ -21,10 +21,6 @@
 
 #include "adc_driver.h"
 #include "board.h"
-#if defined(FLYSKY_GIMBAL)
-  #include "flysky_gimbal_driver.h"
-#endif
-
 #include "edgetx.h"
 
 const etx_hal_adc_driver_t* _hal_adc_driver = nullptr;
@@ -60,12 +56,6 @@ static bool adcSingleRead()
   if (_hal_adc_driver->wait_completion)
     _hal_adc_driver->wait_completion();
 
-  // Need to put all in a group to ensure DMA transfer will not affect ADC sampling
-#if defined(FLYSKY_GIMBAL) && !defined(SIMU)
-  flysky_gimbal_start_read();
-  flysky_gimbal_wait_completion();
-#endif  
-  
   return true;
 }
 

--- a/radio/src/targets/common/arm/stm32/flysky_gimbal_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/flysky_gimbal_driver.cpp
@@ -263,17 +263,21 @@ static int flysky_gimbal_init_uart()
 
 bool flysky_gimbal_init()
 {
+#if defined(HALL_SYNC)
+  gpio_init(HALL_SYNC, GPIO_OUT, GPIO_PIN_SPEED_LOW);
+#endif
+
   if (flysky_gimbal_init_uart() != 0) return false;
 
   _fs_gimbal_detected = false;
 
   // Wait 70ms for serial gimbals to respond
   for (uint16_t i = 0; i < 70; i++) {
-#if defined(HALL_SYNC) && !defined(SIMU)
+#if defined(HALL_SYNC)
     gpio_set(HALL_SYNC);
 #endif
     delay_ms(1);
-#if defined(HALL_SYNC) && !defined(SIMU)
+#if defined(HALL_SYNC)
     gpio_clear(HALL_SYNC);
 #endif
     if (_fs_gimbal_detected) {
@@ -292,7 +296,13 @@ bool flysky_gimbal_init()
 
 void flysky_gimbal_start_read()
 {
-  if(_fs_gimbal_detected && _fs_gimbal_version > GIMBAL_V1) {
+  if (!_fs_gimbal_detected) return;
+
+#if defined(HALL_SYNC)
+  gpio_set(HALL_SYNC);
+#endif
+
+  if(_fs_gimbal_version > GIMBAL_V1) {
     _fs_gimbal_lastReadTick = _fs_gimbal_readTick;
     _fs_gimbal_readTick = timersGetUsTick();
     if (_fs_gimbal_lastReadTick != 0) {
@@ -326,16 +336,22 @@ void flysky_gimbal_start_read()
 
 void flysky_gimbal_wait_completion()
 {
-  if(_fs_gimbal_detected && _fs_gimbal_version > GIMBAL_V1 && _fs_gimbal_mode != V1_MODE) {
-      auto timeout = timersGetUsTick();
+  if (!_fs_gimbal_detected) return;
+
+  if (_fs_gimbal_version > GIMBAL_V1 && _fs_gimbal_mode != V1_MODE) {
+    auto timeout = timersGetUsTick();
     while(!_fs_gimbal_cmd_finished) {
       // busy wait
       if ((uint32_t)(timersGetUsTick() - timeout) >= SAMPLING_TIMEOUT_US) {
 //        TRACE("Gimbal timeout");
-        return;
+        break;
       }
     }
   }
+
+#if defined(HALL_SYNC)
+  gpio_clear(HALL_SYNC);
+#endif
 }
 
 void flysky_gimbal_force_init()

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -289,10 +289,6 @@ void boardInit()
   lcdSetContrast(true);
 #endif
 
-#if defined(RADIO_GX12)
-  gpio_init(HALL_SYNC, GPIO_OUT, GPIO_PIN_SPEED_LOW);
-#endif
-
 #if defined(HAS_IMU)
   gyroInit();
 #endif

--- a/radio/src/tasks/mixer_task.cpp
+++ b/radio/src/tasks/mixer_task.cpp
@@ -31,15 +31,6 @@
 
 #include "hal/watchdog_driver.h"
 
-#if defined(HALL_SYNC) && !defined(SIMU)
-#include "stm32_gpio.h"
-#include "hal/gpio.h"
-#endif
-
-#if defined(FLYSKY_GIMBAL)
-  #include "flysky_gimbal_driver.h"
-#endif
-
 task_handle_t mixerTaskId;
 TASK_DEFINE_STACK(mixerStack, MIXER_STACK_SIZE);
 
@@ -214,10 +205,6 @@ void doMixerCalculations()
 
   tmr10ms_t tmr10ms = get_tmr10ms();
 
-#if defined(HALL_SYNC) && !defined(SIMU)
-  gpio_set(HALL_SYNC);
-#endif
-
 #if defined(DEBUG_LATENCY_MIXER_RF) || defined(DEBUG_LATENCY_RF_ONLY)
   static tmr10ms_t lastLatencyToggle = 0;
   if (tmr10ms - lastLatencyToggle >= 10) {
@@ -243,8 +230,4 @@ void doMixerCalculations()
   DEBUG_TIMER_START(debugTimerEvalMixes);
   evalMixes(tick10ms);
   DEBUG_TIMER_STOP(debugTimerEvalMixes);
-
-#if defined(HALL_SYNC) && !defined(SIMU)
-  gpio_clear(HALL_SYNC);
-#endif
 }


### PR DESCRIPTION
Flysky gimbal synchronization (HALL_SYNC GPIO for V1, command-based start_read/wait_completion for V2) was scattered across the HAL layer (adc_driver.cpp) and mixer task (mixer_task.cpp). This moves it into the board-level ADC callbacks in analog_inputs.cpp, matching the existing ADS79xx SPI ADC integration pattern.

The gimbal driver now owns all its synchronization: GPIO init, HALL_SYNC assert/deassert, and V2 command sequencing. No hardware-specific code remains in hal/ or tasks/.