### PR TITLE
fix(color): outputs widget may crash when upgrading to 3.0

### DIFF
--- a/radio/src/gui/colorlcd/widgets/outputs.cpp
+++ b/radio/src/gui/colorlcd/widgets/outputs.cpp
@@ -283,7 +283,9 @@ class OutputsWidgetFactory : public WidgetFactory
   const void checkOptions(int screenNum, int zoneNum) const override
   {
     auto widgetData = g_model.getWidgetData(screenNum, zoneNum);
-    if (widgetData && widgetData->options.size() < 6 && widgetData->options[1].type == WOV_Bool) {
+    if (widgetData && widgetData->options.size() >= 2 &&
+        widgetData->options.size() < 6 &&
+        widgetData->options[1].type == WOV_Bool) {
       WidgetOptionValueTyped v;
       v.type = WOV_Signed;
       v.value.signedValue = MAX_OUTPUT_CHANNELS;

--- a/radio/src/gui/colorlcd/widgets/outputs.cpp
+++ b/radio/src/gui/colorlcd/widgets/outputs.cpp
@@ -283,16 +283,12 @@ class OutputsWidgetFactory : public WidgetFactory
   const void checkOptions(int screenNum, int zoneNum) const override
   {
     auto widgetData = g_model.getWidgetData(screenNum, zoneNum);
-    if (widgetData && widgetData->options.size() >= 4) {
-      if (widgetData->options[1].type == WOV_Bool) {
-        widgetData->options[5] = widgetData->options[4];
-        widgetData->options[4] = widgetData->options[3];
-        widgetData->options[3] = widgetData->options[2];
-        widgetData->options[2] = widgetData->options[1];
-        widgetData->options[1].type = WOV_Signed;
-        widgetData->options[1].value.signedValue = MAX_OUTPUT_CHANNELS;
-        storageDirty(EE_MODEL);
-      }
+    if (widgetData && widgetData->options.size() < 6 && widgetData->options[1].type == WOV_Bool) {
+      WidgetOptionValueTyped v;
+      v.type = WOV_Signed;
+      v.value.signedValue = MAX_OUTPUT_CHANNELS;
+      widgetData->options.insert(widgetData->options.begin() + 1, v);
+      storageDirty(EE_MODEL);
     }
   }
 };


### PR DESCRIPTION
Fix crash in outputs widget when upgrading.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Applies a targeted legacy fix so older model output settings are restored and display correctly.
  * Prevents overwriting or shifting existing output options during migration.
  * Marks adjusted legacy models as modified so corrections are saved.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->