### PR TITLE
fix(pl18u): reinit I2C when touch screen not working

### DIFF
--- a/radio/src/targets/common/arm/stm32/stm32_i2c_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_i2c_driver.cpp
@@ -19,6 +19,8 @@
  * GNU General Public License for more details.
  */
 
+#include <cstring>
+
 #include "stm32_i2c_driver.h"
 #include "stm32_gpio.h"
 #include "stm32_hal_ll.h"
@@ -546,7 +548,9 @@ int stm32_i2c_deinit(uint8_t bus)
   if (!h) return -1;  
 
   if (HAL_I2C_DeInit(h) != HAL_OK) return -1;
-  
+
+  memset(&h->Init, 0, sizeof(h->Init));
+
   if (i2c_disable_clock(h->Instance) < 0) {
     TRACE("I2C ERROR: HAL_I2C_MspDeInit() I2C misconfiguration");
     return -1;

--- a/radio/src/targets/pl18/touch_driver.cpp
+++ b/radio/src/targets/pl18/touch_driver.cpp
@@ -473,7 +473,7 @@ bool touchPanelEventOccured()
 
 struct TouchState touchPanelRead()
 {
-#if 1
+#if 0
   // For _i2c_reInit testing
   static uint8_t reinitPollCnt = 0;
   TRACE("Polling count: %d", reinitPollCnt);

--- a/radio/src/targets/pl18/touch_driver.cpp
+++ b/radio/src/targets/pl18/touch_driver.cpp
@@ -172,11 +172,11 @@ static void _i2c_reInit(void)
 {
   TRACE("I2C reinit: bus reset triggered");
   i2c_deinit(TOUCH_I2C_BUS);
-  __HAL_RCC_I2C1_FORCE_RESET();
-  __HAL_RCC_I2C1_RELEASE_RESET();
+//  __HAL_RCC_I2C1_FORCE_RESET();
+//  __HAL_RCC_I2C1_RELEASE_RESET();
   delay_ms(1);
   _i2c_init();
-  _touch_reset();
+//  _touch_reset();
   TRACE("I2C reinit: bus reset complete");
 }
 
@@ -473,12 +473,15 @@ bool touchPanelEventOccured()
 
 struct TouchState touchPanelRead()
 {
+#if 1
+  // For _i2c_reInit testing
   static uint8_t reinitPollCnt = 0;
   TRACE("Polling count: %d", reinitPollCnt);
   if (++reinitPollCnt >= 50) {
     reinitPollCnt = 0;
     _i2c_reInit();
   }
+#endif
 
   if (!touchEventOccured) return internalTouchState;
 

--- a/radio/src/targets/pl18/touch_driver.cpp
+++ b/radio/src/targets/pl18/touch_driver.cpp
@@ -171,9 +171,12 @@ static void _i2c_init(void)
 static void _i2c_reInit(void)
 {
   TRACE("I2C reinit: bus reset triggered");
-  stm32_i2c_deinit(TOUCH_I2C_BUS);
+  i2c_deinit(TOUCH_I2C_BUS);
+  __HAL_RCC_I2C1_FORCE_RESET();
+  __HAL_RCC_I2C1_RELEASE_RESET();
   delay_ms(1);
   _i2c_init();
+  _touch_reset();
   TRACE("I2C reinit: bus reset complete");
 }
 
@@ -471,7 +474,7 @@ bool touchPanelEventOccured()
 struct TouchState touchPanelRead()
 {
   static uint8_t reinitPollCnt = 0;
-
+  TRACE("Polling count: %d", reinitPollCnt);
   if (++reinitPollCnt >= 50) {
     reinitPollCnt = 0;
     _i2c_reInit();

--- a/radio/src/targets/pl18/touch_driver.cpp
+++ b/radio/src/targets/pl18/touch_driver.cpp
@@ -170,8 +170,11 @@ static void _i2c_init(void)
 
 static void _i2c_reInit(void)
 {
-//  stm32_i2c_deinit(TOUCH_I2C_BUS);
-//  _i2c_init();
+  TRACE("I2C reinit: bus reset triggered");
+  stm32_i2c_deinit(TOUCH_I2C_BUS);
+  delay_ms(1);
+  _i2c_init();
+  TRACE("I2C reinit: bus reset complete");
 }
 
 static int _i2c_read(uint8_t addr, uint32_t reg, uint8_t regSize, uint8_t* data, uint16_t len, uint32_t timeout)
@@ -467,6 +470,13 @@ bool touchPanelEventOccured()
 
 struct TouchState touchPanelRead()
 {
+  static uint8_t reinitPollCnt = 0;
+
+  if (++reinitPollCnt >= 50) {
+    reinitPollCnt = 0;
+    _i2c_reInit();
+  }
+
   if (!touchEventOccured) return internalTouchState;
 
   touchEventOccured = false;

--- a/radio/src/targets/pl18/touch_driver.cpp
+++ b/radio/src/targets/pl18/touch_driver.cpp
@@ -171,11 +171,18 @@ static void _i2c_init(void)
 static void _i2c_reInit(void)
 {
   TRACE("I2C reinit: bus reset triggered");
-  i2c_deinit(TOUCH_I2C_BUS);
+
+  if (i2c_deinit(TOUCH_I2C_BUS) < 0) {
+    TRACE("I2C reinit WARNING: i2c_deinit failed, proceeding with reinit");
+  }
 //  __HAL_RCC_I2C1_FORCE_RESET();
 //  __HAL_RCC_I2C1_RELEASE_RESET();
   delay_ms(1);
-  _i2c_init();
+
+  if (i2c_init(TOUCH_I2C_BUS) < 0) {
+    TRACE("I2C reinit ERROR: i2c_init failed");
+    return;
+  }
 //  _touch_reset();
   TRACE("I2C reinit: bus reset complete");
 }


### PR DESCRIPTION
PL18U can have touch screen unresponsive, and need I2C reinit to make it work again.

This PR will fix all similar symptom in all Flysky radios supported in pl18 target.

A bug is discovered in stm32_i2c_driver that will make reinit i2c bus not working in other color touch screen (opencode + deepseek did this, yeah)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Strengthened I2C peripheral driver cleanup with enhanced memory clearing during deinitialization to prevent resource leaks and stale state.
  * Improved touch panel driver with an active I2C bus reinitialization sequence, including timing control and diagnostic logging for more reliable recovery.

* **Tests**
  * Added a disabled debugging block for future I2C reinitialization testing and diagnostics.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EdgeTX/edgetx/pull/7402?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->