### PR TITLE
fix(bw): setup menu item cannot be selected in radio setup

### DIFF
--- a/radio/src/gui/128x64/radio_setup.cpp
+++ b/radio/src/gui/128x64/radio_setup.cpp
@@ -185,7 +185,7 @@ void menuRadioSetup(event_t event)
     HEADER_LINE_COLUMNS
     CASE_RTCLOCK(2) CASE_RTCLOCK(2)
     // Sound
-    CASE_AUDIO(LABEL(SOUND))
+    CASE_AUDIO(0)
      CASE_AUDIO(SOUND_ROW(0))
      CASE_AUDIO(SOUND_ROW(0))
      CASE_AUDIO(SOUND_ROW(0))


### PR DESCRIPTION
Broken in #7387 

Fixes #7458

Required for 2.11, 2.12 and 3.0


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the radio setup menu initialization for the Sound section menu entry to use the correct value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->