### PR TITLE
fix(bw128): pot warning navigation

### DIFF
--- a/radio/src/gui/128x64/model_setup.cpp
+++ b/radio/src/gui/128x64/model_setup.cpp
@@ -1254,8 +1254,8 @@ void menuModelSetup(event_t event)
       case ITEM_MODEL_SETUP_SWITCHES_WARNING1:
         {
           uint8_t switchWarningsCount = getSwitchWarningsCount();
-          // Fix for case when there is only one switch that can trigger a warning (MT12)
-          if (switchWarningsCount == 1 && menuHorizontalPosition >= 1)
+          // Fix for case when there is only one switch that can trigger a warning (MT12).
+          if (attr && switchWarningsCount == 1 && menuHorizontalPosition >= 1)
             menuHorizontalPosition = 0;
           horzpos_t l_posHorz = menuHorizontalPosition;
 


### PR DESCRIPTION
Fixes a navigation issue on 128 bw screen that made pot to be no selectable on model setup pre flight warnings

Fixes #7421



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue in the model setup menu where the switches warning layout would incorrectly adjust its position. The layout now properly adjusts only when actively selected by the user.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->