### PR TITLE
fix(color): add lvgl LV_USE_LARGE_COORD support

### DIFF
--- a/radio/src/gui/colorlcd/libui/keyboard_base.cpp
+++ b/radio/src/gui/colorlcd/libui/keyboard_base.cpp
@@ -184,7 +184,7 @@ void Keyboard::setField(FormField* newField)
       lv_obj_get_coords(obj, &coords);
 
       // place keyboard bellow the field with some margin
-      setTop(max(coords.y2 + 21, LCD_H - height()));
+      setTop(max((coord_t)coords.y2 + 21, LCD_H - height()));
 
       // save scroll position
       scroll_pos = lv_obj_get_scroll_y(fieldContainer->getLvObj());

--- a/radio/src/gui/colorlcd/lv_conf.h
+++ b/radio/src/gui/colorlcd/lv_conf.h
@@ -395,7 +395,7 @@
 #define LV_EXPORT_CONST_INT(int_value) struct _silence_gcc_warning /*The default value just prevents GCC warning*/
 
 /*Extend the default -32k..32k coordinate range to -4M..4M by using int32_t for coordinates instead of int16_t*/
-#define LV_USE_LARGE_COORD 0
+#define LV_USE_LARGE_COORD 1
 
 /*==================
  *   FONT USAGE


### PR DESCRIPTION
This is tackling #7343 in a different way than #7346, allowing large coordinates. The only downside of this approach is that it don't let users know that they are doing something wrong by storing way to many files in a single directory that has impact in FAT32, but the fix is programming wise a better fix.

@Philmoz validated this approach 

Fixes https://github.com/EdgeTX/edgetx/issues/7343

This is an alternative to #7346