### PR TITLE
Add adaptive numeric keyboard for color LCD

### DIFF
--- a/radio/src/gui/colorlcd/libui/keyboard_base.cpp
+++ b/radio/src/gui/colorlcd/libui/keyboard_base.cpp
@@ -73,8 +73,10 @@ static void keyboard_event_cb(lv_event_t* e)
 
 static void field_focus_leave(lv_event_t* e) { Keyboard::hide(false); }
 
-Keyboard::Keyboard(coord_t height) :
-    NavWindow(MainWindow::instance(), {0, LCD_H - height, LCD_W, height})
+Keyboard::Keyboard(coord_t height, bool fullScreen) :
+    NavWindow(MainWindow::instance(), {0, fullScreen ? 0 : LCD_H - height,
+                                       LCD_W, height}),
+    fullScreen(fullScreen)
 {
 #if defined(USE_HATS_AS_KEYS)
   hasTwoPageKeys = true;
@@ -176,8 +178,14 @@ void Keyboard::setField(FormField* newField)
 
   lv_obj_t* obj = newField->getLvObj();
   if (obj) {
-    fieldContainer = newField->getFullScreenWindow();
-    if (fieldContainer) {
+    if (fullScreen) {
+      setTop(0);
+      lv_obj_set_parent(lvobj, lv_layer_top());
+      fieldContainer = nullptr;
+    } else {
+      fieldContainer = newField->getFullScreenWindow();
+      if (!fieldContainer) return;
+
       attach(fieldContainer);
 
       lv_area_t coords;
@@ -189,15 +197,15 @@ void Keyboard::setField(FormField* newField)
       // save scroll position
       scroll_pos = lv_obj_get_scroll_y(fieldContainer->getLvObj());
       lv_obj_scroll_to_view(lvobj, LV_ANIM_OFF);
-
-      newField->setEditMode(true);
-
-      lv_keyboard_set_textarea(keyboard, obj);
-      lv_obj_add_event_cb(obj, field_focus_leave, LV_EVENT_DEFOCUSED, nullptr);
-      assignLvGroup(group, false);
-
-      field = newField;
-      fieldGroup = (lv_group_t*)lv_obj_get_group(obj);
     }
+
+    newField->setEditMode(true);
+
+    lv_keyboard_set_textarea(keyboard, obj);
+    lv_obj_add_event_cb(obj, field_focus_leave, LV_EVENT_DEFOCUSED, nullptr);
+    assignLvGroup(group, false);
+
+    field = newField;
+    fieldGroup = (lv_group_t*)lv_obj_get_group(obj);
   }
 }

--- a/radio/src/gui/colorlcd/libui/keyboard_base.h
+++ b/radio/src/gui/colorlcd/libui/keyboard_base.h
@@ -25,7 +25,7 @@ class FormField;
 class Keyboard : public NavWindow
 {
  public:
-  explicit Keyboard(coord_t height);
+  explicit Keyboard(coord_t height, bool fullScreen = false);
   ~Keyboard();
 
   void clearField(bool wasCancelled);
@@ -44,6 +44,7 @@ class Keyboard : public NavWindow
   Window* fieldContainer = nullptr;
   lv_group_t* fieldGroup = nullptr;
   lv_coord_t scroll_pos = 0;
+  bool fullScreen = false;
 
   void setField(FormField* newField);
   bool attachKeyboard();

--- a/radio/src/gui/colorlcd/libui/keyboard_number.cpp
+++ b/radio/src/gui/colorlcd/libui/keyboard_number.cpp
@@ -18,41 +18,177 @@
 
 #include "keyboard_number.h"
 
+#include "etx_lv_theme.h"
 #include "numberedit.h"
 #include "keys.h"
 
-constexpr coord_t KEYBOARD_HEIGHT = 90;
+constexpr coord_t KEYBOARD_HEIGHT = LCD_H;
+constexpr coord_t HEADER_HEIGHT = LAYOUT_SCALE(72);
+constexpr coord_t TITLE_Y = PAD_LARGE;
+constexpr coord_t TITLE_H = LAYOUT_SCALE(18);
+constexpr coord_t VALUE_Y = TITLE_Y + TITLE_H + PAD_TINY;
+constexpr coord_t VALUE_H = HEADER_HEIGHT - VALUE_Y - PAD_MEDIUM;
 NumberKeyboard* NumberKeyboard::_instance = nullptr;
-
-static const char* const number_kb_map[] = {"<<",  "-",   "+",   ">>",  "\n",
-                                            "MIN", "DEF", "+/-", "MAX", ""};
 
 #define LV_KB_BTN(width) LV_BTNMATRIX_CTRL_POPOVER | width
 #define LV_KB_CTRL(width) LV_KEYBOARD_CTRL_BTN_FLAGS | width
 
-static const lv_btnmatrix_ctrl_t number_kb_ctrl_map[] = {
-    LV_KB_BTN(4), LV_KB_BTN(4), LV_KB_BTN(4),  LV_KB_BTN(4),
-    LV_KB_BTN(4), LV_KB_BTN(4), LV_KB_CTRL(4), LV_KB_BTN(4)};
+static char edit_value[32] = "";
+static char edit_title[32] = "";
 
-static void on_key(lv_event_t* e)
+static const char* const positive_integer_kb_map[] = {
+    "1", "2", "3", LV_SYMBOL_OK, "\n",
+    "4", "5", "6", LV_SYMBOL_BACKSPACE, "\n",
+    "7", "8", "9", LV_SYMBOL_LEFT, "\n",
+    "0", LV_SYMBOL_RIGHT, ""};
+
+static const lv_btnmatrix_ctrl_t positive_integer_kb_ctrl_map[] = {
+    LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_CTRL(1),
+    LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1),
+    LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1),
+    LV_KB_BTN(3), LV_KB_BTN(1)};
+
+static const char* const signed_integer_kb_map[] = {
+    "1", "2", "3", LV_SYMBOL_OK, "\n",
+    "4", "5", "6", LV_SYMBOL_BACKSPACE, "\n",
+    "7", "8", "9", LV_SYMBOL_LEFT, "\n",
+    "+/-", "0", LV_SYMBOL_RIGHT, ""};
+
+static const lv_btnmatrix_ctrl_t signed_integer_kb_ctrl_map[] = {
+    LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_CTRL(1),
+    LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1),
+    LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1),
+    LV_KB_BTN(1), LV_KB_BTN(2), LV_KB_BTN(1)};
+
+static const char* const positive_decimal_kb_map[] = {
+    "1", "2", "3", LV_SYMBOL_OK, "\n",
+    "4", "5", "6", LV_SYMBOL_BACKSPACE, "\n",
+    "7", "8", "9", LV_SYMBOL_LEFT, "\n",
+    "0", ".", LV_SYMBOL_RIGHT, ""};
+
+static const lv_btnmatrix_ctrl_t positive_decimal_kb_ctrl_map[] = {
+    LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_CTRL(1),
+    LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1),
+    LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1),
+    LV_KB_BTN(2), LV_KB_BTN(1), LV_KB_BTN(1)};
+
+static const char* const signed_decimal_kb_map[] = {
+    "1", "2", "3", LV_SYMBOL_OK, "\n",
+    "4", "5", "6", LV_SYMBOL_BACKSPACE, "\n",
+    "7", "8", "9", LV_SYMBOL_LEFT, "\n",
+    "+/-", "0", ".", LV_SYMBOL_RIGHT, ""};
+
+static const lv_btnmatrix_ctrl_t signed_decimal_kb_ctrl_map[] = {
+    LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_CTRL(1),
+    LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1),
+    LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1),
+    LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1)};
+
+static const char* const adjust_kb_map[] = {
+    "<<", "-", "+", ">>", "\n",
+    "MIN", "DEF", "+/-", "MAX", "\n",
+    LV_SYMBOL_OK, ""};
+
+static const lv_btnmatrix_ctrl_t adjust_kb_ctrl_map[] = {
+    LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1),
+    LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1), LV_KB_BTN(1),
+    LV_KB_CTRL(4)};
+
+static bool directMode = true;
+
+static void set_edit_title(const char* value)
 {
-  lv_obj_t* obj = lv_event_get_target(e);
-  NumberKeyboard* edit = (NumberKeyboard*)lv_event_get_user_data(e);
-  if (!obj || !edit) return;
+  if (!value || !value[0]) value = "Value";
+  snprintf(edit_title, sizeof(edit_title), "%s", value);
+  if (NumberKeyboard::instance())
+    NumberKeyboard::instance()->setTitleText(edit_title);
+}
 
-  uint16_t btn_id = lv_btnmatrix_get_selected_btn(obj);
-  if (btn_id == LV_BTNMATRIX_BTN_NONE) return;
+static void set_edit_value(const char* value)
+{
+  if (!value) value = "";
+  snprintf(edit_value, sizeof(edit_value), "%s", value);
+  if (NumberKeyboard::instance())
+    NumberKeyboard::instance()->setValueText(edit_value);
+}
 
-  const char* txt =
-      lv_btnmatrix_get_btn_text(obj, lv_btnmatrix_get_selected_btn(obj));
-  if (txt == NULL) return;
+static void refresh_edit_value(lv_obj_t* keyboard, NumberEdit* edit = nullptr)
+{
+  if (directMode) {
+    auto textarea = lv_keyboard_get_textarea(keyboard);
+    if (!textarea) return;
+    set_edit_value(lv_textarea_get_text(textarea));
+  } else {
+    set_edit_value(edit ? edit->getDisplayVal().c_str() : "");
+  }
+  lv_obj_invalidate(keyboard);
+}
 
-  edit->handleEvent(txt);
+static void on_keyboard_event(lv_event_t* e)
+{
+  if (lv_event_get_code(e) != LV_EVENT_VALUE_CHANGED) return;
+
+  auto keyboard = lv_event_get_target(e);
+  auto numberKeyboard = (NumberKeyboard*)lv_event_get_user_data(e);
+  if (!numberKeyboard) return;
+
+  if (directMode) {
+    refresh_edit_value(keyboard);
+  } else {
+    uint16_t btn_id = lv_btnmatrix_get_selected_btn(keyboard);
+    if (btn_id == LV_BTNMATRIX_BTN_NONE) return;
+
+    const char* txt = lv_btnmatrix_get_btn_text(keyboard, btn_id);
+    if (!txt) return;
+
+    numberKeyboard->handleEvent(txt);
+    refresh_edit_value(keyboard, numberKeyboard->getNumberEdit());
+  }
+}
+
+static void set_keyboard_map(lv_obj_t* keyboard, NumberEdit* edit)
+{
+  directMode = edit == nullptr || edit->useDirectKeyboard();
+  set_edit_title(edit ? edit->getEditTitle().c_str() : nullptr);
+  if (!directMode) {
+    set_edit_value(edit ? edit->getDisplayVal().c_str() : "");
+    lv_keyboard_set_map(keyboard, LV_KEYBOARD_MODE_USER_1,
+                        (const char**)adjust_kb_map, adjust_kb_ctrl_map);
+    lv_keyboard_set_mode(keyboard, LV_KEYBOARD_MODE_USER_1);
+    return;
+  }
+
+  bool isSigned = edit && edit->getMin() < 0;
+  bool isDecimal = edit && edit->hasDecimalPrecision();
+
+  set_edit_value(edit ? edit->getEditVal().c_str() : "");
+
+  if (isSigned && isDecimal) {
+    lv_keyboard_set_map(keyboard, LV_KEYBOARD_MODE_USER_1,
+                        (const char**)signed_decimal_kb_map,
+                        signed_decimal_kb_ctrl_map);
+  } else if (isSigned) {
+    lv_keyboard_set_map(keyboard, LV_KEYBOARD_MODE_USER_1,
+                        (const char**)signed_integer_kb_map,
+                        signed_integer_kb_ctrl_map);
+  } else if (isDecimal) {
+    lv_keyboard_set_map(keyboard, LV_KEYBOARD_MODE_USER_1,
+                        (const char**)positive_decimal_kb_map,
+                        positive_decimal_kb_ctrl_map);
+  } else {
+    lv_keyboard_set_map(keyboard, LV_KEYBOARD_MODE_USER_1,
+                        (const char**)positive_integer_kb_map,
+                        positive_integer_kb_ctrl_map);
+  }
+
+  lv_keyboard_set_mode(keyboard, LV_KEYBOARD_MODE_USER_1);
 }
 
 void NumberKeyboard::handleEvent(const char* btn)
 {
-  if (strcmp(btn, "<<") == 0)
+  if (strcmp(btn, LV_SYMBOL_OK) == 0)
+    Keyboard::hide(false);
+  else if (strcmp(btn, "<<") == 0)
     decLarge();
   else if (strcmp(btn, "-") == 0)
     decSmall();
@@ -123,29 +259,56 @@ void NumberKeyboard::onPressPGDN() { if (hasTwoPageKeys) incSmall(); else decLar
 
 #endif
 
-NumberKeyboard::NumberKeyboard() : Keyboard(KEYBOARD_HEIGHT)
+NumberKeyboard::NumberKeyboard() : Keyboard(KEYBOARD_HEIGHT, true)
 {
-  // setup custom keyboard
-  lv_keyboard_set_map(keyboard, LV_KEYBOARD_MODE_USER_1,
-                      (const char**)number_kb_map, number_kb_ctrl_map);
+  etx_solid_bg(lvobj, COLOR_THEME_SECONDARY3_INDEX);
 
-  lv_keyboard_set_mode(keyboard, LV_KEYBOARD_MODE_USER_1);
+  titleLabel = lv_label_create(lvobj);
+  lv_obj_set_pos(titleLabel, 0, TITLE_Y);
+  lv_obj_set_size(titleLabel, LCD_W, TITLE_H);
+  lv_obj_set_style_text_align(titleLabel, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
+  lv_label_set_long_mode(titleLabel, LV_LABEL_LONG_DOT);
+  etx_font(titleLabel, FONT_XS_INDEX);
+  etx_txt_color(titleLabel, COLOR_THEME_PRIMARY3_INDEX);
+
+  valueLabel = lv_label_create(lvobj);
+  lv_obj_set_pos(valueLabel, 0, VALUE_Y);
+  lv_obj_set_size(valueLabel, LCD_W, VALUE_H);
+  lv_obj_set_style_text_align(valueLabel, LV_TEXT_ALIGN_CENTER, LV_PART_MAIN);
+  lv_label_set_long_mode(valueLabel, LV_LABEL_LONG_DOT);
+  etx_font(valueLabel, FONT_L_INDEX);
+  etx_txt_color(valueLabel, COLOR_THEME_PRIMARY1_INDEX);
+
+  lv_obj_set_size(keyboard, LCD_W, LCD_H - HEADER_HEIGHT);
+  lv_obj_align(keyboard, LV_ALIGN_TOP_LEFT, 0, HEADER_HEIGHT);
+  lv_obj_add_event_cb(keyboard, on_keyboard_event, LV_EVENT_VALUE_CHANGED, this);
 }
 
 NumberKeyboard::~NumberKeyboard() { _instance = nullptr; }
 
-void NumberKeyboard::open(FormField* field)
+void NumberKeyboard::open(FormField* field, NumberEdit* edit)
 {
   if (!_instance) _instance = new NumberKeyboard();
+
+  _instance->numberEdit = edit;
+  set_keyboard_map(_instance->keyboard, edit);
 
   lv_obj_clear_flag(_instance->lvobj, LV_OBJ_FLAG_HIDDEN);
   lv_obj_clear_flag(_instance->keyboard, LV_OBJ_FLAG_HIDDEN);
 
   _instance->setField(field);
+  if (!directMode) {
+    lv_keyboard_set_textarea(_instance->keyboard, nullptr);
+  }
+  refresh_edit_value(_instance->keyboard, edit);
+}
 
-  auto kb = _instance->keyboard;
-  lv_keyboard_set_textarea(kb, nullptr);
+void NumberKeyboard::setTitleText(const char* value)
+{
+  if (titleLabel) lv_label_set_text(titleLabel, value ? value : "");
+}
 
-  lv_obj_remove_event_cb(kb, on_key);
-  lv_obj_add_event_cb(kb, on_key, LV_EVENT_VALUE_CHANGED, _instance);
+void NumberKeyboard::setValueText(const char* value)
+{
+  if (valueLabel) lv_label_set_text(valueLabel, value ? value : "");
 }

--- a/radio/src/gui/colorlcd/libui/keyboard_number.h
+++ b/radio/src/gui/colorlcd/libui/keyboard_number.h
@@ -20,6 +20,8 @@
 
 #include "keyboard_base.h"
 
+class NumberEdit;
+
 class NumberKeyboard : public Keyboard
 {
  public:
@@ -30,9 +32,13 @@ class NumberKeyboard : public Keyboard
   std::string getName() const override { return "NumberKeyboard"; }
 #endif
 
-  static void open(FormField* field);
+  static void open(FormField* field, NumberEdit* edit);
+  static NumberKeyboard* instance() { return _instance; }
 
   void handleEvent(const char* btn);
+  NumberEdit* getNumberEdit() const { return numberEdit; }
+  void setTitleText(const char* value);
+  void setValueText(const char* value);
 
  protected:
   void decLarge();
@@ -56,4 +62,7 @@ class NumberKeyboard : public Keyboard
 #endif
 
   static NumberKeyboard* _instance;
+  NumberEdit* numberEdit = nullptr;
+  lv_obj_t* titleLabel = nullptr;
+  lv_obj_t* valueLabel = nullptr;
 };

--- a/radio/src/gui/colorlcd/libui/numberedit.cpp
+++ b/radio/src/gui/colorlcd/libui/numberedit.cpp
@@ -240,8 +240,9 @@ NumberEdit::NumberEdit(Window* parent, const rect_t& rect, int vmin, int vmax,
     vmin(vmin),
     vmax(vmax)
 {
-  if (auto setupLine = dynamic_cast<SetupLine*>(parent)) {
-    editTitle = setupLine->getTitle();
+  if (parent) {
+    const char* title = parent->getFormFieldTitle();
+    if (title) editTitle = title;
   }
 
   if (rect.w == 0 || rect.w == LV_SIZE_CONTENT) setWidth(EdgeTxStyles::EDIT_FLD_WIDTH);
@@ -337,9 +338,9 @@ std::string NumberEdit::getEditVal() const
   }
 
   bool negative = value < 0;
-  uint32_t absValue = negative ? -value : value;
-  uint32_t whole = absValue / scale;
-  uint32_t fraction = absValue % scale;
+  int64_t absValue = negative ? -(int64_t)value : value;
+  int64_t whole = absValue / scale;
+  int64_t fraction = absValue % scale;
 
   auto text = std::string(negative ? "-" : "") + std::to_string(whole) + ".";
   if (scale == 100 && fraction < 10) text += "0";
@@ -358,7 +359,8 @@ void NumberEdit::setValueFromEditVal(const char* text)
   bool negative = false;
   bool afterDecimal = false;
   int decimalDigits = 0;
-  int32_t value = 0;
+  constexpr int64_t VALUE_LIMIT = 2147483647;
+  int64_t value = 0;
 
   if (*text == '-' || *text == '+') {
     negative = *text == '-';
@@ -375,16 +377,24 @@ void NumberEdit::setValueFromEditVal(const char* text)
 
     if (*text >= '0' && *text <= '9') {
       if (!afterDecimal) {
-        value = value * 10 + (*text - '0') * scale;
+        if (value < VALUE_LIMIT) {
+          value = value * 10 + (*text - '0') * scale;
+          if (value > VALUE_LIMIT) value = VALUE_LIMIT;
+        }
       } else if (decimalDigits < (scale == 100 ? 2 : scale == 10 ? 1 : 0)) {
-        value += (*text - '0') * (scale == 100 && decimalDigits == 0 ? 10 : 1);
+        int digitValue = (*text - '0') * (scale == 100 && decimalDigits == 0 ? 10 : 1);
+        if (value <= VALUE_LIMIT - digitValue)
+          value += digitValue;
+        else
+          value = VALUE_LIMIT;
         decimalDigits++;
       }
     }
     text++;
   }
 
-  setValue(negative ? -value : value);
+  int32_t parsedValue = (int32_t)value;
+  setValue(negative ? -parsedValue : parsedValue);
 }
 
 void NumberEdit::updateDisplay()

--- a/radio/src/gui/colorlcd/libui/numberedit.cpp
+++ b/radio/src/gui/colorlcd/libui/numberedit.cpp
@@ -164,8 +164,19 @@ class NumberArea : public FormField
     }
   }
 
-  void openKeyboard() { NumberKeyboard::open(this); }
-  void directEdit() { FormField::onClicked(); }
+  void openKeyboard()
+  {
+    editTextIsRaw = numEdit->useDirectKeyboard();
+    lv_textarea_set_text(lvobj, editTextIsRaw ? numEdit->getEditVal().c_str()
+                                              : numEdit->getDisplayVal().c_str());
+    NumberKeyboard::open(this, numEdit);
+  }
+
+  void directEdit()
+  {
+    editTextIsRaw = false;
+    FormField::onClicked();
+  }
 
   void update()
   {
@@ -175,6 +186,18 @@ class NumberArea : public FormField
 
  protected:
   NumberEdit* numEdit = nullptr;
+  bool editTextIsRaw = false;
+
+  void changeEnd(bool forceChanged = false) override
+  {
+    if (lvobj == nullptr) return;
+
+    if (editTextIsRaw) {
+      numEdit->setValueFromEditVal(lv_textarea_get_text(lvobj));
+      editTextIsRaw = false;
+    }
+    FormField::changeEnd(forceChanged);
+  }
 
   void onCancel() override
   {
@@ -217,6 +240,10 @@ NumberEdit::NumberEdit(Window* parent, const rect_t& rect, int vmin, int vmax,
     vmin(vmin),
     vmax(vmax)
 {
+  if (auto setupLine = dynamic_cast<SetupLine*>(parent)) {
+    editTitle = setupLine->getTitle();
+  }
+
   if (rect.w == 0 || rect.w == LV_SIZE_CONTENT) setWidth(EdgeTxStyles::EDIT_FLD_WIDTH);
 
   setTextFlag(textFlags);
@@ -269,7 +296,7 @@ void NumberEdit::update()
   updateDisplay();
 }
 
-std::string NumberEdit::getDisplayVal()
+std::string NumberEdit::getDisplayVal() const
 {
   std::string str;
   if (displayFunction != nullptr) {
@@ -281,6 +308,83 @@ std::string NumberEdit::getDisplayVal()
                                suffix.c_str());
   }
   return str;
+}
+
+bool NumberEdit::hasDecimalPrecision() const
+{
+  return ((textFlags & PREC2) == PREC2) || (textFlags & PREC1);
+}
+
+bool NumberEdit::useDirectKeyboard() const
+{
+  return directKeyboard;
+}
+
+static int getNumberEditPrecisionScale(LcdFlags flags)
+{
+  if ((flags & PREC2) == PREC2) return 100;
+  if (flags & PREC1) return 10;
+  return 1;
+}
+
+std::string NumberEdit::getEditVal() const
+{
+  int scale = getNumberEditPrecisionScale(textFlags);
+  int value = currentValue;
+
+  if (scale == 1) {
+    return std::to_string(value);
+  }
+
+  bool negative = value < 0;
+  uint32_t absValue = negative ? -value : value;
+  uint32_t whole = absValue / scale;
+  uint32_t fraction = absValue % scale;
+
+  auto text = std::string(negative ? "-" : "") + std::to_string(whole) + ".";
+  if (scale == 100 && fraction < 10) text += "0";
+  text += std::to_string(fraction);
+  return text;
+}
+
+void NumberEdit::setValueFromEditVal(const char* text)
+{
+  if (text == nullptr || *text == '\0') {
+    setValue(0);
+    return;
+  }
+
+  int scale = getNumberEditPrecisionScale(textFlags);
+  bool negative = false;
+  bool afterDecimal = false;
+  int decimalDigits = 0;
+  int32_t value = 0;
+
+  if (*text == '-' || *text == '+') {
+    negative = *text == '-';
+    text++;
+  }
+
+  while (*text != '\0') {
+    if (*text == '.') {
+      if (afterDecimal) break;
+      afterDecimal = true;
+      text++;
+      continue;
+    }
+
+    if (*text >= '0' && *text <= '9') {
+      if (!afterDecimal) {
+        value = value * 10 + (*text - '0') * scale;
+      } else if (decimalDigits < (scale == 100 ? 2 : scale == 10 ? 1 : 0)) {
+        value += (*text - '0') * (scale == 100 && decimalDigits == 0 ? 10 : 1);
+        decimalDigits++;
+      }
+    }
+    text++;
+  }
+
+  setValue(negative ? -value : value);
 }
 
 void NumberEdit::updateDisplay()

--- a/radio/src/gui/colorlcd/libui/numberedit.h
+++ b/radio/src/gui/colorlcd/libui/numberedit.h
@@ -40,7 +40,11 @@ class NumberEdit : public TextButton
 
   virtual void update();
 
+  int32_t getMin() const { return vmin; }
   int32_t getMax() const { return vmax; }
+  bool hasDecimalPrecision() const;
+  bool useDirectKeyboard() const;
+  const std::string& getEditTitle() const { return editTitle; }
 
   void setMin(int value) { vmin = value; }
   void setMax(int value) { vmax = value; }
@@ -76,8 +80,13 @@ class NumberEdit : public TextButton
   void setDisplayHandler(std::function<std::string(int value)> function)
   {
     displayFunction = std::move(function);
+    // Custom display strings are not always safe to parse as direct numeric input.
+    directKeyboard = displayFunction == nullptr;
     update();
   }
+
+  void setDirectKeyboard(bool value) { directKeyboard = value; }
+  void setEditTitle(std::string value) { editTitle = std::move(value); }
 
   void setSetValueHandler(std::function<void(int)> handler)
   {
@@ -95,6 +104,9 @@ class NumberEdit : public TextButton
   }
 
   int32_t getValue() const { return _getValue != nullptr ? _getValue() : 0; }
+  std::string getDisplayVal() const;
+  std::string getEditVal() const;
+  void setValueFromEditVal(const char* text);
 
  protected:
   friend class NumberArea;
@@ -115,8 +127,8 @@ class NumberEdit : public TextButton
   std::string zeroText;
   std::function<std::string(int)> displayFunction;
   std::function<bool(int)> isValueAvailable;
-
-  std::string getDisplayVal();
+  bool directKeyboard = true;
+  std::string editTitle;
 
   void updateDisplay();
   void openEdit();

--- a/radio/src/gui/colorlcd/libui/window.cpp
+++ b/radio/src/gui/colorlcd/libui/window.cpp
@@ -705,7 +705,8 @@ SetupButtonGroup::SetupButtonGroup(Window* parent, const rect_t& rect, const cha
 
 SetupLine::SetupLine(Window* parent, coord_t y, coord_t col2, PaddingSize padding, const char* title,
                     std::function<void(SetupLine*, coord_t, coord_t)> createEdit, coord_t lblYOffset) :
-    Window(parent, {0, y, LCD_W - padding * 2, 0})
+    Window(parent, {0, y, LCD_W - padding * 2, 0}),
+    titleText(title ? title : "")
 {
   padAll(PAD_ZERO);
   coord_t titleY = PAD_LARGE + lblYOffset;

--- a/radio/src/gui/colorlcd/libui/window.h
+++ b/radio/src/gui/colorlcd/libui/window.h
@@ -168,6 +168,7 @@ class Window
   virtual bool isNavWindow() { return false; }
   virtual bool isPageGroup() { return false; }
   virtual bool isBubblePopup() { return false; }
+  virtual const char* getFormFieldTitle() const { return nullptr; }
 
   void setFlexLayout(lv_flex_flow_t flow = LV_FLEX_FLOW_COLUMN,
                      lv_coord_t padding = PAD_TINY, coord_t width = LV_PCT(100),
@@ -287,6 +288,7 @@ class SetupLine : public Window
   SetupLine(Window* parent, coord_t y, coord_t col2, PaddingSize padding, const char* title,
     std::function<void(SetupLine*, coord_t, coord_t)> createEdit, coord_t lblYOffset = 0);
   const std::string& getTitle() const { return titleText; }
+  const char* getFormFieldTitle() const override { return titleText.c_str(); }
 
   static coord_t showLines(Window* parent, coord_t y, coord_t col2, PaddingSize padding, const SetupLineDef* setupLines);
 

--- a/radio/src/gui/colorlcd/libui/window.h
+++ b/radio/src/gui/colorlcd/libui/window.h
@@ -286,12 +286,14 @@ class SetupLine : public Window
  public:
   SetupLine(Window* parent, coord_t y, coord_t col2, PaddingSize padding, const char* title,
     std::function<void(SetupLine*, coord_t, coord_t)> createEdit, coord_t lblYOffset = 0);
+  const std::string& getTitle() const { return titleText; }
 
   static coord_t showLines(Window* parent, coord_t y, coord_t col2, PaddingSize padding, const SetupLineDef* setupLines);
 
   Messaging setupMsg;
 
  protected:
+  std::string titleText;
 };
 
 //-----------------------------------------------------------------------------

--- a/radio/src/gui/colorlcd/radio/radio_setup.cpp
+++ b/radio/src/gui/colorlcd/radio/radio_setup.cpp
@@ -52,6 +52,7 @@ class DateNumberEdit : public NumberEdit
 {
  public:
   DateNumberEdit(Window* parent, coord_t x, coord_t y, int vmin, int vmax, bool leading0,
+                  const char* editTitle,
                   std::function<int()> getValue,
                   std::function<void(int)> setValue) :
       NumberEdit(parent, {x, y, DT_EDT_W, 0}, vmin, vmax,
@@ -64,7 +65,9 @@ class DateNumberEdit : public NumberEdit
     lastValue = this->getValue();
     if (leading0)
       setDisplayHandler([](int32_t value) { return formatNumberAsString(value, LEADING0, 2); });
-}
+    setDirectKeyboard(true);
+    setEditTitle(editTitle);
+  }
 
   static LAYOUT_ORIENTATION(DT_EDT_W, EdgeTxStyles::EDIT_FLD_WIDTH_NARROW, LAYOUT_SCALE(52))
 
@@ -137,7 +140,7 @@ class DateTimeWindow : public Window
 
     // Date
     new StaticText(this, rect_t{PAD_TINY, PAD_TINY + PAD_MEDIUM, SubPage::EDT_X - PAD_TINY - PAD_SMALL, EdgeTxStyles::STD_FONT_HEIGHT}, STR_DATE);
-    new DateNumberEdit(this, SubPage::EDT_X, PAD_TINY, 2023, 2037, false,
+    new DateNumberEdit(this, SubPage::EDT_X, PAD_TINY, 2023, 2037, false, STR_DATE,
         [=]() -> int32_t { return TM_YEAR_BASE + m_tm.tm_year; },
         [=](int32_t newValue) {
           m_tm.tm_year = newValue - TM_YEAR_BASE;
@@ -145,7 +148,7 @@ class DateTimeWindow : public Window
           SET_LOAD_DATETIME(&m_tm);
         });
 
-    new DateNumberEdit(this, SubPage::EDT_X + DateNumberEdit::DT_EDT_W + PAD_TINY, PAD_TINY, 1, 12, false,
+    new DateNumberEdit(this, SubPage::EDT_X + DateNumberEdit::DT_EDT_W + PAD_TINY, PAD_TINY, 1, 12, false, STR_DATE,
         [=]() -> int32_t { return 1 + m_tm.tm_mon; },
         [=](int32_t newValue) {
           m_tm.tm_mon = newValue - 1;
@@ -153,7 +156,7 @@ class DateTimeWindow : public Window
           SET_LOAD_DATETIME(&m_tm);
         });
 
-    day = new DateNumberEdit(this, SubPage::EDT_X + 2 * DateNumberEdit::DT_EDT_W + PAD_SMALL, PAD_TINY, 1, daysInMonth(), true,
+    day = new DateNumberEdit(this, SubPage::EDT_X + 2 * DateNumberEdit::DT_EDT_W + PAD_SMALL, PAD_TINY, 1, daysInMonth(), true, STR_DATE,
         [=]() -> int32_t { return m_tm.tm_mday; },
         [=](int32_t newValue) {
           m_tm.tm_mday = newValue;
@@ -162,21 +165,21 @@ class DateTimeWindow : public Window
 
     // Time
     new StaticText(this, rect_t{PAD_TINY, DT_Y2 + PAD_MEDIUM, SubPage::EDT_X - PAD_TINY - PAD_SMALL, EdgeTxStyles::STD_FONT_HEIGHT}, STR_TIME);
-    new DateNumberEdit(this, SubPage::EDT_X, DT_Y2, 0, 23, true,
+    new DateNumberEdit(this, SubPage::EDT_X, DT_Y2, 0, 23, true, STR_TIME,
         [=]() -> int32_t { return m_tm.tm_hour; },
         [=](int32_t newValue) {
           m_tm.tm_hour = newValue;
           SET_LOAD_DATETIME(&m_tm);
         });
 
-    new DateNumberEdit(this, SubPage::EDT_X + DateNumberEdit::DT_EDT_W + PAD_TINY, DT_Y2, 0, 59, true,
+    new DateNumberEdit(this, SubPage::EDT_X + DateNumberEdit::DT_EDT_W + PAD_TINY, DT_Y2, 0, 59, true, STR_TIME,
         [=]() -> int32_t { return m_tm.tm_min; },
         [=](int32_t newValue) {
           m_tm.tm_min = newValue;
           SET_LOAD_DATETIME(&m_tm);
         });
 
-    new DateNumberEdit(this, SubPage::EDT_X + DateNumberEdit::DT_EDT_W * 2 + PAD_SMALL, DT_Y2, 0, 59, true,
+    new DateNumberEdit(this, SubPage::EDT_X + DateNumberEdit::DT_EDT_W * 2 + PAD_SMALL, DT_Y2, 0, 59, true, STR_TIME,
         [=]() -> int32_t { return m_tm.tm_sec; },
         [=](int32_t newValue) {
           m_tm.tm_sec = newValue;
@@ -419,6 +422,7 @@ const static SetupLineDef alarmsPageSetupLines[] = {
         suffix = " " + suffix;
         return formatNumberAsString(value, 0, 0, nullptr, suffix.c_str());
       });
+      edit->setDirectKeyboard(true);
     }
   },
   {
@@ -587,6 +591,7 @@ const static SetupLineDef gpsPageSetupLines[] = {
                                 SET_DIRTY();
                               });
       tz->setDisplayHandler([](int32_t tz) { return timezoneDisplay(tz); });
+      tz->setDirectKeyboard(false);
     }
   },
   {

--- a/radio/src/gui/colorlcd/radio/radio_trainer.cpp
+++ b/radio/src/gui/colorlcd/radio/radio_trainer.cpp
@@ -73,6 +73,7 @@ void RadioTrainerPage::build(Window* form)
       auto weight = new NumberEdit(line, rect_t{0, 0, EdgeTxStyles::EDIT_FLD_WIDTH_NARROW, 0}, -125, 125,
                                    GET_SET_DEFAULT(td->studWeight));
       weight->setSuffix("%");
+      weight->setEditTitle(std::string(getMainControlLabel(chan)) + " " + STR_WEIGHT);
 
 #if PORTRAIT
       line = form->newLine(grid);


### PR DESCRIPTION
## Summary

This updates the color LCD `NumberEdit` touch keyboard from the step-control pad to a direct, adaptive numeric keypad.

The keypad is optimized for touch entry:

- always shows digits, backspace, cursor movement, and OK
- shows `+/-` only when the edited field can be negative
- shows `.` only for `PREC1` / `PREC2` fields
- keeps existing rotary and hardware-key editing semantics intact
- commits typed text through `NumberEdit::setValue()`, so existing min/max clamping remains authoritative

Fixes #3722.

## Screenshots

| Positive integer | Decimal field |
| --- | --- |
| ![Positive integer date keypad](https://github.com/onliner10/edgetx/releases/download/pr-3722-keypad-screenshots/positive-integer-date.png) | ![Decimal battery low keypad](https://github.com/onliner10/edgetx/releases/download/pr-3722-keypad-screenshots/decimal-battery-low.png) |

| Signed field | Clamped out-of-range input |
| --- | --- |
| ![Signed trainer weight keypad](https://github.com/onliner10/edgetx/releases/download/pr-3722-keypad-screenshots/signed-trainer-weight.png) | ![Date field clamped after out-of-range input](https://github.com/onliner10/edgetx/releases/download/pr-3722-keypad-screenshots/clamped-date-field.png) |

## Implementation Notes

- Adds raw numeric formatting/parsing helpers to `NumberEdit`, separate from display strings with prefixes/suffixes/custom handlers.
- Uses a full-screen `NumberKeyboard` layout for larger finger targets on color LCD radios.
- Adds a small title/value header so the full-screen editor shows what field is being edited without styling the title like the value.
- Keeps custom-display fields on the existing adjustment pad unless they explicitly opt into direct numeric entry.
- Avoids RTTI in firmware builds by using a virtual form-field title hook instead of `dynamic_cast`.
- Saturates very large typed values before clamping to avoid signed integer overflow.

## Testing

- Built the TX16S simulator with the UI harness.
- Exercised the keypad through the UI harness for integer, signed, decimal, fallback/custom-display, and out-of-range clamping scenarios.
- Tested on a TX16S MK2.
- Verified the fork TX16S firmware release workflow builds successfully with strict compiler checks.
