### PR TITLE
fix(radio): exFat directory handling

### DIFF
--- a/radio/src/gui/colorlcd/libui/file_browser.cpp
+++ b/radio/src/gui/colorlcd/libui/file_browser.cpp
@@ -29,22 +29,6 @@
 #define CELL_CTRL_DIR  LV_TABLE_CELL_CTRL_CUSTOM_1
 #define CELL_CTRL_FILE LV_TABLE_CELL_CTRL_CUSTOM_2
 
-static const char* getFullPath(const char* filename)
-{
-  static char full_path[FF_MAX_LFN + 1];
-  f_getcwd((TCHAR*)full_path, FF_MAX_LFN);
-  strcat(full_path, "/");
-  strcat(full_path, filename);
-  return full_path;
-}
-
-static const char* getCurrentPath()
-{
-  static char path[FF_MAX_LFN + 1];
-  f_getcwd((TCHAR*)path, FF_MAX_LFN);
-  return path;
-}
-
 static int strnatcasecmp(char const *s1, char const *s2)
 {
   int i1, i2;
@@ -138,10 +122,18 @@ static int scan_files(std::list<std::string>& files,
   return 0;
 }
 
-FileBrowser::FileBrowser(Window* parent, const rect_t& rect, const char* dir) :
-    TableField(parent, rect)
+void FileBrowser::setFullPath(const char* name)
 {
-  f_chdir(dir);
+  if (currentPath == "/")
+    fullPathBuf = std::string("/") + name;
+  else
+    fullPathBuf = currentPath + "/" + name;
+}
+
+FileBrowser::FileBrowser(Window* parent, const rect_t& rect, const char* dir) :
+    TableField(parent, rect), currentPath((dir && dir[0]) ? dir : "/")
+{
+  f_chdir(currentPath.c_str());
 
   setAutoEdit();
 
@@ -244,18 +236,24 @@ void FileBrowser::onSelected(const char* name, bool is_dir)
     return;
   }
 
-  const char* path = getCurrentPath();
-  const char* fullpath = getFullPath(name);
-  if (fileSelected) fileSelected(path, name, fullpath, is_dir);
+  setFullPath(name);
+  if (fileSelected) fileSelected(currentPath.c_str(), name, fullPathBuf.c_str(), is_dir);
   selected = name;
 }
 
 void FileBrowser::onPress(const char* name, bool is_dir)
 {
-  const char* path = getCurrentPath();
-  const char* fullpath = getFullPath(name);
   if (is_dir) {
-    f_chdir(fullpath);
+    if (strcmp(name, "..") == 0) {
+      // Go up: trim last segment (f_chdir("..") / f_getcwd are no-ops on exFAT).
+      auto pos = currentPath.find_last_of('/');
+      currentPath = (pos == 0 || pos == std::string::npos) ? "/"
+                                                           : currentPath.substr(0, pos);
+    } else {
+      setFullPath(name);
+      currentPath = fullPathBuf;
+    }
+    f_chdir(currentPath.c_str());
     if (fileSelected) fileSelected(nullptr, nullptr, nullptr, is_dir);
     selected = nullptr;
     refresh();
@@ -268,20 +266,19 @@ void FileBrowser::onPress(const char* name, bool is_dir)
   }
 
   if (fileAction){
-    fileAction(path, name, fullpath, is_dir);
+    setFullPath(name);
+    fileAction(currentPath.c_str(), name, fullPathBuf.c_str(), is_dir);
   }
 }
 
 void FileBrowser::onPressLong(const char* name, bool is_dir)
 {
-  const char* path = getCurrentPath();
-  const char* fullpath = getFullPath(name);
-
   if (!selected || (selected != name)) {
     onSelected(name, is_dir);
   }
 
   if (fileAction){
-    fileAction(path, name, fullpath, is_dir);
+    setFullPath(name);
+    fileAction(currentPath.c_str(), name, fullPathBuf.c_str(), is_dir);
   }
 }

--- a/radio/src/gui/colorlcd/libui/file_browser.h
+++ b/radio/src/gui/colorlcd/libui/file_browser.h
@@ -21,6 +21,8 @@
 
 #pragma once
 
+#include <string>
+
 #include "table.h"
 
 class FileBrowser : public TableField
@@ -52,6 +54,12 @@ class FileBrowser : public TableField
   void onPressLong(const char* name, bool is_dir);
 
  private:
+  // Current dir, tracked explicitly because f_getcwd() is broken on exFAT.
+  std::string currentPath;
+  // Outlives the file-action call: callbacks capture the pointer for later use.
+  std::string fullPathBuf;
+  void setFullPath(const char* name);
+
   const char* selected = nullptr;
   FileAction fileAction;
   FileAction fileSelected;

--- a/radio/src/gui/colorlcd/radio/radio_sdmanager.cpp
+++ b/radio/src/gui/colorlcd/radio/radio_sdmanager.cpp
@@ -467,14 +467,18 @@ void RadioSdManagerPage::fileAction(const char* path, const char* name,
   }
   menu->addLine(STR_COPY_FILE, [=]() {
     clipboard.type = CLIPBOARD_TYPE_SD_FILE;
-    f_getcwd(clipboard.data.sd.directory, CLIPBOARD_PATH_LEN);
+    // f_getcwd() is a no-op on exFAT; use the tracked path.
+    strncpy(clipboard.data.sd.directory, path, CLIPBOARD_PATH_LEN - 1);
+    clipboard.data.sd.directory[CLIPBOARD_PATH_LEN - 1] = '\0';
     strncpy(clipboard.data.sd.filename, name, CLIPBOARD_PATH_LEN - 1);
   });
   if (clipboard.type == CLIPBOARD_TYPE_SD_FILE) {
     menu->addLine(STR_PASTE, [=]() {
       static char lfn[FF_MAX_LFN + 1];  // TODO optimize that!
       char destFileName[2 * CLIPBOARD_PATH_LEN + 1];
-      f_getcwd((TCHAR*)lfn, FF_MAX_LFN);
+      // f_getcwd() is a no-op on exFAT; use the tracked path.
+      strncpy(lfn, path, FF_MAX_LFN);
+      lfn[FF_MAX_LFN] = '\0';
       // prevent copying to the same directory with the same name
       char* destNamePtr = clipboard.data.sd.filename;
       if (!strcmp(clipboard.data.sd.directory, lfn)) {

--- a/radio/src/gui/common/stdlcd/radio_sdmanager.cpp
+++ b/radio/src/gui/common/stdlcd/radio_sdmanager.cpp
@@ -61,9 +61,27 @@ inline bool isFilenameLower(bool isfile, const char * fn, const char * line)
   return (!isfile && IS_FILE(line)) || (isfile==IS_FILE(line) && strcasecmp(fn, line) < 0);
 }
 
+// Current dir, tracked explicitly: on exFAT f_getcwd() and f_chdir("..") are no-ops.
+static char sdManagerPath[FF_MAX_LFN + 1] = "/";
+
+static void sdManagerChdir(const char* name)
+{
+  if (!strcmp(name, "..")) {
+    // go up: drop the last path segment
+    char* sep = strrchr(sdManagerPath, '/');
+    if (sep == sdManagerPath) sep[1] = '\0';  // parent is the root
+    else if (sep) *sep = '\0';
+  } else {
+    // descend into 'name'
+    if (sdManagerPath[1] != '\0') strcat(sdManagerPath, "/");
+    strcat(sdManagerPath, name);
+  }
+  f_chdir(sdManagerPath);  // absolute path: resolves on FAT and exFAT alike
+}
+
 void getSelectionFullPath(char * lfn)
 {
-  f_getcwd(lfn, FF_MAX_LFN);
+  strcpy(lfn, sdManagerPath);
   strcat(lfn, "/");
   strcat(lfn, reusableBuffer.sdManager.lines[menuVerticalPosition - HEADER_LINE - menuVerticalOffset]);
 }
@@ -121,12 +139,13 @@ void onSdManagerMenu(const char * result)
   }
   else if (result == STR_COPY_FILE) {
     clipboard.type = CLIPBOARD_TYPE_SD_FILE;
-    f_getcwd(clipboard.data.sd.directory, CLIPBOARD_PATH_LEN);
+    strncpy(clipboard.data.sd.directory, sdManagerPath, CLIPBOARD_PATH_LEN - 1);
+    clipboard.data.sd.directory[CLIPBOARD_PATH_LEN - 1] = '\0';
     strncpy(clipboard.data.sd.filename, line, CLIPBOARD_PATH_LEN-1);
   }
   else if (result == STR_PASTE) {
     char destFileName[2 * CLIPBOARD_PATH_LEN + 1];
-    f_getcwd(lfn, FF_MAX_LFN);
+    strcpy(lfn, sdManagerPath);
     // if destination is dir, copy into that dir
     if (IS_DIRECTORY(line)) {
       strcat(lfn, "/");
@@ -279,6 +298,7 @@ void menuRadioSdManager(event_t _event)
 
   if (_event == EVT_ENTRY) {
     f_chdir(ROOT_PATH);
+    strcpy(sdManagerPath, ROOT_PATH);
 #if LCD_DEPTH > 1
     lastPos = -1;
 #endif
@@ -325,7 +345,7 @@ void menuRadioSdManager(event_t _event)
       else {
         int index = menuVerticalPosition - HEADER_LINE - menuVerticalOffset;
         if (IS_DIRECTORY(reusableBuffer.sdManager.lines[index])) {
-          f_chdir(reusableBuffer.sdManager.lines[index]);
+          sdManagerChdir(reusableBuffer.sdManager.lines[index]);
           menuVerticalOffset = 0;
           menuVerticalPosition = HEADER_LINE;
           REFRESH_FILES();

--- a/radio/src/lib_file.cpp
+++ b/radio/src/lib_file.cpp
@@ -91,8 +91,10 @@ bool isExtensionMatching(const char * extension, const char * pattern, char * ma
 FRESULT sdReadDir(DIR * dir, FILINFO * fno, bool & firstTime)
 {
   FRESULT res;
-  // cdir (0 == root) works on FAT and exFAT; f_getcwd() always reports root on exFAT.
-  if (firstTime && dir->obj.fs->cdir != 0) {
+  // Fake ".." only when browsing the non-root CWD itself (sclust == cdir, 0 == root).
+  // Filesystem-CWD based so it works on exFAT, where f_getcwd() always returns root;
+  // the sclust check keeps callers that open an arbitrary path (no chdir) unaffected.
+  if (firstTime && dir->obj.fs->cdir != 0 && dir->obj.sclust == dir->obj.fs->cdir) {
     // fake parent directory entry
     strcpy(fno->fname, "..");
     fno->fattrib = AM_DIR;

--- a/radio/src/lib_file.cpp
+++ b/radio/src/lib_file.cpp
@@ -83,16 +83,6 @@ bool isExtensionMatching(const char * extension, const char * pattern, char * ma
   return false;
 }
 
-// returns true if current working dir is at the root level
-bool isCwdAtRoot()
-{
-  char path[10];
-  if (f_getcwd(path, sizeof(path)-1) == FR_OK) {
-    return (strcasecmp("/", path) == 0);
-  }
-  return false;
-}
-
 /*
   Wrapper around the f_readdir() function which
   also returns ".." entry for sub-dirs. (FatFS 0.12 does
@@ -101,7 +91,8 @@ bool isCwdAtRoot()
 FRESULT sdReadDir(DIR * dir, FILINFO * fno, bool & firstTime)
 {
   FRESULT res;
-  if (firstTime && !isCwdAtRoot()) {
+  // cdir (0 == root) works on FAT and exFAT; f_getcwd() always reports root on exFAT.
+  if (firstTime && dir->obj.fs->cdir != 0) {
     // fake parent directory entry
     strcpy(fno->fname, "..");
     fno->fattrib = AM_DIR;


### PR DESCRIPTION
On exFAT-formatted SD cards the file browser was broken: the ".." (go up) entry never appeared, you couldn't navigate out of a sub-directory, and copy/paste targeted the wrong location. FAT32 cards were unaffected. As exemple, you could not open txt file for reading in SD manager.

## Root cause

Two FatFs calls the browsers relied on don't work on exFAT, because exFAT directories carry no on-disk "." / ".." entries:

- **`f_getcwd()` always returns `/`** — it rebuilds the path by walking up the ".." chain, which doesn't exist on exFAT
  (FatFs documents this: *"Cannot do getcwd on exFAT and returns root path"*).
This broke ".."  detection, the current-path display, nested navigation and clipboard paths.

- **`f_chdir("..")` is a no-op** — with no ".." entry, FatFs "stays there" (`ff.c`), so "go up" did nothing.

This fixes all of it for both the colorLCD and B&W SD managers.

I have taken great care of not breaking fat32, but I would appreciate some external tests

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved file browser navigation and file operation reliability on SD cards by keeping accurate directory context during selection, navigation, and actions.
  * Enhanced stability of SD file copy/paste behavior by tracking the active directory without relying on filesystem working-directory queries.
  * Better handling of synthetic “..” navigation when browsing the initial directory to match FatFS/exFAT behavior.
* **Refactor**
  * Optimized internal file path tracking for more consistent full-path construction during browsing and file operations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->