### PR TITLE
fix(yaml): correctly write signed enum values

### DIFF
--- a/radio/src/storage/yaml/yaml_tree_walker.cpp
+++ b/radio/src/storage/yaml/yaml_tree_walker.cpp
@@ -181,6 +181,11 @@ static bool yaml_output_attr(void* user, uint8_t* ptr, uint32_t bit_ofs,
             break;
           case YDT_ENUM:
             p_out = yaml_output_enum(i, node->u._enum.choices);
+            if (!p_out) {
+              // Field holds a signed enum value (e.g. AntennaModes)
+              p_out = yaml_output_enum(yaml_to_signed(i, node->size),
+                                        node->u._enum.choices);
+            }
             break;
 
           case YDT_ARRAY:


### PR DESCRIPTION
Handle signed enum values in yaml_tree_walker. AntennaMode is the outlier in question - and appears to have been broken since we moved to yaml. 

Discovered during v12 antennamode refactoring.

There are several old issues that somewhat hint at this, but were more about UI crashes and inconsistencies, none seemed to pick this up. 



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved YAML serialization handling for enum-typed fields to ensure proper conversion in edge cases where standard conversion may not yield output.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->