### PR TITLE
fix(color): fix issues with quick menu, favorites and key shortcuts

### DIFF
--- a/radio/src/edgetx.cpp
+++ b/radio/src/edgetx.cpp
@@ -2106,7 +2106,6 @@ bool validateLSV2Range(LogicalSwitchData* cs, int16_t& v2_min, int16_t& v2_max, 
       v2_min = 0;
     }
   }
-  TRACE(">>>>> %d %d %d",cs->func,v2_min,v2_max);
 
   bool rv = false;
 

--- a/radio/src/gui/colorlcd/libui/page.cpp
+++ b/radio/src/gui/colorlcd/libui/page.cpp
@@ -138,12 +138,11 @@ void Page::doKeyShortcut(event_t event)
   QMPage pg = g_eeGeneral.getKeyShortcut(event);
   if (pg == QM_OPEN_QUICK_MENU) {
     QuickMenu::openQuickMenu();
-  } else {
+  } else if (pg != QM_NONE) {
+    onCancel();
     auto p = navWindow();
-    if (p) {
-      onCancel();
+    if (p)
       p->doKeyShortcut(event);
-    }
   }
 }
 void Page::onLongPressRTN() { onCancel(); }

--- a/radio/src/gui/colorlcd/libui/page.cpp
+++ b/radio/src/gui/colorlcd/libui/page.cpp
@@ -133,65 +133,19 @@ NavWindow* Page::navWindow()
 }
 
 #if defined(HARDWARE_KEYS)
-void Page::onPressSYS()
+void Page::doKeyShortcut(event_t event)
 {
-  QMPage pg = g_eeGeneral.getKeyShortcut(EVT_KEY_BREAK(KEY_SYS));
+  QMPage pg = g_eeGeneral.getKeyShortcut(event);
   if (pg == QM_OPEN_QUICK_MENU) {
     QuickMenu::openQuickMenu();
   } else {
     auto p = navWindow();
     if (p) {
       onCancel();
-      p->onPressSYS();
+      p->doKeyShortcut(event);
     }
   }
 }
-
-void Page::onLongPressSYS()
-{
-  auto p = navWindow();
-  if (p) {
-    onCancel();
-    p->onLongPressSYS();
-  }
-}
-
-void Page::onPressMDL()
-{
-  auto p = navWindow();
-  if (p) {
-    onCancel();
-    p->onPressMDL();
-  }
-}
-
-void Page::onLongPressMDL()
-{
-  auto p = navWindow();
-  if (p) {
-    onCancel();
-    p->onLongPressMDL();
-  }
-}
-
-void Page::onPressTELE()
-{
-  auto p = navWindow();
-  if (p) {
-    onCancel();
-    p->onPressTELE();
-  }
-}
-
-void Page::onLongPressTELE()
-{
-  auto p = navWindow();
-  if (p) {
-    onCancel();
-    p->onLongPressTELE();
-  }
-}
-
 void Page::onLongPressRTN() { onCancel(); }
 #endif
 

--- a/radio/src/gui/colorlcd/libui/page.h
+++ b/radio/src/gui/colorlcd/libui/page.h
@@ -65,12 +65,7 @@ class Page : public NavWindow
   NavWindow* navWindow();
 
 #if defined(HARDWARE_KEYS)
-  void onPressSYS() override;
-  void onLongPressSYS() override;
-  void onPressMDL() override;
-  void onLongPressMDL() override;
-  void onPressTELE() override;
-  void onLongPressTELE() override;
+  void doKeyShortcut(event_t event) override;
   void onLongPressRTN() override;
 #endif
 };

--- a/radio/src/gui/colorlcd/libui/window.cpp
+++ b/radio/src/gui/colorlcd/libui/window.cpp
@@ -639,6 +639,15 @@ NavWindow::NavWindow(Window *parent, const rect_t &rect,
   setWindowFlag(OPAQUE);
 }
 
+#if defined(HARDWARE_KEYS)
+void NavWindow::onPressSYS() { doKeyShortcut(EVT_KEY_BREAK(KEY_SYS)); }
+void NavWindow::onLongPressSYS() { doKeyShortcut(EVT_KEY_LONG(KEY_SYS)); }
+void NavWindow::onPressMDL() { doKeyShortcut(EVT_KEY_BREAK(KEY_MODEL)); }
+void NavWindow::onLongPressMDL() { doKeyShortcut(EVT_KEY_LONG(KEY_MODEL)); }
+void NavWindow::onPressTELE() { doKeyShortcut(EVT_KEY_BREAK(KEY_TELE)); }
+void NavWindow::onLongPressTELE() { doKeyShortcut(EVT_KEY_LONG(KEY_TELE)); }
+#endif
+
 //-----------------------------------------------------------------------------
 
 class SetupTextButton : public TextButton

--- a/radio/src/gui/colorlcd/libui/window.h
+++ b/radio/src/gui/colorlcd/libui/window.h
@@ -236,12 +236,13 @@ class NavWindow : public Window
   bool isNavWindow() override { return true; }
 
 #if defined(HARDWARE_KEYS)
-  virtual void onPressSYS() {}
-  virtual void onLongPressSYS() {}
-  virtual void onPressMDL() {}
-  virtual void onLongPressMDL() {}
-  virtual void onPressTELE() {}
-  virtual void onLongPressTELE() {}
+  virtual void doKeyShortcut(event_t event) {}
+  virtual void onPressSYS();
+  virtual void onLongPressSYS();
+  virtual void onPressMDL();
+  virtual void onLongPressMDL();
+  virtual void onPressTELE();
+  virtual void onLongPressTELE();
   virtual void onPressPGUP() {}
   virtual void onPressPGDN() {}
   virtual void onLongPressPGUP() {}

--- a/radio/src/gui/colorlcd/mainview/view_main.cpp
+++ b/radio/src/gui/colorlcd/mainview/view_main.cpp
@@ -236,12 +236,6 @@ void ViewMain::doKeyShortcut(event_t event)
     QuickMenu::openPage(pg);
   }
 }
-void ViewMain::onPressSYS() { doKeyShortcut(EVT_KEY_BREAK(KEY_SYS)); }
-void ViewMain::onLongPressSYS() { doKeyShortcut(EVT_KEY_LONG(KEY_SYS)); }
-void ViewMain::onPressMDL() { doKeyShortcut(EVT_KEY_BREAK(KEY_MODEL)); }
-void ViewMain::onLongPressMDL() { doKeyShortcut(EVT_KEY_LONG(KEY_MODEL)); }
-void ViewMain::onPressTELE() { doKeyShortcut(EVT_KEY_BREAK(KEY_TELE)); }
-void ViewMain::onLongPressTELE() { doKeyShortcut(EVT_KEY_LONG(KEY_TELE)); }
 void ViewMain::onPressPGUP()
 {
   if (!widget_select) {

--- a/radio/src/gui/colorlcd/mainview/view_main.h
+++ b/radio/src/gui/colorlcd/mainview/view_main.h
@@ -89,13 +89,7 @@ class ViewMain : public NavWindow
   static void ws_timer(lv_timer_t* t);
 
 #if defined(HARDWARE_KEYS)
-  void doKeyShortcut(event_t event);
-  void onPressSYS() override;
-  void onLongPressSYS() override;
-  void onPressMDL() override;
-  void onLongPressMDL() override;
-  void onPressTELE() override;
-  void onLongPressTELE() override;
+  void doKeyShortcut(event_t event) override;
   void onPressPGUP() override;
   void onPressPGDN() override;
 #endif

--- a/radio/src/gui/colorlcd/model/function_switches.cpp
+++ b/radio/src/gui/colorlcd/model/function_switches.cpp
@@ -364,7 +364,7 @@ void FunctionSwitchesBase::checkEvents()
 
 //-----------------------------------------------------------------------------
 
-ModelFunctionSwitches::ModelFunctionSwitches() : FunctionSwitchesBase(ICON_MODEL_SETUP, STR_MAIN_MENU_MODEL_SETTINGS)
+ModelFunctionSwitches::ModelFunctionSwitches() : FunctionSwitchesBase(ICON_MODEL_SETUP, STR_MAIN_MODEL_SETTINGS)
 {
   for (uint8_t i = 0; i < switchGetMaxSwitches(); i += 1) {
     if (switchIsCustomSwitch(i))

--- a/radio/src/gui/colorlcd/model/model_heli.cpp
+++ b/radio/src/gui/colorlcd/model/model_heli.cpp
@@ -41,7 +41,7 @@ static const lv_coord_t row_dsc[] = {LV_GRID_CONTENT, LV_GRID_CONTENT,
 #endif
 
 ModelHeliPage::ModelHeliPage():
-  SubPage(ICON_MODEL_HELI, STR_MAIN_MENU_MODEL_SETTINGS, STR_MENUHELISETUP)
+  SubPage(ICON_MODEL_HELI, STR_MAIN_MODEL_SETTINGS, STR_MENUHELISETUP)
 {
   FlexGridLayout grid(col_dsc, row_dsc, PAD_TINY);
   body->setFlexLayout();

--- a/radio/src/gui/colorlcd/model/model_select.cpp
+++ b/radio/src/gui/colorlcd/model/model_select.cpp
@@ -544,13 +544,8 @@ ModelLabelsWindow::ModelLabelsWindow() : Page(ICON_MODEL_SELECT, PAD_ZERO, true)
 void ModelLabelsWindow::doKeyShortcut(event_t event)
 {
   QMPage pg = g_eeGeneral.getKeyShortcut(event);
-  if (pg != QM_MANAGE_MODELS) {
-    auto p = navWindow();
-    if (p) {
-      onCancel();
-      p->doKeyShortcut(event);
-    }
-  }
+  if (pg != QM_MANAGE_MODELS)
+    Page::doKeyShortcut(event);
 }
 
 void ModelLabelsWindow::onPressPG(bool isNext)

--- a/radio/src/gui/colorlcd/model/model_select.cpp
+++ b/radio/src/gui/colorlcd/model/model_select.cpp
@@ -541,26 +541,18 @@ ModelLabelsWindow::ModelLabelsWindow() : Page(ICON_MODEL_SELECT, PAD_ZERO, true)
 }
 
 #if defined(HARDWARE_KEYS)
-void ModelLabelsWindow::onLongPressSYS()
+void ModelLabelsWindow::doKeyShortcut(event_t event)
 {
-  onCancel();
-  Page::onLongPressSYS();
+  QMPage pg = g_eeGeneral.getKeyShortcut(event);
+  if (pg != QM_MANAGE_MODELS) {
+    auto p = navWindow();
+    if (p) {
+      onCancel();
+      p->doKeyShortcut(event);
+    }
+  }
 }
-void ModelLabelsWindow::onPressMDL()
-{
-  onCancel();
-  Page::onPressMDL();
-}
-void ModelLabelsWindow::onPressTELE()
-{
-  onCancel();
-  Page::onPressTELE();
-}
-void ModelLabelsWindow::onLongPressTELE()
-{
-  onCancel();
-  Page::onLongPressTELE();
-}
+
 void ModelLabelsWindow::onPressPG(bool isNext)
 {
   int rowcount = lblselector->getRowCount();

--- a/radio/src/gui/colorlcd/model/model_select.h
+++ b/radio/src/gui/colorlcd/model/model_select.h
@@ -75,11 +75,7 @@ class ModelLabelsWindow : public Page
   void moveLabel(int selected, int direction);
 
 #if defined(HARDWARE_KEYS)
-  void onLongPressSYS() override;
-  void onPressMDL() override;
-  void onLongPressMDL() override {}
-  void onPressTELE() override;
-  void onLongPressTELE() override;
+  void doKeyShortcut(event_t event) override;
   void onPressPG(bool isNext);
   void onPressPGUP() override;
   void onPressPGDN() override;

--- a/radio/src/gui/colorlcd/model/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model/model_setup.cpp
@@ -465,16 +465,16 @@ const static PageButtonDef modelSetupButtons[] = {
   {STR_DEF(STR_TIMER_3), []() { new TimerWindow(2); }, []() { return g_model.timers[2].mode > 0; }},
 
   {STR_DEF(STR_PREFLIGHT), []() { new PreflightChecks(); }},
-  {STR_DEF(STR_TRIMS), []() { new SubPage(ICON_MODEL_SETUP, STR_MAIN_MENU_MODEL_SETTINGS, STR_TRIMS, trimsSetupLines); }},
-  {STR_DEF(STR_THROTTLE_LABEL), []() { new SubPage(ICON_MODEL_SETUP, STR_MAIN_MENU_MODEL_SETTINGS, STR_THROTTLE_LABEL, throttleParamsSetupLines); }},
-  {STR_DEF(STR_ENABLED_FEATURES), []() { new SubPage(ICON_MODEL_SETUP, STR_MAIN_MENU_MODEL_SETTINGS, STR_ENABLED_FEATURES, viewOptionsPageSetupLines); }},
+  {STR_DEF(STR_TRIMS), []() { new SubPage(ICON_MODEL_SETUP, STR_MAIN_MODEL_SETTINGS, STR_TRIMS, trimsSetupLines); }},
+  {STR_DEF(STR_THROTTLE_LABEL), []() { new SubPage(ICON_MODEL_SETUP, STR_MAIN_MODEL_SETTINGS, STR_THROTTLE_LABEL, throttleParamsSetupLines); }},
+  {STR_DEF(STR_ENABLED_FEATURES), []() { new SubPage(ICON_MODEL_SETUP, STR_MAIN_MODEL_SETTINGS, STR_ENABLED_FEATURES, viewOptionsPageSetupLines); }},
 #if defined(USBJ_EX)
   {STR_DEF(STR_USBJOYSTICK_LABEL), []() { new ModelUSBJoystickPage(); }},
 #endif
 #if defined(FUNCTION_SWITCHES)
   {STR_DEF(STR_FUNCTION_SWITCHES), []() { new ModelFunctionSwitches(); }},
 #endif
-  {STR_DEF(STR_MENU_OTHER), []() { new SubPage(ICON_MODEL_SETUP, STR_MAIN_MENU_MODEL_SETTINGS, STR_MENU_OTHER, otherPageSetupLines); }},
+  {STR_DEF(STR_MENU_OTHER), []() { new SubPage(ICON_MODEL_SETUP, STR_MAIN_MODEL_SETTINGS, STR_MENU_OTHER, otherPageSetupLines); }},
 #if defined(HELI)
   {STR_DEF(STR_MENUHELISETUP), []() { return new ModelHeliPage(); }, nullptr, modelHeliEnabled},
 #endif

--- a/radio/src/gui/colorlcd/model/model_usbjoystick.cpp
+++ b/radio/src/gui/colorlcd/model/model_usbjoystick.cpp
@@ -495,7 +495,7 @@ class USBChannelLineButton : public ListLineButton
 
 ModelUSBJoystickPage::ModelUSBJoystickPage() : Page(ICON_MODEL_USB, PAD_BORDER)
 {
-  header->setTitle(STR_MAIN_MENU_MODEL_SETTINGS);
+  header->setTitle(STR_MAIN_MODEL_SETTINGS);
   header->setTitle2(STR_USBJOYSTICK_LABEL);
 
   body->setFlexLayout();

--- a/radio/src/gui/colorlcd/model/preflight_checks.cpp
+++ b/radio/src/gui/colorlcd/model/preflight_checks.cpp
@@ -194,7 +194,7 @@ class PotWarnMatrix : public ButtonMatrix
   uint8_t pot_idx[MAX_POTS];
 };
 
-PreflightChecks::PreflightChecks() : SubPage(ICON_MODEL_SETUP, STR_MAIN_MENU_MODEL_SETTINGS, STR_PREFLIGHT)
+PreflightChecks::PreflightChecks() : SubPage(ICON_MODEL_SETUP, STR_MAIN_MODEL_SETTINGS, STR_PREFLIGHT)
 {
   body->setFlexLayout();
 

--- a/radio/src/gui/colorlcd/model/throttle_params.cpp
+++ b/radio/src/gui/colorlcd/model/throttle_params.cpp
@@ -75,6 +75,6 @@ static SetupLineDef setupLines[] = {
   },
 };
 
-ThrottleParams::ThrottleParams() : SubPage(ICON_MODEL_SETUP, STR_MAIN_MENU_MODEL_SETTINGS, STR_THROTTLE_LABEL, setupLines, DIM(setupLines))
+ThrottleParams::ThrottleParams() : SubPage(ICON_MODEL_SETUP, STR_MAIN_MODEL_SETTINGS, STR_THROTTLE_LABEL, setupLines, DIM(setupLines))
 {
 }

--- a/radio/src/gui/colorlcd/model/timer_setup.cpp
+++ b/radio/src/gui/colorlcd/model/timer_setup.cpp
@@ -32,7 +32,7 @@
 #define SET_DIRTY() storageDirty(EE_MODEL)
 
 TimerWindow::TimerWindow(uint8_t timer) :
-  SubPage(ICON_STATS_TIMERS, STR_MAIN_MENU_MODEL_SETTINGS, (std::string(STR_TIMER) + std::to_string(timer + 1)).c_str())
+  SubPage(ICON_STATS_TIMERS, STR_MAIN_MODEL_SETTINGS, (std::string(STR_TIMER) + std::to_string(timer + 1)).c_str())
 {
   body->setFlexLayout();
 

--- a/radio/src/gui/colorlcd/model/trainer_setup.cpp
+++ b/radio/src/gui/colorlcd/model/trainer_setup.cpp
@@ -146,7 +146,7 @@ void TrainerModuleWindow::update()
 
 TrainerPage::TrainerPage() : Page(ICON_MODEL_SETUP)
 {
-  header->setTitle(STR_MAIN_MENU_MODEL_SETTINGS);
+  header->setTitle(STR_MAIN_MODEL_SETTINGS);
   header->setTitle2(STR_TRAINER);
 
   body->setFlexLayout();

--- a/radio/src/gui/colorlcd/module/module_setup.cpp
+++ b/radio/src/gui/colorlcd/module/module_setup.cpp
@@ -742,7 +742,7 @@ ModulePage::ModulePage(uint8_t moduleIdx) : Page(ICON_MODEL_SETUP)
 {
   const char* title2 =
       moduleIdx == INTERNAL_MODULE ? STR_INTERNALRF : STR_EXTERNALRF;
-  header->setTitle(STR_MAIN_MENU_MODEL_SETTINGS);
+  header->setTitle(STR_MAIN_MODEL_SETTINGS);
   header->setTitle2(title2);
 
   body->setFlexLayout();

--- a/radio/src/gui/colorlcd/radio/preview_window.cpp
+++ b/radio/src/gui/colorlcd/radio/preview_window.cpp
@@ -23,6 +23,7 @@
 
 #include "edgetx.h"
 #include "etx_lv_theme.h"
+#include "quick_menu.h"
 #include "quick_menu_group.h"
 #include "sliders.h"
 #include "textedit.h"
@@ -163,22 +164,22 @@ PreviewWindow::PreviewWindow(Window *window, rect_t rect,
   auto mask = getBuiltinIcon(ICON_TOP_LOGO);
   new StaticIcon(qm, (QM_W - mask->width) / 2, 0, ICON_TOP_LOGO, COLOR_THEME_QM_FG_INDEX);
 
-  auto qmb = new Window(qm, {PAD_SMALL, mask->height + PAD_SMALL, QuickMenuGroup::QM_BUTTON_WIDTH, QuickMenuGroup::QM_BUTTON_HEIGHT});
+  auto qmb = new Window(qm, {PAD_SMALL, mask->height + PAD_SMALL, QuickMenu::QM_BUTTON_WIDTH, QuickMenu::QM_BUTTON_HEIGHT});
   etx_obj_add_style(qmb->getLvObj(), styles->rounded, LV_PART_MAIN);
   etx_txt_color(qmb->getLvObj(), COLOR_THEME_QM_FG_INDEX, LV_PART_MAIN);
   etx_solid_bg(qmb->getLvObj(), COLOR_THEME_QM_BG_INDEX, LV_PART_MAIN);
-  new StaticIcon(qmb, (QuickMenuGroup::QM_BUTTON_WIDTH - QuickMenuGroup::QM_ICON_SIZE) / 2, PAD_SMALL,
+  new StaticIcon(qmb, (QuickMenu::QM_BUTTON_WIDTH - QuickMenuGroup::QM_ICON_SIZE) / 2, PAD_SMALL,
                   ICON_MODEL_SELECT, COLOR_THEME_QM_FG_INDEX);
-  new StaticText(qmb, {0, QuickMenuGroup::QM_ICON_SIZE + PAD_TINY * 2, QuickMenuGroup::QM_BUTTON_WIDTH - 1, 0},
+  new StaticText(qmb, {0, QuickMenuGroup::QM_ICON_SIZE + PAD_TINY * 2, QuickMenu::QM_BUTTON_WIDTH - 1, 0},
                   STR_QM_MANAGE_MODELS, COLOR_THEME_QM_FG_INDEX, CENTERED | FONT(XS));
 
-  qmb = new Window(qm, {QuickMenuGroup::QM_BUTTON_WIDTH + PAD_SMALL * 2, mask->height + PAD_SMALL, QuickMenuGroup::QM_BUTTON_WIDTH, QuickMenuGroup::QM_BUTTON_HEIGHT});
+  qmb = new Window(qm, {QuickMenu::QM_BUTTON_WIDTH + PAD_SMALL * 2, mask->height + PAD_SMALL, QuickMenu::QM_BUTTON_WIDTH, QuickMenu::QM_BUTTON_HEIGHT});
   etx_obj_add_style(qmb->getLvObj(), styles->rounded, LV_PART_MAIN);
   etx_txt_color(qmb->getLvObj(), COLOR_THEME_QM_BG_INDEX, LV_PART_MAIN);
   etx_solid_bg(qmb->getLvObj(), COLOR_THEME_QM_FG_INDEX, LV_PART_MAIN);
-  new StaticIcon(qmb, (QuickMenuGroup::QM_BUTTON_WIDTH - QuickMenuGroup::QM_ICON_SIZE) / 2, PAD_SMALL,
+  new StaticIcon(qmb, (QuickMenu::QM_BUTTON_WIDTH - QuickMenuGroup::QM_ICON_SIZE) / 2, PAD_SMALL,
                   ICON_MODEL, COLOR_THEME_QM_BG_INDEX);
-  new StaticText(qmb, {0, QuickMenuGroup::QM_ICON_SIZE + PAD_TINY * 2, QuickMenuGroup::QM_BUTTON_WIDTH - 1, 0},
+  new StaticText(qmb, {0, QuickMenuGroup::QM_ICON_SIZE + PAD_TINY * 2, QuickMenu::QM_BUTTON_WIDTH - 1, 0},
                   STR_QM_MODEL_SETUP, COLOR_THEME_QM_BG_INDEX, CENTERED | FONT(XS));
 
   lv_group_set_default(def_group);

--- a/radio/src/gui/colorlcd/radio/radio_setup.cpp
+++ b/radio/src/gui/colorlcd/radio/radio_setup.cpp
@@ -1046,19 +1046,19 @@ static bool hasShortcutKeys()
 
 const static PageButtonDef radioSetupButtons[] = {
 #if defined(AUDIO)
-  {STR_DEF(STR_SOUND_LABEL), []() { new SubPage(ICON_RADIO_SETUP, STR_MAIN_MENU_RADIO_SETTINGS, STR_SOUND_LABEL, soundPageSetupLines); }},
+  {STR_DEF(STR_SOUND_LABEL), []() { new SubPage(ICON_RADIO_SETUP, STR_MAIN_RADIO_SETTINGS, STR_SOUND_LABEL, soundPageSetupLines); }},
 #endif
 #if defined(VARIO)
-  {STR_DEF(STR_VARIO), []() { new SubPage(ICON_RADIO_SETUP, STR_MAIN_MENU_RADIO_SETTINGS, STR_VARIO, varioPageSetupLines); }},
+  {STR_DEF(STR_VARIO), []() { new SubPage(ICON_RADIO_SETUP, STR_MAIN_RADIO_SETTINGS, STR_VARIO, varioPageSetupLines); }},
 #endif
 #if defined(HAPTIC)
-  {STR_DEF(STR_HAPTIC_LABEL), []() { new SubPage(ICON_RADIO_SETUP, STR_MAIN_MENU_RADIO_SETTINGS, STR_HAPTIC_LABEL, hapticPageSetupLines); }},
+  {STR_DEF(STR_HAPTIC_LABEL), []() { new SubPage(ICON_RADIO_SETUP, STR_MAIN_RADIO_SETTINGS, STR_HAPTIC_LABEL, hapticPageSetupLines); }},
 #endif
-  {STR_DEF(STR_ALARMS_LABEL), []() { new SubPage(ICON_RADIO_SETUP, STR_MAIN_MENU_RADIO_SETTINGS, STR_ALARMS_LABEL, alarmsPageSetupLines); }},
-  {STR_DEF(STR_BACKLIGHT_LABEL), []() { (new SubPage(ICON_RADIO_SETUP, STR_MAIN_MENU_RADIO_SETTINGS, STR_BACKLIGHT_LABEL, backlightSetupLines))->useFlexLayout(); }},
-  {STR_DEF(STR_GPS), []() { new SubPage(ICON_RADIO_SETUP, STR_MAIN_MENU_RADIO_SETTINGS, STR_GPS, gpsPageSetupLines); }},
-  {STR_DEF(STR_ENABLED_FEATURES), []() { new SubPage(ICON_RADIO_SETUP, STR_MAIN_MENU_RADIO_SETTINGS, STR_ENABLED_FEATURES, viewOptionsPageSetupLines); }},
-  {STR_DEF(STR_MAIN_MENU_MANAGE_MODELS), []() { new SubPage(ICON_RADIO_SETUP, STR_MAIN_MENU_RADIO_SETTINGS, STR_MAIN_MENU_MANAGE_MODELS, manageModelsSetupLines); }},
+  {STR_DEF(STR_ALARMS_LABEL), []() { new SubPage(ICON_RADIO_SETUP, STR_MAIN_RADIO_SETTINGS, STR_ALARMS_LABEL, alarmsPageSetupLines); }},
+  {STR_DEF(STR_BACKLIGHT_LABEL), []() { (new SubPage(ICON_RADIO_SETUP, STR_MAIN_RADIO_SETTINGS, STR_BACKLIGHT_LABEL, backlightSetupLines))->useFlexLayout(); }},
+  {STR_DEF(STR_GPS), []() { new SubPage(ICON_RADIO_SETUP, STR_MAIN_RADIO_SETTINGS, STR_GPS, gpsPageSetupLines); }},
+  {STR_DEF(STR_ENABLED_FEATURES), []() { new SubPage(ICON_RADIO_SETUP, STR_MAIN_RADIO_SETTINGS, STR_ENABLED_FEATURES, viewOptionsPageSetupLines); }},
+  {STR_DEF(STR_MAIN_MENU_MANAGE_MODELS), []() { new SubPage(ICON_RADIO_SETUP, STR_MAIN_RADIO_SETTINGS, STR_MAIN_MENU_MANAGE_MODELS, manageModelsSetupLines); }},
 #if VERSION_MAJOR > 2
   {STR_DEF(STR_KEY_SHORTCUTS), []() { new QMKeyShortcutsPage(); }, nullptr, []() { return hasShortcutKeys(); }},
   {STR_DEF(STR_QUICK_MENU_FAVORITES), []() { new QMFavoritesPage(); }, nullptr},

--- a/radio/src/gui/colorlcd/setup_menus/key_shortcuts.cpp
+++ b/radio/src/gui/colorlcd/setup_menus/key_shortcuts.cpp
@@ -83,7 +83,7 @@ void QMKeyShortcutsPage::addKey(event_t event, std::vector<std::string> qmPages,
 }
 
 QMKeyShortcutsPage::QMKeyShortcutsPage():
-        SubPage(ICON_RADIO, STR_MAIN_MENU_RADIO_SETTINGS, STR_KEY_SHORTCUTS, true)
+        SubPage(ICON_RADIO, STR_MAIN_RADIO_SETTINGS, STR_KEY_SHORTCUTS, true)
 {
   auto qmPages = QuickMenu::menuPageNames(false);
 

--- a/radio/src/gui/colorlcd/setup_menus/pagegroup.cpp
+++ b/radio/src/gui/colorlcd/setup_menus/pagegroup.cpp
@@ -408,12 +408,6 @@ void PageGroupBase::doKeyShortcut(event_t event)
     }
   }
 }
-void PageGroupBase::onPressSYS() { doKeyShortcut(EVT_KEY_BREAK(KEY_SYS)); }
-void PageGroupBase::onLongPressSYS() { doKeyShortcut(EVT_KEY_LONG(KEY_SYS)); }
-void PageGroupBase::onPressMDL() { doKeyShortcut(EVT_KEY_BREAK(KEY_MODEL)); }
-void PageGroupBase::onLongPressMDL() { doKeyShortcut(EVT_KEY_LONG(KEY_MODEL)); }
-void PageGroupBase::onPressTELE() { doKeyShortcut(EVT_KEY_BREAK(KEY_TELE)); }
-void PageGroupBase::onLongPressTELE() { doKeyShortcut(EVT_KEY_LONG(KEY_TELE)); }
 
 void PageGroupBase::onPressPGUP() { header->prevTab(); }
 void PageGroupBase::onPressPGDN() { header->nextTab(); }

--- a/radio/src/gui/colorlcd/setup_menus/pagegroup.h
+++ b/radio/src/gui/colorlcd/setup_menus/pagegroup.h
@@ -179,13 +179,7 @@ class PageGroupBase : public NavWindow
   void checkEvents() override;
 
 #if defined(HARDWARE_KEYS)
-  void doKeyShortcut(event_t event);
-  void onPressSYS() override;
-  void onLongPressSYS() override;
-  void onPressMDL() override;
-  void onLongPressMDL() override;
-  void onPressTELE() override;
-  void onLongPressTELE() override;
+  void doKeyShortcut(event_t event) override;
   void onPressPGUP() override;
   void onPressPGDN() override;
   void onLongPressPGUP() override;

--- a/radio/src/gui/colorlcd/setup_menus/quick_menu.cpp
+++ b/radio/src/gui/colorlcd/setup_menus/quick_menu.cpp
@@ -169,7 +169,7 @@ class QuickSubMenu
     if (mainDef->subMenuItems[n].pageAction == PAGE_CREATE) {
       quickMenu->getTopMenu()->clearFocus();
       int pgIdx = getPageNumber(n);
-      if (quickMenu->getPageGroup() && quickMenu->getPageGroup()->hasSubMenu(mainDef->subMenuItems[n].qmPage)) {
+      if (quickMenu->getPageGroup() && quickMenu->isInMenu(quickMenu->getPageGroup()->getIcon()) && quickMenu->getPageGroup()->hasSubMenu(mainDef->subMenuItems[n].qmPage)) {
         quickMenu->onSelect(false);
         quickMenu->getPageGroup()->setCurrentTab(pgIdx);
       } else {
@@ -318,6 +318,22 @@ void QuickMenu::openQM(PageGroupBase* newPageGroup, QMPage newCurPage)
 #if VERSION_MAJOR > 2
   for (size_t i = 0; i < subMenus.size(); i += 1)
     subMenus[i]->doLayout();
+
+  // If opening from Favorites check that page is still in Favorites list
+  // Handle case where Favorites was edited and Radio Settings was removed
+  // from Favorites list
+  if (newPageGroup && (newPageGroup->getIcon() == ICON_QM_FAVORITES)) {
+    bool hasPage = false;
+    for (int i = 0; favoritesMenuItems[i].icon != EDGETX_ICONS_COUNT; i += 1)
+      if (favoritesMenuItems[i].qmPage == curPage) {
+        hasPage = true;
+        break;
+      }
+    if (!hasPage) {
+      newPageGroup = nullptr;
+      curPage = QM_NONE;
+    }
+  }
 #endif
 
   show();
@@ -626,12 +642,7 @@ void QuickMenu::doKeyShortcut(event_t event)
     QuickMenu::openPage(pg);
   }
 }
-void QuickMenu::onPressSYS() { doKeyShortcut(EVT_KEY_BREAK(KEY_SYS)); }
-void QuickMenu::onLongPressSYS() { doKeyShortcut(EVT_KEY_LONG(KEY_SYS)); }
-void QuickMenu::onPressMDL() { doKeyShortcut(EVT_KEY_BREAK(KEY_MODEL)); }
-void QuickMenu::onLongPressMDL() { doKeyShortcut(EVT_KEY_LONG(KEY_MODEL)); }
-void QuickMenu::onPressTELE() { doKeyShortcut(EVT_KEY_BREAK(KEY_TELE)); }
-void QuickMenu::onLongPressTELE() { doKeyShortcut(EVT_KEY_LONG(KEY_TELE)); }
+
 void QuickMenu::onLongPressRTN() { closeQM(); }
 
 void QuickMenu::afterPG()

--- a/radio/src/gui/colorlcd/setup_menus/quick_menu.h
+++ b/radio/src/gui/colorlcd/setup_menus/quick_menu.h
@@ -98,18 +98,15 @@ class QuickMenu : public NavWindow
   static int pageIndex(QMPage page);
   static std::vector<std::string>& menuPageNames(bool forFavorites);
 
+  static bool isInMenu(EdgeTxIcon icon) { return instance && instance->curIcon == icon; }
+  static bool isFavoritesMenu() { return isInMenu(ICON_QM_FAVORITES); }
+
 #if VERSION_MAJOR > 2
   static void resetFavorites();
 #endif
 
 #if defined(HARDWARE_KEYS)
-  void doKeyShortcut(event_t event);
-  void onPressSYS() override;
-  void onLongPressSYS() override;
-  void onPressMDL() override;
-  void onLongPressMDL() override;
-  void onPressTELE() override;
-  void onLongPressTELE() override;
+  void doKeyShortcut(event_t event) override;
   void onLongPressRTN() override;
   void onPressPGDN() override;
   void onPressPGUP() override;

--- a/radio/src/gui/colorlcd/setup_menus/quick_menu.h
+++ b/radio/src/gui/colorlcd/setup_menus/quick_menu.h
@@ -65,12 +65,8 @@ std::string replaceAll(std::string str, const std::string& from, const std::stri
 
 //-----------------------------------------------------------------------------
 
-#define GRP_W(n) ((QuickMenuGroup::QM_BUTTON_WIDTH + PAD_MEDIUM) * n - PAD_MEDIUM + PAD_OUTLINE * 2)
-#if LANDSCAPE
-#define GRP_H(n) ((QuickMenuGroup::QM_BUTTON_HEIGHT + PAD_MEDIUM) * n - PAD_MEDIUM + PAD_OUTLINE * 2)
-#else
-#define GRP_H(n) ((QuickMenuGroup::QM_BUTTON_HEIGHT + PAD_SMALL) * n - PAD_SMALL + PAD_OUTLINE * 2)
-#endif
+#define GRP_W(n) ((QuickMenu::QM_BUTTON_WIDTH + QuickMenu::QM_HPAD) * n - QuickMenu::QM_HPAD + PAD_OUTLINE * 2)
+#define GRP_H(n) ((QuickMenu::QM_BUTTON_HEIGHT + QuickMenu::QM_VPAD) * n - QuickMenu::QM_VPAD + PAD_OUTLINE * 2)
 
 class QuickMenu : public NavWindow
 {
@@ -116,6 +112,12 @@ class QuickMenu : public NavWindow
 #if VERSION_MAJOR == 2
   static LAYOUT_ORIENTATION(QM_MAIN_COLS, 5, 3)
   static LAYOUT_ORIENTATION(QM_MAIN_ROWS, 2, 4)
+#if PORTRAIT
+  static LAYOUT_VAL_SCALED(QM_BUTTON_WIDTH, 72)
+#else
+  static LAYOUT_SIZE_SCALED(QM_BUTTON_WIDTH, 72, 60)
+#endif
+  static LAYOUT_VAL_SCALED(QM_BUTTON_HEIGHT, 70)
   static constexpr int QM_MAIN_W = GRP_W(QM_MAIN_COLS);
   static constexpr int QM_MAIN_H = GRP_H(QM_MAIN_ROWS);
   static constexpr coord_t QM_W = QM_MAIN_W + PAD_LARGE * 2;
@@ -128,6 +130,12 @@ class QuickMenu : public NavWindow
   static LAYOUT_ORIENTATION(QM_MAIN_ROWS, 1, 6)
   static LAYOUT_ORIENTATION(QM_SUB_COLS, 6, 3)
   static LAYOUT_ORIENTATION(QM_SUB_ROWS, 2, 6)
+  static LAYOUT_ORIENTATION(QM_COLS, QM_MAIN_COLS, QM_MAIN_COLS + QM_SUB_COLS)
+  static LAYOUT_ORIENTATION(QM_ROWS, QM_MAIN_ROWS + QM_SUB_ROWS, QM_MAIN_ROWS)
+  static LAYOUT_ORIENTATION(QM_HPAD, PAD_MEDIUM, PAD_MEDIUM)
+  static LAYOUT_ORIENTATION(QM_VPAD, PAD_MEDIUM, PAD_SMALL)
+  static constexpr coord_t QM_BUTTON_WIDTH = ((LCD_W - PAD_OUTLINE * 2) + QuickMenu::QM_HPAD) / QM_COLS - QuickMenu::QM_HPAD;
+  static constexpr coord_t QM_BUTTON_HEIGHT = ((LCD_H - EdgeTxStyles::UI_ELEMENT_HEIGHT - PAD_OUTLINE * 3 - PAD_LARGE) + QuickMenu::QM_VPAD) / QM_ROWS - QuickMenu::QM_VPAD;
   static constexpr int QM_MAIN_W = GRP_W(QM_MAIN_COLS);
   static constexpr int QM_MAIN_H = GRP_H(QM_MAIN_ROWS);
   static constexpr int QM_SUB_W = GRP_W(QM_SUB_COLS);

--- a/radio/src/gui/colorlcd/setup_menus/quick_menu_favorites.cpp
+++ b/radio/src/gui/colorlcd/setup_menus/quick_menu_favorites.cpp
@@ -31,7 +31,7 @@
 #define SET_DIRTY() storageDirty(EE_GENERAL)
 
 QMFavoritesPage::QMFavoritesPage():
-        SubPage(ICON_RADIO, STR_MAIN_MENU_RADIO_SETTINGS, STR_QUICK_MENU_FAVORITES, true)
+        SubPage(ICON_RADIO, STR_MAIN_RADIO_SETTINGS, STR_QUICK_MENU_FAVORITES, true)
 {
   auto qmPages = QuickMenu::menuPageNames(true);
 
@@ -60,6 +60,8 @@ QMFavoritesPage::QMFavoritesPage():
                   g_eeGeneral.setFavoriteToolName(i, getLuaTool(pg - QM_APP)->label);
                 }
                 changed = true;
+                // Delete quick menu to force rebuild
+                QuickMenu::resetFavorites();
                 SET_DIRTY();
               }, STR_QUICK_MENU_FAVORITES);
 
@@ -90,9 +92,8 @@ void QMFavoritesPage::onCancel()
 {
   SubPage::onCancel();
 
-  if (changed) {
-    // Delete quick menu, and close parent page group (in case it is Favorites group)
-    QuickMenu::resetFavorites();
+  if (changed && QuickMenu::isFavoritesMenu()) {
+    // Close parent page group (in case it is Favorites group)
     QuickMenu::setCurrentPage(QM_NONE);
     Window::topWindow()->onCancel();
   }

--- a/radio/src/gui/colorlcd/setup_menus/quick_menu_group.cpp
+++ b/radio/src/gui/colorlcd/setup_menus/quick_menu_group.cpp
@@ -24,6 +24,7 @@
 #include "bitmaps.h"
 #include "button.h"
 #include "static.h"
+#include "quick_menu.h"
 #include "quick_menu_def.h"
 
 static void etx_quick_button_constructor(const lv_obj_class_t* class_p,
@@ -43,8 +44,8 @@ static const lv_obj_class_t etx_quick_button_class = {
     .destructor_cb = nullptr,
     .user_data = nullptr,
     .event_cb = nullptr,
-    .width_def = QuickMenuGroup::QM_BUTTON_WIDTH,
-    .height_def = QuickMenuGroup::QM_BUTTON_HEIGHT,
+    .width_def = QuickMenu::QM_BUTTON_WIDTH,
+    .height_def = QuickMenu::QM_BUTTON_HEIGHT,
     .editable = LV_OBJ_CLASS_EDITABLE_INHERIT,
     .group_def = LV_OBJ_CLASS_GROUP_DEF_TRUE,
     .instance_size = sizeof(lv_btn_t),
@@ -64,13 +65,13 @@ class QuickMenuButton : public ButtonBase
       ButtonBase(parent, {}, pressHandler, etx_quick_button_create),
       visibleHandler(std::move(visibleHandler))
   {
-    iconPtr = new StaticIcon(this, (QuickMenuGroup::QM_BUTTON_WIDTH - QuickMenuGroup::QM_ICON_SIZE) / 2, PAD_SMALL, icon, COLOR_THEME_QM_FG_INDEX);
+    iconPtr = new StaticIcon(this, (QuickMenu::QM_BUTTON_WIDTH - QuickMenuGroup::QM_ICON_SIZE) / 2, PAD_SMALL, icon, COLOR_THEME_QM_FG_INDEX);
 #if VERSION_MAJOR > 2
     etx_obj_add_style(iconPtr->getLvObj(), styles->qmdisabled, LV_PART_MAIN | LV_STATE_DISABLED);
 #endif
     etx_img_color(iconPtr->getLvObj(), COLOR_THEME_QM_BG_INDEX, LV_STATE_USER_1);
 
-    textPtr = new StaticText(this, {0, QuickMenuGroup::QM_ICON_SIZE + PAD_TINY * 2, QuickMenuGroup::QM_BUTTON_WIDTH - 1, 0},
+    textPtr = new StaticText(this, {0, QuickMenuGroup::QM_ICON_SIZE + PAD_TINY * 2, QuickMenu::QM_BUTTON_WIDTH - 1, 0},
                    title, COLOR_THEME_QM_FG_INDEX, CENTERED | FONT(XS));
 #if VERSION_MAJOR > 2
     etx_obj_add_style(textPtr->getLvObj(), styles->qmdisabled, LV_PART_MAIN | LV_STATE_DISABLED);
@@ -241,8 +242,8 @@ void QuickMenuGroup::doLayout(int cols)
   int n = 0;
   for (size_t i = 0; i < btns.size(); i += 1) {
     if (((QuickMenuButton*)btns[i])->isVisible()) {
-      coord_t x = (n % cols) * (QM_BUTTON_WIDTH + PAD_MEDIUM);
-      coord_t y = (n / cols) * (QM_BUTTON_HEIGHT + PAD_MEDIUM);
+      coord_t x = (n % cols) * (QuickMenu::QM_BUTTON_WIDTH + QuickMenu::QM_HPAD);
+      coord_t y = (n / cols) * (QuickMenu::QM_BUTTON_HEIGHT + QuickMenu::QM_VPAD);
       lv_obj_set_pos(btns[i]->getLvObj(), x, y);
       n += 1;
     }

--- a/radio/src/gui/colorlcd/setup_menus/quick_menu_group.h
+++ b/radio/src/gui/colorlcd/setup_menus/quick_menu_group.h
@@ -57,13 +57,6 @@ class QuickMenuGroup : public Window
 
   void deleteLater() override;
 
-#if PORTRAIT
-  static LAYOUT_VAL_SCALED(QM_BUTTON_WIDTH, 72)
-#else
-  static LAYOUT_SIZE_SCALED(QM_BUTTON_WIDTH, 72, 60)
-#endif
-  static LAYOUT_VAL_SCALED(QM_BUTTON_HEIGHT, 70)
-
   static LAYOUT_VAL_SCALED(QM_ICON_SIZE, 30)
   static LAYOUT_ORIENTATION(QM_ICON_PAD, PAD_MEDIUM, PAD_SMALL)
 


### PR DESCRIPTION
Fixes:
- quick menu navigation when editing favorites (fixes #7336)
- fix key shortcut usage on all pages
- use correct text for page header titles (Model Settings and Radio Settings)
- size quick menu  buttons to fill screen
- fix quick menu layout on portrait orientation displays

3.0 only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved Quick Menu layout with consistent button sizing, spacing, and portrait scaling.

* **Bug Fixes**
  * Prevent opening removed/stale Quick Menu favorites.
  * Removed an extraneous debug log during LSV2 range validation.
  * Ensure favorites are rebuilt immediately after changes.

* **UI/UX Updates**
  * Standardized main titles across Model and Radio settings for clearer navigation.

* **Refactor**
  * Consolidated hardware-key handling into a common shortcut dispatcher.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->