### PR TITLE
fix(cli): add missing format args in serialpassthrough errors

### DIFF
--- a/radio/src/cli.cpp
+++ b/radio/src/cli.cpp
@@ -1331,7 +1331,7 @@ int cliSerialPassthrough(const char **argv)
     // TODO:
     //  - external module (S.PORT?)
     default:
-      cliSerialPrint("%s: invalid port # '%i'", port_n);
+      cliSerialPrint("%s: invalid port # '%i'", argv[0], port_n);
       return -1;
     }
   } else if (!strcmp("gimbals", port_type)) {
@@ -1344,11 +1344,11 @@ int cliSerialPassthrough(const char **argv)
     initCB = spGimbalInit;
     deinitCB = spGimbalDeInit;
 #else
-    cliSerialPrint("%s: serial gimbals not supported");
+    cliSerialPrint("%s: serial gimbals not supported", argv[0]);
     return -1;
 #endif
   } else {
-    cliSerialPrint("%s: invalid port type '%s'", port_type);
+    cliSerialPrint("%s: invalid port type '%s'", argv[0], port_type);
     return -1;
   }
 


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->


Summary of changes:

Here's what I found and how I fixed it.

While using the CLI, I needed to test the functionality of the `serialpassthrough <port type> <port number>` command. I noticed it was printing garbage values in its error messages. When I looked into the code, I found three `cliSerialPrint` calls in `cliSerialPassthrough()` (`radio/src/cli.cpp`) which have format strings containing more format specifiers (namely `%s` and `%i`) than arguments:

- `"%s: invalid port # '%i'"` passes only `port_n` and is missing `argv[0]`
- `"%s: serial gimbals not supported"` passes no arguments and is missing `argv[0]`
- `"%s: invalid port type '%s'"` passes only `port_type` and is missing `argv[0]`

I dug into the code a bit, and I figured out that since the number of format specifiers exceeds the number of arguments, `vsnprintf` (from the `_stdio.c` library) results in undefined behavior by reading beyond the provided arguments (likely reading uninitialized stack values), so the CLI prints garbage (and in my case, unrelated string data) over the serial port instead of the intended message. Any user with access to the CLI (such as over VCP, as in my case) could trigger this with a malformed command.

For example (screenshot attached), `serialpassthrough rfmod 1` gave me:

`serialpassthrough: Invalid argument "(null)"`
`OOT10edgetx-<string redacted for privacy>-2.11.5-3 (eae1b45d): invalid port # '604036564'`

while `serialpassthrough rfmod 0` gave me:
`serialpassthrough: Invalid argument "(null)"`
`(null): invalid port # '604036564'`

The leading `%s` printed an unrelated string and `%i` printed an uninitialized stack value. The examples suggest that the address being read is controlled by the caller via the `port_n` argument (due to the current bug). Varying it seems to read different memory. This is displayed through the example when passing in `0` to be the intended argument for `port_n`, which causes the function to incorrectly use `0` as an argument for the first format specifier, `%s`, and check if it is a `null` pointer, hence `(null)` being printed for that specific case. Otherwise, `%s` treats the value as an address, dereferences it until the null terminator (`\0`) as it expects to read a string, and prints out garbage.
My fix just supplies the missing `argv[0]` arguments so each format specifier has a matching argument. There are no behavioral changes beyond correcting the error output.

<img width="736" height="519" alt="bug" src="https://github.com/user-attachments/assets/765c54c0-eef6-4722-80c1-46f609e573d5" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI error message formatting and consistency across multiple error scenarios. Error messages now display correctly and provide clearer diagnostic feedback to help users identify and resolve configuration issues more effectively.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->