### PR TITLE
fix(pl18): add timeout to isChargerActive() to prevent hang when batt…

### DIFF
--- a/radio/src/targets/pl18/battery_driver.cpp
+++ b/radio/src/targets/pl18/battery_driver.cpp
@@ -61,6 +61,7 @@
 #endif
 #define WCHARGER_LOW_CURRENT_DELAY_CNT       6000
 #define WCHARGER_HIGH_CURRENT_DELAY_CNT      24000
+#define CHARGER_DETECTION_TIMEOUT            40    // 400ms
 
 typedef struct
 {
@@ -298,7 +299,7 @@ uint16_t get_battery_charge_state()
 bool isChargerActive()
 {  
 #if defined(WIRELESS_CHARGER)
-  uint16_t timeout = 200;
+  uint16_t timeout = CHARGER_DETECTION_TIMEOUT;
   while (!(uCharger.isChargerDetectionReady && wCharger.isChargerDetectionReady) && timeout--)
   {
     get_battery_charge_state();
@@ -306,7 +307,7 @@ bool isChargerActive()
   }
   return uCharger.hasCharger || wCharger.hasCharger;
 #else
-  uint16_t timeout = 200;
+  uint16_t timeout = CHARGER_DETECTION_TIMEOUT;
   while (!uCharger.isChargerDetectionReady && timeout--)
   {
     get_battery_charge_state();

--- a/radio/src/targets/pl18/battery_driver.cpp
+++ b/radio/src/targets/pl18/battery_driver.cpp
@@ -298,14 +298,16 @@ uint16_t get_battery_charge_state()
 bool isChargerActive()
 {  
 #if defined(WIRELESS_CHARGER)
-  while (!(uCharger.isChargerDetectionReady && wCharger.isChargerDetectionReady))
+  uint16_t timeout = 200;
+  while (!(uCharger.isChargerDetectionReady && wCharger.isChargerDetectionReady) && timeout--)
   {
     get_battery_charge_state();
     delay_ms(10);
   }
   return uCharger.hasCharger || wCharger.hasCharger;
 #else
-  while (!uCharger.isChargerDetectionReady)
+  uint16_t timeout = 200;
+  while (!uCharger.isChargerDetectionReady && timeout--)
   {
     get_battery_charge_state();
     delay_ms(10);


### PR DESCRIPTION
…ery missing

Add 2-second timeout to the blocking charger detection loops in isChargerActive(). When no battery is installed and the radio is USB-powered, the TP5100 charger IC status pins can oscillate due to capacitive-load charge/discharge cycling. This causes the consecutive-sample debounce counter in chargerDetection() to perpetually reset, hanging the boot before LCD initialization results in a blank screen.

Fixes EL18 blank screen when powered via USB without batteries.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved charger detection stability by adding a bounded polling timeout, preventing potential indefinite waiting when charger detection readiness is not reached.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->