### PR TITLE
fix(serial): enable TX DMA FIFO to prevent bus contention (#5011)

### DIFF
--- a/radio/src/targets/common/arm/stm32/stm32_usart_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_usart_driver.cpp
@@ -596,6 +596,12 @@ void stm32_usart_send_buffer(const stm32_usart_t* usart, const uint8_t * data, u
     dmaInit.NbData = size;
     dmaInit.Priority = LL_DMA_PRIORITY_VERYHIGH;  // TODO: make it configurable
 
+    // Prefetch the frame into the DMA FIFO instead of fetching one byte per
+    // USART request (direct mode), so bus contention from another stream on the
+    // same controller (e.g. SDIO) cannot starve a byte and corrupt the frame.
+    dmaInit.FIFOMode = LL_DMA_FIFOMODE_ENABLE;
+    dmaInit.FIFOThreshold = LL_DMA_FIFOTHRESHOLD_FULL;
+
     LL_DMA_Init(usart->txDMA, usart->txDMA_Stream, &dmaInit);
 
     if (IS_HALF_DUPLEX(usart) && (int32_t)(usart->txDMA_IRQn) >= 0) {


### PR DESCRIPTION
The serial TX DMA ran in direct mode, fetching one byte per USART request. On the internal module path (USART1 TX -> DMA2 Stream7) this shares the DMA2 controller with the SD card (SDIO -> DMA2 Stream3). Heavy SD read activity, e.g. playing high-sample-rate WAV files, could starve a byte and corrupt the outgoing multi frame, intermittently dropping the RF link.

Enable the DMA FIFO so the stream prefetches the frame, decoupling the per-byte TX deadline from AHB bus arbitration. Memory/peripheral bursts stay single, so any frame size is valid. Safe for half-duplex, whose TX->RX turnaround keys off USART TC (after the FIFO has fully drained).

Fixes #5011 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UART transmit reliability under heavy system activity.
  * Reduced the chance of corrupted or missing bytes during DMA-based serial transfers by making buffering more robust.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->