### PR TITLE
Targets that uses spi flash should not enable disk cache

### DIFF
--- a/radio/src/targets/pl18/CMakeLists.txt
+++ b/radio/src/targets/pl18/CMakeLists.txt
@@ -1,4 +1,4 @@
-option(DISK_CACHE "Enable SD card disk cache" ON)
+option(DISK_CACHE "Enable SD card disk cache" OFF)
 option(UNEXPECTED_SHUTDOWN "Enable the Unexpected Shutdown screen" ON)
 option(STICK_DEAD_ZONE "Enable sticks dead zone" YES)
 option(PXX1 "PXX1 protocol support" ON)


### PR DESCRIPTION
Disk cache should not enable together with spi flash storage that uses frftl, this will cause double caching in sdram and wasting sdram space and slowdown file access.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Modified default disk cache configuration setting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->