### PR TITLE
fix(color): 'Group' label should not be shown when editing radio settings for custom switches

### DIFF
--- a/radio/src/gui/colorlcd/model/function_switches.cpp
+++ b/radio/src/gui/colorlcd/model/function_switches.cpp
@@ -330,7 +330,8 @@ FunctionSwitchesBase::FunctionSwitchesBase(EdgeTxIcon icon, const char* title) :
   new StaticText(box, {FunctionSwitch::NM_X + PAD_OUTLINE, 0, FunctionSwitch::NM_W, 0}, STR_NAME, COLOR_THEME_PRIMARY1_INDEX, FONT(XS));
   new StaticText(box, {FunctionSwitch::TP_X + PAD_OUTLINE, 0, FunctionSwitch::TP_W, 0}, STR_SWITCH_TYPE,
                  COLOR_THEME_PRIMARY1_INDEX, FONT(XS));
-  new StaticText(box, {FunctionSwitch::GR_X + PAD_OUTLINE, 0, FunctionSwitch::GR_W, 0}, STR_GROUP, COLOR_THEME_PRIMARY1_INDEX, FONT(XS));
+  if (icon == ICON_MODEL_SETUP)
+    new StaticText(box, {FunctionSwitch::GR_X + PAD_OUTLINE, 0, FunctionSwitch::GR_W, 0}, STR_GROUP, COLOR_THEME_PRIMARY1_INDEX, FONT(XS));
   startupHeader = new StaticText(box, {FunctionSwitch::ST_X + PAD_OUTLINE, 0, FunctionSwitch::ST_W, 0}, STR_SWITCH_STARTUP,
                  COLOR_THEME_PRIMARY1_INDEX, FONT(XS));
 #if defined(FUNCTION_SWITCHES_RGB_LEDS) && !NARROW_LAYOUT


### PR DESCRIPTION
Don't show 'Group' label in the header when editing radio settings for a custom switch.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed conditional rendering of the group column header in function switches to display only in appropriate contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->