### PR TITLE
fix(afhds2): add missing txCompleted to prevent crash on NV14

### DIFF
--- a/radio/src/pulses/afhds2.cpp
+++ b/radio/src/pulses/afhds2.cpp
@@ -95,4 +95,5 @@ const etx_proto_driver_t Afhds2InternalDriver = {
   .processData = afhds2ProcessData,
   .processFrame = nullptr,
   .onConfigChange = nullptr,
+  .txCompleted = modulePortSerialTxCompleted,
 };

--- a/radio/src/pulses/pulses.cpp
+++ b/radio/src/pulses/pulses.cpp
@@ -565,7 +565,7 @@ void pulsesSendNextFrame(uint8_t module)
     }
 
     // if previous frame not completed, skip this one
-    if (!drv->txCompleted(ctx)) return;
+    if (drv->txCompleted && !drv->txCompleted(ctx)) return;
 
     uint8_t channelStart = g_model.moduleData[module].channelsStart;
     int16_t* channels = &channelOutputs[channelStart];


### PR DESCRIPTION
Fixes #7286
Supersedes #7300

## Summary

- `Afhds2InternalDriver` was missing the `.txCompleted` callback (left as `nullptr`), and `pulsesSendNextFrame()` called it without a null check — crashing (rebooting) the NV14 when the internal AFHDS2A module was enabled.
- Use `modulePortSerialTxCompleted` as the callback, consistent with every other serial protocol driver (multi, crossfire, ghost, sbus, dsm2, pxx1, pxx2, dsmp).
- Add a null guard in the caller so a missing `.txCompleted` is treated as "completed" rather than crashing — same pattern already used for `.onConfigChange`.

## Test plan

- [x] NV14 with internal AFHDS2A module: enable module, verify no reboot
- [x] Verify AFHDS2A binding and channel output still work correctly