### PR TITLE
feat: support POWER_LED_BLUE compile option on H7 RM/JP radios

### DIFF
--- a/radio/src/boards/jumper-h750/board.cpp
+++ b/radio/src/boards/jumper-h750/board.cpp
@@ -131,7 +131,11 @@ void boardInit()
   delaysInit();
   timersInit();
 
-  gpio_set(LED_BLUE_GPIO);
+#if !defined(POWER_LED_BLUE)
+  ledBlue();
+#else
+  ledGreen();
+#endif
 
   ExtFLASH_InitRuntime();
 

--- a/radio/src/boards/rm-h750/board.cpp
+++ b/radio/src/boards/rm-h750/board.cpp
@@ -170,7 +170,11 @@ void boardInit()
   timersInit();
 
   usbChargerInit();
-  gpio_set(LED_BLUE_GPIO);
+#if !defined(POWER_LED_BLUE)
+  ledBlue();
+#else
+  ledGreen();
+#endif
 
   ExtFLASH_InitRuntime();
 


### PR DESCRIPTION
Needed for 2.12 too I guess
