### PR TITLE
chore(radio): translate several UF2 boot messages

### DIFF
--- a/companion/src/translations/companion_da.ts
+++ b/companion/src/translations/companion_da.ts
@@ -1798,7 +1798,7 @@ Vil du indlæse indstillinger fra en fil?</translation>
     <message>
         <location filename="../storage/appdata.h" line="568"/>
         <source>Nightly</source>
-        <translation>Natlig byg (måske ustabile)</translation>
+        <translation>Nattens byg (måske ustabile)</translation>
     </message>
 </context>
 <context>
@@ -14506,7 +14506,7 @@ For mange fejl - afbryder.</translation>
     <message>
         <location filename="../modeledit/telemetry.ui" line="53"/>
         <source>RF Quality</source>
-        <translation></translation>
+        <translation>Link kvalitet</translation>
     </message>
     <message>
         <location filename="../modeledit/telemetry.ui" line="568"/>

--- a/radio/src/translations/bl_translations.h
+++ b/radio/src/translations/bl_translations.h
@@ -360,10 +360,10 @@
     #define TR_BL_EXIT_KEY                 BL_EXIT_KEY " foer att avbryta"
 
     // Bootloader UF2 specific - ASCII characters only
-    #define TR_BL_DFU_MODE                "DFU mode"
-    #define TR_BL_PLUG_USB                "Plug USB cable"
-    #define TR_BL_COPY_UF2                "Copy firmware.uf2 to EDGETX_UF2 drive"
-    #define TR_BL_NO_VERSION              "No version"
+    #define TR_BL_DFU_MODE                "DFU-laege"
+    #define TR_BL_PLUG_USB                "Plugga in USB-kabeln"
+    #define TR_BL_COPY_UF2                "Kopiera firmware.uf2 till enhet EDGETX_UF2"
+    #define TR_BL_NO_VERSION              "Ingen version"
 
 #else
 

--- a/radio/src/translations/bl_translations.h
+++ b/radio/src/translations/bl_translations.h
@@ -224,10 +224,10 @@
     #define TR_BL_EXIT_KEY                 BL_EXIT_KEY " pour quitter"
 
     // Bootloader UF2 specific - ASCII characters only
-    #define TR_BL_DFU_MODE          "DFU mode"
-    #define TR_BL_PLUG_USB          "Plug USB cable"
-    #define TR_BL_COPY_UF2          "Copy firmware.uf2 to EDGETX_UF2 drive"
-    #define TR_BL_NO_VERSION        "No version"
+    #define TR_BL_DFU_MODE "Mode DFU"
+    #define TR_BL_PLUG_USB "Inserer cable USB"
+    #define TR_BL_COPY_UF2 "Copier firmware.uf2 vers disque EDGETX_UF2"
+    #define TR_BL_NO_VERSION "Pas de version"
 
 #elif defined(TRANSLATIONS_IT)
 
@@ -269,10 +269,10 @@
     #define TR_BL_EXIT_KEY                 BL_EXIT_KEY " per uscire"
     
     // Bootloader UF2 specific - ASCII characters only
-    #define TR_BL_DFU_MODE          "DFU mode"
-    #define TR_BL_PLUG_USB          "Plug USB cable"
-    #define TR_BL_COPY_UF2          "Copy firmware.uf2 to EDGETX_UF2 drive"
-    #define TR_BL_NO_VERSION        "No version"
+    #define TR_BL_DFU_MODE "Modo DFU"
+    #define TR_BL_PLUG_USB "Inserisci connettore USB"
+    #define TR_BL_COPY_UF2 "Copia firmware.uf2 sul disco EDGETX_UF2"
+    #define TR_BL_NO_VERSION "Nessuna versione"
 
 #elif defined(TRANSLATIONS_PL)
 

--- a/radio/src/translations/bl_translations.h
+++ b/radio/src/translations/bl_translations.h
@@ -49,6 +49,8 @@
 
 #if defined(TRANSLATIONS_CZ)
 
+    // ASCII characters only
+    
     // Poznamka: nutne pouziti textu bez diakritiky - omezeni velikosti pameti bootloader!
     #define TR_BL_USB_CONNECTED           "USB pripojeno"
     #define TR_BL_USB_PLUGIN              "nebo pripojte USB kabel"
@@ -95,6 +97,8 @@
 
 #elif defined(TRANSLATIONS_DA)
 
+    // ASCII characters only
+
     #define TR_BL_USB_CONNECTED           "USB forbundet"
     #define TR_BL_USB_PLUGIN              "eller brug USB kabel"
     #define TR_BL_USB_MASS_STORE          "for USB disk"
@@ -140,6 +144,8 @@
 
 #elif defined(TRANSLATIONS_DE)
 
+    // ASCII characters only
+    
     #define TR_BL_USB_CONNECTED           "USB verbunden"
     #define TR_BL_USB_PLUGIN              "oder USB-Kabel anschl."
     #define TR_BL_USB_MASS_STORE          "fuer den SD-Speicher an"
@@ -186,6 +192,8 @@
 
 #elif defined(TRANSLATIONS_FR)
 
+    // ASCII characters only
+    
     #define TR_BL_USB_CONNECTED           "USB Connecte"
     #define TR_BL_USB_PLUGIN              "ou branchez cable USB"
     #define TR_BL_USB_MASS_STORE          "pour stockage de masse"
@@ -231,6 +239,8 @@
 
 #elif defined(TRANSLATIONS_IT)
 
+    // ASCII characters only
+    
     #define TR_BL_USB_CONNECTED           "USB Connessa"
     #define TR_BL_USB_PLUGIN              "O connetti il cavo USB"
     #define TR_BL_USB_MASS_STORE          "per memoria di massa"
@@ -276,6 +286,8 @@
 
 #elif defined(TRANSLATIONS_PL)
 
+    // ASCII characters only
+    
     #define TR_BL_USB_CONNECTED           "USB polaczone"
     #define TR_BL_USB_PLUGIN              "lub podlacz kabel USB"
     #define TR_BL_USB_MASS_STORE          "dla trybu danych"
@@ -314,14 +326,15 @@
     #define TR_BL_EXIT_KEY                 BL_EXIT_KEY " aby wyjsc"
 
     // Bootloader UF2 specific - ASCII characters only
-    #define TR_BL_DFU_MODE                "DFU mode"
-    #define TR_BL_PLUG_USB                "Plug USB cable"
-    #define TR_BL_COPY_UF2                "Copy firmware.uf2 to EDGETX_UF2 drive"
-    #define TR_BL_NO_VERSION              "No version"
+    #define TR_BL_DFU_MODE                "Tryb DFU"
+    #define TR_BL_PLUG_USB                "Podlacz kabel USB"
+    #define TR_BL_COPY_UF2                "Skopiuj firmware.uf2 na dysk EDGETX_UF2"
+    #define TR_BL_NO_VERSION              "Brak wersji"
 
 #elif defined(TRANSLATIONS_SE)
 
-    // Bootloader common
+    // ASCII characters only
+
     #define TR_BL_USB_CONNECTED            "USB ansluten"
     #define TR_BL_USB_PLUGIN               "Eller anslut med USB-kabel"
     #define TR_BL_USB_MASS_STORE           "foer masslagring"
@@ -365,8 +378,10 @@
     #define TR_BL_COPY_UF2                "Kopiera firmware.uf2 till enhet EDGETX_UF2"
     #define TR_BL_NO_VERSION              "Ingen version"
 
-#else
+#else  // EN
 
+    // ASCII characters only
+    
     #define TR_BL_USB_CONNECTED           "USB Connected"
     #define TR_BL_USB_PLUGIN              "Or plug in a USB cable"
     #define TR_BL_USB_MASS_STORE          "for mass storage"

--- a/radio/src/translations/bl_translations.h
+++ b/radio/src/translations/bl_translations.h
@@ -88,10 +88,10 @@
     #define TR_BL_EXIT_KEY                 BL_EXIT_KEY " pro ukonceni"
 
     // Bootloader UF2 specific - ASCII characters only
-    #define TR_BL_DFU_MODE          "DFU mode"
-    #define TR_BL_PLUG_USB          "Plug USB cable"
-    #define TR_BL_COPY_UF2          "Copy firmware.uf2 to EDGETX_UF2 drive"
-    #define TR_BL_NO_VERSION        "No version"
+    #define TR_BL_DFU_MODE "DFU rezim"
+    #define TR_BL_PLUG_USB "Pripojit USB kabel"
+    #define TR_BL_COPY_UF2 "Kopirovat firmware.uf2 na EDGETX_UF2 uloziste"
+    #define TR_BL_NO_VERSION "Zadna verze"
 
 #elif defined(TRANSLATIONS_DA)
 

--- a/radio/src/translations/bl_translations.h
+++ b/radio/src/translations/bl_translations.h
@@ -88,10 +88,10 @@
     #define TR_BL_EXIT_KEY                 BL_EXIT_KEY " pro ukonceni"
 
     // Bootloader UF2 specific - ASCII characters only
-    #define TR_BL_DFU_MODE "DFU rezim"
-    #define TR_BL_PLUG_USB "Pripojit USB kabel"
-    #define TR_BL_COPY_UF2 "Kopirovat firmware.uf2 na EDGETX_UF2 uloziste"
-    #define TR_BL_NO_VERSION "Zadna verze"
+    #define TR_BL_DFU_MODE                "DFU rezim"
+    #define TR_BL_PLUG_USB                "Pripojit USB kabel"
+    #define TR_BL_COPY_UF2                "Kopirovat firmware.uf2 na EDGETX_UF2 uloziste"
+    #define TR_BL_NO_VERSION              "Zadna verze"
 
 #elif defined(TRANSLATIONS_DA)
 
@@ -133,16 +133,16 @@
     #define TR_BL_EXIT_KEY                 BL_EXIT_KEY " for at forlade"
 
     // Bootloader UF2 specific - ASCII characters only
-    #define TR_BL_DFU_MODE          "DFU tilstand"
-    #define TR_BL_PLUG_USB          "Forbind USB kabel"
-    #define TR_BL_COPY_UF2          "Kopier firmware.uf2 til EDGETX_UF2 drev"
-    #define TR_BL_NO_VERSION        "Ingen version"
+    #define TR_BL_DFU_MODE                "DFU tilstand"
+    #define TR_BL_PLUG_USB                "Forbind USB kabel"
+    #define TR_BL_COPY_UF2                "Kopier firmware.uf2 til EDGETX_UF2 drev"
+    #define TR_BL_NO_VERSION              "Ingen version"
 
 #elif defined(TRANSLATIONS_DE)
 
     #define TR_BL_USB_CONNECTED           "USB verbunden"
     #define TR_BL_USB_PLUGIN              "oder USB-Kabel anschl."
-    #define TR_BL_USB_MASS_STORE          "für den SD-Speicher an"
+    #define TR_BL_USB_MASS_STORE          "fuer den SD-Speicher an"
     #define TR_BL_WRITE_FW                "Schreibe Firmware"
     #define TR_BL_FORK                    "Fork:"
     #define TR_BL_VERSION                 "Version:"
@@ -156,13 +156,13 @@
     #define TR_BL_DISABLE                 "Deaktivieren"
 
     #if !defined(COLORLCD)
-      #define TR_BL_OR_PLUGIN_USB_CABLE    TR(TR_BL_USB_PLUGIN, "Oder schließen Sie ein USB-Kabel " TR_BL_USB_MASS_STORE)
-      #define TR_BL_HOLD_ENTER_TO_START    TR("Zum Starten [ENT] halten", "Halte [ENT] gedrückt, um mit dem Schreiben zu beginnen")
+      #define TR_BL_OR_PLUGIN_USB_CABLE    TR(TR_BL_USB_PLUGIN, "Oder schliessen Sie ein USB-Kabel " TR_BL_USB_MASS_STORE)
+      #define TR_BL_HOLD_ENTER_TO_START    TR("Zum Starten [ENT] halten", "Halte [ENT] gedrueckt, um mit dem Schreiben zu beginnen")
     #endif
-    #define TR_BL_INVALID_FIRMWARE         TR("Keine gültige Firmware!", "Keine gültige Firmwaredatei!")
+    #define TR_BL_INVALID_FIRMWARE         TR("Keine gueltige Firmware!", "Keine gueltige Firmwaredatei!")
 
     // Bootloader Taranis specific - ASCII characters only
-    #define TR_BL_POWER_KEY                "Drücke den Power Knopf."
+    #define TR_BL_POWER_KEY                "Druecke den Power Knopf."
     #define TR_BL_FLASH_EXIT               "Verlasse den Flashmodus."
 
     // Bootloader Horus specific - ASCII characters only
@@ -172,17 +172,17 @@
     #define TR_BL_RF_USB_ACCESS            "RF USB Zugriff"
     #define TR_BL_CURRENT_FW               "Aktuelle Firmware:"
 
-    #define TR_BL_SELECT_KEY               BL_SELECT_KEY " um Datei auszuwählen"
-    #define TR_BL_FLASH_KEY                "Halte " BL_SELECT_KEY " gedrückt, zum schreiben"
-    #define TR_BL_ERASE_KEY                "Halte " BL_SELECT_KEY " gedrückt, to erase"
+    #define TR_BL_SELECT_KEY               BL_SELECT_KEY " um Datei auszuwaehlen"
+    #define TR_BL_FLASH_KEY                "Halte " BL_SELECT_KEY " gedrueckt, zum schreiben"
+    #define TR_BL_ERASE_KEY                "Halte " BL_SELECT_KEY " gedrueckt, to erase"
     #define TR_BL_TOGGLE_KEY               BL_SELECT_KEY " to toggle"
     #define TR_BL_EXIT_KEY                 BL_EXIT_KEY " zum beenden"
 
     // Bootloader UF2 specific - ASCII characters only
-    #define TR_BL_DFU_MODE          "DFU mode"
-    #define TR_BL_PLUG_USB          "Plug USB cable"
-    #define TR_BL_COPY_UF2          "Copy firmware.uf2 to EDGETX_UF2 drive"
-    #define TR_BL_NO_VERSION        "No version"
+    #define TR_BL_DFU_MODE                "DFU Modus"
+    #define TR_BL_PLUG_USB                "USB-Kabel einstecken"
+    #define TR_BL_COPY_UF2                "Kopiere firmware.uf2 nach EDGETX_UF2"
+    #define TR_BL_NO_VERSION              "Keine Version"
 
 #elif defined(TRANSLATIONS_FR)
 
@@ -224,10 +224,10 @@
     #define TR_BL_EXIT_KEY                 BL_EXIT_KEY " pour quitter"
 
     // Bootloader UF2 specific - ASCII characters only
-    #define TR_BL_DFU_MODE "Mode DFU"
-    #define TR_BL_PLUG_USB "Inserer cable USB"
-    #define TR_BL_COPY_UF2 "Copier firmware.uf2 vers disque EDGETX_UF2"
-    #define TR_BL_NO_VERSION "Pas de version"
+    #define TR_BL_DFU_MODE                "Mode DFU"
+    #define TR_BL_PLUG_USB                "Inserer cable USB"
+    #define TR_BL_COPY_UF2                "Copier firmware.uf2 vers disque EDGETX_UF2"
+    #define TR_BL_NO_VERSION              "Pas de version"
 
 #elif defined(TRANSLATIONS_IT)
 
@@ -269,10 +269,10 @@
     #define TR_BL_EXIT_KEY                 BL_EXIT_KEY " per uscire"
     
     // Bootloader UF2 specific - ASCII characters only
-    #define TR_BL_DFU_MODE "Modo DFU"
-    #define TR_BL_PLUG_USB "Inserisci connettore USB"
-    #define TR_BL_COPY_UF2 "Copia firmware.uf2 sul disco EDGETX_UF2"
-    #define TR_BL_NO_VERSION "Nessuna versione"
+    #define TR_BL_DFU_MODE                "Modo DFU"
+    #define TR_BL_PLUG_USB                "Inserisci connettore USB"
+    #define TR_BL_COPY_UF2                "Copia firmware.uf2 sul disco EDGETX_UF2"
+    #define TR_BL_NO_VERSION              "Nessuna versione"
 
 #elif defined(TRANSLATIONS_PL)
 
@@ -314,10 +314,10 @@
     #define TR_BL_EXIT_KEY                 BL_EXIT_KEY " aby wyjsc"
 
     // Bootloader UF2 specific - ASCII characters only
-    #define TR_BL_DFU_MODE          "DFU mode"
-    #define TR_BL_PLUG_USB          "Plug USB cable"
-    #define TR_BL_COPY_UF2          "Copy firmware.uf2 to EDGETX_UF2 drive"
-    #define TR_BL_NO_VERSION        "No version"
+    #define TR_BL_DFU_MODE                "DFU mode"
+    #define TR_BL_PLUG_USB                "Plug USB cable"
+    #define TR_BL_COPY_UF2                "Copy firmware.uf2 to EDGETX_UF2 drive"
+    #define TR_BL_NO_VERSION              "No version"
 
 #elif defined(TRANSLATIONS_SE)
 
@@ -360,10 +360,10 @@
     #define TR_BL_EXIT_KEY                 BL_EXIT_KEY " foer att avbryta"
 
     // Bootloader UF2 specific - ASCII characters only
-    #define TR_BL_DFU_MODE          "DFU mode"
-    #define TR_BL_PLUG_USB          "Plug USB cable"
-    #define TR_BL_COPY_UF2          "Copy firmware.uf2 to EDGETX_UF2 drive"
-    #define TR_BL_NO_VERSION        "No version"
+    #define TR_BL_DFU_MODE                "DFU mode"
+    #define TR_BL_PLUG_USB                "Plug USB cable"
+    #define TR_BL_COPY_UF2                "Copy firmware.uf2 to EDGETX_UF2 drive"
+    #define TR_BL_NO_VERSION              "No version"
 
 #else
 
@@ -405,10 +405,10 @@
     #define TR_BL_EXIT_KEY                 BL_EXIT_KEY " to exit"
 
     // Bootloader UF2 specific - ASCII characters only
-    #define TR_BL_DFU_MODE          "DFU mode"
-    #define TR_BL_PLUG_USB          "Plug USB cable"
-    #define TR_BL_COPY_UF2          "Copy firmware.uf2 to EDGETX_UF2 drive"
-    #define TR_BL_NO_VERSION        "No version"
+    #define TR_BL_DFU_MODE                "DFU mode"
+    #define TR_BL_PLUG_USB                "Plug USB cable"
+    #define TR_BL_COPY_UF2                "Copy firmware.uf2 to EDGETX_UF2 drive"
+    #define TR_BL_NO_VERSION              "No version"
 
 #endif
 

--- a/radio/src/translations/bl_translations.h
+++ b/radio/src/translations/bl_translations.h
@@ -87,6 +87,12 @@
     #define TR_BL_TOGGLE_KEY               BL_SELECT_KEY " to toggle"
     #define TR_BL_EXIT_KEY                 BL_EXIT_KEY " pro ukonceni"
 
+    // Bootloader UF2 specific - ASCII characters only
+    #define TR_BL_DFU_MODE          "DFU mode"
+    #define TR_BL_PLUG_USB          "Plug USB cable"
+    #define TR_BL_COPY_UF2          "Copy firmware.uf2 to EDGETX_UF2 drive"
+    #define TR_BL_NO_VERSION        "No version"
+
 #elif defined(TRANSLATIONS_DA)
 
     #define TR_BL_USB_CONNECTED           "USB forbundet"
@@ -125,6 +131,12 @@
     #define TR_BL_ERASE_KEY                "Hold " BL_SELECT_KEY " laenge, for at slette"
     #define TR_BL_TOGGLE_KEY               BL_SELECT_KEY " to toggle"
     #define TR_BL_EXIT_KEY                 BL_EXIT_KEY " for at forlade"
+
+    // Bootloader UF2 specific - ASCII characters only
+    #define TR_BL_DFU_MODE          "DFU tilstand"
+    #define TR_BL_PLUG_USB          "Forbind USB kabel"
+    #define TR_BL_COPY_UF2          "Kopier firmware.uf2 til EDGETX_UF2 drev"
+    #define TR_BL_NO_VERSION        "Ingen version"
 
 #elif defined(TRANSLATIONS_DE)
 
@@ -166,6 +178,12 @@
     #define TR_BL_TOGGLE_KEY               BL_SELECT_KEY " to toggle"
     #define TR_BL_EXIT_KEY                 BL_EXIT_KEY " zum beenden"
 
+    // Bootloader UF2 specific - ASCII characters only
+    #define TR_BL_DFU_MODE          "DFU mode"
+    #define TR_BL_PLUG_USB          "Plug USB cable"
+    #define TR_BL_COPY_UF2          "Copy firmware.uf2 to EDGETX_UF2 drive"
+    #define TR_BL_NO_VERSION        "No version"
+
 #elif defined(TRANSLATIONS_FR)
 
     #define TR_BL_USB_CONNECTED           "USB Connecte"
@@ -205,6 +223,12 @@
     #define TR_BL_TOGGLE_KEY               BL_SELECT_KEY " to toggle"
     #define TR_BL_EXIT_KEY                 BL_EXIT_KEY " pour quitter"
 
+    // Bootloader UF2 specific - ASCII characters only
+    #define TR_BL_DFU_MODE          "DFU mode"
+    #define TR_BL_PLUG_USB          "Plug USB cable"
+    #define TR_BL_COPY_UF2          "Copy firmware.uf2 to EDGETX_UF2 drive"
+    #define TR_BL_NO_VERSION        "No version"
+
 #elif defined(TRANSLATIONS_IT)
 
     #define TR_BL_USB_CONNECTED           "USB Connessa"
@@ -243,6 +267,12 @@
     #define TR_BL_ERASE_KEY                "Premi " BL_SELECT_KEY " a lungo per cancellare"
     #define TR_BL_TOGGLE_KEY               BL_SELECT_KEY " per cambiare"
     #define TR_BL_EXIT_KEY                 BL_EXIT_KEY " per uscire"
+    
+    // Bootloader UF2 specific - ASCII characters only
+    #define TR_BL_DFU_MODE          "DFU mode"
+    #define TR_BL_PLUG_USB          "Plug USB cable"
+    #define TR_BL_COPY_UF2          "Copy firmware.uf2 to EDGETX_UF2 drive"
+    #define TR_BL_NO_VERSION        "No version"
 
 #elif defined(TRANSLATIONS_PL)
 
@@ -282,6 +312,12 @@
     #define TR_BL_ERASE_KEY                "Przytrzymaj " BL_SELECT_KEY " long to erase"
     #define TR_BL_TOGGLE_KEY               BL_SELECT_KEY " to toggle"
     #define TR_BL_EXIT_KEY                 BL_EXIT_KEY " aby wyjsc"
+
+    // Bootloader UF2 specific - ASCII characters only
+    #define TR_BL_DFU_MODE          "DFU mode"
+    #define TR_BL_PLUG_USB          "Plug USB cable"
+    #define TR_BL_COPY_UF2          "Copy firmware.uf2 to EDGETX_UF2 drive"
+    #define TR_BL_NO_VERSION        "No version"
 
 #elif defined(TRANSLATIONS_SE)
 
@@ -323,6 +359,12 @@
     #define TR_BL_TOGGLE_KEY               BL_SELECT_KEY " to toggle"
     #define TR_BL_EXIT_KEY                 BL_EXIT_KEY " foer att avbryta"
 
+    // Bootloader UF2 specific - ASCII characters only
+    #define TR_BL_DFU_MODE          "DFU mode"
+    #define TR_BL_PLUG_USB          "Plug USB cable"
+    #define TR_BL_COPY_UF2          "Copy firmware.uf2 to EDGETX_UF2 drive"
+    #define TR_BL_NO_VERSION        "No version"
+
 #else
 
     #define TR_BL_USB_CONNECTED           "USB Connected"
@@ -362,13 +404,15 @@
     #define TR_BL_TOGGLE_KEY               BL_SELECT_KEY " to toggle"
     #define TR_BL_EXIT_KEY                 BL_EXIT_KEY " to exit"
 
+    // Bootloader UF2 specific - ASCII characters only
+    #define TR_BL_DFU_MODE          "DFU mode"
+    #define TR_BL_PLUG_USB          "Plug USB cable"
+    #define TR_BL_COPY_UF2          "Copy firmware.uf2 to EDGETX_UF2 drive"
+    #define TR_BL_NO_VERSION        "No version"
+
 #endif
 
 #if !defined(COLORLCD) && !defined(TR_BL_OR_PLUGIN_USB_CABLE)
   #define TR_BL_OR_PLUGIN_USB_CABLE  TR(TR_BL_USB_PLUGIN, TR_BL_USB_PLUGIN " " TR_BL_USB_MASS_STORE)
 #endif
 
-#define TR_BL_DFU_MODE          "DFU mode"
-#define TR_BL_PLUG_USB          "Plug USB cable"
-#define TR_BL_COPY_UF2          "Copy firmware.uf2 to EDGETX_UF2 drive"
-#define TR_BL_NO_VERSION        "No version"


### PR DESCRIPTION
Make it possible to translate the 4 UF2 defines
    #define TR_BL_DFU_MODE          "DFU mode"
    #define TR_BL_PLUG_USB          "Plug USB cable"
    #define TR_BL_COPY_UF2          "Copy firmware.uf2 to EDGETX_UF2 drive"
    #define TR_BL_NO_VERSION        "No version"

Notice: Special chars are not working well at bootloader envoriment, translate without them, ie. ascii only.

If you want to translate😃

- [x]  @Eldenroot CZ
- [x]  @ParkerEde / @TheIsotopes DE
- [x]  @Pat6874 FR
- [x]  @robustini IT
- [x]  @ulfhedlund SE
- [x]  @ajjjjjjjj PL