### PR TITLE
fix(pa01): Change the SDRAM clock from 66.6 MHz to 100 MHz.

### DIFF
--- a/radio/src/targets/pa01/sdram_driver.cpp
+++ b/radio/src/targets/pa01/sdram_driver.cpp
@@ -238,7 +238,7 @@ extern "C" void SDRAM_Init(void)
   FMC_SDRAMInitStructure.InternalBankNumber = FMC_SDRAM_INTERN_BANKS_NUM_4;
   FMC_SDRAMInitStructure.CASLatency = FMC_SDRAM_CAS_LATENCY_3;
   FMC_SDRAMInitStructure.WriteProtection = FMC_SDRAM_WRITE_PROTECTION_DISABLE;
-  FMC_SDRAMInitStructure.SDClockPeriod = FMC_SDRAM_CLOCK_PERIOD_3;
+  FMC_SDRAMInitStructure.SDClockPeriod = FMC_SDRAM_CLOCK_PERIOD_2;
   FMC_SDRAMInitStructure.ReadBurst = FMC_SDRAM_RBURST_ENABLE;
   FMC_SDRAMInitStructure.ReadPipeDelay = FMC_SDRAM_RPIPE_DELAY_0;
 


### PR DESCRIPTION
1.PA01 is very prone to failing to read SD card files. When debugging, the error "Received FIFO overrun error" appears. At this time, the receive address is in the SDRAM area. This error is caused by the DMA transferring data to SDRAM too slowly.
2.Even after changing the SD card clock to 50MHz, there is still a chance of encountering the "Received FIFO overrun error". It is recommended to use the internal RAM when reading the SD card via DMA, and then copy it to SDRAM.