### PR TITLE
fix: round GPS time to nearest second using milliseconds field

### DIFF
--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -191,6 +191,26 @@ void processCrossfireTelemetryFrame(uint8_t module, uint8_t* rxBuffer,
       uint8_t hour   = rxBuffer[7];
       uint8_t minute = rxBuffer[8];
       uint8_t sec    = rxBuffer[9];
+      uint16_t msec  = (rxBuffer[10] << 8) + rxBuffer[11];
+      if (msec >= 500) {
+        if (++sec >= 60) {
+          sec = 0;
+          if (++minute >= 60) {
+            minute = 0;
+            if (++hour >= 24) {
+              hour = 0;
+              uint8_t month_days[] = {0, 31, (uint8_t)((((year%4==0) && (year%100!=0)) || (year%400==0)) ? 29:28), 31, 30, 31, 30, 31, 31, 30, 31, 30, 31};
+              if (++day > month_days[month]) {
+                day = 1;
+                if (++month > 12) {
+                  month = 1;
+                  ++year;
+                }
+              }
+            }
+          }
+        }
+      }
       // Date record: low byte non-zero (acts as date/time discriminator)
       uint32_t dateVal = ((uint32_t)year << 24) | ((uint32_t)month << 16)
                        | ((uint32_t)day << 8) | 0xFF;


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Enhancement to #7317: adequately handles the millisecond field in the 0x03 GPSTime frames

Summary of changes:
Per https://github.com/EdgeTX/edgetx/pull/7317#issuecomment-4351915904, and moreover https://github.com/EdgeTX/edgetx/pull/7317#issuecomment-4366876301, this adds correct handling of the milliseconds field to PR#7317 by adequately rounding up the seconds field whenever it's equal to or larger  than 500ms (half a second). This, besides being more correct than simply ignoring the milliseconds field, is also necessary to get the time exactly in sync between the transmitter and the drone as explained in the second comment linked above.
