### PR TITLE
chore(radio): remove 20% deadband for low volume

### DIFF
--- a/radio/src/boards/rm-h750/audio_driver.cpp
+++ b/radio/src/boards/rm-h750/audio_driver.cpp
@@ -26,7 +26,6 @@
 #include "stm32_i2c_driver.h"
 
 #include "stm32_hal_ll.h"
-#include "timers_driver.h"
 
 #include "audio.h"
 #include "debug.h"
@@ -176,7 +175,7 @@ void audioSetVolume(uint8_t volume)
   if (btAudioLinked())
     volume = volume + (volume	>> 2);
 #endif
-  tas2505_set_volume(&_tas2505, volume * 9 / 10, audioHeadphoneDetect()); // TX15 HP cannot handle the full power of TAS2505
+  tas2505_set_volume(&_tas2505, volume, audioHeadphoneDetect());
 }
 
 extern "C" void DMA1_Stream4_IRQHandler(void)

--- a/radio/src/drivers/tas2505.cpp
+++ b/radio/src/drivers/tas2505.cpp
@@ -131,10 +131,11 @@ int tas2505_init(tas2505_t* dev)
 // adjust this value for a volume level just above the silence
 // values is attenuation in dB, higher value - less volume
 // max value is 126
-#define VOLUME_MIN_DB     60
+#define VOLUME_MIN_DB     45
 
 void tas2505_set_volume(tas2505_t* dev, uint8_t volume, bool headphone_mode = false)
 {
+  TRACE("Set volume: %d, headphone_mode: %d", volume, headphone_mode);
   if (volume > VOLUME_LEVEL_MAX) {
     volume = VOLUME_LEVEL_MAX;
   }

--- a/radio/src/edgetx.cpp
+++ b/radio/src/edgetx.cpp
@@ -614,19 +614,20 @@ void calcBacklightValue(int16_t source)
 #endif
 }
 
-#define VOLUME_HYSTERESIS 10            // how much must a input value change to actually be considered for new volume setting
-getvalue_t requiredSpeakerVolumeRawLast = 1024 + 1; //initial value must be outside normal range
+#define VOLUME_SOURCE_DEADZONE 10       // how much must a input value change to actually be considered for new volume setting
 
 void calcVolumeValue(int16_t source)
 {
-  getvalue_t raw = getValue(source);
-  // only set volume if input changed more than hysteresis
-  if (abs(requiredSpeakerVolumeRawLast - raw) > VOLUME_HYSTERESIS) {
-    requiredSpeakerVolumeRawLast = raw;
+  int32_t shifted = 1024 + getValue(source);
+  int32_t v;
+  if (shifted < VOLUME_SOURCE_DEADZONE) {
+    v = 0;
+  } else {
+    v = 1 + ((shifted - VOLUME_SOURCE_DEADZONE) * (VOLUME_LEVEL_MAX - 1)) /
+            (2048 - VOLUME_SOURCE_DEADZONE);
+    if (v > VOLUME_LEVEL_MAX) v = VOLUME_LEVEL_MAX;
   }
-  requiredSpeakerVolume =
-      ((1024 + requiredSpeakerVolumeRawLast) * VOLUME_LEVEL_MAX) /
-      2048;
+  requiredSpeakerVolume = (int16_t)v;
 }
 
 void checkBacklight()

--- a/radio/src/hal/audio_driver.h
+++ b/radio/src/hal/audio_driver.h
@@ -24,9 +24,13 @@
 #include <stdint.h>
 
 // Audio volume is defined between 0 and VOLUME_LEVEL_MAX.
-// Targets that need a different range must `#undef` and redefine in their board/hal header.
+// Targets that need a different range can define it in their board/hal header.
+#ifndef VOLUME_LEVEL_MAX
 #define VOLUME_LEVEL_MAX 23
+#endif
+#ifndef VOLUME_LEVEL_DEF
 #define VOLUME_LEVEL_DEF 12
+#endif
 
 #define AUDIO_SAMPLE_RATE 32000
 

--- a/radio/src/hal/audio_driver.h
+++ b/radio/src/hal/audio_driver.h
@@ -24,9 +24,8 @@
 #include <stdint.h>
 
 // Audio volume is defined between 0 and VOLUME_LEVEL_MAX.
-#if !defined(VOLUME_LEVEL_MAX)
+// Targets that need a different range must `#undef` and redefine in their board/hal header.
 #define VOLUME_LEVEL_MAX 23
-#endif
 #define VOLUME_LEVEL_DEF 12
 
 #define AUDIO_SAMPLE_RATE 32000

--- a/radio/src/hal/audio_driver.h
+++ b/radio/src/hal/audio_driver.h
@@ -24,7 +24,9 @@
 #include <stdint.h>
 
 // Audio volume is defined between 0 and VOLUME_LEVEL_MAX.
+#if !defined(VOLUME_LEVEL_MAX)
 #define VOLUME_LEVEL_MAX 23
+#endif
 #define VOLUME_LEVEL_DEF 12
 
 #define AUDIO_SAMPLE_RATE 32000

--- a/radio/src/targets/tx15/hal.h
+++ b/radio/src/targets/tx15/hal.h
@@ -195,6 +195,7 @@ TIM17:	ROTARY_ENCODER_TIMER
 #define AUDIO_SPI                       SPI2
 #define AUDIO_RESET_PIN                 GPIO_PIN(GPIOH, 10)
 #define AUDIO_HP_DETECT_PIN             GPIO_PIN(GPIOA, 5)
+#undef VOLUME_LEVEL_MAX
 #define VOLUME_LEVEL_MAX                20
 #define I2S_DMA                         DMA1
 #define I2S_DMA_Stream                  LL_DMA_STREAM_4

--- a/radio/src/targets/tx15/hal.h
+++ b/radio/src/targets/tx15/hal.h
@@ -195,11 +195,12 @@ TIM17:	ROTARY_ENCODER_TIMER
 #define AUDIO_SPI                       SPI2
 #define AUDIO_RESET_PIN                 GPIO_PIN(GPIOH, 10)
 #define AUDIO_HP_DETECT_PIN             GPIO_PIN(GPIOA, 5)
-#define I2S_DMA                   		DMA1
-#define I2S_DMA_Stream            		LL_DMA_STREAM_4
-#define I2S_DMA_Stream_Request    		LL_DMAMUX1_REQ_SPI2_TX
-#define I2S_DMA_Stream_IRQn       		DMA1_Stream4_IRQn
-#define I2S_DMA_Stream_IRQHandler 		DMA1_Stream4_IRQHandler
+#define VOLUME_LEVEL_MAX                20
+#define I2S_DMA                   	DMA1
+#define I2S_DMA_Stream            	LL_DMA_STREAM_4
+#define I2S_DMA_Stream_Request    	LL_DMAMUX1_REQ_SPI2_TX
+#define I2S_DMA_Stream_IRQn       	DMA1_Stream4_IRQn
+#define I2S_DMA_Stream_IRQHandler 	DMA1_Stream4_IRQHandler
 
 
 // I2C Bus

--- a/radio/src/targets/tx15/hal.h
+++ b/radio/src/targets/tx15/hal.h
@@ -196,11 +196,11 @@ TIM17:	ROTARY_ENCODER_TIMER
 #define AUDIO_RESET_PIN                 GPIO_PIN(GPIOH, 10)
 #define AUDIO_HP_DETECT_PIN             GPIO_PIN(GPIOA, 5)
 #define VOLUME_LEVEL_MAX                20
-#define I2S_DMA                   	DMA1
-#define I2S_DMA_Stream            	LL_DMA_STREAM_4
-#define I2S_DMA_Stream_Request    	LL_DMAMUX1_REQ_SPI2_TX
-#define I2S_DMA_Stream_IRQn       	DMA1_Stream4_IRQn
-#define I2S_DMA_Stream_IRQHandler 	DMA1_Stream4_IRQHandler
+#define I2S_DMA                         DMA1
+#define I2S_DMA_Stream                  LL_DMA_STREAM_4
+#define I2S_DMA_Stream_Request          LL_DMAMUX1_REQ_SPI2_TX
+#define I2S_DMA_Stream_IRQn             DMA1_Stream4_IRQn
+#define I2S_DMA_Stream_IRQHandler       DMA1_Stream4_IRQHandler
 
 
 // I2C Bus

--- a/radio/src/targets/tx16smk3/hal.h
+++ b/radio/src/targets/tx16smk3/hal.h
@@ -400,11 +400,11 @@ USART6: INTMODULE_USART
 #define AUDIO_RESET_PIN                 GPIO_PIN(GPIOH, 10)
 #define AUDIO_HP_DETECT_PIN             GPIO_PIN(GPIOH, 14)
 #define VOLUME_LEVEL_MAX                20
-#define I2S_DMA                   	DMA1
-#define I2S_DMA_Stream            	LL_DMA_STREAM_4
-#define I2S_DMA_Stream_Request    	LL_DMAMUX1_REQ_SPI2_TX
-#define I2S_DMA_Stream_IRQn       	DMA1_Stream4_IRQn
-#define I2S_DMA_Stream_IRQHandler 	DMA1_Stream4_IRQHandler
+#define I2S_DMA                         DMA1
+#define I2S_DMA_Stream                  LL_DMA_STREAM_4
+#define I2S_DMA_Stream_Request          LL_DMAMUX1_REQ_SPI2_TX
+#define I2S_DMA_Stream_IRQn             DMA1_Stream4_IRQn
+#define I2S_DMA_Stream_IRQHandler       DMA1_Stream4_IRQHandler
 
 // I2C Bus
 #define I2C_B1                          I2C4

--- a/radio/src/targets/tx16smk3/hal.h
+++ b/radio/src/targets/tx16smk3/hal.h
@@ -399,11 +399,12 @@ USART6: INTMODULE_USART
 #define AUDIO_SPI                       SPI2
 #define AUDIO_RESET_PIN                 GPIO_PIN(GPIOH, 10)
 #define AUDIO_HP_DETECT_PIN             GPIO_PIN(GPIOH, 14)
-#define I2S_DMA                   		DMA1
-#define I2S_DMA_Stream            		LL_DMA_STREAM_4
-#define I2S_DMA_Stream_Request    		LL_DMAMUX1_REQ_SPI2_TX
-#define I2S_DMA_Stream_IRQn       		DMA1_Stream4_IRQn
-#define I2S_DMA_Stream_IRQHandler 		DMA1_Stream4_IRQHandler
+#define VOLUME_LEVEL_MAX                20
+#define I2S_DMA                   	DMA1
+#define I2S_DMA_Stream            	LL_DMA_STREAM_4
+#define I2S_DMA_Stream_Request    	LL_DMAMUX1_REQ_SPI2_TX
+#define I2S_DMA_Stream_IRQn       	DMA1_Stream4_IRQn
+#define I2S_DMA_Stream_IRQHandler 	DMA1_Stream4_IRQHandler
 
 // I2C Bus
 #define I2C_B1                          I2C4

--- a/radio/src/targets/tx16smk3/hal.h
+++ b/radio/src/targets/tx16smk3/hal.h
@@ -399,6 +399,7 @@ USART6: INTMODULE_USART
 #define AUDIO_SPI                       SPI2
 #define AUDIO_RESET_PIN                 GPIO_PIN(GPIOH, 10)
 #define AUDIO_HP_DETECT_PIN             GPIO_PIN(GPIOH, 14)
+#undef VOLUME_LEVEL_MAX
 #define VOLUME_LEVEL_MAX                20
 #define I2S_DMA                         DMA1
 #define I2S_DMA_Stream                  LL_DMA_STREAM_4


### PR DESCRIPTION
This improves settings sound level by special function or sound settings by source. It reduces the dead band before any sound can be played (previously volume was set a 0 until at least -80%)

This also simplifies the mechanic when hardware needs a fixed volume limitation


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More immediate speaker volume updates by replacing hysteresis with a deadzone-based input filter.
  * Removed internal volume scaling so headphone volume matches the user-set level.
  * Lowered minimum volume threshold for improved low-volume audio fidelity.

* **New Features**
  * Added trace logging for volume changes to aid diagnostics.

* **Chores**
  * Introduced configurable/default max volume handling and standardized per-target max volume to 20 for affected transmitters.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EdgeTX/edgetx/pull/7347?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->