### PR TITLE
feat(color): add location marker to GPS Model Locator QR code

### DIFF
--- a/radio/src/gui/colorlcd/radio/radio_gps_tool.cpp
+++ b/radio/src/gui/colorlcd/radio/radio_gps_tool.cpp
@@ -68,7 +68,7 @@ void RadioGpsTool::refresh()
   if (gpsSensorID >= 0) {
     static TelemetryItem& gpsItem = telemetryItems[gpsSensorID];
     char gps_uri[64];
-    snprintf(gps_uri, sizeof(gps_uri), "geo:%f,%f", (float)gpsItem.gps.latitude / 1000000, (float)gpsItem.gps.longitude / 1000000);
+    snprintf(gps_uri, sizeof(gps_uri), "geo:0,0?q=%f,%f", (float)gpsItem.gps.latitude / 1000000, (float)gpsItem.gps.longitude / 1000000);
     gpsQR->setData(gps_uri);
     gpsQR->show();
     gpsLabel->setText(getGPSSensorValue(gpsItem, 0));


### PR DESCRIPTION
Improves: https://github.com/EdgeTX/edgetx/pull/6431

Summary of changes: Adds a marker on the map when using the GPS model locator

The current implemenation of the GPS model locator [at least when using Google Maps] only zooms in on the GPS location.
This PR slightly modifies the QR code generation so that a marker is placed on the map at the provided location.

This works by using "geo:0,0?q=LAT,LON" instead of "geo:LAT,LON".