### PR TITLE
fix(tx15): mic not available on 2.12

### DIFF
--- a/radio/src/targets/tx15/CMakeLists.txt
+++ b/radio/src/targets/tx15/CMakeLists.txt
@@ -8,7 +8,7 @@ option(MODULE_SIZE_STD "Standard size TX Module" ON)
 option(LUA_MIXER "Enable LUA mixer/model scripts support" ON)
 option(DISK_CACHE "Enable SD card disk cache" ON)
 option(BLUETOOTH "FrSky BT module support" OFF)
-option(FLYSKY_GIMBAL "Serial gimbal support" ON)
+option(FLYSKY_GIMBAL "Serial gimbal support" OFF)
 option(INTERNAL_GPS "Support for internal GPS" ON)
 
 set(FIRMWARE_QSPI YES)


### PR DESCRIPTION
## Summary of changes:
Fix the backport of #7328, where the MIC was not available because FLYSKY_GIMBAL has not been disabled