### PR TITLE
Optimize PA01's matrix keyboard scanning

### DIFF
--- a/radio/src/targets/pa01/key_driver.cpp
+++ b/radio/src/targets/pa01/key_driver.cpp
@@ -87,6 +87,8 @@ void pollKeys()
       keyState |= 1<<ENT;
 
     nonReadCount++;
+    //If no interrupt occurs, it means no key is pressed, so no scanning is needed this time,exit.
+    return;
   }
   nonReadCount = 0;
 #endif
@@ -114,6 +116,7 @@ void pollKeys()
   // If ui8ReadInProgress is above 1, then there was concurrent task calling it, exit
   if (syncelem.ui8ReadInProgress > 1) {
     keyState = syncelem.oldResult;
+    return;
   }
 
   // If we land here, we have exclusive access to Matrix


### PR DESCRIPTION
1.Resubmit program #7315
2.Exit key scanning when no interrupt occurs or a concurrent task is invoked.However. But，I'm not sure if this function is intended to be called concurrently.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized key polling logic with early exit conditions to reduce unnecessary scanning operations during specific system states and concurrent read scenarios.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EdgeTX/edgetx/pull/7394?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->