### PR TITLE
chore(cpn): radio profile settings default options ui

### DIFF
--- a/companion/src/apppreferencesdialog.cpp
+++ b/companion/src/apppreferencesdialog.cpp
@@ -335,10 +335,6 @@ void AppPreferencesDialog::initSettings()
   ui->externalModuleSizeCB->setCurrentIndex(ui->externalModuleSizeCB->findData(profile.externalModuleSize()));
   panelItemModels->getItemModel(FIM_TEMPLATESETUP)->setFilterFlags(Boards::isAir() ? GeneralSettings::RadioTypeContextAir :
                                                                                      GeneralSettings::RadioTypeContextSurface);
-  ui->channelorderCB->setModel(panelItemModels->getItemModel(FIM_TEMPLATESETUP));
-  ui->channelorderCB->setCurrentIndex(ui->channelorderCB->findData(profile.channelOrder()));
-  ui->stickmodeCB->setModel(GeneralSettings::stickModeItemModel());
-  ui->stickmodeCB->setCurrentIndex(ui->stickmodeCB->findData(profile.defaultMode()));
   ui->sdPath->setText(profile.sdPath());
 
   ui->profileBackupPath->setText(profile.pBackupDir());
@@ -358,28 +354,36 @@ void AppPreferencesDialog::initSettings()
     ui->profileBackupEnable->setEnabled(false);
   }
 
-  if (Boards::isSurface()) {
-    ui->stickmodeLabel->hide();
-    ui->stickmodeCB->hide();
-  }
-
   ui->profileNameLE->setText(profile.name());
 
   QString hwSettings;
 
   if (profile.generalSettings().isEmpty()) {
-    hwSettings = tr("EMPTY: No radio settings stored in profile");
+    hwSettings = tr("No backup available for this profile");
   }
   else  {
     QString str = profile.timeStamp();
     if (str.isEmpty())
-      hwSettings = tr("AVAILABLE: Radio settings of unknown age");
+      hwSettings = tr("Backup available of unknown age");
     else
-      hwSettings = tr("AVAILABLE: Radio settings stored %1").arg(str);
+      hwSettings = tr("Backup available dated %1").arg(str);
   }
+
+  ui->stickmodeCB->setModel(GeneralSettings::stickModeItemModel());
+  ui->stickmodeCB->setCurrentIndex(ui->stickmodeCB->findData(profile.defaultMode()));
+
+  if (Boards::isSurface()) {
+    ui->stickmodeLabel->hide();
+    ui->stickmodeCB->hide();
+  }
+
+  ui->channelorderCB->setModel(panelItemModels->getItemModel(FIM_TEMPLATESETUP));
+  ui->channelorderCB->setCurrentIndex(ui->channelorderCB->findData(profile.channelOrder()));
 
   ui->chkUseSavedSettingsProfile->setChecked(profile.useSavedSettings());
   ui->lblGeneralSettings->setText(hwSettings);
+  on_chkUseSavedSettingsProfile_stateChanged();
+
   ui->chkPromptSDSync->setChecked(profile.runSDSync());
   ui->lblRadioColorSample->setPalette(QPalette(profile.radioSimCaseColor()));
   ui->chkSimBtnClickedUseOSTheme->setChecked(profile.simBtnClickedUseOSTheme());
@@ -919,6 +923,7 @@ void AppPreferencesDialog::onProfileBackupPathEditingFinished()
     ui->profileBackupEnable->setEnabled(false);
   }
 }
+
 void AppPreferencesDialog::on_chkSimBtnClickedUseOSTheme_stateChanged()
 {
   if (ui->chkSimBtnClickedUseOSTheme->isChecked()) {
@@ -936,4 +941,19 @@ void AppPreferencesDialog::on_btnSimBtnClickedColor_clicked()
   QColor color = dlg->getColor(g.currentProfile().simBtnClickedColor(), this);
   ui->lblSimBtnClickedColorSample->setPalette(QPalette(color));
   ui->lblSimBtnClickedColorSample->repaint();
+}
+
+void AppPreferencesDialog::on_chkUseSavedSettingsProfile_stateChanged()
+{
+  if (ui->chkUseSavedSettingsProfile->isChecked() && !g.currentProfile().generalSettings().isEmpty()) {
+    ui->stickmodeLabel->setEnabled(false);
+    ui->stickmodeCB->setEnabled(false);
+    ui->channelorderLabel->setEnabled(false);
+    ui->channelorderCB->setEnabled(false);
+  } else {
+    ui->stickmodeLabel->setEnabled(true);
+    ui->stickmodeCB->setEnabled(true);
+    ui->channelorderLabel->setEnabled(true);
+    ui->channelorderCB->setEnabled(true);
+  }
 }

--- a/companion/src/apppreferencesdialog.h
+++ b/companion/src/apppreferencesdialog.h
@@ -84,6 +84,7 @@ class AppPreferencesDialog : public QDialog
     void on_btnSimBtnClickedColor_clicked();
     void onBackupPathEditingFinished();
     void onProfileBackupPathEditingFinished();
+    void on_chkUseSavedSettingsProfile_stateChanged();
 
   private:
     void initSettings();

--- a/companion/src/apppreferencesdialog.ui
+++ b/companion/src/apppreferencesdialog.ui
@@ -26,17 +26,7 @@
    <bool>true</bool>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="4" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Orientation::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
+   <item row="5" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -52,307 +42,42 @@
        <string>Radio Profile</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,0,0,0,0">
-       <item row="14" column="2">
-        <widget class="QLabel" name="lblGeneralSettings">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string notr="true">Radio Settings Label</string>
-         </property>
-        </widget>
-       </item>
-       <item row="17" column="2">
-        <widget class="QComboBox" name="stickmodeCB">
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="whatsThis">
-          <string>Mode selection:
-
-Mode 1:
-  Left stick:  Elevator, Rudder
-  Right stick:  Throttle, Aileron
-
-Mode 2:
-  Left stick:  Throttle, Rudder
-  Right stick:  Elevator, Aileron
-
-Mode 3:
-  Left stick:  Elevator, Aileron
-  Right stick:  Throttle, Rudder
-
-Mode 4:
-  Left stick:  Throttle, Aileron
-  Right stick:  Elevator, Rudder
-
-</string>
-         </property>
-         <property name="currentIndex">
-          <number>1</number>
-         </property>
-         <item>
-          <property name="text">
-           <string>Mode 1 (RUD ELE THR AIL)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Mode 2 (RUD THR ELE AIL)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Mode 3 (AIL ELE THR RUD)</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>Mode 4 (AIL THR ELE RUD)</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="langLabel">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Language</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="18" column="0">
-        <widget class="QLabel" name="channelorderLabel">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Default Channel Order</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
        <item row="23" column="2">
-        <widget class="QCheckBox" name="profileBackupEnable">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="toolTip">
-          <string>if set, will override general backup enable</string>
-         </property>
-         <property name="text">
-          <string>Prompt to backup current firmware before writing firmware</string>
-         </property>
-        </widget>
+        <layout class="QHBoxLayout" name="horizontalLayout_5">
+         <item>
+          <widget class="QCheckBox" name="chkSimBtnClickedUseOSTheme">
+           <property name="text">
+            <string>Operating System theme</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="lblSimBtnClickedColorSample">
+           <property name="autoFillBackground">
+            <bool>true</bool>
+           </property>
+           <property name="frameShape">
+            <enum>QFrame::Shape::Box</enum>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_29">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
-       <item row="2" column="0">
-        <widget class="QLabel" name="label_7">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="font">
-          <font>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Radio Type</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="25" column="2">
-        <widget class="QCheckBox" name="burnFirmware">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Prompt to write firmware to radio after update</string>
-         </property>
-        </widget>
-       </item>
-       <item row="18" column="2">
-        <widget class="QComboBox" name="channelorderCB">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="whatsThis">
-          <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-         <property name="currentIndex">
-          <number>0</number>
-         </property>
-         <item>
-          <property name="text">
-           <string>R E T A</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>R E A T</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>R T E A</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>R T A E</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>R A E T</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>R A T E</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>E R T A</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>E R A T</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>E T R A</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>E T A R</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>E A R T</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>E A T R</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>T R E A</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>T R A E</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>T E R A</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>T E A R</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>T A R E</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>T A E R</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>A R E T</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>A R T E</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>A E R T</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>A E T R</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>A T R E</string>
-          </property>
-         </item>
-         <item>
-          <property name="text">
-           <string>A T E R</string>
-          </property>
-         </item>
-        </widget>
-       </item>
-       <item row="9" column="3" colspan="2">
-        <widget class="QPushButton" name="sdPathButton">
-         <property name="text">
-          <string>Select Folder</string>
-         </property>
-        </widget>
-       </item>
-       <item row="16" column="0">
-        <widget class="QLabel" name="label_18">
-         <property name="text">
-          <string>External Module</string>
-         </property>
-        </widget>
+       <item row="19" column="2">
+        <widget class="QComboBox" name="externalModuleSizeCB"/>
        </item>
        <item row="0" column="0">
         <widget class="QLabel" name="label_2">
@@ -372,44 +97,31 @@ Mode 4:
          </property>
         </widget>
        </item>
-       <item row="10" column="3" colspan="2">
-        <widget class="QPushButton" name="profileBackupPathButton">
-         <property name="toolTip">
-          <string>The profile specific folder,  if set, will override general Backup folder</string>
-         </property>
-         <property name="text">
-          <string>Select Folder</string>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0">
-        <widget class="QLabel" name="label_6">
+       <item row="24" column="0" colspan="5">
+        <widget class="Line" name="line_9">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="text">
-          <string>Options</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+         <property name="orientation">
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
         </widget>
        </item>
-       <item row="27" column="2">
-        <spacer name="verticalSpacer_3">
+       <item row="6" column="0" colspan="5">
+        <widget class="Line" name="splashSeparator">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="orientation">
-          <enum>Qt::Orientation::Vertical</enum>
+          <enum>Qt::Orientation::Horizontal</enum>
          </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>5</height>
-          </size>
-         </property>
-        </spacer>
+        </widget>
        </item>
        <item row="12" column="0">
         <widget class="QLabel" name="label_4">
@@ -424,10 +136,35 @@ Mode 4:
          </property>
         </widget>
        </item>
-       <item row="20" column="0">
-        <widget class="QLabel" name="label_26">
+       <item row="18" column="0">
+        <widget class="QLabel" name="label_21">
          <property name="text">
-          <string>Simulator Button Clicked Colour</string>
+          <string>Default Int. Module</string>
+         </property>
+        </widget>
+       </item>
+       <item row="29" column="2">
+        <widget class="QCheckBox" name="chkPromptSDSync">
+         <property name="text">
+          <string>Prompt to run SD Sync after update</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0" colspan="5">
+        <widget class="QLabel" name="label">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Other Settings</string>
          </property>
         </widget>
        </item>
@@ -444,25 +181,36 @@ Mode 4:
          </property>
         </widget>
        </item>
-       <item row="10" column="2">
-        <widget class="QLineEdit" name="profileBackupPath">
-         <property name="toolTip">
-          <string>If set it will override the application general setting</string>
-         </property>
-         <property name="readOnly">
-          <bool>false</bool>
-         </property>
-         <property name="clearButtonEnabled">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="26" column="2">
-        <widget class="QCheckBox" name="chkPromptSDSync">
-         <property name="text">
-          <string>Prompt to run SD Sync after update</string>
-         </property>
-        </widget>
+       <item row="22" column="2">
+        <layout class="QHBoxLayout" name="horizontalLayout_6">
+         <item>
+          <widget class="QLabel" name="lblRadioColorSample">
+           <property name="autoFillBackground">
+            <bool>true</bool>
+           </property>
+           <property name="frameShape">
+            <enum>QFrame::Shape::Box</enum>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_27">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QLabel" name="label_28">
+           <property name="text">
+            <string/>
+           </property>
+          </widget>
+         </item>
+        </layout>
        </item>
        <item row="5" column="2">
         <widget class="QWidget" name="optionsWidget" native="true">
@@ -494,8 +242,63 @@ Mode 4:
          </layout>
         </widget>
        </item>
-       <item row="15" column="2">
-        <widget class="QComboBox" name="defaultInternalModuleCB"/>
+       <item row="2" column="2">
+        <widget class="QComboBox" name="boardCB">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="26" column="0">
+        <widget class="QLabel" name="label_25">
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Updates</string>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="2">
+        <widget class="QLineEdit" name="sdPath">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="text">
+          <string/>
+         </property>
+         <property name="readOnly">
+          <bool>false</bool>
+         </property>
+         <property name="clearButtonEnabled">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item row="19" column="0">
+        <widget class="QLabel" name="label_18">
+         <property name="text">
+          <string>External Module</string>
+         </property>
+        </widget>
+       </item>
+       <item row="26" column="2">
+        <widget class="QCheckBox" name="profileBackupEnable">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>if set, will override general backup enable</string>
+         </property>
+         <property name="text">
+          <string>Prompt to backup current firmware before writing firmware</string>
+         </property>
+        </widget>
        </item>
        <item row="9" column="0">
         <widget class="QLabel" name="sdPathLabel">
@@ -507,6 +310,146 @@ Mode 4:
          </property>
          <property name="text">
           <string>SD Structure path</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="30" column="2">
+        <spacer name="verticalSpacer_3">
+         <property name="orientation">
+          <enum>Qt::Orientation::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>5</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+       <item row="5" column="0">
+        <widget class="QLabel" name="label_6">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Options</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignTop</set>
+         </property>
+        </widget>
+       </item>
+       <item row="9" column="3" colspan="2">
+        <widget class="QPushButton" name="sdPathButton">
+         <property name="text">
+          <string>Select Folder</string>
+         </property>
+        </widget>
+       </item>
+       <item row="28" column="2">
+        <widget class="QCheckBox" name="burnFirmware">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Prompt to write firmware to radio after update</string>
+         </property>
+        </widget>
+       </item>
+       <item row="14" column="2">
+        <widget class="QLabel" name="lblGeneralSettings">
+         <property name="enabled">
+          <bool>true</bool>
+         </property>
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string notr="true">Radio Settings Label</string>
+         </property>
+        </widget>
+       </item>
+       <item row="12" column="2">
+        <widget class="QCheckBox" name="chkUseSavedSettingsProfile">
+         <property name="text">
+          <string>Use backup for new models and settings files</string>
+         </property>
+        </widget>
+       </item>
+       <item row="22" column="0">
+        <widget class="QLabel" name="label_24">
+         <property name="text">
+          <string>Simulator Radio Case Colour</string>
+         </property>
+        </widget>
+       </item>
+       <item row="23" column="3">
+        <widget class="QPushButton" name="btnSimBtnClickedColor">
+         <property name="enabled">
+          <bool>false</bool>
+         </property>
+         <property name="text">
+          <string>Select Colour</string>
+         </property>
+        </widget>
+       </item>
+       <item row="22" column="3">
+        <widget class="QPushButton" name="btnRadioColor">
+         <property name="text">
+          <string>Select Colour</string>
+         </property>
+        </widget>
+       </item>
+       <item row="10" column="3" colspan="2">
+        <widget class="QPushButton" name="profileBackupPathButton">
+         <property name="toolTip">
+          <string>The profile specific folder,  if set, will override general Backup folder</string>
+         </property>
+         <property name="text">
+          <string>Select Folder</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="2">
+        <widget class="QComboBox" name="langCombo">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <widget class="QLineEdit" name="profileNameLE"/>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_7">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="font">
+          <font>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>Radio Type</string>
          </property>
          <property name="alignment">
           <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
@@ -629,81 +572,6 @@ Mode 4:
          </layout>
         </widget>
        </item>
-       <item row="0" column="2">
-        <widget class="QLineEdit" name="profileNameLE"/>
-       </item>
-       <item row="9" column="2">
-        <widget class="QLineEdit" name="sdPath">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-         <property name="text">
-          <string/>
-         </property>
-         <property name="readOnly">
-          <bool>false</bool>
-         </property>
-         <property name="clearButtonEnabled">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="8" column="0" colspan="5">
-        <widget class="QLabel" name="label">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="font">
-          <font>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Other Settings</string>
-         </property>
-        </widget>
-       </item>
-       <item row="6" column="0" colspan="5">
-        <widget class="Line" name="splashSeparator">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="orientation">
-          <enum>Qt::Orientation::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="23" column="0">
-        <widget class="QLabel" name="label_25">
-         <property name="font">
-          <font>
-           <bold>true</bold>
-          </font>
-         </property>
-         <property name="text">
-          <string>Updates</string>
-         </property>
-        </widget>
-       </item>
-       <item row="17" column="0">
-        <widget class="QLabel" name="stickmodeLabel">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="text">
-          <string>Default Stick Mode</string>
-         </property>
-        </widget>
-       </item>
        <item row="10" column="0">
         <widget class="QLabel" name="profilebackupPathLabel">
          <property name="sizePolicy">
@@ -720,97 +588,116 @@ Mode 4:
          </property>
         </widget>
        </item>
-       <item row="15" column="0">
-        <widget class="QLabel" name="label_21">
-         <property name="text">
-          <string>Default Int. Module</string>
+       <item row="10" column="2">
+        <widget class="QLineEdit" name="profileBackupPath">
+         <property name="toolTip">
+          <string>If set it will override the application general setting</string>
          </property>
-        </widget>
-       </item>
-       <item row="16" column="2">
-        <widget class="QComboBox" name="externalModuleSizeCB"/>
-       </item>
-       <item row="21" column="0" colspan="5">
-        <widget class="Line" name="line_9">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
+         <property name="readOnly">
+          <bool>false</bool>
          </property>
-         <property name="orientation">
-          <enum>Qt::Orientation::Horizontal</enum>
-         </property>
-        </widget>
-       </item>
-       <item row="19" column="0">
-        <widget class="QLabel" name="label_24">
-         <property name="text">
-          <string>Simulator Radio Case Colour</string>
-         </property>
-        </widget>
-       </item>
-       <item row="12" column="2">
-        <widget class="QCheckBox" name="chkUseSavedSettingsProfile">
-         <property name="text">
-          <string>Use settings backup for new models and settings files</string>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="2">
-        <widget class="QComboBox" name="langCombo">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="2">
-        <widget class="QComboBox" name="boardCB">
-         <property name="enabled">
+         <property name="clearButtonEnabled">
           <bool>true</bool>
          </property>
         </widget>
        </item>
-       <item row="20" column="3">
-        <widget class="QPushButton" name="btnSimBtnClickedColor">
-         <property name="enabled">
-          <bool>false</bool>
+       <item row="4" column="0">
+        <widget class="QLabel" name="langLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
          </property>
          <property name="text">
-          <string>Select Colour</string>
+          <string>Language</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
          </property>
         </widget>
        </item>
-       <item row="20" column="2">
-        <layout class="QHBoxLayout" name="horizontalLayout_5">
+       <item row="18" column="2">
+        <widget class="QComboBox" name="defaultInternalModuleCB"/>
+       </item>
+       <item row="23" column="0">
+        <widget class="QLabel" name="label_26">
+         <property name="text">
+          <string>Simulator Button Clicked Colour</string>
+         </property>
+        </widget>
+       </item>
+       <item row="15" column="2">
+        <layout class="QHBoxLayout" name="horizontalLayout_12">
          <item>
-          <widget class="QCheckBox" name="chkSimBtnClickedUseOSTheme">
-           <property name="text">
-            <string>Operating System theme</string>
+          <widget class="QLabel" name="stickmodeLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
            </property>
-           <property name="checked">
-            <bool>true</bool>
+           <property name="text">
+            <string>Default Stick Mode</string>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QLabel" name="lblSimBtnClickedColorSample">
-           <property name="autoFillBackground">
-            <bool>true</bool>
+          <widget class="QComboBox" name="stickmodeCB">
+           <property name="maximumSize">
+            <size>
+             <width>16777215</width>
+             <height>16777215</height>
+            </size>
            </property>
-           <property name="frameShape">
-            <enum>QFrame::Shape::Box</enum>
+           <property name="whatsThis">
+            <string>Mode selection:
+
+Mode 1:
+  Left stick:  Elevator, Rudder
+  Right stick:  Throttle, Aileron
+
+Mode 2:
+  Left stick:  Throttle, Rudder
+  Right stick:  Elevator, Aileron
+
+Mode 3:
+  Left stick:  Elevator, Aileron
+  Right stick:  Throttle, Rudder
+
+Mode 4:
+  Left stick:  Throttle, Aileron
+  Right stick:  Elevator, Rudder
+
+</string>
            </property>
-           <property name="text">
-            <string/>
+           <property name="currentIndex">
+            <number>1</number>
            </property>
+           <item>
+            <property name="text">
+             <string>Mode 1 (RUD ELE THR AIL)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Mode 2 (RUD THR ELE AIL)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Mode 3 (AIL ELE THR RUD)</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>Mode 4 (AIL THR ELE RUD)</string>
+            </property>
+           </item>
           </widget>
          </item>
          <item>
-          <widget class="QLabel" name="label_29">
+          <widget class="QLabel" name="label_30">
            <property name="text">
             <string/>
            </property>
@@ -818,43 +705,168 @@ Mode 4:
          </item>
         </layout>
        </item>
-       <item row="19" column="2">
-        <layout class="QHBoxLayout" name="horizontalLayout_6">
+       <item row="16" column="2">
+        <layout class="QHBoxLayout" name="horizontalLayout_13">
          <item>
-          <widget class="QLabel" name="lblRadioColorSample">
-           <property name="autoFillBackground">
-            <bool>true</bool>
-           </property>
-           <property name="frameShape">
-            <enum>QFrame::Shape::Box</enum>
+          <widget class="QLabel" name="channelorderLabel">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
            </property>
            <property name="text">
-            <string/>
+            <string>Default Channel Order</string>
+           </property>
+           <property name="alignment">
+            <set>Qt::AlignmentFlag::AlignLeading|Qt::AlignmentFlag::AlignLeft|Qt::AlignmentFlag::AlignVCenter</set>
            </property>
           </widget>
          </item>
          <item>
-          <widget class="QLabel" name="label_27">
-           <property name="text">
-            <string/>
+          <widget class="QComboBox" name="channelorderCB">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
            </property>
+           <property name="whatsThis">
+            <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;Channel order&lt;/p&gt;&lt;p&gt;&lt;br/&gt;&lt;/p&gt;&lt;p&gt;Defines the order of the default mixes created on a new model.&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+           </property>
+           <property name="currentIndex">
+            <number>0</number>
+           </property>
+           <item>
+            <property name="text">
+             <string>R E T A</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>R E A T</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>R T E A</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>R T A E</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>R A E T</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>R A T E</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>E R T A</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>E R A T</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>E T R A</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>E T A R</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>E A R T</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>E A T R</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>T R E A</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>T R A E</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>T E R A</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>T E A R</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>T A R E</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>T A E R</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>A R E T</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>A R T E</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>A E R T</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>A E T R</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>A T R E</string>
+            </property>
+           </item>
+           <item>
+            <property name="text">
+             <string>A T E R</string>
+            </property>
+           </item>
           </widget>
          </item>
          <item>
-          <widget class="QLabel" name="label_28">
+          <widget class="QLabel" name="label_31">
            <property name="text">
             <string/>
            </property>
           </widget>
          </item>
         </layout>
-       </item>
-       <item row="19" column="3">
-        <widget class="QPushButton" name="btnRadioColor">
-         <property name="text">
-          <string>Select Colour</string>
-         </property>
-        </widget>
        </item>
       </layout>
      </widget>
@@ -1799,6 +1811,16 @@ Mode 4:
      </widget>
     </widget>
    </item>
+   <item row="6" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Orientation::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::StandardButton::Cancel|QDialogButtonBox::StandardButton::Ok</set>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
  <tabstops>
@@ -1808,8 +1830,6 @@ Mode 4:
   <tabstop>sdPathButton</tabstop>
   <tabstop>profileBackupPath</tabstop>
   <tabstop>profileBackupPathButton</tabstop>
-  <tabstop>stickmodeCB</tabstop>
-  <tabstop>channelorderCB</tabstop>
   <tabstop>burnFirmware</tabstop>
   <tabstop>splashincludeCB</tabstop>
   <tabstop>snapshotPath</tabstop>


### PR DESCRIPTION
This moves Default Stick Mode and Default Channel Order within Radio Settings group and whether they are available for user editing based on backup setting and state.

<img width="464" height="89" alt="Screenshot 2026-04-20 123300" src="https://github.com/user-attachments/assets/ef88503a-f891-4576-9bb7-73a7e32204fd" />

<img width="469" height="89" alt="Screenshot 2026-04-20 122518" src="https://github.com/user-attachments/assets/5aa24c12-cd9c-43b4-a13c-4ca4de6b0862" />

<img width="479" height="88" alt="Screenshot 2026-04-20 122640" src="https://github.com/user-attachments/assets/71d95fea-ed21-4e37-983e-4dfdf128cda3" />

<img width="475" height="88" alt="Screenshot 2026-04-20 122604" src="https://github.com/user-attachments/assets/4d2d217c-0814-4a21-a8ce-5c83f4fd361c" />
