### PR TITLE
fix(color): progress bar dialog window may be clipped on TX16S Mk3

### DIFF
--- a/radio/src/gui/colorlcd/libui/dialog.cpp
+++ b/radio/src/gui/colorlcd/libui/dialog.cpp
@@ -76,7 +76,7 @@ ProgressDialog::ProgressDialog(const char* title,
                                std::function<void()> onClose) :
     BaseDialog(title, false), onClose(std::move(onClose))
 {
-  progress = new Progress(form, rect_t{0, 0, LV_PCT(100), 32});
+  progress = new Progress(form, rect_t{0, 0, LV_PCT(100), EdgeTxStyles::UI_ELEMENT_HEIGHT});
   updateProgress(0);
 }
 


### PR DESCRIPTION
Correctly size progress bar dialog window.

2.12 & 3.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Progress dialog height now aligns with standard application UI element sizing for improved visual consistency.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EdgeTX/edgetx/pull/7378?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->