### PR TITLE
fix(cpn): initialise all serialised fields in FrSkyData::clear()

### DIFF
--- a/companion/src/firmwares/telem_data.cpp
+++ b/companion/src/firmwares/telem_data.cpp
@@ -61,9 +61,11 @@ void FrSkyData::clear()
   varioCenterMin = 0;    // if increment in 0.2m/s = 3.0m/s max
   varioCenterMax = 0;
   varioMax = 0;
+  varioCenterSilent = false;
   mAhPersistent = 0;
   storedMah = 0;
   fasOffset = 0;
+  ignoreSensorIds = false;
   for (int i=0; i<4; i++)
     screens[i].clear();
   varioSource = 0;

--- a/companion/src/tests/frsky_clear_test.cpp
+++ b/companion/src/tests/frsky_clear_test.cpp
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "gtests.h"
+
+#include <cstring>
+
+#include "firmwares/telem_data.h"
+
+// FrSkyData::clear() is a hand-written field-by-field reset (not a memset),
+// so any field it forgets is left uninitialised. varioCenterSilent and
+// ignoreSensorIds were both omitted yet are serialised to YAML, which made a
+// freshly-cleared model emit non-deterministic values (e.g. centerSilent
+// emitted as a stray byte, then masked to 0/1 on reload -> non-idempotent
+// round-trip).
+//
+// Poison the storage first so the test fails deterministically if clear()
+// ever stops initialising one of these fields.
+TEST(FrSkyDataClear, InitialisesAllSerialisedFields)
+{
+  FrSkyData fs;
+  memset(reinterpret_cast<void*>(&fs), 0x2D, sizeof(fs));  // 0x2D == 45
+  fs.clear();
+
+  EXPECT_FALSE(fs.varioCenterSilent)
+      << "varioCenterSilent left uninitialised by FrSkyData::clear()";
+  EXPECT_FALSE(fs.ignoreSensorIds)
+      << "ignoreSensorIds left uninitialised by FrSkyData::clear()";
+}


### PR DESCRIPTION
## Summary
`FrSkyData::clear()` resets its members field-by-field (not via `memset`), and it **omitted `varioCenterSilent` and `ignoreSensorIds`**. Both are serialised to a model's YAML, so a freshly-cleared model emitted whatever bytes happened to be in those fields.

For `varioCenterSilent` (a `bool` written as `int`, read back through the radio's 1-bit field) this manifested as a **non-idempotent YAML round-trip**: a stray byte such as `45` was emitted on the first save, then masked to `1` on reload — so `save → load → save` did not converge.

## Fix
Initialise both fields in `clear()`:
```cpp
varioCenterSilent = false;
...
ignoreSensorIds = false;
```

## Regression test
`companion/src/tests/frsky_clear_test.cpp` poisons the storage (`memset(..., 0x2D, ...)`) before calling `clear()` and asserts both fields are reset, so it fails deterministically if a serialised field is ever left out of `clear()` again.

Verified locally (on the harness branch): the test **fails before** the fix and **passes after**.

## Notes
- Found via the model YAML round-trip test added in #7438.
- The companion gtests are not currently built/run on `main` (the harness is reactivated by #7438). The regression test here therefore builds and runs in CI once #7438 lands; the fix itself is independent and compiles on `main` today (the `firmwares` library builds cleanly).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the FrSky data reset behavior to fully reinitialize additional configuration fields, preventing inconsistent values after clearing.

* **Tests**
  * Added a unit test to verify the clear/reset operation initializes all serialized fields deterministically, including the updated configuration flags.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->