### PR TITLE
fix(color): model setup and logical switch monitor may not display correctly

### DIFF
--- a/radio/src/gui/colorlcd/libui/button.cpp
+++ b/radio/src/gui/colorlcd/libui/button.cpp
@@ -102,6 +102,12 @@ void ButtonBase::checkEvents()
   if (checkHandler) checkHandler();
 }
 
+void ButtonBase::setCheckHandler(std::function<void(void)> handler)
+{
+  checkHandler = std::move(handler);
+  if (checkHandler) checkHandler();
+}
+
 //-----------------------------------------------------------------------------
 
 TextButton::TextButton(Window* parent, const rect_t& rect, std::string text,

--- a/radio/src/gui/colorlcd/libui/button.h
+++ b/radio/src/gui/colorlcd/libui/button.h
@@ -54,10 +54,7 @@ class ButtonBase : public FormField
     longPressHandler = std::move(handler);
   }
 
-  void setCheckHandler(std::function<void(void)> handler)
-  {
-    checkHandler = std::move(handler);
-  }
+  void setCheckHandler(std::function<void(void)> handler);
 
  protected:
   std::function<uint8_t(void)> pressHandler;

--- a/radio/src/gui/colorlcd/libui/filechoice.cpp
+++ b/radio/src/gui/colorlcd/libui/filechoice.cpp
@@ -98,8 +98,7 @@ FileChoice::FileChoice(Window *parent, const rect_t &rect, const std::string fol
                        std::function<std::string()> getValue,
                        std::function<void(std::string)> setValue,
                        bool stripExtension, const char *title) :
-    Choice(
-        parent, rect, 0, 0, [=]() { return selectedIdx; },
+    Choice(parent, rect, 0, 0, nullptr,
         [=](int val) { setValue(getString(val)); selectedIdx = val; }, title, CHOICE_TYPE_FOLDER),
     folder(std::move(folder)),
     extension(std::move(extension)),
@@ -107,6 +106,8 @@ FileChoice::FileChoice(Window *parent, const rect_t &rect, const std::string fol
     getValue(std::move(getValue)),
     stripExtension(stripExtension)
 {
+  // getValue function set here to ensure selectedIdx is set before use
+  setGetValueHandler([=]() { return selectedIdx; });
   update();
 }
 

--- a/radio/src/gui/colorlcd/model/model_flightmodes.cpp
+++ b/radio/src/gui/colorlcd/model/model_flightmodes.cpp
@@ -487,7 +487,7 @@ void ModelFlightModesPage::build(Window* form)
 
     btn->setPressHandler([=]() {
       (new FlightModeEdit(i))->setCloseHandler([=]() { btn->refresh(); });
-      return 0;
+      return btn->isActive();
     });
   }
 

--- a/radio/src/gui/colorlcd/model/model_inputs.cpp
+++ b/radio/src/gui/colorlcd/model/model_inputs.cpp
@@ -182,10 +182,10 @@ class InputLineButton : public InputMixButtonBase
     }
   }
 
+  bool isActive() const override { return isExpoActive(index); }
+
  protected:
   Messaging refreshMsg;
-
-  bool isActive() const override { return isExpoActive(index); }
 };
 
 class InputGroup : public InputMixGroupBase
@@ -277,7 +277,7 @@ InputMixButtonBase* ModelInputsPage::createLineButton(InputMixGroupBase* group,
       uint8_t idx = button->getIndex();
       deleteInput(idx);
     });
-    return 0;
+    return button->isActive();
   });
 
   return button;

--- a/radio/src/gui/colorlcd/model/model_logical_switches.cpp
+++ b/radio/src/gui/colorlcd/model/model_logical_switches.cpp
@@ -620,7 +620,7 @@ void ModelLogicalSwitchesPage::build(Window* window)
           storageDirty(EE_MODEL);
           rebuild(window);
         });
-        return 0;
+        return button->isActive();
       });
 
       if (focusIndex == i) {

--- a/radio/src/gui/colorlcd/model/model_mixes.cpp
+++ b/radio/src/gui/colorlcd/model/model_mixes.cpp
@@ -164,12 +164,12 @@ class MixLineButton : public InputMixButtonBase
     }
   }
 
+  bool isActive() const override { return isMixActive(index); }
+
   static LAYOUT_VAL_SCALED(MPLEX_XO, 28)
 
  protected:
   MPlexIcon* mplex = nullptr;
-
-  bool isActive() const override { return isMixActive(index); }
 };
 
 class MixGroup : public InputMixGroupBase
@@ -301,7 +301,7 @@ InputMixButtonBase* ModelMixesPage::createLineButton(InputMixGroupBase *group, u
       uint8_t idx = button->getIndex();
       deleteMix(idx);
     });
-    return 0;
+    return button->isActive();
   });
 
   return button;


### PR DESCRIPTION
Fix minor rendering issues with color UI.
- Model bitmap name may show as '-1' when opening the model setup page
- Model Timer buttons may not show as active when opening the model setup page
- Logical switches may not show as active when opening the LS view monitor page

Applies to 2.12 and 3.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * UI buttons now correctly reflect their active/checked state immediately after edits, deletes, or menu actions.
  * File/choice lists initialize more reliably so the selected item is available when the UI first renders.

* **Refactor**
  * Check-state handlers are registered and invoked immediately for consistent button behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->