### PR TITLE
fix widget updating in the middle of model change

### DIFF
--- a/radio/src/gui/colorlcd/model/model_select.cpp
+++ b/radio/src/gui/colorlcd/model/model_select.cpp
@@ -365,6 +365,9 @@ class ModelsPageBody : public Window
       memcpy(g_eeGeneral.currModelFilename, model->modelFilename,
              LEN_MODEL_FILENAME);
 
+      // Pause widget refresh
+      MainWindow::instance()->enableWidgetRefresh(false);
+
       // Delete old main view layout
       LayoutFactory::deleteCustomScreens();
 
@@ -373,6 +376,9 @@ class ModelsPageBody : public Window
 
       // Load new main view layout
       LayoutFactory::loadCustomScreens();
+
+      // Enable widget refresh
+      MainWindow::instance()->enableWidgetRefresh(true);
 
       storageDirty(EE_GENERAL);
       storageCheck(true);

--- a/radio/src/gui/colorlcd/model/model_select.cpp
+++ b/radio/src/gui/colorlcd/model/model_select.cpp
@@ -368,8 +368,12 @@ class ModelsPageBody : public Window
       // Pause widget refresh
       MainWindow::instance()->enableWidgetRefresh(false);
 
-      // Delete old main view layout
+      // Delete old main view layout and top bar widgets: loadModel() can
+      // re-enter the UI refresh loop (throttle / switch warnings spin
+      // MainWindow::run()) while g_model is being reset, and a surviving
+      // widget would then read torn-down persistent data.
       LayoutFactory::deleteCustomScreens();
+      LayoutFactory::deleteTopBarWidgets();
 
       loadModel(g_eeGeneral.currModelFilename, true);
       modelslist.setCurrentModel(model);


### PR DESCRIPTION
## Summary of changes:

Fix #7499 where widgets are updating while model load is in progress on model changes, resulting in hardfault.

Fix was designed by @philmoz  (see #7498)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the model-switching experience by temporarily pausing screen refreshes during the transition.
  * Restored refreshes after the new model and screens finish loading, helping avoid visual glitches or partial redraws.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->