### PR TITLE
fix(lua): playNumber with PREC2 - last decimal digit missing

### DIFF
--- a/radio/src/translations/tts/tts_cn.cpp
+++ b/radio/src/translations/tts/tts_cn.cpp
@@ -52,13 +52,19 @@ I18N_PLAY_FUNCTION(cn, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
 
   int8_t mode = MODE(att);
   if (mode > 0) {
+    uint8_t rem2 = 0;
     if (mode == 2) {
-      number /= 10;
+      div_t qr2 = div((int)number, 10);
+      number = qr2.quot;
+      rem2 = qr2.rem;
     }
     div_t qr = div((int)number, 10);
-    if (qr.rem) {
+    if (qr.rem || (mode == 2 && rem2)) {
       PLAY_NUMBER(qr.quot, 0, 0);
       PUSH_NUMBER_PROMPT(CN_PROMPT_POINT_BASE + qr.rem);
+      if (mode == 2 && rem2) {
+        PLAY_NUMBER(rem2, 0, 0);
+      }
       number = -1;
     }
     else {

--- a/radio/src/translations/tts/tts_cz.cpp
+++ b/radio/src/translations/tts/tts_cz.cpp
@@ -66,11 +66,14 @@ I18N_PLAY_FUNCTION(cz, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
 
   int8_t mode = MODE(att);
   if (mode > 0) {
+    uint8_t rem2 = 0;
     if (mode == 2) {
-      number /= 10;
+      div_t qr2 = div((int)number, 10);
+      number = qr2.quot;
+      rem2 = qr2.rem;
     }
     div_t qr = div((int)number, 10);
-    if (qr.rem) {
+    if (qr.rem || (mode == 2 && rem2)) {
       PLAY_NUMBER(qr.quot, 0, FEMALE);
       if (qr.quot < 2) {
         PUSH_NUMBER_PROMPT(CZ_PROMPT_CELA);
@@ -82,6 +85,10 @@ I18N_PLAY_FUNCTION(cz, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
         PUSH_NUMBER_PROMPT(CZ_PROMPT_CELYCH);
       };
       PLAY_NUMBER(qr.rem, 0, FEMALE);
+      // TODO: make sure this is correct for CZ
+      if (mode == 2 && rem2) {
+        PLAY_NUMBER(rem2, 0, 0);
+      }
       PUSH_UNIT_PROMPT(unit, 3);
       return;
     }
@@ -187,4 +194,3 @@ I18N_PLAY_FUNCTION(cz, playDuration, int seconds PLAY_DURATION_ATT)
 }
 
 LANGUAGE_PACK_DECLARE(cz, STR_VOICE_CZECH);
-

--- a/radio/src/translations/tts/tts_cz.cpp
+++ b/radio/src/translations/tts/tts_cz.cpp
@@ -85,9 +85,8 @@ I18N_PLAY_FUNCTION(cz, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
         PUSH_NUMBER_PROMPT(CZ_PROMPT_CELYCH);
       };
       PLAY_NUMBER(qr.rem, 0, FEMALE);
-      // TODO: make sure this is correct for CZ
       if (mode == 2 && rem2) {
-        PLAY_NUMBER(rem2, 0, 0);
+        PLAY_NUMBER(rem2, 0, FEMALE);
       }
       PUSH_UNIT_PROMPT(unit, 3);
       return;

--- a/radio/src/translations/tts/tts_da.cpp
+++ b/radio/src/translations/tts/tts_da.cpp
@@ -9,7 +9,7 @@
  *
  * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
  *
- * This program is free software; you can redistribute it and/or modify 
+ * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License version 2 as
  * published by the Free Software Foundation.
  *
@@ -19,7 +19,7 @@
  * GNU General Public License for more details.
  */
 
-#include "edgetx.h" 
+#include "edgetx.h"
 
 enum DanishPrompts {
   DA_PROMPT_NUMBERS_BASE = 0,
@@ -30,7 +30,7 @@ enum DanishPrompts {
   DA_PROMPT_MINUS = DA_PROMPT_NUMBERS_BASE+111,
   DA_PROMPT_POINT = DA_PROMPT_NUMBERS_BASE+112,
   DA_PROMPT_UNITS_BASE = 113,
-  DA_PROMPT_POINT_BASE = 165, //.0 - .9
+  DA_PROMPT_POINT_BASE = 167, //.0 - .9
 };
 
 
@@ -51,16 +51,21 @@ I18N_PLAY_FUNCTION(da, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
     number = -number;
   }
 
-
   int8_t mode = MODE(att);
   if (mode > 0) {
+    uint8_t rem2 = 0;
     if (mode == 2) {
-      number /= 10;
+      div_t qr2 = div((int)number, 10);
+      number = qr2.quot;
+      rem2 = qr2.rem;
     }
     div_t qr = div((int)number, 10);
-    if (qr.rem) {
+    if (qr.rem || (mode == 2 && rem2)) {
       PLAY_NUMBER(qr.quot, 0, 0);
       PUSH_NUMBER_PROMPT(DA_PROMPT_POINT_BASE + qr.rem);
+      if (mode == 2 && rem2) {
+        PLAY_NUMBER(rem2, 0, 0);
+      }
       number = -1;
     }
     else {
@@ -125,4 +130,3 @@ I18N_PLAY_FUNCTION(da, playDuration, int seconds PLAY_DURATION_ATT)
 }
 
 LANGUAGE_PACK_DECLARE(da, STR_VOICE_DANISH);
-

--- a/radio/src/translations/tts/tts_de.cpp
+++ b/radio/src/translations/tts/tts_de.cpp
@@ -33,11 +33,11 @@ enum GermanPrompts {
   DE_PROMPT_MINUS,
 };
 
-static inline bool hasDualUnits(uint8_t unit) { // true if unit has a secondary unit for value 1 
+static inline bool hasDualUnits(uint8_t unit) { // true if unit has a secondary unit for value 1
   return (unit == UNIT_HOURS ||                 // example with sec. unit: "null Stunden", "eine Stunde", "zwei Stunden", ...
           unit == UNIT_MINUTES ||               // exmple without sec. unit "null Volt", "ein Volt", "zwei Volt", ...
-          unit == UNIT_SECONDS ||              
-          unit == UNIT_FLOZ ||                
+          unit == UNIT_SECONDS ||
+          unit == UNIT_FLOZ ||
           unit == UNIT_MS ||
           unit == UNIT_US ||
           unit == UNIT_MPH ||
@@ -66,19 +66,23 @@ I18N_PLAY_FUNCTION(de, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
   int8_t mode = MODE(att);
 
   if (mode > 0) {
+    uint8_t rem2 = 0;
     if (mode == 2) {
-      number /= 10;
+      div_t qr2 = div((int)number, 10);
+      number = qr2.quot;
+      rem2 = qr2.rem;
     }
 
     div_t qr = div((int)number, 10);
-
-    if (qr.rem > 0) {
+    if (qr.rem || (mode == 2 && rem2)) {
       PLAY_NUMBER(qr.quot, 0, 0);
       PUSH_NUMBER_PROMPT(DE_PROMPT_COMMA);
       PUSH_NUMBER_PROMPT(DE_PROMPT_NUMBERS_BASE + qr.rem);
-      
+      if (mode == 2 && rem2) {
+        PLAY_NUMBER(rem2, 0, 0);
+      }
       number = -1;      // force secondary unit if unit has one
-                        // skips the following integer processing 
+                        // skips the following integer processing
     }
     else {
       number = qr.quot;   // no remainder, continue with integer part
@@ -90,7 +94,7 @@ I18N_PLAY_FUNCTION(de, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
     PUSH_NUMBER_PROMPT(DE_PROMPT_TAUSEND);
     number %= 1000;
     if (number == 0)
-      number = -1;       
+      number = -1;
   }
 
   if ((number >= 1000) && (number < 2000)) {
@@ -98,15 +102,15 @@ I18N_PLAY_FUNCTION(de, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
     PUSH_NUMBER_PROMPT(DE_PROMPT_TAUSEND);
     number %= 1000;
     if (number == 0)
-      number = -1;    
+      number = -1;
   }
 
   if ((number >= 200) && (number < 1000)) {
     PUSH_NUMBER_PROMPT(DE_PROMPT_NULL + number / 100);
-    PUSH_NUMBER_PROMPT(DE_PROMPT_HUNDERT);	
+    PUSH_NUMBER_PROMPT(DE_PROMPT_HUNDERT);
     number %= 100;
     if (number == 0)
-      number = -1;    
+      number = -1;
   }
 
   if ((number >= 100) && (number < 200)) {
@@ -120,7 +124,7 @@ I18N_PLAY_FUNCTION(de, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
   if (number >= 0) {
     if (number == 1) {
       if(unit) {
-        if(hasDualUnits(unit) && unit != UNIT_RADIANS) 
+        if(hasDualUnits(unit) && unit != UNIT_RADIANS)
           PUSH_NUMBER_PROMPT(DE_PROMPT_EINE);           // value is 1, has unit and unit has secondary unit -> "eine",
                                                         // except radians -> "ein"
         else
@@ -129,12 +133,13 @@ I18N_PLAY_FUNCTION(de, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
       } else
         PUSH_NUMBER_PROMPT(DE_PROMPT_NULL + 1);         // value is 1, has no unit -> regular number "eins"
     } else
-      PUSH_NUMBER_PROMPT(DE_PROMPT_NULL + number);      // value is not 1, has no unit or unit has 
+      PUSH_NUMBER_PROMPT(DE_PROMPT_NULL + number);      // value is not 1, has no unit or unit has
                                                         // no secondary unit -> regular number
   }
 
-  if(unit)
+  if(unit) {
     DE_PUSH_UNIT_PROMPT(unit, number);
+  }
 }
 
 I18N_PLAY_FUNCTION(de, playDuration, int seconds PLAY_DURATION_ATT)
@@ -165,10 +170,9 @@ I18N_PLAY_FUNCTION(de, playDuration, int seconds PLAY_DURATION_ATT)
   if (!IS_PLAY_LONG_TIMER() && seconds > 0) {
     if (minutes)
       PUSH_NUMBER_PROMPT(DE_PROMPT_UND);
-      
+
     PLAY_NUMBER(seconds, UNIT_SECONDS, 0);
   }
 }
 
 LANGUAGE_PACK_DECLARE(de, STR_VOICE_DEUTSCH);
-

--- a/radio/src/translations/tts/tts_en.cpp
+++ b/radio/src/translations/tts/tts_en.cpp
@@ -63,7 +63,7 @@ I18N_PLAY_FUNCTION(en, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
       PLAY_NUMBER(qr.quot, 0, 0);
       PUSH_NUMBER_PROMPT(EN_PROMPT_POINT_BASE + qr.rem);
       if (mode == 2 && rem2) {
-	PLAY_NUMBER(rem2, 0, 0);
+        PLAY_NUMBER(rem2, 0, 0);
       }
       number = -1;
     }

--- a/radio/src/translations/tts/tts_en.cpp
+++ b/radio/src/translations/tts/tts_en.cpp
@@ -49,7 +49,6 @@ I18N_PLAY_FUNCTION(en, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
     PUSH_NUMBER_PROMPT(EN_PROMPT_MINUS);
     number = -number;
   }
-
   int8_t mode = MODE(att);
   if (mode > 0) {
     uint8_t rem2 = 0;

--- a/radio/src/translations/tts/tts_en.cpp
+++ b/radio/src/translations/tts/tts_en.cpp
@@ -52,13 +52,19 @@ I18N_PLAY_FUNCTION(en, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
 
   int8_t mode = MODE(att);
   if (mode > 0) {
+    uint8_t rem2 = 0;
     if (mode == 2) {
-      number /= 10;
+      div_t qr2 = div((int)number, 10);
+      number = qr2.quot;
+      rem2 = qr2.rem;
     }
     div_t qr = div((int)number, 10);
-    if (qr.rem) {
+    if (qr.rem || (mode == 2 && rem2)) {
       PLAY_NUMBER(qr.quot, 0, 0);
       PUSH_NUMBER_PROMPT(EN_PROMPT_POINT_BASE + qr.rem);
+      if (mode == 2 && rem2) {
+	PLAY_NUMBER(rem2, 0, 0);
+      }
       number = -1;
     }
     else {

--- a/radio/src/translations/tts/tts_es.cpp
+++ b/radio/src/translations/tts/tts_es.cpp
@@ -95,25 +95,27 @@ I18N_PLAY_FUNCTION(es, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
     PUSH_NUMBER_PROMPT(ES_PROMPT_MENO);
     number = -number;
   }
-
-
   int8_t mode = MODE(att);
   if (mode > 0) {
+    uint8_t rem2 = 0;
     if (mode == 2) {
-      number /= 10;
+      div_t qr2 = div((int)number, 10);
+      number = qr2.quot;
+      rem2 = qr2.rem;
     }
     div_t qr = div((int)number, 10);
-    if (qr.rem > 0) {
+    if (qr.rem || (mode == 2 && rem2)) {
       PLAY_NUMBER(qr.quot, 0, 0);
       PUSH_NUMBER_PROMPT(ES_PROMPT_VIRGOLA);
-      if (mode==2 && qr.rem < 10)
-        PUSH_NUMBER_PROMPT(ES_PROMPT_ZERO);
-      PLAY_NUMBER(qr.rem, unit, 0);
+      PLAY_NUMBER(qr.rem, 0, 0);
+      if (mode == 2 && rem2) {
+        PLAY_NUMBER(rem2, 0, 0);
+      }
+      number = -1;
     }
     else {
-      PLAY_NUMBER(qr.quot, unit, 0);
+      number = qr.quot;
     }
-    return;
   }
 
   if (number >= 1000) {

--- a/radio/src/translations/tts/tts_fr.cpp
+++ b/radio/src/translations/tts/tts_fr.cpp
@@ -77,17 +77,21 @@ I18N_PLAY_FUNCTION(fr, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
     PUSH_NUMBER_PROMPT(FR_PROMPT_MOINS);
     number = -number;
   }
-
-
   int8_t mode = MODE(att);
   if (mode > 0) {
+    uint8_t rem2 = 0;
     if (mode == 2) {
-      number /= 10;
+      div_t qr2 = div((int)number, 10);
+      number = qr2.quot;
+      rem2 = qr2.rem;
     }
     div_t qr = div((int)number, 10);
-    if (qr.rem) {
+    if (qr.rem || (mode == 2 && rem2)) {
       PLAY_NUMBER(qr.quot, 0, 0);
       PUSH_NUMBER_PROMPT(FR_PROMPT_VIRGULE_BASE + qr.rem);
+      if (mode == 2 && rem2) {
+        PLAY_NUMBER(rem2, 0, 0);
+      }
       number = -1;
     }
     else {

--- a/radio/src/translations/tts/tts_he.cpp
+++ b/radio/src/translations/tts/tts_he.cpp
@@ -50,17 +50,21 @@ I18N_PLAY_FUNCTION(he, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
     PUSH_NUMBER_PROMPT(HE_PROMPT_MINUS);
     number = -number;
   }
-
-
   int8_t mode = MODE(att);
   if (mode > 0) {
+    uint8_t rem2 = 0;
     if (mode == 2) {
-      number /= 10;
+      div_t qr2 = div((int)number, 10);
+      number = qr2.quot;
+      rem2 = qr2.rem;
     }
     div_t qr = div((int)number, 10);
-    if (qr.rem) {
+    if (qr.rem || (mode == 2 && rem2)) {
       PLAY_NUMBER(qr.quot, 0, 0);
       PUSH_NUMBER_PROMPT(HE_PROMPT_POINT_BASE + qr.rem);
+      if (mode == 2 && rem2) {
+        PLAY_NUMBER(rem2, 0, 0);
+      }
       number = -1;
     }
     else {

--- a/radio/src/translations/tts/tts_hu.cpp
+++ b/radio/src/translations/tts/tts_hu.cpp
@@ -30,7 +30,7 @@ enum HungarianPrompts {
   HU_PROMPT_MINUS = HU_PROMPT_NUMBERS_BASE+111,
   HU_PROMPT_POINT = HU_PROMPT_NUMBERS_BASE+112,
   HU_PROMPT_UNITS_BASE = 113,
-  HU_PROMPT_POINT_BASE = 165, //.0 - .9
+  HU_PROMPT_POINT_BASE = 167, //.0 - .9
 };
 
 
@@ -50,17 +50,21 @@ I18N_PLAY_FUNCTION(hu, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
     PUSH_NUMBER_PROMPT(HU_PROMPT_MINUS);
     number = -number;
   }
-
-
   int8_t mode = MODE(att);
   if (mode > 0) {
+    uint8_t rem2 = 0;
     if (mode == 2) {
-      number /= 10;
+      div_t qr2 = div((int)number, 10);
+      number = qr2.quot;
+      rem2 = qr2.rem;
     }
     div_t qr = div((int)number, 10);
-    if (qr.rem) {
+    if (qr.rem || (mode == 2 && rem2)) {
       PLAY_NUMBER(qr.quot, 0, 0);
       PUSH_NUMBER_PROMPT(HU_PROMPT_POINT_BASE + qr.rem);
+      if (mode == 2 && rem2) {
+        PLAY_NUMBER(rem2, 0, 0);
+      }
       number = -1;
     }
     else {

--- a/radio/src/translations/tts/tts_it.cpp
+++ b/radio/src/translations/tts/tts_it.cpp
@@ -89,24 +89,24 @@ I18N_PLAY_FUNCTION(it, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
 
   int8_t mode = MODE(att);
   if (mode > 0) {
+    uint8_t rem2 = 0;
     if (mode == 2) {
-      number /= 10;
+      div_t qr2 = div((int)number, 10);
+      number = qr2.quot;
+      rem2 = qr2.rem;
     }
     div_t qr = div((int)number, 10);
-    if (qr.rem > 0) {
+    if (qr.rem || (mode == 2 && rem2)) {
       PLAY_NUMBER(qr.quot, 0, 0);
       PUSH_NUMBER_PROMPT(IT_PROMPT_VIRGOLA);
-      if (mode==2 && qr.rem < 10)
-        PUSH_NUMBER_PROMPT(IT_PROMPT_ZERO);
       PLAY_NUMBER(qr.rem, 0, 0);
+      if (mode == 2 && rem2) {
+        PLAY_NUMBER(rem2, 0, 0);
+      }
     }
     else {
-      if (qr.quot==1) {
+      if (qr.quot == 1) {
         PUSH_NUMBER_PROMPT(IT_PROMPT_UN);
-        if (unit) {
-          PUSH_NUMBER_PROMPT(IT_PROMPT_UNITS_BASE+(unit*2));
-        }
-        return;
       } else {
         PLAY_NUMBER(qr.quot, 0, 0);
       }
@@ -180,4 +180,3 @@ I18N_PLAY_FUNCTION(it, playDuration, int seconds PLAY_DURATION_ATT)
 }
 
 LANGUAGE_PACK_DECLARE(it, STR_VOICE_ITALIANO);
-

--- a/radio/src/translations/tts/tts_it.cpp
+++ b/radio/src/translations/tts/tts_it.cpp
@@ -105,8 +105,12 @@ I18N_PLAY_FUNCTION(it, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
       }
     }
     else {
-      if (qr.quot == 1) {
+      if (qr.quot==1) {
         PUSH_NUMBER_PROMPT(IT_PROMPT_UN);
+        if (unit) {
+          PUSH_NUMBER_PROMPT(IT_PROMPT_UNITS_BASE+(unit*2));
+        }
+        return;
       } else {
         PLAY_NUMBER(qr.quot, 0, 0);
       }

--- a/radio/src/translations/tts/tts_jp.cpp
+++ b/radio/src/translations/tts/tts_jp.cpp
@@ -50,17 +50,21 @@ I18N_PLAY_FUNCTION(jp, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
     PUSH_NUMBER_PROMPT(JP_PROMPT_MINUS);
     number = -number;
   }
-
-
   int8_t mode = MODE(att);
   if (mode > 0) {
+    uint8_t rem2 = 0;
     if (mode == 2) {
-      number /= 10;
+      div_t qr2 = div((int)number, 10);
+      number = qr2.quot;
+      rem2 = qr2.rem;
     }
     div_t qr = div((int)number, 10);
-    if (qr.rem) {
+    if (qr.rem || (mode == 2 && rem2)) {
       PLAY_NUMBER(qr.quot, 0, 0);
       PUSH_NUMBER_PROMPT(JP_PROMPT_POINT_BASE + qr.rem);
+      if (mode == 2 && rem2) {
+        PLAY_NUMBER(rem2, 0, 0);
+      }
       number = -1;
     }
     else {
@@ -130,4 +134,3 @@ I18N_PLAY_FUNCTION(jp, playDuration, int seconds PLAY_DURATION_ATT)
 }
 
 LANGUAGE_PACK_DECLARE(jp, STR_VOICE_JAPANESE);
-

--- a/radio/src/translations/tts/tts_ko.cpp
+++ b/radio/src/translations/tts/tts_ko.cpp
@@ -50,16 +50,21 @@ I18N_PLAY_FUNCTION(ko, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
     PUSH_NUMBER_PROMPT(KO_PROMPT_MINUS);
     number = -number;
   }
-
   int8_t mode = MODE(att);
   if (mode > 0) {
+    uint8_t rem2 = 0;
     if (mode == 2) {
-      number /= 10;
+      div_t qr2 = div((int)number, 10);
+      number = qr2.quot;
+      rem2 = qr2.rem;
     }
     div_t qr = div((int)number, 10);
-    if (qr.rem) {
+    if (qr.rem || (mode == 2 && rem2)) {
       PLAY_NUMBER(qr.quot, 0, 0);
       PUSH_NUMBER_PROMPT(KO_PROMPT_POINT_BASE + qr.rem);
+      if (mode == 2 && rem2) {
+        PLAY_NUMBER(rem2, 0, 0);
+      }
       number = -1;
     } else {
       number = qr.quot;
@@ -126,4 +131,3 @@ I18N_PLAY_FUNCTION(ko, playDuration, int seconds PLAY_DURATION_ATT)
 }
 
 LANGUAGE_PACK_DECLARE(ko, STR_VOICE_KOREAN);
-

--- a/radio/src/translations/tts/tts_nl.cpp
+++ b/radio/src/translations/tts/tts_nl.cpp
@@ -52,17 +52,21 @@ I18N_PLAY_FUNCTION(nl, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
     PUSH_NUMBER_PROMPT(NL_PROMPT_MINUS);
     number = -number;
   }
-
-
   int8_t mode = MODE(att);
   if (mode > 0) {
+    uint8_t rem2 = 0;
     if (mode == 2) {
-      number /= 10;
+      div_t qr2 = div((int)number, 10);
+      number = qr2.quot;
+      rem2 = qr2.rem;
     }
     div_t qr = div((int)number, 10);
-    if (qr.rem) {
+    if (qr.rem || (mode == 2 && rem2)) {
       PLAY_NUMBER(qr.quot, 0, 0);
       PUSH_NUMBER_PROMPT(NL_PROMPT_POINT_BASE + qr.rem);
+      if (mode == 2 && rem2) {
+        PLAY_NUMBER(rem2, 0, 0);
+      }
       number = -1;
     }
     else {
@@ -132,4 +136,3 @@ I18N_PLAY_FUNCTION(nl, playDuration, int seconds PLAY_DURATION_ATT)
 }
 
 LANGUAGE_PACK_DECLARE(nl, STR_VOICE_DUTCH);
-

--- a/radio/src/translations/tts/tts_pl.cpp
+++ b/radio/src/translations/tts/tts_pl.cpp
@@ -94,21 +94,25 @@ I18N_PLAY_FUNCTION(pl, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
     PUSH_NUMBER_PROMPT(PL_PROMPT_MINUS);
     number = -number;
   }
-
-
   int8_t mode = MODE(att);
   if (mode > 0) {
+    uint8_t rem2 = 0;
     if (mode == 2) {
-      number /= 10;
+      div_t qr2 = div((int)number, 10);
+      number = qr2.quot;
+      rem2 = qr2.rem;
     }
     div_t qr = div((int)number, 10);
-    if (qr.rem) {
+    if (qr.rem || (mode == 2 && rem2)) {
       PLAY_NUMBER(qr.quot, 0, ZENSKI);
       if (qr.quot == 0)
         PUSH_NUMBER_PROMPT(PL_PROMPT_CALA);
       else
         PL_PUSH_UNIT_PROMPT(PL_PROMPT_CALA, qr.quot);
       PLAY_NUMBER(qr.rem, 0, ZENSKI);
+      if (mode == 2 && rem2) {
+        PLAY_NUMBER(rem2, 0, 0);
+      }
       PUSH_NUMBER_PROMPT(PL_PROMPT_UNITS_BASE+((unit-1)*4)+3);
       return;
     }
@@ -235,4 +239,3 @@ I18N_PLAY_FUNCTION(pl, playDuration, int seconds PLAY_DURATION_ATT)
 }
 
 LANGUAGE_PACK_DECLARE(pl, STR_VOICE_POLISH);
-

--- a/radio/src/translations/tts/tts_pt.cpp
+++ b/radio/src/translations/tts/tts_pt.cpp
@@ -80,19 +80,24 @@ I18N_PLAY_FUNCTION(pt, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
     PUSH_NUMBER_PROMPT(PT_PROMPT_MENOS);
     number = -number;
   }
-
   int8_t mode = MODE(att);
   if (mode > 0) {
+    uint8_t rem2 = 0;
     if (mode == 2) {
-      number /= 10;
+      div_t qr2 = div((int)number, 10);
+      number = qr2.quot;
+      rem2 = qr2.rem;
     }
     div_t qr = div((int)number, 10);
-    if (qr.rem > 0) {
+    if (qr.rem || (mode == 2 && rem2)) {
       PLAY_NUMBER(qr.quot, 0, 0);
       PUSH_NUMBER_PROMPT(PT_PROMPT_VIRGULA);
-      if (mode==2 && qr.rem < 10)
-        PUSH_NUMBER_PROMPT(PT_PROMPT_ZERO);
-      PLAY_NUMBER(qr.rem, unit, 0);
+      if (mode == 2 && rem2) {
+	PLAY_NUMBER(qr.rem, 0, 0);
+        PLAY_NUMBER(rem2, unit, 0);
+      } else {
+        PLAY_NUMBER(qr.rem, unit, 0);
+      }
     }
     else {
       PLAY_NUMBER(qr.quot, unit, 0);
@@ -185,4 +190,3 @@ I18N_PLAY_FUNCTION(pt, playDuration, int seconds PLAY_DURATION_ATT)
 }
 
 LANGUAGE_PACK_DECLARE(pt, STR_VOICE_PORTUGUES);
-

--- a/radio/src/translations/tts/tts_pt.cpp
+++ b/radio/src/translations/tts/tts_pt.cpp
@@ -93,7 +93,7 @@ I18N_PLAY_FUNCTION(pt, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
       PLAY_NUMBER(qr.quot, 0, 0);
       PUSH_NUMBER_PROMPT(PT_PROMPT_VIRGULA);
       if (mode == 2 && rem2) {
-	PLAY_NUMBER(qr.rem, 0, 0);
+        PLAY_NUMBER(qr.rem, 0, 0);
         PLAY_NUMBER(rem2, unit, 0);
       } else {
         PLAY_NUMBER(qr.rem, unit, 0);

--- a/radio/src/translations/tts/tts_ru.cpp
+++ b/radio/src/translations/tts/tts_ru.cpp
@@ -78,12 +78,18 @@ I18N_PLAY_FUNCTION(ru, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
   div_t qr = div((int)number, 10);
   int8_t mode = MODE(att);
   if (mode > 0 && att != RU_FEMALE_UNIT) {
+    uint8_t rem2 = 0;
     if (mode == 2) {
-      number /= 10;
+      div_t qr2 = div((int)number, 10);
+      number = qr2.quot;
+      rem2 = qr2.rem;
     }
-    if (qr.rem) {
+    if (qr.rem || (mode == 2 && rem2)) {
       PLAY_NUMBER(qr.quot, 0, 0);
       PUSH_NUMBER_PROMPT(RU_PROMPT_POINT_BASE + qr.rem);
+      if (mode == 2 && rem2) {
+        PLAY_NUMBER(rem2, 0, 0);
+      }
       number = -1;
     }
     else {
@@ -189,4 +195,3 @@ I18N_PLAY_FUNCTION(ru, playDuration, int seconds PLAY_DURATION_ATT)
 }
 
 LANGUAGE_PACK_DECLARE(ru, STR_VOICE_RUSSIAN);
-

--- a/radio/src/translations/tts/tts_ru.cpp
+++ b/radio/src/translations/tts/tts_ru.cpp
@@ -84,6 +84,7 @@ I18N_PLAY_FUNCTION(ru, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
       number = qr2.quot;
       rem2 = qr2.rem;
     }
+    qr = div((int)number, 10);
     if (qr.rem || (mode == 2 && rem2)) {
       PLAY_NUMBER(qr.quot, 0, 0);
       PUSH_NUMBER_PROMPT(RU_PROMPT_POINT_BASE + qr.rem);

--- a/radio/src/translations/tts/tts_ru.cpp
+++ b/radio/src/translations/tts/tts_ru.cpp
@@ -77,8 +77,8 @@ I18N_PLAY_FUNCTION(ru, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
 
   div_t qr = div((int)number, 10);
   int8_t mode = MODE(att);
+  uint8_t rem2 = 0;
   if (mode > 0 && att != RU_FEMALE_UNIT) {
-    uint8_t rem2 = 0;
     if (mode == 2) {
       div_t qr2 = div((int)number, 10);
       number = qr2.quot;
@@ -151,7 +151,7 @@ I18N_PLAY_FUNCTION(ru, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
   }
 
   if (unit) {
-    if (mode > 0 && qr.rem) // number with decimal point
+    if (mode > 0 && (qr.rem || rem2)) // number with decimal point
       RU_PUSH_UNIT_PROMPT(unit, -1); // force 2 units form, if float value
     else
       RU_PUSH_UNIT_PROMPT(unit, tmp);

--- a/radio/src/translations/tts/tts_se.cpp
+++ b/radio/src/translations/tts/tts_se.cpp
@@ -30,7 +30,7 @@ enum SwedishPrompts {
   SE_PROMPT_MINUS = SE_PROMPT_NUMBERS_BASE+111,
   SE_PROMPT_POINT = SE_PROMPT_NUMBERS_BASE+112,
   SE_PROMPT_UNITS_BASE = 113,
-  SE_PROMPT_POINT_BASE = 165, //.0 - .9
+  SE_PROMPT_POINT_BASE = 167, //.0 - .9
 };
 
 
@@ -50,17 +50,21 @@ I18N_PLAY_FUNCTION(se, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
     PUSH_NUMBER_PROMPT(SE_PROMPT_MINUS);
     number = -number;
   }
-
-
   int8_t mode = MODE(att);
   if (mode > 0) {
+    uint8_t rem2 = 0;
     if (mode == 2) {
-      number /= 10;
+      div_t qr2 = div((int)number, 10);
+      number = qr2.quot;
+      rem2 = qr2.rem;
     }
     div_t qr = div((int)number, 10);
-    if (qr.rem) {
+    if (qr.rem || (mode == 2 && rem2)) {
       PLAY_NUMBER(qr.quot, 0, 0);
       PUSH_NUMBER_PROMPT(SE_PROMPT_POINT_BASE + qr.rem);
+      if (mode == 2 && rem2) {
+        PLAY_NUMBER(rem2, 0, 0);
+      }
       number = -1;
     }
     else {
@@ -125,4 +129,3 @@ I18N_PLAY_FUNCTION(se, playDuration, int seconds PLAY_DURATION_ATT)
 }
 
 LANGUAGE_PACK_DECLARE(se, STR_VOICE_SWEDISH);
-

--- a/radio/src/translations/tts/tts_sk.cpp
+++ b/radio/src/translations/tts/tts_sk.cpp
@@ -63,21 +63,25 @@ I18N_PLAY_FUNCTION(sk, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
     PUSH_NUMBER_PROMPT(SK_PROMPT_MINUS);
     number = -number;
   }
-
-
   int8_t mode = MODE(att);
   if (mode > 0) {
+    uint8_t rem2 = 0;
     if (mode == 2) {
-      number /= 10;
+      div_t qr2 = div((int)number, 10);
+      number = qr2.quot;
+      rem2 = qr2.rem;
     }
     div_t qr = div((int)number, 10);
-    if (qr.rem) {
+    if (qr.rem || (mode == 2 && rem2)) {
       PLAY_NUMBER(qr.quot, 0, ZENSKY);
       if (qr.quot == 0)
         PUSH_NUMBER_PROMPT(SK_PROMPT_CELA);
       else
         SK_PUSH_UNIT_PROMPT(SK_PROMPT_CELA, qr.quot);
       PLAY_NUMBER(qr.rem, 0, ZENSKY);
+      if (mode == 2 && rem2) {
+        PLAY_NUMBER(rem2, 0, 0);
+      }
       PUSH_NUMBER_PROMPT(SK_PROMPT_UNITS_BASE+((unit-1)*4)+3);
       return;
     }
@@ -185,4 +189,3 @@ I18N_PLAY_FUNCTION(sk, playDuration, int seconds PLAY_DURATION_ATT)
 }
 
 LANGUAGE_PACK_DECLARE(sk, STR_VOICE_SLOVAK);
-

--- a/radio/src/translations/tts/tts_ua.cpp
+++ b/radio/src/translations/tts/tts_ua.cpp
@@ -83,6 +83,7 @@ I18N_PLAY_FUNCTION(ua, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
       number = qr2.quot;
       rem2 = qr2.rem;
     }
+    qr = div((int)number, 10);
     if (qr.rem || (mode == 2 && rem2)) {
       PLAY_NUMBER(qr.quot, 0, 0);
       PUSH_NUMBER_PROMPT(UA_PROMPT_POINT_BASE + qr.rem);

--- a/radio/src/translations/tts/tts_ua.cpp
+++ b/radio/src/translations/tts/tts_ua.cpp
@@ -77,12 +77,18 @@ I18N_PLAY_FUNCTION(ua, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
   div_t qr = div((int)number, 10);
   int8_t mode = MODE(att);
   if (mode > 0 && att != UA_FEMALE_UNIT) {
+    uint8_t rem2 = 0;
     if (mode == 2) {
-      number /= 10;
+      div_t qr2 = div((int)number, 10);
+      number = qr2.quot;
+      rem2 = qr2.rem;
     }
-    if (qr.rem) {
+    if (qr.rem || (mode == 2 && rem2)) {
       PLAY_NUMBER(qr.quot, 0, 0);
       PUSH_NUMBER_PROMPT(UA_PROMPT_POINT_BASE + qr.rem);
+      if (mode == 2 && rem2) {
+        PLAY_NUMBER(rem2, 0, 0);
+      }
       number = -1;
     }
     else {

--- a/radio/src/translations/tts/tts_ua.cpp
+++ b/radio/src/translations/tts/tts_ua.cpp
@@ -76,8 +76,8 @@ I18N_PLAY_FUNCTION(ua, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
 
   div_t qr = div((int)number, 10);
   int8_t mode = MODE(att);
+  uint8_t rem2 = 0;
   if (mode > 0 && att != UA_FEMALE_UNIT) {
-    uint8_t rem2 = 0;
     if (mode == 2) {
       div_t qr2 = div((int)number, 10);
       number = qr2.quot;
@@ -150,7 +150,7 @@ I18N_PLAY_FUNCTION(ua, playNumber, getvalue_t number, uint8_t unit, uint8_t att)
   }
 
   if (unit) {
-    if (mode > 0 && qr.rem) // number with decimal point
+    if (mode > 0 && (qr.rem || rem2)) // number with decimal point
       UA_PUSH_UNIT_PROMPT(unit, -1); // force 2 units form, if float value
     else
       UA_PUSH_UNIT_PROMPT(unit, tmp);


### PR DESCRIPTION
Tested with:
    playNumber(123, UNIT_VOLTS, PREC2) -- says 1.23 Volts
    playNumber(103, UNIT_VOLTS, PREC2) -- says 1.03 Volts
    playNumber(100, UNIT_VOLTS, PREC2) -- says 1 Volt
    playNumber(110, UNIT_VOLTS, PREC2) -- says 1.1 Volts

Just want to check this is the right approach and if you approve I'll go in and fix the other languages too, before asking for final merge.

Fixes #5480

Summary of changes:

remember the remainder of the first division by 10 and then say that if it's appropriate.

playNumber PREC2 is only accessible via Lua API, so there is no internal/built-in announcement path that will get longer.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved TTS decimal-number playback across many languages: the decimal-point mode now emits an extra fractional digit when appropriate, producing more complete and consistent decimal readouts.
  * Reduced cases of omitted trailing fractional digits and standardized when the decimal separator is announced, improving numeric announcement accuracy in multilingual voices.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EdgeTX/edgetx/pull/7364)
<!-- end of auto-generated comment: release notes by coderabbit.ai -->