### PR TITLE
fix(pl18u): rotary encoder emulation acceleration not fully implemented

### DIFF
--- a/radio/src/targets/pl18/pl18u_key_driver.cpp
+++ b/radio/src/targets/pl18/pl18u_key_driver.cpp
@@ -27,6 +27,7 @@
 #include "hal.h"
 #include "delays_driver.h"
 #include "keys.h"
+#include "timers_driver.h"
 
 #define REPEAT_DELAY 20
 
@@ -72,7 +73,7 @@ enum PhysicalTrims
 };
 
 volatile uint32_t rotencDt = 0;
-static rotenc_t rotencValue = 0;
+volatile static rotenc_t rotencValue = 0;
 static uint8_t lastRotState = 0;
 static uint8_t stateCount = 0;
 
@@ -215,6 +216,9 @@ uint32_t readKeys()
   } else {
     stateCount++;
     if (stateCount == 3) {
+#if !defined(BOOT)
+      rotencDt = get_tmr10ms();
+#endif
       if (rotState == 1)
         rotencValue++;
       else if (rotState == 2)


### PR DESCRIPTION
PL18U uses encoder emulation by key presses, acceleration is not implemented properly.

opencode + deepseek pro find the bug by just code reading ^.^

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved rotary encoder timing and responsiveness during key processing.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/EdgeTX/edgetx/pull/7403?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->