### PR TITLE
fix(pl18): telemetry RX DMA can be enabled for non-DAC audio radios

### DIFF
--- a/radio/src/targets/pl18/CMakeLists.txt
+++ b/radio/src/targets/pl18/CMakeLists.txt
@@ -234,6 +234,7 @@ if(PCBREV STREQUAL NB4P)
 endif()
 
 if(USE_VS1053B)
+  add_definitions(-DUSE_VS1053B)
   target_sources(board PRIVATE targets/common/arm/stm32/vs1053b.cpp)
 else()
   target_sources(board PRIVATE targets/common/arm/stm32/audio_dac_driver.cpp)

--- a/radio/src/targets/pl18/hal.h
+++ b/radio/src/targets/pl18/hal.h
@@ -212,8 +212,10 @@
 #define TELEMETRY_DMA_TX_Stream_IRQ     DMA1_Stream6_IRQn
 #define TELEMETRY_DMA_TX_IRQHandler     DMA1_Stream6_IRQHandler
 #define TELEMETRY_DMA_TX_FLAG_TC        DMA_IT_TCIF6
-// #define TELEMETRY_DMA_Stream_RX         LL_DMA_STREAM_5
-// #define TELEMETRY_DMA_Channel_RX        LL_DMA_CHANNEL_4
+#if defined(RADIO_NV14_FAMILY) || defined(RADIO_PL18U)
+#define TELEMETRY_DMA_Stream_RX         LL_DMA_STREAM_5
+#define TELEMETRY_DMA_Channel_RX        LL_DMA_CHANNEL_4
+#endif
 #define TELEMETRY_USART_IRQHandler      USART2_IRQHandler
 
 #define TELEMETRY_DIR_OUTPUT()          TELEMETRY_DIR_GPIO->BSRRH = TELEMETRY_DIR_GPIO_PIN

--- a/radio/src/targets/pl18/hal.h
+++ b/radio/src/targets/pl18/hal.h
@@ -212,9 +212,9 @@
 #define TELEMETRY_DMA_TX_Stream_IRQ     DMA1_Stream6_IRQn
 #define TELEMETRY_DMA_TX_IRQHandler     DMA1_Stream6_IRQHandler
 #define TELEMETRY_DMA_TX_FLAG_TC        DMA_IT_TCIF6
-#if defined(RADIO_NV14_FAMILY) || defined(RADIO_PL18U)
+#if defined(USE_VS1053B)
 // RX DMA can only be enabled when DAC audio is not used,
-// having DMA conflict with DAC audio
+// as it would conflict with the DAC audio DMA (DMA1 Stream 5)
 #define TELEMETRY_DMA_Stream_RX         LL_DMA_STREAM_5
 #define TELEMETRY_DMA_Channel_RX        LL_DMA_CHANNEL_4
 #endif
@@ -330,7 +330,7 @@
 #define SDRAM_RCC_AHB3Periph            RCC_AHB3Periph_FMC
 
 // Audio
-#if defined(RADIO_NV14_FAMILY) || defined(RADIO_PL18U)
+#if defined(USE_VS1053B)
   #define AUDIO_XDCS_GPIO               GPIO_PIN(GPIOH, 14) // PH.14
   #define AUDIO_CS_GPIO                 GPIO_PIN(GPIOH, 13) // PH.13
   #define AUDIO_DREQ_GPIO               GPIO_PIN(GPIOH, 15) // PH.15

--- a/radio/src/targets/pl18/hal.h
+++ b/radio/src/targets/pl18/hal.h
@@ -213,6 +213,8 @@
 #define TELEMETRY_DMA_TX_IRQHandler     DMA1_Stream6_IRQHandler
 #define TELEMETRY_DMA_TX_FLAG_TC        DMA_IT_TCIF6
 #if defined(RADIO_NV14_FAMILY) || defined(RADIO_PL18U)
+// RX DMA can only be enabled when DAC audio is not used,
+// having DMA conflict with DAC audio
 #define TELEMETRY_DMA_Stream_RX         LL_DMA_STREAM_5
 #define TELEMETRY_DMA_Channel_RX        LL_DMA_CHANNEL_4
 #endif


### PR DESCRIPTION
Summary of changes:

Enable RX DMA for S.Port if non-DAC audio is used


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Restored reliable telemetry reception on compatible VS1053B-based radio hardware by ensuring the correct RX DMA settings are enabled.
  * Fixed the VS1053B-related audio build selection so supported devices compile and run with the intended audio configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->