### PR TITLE
refactor(driver): move 6POS tracker into board-level ADC callback

### DIFF
--- a/radio/src/boards/generic_stm32/analog_inputs.cpp
+++ b/radio/src/boards/generic_stm32/analog_inputs.cpp
@@ -31,6 +31,10 @@
   #include "ads79xx.h"
 #endif
 
+#if defined(SIXPOS_SWITCH_INDEX)
+  #include "rgb_leds.h"
+#endif
+
 #include "definitions.h"
 
 #include "myeeprom.h"
@@ -85,6 +89,9 @@ static void adc_wait_completion()
   if (n_ADC_spi > 0) ads79xx_adc_wait_completion(&_ADC_spi[0], _ADC_inputs);
 #endif
   stm32_hal_adc_wait_completion(_ADC_adc, n_ADC, _ADC_inputs, n_inputs);
+#if defined(SIXPOS_SWITCH_INDEX)
+  sixPosUpdateFromAdc();
+#endif
 }
 
 const etx_hal_adc_driver_t _adc_driver = {

--- a/radio/src/boards/generic_stm32/rgb_6pos.cpp
+++ b/radio/src/boards/generic_stm32/rgb_6pos.cpp
@@ -23,29 +23,36 @@
 
 #if defined(SIXPOS_SWITCH_INDEX) && !defined(SIMU)
 
+#include "hal/adc_driver.h"
 #include "rgb_leds.h"
 
 #include <stdint.h>
 
 // 6POS switch position tracking.
 //
-// The ADC path (mixer task) feeds raw samples into getSixPosAnalogValue()
-// which maintains a sticky "last pressed" position — the switch reads
-// ~0 when no button is held, so a plain ADC threshold would bounce back
-// to position 0. The mixer uses the returned value (0..4096) as the pot
-// position for the multipos source.
+// sixPosUpdateFromAdc() runs once per ADC conversion from the board
+// adc_wait_completion callback. It reads the raw sample out of
+// adcValues[SIXPOS_SWITCH_INDEX], maintains a sticky "last pressed"
+// position (the switch reads ~0 when no button is held, so a plain
+// threshold would bounce back to position 0), and writes the scaled
+// 0..4096 sticky value back in place. Downstream consumers
+// (getAnalogValue, diaganas, the mixer multipos source, …) then see a
+// stable value without any of them driving the state machine.
 //
-// The LED update is NOT done here: _six_pos_state is written by the
-// mixer and consumed by rgbLedOnUpdate() below, which runs in the LED
-// refresh timer task. That keeps the rgb_leds.cpp back buffer
-// single-writer (the LED timer task) for the 6POS range, so Lua's
-// applyRGBLedColors pattern cannot race with a mixer-context write.
+// The LED update is NOT done here: _six_pos_state is consumed by
+// rgbLedOnUpdate() below, which runs in the LED refresh timer task.
+// That keeps the rgb_leds.cpp back buffer single-writer (the LED
+// timer task) for the 6POS range, so Lua's applyRGBLedColors pattern
+// cannot race with an ADC-context write.
 
 static uint8_t _last_adc_state = 0;
 static volatile uint8_t _six_pos_state = 0;
 
-uint16_t getSixPosAnalogValue(uint16_t adcValue)
+void sixPosUpdateFromAdc()
 {
+  uint16_t* values = getAnalogValues();
+  uint16_t adcValue = values[SIXPOS_SWITCH_INDEX];
+
   uint8_t current = 0;
   if (adcValue > 3800) current = 6;
   else if (adcValue > 3100) current = 5;
@@ -60,7 +67,7 @@ uint16_t getSixPosAnalogValue(uint16_t adcValue)
     _six_pos_state = _last_adc_state - 1;
   }
 
-  return (4096 / 5) * _six_pos_state;
+  values[SIXPOS_SWITCH_INDEX] = (4096 / 5) * _six_pos_state;
 }
 
 void rgbLedOnUpdate()

--- a/radio/src/boards/generic_stm32/rgb_leds.h
+++ b/radio/src/boards/generic_stm32/rgb_leds.h
@@ -43,3 +43,9 @@ void rgbLedColorApply();
 // indicator) implement this to update their LEDs in the timer task
 // context, keeping rgb_leds.cpp's back buffer single-writer.
 void rgbLedOnUpdate();
+
+// Invoked by the board ADC wait_completion callback once per conversion
+// on radios with a 6POS switch. Reads the raw sample from adcValues[],
+// runs the sticky-position state machine, and writes the scaled sticky
+// value back in place. Linked only when SIXPOS_SWITCH_INDEX is defined.
+void sixPosUpdateFromAdc();

--- a/radio/src/hal/adc_driver.cpp
+++ b/radio/src/hal/adc_driver.cpp
@@ -242,11 +242,6 @@ void adcCalibStore()
 uint16_t getAnalogValue(uint8_t index)
 {
   if (index >= MAX_ANALOG_INPUTS) return 0;
-#if defined(SIXPOS_SWITCH_INDEX) && !defined(SIMU)
-  if (index == SIXPOS_SWITCH_INDEX)
-    return getSixPosAnalogValue(adcValues[index]);
-  else
-#endif
   return adcValues[index];
 }
 

--- a/radio/src/targets/horus/board.h
+++ b/radio/src/targets/horus/board.h
@@ -242,10 +242,6 @@ bool isBacklightEnabled();
 }
 #endif
 
-#if defined(RADIO_V16)
-  uint16_t getSixPosAnalogValue(uint16_t adcValue);
-#endif
-
 // Audio driver
 void audioInit();
 

--- a/radio/src/targets/taranis/board.h
+++ b/radio/src/targets/taranis/board.h
@@ -241,10 +241,6 @@ void usbChargerInit();
 bool usbChargerLed();
 #endif
 
-#if defined(RADIO_V14) || defined(RADIO_V12)
-  uint16_t getSixPosAnalogValue(uint16_t adcValue);
-#endif
-
 // LED driver
 void ledInit();
 void ledOff();


### PR DESCRIPTION
## Summary

Follow-up to #7304. The 6POS sticky-position tracker lived in `hal/adc_driver.cpp:getAnalogValue()` behind a `SIXPOS_SWITCH_INDEX` special case. Every reader (`cli`, `diaganas`, `switches`, `inactivity_timer`, …) re-triggered the state machine, which is wasteful and ran state updates from contexts that were never meant to drive them.

This moves the tracker into `sixPosUpdateFromAdc()`, invoked once per conversion from the board `adc_wait_completion` callback in `boards/generic_stm32/analog_inputs.cpp`. The pattern matches the existing ADS79xx SPI ADC integration, keeping all ADC post-processing in one well-defined layer.

- `getAnalogValue()` becomes a plain array read — no `SIXPOS_SWITCH_INDEX` branch.
- `getSixPosAnalogValue` is no longer a board-level API; it's internal to `rgb_6pos.cpp`.
- `rgbLedOnUpdate()` still reads `_six_pos_state` from the LED timer task, unchanged.

Stacked on #7304 — merge that first. Targets base `ws2812-double-buffering` here; retarget to `main` once #7304 lands.

## Test plan

- [x] `make firmware` builds on V16 (RADIO_V16, Horus-family 6POS)
- [x] `make firmware` builds on V14 (RADIO_V14, Taranis-family 6POS)
- [x] `make firmware` builds on tx16s (non-6POS sanity check)
- [x] On-radio smoke test: 6POS switch positions still register correctly and LEDs follow the pressed position