### PR TITLE
fix(spiflash): USB storage cannot persist files copied

### DIFF
--- a/radio/src/targets/common/arm/stm32/diskio_spi_flash.cpp
+++ b/radio/src/targets/common/arm/stm32/diskio_spi_flash.cpp
@@ -91,13 +91,21 @@ static DSTATUS spi_flash_initialize(BYTE lun)
   }
 
 #if defined(USE_FLASH_FTL)
-  int flashSize = flashSpiGetSize();
-  int flashSizeMB = flashSize  / 1024 / 1024;
+  if (frftlInitDone) {
+    // Do flush when trying to reinit spi flash,
+    // because the frftl only need to be initialized once
+    if (!ftlSync(&_frftl)) {
+      return STA_NOINIT;
+    }
+  } else {
+    int flashSize = flashSpiGetSize();
+    int flashSizeMB = flashSize  / 1024 / 1024;
 
-  if (!ftlInit(&_frftl, &_frftl_cb, flashSizeMB)) {
-    return STA_NOINIT;
+    if (!ftlInit(&_frftl, &_frftl_cb, flashSizeMB)) {
+      return STA_NOINIT;
+    }
+    frftlInitDone = true;
   }
-  frftlInitDone = true;
 #endif
 
   return 0;


### PR DESCRIPTION
The root cause is after USB unplugged, static DSTATUS spi_flash_initialize(BYTE lun) will be called again.  frftl need to be initialized only once, a second init will cause memory leak and data loss.

No problem in 2.10.x, the bug is introduce from 2.11 onwards.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced flash memory initialization to properly handle repeated initialization attempts and ensure reliable storage synchronization when the flash file transfer layer is enabled.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->