### PR TITLE
fix(firmware): prevent LTO from eliminating the ISR vector table

### DIFF
--- a/radio/src/targets/common/arm/stm32/cortex_m_isr.h
+++ b/radio/src/targets/common/arm/stm32/cortex_m_isr.h
@@ -20,7 +20,7 @@
  */
 
 #define WEAK_DEFAULT __attribute__((weak,alias("Default_Handler")))
-#define ISR_VECTOR __attribute__((section(".isr_vector")))
+#define ISR_VECTOR __attribute__((section(".isr_vector"), used))
 
 typedef void (*isr_t)(void);
 extern void* _estack;


### PR DESCRIPTION
## Summary

- With LTO (`-flto`) enabled (currently used for X9D+2019 builds), the linker discards `_isr_vector[]` because no C code references it directly — the hardware reads it via the `VTOR` register. `KEEP()` in the linker script prevents gc-sections from removing it, but LTO operates before that stage and eliminates the symbol entirely, resulting in an empty `.isr_vector` section.
- This causes the firmware binary to have `.fwversiondata` (the version string) placed at the application start offset (`BOOTLOADER_SIZE`) instead of the ARM vector table, so `isFirmwareStart()` reads ASCII bytes instead of valid stack/ISR pointers and rejects the file as `FC_ERROR`.
- Fix: add `used` to the `ISR_VECTOR` macro in `cortex_m_isr.h`, matching the same pattern already applied to `BOOTSTRAP` and `init_hooks()` in `system_init.c` as part of the LTO work.
- Resolves regression introduced in #7255

## Test plan

- [x] Build X9D+2019 firmware with LTO and confirm `.isr_vector` section is non-empty in `firmware.map`
- [x] Confirm valid firmware file is recognised in the bootloader (no longer shows FC_ERROR / "Invalid firmware")
- [x] Confirm firmware boots correctly on hardware
- [ ] Verify non-LTO targets (X9D+, X9E, etc.) are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved interrupt handler reliability by ensuring ISR vector entries are properly retained during compilation, preventing potential unintended removal by the linker.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EdgeTX/edgetx/pull/7369)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->