### PR TITLE
fix(color): solve strcat on uninitialized variable errors

### DIFF
--- a/radio/src/gui/colorlcd/mainview/view_logical_switches.cpp
+++ b/radio/src/gui/colorlcd/mainview/view_logical_switches.cpp
@@ -139,7 +139,6 @@ class LogicalSwitchDisplayFooter : public Window
     }
 
     // CSW params - V2
-    strcat(s, " ");
     switch (lsFamily) {
       case LS_FAMILY_BOOL:
       case LS_FAMILY_STICKY:

--- a/radio/src/gui/colorlcd/model/model_logical_switches.cpp
+++ b/radio/src/gui/colorlcd/model/model_logical_switches.cpp
@@ -434,7 +434,6 @@ class LogicalSwitchButton : public ListLineButton
     }
 
     // CSW params - V2
-    strcat(s, " ");
     switch (lsFamily) {
       case LS_FAMILY_BOOL:
       case LS_FAMILY_STICKY:


### PR DESCRIPTION
Summary of changes:

* fix(radiogui): solve strcat on uninitialized variable errors


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed display formatting for logical switch parameter panels so V2/edge‑delay values render with correct spacing and alignment, improving readability and preventing stray or missing spaces in parameter labels.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->