### PR TITLE
refactor(boot): move BT and rotary encoder init to board specifics

### DIFF
--- a/radio/src/boards/jumper-h750/board.cpp
+++ b/radio/src/boards/jumper-h750/board.cpp
@@ -108,6 +108,10 @@ void boardBLPreJump()
 
 void boardBLInit()
 {
+#if defined(ROTARY_ENCODER_NAVIGATION)
+  rotaryEncoderInit();
+#endif
+
   ExtFLASH_Init();
   SDRAM_Init();
 

--- a/radio/src/boards/rm-h750/board.cpp
+++ b/radio/src/boards/rm-h750/board.cpp
@@ -142,6 +142,10 @@ void boardBLPreJump()
 
 void boardBLInit()
 {
+#if defined(ROTARY_ENCODER_NAVIGATION)
+  rotaryEncoderInit();
+#endif
+
   ExtFLASH_Init();
   SDRAM_Init();
 

--- a/radio/src/bootloader/boot.cpp
+++ b/radio/src/bootloader/boot.cpp
@@ -23,17 +23,11 @@
 
 #include "hal/usb_driver.h"
 #include "hal/abnormal_reboot.h"
-#include "hal/rotary_encoder.h"
 
 #include "board.h"
 #include "debug.h"
 
 #include "timers_driver.h"
-
-#if defined(BLUETOOTH)
-  #include "bluetooth_driver.h"
-  #include "stm32_serial_driver.h"
-#endif
 
 #if defined(DEBUG_SEGGER_RTT)
   #include "thirdparty/Segger/SEGGER/SEGGER_RTT.h"
@@ -107,26 +101,12 @@ void bootloaderInitApp()
 #endif
   }
 
-  // TODO: move all this into board specifics
   pwrOn();
-
-#if defined(ROTARY_ENCODER_NAVIGATION) && !defined(USE_HATS_AS_KEYS)
-  rotaryEncoderInit();
-#endif
-
   __enable_irq();
 
   TRACE("\nBootloader started :)");
 
-  // TODO: move BT into board specifics
-#if defined(BLUETOOTH)
-  // we shutdown the bluetooth module now to be sure it will be detected on
-  // firmware start
-  bluetoothInit(BLUETOOTH_DEFAULT_BAUDRATE, false);
-#endif
-
   timersInit();
-
   usbInit();
   boardBLInit();
 }

--- a/radio/src/targets/common/arm/stm32/bluetooth_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/bluetooth_driver.cpp
@@ -24,13 +24,10 @@
 
 #include "stm32_hal_ll.h"
 #include "stm32_gpio.h"
+#include "stm32_serial_driver.h"
 
 #include "board.h"
 #include "debug.h"
-
-#if !defined(BOOT)
-
-#include "stm32_serial_driver.h"
 
 #define BT_USART_IRQ_PRIORITY 6
 
@@ -54,9 +51,7 @@ DEFINE_STM32_SERIAL_PORT(BTModule, btUSART, BT_RX_FIFO_SIZE, BT_TX_FIFO_SIZE);
 volatile uint8_t btChipPresent = 0;
 #endif
 
-// const etx_serial_driver_t* _bt_usart_drv = nullptr;
 void* _bt_usart_ctx = nullptr;
-#endif
 
 void bluetoothInit(uint32_t baudrate, bool enable)
 {
@@ -67,7 +62,6 @@ void bluetoothInit(uint32_t baudrate, bool enable)
   gpio_init(BT_PWR_GPIO, GPIO_OUT, GPIO_PIN_SPEED_LOW);
 #endif
 
-#if !defined(BOOT)
   etx_serial_init cfg = {
     .baudrate = baudrate,
     .encoding = ETX_Encoding_8N1,
@@ -81,7 +75,6 @@ void bluetoothInit(uint32_t baudrate, bool enable)
   } else {
     STM32SerialDriver.setBaudrate(_bt_usart_ctx, baudrate);
   }
-#endif
 
 #if defined(BT_EN_GPIO)
   gpio_write(BT_EN_GPIO, !enable);
@@ -91,7 +84,6 @@ void bluetoothInit(uint32_t baudrate, bool enable)
 #endif
 }
 
-#if !defined(BOOT)
 void bluetoothDisable()
 {
 #if defined(BT_EN_GPIO)
@@ -123,7 +115,6 @@ uint8_t bluetoothIsWriting(void)
 {
   if (!_bt_usart_ctx)
     return false;
-  
+
   return !STM32SerialDriver.txCompleted(_bt_usart_ctx);
 }
-#endif // !BOOT

--- a/radio/src/targets/horus/CMakeLists.txt
+++ b/radio/src/targets/horus/CMakeLists.txt
@@ -264,12 +264,6 @@ else()
   )
 endif()
 
-if(BLUETOOTH)
-  set(BOARD_COMMON_SRC ${BOARD_COMMON_SRC}
-    targets/common/arm/stm32/bluetooth_driver.cpp
-  )
-endif()
-
 if (VIDEO_SWITCH)
   add_definitions(-DVIDEO_SWITCH)
   set(BOARD_COMMON_SRC ${BOARD_COMMON_SRC}
@@ -302,6 +296,10 @@ add_library(board OBJECT EXCLUDE_FROM_ALL
   targets/common/arm/stm32/stm32_ws2812.cpp
 )
 set(FIRMWARE_SRC ${FIRMWARE_SRC} $<TARGET_OBJECTS:board>)
+
+if(BLUETOOTH)
+  target_sources(board PRIVATE targets/common/arm/stm32/bluetooth_driver.cpp)
+endif()
 
 if(HARDWARE_TOUCH)
   add_definitions(-DHARDWARE_TOUCH)

--- a/radio/src/targets/horus/board.cpp
+++ b/radio/src/targets/horus/board.cpp
@@ -60,12 +60,29 @@
 HardwareOptions hardwareOptions;
 bool boardBacklightOn = false;
 
+#if defined(VIDEO_SWITCH) || (defined(BLUETOOTH) && defined(BOOT))
+
 #if defined(VIDEO_SWITCH)
 #include "videoswitch_driver.h"
+#endif
 
 void boardBLEarlyInit()
 {
+#if defined(VIDEO_SWITCH)
   videoSwitchInit();
+#endif
+
+#if defined(BLUETOOTH)
+  // Disable the BT module so it will be detected on firmware start
+#if defined(BT_EN_GPIO)
+  gpio_init(BT_EN_GPIO, GPIO_OUT, GPIO_PIN_SPEED_LOW);
+  gpio_write(BT_EN_GPIO, 1);
+#endif
+#if defined(BT_PWR_GPIO)
+  gpio_init(BT_PWR_GPIO, GPIO_OUT, GPIO_PIN_SPEED_LOW);
+  gpio_set(BT_PWR_GPIO);
+#endif
+#endif
 }
 #endif
 
@@ -78,6 +95,7 @@ void boardBLPreJump()
 
 void boardBLInit()
 {
+  rotaryEncoderInit();
   SDRAM_Init();
 }
 

--- a/radio/src/targets/pa01/board.cpp
+++ b/radio/src/targets/pa01/board.cpp
@@ -117,6 +117,8 @@ void boardBLPreJump()
 
 void boardBLInit()
 {
+  rotaryEncoderInit();
+
   ExtFLASH_Init();
   SDRAM_Init();
 

--- a/radio/src/targets/pl18/board.cpp
+++ b/radio/src/targets/pl18/board.cpp
@@ -187,6 +187,9 @@ void boardBLPreJump()
 
 void boardBLInit()
 {
+#if defined(ROTARY_ENCODER_NAVIGATION) && !defined(USE_HATS_AS_KEYS)
+  rotaryEncoderInit();
+#endif
   SDRAM_Init();
 }
 

--- a/radio/src/targets/st16/board.cpp
+++ b/radio/src/targets/st16/board.cpp
@@ -164,6 +164,8 @@ void boardBLPreJump()
 
 void boardBLInit()
 {
+  rotaryEncoderInit();
+
   ExtFLASH_Init();
   SDRAM_Init();
 

--- a/radio/src/targets/taranis/CMakeLists.txt
+++ b/radio/src/targets/taranis/CMakeLists.txt
@@ -581,12 +581,6 @@ if(ROTARY_ENCODER)
   )
 endif()
 
-if(BLUETOOTH)
-  list(APPEND BOARD_COMMON_SRC
-    targets/common/arm/stm32/bluetooth_driver.cpp
-  )
-endif()
-
 # Bootloader board library
 add_library(board_bl OBJECT EXCLUDE_FROM_ALL
   ${BOARD_COMMON_SRC}
@@ -611,6 +605,10 @@ add_library(board OBJECT EXCLUDE_FROM_ALL
   targets/common/arm/stm32/stm32_ws2812.cpp
 )
 set(FIRMWARE_SRC ${FIRMWARE_SRC} $<TARGET_OBJECTS:board>)
+
+if(BLUETOOTH)
+  target_sources(board PRIVATE targets/common/arm/stm32/bluetooth_driver.cpp)
+endif()
 
 if(BIND_KEY)
   add_definitions(-DBIND_KEY)

--- a/radio/src/targets/taranis/board.cpp
+++ b/radio/src/targets/taranis/board.cpp
@@ -28,6 +28,7 @@
 #include "hal/switch_driver.h"
 #include "hal/module_port.h"
 #include "hal/abnormal_reboot.h"
+#include "hal/rotary_encoder.h"
 #include "hal/usb_driver.h"
 #include "hal/gpio.h"
 #include "hal/rgbleds.h"
@@ -48,6 +49,28 @@
 #if defined(FLYSKY_GIMBAL)
   #include "flysky_gimbal_driver.h"
 #endif
+
+#if defined(BOOT)
+
+#if defined(BLUETOOTH)
+void boardBLEarlyInit()
+{
+  // Disable the BT module so it will be detected on firmware start
+#if defined(BT_EN_GPIO)
+  gpio_init(BT_EN_GPIO, GPIO_OUT, GPIO_PIN_SPEED_LOW);
+  gpio_write(BT_EN_GPIO, 1);
+#endif
+}
+#endif
+
+#if defined(ROTARY_ENCODER_NAVIGATION)
+void boardBLInit()
+{
+  rotaryEncoderInit();
+}
+#endif
+
+#endif // BOOT
 
 #if !defined(BOOT)
   #include "edgetx.h"

--- a/radio/src/targets/tx15/CMakeLists.txt
+++ b/radio/src/targets/tx15/CMakeLists.txt
@@ -158,12 +158,6 @@ set(BOARD_COMMON_SRC
   targets/common/arm/stm32/watchdog_driver.cpp
 )
 
-if(BLUETOOTH)
-  set(BOARD_COMMON_SRC ${BOARD_COMMON_SRC}
-    targets/common/arm/stm32/bluetooth_driver.cpp
-  )
-endif()
-
 if(KCX_BTAUDIO)
   set(BOARD_COMMON_SRC ${BOARD_COMMON_SRC}
     drivers/kcx_btaudio.cpp
@@ -203,6 +197,10 @@ add_library(board OBJECT EXCLUDE_FROM_ALL
 )
 add_dependencies(board board_lib)
 set(FIRMWARE_SRC ${FIRMWARE_SRC} $<TARGET_OBJECTS:board>)
+
+if(BLUETOOTH)
+  target_sources(board PRIVATE targets/common/arm/stm32/bluetooth_driver.cpp)
+endif()
 
 include_directories(${RADIO_SRC_DIR}/fonts/colorlcd gui/${GUI_DIR} gui/${GUI_DIR}/layouts)
 


### PR DESCRIPTION
Move bootloader Bluetooth GPIO disable into boardBLEarlyInit() for taranis and horus targets, and rotary encoder init into boardBLInit() for all targets that use it. This removes board-specific #ifdef logic from the generic bootloader code.

Also move bluetooth_driver.cpp from BOARD_COMMON_SRC (shared by bootloader and firmware) to firmware-only via target_sources(), and remove the #if !defined(BOOT) guards from the driver since it is no longer compiled for the bootloader.