### PR TITLE
fix(cpn): new settings use default stick mode and channel order

### DIFF
--- a/companion/src/firmwares/generalsettings.cpp
+++ b/companion/src/firmwares/generalsettings.cpp
@@ -235,6 +235,8 @@ void GeneralSettings::init()
   hatsMode = HATSMODE_SWITCHABLE;
   inactivityTimer = 10;
   internalModule = g.profile[g.sessionId()].defaultInternalModule();
+  stickMode = g.profile[g.sessionId()].defaultMode();
+  templateSetup = g.profile[g.sessionId()].channelOrder();
 
   QString lang = getCurrentFirmware()->getLanguage();
   if (lang.size() > 1) {


### PR DESCRIPTION
Fixes #7290

Summary of changes:
- use radio profile Default Stick Mode and Default Channel Order when creating a new models and settings files

Note: this is overridden if the radio profile has use backup for new models and settings selected and there is a backup