### PR TITLE
ci: fix broken link in release drafter

### DIFF
--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -197,7 +197,7 @@ jobs:
             The full list of supported radios and their support status can be viewed [here on the EdgeTX website](https://edgetx.org/supportedradios).
 
             ## Installation Guide
-            https://manual.edgetx.org/edgetx-user-manual/installing-and-updating-edgetx
+            https://manual.edgetx.org/installing-and-updating-edgetx
 
             ## Flash firmware via Chrome based browser
             https://buddy.edgetx.org/#/flash?version=${{ steps.version.outputs.version }}


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

The current "Installation Guide" link written by the [release-drafter workflow](https://github.com/meanwhile131/edgetx/blob/00d754412bb7f5064575b5c9abc00814cad37fb2/.github/workflows/release-drafter.yml) leads to a 404.

### Summary of changes:
Change "Installation Guide" link to a valid page.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guide link in release notes to use the correct URL path.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->