### PR TITLE
fix(color): trims may move by an extra step when trim key released

### DIFF
--- a/radio/src/edgetx.cpp
+++ b/radio/src/edgetx.cpp
@@ -985,7 +985,8 @@ void alert(const char * title, const char * msg , uint8_t sound)
 void checkTrims()
 {
   event_t event = getTrimEvent();
-  if (event && !IS_KEY_BREAK(event)) {
+  // Only use press and repeat trim events
+  if (event && (IS_KEY_FIRST(event) || IS_KEY_REPT(event))) {
     int8_t k = EVT_KEY_MASK(event);
     uint8_t idx = inputMappingConvertMode(uint8_t(k / 2));
     uint8_t phase;

--- a/radio/src/keys.h
+++ b/radio/src/keys.h
@@ -116,11 +116,6 @@ constexpr bool IS_KEY_EVENT(event_t event)
   return (event & 0xF000) == 0;  // fired when key is released (short or long), but only if the event was not killed
 }
 
-// constexpr bool IS_TRIM_EVENT(event_t event)
-// {
-//   return (IS_KEY_EVENT(event) && EVT_KEY_MASK(event) >= TRM_BASE);
-// }
-
 inline bool IS_KEY_FIRST(event_t evt)
 {
   return (evt & _MSK_KEY_FLAGS) == _MSK_KEY_FIRST;
@@ -134,11 +129,6 @@ inline bool IS_KEY_REPT(event_t evt)
 inline bool IS_KEY_LONG(event_t evt)
 {
   return (evt & _MSK_KEY_FLAGS) == _MSK_KEY_LONG;
-}
-
-inline bool IS_KEY_BREAK(event_t evt)
-{
-  return (evt & _MSK_KEY_FLAGS) == _MSK_KEY_BREAK;
 }
 
 inline bool IS_KEY_EVT(event_t evt, uint8_t key)


### PR DESCRIPTION
When a trim key is released after being held until it starts repeating, the trim may jump an extra step.
Introduced for color radios when the long key press logic was refactored.

Fixes #7329

Applies to 2.11, 2.12 and 3.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved trim event handling so trim actions are processed only for valid “first press” and “repeat” events, avoiding accidental processing of other trim event types. This makes trim control more accurate and reliable during key interactions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->