### PR TITLE
fix(radio): fix X9D+ crash with Master/SBUS trainer mode

### DIFF
--- a/radio/src/boards/generic_stm32/module_ports.cpp
+++ b/radio/src/boards/generic_stm32/module_ports.cpp
@@ -193,8 +193,8 @@ static void _extmod_init_inverter()
 static const stm32_usart_t sbus_trainer_USART = {
   .USARTx = TRAINER_MODULE_SBUS_USART,
   .rxGPIO = TRAINER_MODULE_SBUS_GPIO,
-  .IRQn = (IRQn_Type)-1,
-  .IRQ_Prio = 0,
+  .IRQn = TRAINER_MODULE_SBUS_USART_IRQn,
+  .IRQ_Prio = 6,
   .txDMA = nullptr,
   .txDMA_Stream = 0,
   .txDMA_Channel = 0,

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -879,6 +879,7 @@
   #define TRAINER_MODULE_CPPM_GPIO_AF             GPIO_AF2
   // Trainer SBUS input on heartbeat pin
   #define TRAINER_MODULE_SBUS_USART               USART6
+  #define TRAINER_MODULE_SBUS_USART_IRQn          USART6_IRQn
   #define TRAINER_MODULE_SBUS_GPIO                INTMODULE_HEARTBEAT_GPIO
   #define TRAINER_MODULE_SBUS_DMA                 DMA2
   #define TRAINER_MODULE_SBUS_DMA_STREAM          DMA2_Stream1


### PR DESCRIPTION
The `sbus_trainer_USART` had `IRQn` set to `(IRQn_Type)-1` which maps to `SysTick_IRQn` in CMSIS. When the IDLE callback was enabled, this caused `NVIC_SetPriority(-1, 0)` to set SysTick to highest priority, violating FreeRTOS requirements and crashing the system. The USART6 IRQ was also never enabled in NVIC, so SBUS frames were never detected.

Fix by defining `TRAINER_MODULE_SBUS_USART_IRQn` (`USART6_IRQn`) and using it in the port definition.

Fixes #7270