### PR TITLE
fix(lua): pack TValue and TKey structs to reduce RAM usage

### DIFF
--- a/radio/src/thirdparty/Lua/src/lobject.h
+++ b/radio/src/thirdparty/Lua/src/lobject.h
@@ -117,19 +117,17 @@ typedef union Value {
 } Value;
 
 
-#define TValuefields	Value value_; int tt_
+#define TValuefields	Value value_; lu_byte tt_
 
-// #ifdef LUA_USE_ESP
-// #  pragma pack(4)
-// #endif
+#if defined(__GNUC__) || defined(__clang__)
+#define LUA_PACKED __attribute__((__packed__))
+#else
+#define LUA_PACKED
+#endif
 
-typedef struct lua_TValue {
+typedef struct LUA_PACKED lua_TValue {
   TValuefields;
 } TValue;
-
-// #ifdef LUA_USE_ESP
-// #  pragma pack()
-// #endif
 
 /* macro defining a nil value */
 #define NILCONSTANT	{NULL}, LUA_TNIL
@@ -509,7 +507,7 @@ typedef union Closure {
 */
 
 typedef union TKey {
-  struct {
+  struct LUA_PACKED {
     TValuefields;
     int next;  /* for chaining (offset for next node) */
   } nk;


### PR DESCRIPTION
The Lua 5.2 → 5.3 upgrade (2.11) changed `TValue.tt_` from `int8_t (packed)` to `int` (unpacked), inflating every `TValue` from 5 to 8 bytes and every table Node from 14 to 20 bytes on 32-bit ARM.

This restores the packed layout by using `lu_byte` for `tt_` (all tag values fit in 0–102) and `__attribute__((packed))` on `TValue` and `TKey`.

On STM32 (Cortex-M3/M4) this saves 3 bytes per `TValue` and 6 bytes per table hash Node, recovering significant RAM for Lua scripts on memory-constrained radios like the X9D (STM32F2, 128KB RAM).

Fixes #7251
