### PR TITLE
fix(pl18): prevent hang when pressing power button during USB charging

### DIFF
--- a/radio/src/targets/pl18/battery_driver.cpp
+++ b/radio/src/targets/pl18/battery_driver.cpp
@@ -443,9 +443,11 @@ void drawChargingInfo(uint16_t chargeState) {
 
 void battery_charge_end()
 {
-  chargeWindow->clear();
-  delete chargeWindow;
-  chargeWindow = nullptr;
+  if (chargeWindow) {
+    chargeWindow->clear();
+    delete chargeWindow;
+    chargeWindow = nullptr;
+  }
 }
 
 #define CHARGE_INFO_DURATION 5000 // ms

--- a/radio/src/targets/pl18/board.cpp
+++ b/radio/src/targets/pl18/board.cpp
@@ -252,6 +252,7 @@ void boardInit()
         if ((now - press_start) > POWER_ON_DELAY) {
           break;
         }
+        delay_ms(10);
       } else if (!isChargerActive()) {
         boardOff();
       } else {


### PR DESCRIPTION
Fixed by opencode + deepseek with prompt:

Try to explore the code and figure out how to fix the problem:

1. Start investigating in @radio/src/targets/pl18/board.cpp
2. PL18U radio has this problem
3. When plugin USB the radio will automatic power up and run board.cpp and enter battery charging loop
4. if we presses the power on button before or during battery charging (not sure the exact timing) the radio will hangs
5. Battery charging will have animation using w2812 LEDs, and pressing power button will make the animation stops and hangs

It found the problem and fixed it automatically ^.^

