### PR TITLE
fix(pa01): Intermitten trim sounds

### DIFF
--- a/radio/src/targets/common/arm/stm32/audio_dac_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/audio_dac_driver.cpp
@@ -255,10 +255,11 @@ void audioConsumeCurrentBuffer()
 {
 #if defined(STM32H5) || defined(STM32H7) || defined(STM32H7RS)
   if (!LL_DMA_IsEnabledStream(AUDIO_DMA, AUDIO_DMA_Stream)) {
-    if (!audio_update_dma_buffer(0)) {
 #if defined(AUDIO_MUTE_GPIO)
-      audioUnmute();
+    audioUnmute();
 #endif
+    if (!audio_update_dma_buffer(0)) {
+      audio_update_dma_buffer(1);
 
       LL_DMA_DisableStream(AUDIO_DMA, AUDIO_DMA_Stream);
       stm32_dma_check_tc_flag(AUDIO_DMA, AUDIO_DMA_Stream);


### PR DESCRIPTION
Sometimes the trim tone cannot play properly.  Problem discovered by opencode + deepseek v4, and seems works better.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added support for additional radio models: Flysky PA01, PL18U, ST16, and HelloRadioSky V14
  * Added Korean language support to Companion
  * Added "Log Once Per Day" option to general settings

* **Chores**
  * Updated build infrastructure and dependencies to stable versions
  * Enhanced release automation workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->