### PR TITLE
fix(color): model settings may not be saved when editing global variables

### DIFF
--- a/radio/src/gui/colorlcd/model/model_gvars.cpp
+++ b/radio/src/gui/colorlcd/model/model_gvars.cpp
@@ -489,11 +489,10 @@ class GVarEditWindow : public Page
             line, rect_t{}, [=] { return fmData->gvars[index] <= GVAR_MAX; },
             [=](uint8_t checked) {
               fmData->gvars[index] = checked ? 0 : GVAR_MAX + 1;
+              SET_DIRTY();
               setProperties(flightMode);
             });
-        lv_obj_set_style_grid_cell_x_align(cb->getLvObj(), LV_GRID_ALIGN_END,
-                                           0);
-        lv_obj_invalidate(cb->getLvObj());
+        lv_obj_set_style_grid_cell_x_align(cb->getLvObj(), LV_GRID_ALIGN_END, 0);
       } else {
         grid.nextCell();
       }
@@ -553,10 +552,15 @@ void ModelGVarsPage::build(Window* window)
         editWindow->setCloseHandler([=]() { rebuild(window); });
       });
       menu->addLine(STR_CLEAR, [=]() {
-        for (auto& flightMode : g_model.flightModeData) {
+        for (auto& flightMode : g_model.flightModeData)
           flightMode.gvars[index] = 0;
-        }
-        storageDirty(EE_MODEL);
+        SET_DIRTY();
+      });
+      menu->addLine(STR_SF_RESET, [=]() {
+        for (auto& flightMode : g_model.flightModeData)
+          flightMode.gvars[index] = GVAR_MAX + 1;
+        g_model.flightModeData[0].gvars[index] = 0;
+        SET_DIRTY();
       });
       return 0;
     });


### PR DESCRIPTION
Changes:
- set dirty flag when the flight mode toggle switches are changed for a GV
- add a 'Reset' menu option to set the GV values back to default

The 'Reset' option is added to clear the flight mode GV values back to the default setting.
The 'Clear' option sets the flight mode GV values to 0 instead of the default value.

2.12 & 3.0.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved how global-variable edits are tracked by ensuring changes are consistently marked as modified and propagate correctly through the interface.
* **Bug Fixes**
  * Fixed flight-mode “value present” toggles so the associated flight-mode properties refresh reliably after edits.
  * Updated the “clear” and “SF reset” actions to reset the correct global-variable entries and properly mark the model as changed.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->