### PR TITLE
fix(bw): rotary encoder mode and enabled features not working in radio setup page

### DIFF
--- a/radio/src/gui/128x64/radio_setup.cpp
+++ b/radio/src/gui/128x64/radio_setup.cpp
@@ -185,7 +185,7 @@ void menuRadioSetup(event_t event)
     HEADER_LINE_COLUMNS
     CASE_RTCLOCK(2) CASE_RTCLOCK(2)
     // Sound
-    0, 
+    CASE_AUDIO(LABEL(SOUND))
      CASE_AUDIO(SOUND_ROW(0))
      CASE_AUDIO(SOUND_ROW(0))
      CASE_AUDIO(SOUND_ROW(0))
@@ -228,6 +228,7 @@ void menuRadioSetup(event_t event)
      CASE_BACKLIGHT(0)
      CASE_BACKLIGHT(BACKLIGHT_WARNING_ROW(LABEL(0)))
      CASE_BACKLIGHT(0)
+    0,
     CASE_SPLASH_PARAM(0)
     CASE_PWR_BUTTON_PRESS(0)
     CASE_PWR_BUTTON_PRESS(0)
@@ -241,10 +242,11 @@ void menuRadioSetup(event_t event)
      CASE_GPS(0)
      CASE_GPS(0)
     CASE_PXX1(0)
-    0, 0, 0,
+    0,
 #if defined(ALL_LANGS)
     0, // text language
 #endif
+    0, 0,
     IF_FAI_CHOICE(0)
     0,
     0, // USB mode

--- a/radio/src/gui/212x64/radio_setup.cpp
+++ b/radio/src/gui/212x64/radio_setup.cpp
@@ -228,6 +228,7 @@ void menuRadioSetup(event_t event)
       0, // backlight control
       BACKLIGHT_WARNING_ROW(LABEL(0)), // backlight control override warning
       0, // flash beep
+    0,
     CASE_SPLASH_PARAM(0) // disable splash
     CASE_PWR_BUTTON_PRESS(0) // pwr on speed
     CASE_PWR_BUTTON_PRESS(0) // pwr off speed


### PR DESCRIPTION
Fix radio setup page.
Broken in PR #7163

Fixes #7386, fixes #7410

Required in 2.11, 2.12 and 3.0.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Adjusted the Radio Setup menu item layout and indexing across display configurations to ensure correct menu positioning and visual organization.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EdgeTX/edgetx/pull/7387?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->