### PR TITLE
fix(pa01): Optimize matrix keyboard scanning

### DIFF
--- a/radio/src/targets/pa01/bsp_io.cpp
+++ b/radio/src/targets/pa01/bsp_io.cpp
@@ -40,23 +40,10 @@
 #define BSP_CHECK(x) if ((x) < 0) return -1
 
 static aw9523b_t i2c_exp;
-
 static uint16_t inputState = 0;
-static bool shouldReadKeys = false;
-
-static void _io_int_handler()
-{
-  shouldReadKeys = true;
-}
-
-bool bsp_get_shouldReadKeys()
-{
-  bool tmp = shouldReadKeys;
-  shouldReadKeys = false;
-  return tmp;
-}
-
 static volatile bool errorOccurs = false;
+
+
 static void bsp_input_read()
 {
   uint16_t value;
@@ -75,8 +62,6 @@ int bsp_io_init()
     BSP_KEY_OUT1 | BSP_KEY_OUT2 | BSP_KEY_OUT3 | BSP_KEY_OUT4));
   BSP_CHECK(aw9523b_set_direction(&i2c_exp, 0xFFFF, BSP_IN_MASK));
 
-  // setup expanders pin change interrupt
-  gpio_init_int(IO_INT_GPIO, GPIO_IN, GPIO_FALLING, _io_int_handler);
   bsp_output_clear(BSP_U6_SELECT);
   return 0;
 }

--- a/radio/src/targets/pa01/bsp_io.cpp
+++ b/radio/src/targets/pa01/bsp_io.cpp
@@ -40,10 +40,23 @@
 #define BSP_CHECK(x) if ((x) < 0) return -1
 
 static aw9523b_t i2c_exp;
+
 static uint16_t inputState = 0;
+static bool shouldReadKeys = false;
+
+static void _io_int_handler()
+{
+  shouldReadKeys = true;
+}
+
+bool bsp_get_shouldReadKeys()
+{
+  bool tmp = shouldReadKeys;
+  shouldReadKeys = false;
+  return tmp;
+}
+
 static volatile bool errorOccurs = false;
-
-
 static void bsp_input_read()
 {
   uint16_t value;
@@ -62,6 +75,8 @@ int bsp_io_init()
     BSP_KEY_OUT1 | BSP_KEY_OUT2 | BSP_KEY_OUT3 | BSP_KEY_OUT4));
   BSP_CHECK(aw9523b_set_direction(&i2c_exp, 0xFFFF, BSP_IN_MASK));
 
+  // setup expanders pin change interrupt
+  gpio_init_int(IO_INT_GPIO, GPIO_IN, GPIO_FALLING, _io_int_handler);
   bsp_output_clear(BSP_U6_SELECT);
   return 0;
 }

--- a/radio/src/targets/pa01/key_driver.cpp
+++ b/radio/src/targets/pa01/key_driver.cpp
@@ -79,7 +79,6 @@ static uint32_t keyState = 0;
                             else keyState &= ~(1UL<<ENT);\
                           }while(0)
 
-// extern RTOS_MUTEX_HANDLE I2CMutex;
 extern bool suspendI2CTasks;
 extern volatile bool errorOccurs;
 static volatile uint32_t pollkey_step;
@@ -91,24 +90,6 @@ void pollKeys()
   volatile static uint32_t result = 0;
   uint16_t bsp_input = 0;
 
-  // if(errorOccurs)
-  // {
-  //   TRACE_ERROR("I2C ERORR\n\r");
-  //   errorOccurs =false;
-  //   int bsp_io_init();
-  //   RTOS_LOCK_MUTEX(I2CMutex);
-  //   (RCC->APB1LENR) |= (RCC_APB1LENR_I2C1EN);
-  //   RCC->APB1LRSTR |= (RCC_APB1LRSTR_I2C1RST);
-  //   delay_us(BSP_READ_AFTER_WRITE_DELAY);
-  //   RCC->APB1LRSTR &= ~(RCC_APB1LRSTR_I2C1RST);
-  //   bsp_io_init();
-  //   RTOS_UNLOCK_MUTEX(I2CMutex);
-  //   bsp_output_set(0, 0);
-  //   TRACE_ERROR("I2C OK\n\r");
-  //   pollkey_step = 0;
-  //   return;
-  // }
-
   if( !pollkey_step )
   {
     pollkey_step = 0x03;
@@ -117,7 +98,6 @@ void pollKeys()
   else if(0x03==pollkey_step)
   {
     pollkey_step = 0x07;
-    // delay_us(BSP_READ_AFTER_WRITE_DELAY);
     bsp_input = bsp_input_get();
     if ((bsp_input & BSP_KEY_IN1) == 0)
       result |= 1<<TR1U;
@@ -133,7 +113,6 @@ void pollKeys()
   else if(0x07==pollkey_step)
   {
     pollkey_step = 0x0F;
-    // delay_us(BSP_READ_AFTER_WRITE_DELAY);
     bsp_input = bsp_input_get();
     if ((bsp_input & BSP_KEY_IN1) == 0)
       result |= 1<<TR3L;
@@ -149,7 +128,6 @@ void pollKeys()
   else if(0x0F==pollkey_step)
   {
     pollkey_step = 0x01;
-    // delay_us(BSP_READ_AFTER_WRITE_DELAY);
     bsp_input = bsp_input_get();
     if ((bsp_input & BSP_KEY_IN1) == 0)
       result |= 1<<PGDN;
@@ -165,7 +143,6 @@ void pollKeys()
   else if(0x01==pollkey_step)
   {
     pollkey_step = 0x03;
-    // delay_us(BSP_READ_AFTER_WRITE_DELAY);
     bsp_input = bsp_input_get();
     if ((bsp_input & BSP_KEY_IN1) == 0)
       result |= 1<<KEY1;
@@ -245,8 +222,7 @@ void pollKeys(){
   if (gpio_read(KEYS_GPIO_ENTER) == 0)
     result |= 1<<ENT;
   bsp_output_set(BSP_KEY_OUT_MASK, 0);
-  bsp_get_shouldReadKeys();
-
+  
   fct_state[0] = (result & 1<<KEY1)?true:false;
   fct_state[1] = (result & 1<<KEY2)?true:false;
   fct_state[2] = (result & 1<<KEY3)?true:false;

--- a/radio/src/targets/pa01/key_driver.cpp
+++ b/radio/src/targets/pa01/key_driver.cpp
@@ -70,51 +70,128 @@ enum PhysicalKeys
   ENT  = 16
 };
 
-extern bool suspendI2CTasks;
-
 static bool fct_state[4] = {false, false, false, false};
 static uint32_t keyState = 0;
+
 #if !defined(BOOT)
-static uint32_t nonReadCount = 0;
-#endif
+
+#define READ_ENTER_KEY()  do{if(gpio_read(KEYS_GPIO_ENTER) == 0) keyState |= 1<<ENT;\
+                            else keyState &= ~(1UL<<ENT);\
+                          }while(0)
+
+// extern RTOS_MUTEX_HANDLE I2CMutex;
+extern bool suspendI2CTasks;
+extern volatile bool errorOccurs;
+static volatile uint32_t pollkey_step;
 
 void pollKeys()
 {
-#if !defined(BOOT)
-  if(!bsp_get_shouldReadKeys() && nonReadCount < 10)
-  {
-    if (gpio_read(KEYS_GPIO_ENTER) == 0)
-      keyState |= 1<<ENT;
-
-    nonReadCount++;
-  }
-  nonReadCount = 0;
-#endif
-
   if (suspendI2CTasks) return;
   
-  // This function avoids concurrent matrix agitation
-
-  uint32_t result = 0;
+  volatile static uint32_t result = 0;
   uint16_t bsp_input = 0;
 
-  volatile static struct
+  // if(errorOccurs)
+  // {
+  //   TRACE_ERROR("I2C ERORR\n\r");
+  //   errorOccurs =false;
+  //   int bsp_io_init();
+  //   RTOS_LOCK_MUTEX(I2CMutex);
+  //   (RCC->APB1LENR) |= (RCC_APB1LENR_I2C1EN);
+  //   RCC->APB1LRSTR |= (RCC_APB1LRSTR_I2C1RST);
+  //   delay_us(BSP_READ_AFTER_WRITE_DELAY);
+  //   RCC->APB1LRSTR &= ~(RCC_APB1LRSTR_I2C1RST);
+  //   bsp_io_init();
+  //   RTOS_UNLOCK_MUTEX(I2CMutex);
+  //   bsp_output_set(0, 0);
+  //   TRACE_ERROR("I2C OK\n\r");
+  //   pollkey_step = 0;
+  //   return;
+  // }
+
+  if( !pollkey_step )
   {
-    uint32_t oldResult = 0;
-    uint8_t ui8ReadInProgress = 0;
-  } syncelem;
-
-  if (syncelem.ui8ReadInProgress != 0) {
-    keyState = syncelem.oldResult;
+    pollkey_step = 0x03;
+    bsp_output_set(BSP_KEY_OUT_MASK, ~BSP_KEY_OUT1);
   }
-
-  // ui8ReadInProgress was 0, increment it
-  syncelem.ui8ReadInProgress++;
-  // Double check before continuing, as non-atomic, non-blocking so far
-  // If ui8ReadInProgress is above 1, then there was concurrent task calling it, exit
-  if (syncelem.ui8ReadInProgress > 1) {
-    keyState = syncelem.oldResult;
+  else if(0x03==pollkey_step)
+  {
+    pollkey_step = 0x07;
+    // delay_us(BSP_READ_AFTER_WRITE_DELAY);
+    bsp_input = bsp_input_get();
+    if ((bsp_input & BSP_KEY_IN1) == 0)
+      result |= 1<<TR1U;
+    if ((bsp_input & BSP_KEY_IN2) == 0)
+      result |= 1<<TR1D;
+    if ((bsp_input & BSP_KEY_IN3) == 0)
+      result |= 1<<TR2U;
+    if ((bsp_input & BSP_KEY_IN4) == 0)
+      result |= 1<<TR2D;
+    READ_ENTER_KEY();
+    bsp_output_set(BSP_KEY_OUT_MASK, ~BSP_KEY_OUT2);
   }
+  else if(0x07==pollkey_step)
+  {
+    pollkey_step = 0x0F;
+    // delay_us(BSP_READ_AFTER_WRITE_DELAY);
+    bsp_input = bsp_input_get();
+    if ((bsp_input & BSP_KEY_IN1) == 0)
+      result |= 1<<TR3L;
+    if ((bsp_input & BSP_KEY_IN2) == 0)
+      result |= 1<<TR3R;
+    if ((bsp_input & BSP_KEY_IN3) == 0)
+      result |= 1<<TR4L;
+    if ((bsp_input & BSP_KEY_IN4) == 0)
+      result |= 1<<TR4R;
+    READ_ENTER_KEY();
+    bsp_output_set(BSP_KEY_OUT_MASK, ~BSP_KEY_OUT3);
+  }
+  else if(0x0F==pollkey_step)
+  {
+    pollkey_step = 0x01;
+    // delay_us(BSP_READ_AFTER_WRITE_DELAY);
+    bsp_input = bsp_input_get();
+    if ((bsp_input & BSP_KEY_IN1) == 0)
+      result |= 1<<PGDN;
+    if ((bsp_input & BSP_KEY_IN2) == 0)
+      result |= 1<<PGUP;
+    if ((bsp_input & BSP_KEY_IN3) == 0)
+      result |= 1<<RTN;
+    if ((bsp_input & BSP_KEY_IN4) == 0)
+      result |= 1<<MODEL;
+    READ_ENTER_KEY();
+    bsp_output_set(BSP_KEY_OUT_MASK, ~BSP_KEY_OUT4);
+  }
+  else if(0x01==pollkey_step)
+  {
+    pollkey_step = 0x03;
+    // delay_us(BSP_READ_AFTER_WRITE_DELAY);
+    bsp_input = bsp_input_get();
+    if ((bsp_input & BSP_KEY_IN1) == 0)
+      result |= 1<<KEY1;
+    if ((bsp_input & BSP_KEY_IN2) == 0)
+      result |= 1<<KEY2;
+    if ((bsp_input & BSP_KEY_IN3) == 0)
+      result |= 1<<KEY3;
+    if ((bsp_input & BSP_KEY_IN4) == 0)
+      result |= 1<<KEY4;
+  
+    keyState = result;
+    READ_ENTER_KEY();
+
+    fct_state[0] = (result & 1<<KEY1)?true:false;
+    fct_state[1] = (result & 1<<KEY2)?true:false;
+    fct_state[2] = (result & 1<<KEY3)?true:false;
+    fct_state[3] = (result & 1<<KEY4)?true:false;
+    bsp_output_set(BSP_KEY_OUT_MASK, ~BSP_KEY_OUT1);
+    result = 0;
+  }
+}
+#else
+void pollKeys(){
+  // This function avoids concurrent matrix agitation
+  uint32_t result = 0;
+  uint16_t bsp_input = 0;
 
   // If we land here, we have exclusive access to Matrix
   bsp_output_set(BSP_KEY_OUT_MASK, ~BSP_KEY_OUT1);
@@ -167,10 +244,6 @@ void pollKeys()
 
   if (gpio_read(KEYS_GPIO_ENTER) == 0)
     result |= 1<<ENT;
-
-  syncelem.oldResult = result;
-  syncelem.ui8ReadInProgress = 0;
-
   bsp_output_set(BSP_KEY_OUT_MASK, 0);
   bsp_get_shouldReadKeys();
 
@@ -181,6 +254,9 @@ void pollKeys()
 
   keyState = result;
 }
+#endif
+
+
 
 void keysInit()
 {

--- a/radio/src/targets/pa01/key_driver.cpp
+++ b/radio/src/targets/pa01/key_driver.cpp
@@ -70,105 +70,53 @@ enum PhysicalKeys
   ENT  = 16
 };
 
+extern bool suspendI2CTasks;
+
 static bool fct_state[4] = {false, false, false, false};
 static uint32_t keyState = 0;
-
 #if !defined(BOOT)
-
-#define READ_ENTER_KEY()  do{if(gpio_read(KEYS_GPIO_ENTER) == 0) keyState |= 1<<ENT;\
-                            else keyState &= ~(1UL<<ENT);\
-                          }while(0)
-
-extern bool suspendI2CTasks;
-extern volatile bool errorOccurs;
-static volatile uint32_t pollkey_step;
+static uint32_t nonReadCount = 0;
+#endif
 
 void pollKeys()
 {
+#if !defined(BOOT)
+  if(!bsp_get_shouldReadKeys() && nonReadCount < 10)
+  {
+    if (gpio_read(KEYS_GPIO_ENTER) == 0)
+      keyState |= 1<<ENT;
+
+    nonReadCount++;
+    return;
+  }
+  nonReadCount = 0;
+#endif
+
   if (suspendI2CTasks) return;
   
-  volatile static uint32_t result = 0;
-  uint16_t bsp_input = 0;
-
-  if( !pollkey_step )
-  {
-    pollkey_step = 0x03;
-    bsp_output_set(BSP_KEY_OUT_MASK, ~BSP_KEY_OUT1);
-  }
-  else if(0x03==pollkey_step)
-  {
-    pollkey_step = 0x07;
-    bsp_input = bsp_input_get();
-    if ((bsp_input & BSP_KEY_IN1) == 0)
-      result |= 1<<TR1U;
-    if ((bsp_input & BSP_KEY_IN2) == 0)
-      result |= 1<<TR1D;
-    if ((bsp_input & BSP_KEY_IN3) == 0)
-      result |= 1<<TR2U;
-    if ((bsp_input & BSP_KEY_IN4) == 0)
-      result |= 1<<TR2D;
-    READ_ENTER_KEY();
-    bsp_output_set(BSP_KEY_OUT_MASK, ~BSP_KEY_OUT2);
-  }
-  else if(0x07==pollkey_step)
-  {
-    pollkey_step = 0x0F;
-    bsp_input = bsp_input_get();
-    if ((bsp_input & BSP_KEY_IN1) == 0)
-      result |= 1<<TR3L;
-    if ((bsp_input & BSP_KEY_IN2) == 0)
-      result |= 1<<TR3R;
-    if ((bsp_input & BSP_KEY_IN3) == 0)
-      result |= 1<<TR4L;
-    if ((bsp_input & BSP_KEY_IN4) == 0)
-      result |= 1<<TR4R;
-    READ_ENTER_KEY();
-    bsp_output_set(BSP_KEY_OUT_MASK, ~BSP_KEY_OUT3);
-  }
-  else if(0x0F==pollkey_step)
-  {
-    pollkey_step = 0x01;
-    bsp_input = bsp_input_get();
-    if ((bsp_input & BSP_KEY_IN1) == 0)
-      result |= 1<<PGDN;
-    if ((bsp_input & BSP_KEY_IN2) == 0)
-      result |= 1<<PGUP;
-    if ((bsp_input & BSP_KEY_IN3) == 0)
-      result |= 1<<RTN;
-    if ((bsp_input & BSP_KEY_IN4) == 0)
-      result |= 1<<MODEL;
-    READ_ENTER_KEY();
-    bsp_output_set(BSP_KEY_OUT_MASK, ~BSP_KEY_OUT4);
-  }
-  else if(0x01==pollkey_step)
-  {
-    pollkey_step = 0x03;
-    bsp_input = bsp_input_get();
-    if ((bsp_input & BSP_KEY_IN1) == 0)
-      result |= 1<<KEY1;
-    if ((bsp_input & BSP_KEY_IN2) == 0)
-      result |= 1<<KEY2;
-    if ((bsp_input & BSP_KEY_IN3) == 0)
-      result |= 1<<KEY3;
-    if ((bsp_input & BSP_KEY_IN4) == 0)
-      result |= 1<<KEY4;
-  
-    keyState = result;
-    READ_ENTER_KEY();
-
-    fct_state[0] = (result & 1<<KEY1)?true:false;
-    fct_state[1] = (result & 1<<KEY2)?true:false;
-    fct_state[2] = (result & 1<<KEY3)?true:false;
-    fct_state[3] = (result & 1<<KEY4)?true:false;
-    bsp_output_set(BSP_KEY_OUT_MASK, ~BSP_KEY_OUT1);
-    result = 0;
-  }
-}
-#else
-void pollKeys(){
   // This function avoids concurrent matrix agitation
+
   uint32_t result = 0;
   uint16_t bsp_input = 0;
+
+  volatile static struct
+  {
+    uint32_t oldResult = 0;
+    uint8_t ui8ReadInProgress = 0;
+  } syncelem;
+
+  if (syncelem.ui8ReadInProgress != 0) {
+    keyState = syncelem.oldResult;
+  }
+
+  // ui8ReadInProgress was 0, increment it
+  syncelem.ui8ReadInProgress++;
+  // Double check before continuing, as non-atomic, non-blocking so far
+  // If ui8ReadInProgress is above 1, then there was concurrent task calling it, exit
+  if (syncelem.ui8ReadInProgress > 1) {
+    keyState = syncelem.oldResult;
+    return;
+  }
 
   // If we land here, we have exclusive access to Matrix
   bsp_output_set(BSP_KEY_OUT_MASK, ~BSP_KEY_OUT1);
@@ -221,8 +169,13 @@ void pollKeys(){
 
   if (gpio_read(KEYS_GPIO_ENTER) == 0)
     result |= 1<<ENT;
+
+  syncelem.oldResult = result;
+  syncelem.ui8ReadInProgress = 0;
+
   bsp_output_set(BSP_KEY_OUT_MASK, 0);
-  
+  bsp_get_shouldReadKeys();
+
   fct_state[0] = (result & 1<<KEY1)?true:false;
   fct_state[1] = (result & 1<<KEY2)?true:false;
   fct_state[2] = (result & 1<<KEY3)?true:false;
@@ -230,9 +183,6 @@ void pollKeys(){
 
   keyState = result;
 }
-#endif
-
-
 
 void keysInit()
 {


### PR DESCRIPTION
1.I2C errors can easily occur in certain situations, such as when sound plays during model switching. Switching to a four-cycle step-by-step scan resolved the issue (tested hundreds of times without errors).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard input handling by preventing concurrent read attempts and optimizing polling behavior during key polling operations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EdgeTX/edgetx/pull/7315?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->