### PR TITLE
feat(simulator): add local socket backend for aux serial ports

### DIFF
--- a/cmake/QtDefs.cmake
+++ b/cmake/QtDefs.cmake
@@ -13,7 +13,7 @@ if(Qt6_FOUND)
   # call after Qt6Core package is found
   qt_standard_project_setup()
 
-  find_package(Qt6 REQUIRED COMPONENTS Widgets LinguistTools Multimedia PrintSupport SerialPort Svg Xml)
+  find_package(Qt6 REQUIRED COMPONENTS Widgets LinguistTools Multimedia Network PrintSupport SerialPort Svg Xml)
 
   ### Get locations of Qt binary executables & libs (libs are for distros, not for linking)
   # first set up some hints

--- a/companion/src/CMakeLists.txt
+++ b/companion/src/CMakeLists.txt
@@ -189,6 +189,7 @@ target_link_libraries(common
   Qt::Xml
   Qt::Widgets
   Qt::SerialPort
+  Qt::Network
   ${SDL2_LIBRARIES}
 )
 

--- a/companion/src/simulation/CMakeLists.txt
+++ b/companion/src/simulation/CMakeLists.txt
@@ -20,6 +20,7 @@ set(${PROJECT_NAME}_NAMES
   widgets/radiowidget
   widgets/virtualjoystickwidget
   serialportsdialog
+  hostserialbackend_serialport
   hostserialconnector
   simulateduiwidgetGeneric
   wasmsimulatorinterface
@@ -36,6 +37,7 @@ AddHeadersSources()
 
 set(${PROJECT_NAME}_HDRS
   ${${PROJECT_NAME}_HDRS}
+  hostserialbackend.h
   radiouiaction.h
   widgets/buttonswidget.h
   widgets/radiofaderwidget.h

--- a/companion/src/simulation/CMakeLists.txt
+++ b/companion/src/simulation/CMakeLists.txt
@@ -21,6 +21,7 @@ set(${PROJECT_NAME}_NAMES
   widgets/virtualjoystickwidget
   serialportsdialog
   hostserialbackend_serialport
+  hostserialbackend_localsocket
   hostserialconnector
   simulateduiwidgetGeneric
   wasmsimulatorinterface

--- a/companion/src/simulation/hostserialbackend.h
+++ b/companion/src/simulation/hostserialbackend.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include <QByteArray>
+#include <QObject>
+#include <QString>
+
+// Abstract host-side transport for a simulator aux serial port.
+//
+// The simulator firmware sees a generic byte stream; on the host side
+// the bytes can come from a real QSerialPort device, a local socket,
+// or any other source. Each backend implementation hides the
+// transport details behind this interface so HostSerialConnector can
+// stay transport-agnostic.
+//
+// Backends are owned by HostSerialConnector and live on the same
+// thread as the connector. Implementations should emit dataReceived
+// for incoming bytes and errorOccurred (with a user-facing message)
+// when something goes wrong opening or operating the transport.
+class HostSerialBackend : public QObject
+{
+    Q_OBJECT
+
+  public:
+    explicit HostSerialBackend(QObject * parent = nullptr) : QObject(parent) {}
+    ~HostSerialBackend() override = default;
+
+    virtual bool open() = 0;
+    virtual void close() = 0;
+    virtual bool isOpen() const = 0;
+
+    virtual void write(const QByteArray & data) = 0;
+
+    // No-ops for transports without a notion of bit-level encoding /
+    // baudrate (e.g. local sockets). Serial backends override these.
+    virtual void setBaudrate(quint32 /*baudrate*/) {}
+    virtual void setEncoding(quint8 /*encoding*/) {}
+
+    // Human-readable identifier (port name, socket path, ...) shown
+    // in dialogs and log output.
+    virtual QString displayName() const = 0;
+
+  signals:
+    void dataReceived(const QByteArray & data);
+    void errorOccurred(const QString & message);
+};

--- a/companion/src/simulation/hostserialbackend_localsocket.cpp
+++ b/companion/src/simulation/hostserialbackend_localsocket.cpp
@@ -40,19 +40,36 @@ QLocalSocketBackend::~QLocalSocketBackend()
   close();
 }
 
+QString QLocalSocketBackend::resolveListenName(const QString & name)
+{
+#ifdef Q_OS_UNIX
+  // Qt defaults to QStandardPaths::TempLocation, which on macOS is
+  // a per-user $TMPDIR (e.g. /var/folders/.../T/) — fine for IPC
+  // between Qt apps, painful when the other end is a Python script
+  // a user is poking from a shell. Pin bare names to /tmp/<name>
+  // so the resolved path is predictable on both macOS and Linux.
+  // Absolute paths supplied by the user are passed through as-is.
+  if (!name.startsWith(QLatin1Char('/')))
+    return QStringLiteral("/tmp/") + name;
+#endif
+  return name;
+}
+
 bool QLocalSocketBackend::open()
 {
   if (server->isListening())
     return true;
 
+  const QString listenName = resolveListenName(socketName);
+
   // A previous run (or another process) may have left a stale socket
   // file behind on Unix; QLocalServer::removeServer is the documented
   // way to clear it before re-listening.
-  QLocalServer::removeServer(socketName);
+  QLocalServer::removeServer(listenName);
 
-  if (!server->listen(socketName)) {
+  if (!server->listen(listenName)) {
     emit errorOccurred(tr("Failed to listen on local socket \"%1\": %2")
-                       .arg(socketName, server->errorString()));
+                       .arg(listenName, server->errorString()));
     return false;
   }
 

--- a/companion/src/simulation/hostserialbackend_localsocket.cpp
+++ b/companion/src/simulation/hostserialbackend_localsocket.cpp
@@ -1,0 +1,130 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "hostserialbackend_localsocket.h"
+
+#include <QLocalServer>
+#include <QLocalSocket>
+#include <QtDebug>
+
+QLocalSocketBackend::QLocalSocketBackend(const QString & socketName, QObject * parent)
+  : HostSerialBackend(parent),
+    socketName(socketName),
+    server(new QLocalServer(this)),
+    client(nullptr)
+{
+  connect(server, &QLocalServer::newConnection,
+          this, &QLocalSocketBackend::onNewConnection);
+}
+
+QLocalSocketBackend::~QLocalSocketBackend()
+{
+  close();
+}
+
+bool QLocalSocketBackend::open()
+{
+  if (server->isListening())
+    return true;
+
+  // A previous run (or another process) may have left a stale socket
+  // file behind on Unix; QLocalServer::removeServer is the documented
+  // way to clear it before re-listening.
+  QLocalServer::removeServer(socketName);
+
+  if (!server->listen(socketName)) {
+    emit errorOccurred(tr("Failed to listen on local socket \"%1\": %2")
+                       .arg(socketName, server->errorString()));
+    return false;
+  }
+
+  qDebug() << "Listening on local socket" << server->fullServerName();
+  return true;
+}
+
+void QLocalSocketBackend::close()
+{
+  if (client != nullptr) {
+    client->disconnect(this);
+    client->disconnectFromServer();
+    client->deleteLater();
+    client = nullptr;
+  }
+  if (server->isListening())
+    server->close();
+}
+
+bool QLocalSocketBackend::isOpen() const
+{
+  return server->isListening();
+}
+
+void QLocalSocketBackend::write(const QByteArray & data)
+{
+  if (client != nullptr && client->state() == QLocalSocket::ConnectedState)
+    client->write(data);
+}
+
+QString QLocalSocketBackend::displayName() const
+{
+  return socketName;
+}
+
+QString QLocalSocketBackend::fullServerName() const
+{
+  return server->isListening() ? server->fullServerName() : QString();
+}
+
+void QLocalSocketBackend::onNewConnection()
+{
+  while (server->hasPendingConnections()) {
+    QLocalSocket * incoming = server->nextPendingConnection();
+    if (client != nullptr) {
+      // Single-client backend: politely refuse extra connections.
+      incoming->disconnectFromServer();
+      incoming->deleteLater();
+      continue;
+    }
+
+    client = incoming;
+    connect(client, &QLocalSocket::readyRead,
+            this, &QLocalSocketBackend::onClientReadyRead);
+    connect(client, &QLocalSocket::disconnected,
+            this, &QLocalSocketBackend::onClientDisconnected);
+    qDebug() << "Local socket client connected on" << socketName;
+  }
+}
+
+void QLocalSocketBackend::onClientReadyRead()
+{
+  if (client == nullptr)
+    return;
+  emit dataReceived(client->readAll());
+}
+
+void QLocalSocketBackend::onClientDisconnected()
+{
+  if (client == nullptr)
+    return;
+  client->deleteLater();
+  client = nullptr;
+  qDebug() << "Local socket client disconnected from" << socketName;
+}

--- a/companion/src/simulation/hostserialbackend_localsocket.h
+++ b/companion/src/simulation/hostserialbackend_localsocket.h
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include "hostserialbackend.h"
+
+class QLocalServer;
+class QLocalSocket;
+
+// HostSerialBackend backed by a QLocalServer (Unix domain socket on
+// macOS / Linux, named pipe on Windows). Lets external scripts stand
+// in for hardware on a simulator aux serial port.
+//
+// Single-client semantics: while one client is connected, additional
+// connection attempts are accepted briefly and then closed. We use
+// last-write-wins for outgoing data — bytes from the simulator only
+// reach the active client.
+class QLocalSocketBackend : public HostSerialBackend
+{
+    Q_OBJECT
+
+  public:
+    QLocalSocketBackend(const QString & socketName, QObject * parent = nullptr);
+    ~QLocalSocketBackend() override;
+
+    bool open() override;
+    void close() override;
+    bool isOpen() const override;
+
+    void write(const QByteArray & data) override;
+
+    QString displayName() const override;
+
+    // Resolved native path / pipe name (e.g.
+    // /var/folders/.../edgetx-sim-aux1 or
+    // \\.\pipe\edgetx-sim-aux1). Empty when the server is not
+    // listening.
+    QString fullServerName() const;
+
+  private slots:
+    void onNewConnection();
+    void onClientReadyRead();
+    void onClientDisconnected();
+
+  private:
+    QString socketName;
+    QLocalServer * server;
+    QLocalSocket * client;
+};

--- a/companion/src/simulation/hostserialbackend_localsocket.h
+++ b/companion/src/simulation/hostserialbackend_localsocket.h
@@ -62,6 +62,8 @@ class QLocalSocketBackend : public HostSerialBackend
     void onClientDisconnected();
 
   private:
+    static QString resolveListenName(const QString & name);
+
     QString socketName;
     QLocalServer * server;
     QLocalSocket * client;

--- a/companion/src/simulation/hostserialbackend_serialport.cpp
+++ b/companion/src/simulation/hostserialbackend_serialport.cpp
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "hostserialbackend_serialport.h"
+
+#include "simulatorinterface.h"
+
+#include <QtDebug>
+
+QSerialPortBackend::QSerialPortBackend(const QString & portName, QObject * parent)
+  : HostSerialBackend(parent),
+    port(new QSerialPort(portName, this))
+{
+  connect(port, &QSerialPort::readyRead, this, [this]() {
+    emit dataReceived(port->readAll());
+  });
+}
+
+QSerialPortBackend::~QSerialPortBackend()
+{
+  if (port->isOpen())
+    port->close();
+}
+
+bool QSerialPortBackend::open()
+{
+  if (port->open(QIODevice::ReadWrite)) {
+    qDebug() << "Opened host serial" << port->portName();
+    return true;
+  }
+  emit errorOccurred(port->errorString());
+  return false;
+}
+
+void QSerialPortBackend::close()
+{
+  port->close();
+}
+
+bool QSerialPortBackend::isOpen() const
+{
+  return port->isOpen();
+}
+
+void QSerialPortBackend::write(const QByteArray & data)
+{
+  port->write(data);
+}
+
+void QSerialPortBackend::setBaudrate(quint32 baudrate)
+{
+  if (!port->setBaudRate(baudrate))
+    qDebug() << "Failed to set baudrate";
+}
+
+void QSerialPortBackend::setEncoding(quint8 encoding)
+{
+  switch (encoding) {
+    case SERIAL_ENCODING_8N1:
+      port->setDataBits(QSerialPort::Data8);
+      port->setParity(QSerialPort::NoParity);
+      port->setStopBits(QSerialPort::OneStop);
+      break;
+    case SERIAL_ENCODING_8E2:
+      port->setDataBits(QSerialPort::Data8);
+      port->setParity(QSerialPort::EvenParity);
+      port->setStopBits(QSerialPort::TwoStop);
+      break;
+    default:
+      // QSerialPort can't do SERIAL_ENCODING_PXX1_PWM
+      break;
+  }
+}
+
+QString QSerialPortBackend::displayName() const
+{
+  return port->portName();
+}

--- a/companion/src/simulation/hostserialbackend_serialport.h
+++ b/companion/src/simulation/hostserialbackend_serialport.h
@@ -1,0 +1,52 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#pragma once
+
+#include "hostserialbackend.h"
+
+#include <QSerialPort>
+
+// HostSerialBackend implementation backed by a real QSerialPort
+// device (USB-serial adapter, native UART, ...). Mirrors the original
+// HostSerialConnector behaviour 1:1.
+class QSerialPortBackend : public HostSerialBackend
+{
+    Q_OBJECT
+
+  public:
+    QSerialPortBackend(const QString & portName, QObject * parent = nullptr);
+    ~QSerialPortBackend() override;
+
+    bool open() override;
+    void close() override;
+    bool isOpen() const override;
+
+    void write(const QByteArray & data) override;
+
+    void setBaudrate(quint32 baudrate) override;
+    void setEncoding(quint8 encoding) override;
+
+    QString displayName() const override;
+
+  private:
+    QSerialPort * port;
+};

--- a/companion/src/simulation/hostserialconnector.cpp
+++ b/companion/src/simulation/hostserialconnector.cpp
@@ -20,13 +20,16 @@
  */
 
 #include "hostserialconnector.h"
-#include <QMessageBox>
+
+#include "hostserialbackend.h"
+#include "hostserialbackend_serialport.h"
 
 HostSerialConnector::HostSerialConnector(QObject *parent, SimulatorInterface *simulator)
-  : simulator(simulator)
+  : QObject(parent),
+    simulator(simulator)
 {
   for (int i = 0; i < MAX_HOST_SERIAL; i++) {
-    hostAuxPorts[i] = nullptr;
+    hostAuxBackends[i] = nullptr;
     hostAuxPortsEncoding[i] = SERIAL_ENCODING_8N1;
     hostAuxPortsBaudRate[i] = 9600;
     hostAuxPortsOpen[i] = false;
@@ -36,9 +39,9 @@ HostSerialConnector::HostSerialConnector(QObject *parent, SimulatorInterface *si
 HostSerialConnector::~HostSerialConnector()
 {
   for (int i = 0; i < MAX_HOST_SERIAL; i++) {
-    if (hostAuxPorts[i] != nullptr) {
-      hostAuxPorts[i]->close();
-      hostAuxPorts[i]->deleteLater();
+    if (hostAuxBackends[i] != nullptr) {
+      hostAuxBackends[i]->close();
+      hostAuxBackends[i]->deleteLater();
     }
   }
 }
@@ -50,11 +53,39 @@ QString HostSerialConnector::getConnectedSerialPortName(int index)
 
   QMutexLocker locker(&hostAuxPortsMutex);
 
-  QSerialPort * port = hostAuxPorts[index];
-  if (port == nullptr)
+  HostSerialBackend * backend = hostAuxBackends[index];
+  if (backend == nullptr)
     return QString("");
 
-  return port->portName();
+  return backend->displayName();
+}
+
+void HostSerialConnector::setBackend(int index, HostSerialBackend * backend)
+{
+  // Caller holds hostAuxPortsMutex.
+  HostSerialBackend * old = hostAuxBackends[index];
+  if (old != nullptr) {
+    old->close();
+    old->deleteLater();
+  }
+
+  hostAuxBackends[index] = backend;
+
+  if (backend == nullptr)
+    return;
+
+  connect(backend, &HostSerialBackend::dataReceived, this,
+          [this, index](const QByteArray & data) {
+            simulator->receiveAuxSerialData(index, data);
+          });
+  connect(backend, &HostSerialBackend::errorOccurred, this,
+          [this, index](const QString & message) {
+            emit backendError(index, message);
+          });
+
+  // Re-apply cached settings to the freshly created backend.
+  backend->setEncoding(hostAuxPortsEncoding[index]);
+  backend->setBaudrate(hostAuxPortsBaudRate[index]);
 }
 
 void HostSerialConnector::connectSerialPort(int index, QString portName)
@@ -64,27 +95,12 @@ void HostSerialConnector::connectSerialPort(int index, QString portName)
 
   QMutexLocker locker(&hostAuxPortsMutex);
 
-  QSerialPort * port = hostAuxPorts[index];
-  if (port != nullptr) {
-    port->close();
-    port->deleteLater();
-  }
-
   if (portName.isEmpty()) {
-    hostAuxPorts[index] = nullptr;
+    setBackend(index, nullptr);
     return;
   }
 
-  port = new QSerialPort(portName, this);
-  hostAuxPorts[index] = port;
-
-  setSerialEncoding(index, hostAuxPortsEncoding[index]);
-  setSerialBaudRate(index, hostAuxPortsBaudRate[index]);
-
-  connect(port, &QSerialPort::readyRead, [this, index, port]() {
-    QByteArray data = port->readAll();
-    simulator->receiveAuxSerialData(index, data);
-  });
+  setBackend(index, new QSerialPortBackend(portName, this));
 
   if (hostAuxPortsOpen[index])
     serialStart(index);
@@ -97,11 +113,11 @@ void HostSerialConnector::sendSerialData(const quint8 index, const QByteArray & 
 
   QMutexLocker locker(&hostAuxPortsMutex);
 
-  QSerialPort * port = hostAuxPorts[index];
-  if (port == nullptr)
+  HostSerialBackend * backend = hostAuxBackends[index];
+  if (backend == nullptr)
     return;
 
-  port->write(data);
+  backend->write(data);
 }
 
 void HostSerialConnector::setSerialEncoding(const quint8 index, const quint8 encoding)
@@ -113,25 +129,11 @@ void HostSerialConnector::setSerialEncoding(const quint8 index, const quint8 enc
 
   hostAuxPortsEncoding[index] = encoding;
 
-  QSerialPort * port = hostAuxPorts[index];
-  if (port == nullptr)
+  HostSerialBackend * backend = hostAuxBackends[index];
+  if (backend == nullptr)
     return;
-      
-  switch(encoding) {
-  case SERIAL_ENCODING_8N1:
-    port->setDataBits(QSerialPort::Data8);
-    port->setParity(QSerialPort::NoParity);
-    port->setStopBits(QSerialPort::OneStop);
-    break;
-  case SERIAL_ENCODING_8E2:
-    port->setDataBits(QSerialPort::Data8);
-    port->setParity(QSerialPort::EvenParity);
-    port->setStopBits(QSerialPort::TwoStop);
-    break;
-  default:
-    // Do nothing, QSerialPort can't do SERIAL_ENCODING_PXX1_PWM
-    break;
-  }
+
+  backend->setEncoding(encoding);
 }
 
 void HostSerialConnector::setSerialBaudRate(const quint8 index, const quint32 baudrate)
@@ -143,12 +145,11 @@ void HostSerialConnector::setSerialBaudRate(const quint8 index, const quint32 ba
 
   hostAuxPortsBaudRate[index] = baudrate;
 
-  QSerialPort * port = hostAuxPorts[index];
-  if (port == nullptr)
+  HostSerialBackend * backend = hostAuxBackends[index];
+  if (backend == nullptr)
     return;
 
-  if (!port->setBaudRate(baudrate))
-    qDebug() << "Failed to set baudrate";
+  backend->setBaudrate(baudrate);
 }
 
 void HostSerialConnector::serialStart(const quint8 index)
@@ -160,14 +161,11 @@ void HostSerialConnector::serialStart(const quint8 index)
 
   hostAuxPortsOpen[index] = true;
 
-  QSerialPort * port = hostAuxPorts[index];
-  if (port == nullptr)
+  HostSerialBackend * backend = hostAuxBackends[index];
+  if (backend == nullptr)
     return;
 
-  if (port->open(QIODevice::ReadWrite))
-    qDebug() << "Opened host serial " << index;
-  else
-    QMessageBox::warning(nullptr, tr("Host Serial Error"), port->errorString(), QMessageBox::Cancel, QMessageBox::Cancel);
+  backend->open();
 }
 
 void HostSerialConnector::serialStop(const quint8 index)
@@ -179,9 +177,9 @@ void HostSerialConnector::serialStop(const quint8 index)
 
   hostAuxPortsOpen[index] = false;
 
-  QSerialPort * port = hostAuxPorts[index];
-  if (port == nullptr)
+  HostSerialBackend * backend = hostAuxBackends[index];
+  if (backend == nullptr)
     return;
 
-  port->close();
+  backend->close();
 }

--- a/companion/src/simulation/hostserialconnector.cpp
+++ b/companion/src/simulation/hostserialconnector.cpp
@@ -23,6 +23,7 @@
 
 #include "hostserialbackend.h"
 #include "hostserialbackend_serialport.h"
+#include "hostserialbackend_localsocket.h"
 
 HostSerialConnector::HostSerialConnector(QObject *parent, SimulatorInterface *simulator)
   : QObject(parent),
@@ -30,6 +31,7 @@ HostSerialConnector::HostSerialConnector(QObject *parent, SimulatorInterface *si
 {
   for (int i = 0; i < MAX_HOST_SERIAL; i++) {
     hostAuxBackends[i] = nullptr;
+    hostAuxBackendKinds[i] = BackendNone;
     hostAuxPortsEncoding[i] = SERIAL_ENCODING_8N1;
     hostAuxPortsBaudRate[i] = 9600;
     hostAuxPortsOpen[i] = false;
@@ -46,21 +48,44 @@ HostSerialConnector::~HostSerialConnector()
   }
 }
 
-QString HostSerialConnector::getConnectedSerialPortName(int index)
+HostSerialConnector::BackendKind HostSerialConnector::getBackendKind(int index) const
 {
   if (index >= MAX_HOST_SERIAL)
-    return QString("");
+    return BackendNone;
+
+  QMutexLocker locker(&hostAuxPortsMutex);
+  return hostAuxBackendKinds[index];
+}
+
+QString HostSerialConnector::getBackendSpec(int index) const
+{
+  if (index >= MAX_HOST_SERIAL)
+    return QString();
 
   QMutexLocker locker(&hostAuxPortsMutex);
 
   HostSerialBackend * backend = hostAuxBackends[index];
   if (backend == nullptr)
-    return QString("");
+    return QString();
 
   return backend->displayName();
 }
 
-void HostSerialConnector::setBackend(int index, HostSerialBackend * backend)
+QString HostSerialConnector::getLocalSocketFullName(int index) const
+{
+  if (index >= MAX_HOST_SERIAL)
+    return QString();
+
+  QMutexLocker locker(&hostAuxPortsMutex);
+
+  if (hostAuxBackendKinds[index] != BackendLocalSocket)
+    return QString();
+
+  auto * backend = qobject_cast<QLocalSocketBackend *>(hostAuxBackends[index]);
+  return backend != nullptr ? backend->fullServerName() : QString();
+}
+
+void HostSerialConnector::setBackend(int index, HostSerialBackend * backend, BackendKind kind)
 {
   // Caller holds hostAuxPortsMutex.
   HostSerialBackend * old = hostAuxBackends[index];
@@ -70,6 +95,7 @@ void HostSerialConnector::setBackend(int index, HostSerialBackend * backend)
   }
 
   hostAuxBackends[index] = backend;
+  hostAuxBackendKinds[index] = backend != nullptr ? kind : BackendNone;
 
   if (backend == nullptr)
     return;
@@ -88,19 +114,31 @@ void HostSerialConnector::setBackend(int index, HostSerialBackend * backend)
   backend->setBaudrate(hostAuxPortsBaudRate[index]);
 }
 
-void HostSerialConnector::connectSerialPort(int index, QString portName)
+void HostSerialConnector::connectBackend(int index, int kind, const QString & spec)
 {
   if (index >= MAX_HOST_SERIAL)
     return;
 
   QMutexLocker locker(&hostAuxPortsMutex);
 
-  if (portName.isEmpty()) {
-    setBackend(index, nullptr);
+  if (kind == BackendNone || spec.isEmpty()) {
+    setBackend(index, nullptr, BackendNone);
     return;
   }
 
-  setBackend(index, new QSerialPortBackend(portName, this));
+  HostSerialBackend * backend = nullptr;
+  switch (kind) {
+    case BackendSerialPort:
+      backend = new QSerialPortBackend(spec, this);
+      break;
+    case BackendLocalSocket:
+      backend = new QLocalSocketBackend(spec, this);
+      break;
+    default:
+      return;
+  }
+
+  setBackend(index, backend, static_cast<BackendKind>(kind));
 
   if (hostAuxPortsOpen[index])
     serialStart(index);

--- a/companion/src/simulation/hostserialconnector.h
+++ b/companion/src/simulation/hostserialconnector.h
@@ -23,11 +23,17 @@
 
 #include "simulatorinterface.h"
 
-#include <QSerialPort>
 #include <QMutex>
+
+class HostSerialBackend;
 
 #define MAX_HOST_SERIAL 2
 
+// Owns one HostSerialBackend per simulator aux serial port and
+// shuttles bytes between the simulator and whichever transport the
+// user picked (real serial port, local socket, ...). Per-port
+// encoding / baudrate state is cached here so it survives backend
+// swaps and reconnects.
 class HostSerialConnector : public QObject
 {
     Q_OBJECT
@@ -46,11 +52,18 @@ class HostSerialConnector : public QObject
     void serialStart(const quint8 index);
     void serialStop(const quint8 index);
 
- private:
+  signals:
+    // Surfaced to the UI layer (e.g. SimulatorMainWindow) so it can
+    // show the user a message box. Index identifies the aux port.
+    void backendError(int index, const QString & message);
+
+  private:
+    void setBackend(int index, HostSerialBackend * backend);
+
     SimulatorInterface * simulator;
 
     QRecursiveMutex hostAuxPortsMutex;
-    QSerialPort * hostAuxPorts[MAX_HOST_SERIAL];
+    HostSerialBackend * hostAuxBackends[MAX_HOST_SERIAL];
     quint8 hostAuxPortsEncoding[MAX_HOST_SERIAL];
     quint32 hostAuxPortsBaudRate[MAX_HOST_SERIAL];
     bool hostAuxPortsOpen[MAX_HOST_SERIAL];

--- a/companion/src/simulation/hostserialconnector.h
+++ b/companion/src/simulation/hostserialconnector.h
@@ -39,13 +39,28 @@ class HostSerialConnector : public QObject
     Q_OBJECT
 
   public:
+    enum BackendKind {
+      BackendNone = 0,
+      BackendSerialPort,
+      BackendLocalSocket,
+    };
+    Q_ENUM(BackendKind)
+
     explicit HostSerialConnector(QObject * parent, SimulatorInterface * simulator);
     ~HostSerialConnector();
 
-    QString getConnectedSerialPortName(int index);
+    BackendKind getBackendKind(int index) const;
+    QString getBackendSpec(int index) const;
+
+    // Convenience: only meaningful when the active backend is a
+    // QLocalSocketBackend. Returns an empty string otherwise.
+    QString getLocalSocketFullName(int index) const;
 
   public slots:
-    void connectSerialPort(int index, QString portName);
+    // kind=BackendNone or empty spec disconnects the port. For
+    // BackendSerialPort, spec is the device name (e.g. "ttyUSB0");
+    // for BackendLocalSocket, spec is the QLocalServer listen name.
+    void connectBackend(int index, int kind, const QString & spec);
     void sendSerialData(const quint8 index, const QByteArray & data);
     void setSerialEncoding(const quint8 index, const quint8 encoding);
     void setSerialBaudRate(const quint8 index, const quint32 baudrate);
@@ -58,12 +73,13 @@ class HostSerialConnector : public QObject
     void backendError(int index, const QString & message);
 
   private:
-    void setBackend(int index, HostSerialBackend * backend);
+    void setBackend(int index, HostSerialBackend * backend, BackendKind kind);
 
     SimulatorInterface * simulator;
 
-    QRecursiveMutex hostAuxPortsMutex;
+    mutable QRecursiveMutex hostAuxPortsMutex;
     HostSerialBackend * hostAuxBackends[MAX_HOST_SERIAL];
+    BackendKind hostAuxBackendKinds[MAX_HOST_SERIAL];
     quint8 hostAuxPortsEncoding[MAX_HOST_SERIAL];
     quint32 hostAuxPortsBaudRate[MAX_HOST_SERIAL];
     bool hostAuxPortsOpen[MAX_HOST_SERIAL];

--- a/companion/src/simulation/serialportsdialog.cpp
+++ b/companion/src/simulation/serialportsdialog.cpp
@@ -22,22 +22,36 @@
 #include "serialportsdialog.h"
 #include "ui_serialportsdialog.h"
 
+#include <QComboBox>
+#include <QLabel>
+#include <QLineEdit>
+#include <QStackedWidget>
+
 SerialPortsDialog::SerialPortsDialog(QWidget *parent, SimulatorInterface *simulator, HostSerialConnector *connector) :
   QDialog(parent),
+  aux1Kind(HostSerialConnector::BackendNone),
+  aux2Kind(HostSerialConnector::BackendNone),
   simulator(simulator),
   connector(connector),
   ui(new Ui::SerialPortsDialog)
 {
   ui->setupUi(this);
 
-  aux1 = connector->getConnectedSerialPortName(0);
-  aux2 = connector->getConnectedSerialPortName(1);
+  buildPortRow(0, tr("AUX1 Port"));
+  buildPortRow(1, tr("AUX2 Port"));
 
-  populateSerialPortCombo(ui->aux1Combo, aux1);
-  populateSerialPortCombo(ui->aux2Combo, aux2);
+  loadPortState(0);
+  loadPortState(1);
 
-  ui->aux1Combo->setEnabled(simulator->getCapability(SimulatorInterface::Capability::CAP_SERIAL_AUX1));
-  ui->aux2Combo->setEnabled(simulator->getCapability(SimulatorInterface::Capability::CAP_SERIAL_AUX2));
+  // Disable rows whose AUX is not supported by this simulator build.
+  const bool aux1Supported =
+      simulator->getCapability(SimulatorInterface::Capability::CAP_SERIAL_AUX1);
+  const bool aux2Supported =
+      simulator->getCapability(SimulatorInterface::Capability::CAP_SERIAL_AUX2);
+  auxRows[0].typeCombo->setEnabled(aux1Supported);
+  auxRows[0].specStack->setEnabled(aux1Supported);
+  auxRows[1].typeCombo->setEnabled(aux2Supported);
+  auxRows[1].specStack->setEnabled(aux2Supported);
 }
 
 SerialPortsDialog::~SerialPortsDialog()
@@ -45,13 +59,119 @@ SerialPortsDialog::~SerialPortsDialog()
   delete ui;
 }
 
-void SerialPortsDialog::populateSerialPortCombo(QComboBox * cb, QString currentPortName)
+QString SerialPortsDialog::defaultSocketName(int index)
+{
+  return QStringLiteral("edgetx-sim-aux%1").arg(index + 1);
+}
+
+void SerialPortsDialog::buildPortRow(int index, const QString & labelText)
+{
+  PortRow & row = auxRows[index];
+
+  auto * label = new QLabel(labelText, this);
+
+  row.typeCombo = new QComboBox(this);
+  row.typeCombo->addItem(tr("Not assigned"), HostSerialConnector::BackendNone);
+  row.typeCombo->addItem(tr("Serial port"), HostSerialConnector::BackendSerialPort);
+  row.typeCombo->addItem(tr("Local socket"), HostSerialConnector::BackendLocalSocket);
+
+  row.specStack = new QStackedWidget(this);
+
+  // Page: none
+  auto * nonePage = new QWidget(this);
+  auto * noneLayout = new QHBoxLayout(nonePage);
+  noneLayout->setContentsMargins(0, 0, 0, 0);
+  noneLayout->addStretch();
+  row.specStack->insertWidget(PageNone, nonePage);
+
+  // Page: serial port combo
+  auto * serialPage = new QWidget(this);
+  auto * serialLayout = new QHBoxLayout(serialPage);
+  serialLayout->setContentsMargins(0, 0, 0, 0);
+  row.serialCombo = new QComboBox(serialPage);
+  row.serialCombo->setSizePolicy(QSizePolicy::MinimumExpanding, QSizePolicy::Fixed);
+  serialLayout->addWidget(row.serialCombo);
+  row.specStack->insertWidget(PageSerial, serialPage);
+
+  // Page: local socket name + resolved-path label
+  auto * socketPage = new QWidget(this);
+  auto * socketLayout = new QVBoxLayout(socketPage);
+  socketLayout->setContentsMargins(0, 0, 0, 0);
+  socketLayout->setSpacing(2);
+  row.socketEdit = new QLineEdit(socketPage);
+  row.socketEdit->setPlaceholderText(defaultSocketName(index));
+  socketLayout->addWidget(row.socketEdit);
+  row.socketStatusLabel = new QLabel(socketPage);
+  row.socketStatusLabel->setStyleSheet(QStringLiteral("color: gray;"));
+  row.socketStatusLabel->setTextInteractionFlags(Qt::TextSelectableByMouse);
+  socketLayout->addWidget(row.socketStatusLabel);
+  row.specStack->insertWidget(PageSocket, socketPage);
+
+  ui->portsLayout->addWidget(label, index, 0);
+  ui->portsLayout->addWidget(row.typeCombo, index, 1);
+  ui->portsLayout->addWidget(row.specStack, index, 2);
+  ui->portsLayout->setColumnStretch(2, 1);
+
+  connect(row.typeCombo, QOverload<int>::of(&QComboBox::currentIndexChanged),
+          this, [this, index](int comboIndex) { onTypeChanged(index, comboIndex); });
+}
+
+void SerialPortsDialog::loadPortState(int index)
+{
+  PortRow & row = auxRows[index];
+
+  const auto kind = connector->getBackendKind(index);
+  const QString spec = connector->getBackendSpec(index);
+
+  // Always populate the serial combo so the user can switch to it
+  // even when the current backend is something else.
+  populateSerialPortCombo(row.serialCombo, kind == HostSerialConnector::BackendSerialPort ? spec : QString());
+
+  if (kind == HostSerialConnector::BackendLocalSocket) {
+    row.socketEdit->setText(spec);
+    const QString resolved = connector->getLocalSocketFullName(index);
+    row.socketStatusLabel->setText(resolved.isEmpty()
+                                       ? tr("Not listening")
+                                       : tr("Listening on %1").arg(resolved));
+  } else {
+    row.socketEdit->clear();
+    row.socketStatusLabel->clear();
+  }
+
+  const int kindIndex = row.typeCombo->findData(static_cast<int>(kind));
+  row.typeCombo->setCurrentIndex(kindIndex >= 0 ? kindIndex : 0);
+  // Make sure the stack mirrors the (possibly unchanged) combo.
+  onTypeChanged(index, row.typeCombo->currentIndex());
+}
+
+void SerialPortsDialog::onTypeChanged(int index, int comboIndex)
+{
+  PortRow & row = auxRows[index];
+  const int kind = row.typeCombo->itemData(comboIndex).toInt();
+
+  switch (kind) {
+    case HostSerialConnector::BackendSerialPort:
+      row.specStack->setCurrentIndex(PageSerial);
+      break;
+    case HostSerialConnector::BackendLocalSocket:
+      row.specStack->setCurrentIndex(PageSocket);
+      // Pre-fill with the default name if the field is empty so users
+      // who just pick "Local socket" get a working setup on Ok.
+      if (row.socketEdit->text().isEmpty())
+        row.socketEdit->setText(defaultSocketName(index));
+      break;
+    default:
+      row.specStack->setCurrentIndex(PageNone);
+      break;
+  }
+}
+
+void SerialPortsDialog::populateSerialPortCombo(QComboBox * cb, const QString & currentPortName)
 {
   cb->clear();
   cb->addItem(tr("Not Assigned"), "");
-  if (currentPortName == "") {
+  if (currentPortName.isEmpty())
     cb->setCurrentIndex(0);
-  }
 
   const auto serialPortInfos = QSerialPortInfo::availablePorts();
   for (int i = 0; i < serialPortInfos.size(); i++) {
@@ -62,6 +182,33 @@ void SerialPortsDialog::populateSerialPortCombo(QComboBox * cb, QString currentP
   }
 }
 
+void SerialPortsDialog::writeOutputs()
+{
+  const auto readRow = [this](int index, int & outKind, QString & outSpec) {
+    PortRow & row = auxRows[index];
+    const int kind = row.typeCombo->currentData().toInt();
+    outKind = kind;
+    switch (kind) {
+      case HostSerialConnector::BackendSerialPort:
+        outSpec = row.serialCombo->currentData().toString();
+        break;
+      case HostSerialConnector::BackendLocalSocket: {
+        QString name = row.socketEdit->text().trimmed();
+        if (name.isEmpty())
+          name = defaultSocketName(index);
+        outSpec = name;
+        break;
+      }
+      default:
+        outSpec.clear();
+        break;
+    }
+  };
+
+  readRow(0, aux1Kind, aux1Spec);
+  readRow(1, aux2Kind, aux2Spec);
+}
+
 void SerialPortsDialog::on_cancelButton_clicked()
 {
   this->reject();
@@ -69,21 +216,16 @@ void SerialPortsDialog::on_cancelButton_clicked()
 
 void SerialPortsDialog::on_okButton_clicked()
 {
+  writeOutputs();
   this->accept();
 }
 
 void SerialPortsDialog::on_refreshButton_clicked()
 {
-  populateSerialPortCombo(ui->aux1Combo, aux1);
-  populateSerialPortCombo(ui->aux2Combo, aux2);
-}
-
-void SerialPortsDialog::on_aux1Combo_currentIndexChanged(int index)
-{
-  aux1 = ui->aux1Combo->itemData(index).toString();
-}
-
-void SerialPortsDialog::on_aux2Combo_currentIndexChanged(int index)
-{
-  aux2 = ui->aux2Combo->itemData(index).toString();
+  // Preserve current selection across refresh.
+  for (int i = 0; i < 2; i++) {
+    PortRow & row = auxRows[i];
+    const QString current = row.serialCombo->currentData().toString();
+    populateSerialPortCombo(row.serialCombo, current);
+  }
 }

--- a/companion/src/simulation/serialportsdialog.h
+++ b/companion/src/simulation/serialportsdialog.h
@@ -21,14 +21,17 @@
 
 #pragma once
 
+#include "hostserialconnector.h"
+#include "simulatorinterface.h"
+
 #include <QSerialPort>
 #include <QSerialPortInfo>
 #include <QtWidgets>
 
-#include "simulatorinterface.h"
-#include "hostserialconnector.h"
-
 class QComboBox;
+class QLabel;
+class QLineEdit;
+class QStackedWidget;
 
 namespace Ui {
     class SerialPortsDialog;
@@ -41,19 +44,45 @@ class SerialPortsDialog : public QDialog
   public:
     explicit SerialPortsDialog(QWidget *parent, SimulatorInterface *simulator, HostSerialConnector *connector);
     ~SerialPortsDialog();
-    QString aux1;
-    QString aux2;
+
+    // Output state, read by SimulatorMainWindow on accept().
+    int aux1Kind;
+    QString aux1Spec;
+    int aux2Kind;
+    QString aux2Spec;
+
     SimulatorInterface *simulator;
     HostSerialConnector *connector;
 
   private:
+    // Stack page indices for the per-port spec stack.
+    enum SpecPage {
+      PageNone = 0,
+      PageSerial,
+      PageSocket,
+    };
+
+    struct PortRow {
+      QComboBox * typeCombo = nullptr;
+      QStackedWidget * specStack = nullptr;
+      QComboBox * serialCombo = nullptr;
+      QLineEdit * socketEdit = nullptr;
+      QLabel * socketStatusLabel = nullptr;
+    };
+
+    PortRow auxRows[2];
+
     Ui::SerialPortsDialog *ui;
 
+    void buildPortRow(int row, const QString & label);
+    void loadPortState(int index);
+    void onTypeChanged(int index, int comboIndex);
+    void populateSerialPortCombo(QComboBox * cb, const QString & currentPortName);
+    static QString defaultSocketName(int index);
+    void writeOutputs();
+
   private slots:
-    void populateSerialPortCombo(QComboBox * cb, QString currentPortName);
     void on_cancelButton_clicked();
     void on_okButton_clicked();
     void on_refreshButton_clicked();
-    void on_aux1Combo_currentIndexChanged(int index);
-    void on_aux2Combo_currentIndexChanged(int index);
 };

--- a/companion/src/simulation/serialportsdialog.ui
+++ b/companion/src/simulation/serialportsdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>558</width>
-    <height>108</height>
+    <width>620</width>
+    <height>180</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -19,98 +19,54 @@
   <property name="windowTitle">
    <string>Configure Serial Ports</string>
   </property>
-  <widget class="QWidget" name="layoutWidget">
-   <property name="geometry">
-    <rect>
-     <x>10</x>
-     <y>10</y>
-     <width>534</width>
-     <height>89</height>
-    </rect>
-   </property>
-   <layout class="QGridLayout" name="gridLayout">
-    <item row="0" column="0">
-     <widget class="QLabel" name="aux1Label">
-      <property name="text">
-       <string>AUX1 Port</string>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="3">
-     <spacer name="horizontalSpacer_2">
-      <property name="orientation">
-       <enum>Qt::Horizontal</enum>
-      </property>
-      <property name="sizeHint" stdset="0">
-       <size>
-        <width>360</width>
-        <height>20</height>
-       </size>
-      </property>
-     </spacer>
-    </item>
-    <item row="2" column="0" colspan="2">
-     <widget class="QPushButton" name="cancelButton">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="text">
-       <string>Cancel</string>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="0">
-     <widget class="QLabel" name="aux2Label">
-      <property name="text">
-       <string>AUX2 Port</string>
-      </property>
-     </widget>
-    </item>
-    <item row="0" column="1" colspan="4">
-     <widget class="QComboBox" name="aux1Combo">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-     </widget>
-    </item>
-    <item row="1" column="1" colspan="4">
-     <widget class="QComboBox" name="aux2Combo">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="4">
-     <widget class="QPushButton" name="okButton">
-      <property name="sizePolicy">
-       <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-        <horstretch>0</horstretch>
-        <verstretch>0</verstretch>
-       </sizepolicy>
-      </property>
-      <property name="text">
-       <string>Ok</string>
-      </property>
-     </widget>
-    </item>
-    <item row="2" column="2">
-     <widget class="QPushButton" name="refreshButton">
-      <property name="text">
-       <string>Search for Serial Ports</string>
-      </property>
-     </widget>
-    </item>
-   </layout>
-  </widget>
+  <layout class="QVBoxLayout" name="mainLayout">
+   <item>
+    <widget class="QGroupBox" name="portsGroup">
+     <property name="title">
+      <string/>
+     </property>
+     <layout class="QGridLayout" name="portsLayout"/>
+    </widget>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="buttonLayout">
+     <item>
+      <widget class="QPushButton" name="cancelButton">
+       <property name="text">
+        <string>Cancel</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="refreshButton">
+       <property name="text">
+        <string>Search for Serial Ports</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="okButton">
+       <property name="text">
+        <string>Ok</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
  </widget>
  <resources/>
  <connections/>

--- a/companion/src/simulation/simulatormainwindow.cpp
+++ b/companion/src/simulation/simulatormainwindow.cpp
@@ -505,8 +505,8 @@ void SimulatorMainWindow::openSerialPortsDialog(bool)
 {
   SerialPortsDialog * dialog = new SerialPortsDialog(this, m_simulator, hostSerialConnector);
   if (dialog->exec() == QDialog::Accepted && m_simulator) {
-    hostSerialConnector->connectSerialPort(0, dialog->aux1);
-    hostSerialConnector->connectSerialPort(1, dialog->aux2);
+    hostSerialConnector->connectBackend(0, dialog->aux1Kind, dialog->aux1Spec);
+    hostSerialConnector->connectBackend(1, dialog->aux2Kind, dialog->aux2Spec);
   }
   dialog->deleteLater();
 }

--- a/companion/src/simulation/simulatormainwindow.cpp
+++ b/companion/src/simulation/simulatormainwindow.cpp
@@ -172,6 +172,12 @@ SimulatorMainWindow::SimulatorMainWindow(QWidget *parent, const QString & simula
   connect(m_simulator, &SimulatorInterface::auxSerialSetBaudrate, hostSerialConnector, &HostSerialConnector::setSerialBaudRate);
   connect(m_simulator, &SimulatorInterface::auxSerialStart, hostSerialConnector, &HostSerialConnector::serialStart);
   connect(m_simulator, &SimulatorInterface::auxSerialStop, hostSerialConnector, &HostSerialConnector::serialStop);
+  connect(hostSerialConnector, &HostSerialConnector::backendError, this,
+          [this](int index, const QString & message) {
+            QMessageBox::warning(this, tr("Host Serial Error"),
+                                 tr("AUX%1: %2").arg(index + 1).arg(message),
+                                 QMessageBox::Cancel, QMessageBox::Cancel);
+          });
   connect(m_simulator, &SimulatorInterface::txBatteryVoltageChanged, this, &SimulatorMainWindow::onTxBatteryVoltageChanged);
 }
 


### PR DESCRIPTION
## Summary

Lets simulator aux serial ports talk to a local socket (`QLocalServer` — AF_UNIX on macOS / Linux, named pipes on Windows), so user scripts can stand in for hardware without a USB-serial adapter. Backends are now pluggable behind a `HostSerialBackend` interface; the existing `QSerialPort` path is the other implementation. Configure via *Settings → Configure Serial Ports*; the dialog gains a per-port type selector and shows the resolved socket path.

Stacked on #7284 — review that first.

## Test plan

- [ ] Pick *Local socket* for an AUX port, exchange bytes with a Python `AF_UNIX` client at `/tmp/edgetx-sim-aux1`.
- [ ] Switch back to *Serial port*, confirm a real USB-serial device still works (refactor regression check).
- [ ] Re-open the dialog and confirm the current type + spec round-trip.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple serial transport backends, including local socket connections alongside traditional serial ports.
  * Enhanced Serial Ports dialog with backend type selection and configuration options.

* **Bug Fixes**
  * Improved error reporting and handling for serial communication failures.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EdgeTX/edgetx/pull/7285)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->