### PR TITLE
refactor(flysky_gimbal_driver): remove inefficiences in packet parsing function

### DIFF
--- a/radio/src/targets/common/arm/stm32/flysky_gimbal_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/flysky_gimbal_driver.cpp
@@ -105,12 +105,14 @@ static void _fs_parse(STRUCT_HALL *hallBuffer, unsigned char ch)
     case GET_LENGTH:
       hallBuffer->length = ch;
       hallBuffer->dataIndex = 0;
-      hallBuffer->status = GET_DATA;
-      if(hallBuffer->length > HALLSTICK_BUFF_SIZE - 5) { // buffer size - header size (1 byte header + 1 byte ID + 1 byte length + 2 bytes CRC = 5 bytes)
+      
+      if (hallBuffer->length > HALLSTICK_BUFF_SIZE - 5) { // buffer size - header size (1 byte header + 1 byte ID + 1 byte length + 2 bytes CRC = 5 bytes)
         hallBuffer->status = GET_START;
       } else if (0 == hallBuffer->length) {
         hallBuffer->status = GET_CHECKSUM;
         hallBuffer->checkSum = 0;
+      } else {
+        hallBuffer->status = GET_DATA; // length is in a valid range, next state should extract data
       }
       break;
 
@@ -119,15 +121,9 @@ static void _fs_parse(STRUCT_HALL *hallBuffer, unsigned char ch)
       if (hallBuffer->dataIndex >= hallBuffer->length) {
         hallBuffer->checkSum = 0;
         hallBuffer->dataIndex = 0;
-        hallBuffer->status = GET_STATE;
+        hallBuffer->status = GET_CHECKSUM;
       }
       break;
-
-    case GET_STATE:
-      hallBuffer->checkSum = 0;
-      hallBuffer->dataIndex = 0;
-      hallBuffer->status = GET_CHECKSUM;
-      // fall through!
 
     case GET_CHECKSUM:
       hallBuffer->checkSum |= ch << ((hallBuffer->dataIndex++) * 8);

--- a/radio/src/targets/common/arm/stm32/flysky_gimbal_driver.h
+++ b/radio/src/targets/common/arm/stm32/flysky_gimbal_driver.h
@@ -107,7 +107,6 @@ enum
   GET_ID,
   GET_LENGTH,
   GET_DATA,
-  GET_STATE,
   GET_CHECKSUM,
   CHECKSUM,
 };


### PR DESCRIPTION
Summary of changes:

This change removes an inefficiency in the Flysky Hall Effect Gimbal driver's serial packet parser, specifically in `_fs_parse()`. I've attached a state diagram which visualizes the inefficiency of the previous implementation.

- The `GET_STATE` parser state was dead code always unnecessarily entered once by the parser on each packet parse. The only way to branch into the `GET_STATE` block was after the parser was finished reading all the data bytes in the `GET_DATA` parser state, at which point it would assign the `checkSum` and `dataIndex` variables to `0` and update the parser state to `GET_STATE`. The `GET_STATE` block was redundantly entered, assigning the same variables previously assigned to `0`, and would fall through unconditionally to the `GET_CHECKSUM` state. The fix introduced was to have the parser move from `GET_DATA` to `GET_CHECKSUM` after data parsing was complete, avoiding redundant variable assignments and removing inefficiency in the parser. This is consistent with the packet structure defined on line 26 of `radio/src/targets/common/arm/stm32/flysky_gimbal_driver.h`. The header file shows that the checksum bytes are immediately after the data bytes in the packets: 
    `// Max packet size = 1 byte header + 1 byte ID + 1 byte length + 25 bytes payload + 2 bytes CRC = 30 bytes`.
- To verify correctness, the only two ways to now reach `GET_CHECKSUM` are either from `GET_LENGTH` or `GET_DATA`. Both states correctly set the `checkSum` and `dataIndex` variables to `0` before updating the parser state to `GET_CHECKSUM`. `GET_LENGTH` will take this path when the length byte parsed has a value of 0.
- The `GET_LENGTH` block would prematurely set the `status` variable to `GET_DATA`, but on errors with the value of the `length` variable, that initial assignment is overwritten. I moved the assignment to `GET_DATA` after the error checking `if/else if` statements, creating a consistent and `if/else if/else` structure.
- In `flysky_gimbal_driver.h`, the unnecessary enum `GET_STATE` was removed since it served no purpose.

Overall, this removes inefficiencies in the driver code's parsing function and maintains correctness.

<img width="1293" height="771" alt="gimbal_driver_parser_state_diagram" src="https://github.com/user-attachments/assets/a9260b2a-3b0f-4275-a7ca-211b92cd0ca4" />


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized Flysky gimbal UART message parser state machine for improved message handling efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->