### PR TITLE
feat(cpn): refactor handling of erroneous models

### DIFF
--- a/companion/src/firmwares/modeldata.cpp
+++ b/companion/src/firmwares/modeldata.cpp
@@ -2128,7 +2128,7 @@ void ModelData::validate()
 
 QStringList ModelData::errorsList()
 {
-  QStringList list;
+  QStringList list { "" };
 
   for (int i = 0; i < CPN_MAX_INPUTS; i++) {
     if (!expoData[i].isEmpty() && expoData[i].srcRaw == SOURCE_TYPE_NONE)

--- a/companion/src/firmwares/radiodata.cpp
+++ b/companion/src/firmwares/radiodata.cpp
@@ -358,3 +358,18 @@ int RadioData::invalidModels()
 
   return cnt;
 }
+
+QStringList RadioData::modelErrorsList()
+{
+  QStringList ret;
+
+  for(auto &model: models) {
+    if (!model.isValid()) {
+      ret.append("");
+      ret.append(model.name);
+      ret.append(model.errorsList());
+    }
+  }
+
+  return ret;
+}

--- a/companion/src/firmwares/radiodata.h
+++ b/companion/src/firmwares/radiodata.h
@@ -68,6 +68,7 @@ class RadioData {
     QString getNextModelFilename();
     void validateModels();
     int invalidModels();
+    QStringList modelErrorsList();
 
     static QString modelSortOrderToString(int value);
     static AbstractStaticItemModel * modelSortOrderItemModel();

--- a/companion/src/mainwindow.cpp
+++ b/companion/src/mainwindow.cpp
@@ -677,9 +677,9 @@ void MainWindow::updateMenus()
   saveAsAct->setEnabled(activeChild);
   closeAct->setEnabled(activeChild);
   compareAct->setEnabled(activeChild);
-  writeSettingsAct->setEnabled(activeChild && !activeMdiChild()->invalidModels());
+  writeSettingsAct->setEnabled(activeChild);
   readSettingsAct->setEnabled(true);
-  writeSettingsSDPathAct->setEnabled(activeChild && isSDPathValid() && !activeMdiChild()->invalidModels());
+  writeSettingsSDPathAct->setEnabled(activeChild && isSDPathValid());
   readSettingsSDPathAct->setEnabled(isSDPathValid());
   writeBUToRadioAct->setEnabled(false);
   readBUToFileAct->setEnabled(false);
@@ -1518,12 +1518,20 @@ bool MainWindow::readSettingsFromSDPath(const QString & filename)
 
 void MainWindow::writeSettingsSDPath()
 {
-  StatusDialog *status = new StatusDialog(this, tr("Writing models and settings to SD path"), tr("In progress..."), 400);
+  if (activeMdiChild()) {
+    int cnt = activeMdiChild()->invalidModels();
 
-  if (activeMdiChild())
+    if (cnt) {
+      QMessageBox::critical(this, tr("Write Models and Settings to SD Path"),
+        tr("Operation aborted: %1 models have errors that may affect operation.").arg(cnt));
+
+      return;
+    }
+
+    StatusDialog *status = new StatusDialog(this, tr("Writing models and settings to SD path"), tr("In progress..."), 400);
     activeMdiChild()->writeSettings(status, false);
-
-  delete status;
+    delete status;
+  }
 }
 
 bool MainWindow::isSDPathValid()

--- a/companion/src/mainwindow.cpp
+++ b/companion/src/mainwindow.cpp
@@ -1523,7 +1523,9 @@ void MainWindow::writeSettingsSDPath()
 
     if (cnt) {
       QMessageBox::critical(this, tr("Write Models and Settings to SD Path"),
-        tr("Operation aborted: %1 models have errors that may affect operation.").arg(cnt));
+        tr("Operation aborted: %1 models have errors that may affect operation.\n%2")
+          .arg(cnt)
+          .arg(activeMdiChild()->modelErrorsList().join("\n")));
 
       return;
     }

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -38,6 +38,17 @@
 #include <algorithm>
 #include <ExportableTableView>
 
+
+void StatusBarIcon::mouseDoubleClickEvent(QMouseEvent * event)
+{
+  QLabel::mouseDoubleClickEvent(event);
+  emit doubleClicked();
+}
+
+/*
+  class MdiChild
+*/
+
 MdiChild::MdiChild(QWidget * parent, QWidget * parentWin, Qt::WindowFlags f):
   QWidget(parent, f),
   ui(new Ui::MdiChild),
@@ -1272,7 +1283,9 @@ void MdiChild::radioSimulate()
 
   if (cnt) {
     QMessageBox::critical(this, tr("Simulate Radio"),
-      tr("Operation aborted: %1 models have errors that may affect simulation.").arg(cnt));
+      tr("Operation aborted: %1 models have errors that may affect simulation.\n%2")
+      .arg(cnt)
+      .arg(radioData.modelErrorsList().join("\n")));
     return;
   }
 
@@ -1285,7 +1298,8 @@ void MdiChild::modelSimulate()
 
   if (currMdlIdx > -1 && !radioData.models[currMdlIdx].isValid()) {
     QMessageBox::critical(this, tr("Simulate Model"),
-      tr("Operation aborted: selected model has errors that may affect simulation."));
+      tr("Operation aborted: selected model has errors that may affect simulation.\n%1")
+      .arg(radioData.models[currMdlIdx].errorsList().join("\n")));
     return;
   }
 
@@ -1547,7 +1561,10 @@ void MdiChild::writeSettings(StatusDialog * status, bool toRadio)
   int cnt = radioData.invalidModels();
 
   if (cnt) {
-    QMessageBox::critical(this, tr("Write Models and Settings"), tr("Operation aborted as %1 models have significant errors that may affect model operation.").arg(cnt));
+    QMessageBox::critical(this, tr("Write Models and Settings"),
+      tr("Operation aborted as %1 models have significant errors that may affect model operation.\n%2")
+      .arg(cnt)
+      .arg(radioData.modelErrorsList().join("\n")));
     return;
   }
 
@@ -1922,6 +1939,11 @@ int MdiChild::invalidModels()
   return radioData.invalidModels();
 }
 
+QStringList MdiChild::modelErrorsList()
+{
+  return radioData.modelErrorsList();
+}
+
 void MdiChild::modelShowErrors()
 {
   ModelData &mdl = radioData.models[getCurrentModel()];
@@ -1940,7 +1962,7 @@ void MdiChild::setupStatusBar()
   ui->statusBarLayout->addWidget(statusBar);
   QLabel *lbl = new QLabel(tr("Models status"));
   statusBar->addPermanentWidget(lbl);
-  statusBarIcon = new QLabel();
+  statusBarIcon = new StatusBarIcon(this);
   statusBar->addPermanentWidget(statusBarIcon);
   statusBarCount = new QLabel();
   statusBar->addPermanentWidget(statusBarCount);
@@ -1951,13 +1973,16 @@ void MdiChild::updateStatusBar()
   QPixmap p;
   QLabel cnt;
   int invalid = radioData.invalidModels();
+  disconnect(statusBarIcon, &StatusBarIcon::doubleClicked, nullptr, nullptr);
 
   if (!invalidModels()) {
     statusBarIcon->setToolTip(tr("No errors"));
     p.load(":/images/png/tick-green.png");
-  }
-  else {
-    statusBarIcon->setToolTip(tr("Errors"));
+  } else {
+    statusBarIcon->setToolTip(tr("Double click to display errors"));
+    connect(statusBarIcon, &StatusBarIcon::doubleClicked, [this] () {
+      QMessageBox::critical(this, tr("Models Status"), radioData.modelErrorsList().join("\n"));
+    });
     p.load(":/images/png/cross-red.png");
     cnt.setText(QString::number(invalid));
   }

--- a/companion/src/mdichild.cpp
+++ b/companion/src/mdichild.cpp
@@ -352,7 +352,7 @@ void MdiChild::updateNavigation()
     cboModelSortOrder->setCurrentIndex(radioData.sortOrder);
     cboModelSortOrder->blockSignals(false);
   }
-  action[ACT_GEN_SIM]->setEnabled(!invalidModels());
+  action[ACT_GEN_SIM]->setEnabled(true);
   action[ACT_GEN_SRT]->setVisible(hasLabels);
 
   action[ACT_MDL_DEL]->setEnabled(modelsSelected);
@@ -375,7 +375,7 @@ void MdiChild::updateNavigation()
   action[ACT_MDL_WIZ]->setEnabled(singleModelSelected);
   action[ACT_MDL_DFT]->setEnabled(singleModelSelected && getCurrentModel() != (int)radioData.generalSettings.currModelIndex);
   action[ACT_MDL_PRT]->setEnabled(singleModelSelected);
-  action[ACT_MDL_SIM]->setEnabled(singleModelSelected && !invalidModels());
+  action[ACT_MDL_SIM]->setEnabled(singleModelSelected);
   action[ACT_MDL_ERR]->setEnabled(singleModelSelected && radioData.models[getCurrentModel()].modelErrors);
 
   emit navigationUpdated();
@@ -1267,12 +1267,32 @@ void MdiChild::setDefault()
 
 void MdiChild::radioSimulate()
 {
+  //  safeguard as the menu actions are enabled
+  int cnt = radioData.invalidModels();
+
+  if (cnt) {
+    QMessageBox::critical(this, tr("Simulate Radio"),
+      tr("Operation aborted: %1 models have errors that may affect simulation.").arg(cnt));
+    return;
+  }
+
   startSimulation(this, radioData, -1);
 }
 
 void MdiChild::modelSimulate()
 {
-  startSimulation(this, radioData, getCurrentModel());
+  int currMdlIdx = getCurrentModel();
+
+  if (currMdlIdx > -1 && !radioData.models[currMdlIdx].isValid()) {
+    QMessageBox::critical(this, tr("Simulate Model"),
+      tr("Operation aborted: selected model has errors that may affect simulation."));
+    return;
+  }
+
+  if (currMdlIdx < 0)
+    radioSimulate();
+  else
+    startSimulation(this, radioData, getCurrentModel());
 }
 
 void MdiChild::newFile(bool useProfileSettings)
@@ -1523,7 +1543,7 @@ int MdiChild::askQuestion(const QString & msg, QMessageBox::StandardButtons butt
 
 void MdiChild::writeSettings(StatusDialog * status, bool toRadio)
 {
-  //  safeguard as the menu actions should be disabled
+  //  safeguard as the menu actions are enabled
   int cnt = radioData.invalidModels();
 
   if (cnt) {
@@ -1897,9 +1917,9 @@ QAction * MdiChild::actionsSeparator()
   return act;
 }
 
-bool MdiChild::invalidModels()
+int MdiChild::invalidModels()
 {
-  return (bool)radioData.invalidModels();
+  return radioData.invalidModels();
 }
 
 void MdiChild::modelShowErrors()

--- a/companion/src/mdichild.h
+++ b/companion/src/mdichild.h
@@ -91,7 +91,7 @@ class MdiChild : public QWidget
     QList<QAction *> getModelActions();
     QList<QAction *> getLabelsActions();
     QAction * getAction(const Actions type);
-    bool invalidModels();
+    int invalidModels();
 
   public slots:
     void newFile(bool useProfileSettings = false);

--- a/companion/src/mdichild.h
+++ b/companion/src/mdichild.h
@@ -44,6 +44,21 @@ class MdiChild;
 class LabelsDelegate;
 class LabelsProxy;
 
+class StatusBarIcon : public QLabel
+{
+    Q_OBJECT
+
+  public:
+    StatusBarIcon(QWidget * parent) : QLabel(parent) {}
+    virtual ~StatusBarIcon() {}
+
+  signals:
+    void doubleClicked();
+
+  protected:
+    virtual void mouseDoubleClickEvent(QMouseEvent * event);
+};
+
 class MdiChild : public QWidget
 {
   Q_OBJECT
@@ -92,6 +107,7 @@ class MdiChild : public QWidget
     QList<QAction *> getLabelsActions();
     QAction * getAction(const Actions type);
     int invalidModels();
+    QStringList modelErrorsList();
 
   public slots:
     void newFile(bool useProfileSettings = false);
@@ -228,7 +244,7 @@ class MdiChild : public QWidget
     QToolBar * labelsToolbar;
     QLabel *lblLabels;
     QStatusBar *statusBar;
-    QLabel *statusBarIcon;
+    StatusBarIcon *statusBarIcon;
     QLabel *statusBarCount;
 
     Firmware * firmware;

--- a/companion/src/modeledit/modeledit.cpp
+++ b/companion/src/modeledit/modeledit.cpp
@@ -168,5 +168,11 @@ void ModelEdit::onTabIndexChanged(int index)
 
 void ModelEdit::launchSimulation()
 {
+  if (!radioData.models[modelId].isValid()) {
+    QMessageBox::critical(this, tr("Simulate Model"),
+      tr("Operation aborted: model has errors that may affect simulation."));
+    return;
+  }
+
   startSimulation(this, radioData, modelId);
 }

--- a/companion/src/modeledit/modeledit.cpp
+++ b/companion/src/modeledit/modeledit.cpp
@@ -170,7 +170,8 @@ void ModelEdit::launchSimulation()
 {
   if (!radioData.models[modelId].isValid()) {
     QMessageBox::critical(this, tr("Simulate Model"),
-      tr("Operation aborted: model has errors that may affect simulation."));
+      tr("Operation aborted: model has errors that may affect simulation.\n%1")
+      .arg(radioData.models[modelId].errorsList().join("\n")));
     return;
   }
 


### PR DESCRIPTION
Fixes #6153

Summary of changes:
- reenable menus, toolbars and context menus even when model errors
- display detailed model errors dialogs when attempt to run a process that prohibits erroneous data and abort the process
- double clicking status bar model error icon displays detailed errors for all models
- allow individual error free models to be simulated

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Added model validation checks before writing settings and running simulations; operations now abort with detailed error reports if models are invalid.

* **New Features**
  * Status bar errors are now interactive (double-click to display details).
  * Expanded error reporting in pre-operation dialogs with comprehensive model error lists.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EdgeTX/edgetx/pull/7377?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->