### PR TITLE
fix(lua): numberEdit getter and prevent fillTriangle crash

### DIFF
--- a/radio/src/gui/colorlcd/libui/numberedit.cpp
+++ b/radio/src/gui/colorlcd/libui/numberedit.cpp
@@ -300,3 +300,15 @@ void NumberEdit::setValue(int value)
   updateDisplay();
   if (edit) edit->update();
 }
+
+void NumberEdit::checkEvents()
+{
+  if (_getValue) {
+    int newValue = _getValue();
+    if (newValue != currentValue) {
+      currentValue = newValue;
+      updateDisplay();
+    }
+  }
+  TextButton::checkEvents();
+}

--- a/radio/src/gui/colorlcd/libui/numberedit.h
+++ b/radio/src/gui/colorlcd/libui/numberedit.h
@@ -120,4 +120,6 @@ class NumberEdit : public TextButton
 
   void updateDisplay();
   void openEdit();
+
+  void checkEvents() override;
 };

--- a/radio/src/lua/lua_lvgl_widget.cpp
+++ b/radio/src/lua/lua_lvgl_widget.cpp
@@ -1337,8 +1337,8 @@ next2:
   }
 next:
   // Second half
-  dx1 = (int8_t)(x3 - x2); if(dx1<0) { dx1 = -dx1; signx1 = -1; } else signx1 = 1;
-  dy1 = (int8_t)(y3 - y2);
+  dx1 = (coord_t)(x3 - x2); if(dx1<0) { dx1 = -dx1; signx1 = -1; } else signx1 = 1;
+  dy1 = (coord_t)(y3 - y2);
   t1x = x2;
 
   if (dy1 > dx1) { // swap values


### PR DESCRIPTION
This PR fixes two disjoint LUA problems:

* the `numberEdit` `get`-function isn't called after creating
* the `triangle` draws wrong figures or crashes the radio for special point coordinates

This PR contains the patches and great work from @philmoz , my part is only to write this PR.

Fixes #7244