### PR TITLE
chore(color): reduce busy wait time on LCD refresh

### DIFF
--- a/radio/src/boards/jumper-h750/lcd_driver.cpp
+++ b/radio/src/boards/jumper-h750/lcd_driver.cpp
@@ -24,9 +24,7 @@
 #include "stm32_hal.h"
 #include "stm32_gpio_driver.h"
 #include "edgetx_types.h"
-#include "dma2d.h"
 #include "hal.h"
-#include "delays_driver.h"
 #include "debug.h"
 #include "lcd.h"
 #include "lcd_driver.h"
@@ -35,20 +33,24 @@
 #include "stm32_gpio.h"
 #include "hal/gpio.h"
 
-uint8_t TouchControllerType = 0;  // 0: other; 1: CST836U
 static volatile uint16_t lcd_phys_w = LCD_H;
 static volatile uint16_t lcd_phys_h = LCD_W;
 
 static LTDC_HandleTypeDef hltdc;
 static void* initialFrameBuffer = nullptr;
 
-static volatile uint8_t _frame_addr_reloaded = 0;
+static volatile uint8_t _frame_addr_reloaded = 1;
 
 static void startLcdRefresh(lv_disp_drv_t *disp_drv, uint16_t *buffer,
                             const rect_t &copy_area)
 {
   (void)disp_drv;
   (void)copy_area;
+
+#if !defined(BOOT)
+  // wait for last reload to finish
+  while(_frame_addr_reloaded == 0);
+#endif
 
   // given the data cache size, this is probably
   // faster than cleaning by address
@@ -61,17 +63,16 @@ static void startLcdRefresh(lv_disp_drv_t *disp_drv, uint16_t *buffer,
   LTDC->SRCR = LTDC_SRCR_VBR;
   __HAL_LTDC_ENABLE_IT(&hltdc, LTDC_IT_LI);
 
-  // wait for reload
-  // TODO: replace through some smarter mechanism without busy wait
+#if defined(BOOT)
+  // wait for reload to finish - required for bootloader
   while(_frame_addr_reloaded == 0);
+#endif
 }
 
 lcdSpiInitFucPtr lcdInitFunction;
 lcdSpiInitFucPtr lcdOffFunction;
 lcdSpiInitFucPtr lcdOnFunction;
 uint32_t lcdPixelClock;
-
-volatile uint8_t LCD_ReadBuffer[24] = { 0, 0 };
 
 static void LCD_Delay(void) {
   volatile unsigned int i;

--- a/radio/src/boards/jumper-h750/lcd_driver.h
+++ b/radio/src/boards/jumper-h750/lcd_driver.h
@@ -19,8 +19,7 @@
  * GNU General Public License for more details.
  */
 
-#ifndef __LCD_DRIVER_H__
-#define __LCD_DRIVER_H__
+#pragma once
 
 #define HBP  ( 24 ) // TODO use names from FlySky
 #define VBP  ( 10 )
@@ -66,12 +65,9 @@ extern lcdSpiInitFucPtr lcdOnFunction;
 
 #define LCD_READ_DATA_PIN()           LL_GPIO_IsInputPinSet(LCD_SPI_GPIO, LCD_SPI_MOSI_GPIO_PIN)
 
-
 #define HORIZONTAL_SYNC_WIDTH 			       ( 4 )
 #define HORIZONTAL_BACK_PORCH		               ( 24 )
 #define HORIZONTAL_FRONT_PORCH                         ( 140 - HORIZONTAL_BACK_PORCH )
 #define VERTICAL_SYNC_HEIGHT   		               ( 2 )
 #define VERTICAL_BACK_PORCH  		               ( 10 )
 #define VERTICAL_FRONT_PORCH    	               ( 22 - VERTICAL_BACK_PORCH )
-
-#endif

--- a/radio/src/boards/rm-h750/lcd_driver_480.cpp
+++ b/radio/src/boards/rm-h750/lcd_driver_480.cpp
@@ -22,9 +22,7 @@
 #include "stm32_hal_ll.h"
 #include "stm32_hal.h"
 #include "edgetx_types.h"
-#include "dma2d.h"
 #include "hal.h"
-#include "delays_driver.h"
 #include "debug.h"
 #include "lcd.h"
 #include "lcd_driver_480.h"
@@ -34,20 +32,21 @@
 #include "stm32_gpio.h"
 #include "stm32_qspi.h"
 
-uint8_t TouchControllerType = 0;  // 0: other; 1: CST836U
-static volatile uint16_t lcd_phys_w = LCD_PHYS_W;
-static volatile uint16_t lcd_phys_h = LCD_PHYS_H;
-
 static LTDC_HandleTypeDef hltdc;
 static void* initialFrameBuffer = nullptr;
 
-static volatile uint8_t _frame_addr_reloaded = 0;
+static volatile uint8_t _frame_addr_reloaded = 1;
 
 static void startLcdRefresh(lv_disp_drv_t *disp_drv, uint16_t *buffer,
                             const rect_t &copy_area)
 {
   (void)disp_drv;
   (void)copy_area;
+
+#if !defined(BOOT)
+  // wait for last reload to finish
+  while(_frame_addr_reloaded == 0);
+#endif
 
   // given the data cache size, this is probably
   // faster than cleaning by address
@@ -60,17 +59,11 @@ static void startLcdRefresh(lv_disp_drv_t *disp_drv, uint16_t *buffer,
 
   __HAL_LTDC_ENABLE_IT(&hltdc, LTDC_IT_LI);
 
-  // wait for reload
-  // TODO: replace through some smarter mechanism without busy wait
+#if defined(BOOT)
+  // wait for reload to finish - required for bootloader
   while(_frame_addr_reloaded == 0);
+#endif
 }
-
-lcdSpiInitFucPtr lcdInitFunction;
-lcdSpiInitFucPtr lcdOffFunction;
-lcdSpiInitFucPtr lcdOnFunction;
-uint32_t lcdPixelClock;
-
-volatile uint8_t LCD_ReadBuffer[24] = { 0, 0 };
 
 static void LCD_Delay(void) {
   volatile unsigned int i;
@@ -424,13 +417,13 @@ void LCD_Init_LTDC() {
   /* Configure accumulated vertical back porch */
   hltdc.Init.AccumulatedVBP = VSH+VBP-1;
   /* Configure accumulated active width */
-  hltdc.Init.AccumulatedActiveW = lcd_phys_w + HBP+HSW-1;
+  hltdc.Init.AccumulatedActiveW = LCD_PHYS_W + HBP+HSW-1;
   /* Configure accumulated active height */
-  hltdc.Init.AccumulatedActiveH = lcd_phys_h + VBP+VSH-1;
+  hltdc.Init.AccumulatedActiveH = LCD_PHYS_H + VBP+VSH-1;
   /* Configure total width */
-  hltdc.Init.TotalWidth = lcd_phys_w + HBP + HFP + HSW -1;
+  hltdc.Init.TotalWidth = LCD_PHYS_W + HBP + HFP + HSW -1;
   /* Configure total height */
-  hltdc.Init.TotalHeigh = lcd_phys_h + VBP + VFP+VSH-1;
+  hltdc.Init.TotalHeigh = LCD_PHYS_H + VBP + VFP+VSH-1;
 
   HAL_LTDC_Init(&hltdc);
 
@@ -439,7 +432,7 @@ void LCD_Init_LTDC() {
   NVIC_EnableIRQ(LTDC_IRQn);
   
   // Trigger on last line
-  HAL_LTDC_ProgramLineEvent(&hltdc, lcd_phys_h);
+  HAL_LTDC_ProgramLineEvent(&hltdc, LCD_PHYS_H);
   __HAL_LTDC_ENABLE_IT(&hltdc, LTDC_IT_LI);
 }
 
@@ -448,9 +441,9 @@ void LCD_LayerInit() {
 
   /* Windowing configuration */
   layer.WindowX0 = 0;
-  layer.WindowX1 = lcd_phys_w;
+  layer.WindowX1 = LCD_PHYS_W;
   layer.WindowY0 = 0;
-  layer.WindowY1 = lcd_phys_h;
+  layer.WindowY1 = LCD_PHYS_H;
 
   /* Pixel Format configuration*/
   layer.PixelFormat = LTDC_PIXEL_FORMAT_RGB565;
@@ -468,8 +461,8 @@ void LCD_LayerInit() {
   layer.BlendingFactor1 = LTDC_BLENDING_FACTOR1_CA;
   layer.BlendingFactor2 = LTDC_BLENDING_FACTOR2_CA;
 
-  layer.ImageWidth = lcd_phys_w;
-  layer.ImageHeight = lcd_phys_h;
+  layer.ImageWidth = LCD_PHYS_W;
+  layer.ImageHeight = LCD_PHYS_H;
 
   /* Start Address configuration : the LCD Frame buffer is defined on SDRAM w/ Offset */
   layer.FBStartAdress = (intptr_t)initialFrameBuffer;
@@ -508,12 +501,9 @@ void lcdInit(void)
   /* Send LCD initialization commands */
   TRACE("LCD INIT (default): ST7365");
   boardLcdType = "ST7365 (Default)";
-  lcdInitFunction = LCD_ST7365_Init;
-  lcdOffFunction = LCD_ST7365_Off;
-  lcdOnFunction = LCD_ST7365_On;
 
   __HAL_RCC_LTDC_CLK_ENABLE();
-  lcdInitFunction();
+  LCD_ST7365_Init();
 
   LCD_Init_LTDC();
   LCD_LayerInit();

--- a/radio/src/boards/rm-h750/lcd_driver_480.h
+++ b/radio/src/boards/rm-h750/lcd_driver_480.h
@@ -19,10 +19,7 @@
  * GNU General Public License for more details.
  */
 
-#ifndef __LCD_DRIVER_H__
-#define __LCD_DRIVER_H__
-
-#include "bsp_io.h"
+#pragma once
 
 #define HBP  ( 20 )
 #define VBP  ( 10 )
@@ -34,9 +31,6 @@
 #define VFP  ( 10 )
 
 #define LCD_DELAY()         LCD_Delay()
-
-typedef void (*lcdSpiInitFucPtr)(void);
-typedef unsigned int  LcdReadIDFucPtr( void );
 
 #define SET_IO_INPUT( PORT, PIN )            LL_GPIO_SetPinMode( PORT, PIN, LL_GPIO_MODE_INPUT )
 #define SET_IO_OUTPUT( PORT, PIN )           LL_GPIO_SetPinMode( PORT, PIN, LL_GPIO_MODE_OUTPUT )
@@ -57,9 +51,3 @@ typedef unsigned int  LcdReadIDFucPtr( void );
 #define LCD_MOSI_AS_OUTPUT()          SET_IO_OUTPUT( LCD_SPI_MOSI_GPIO, LCD_SPI_MOSI_GPIO_PIN )
 
 #define LCD_READ_DATA_PIN()           LL_GPIO_IsInputPinSet(LCD_SPI_MOSI_GPIO, LCD_SPI_MOSI_GPIO_PIN)
-
-#endif
-
-
-
-

--- a/radio/src/boards/rm-h750/lcd_driver_800.cpp
+++ b/radio/src/boards/rm-h750/lcd_driver_800.cpp
@@ -22,9 +22,7 @@
 #include "stm32_hal_ll.h"
 #include "stm32_hal.h"
 #include "edgetx_types.h"
-#include "dma2d.h"
 #include "hal.h"
-#include "delays_driver.h"
 #include "debug.h"
 #include "lcd.h"
 #include "lcd_driver_800.h"
@@ -34,20 +32,21 @@
 #include "stm32_gpio.h"
 #include "stm32_qspi.h"
 
-uint8_t TouchControllerType = 0;  // 0: other; 1: CST836U
-static const uint16_t lcd_phys_w = LCD_PHYS_W;
-static const uint16_t lcd_phys_h = LCD_PHYS_H;
-
 static LTDC_HandleTypeDef hltdc;
 static void* initialFrameBuffer = nullptr;
 
-static volatile uint8_t _frame_addr_reloaded = 0;
+static volatile uint8_t _frame_addr_reloaded = 1;
 
 static void startLcdRefresh(lv_disp_drv_t *disp_drv, uint16_t *buffer,
                             const rect_t &copy_area)
 {
   (void)disp_drv;
   (void)copy_area;
+
+#if !defined(BOOT)
+  // wait for last reload to finish
+  while(_frame_addr_reloaded == 0);
+#endif
 
   // given the data cache size, this is probably
   // faster than cleaning by address
@@ -60,17 +59,11 @@ static void startLcdRefresh(lv_disp_drv_t *disp_drv, uint16_t *buffer,
 
   __HAL_LTDC_ENABLE_IT(&hltdc, LTDC_IT_LI);
 
-  // wait for reload
-  // TODO: replace through some smarter mechanism without busy wait
+#if defined(BOOT)
+  // wait for reload to finish - required for bootloader
   while(_frame_addr_reloaded == 0);
+#endif
 }
-
-lcdSpiInitFucPtr lcdInitFunction;
-lcdSpiInitFucPtr lcdOffFunction;
-lcdSpiInitFucPtr lcdOnFunction;
-uint32_t lcdPixelClock;
-
-volatile uint8_t LCD_ReadBuffer[24] = { 0, 0 };
 
 static void LCD_AF_GPIOConfig(void)
 {
@@ -121,8 +114,6 @@ static void lcdReset() {
   delay_ms(100);
 }
 
-
-
 void LCD_Init_LTDC() {
   hltdc.Instance = LTDC;
 
@@ -166,13 +157,13 @@ void LCD_Init_LTDC() {
   /* Configure accumulated vertical back porch */
   hltdc.Init.AccumulatedVBP = VSH+VBP-1;
   /* Configure accumulated active width */
-  hltdc.Init.AccumulatedActiveW = lcd_phys_w + HBP+HSW-1;
+  hltdc.Init.AccumulatedActiveW = LCD_PHYS_W + HBP+HSW-1;
   /* Configure accumulated active height */
-  hltdc.Init.AccumulatedActiveH = lcd_phys_h + VBP+VSH-1;
+  hltdc.Init.AccumulatedActiveH = LCD_PHYS_H + VBP+VSH-1;
   /* Configure total width */
-  hltdc.Init.TotalWidth = lcd_phys_w + HBP + HFP + HSW -1;
+  hltdc.Init.TotalWidth = LCD_PHYS_W + HBP + HFP + HSW -1;
   /* Configure total height */
-  hltdc.Init.TotalHeigh = lcd_phys_h + VBP + VFP+VSH-1;
+  hltdc.Init.TotalHeigh = LCD_PHYS_H + VBP + VFP+VSH-1;
 
   HAL_LTDC_Init(&hltdc);
 
@@ -181,7 +172,7 @@ void LCD_Init_LTDC() {
   NVIC_EnableIRQ(LTDC_IRQn);
 
   // Trigger on last line
-  HAL_LTDC_ProgramLineEvent(&hltdc, lcd_phys_h);
+  HAL_LTDC_ProgramLineEvent(&hltdc, LCD_PHYS_H);
   __HAL_LTDC_ENABLE_IT(&hltdc, LTDC_IT_LI);
 }
 
@@ -190,9 +181,9 @@ void LCD_LayerInit() {
 
   /* Windowing configuration */
   layer.WindowX0 = 0;
-  layer.WindowX1 = lcd_phys_w;
+  layer.WindowX1 = LCD_PHYS_W;
   layer.WindowY0 = 0;
-  layer.WindowY1 = lcd_phys_h;
+  layer.WindowY1 = LCD_PHYS_H;
 
   /* Pixel Format configuration*/
   layer.PixelFormat = LTDC_PIXEL_FORMAT_RGB565;
@@ -210,8 +201,8 @@ void LCD_LayerInit() {
   layer.BlendingFactor1 = LTDC_BLENDING_FACTOR1_CA;
   layer.BlendingFactor2 = LTDC_BLENDING_FACTOR2_CA;
 
-  layer.ImageWidth = lcd_phys_w;
-  layer.ImageHeight = lcd_phys_h;
+  layer.ImageWidth = LCD_PHYS_W;
+  layer.ImageHeight = LCD_PHYS_H;
 
   /* Start Address configuration : the LCD Frame buffer is defined on SDRAM w/ Offset */
   layer.FBStartAdress = (intptr_t)initialFrameBuffer;

--- a/radio/src/boards/rm-h750/lcd_driver_800.h
+++ b/radio/src/boards/rm-h750/lcd_driver_800.h
@@ -32,13 +32,6 @@
 #define HFP  ( 16 )
 #define VFP  ( 8 )
 
-typedef void (*lcdSpiInitFucPtr)(void);
-typedef unsigned int  LcdReadIDFucPtr( void );
-
-extern lcdSpiInitFucPtr lcdInitFunction;
-extern lcdSpiInitFucPtr lcdOffFunction;
-extern lcdSpiInitFucPtr lcdOnFunction;
-
 #define SET_IO_INPUT( PORT, PIN )            LL_GPIO_SetPinMode( PORT, PIN, LL_GPIO_MODE_INPUT )
 #define SET_IO_OUTPUT( PORT, PIN )           LL_GPIO_SetPinMode( PORT, PIN, LL_GPIO_MODE_OUTPUT )
 

--- a/radio/src/targets/horus/lcd_driver.cpp
+++ b/radio/src/targets/horus/lcd_driver.cpp
@@ -119,19 +119,25 @@ static void _rotate_area_180(lv_area_t& area)
 }
 #endif
 
-static volatile uint8_t _frame_addr_reloaded = 0;
+static volatile uint8_t _frame_addr_reloaded = 1;
 
 static void _update_frame_buffer_addr(uint16_t* addr)
 {
+#if !defined(BOOT)
+  // wait for last reload to finish
+  while(_frame_addr_reloaded == 0);
+#endif
+
   LTDC_Layer1->CFBAR = (uint32_t)addr;
 
   // reload shadow registers on vertical blank
   _frame_addr_reloaded = 0;
   LTDC->SRCR = LTDC_SRCR_VBR;
 
-  // wait for reload
-  // TODO: replace through some smarter mechanism without busy wait
+#if defined(BOOT)
+  // wait for reload to finish - required for bootloader
   while(_frame_addr_reloaded == 0);
+#endif
 }
 
 static void startLcdRefresh(lv_disp_drv_t *disp_drv, uint16_t *buffer,

--- a/radio/src/targets/horus/lcd_st7796s_driver.cpp
+++ b/radio/src/targets/horus/lcd_st7796s_driver.cpp
@@ -36,13 +36,18 @@
 static LTDC_HandleTypeDef hltdc;
 static void* initialFrameBuffer = nullptr;
 
-static volatile uint8_t _frame_addr_reloaded = 0;
+static volatile uint8_t _frame_addr_reloaded = 1;
 
 static void startLcdRefresh(lv_disp_drv_t* disp_drv, uint16_t* buffer,
                             const rect_t& copy_area)
 {
   (void)disp_drv;
   (void)copy_area;
+
+#if !defined(BOOT)
+  // wait for last reload to finish
+  while(_frame_addr_reloaded == 0);
+#endif
 
   LTDC_Layer1->CFBAR &= ~(LTDC_LxCFBAR_CFBADD);
   LTDC_Layer1->CFBAR = (uint32_t)buffer;
@@ -51,9 +56,10 @@ static void startLcdRefresh(lv_disp_drv_t* disp_drv, uint16_t* buffer,
   LTDC->SRCR = LTDC_SRCR_VBR;
   __HAL_LTDC_ENABLE_IT(&hltdc, LTDC_IT_LI);
 
-  // wait for reload
-  // TODO: replace through some smarter mechanism without busy wait
-  while (_frame_addr_reloaded == 0);
+#if defined(BOOT)
+  // wait for reload to finish - required for bootloader
+  while(_frame_addr_reloaded == 0);
+#endif
 }
 
 uint32_t lcdPixelClock;

--- a/radio/src/targets/pl18/lcd_driver.cpp
+++ b/radio/src/targets/pl18/lcd_driver.cpp
@@ -40,13 +40,18 @@ static void* initialFrameBuffer = nullptr;
 
 #define GPIO_AF_LTDC GPIO_AF14
 
-static volatile uint8_t _frame_addr_reloaded = 0;
+static volatile uint8_t _frame_addr_reloaded = 1;
 
 static void startLcdRefresh(lv_disp_drv_t *disp_drv, uint16_t *buffer,
                             const rect_t &copy_area)
 {
   (void)disp_drv;
   (void)copy_area;
+
+#if !defined(BOOT)
+  // wait for last reload to finish
+  while(_frame_addr_reloaded == 0);
+#endif
 
   LTDC_Layer1->CFBAR &= ~(LTDC_LxCFBAR_CFBADD);
   LTDC_Layer1->CFBAR = (uint32_t)buffer;
@@ -55,9 +60,10 @@ static void startLcdRefresh(lv_disp_drv_t *disp_drv, uint16_t *buffer,
   LTDC->SRCR = LTDC_SRCR_VBR;
   __HAL_LTDC_ENABLE_IT(&hltdc, LTDC_IT_LI);
 
-  // wait for reload
-  // TODO: replace through some smarter mechanism without busy wait
+#if defined(BOOT)
+  // wait for reload to finish - required for bootloader
   while(_frame_addr_reloaded == 0);
+#endif
 }
 
 lcdSpiInitFucPtr lcdInitFunction;

--- a/radio/src/targets/st16/lcd_driver.cpp
+++ b/radio/src/targets/st16/lcd_driver.cpp
@@ -40,13 +40,18 @@ static volatile uint16_t lcd_phys_h = LCD_PHYS_H;
 static LTDC_HandleTypeDef hltdc;
 static void* initialFrameBuffer = nullptr;
 
-static volatile uint8_t _frame_addr_reloaded = 0;
+static volatile uint8_t _frame_addr_reloaded = 1;
 
 static void startLcdRefresh(lv_disp_drv_t *disp_drv, uint16_t *buffer,
                             const rect_t &copy_area)
 {
   (void)disp_drv;
   (void)copy_area;
+
+#if !defined(BOOT)
+  // wait for last reload to finish
+  while(_frame_addr_reloaded == 0);
+#endif
 
   // given the data cache size, this is probably
   // faster than cleaning by address
@@ -60,9 +65,10 @@ static void startLcdRefresh(lv_disp_drv_t *disp_drv, uint16_t *buffer,
 
   __HAL_LTDC_ENABLE_IT(&hltdc, LTDC_IT_LI);
 
-  // wait for reload
-  // TODO: replace through some smarter mechanism without busy wait
+#if defined(BOOT)
+  // wait for reload to finish - required for bootloader
   while(_frame_addr_reloaded == 0);
+#endif
 }
 
 lcdSpiInitFucPtr lcdInitFunction;

--- a/radio/src/targets/stm32h7s78-dk/lcd_driver.cpp
+++ b/radio/src/targets/stm32h7s78-dk/lcd_driver.cpp
@@ -417,13 +417,18 @@ extern "C" void backlightInit()
   LPTIMx_PWM_Init(&hlcd_lptim);
 }
 
-static volatile uint8_t _frame_addr_reloaded = 0;
+static volatile uint8_t _frame_addr_reloaded = 1;
 
 static void startLcdRefresh(lv_disp_drv_t *disp_drv, uint16_t *buffer,
                             const rect_t &copy_area)
 {
   (void)disp_drv;
   (void)copy_area;
+
+#if !defined(BOOT)
+  // wait for last reload to finish
+  while(_frame_addr_reloaded == 0);
+#endif
 
   SCB_CleanDCache();
 
@@ -436,9 +441,10 @@ static void startLcdRefresh(lv_disp_drv_t *disp_drv, uint16_t *buffer,
 
   __HAL_LTDC_ENABLE_IT(&hlcd_ltdc, LTDC_IT_LI);
 
-  // wait for reload
-  // TODO: replace through some smarter mechanism without busy wait
+#if defined(BOOT)
+  // wait for reload to finish - required for bootloader
   while(_frame_addr_reloaded == 0);
+#endif
 }
 
 extern "C" void lcdSetInitalFrameBuffer(void* fbAddress)


### PR DESCRIPTION
Currently when the LCD display needs updating, the code initiates a hardware display update then enters a busy wait loop until the update is done.
This blocks LVGL until the busy wait loop ends.

Testing on current radios shows this busy wait averages ~9ms whenever the display is refreshed.

Since the display is double buffered the busy wait can be moved to before the display update is triggered - i.e. only wait if the previous frame has not finished.

This reduces the average busy wait to < 1us.

Applies to 2.12 and 3.0. Could be added to 2.11 if desired.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved LCD frame-buffer reload synchronization across several targets, including clearer wait behavior for bootloader builds to ensure updates complete at the right time.

* **Refactor**
  * Standardized LCD timing/geometry calculations to use fixed physical dimension constants.
  * Updated headers to use `#pragma once`.
  * Removed unused global variables and legacy function-pointer based initialization for the affected LCD drivers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->