### PR TITLE
fix(bw212): SD card image viewer may show corrupted image

### DIFF
--- a/radio/src/gui/212x64/bmp.cpp
+++ b/radio/src/gui/212x64/bmp.cpp
@@ -191,6 +191,15 @@ uint8_t * lcdLoadBitmap(uint8_t * bmp, const char * filename, uint16_t width, ui
 
 uint8_t modelBitmap[MODEL_BITMAP_SIZE] __DMA;
 
+void loadLogoBitmap(uint8_t* bitmap)
+{
+  RleBitmap pic(logo_taranis, 0);
+  *bitmap++ = pic.getWidth();
+  *bitmap++ = pic.getRawRows();
+  for(int i=0; i < MODEL_BITMAP_SIZE-2; i++)
+    *bitmap++ = pic.getNext();
+}
+
 bool loadModelBitmap(char * name, uint8_t * bitmap)
 {
   uint8_t len = zlen(name, LEN_BITMAP_NAME);
@@ -204,10 +213,6 @@ bool loadModelBitmap(char * name, uint8_t * bitmap)
   }
 
   // In all error cases, we set the default logo
-  RleBitmap pic(logo_taranis, 0);
-  *bitmap++ = pic.getWidth();
-  *bitmap++ = pic.getRawRows();
-  for(int i=0; i < MODEL_BITMAP_SIZE-2; i++)
-    *bitmap++ = pic.getNext();
+  loadLogoBitmap(bitmap);
   return false;
 }

--- a/radio/src/gui/212x64/gui.h
+++ b/radio/src/gui/212x64/gui.h
@@ -40,6 +40,7 @@
 
 extern uint8_t modelBitmap[MODEL_BITMAP_SIZE];
 bool loadModelBitmap(char * name, uint8_t * bitmap);
+void loadLogoBitmap(uint8_t* bitmap);
 
 void drawColumnHeader(const char * const * headers, uint8_t index);
 

--- a/radio/src/gui/common/stdlcd/radio_sdmanager.cpp
+++ b/radio/src/gui/common/stdlcd/radio_sdmanager.cpp
@@ -603,7 +603,7 @@ void menuRadioSdManager(event_t _event)
     if (ext && isExtensionMatching(ext, BITMAPS_EXT)) {
       if (lastPos != menuVerticalPosition) {
         if (!lcdLoadBitmap(modelBitmap, reusableBuffer.sdManager.lines[index], MODEL_BITMAP_WIDTH, MODEL_BITMAP_HEIGHT)) {
-          memcpy(modelBitmap, logo_taranis, MODEL_BITMAP_SIZE);
+          loadLogoBitmap(modelBitmap);
         }
       }
       lcdDrawBitmap(22*FW+2, 2*FH+FH/2, modelBitmap);


### PR DESCRIPTION
On B&W radios with 212x64 LCD size, the SD card file viewer can preview the image for some BMP files.

Only BMP files that can be used as model images are shown (size <= 64x32 pixels).

If the BMP bitmap is not suitable as a model image then the radio should show the EdgeTX logo instead, however the code instead showed a garbage image.

Applies to 2.11, 2.12 and 3.0. Bug is also present in 2.10 and possibly earlier versions.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal bitmap loading code organization for better maintainability and code reusability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->