### PR TITLE
feat(color): allow Lua script to change the value of a textEdit control independently of user input

### DIFF
--- a/radio/src/gui/colorlcd/libui/textedit.cpp
+++ b/radio/src/gui/colorlcd/libui/textedit.cpp
@@ -166,6 +166,7 @@ void TextEdit::openEdit()
       edit->hide();
     });
   }
+  edit->update();
   edit->show();
   lv_group_focus_obj(edit->getLvObj());
   edit->openKeyboard();

--- a/radio/src/lua/lua_lvgl_widget.cpp
+++ b/radio/src/lua/lua_lvgl_widget.cpp
@@ -2249,11 +2249,11 @@ void LvglWidgetToggleSwitch::build(lua_State *L)
 void LvglWidgetTextEdit::parseParam(lua_State *L, const char *key)
 {
   if (!strcmp(key, "value")) {
-    txt = luaL_checkstring(L, -1);
+    txt.parse(L);
   } else if (!strcmp(key, "length")) {
     maxLen = luaL_checkinteger(L, -1);
-    if (maxLen > 128) maxLen = 128;
-    if (maxLen <= 0) maxLen = 32;
+    if (maxLen > MAX_TEXT_EDIT_LEN) maxLen = MAX_TEXT_EDIT_LEN;
+    if (maxLen <= 0) maxLen = DEFAULT_TEXT_EDIT_LEN;
   } else if (!strcmp(key, "set")) {
     setFunction = ::getRef(L, LUA_REGISTRYINDEX);
   } else {
@@ -2261,15 +2261,33 @@ void LvglWidgetTextEdit::parseParam(lua_State *L, const char *key)
   }
 }
 
+bool LvglWidgetTextEdit::callRefs(lua_State *L)
+{
+  if (!LvglWidgetObject::callRefs(L)) return false;
+
+  if (isVisible()) {
+    if (!pcallUpdateStringVal(L, txt.function, [=](const char* s) {
+              if (txt.changedText(s)) {
+                strAppend(value, txt.chars(), MAX_TEXT_EDIT_LEN);
+                ((TextEdit*)window)->update();
+              }
+            }))
+      return false;
+  }
+
+  return true;
+}
+
 void LvglWidgetTextEdit::clearRefs(lua_State *L)
 {
+  txt.clearRef(L);
   clearRef(L, setFunction);
   LvglWidgetObject::clearRefs(L);
 }
 
 void LvglWidgetTextEdit::build(lua_State *L)
 {
-  strcpy(value, txt);
+  strAppend(value, txt.chars(), MAX_TEXT_EDIT_LEN);
   if (h == LV_SIZE_CONTENT) h = 0;
   window = new TextEdit(lvglManager->getCurrentParent(), {x, y, w, h}, value,
                         maxLen, [=]() {

--- a/radio/src/lua/lua_lvgl_widget.cpp
+++ b/radio/src/lua/lua_lvgl_widget.cpp
@@ -2296,6 +2296,7 @@ void LvglWidgetTextEdit::build(lua_State *L)
                             PROTECT_LUA()
                             {
                               std::string s(value, maxLen); // Ensure string is terminated
+                              txt.changedText(s.c_str());
                               if (!pcallFuncWithString(L, setFunction, 0, s.c_str())) {
                                 lvglManager->luaShowError();
                               }

--- a/radio/src/lua/lua_lvgl_widget.h
+++ b/radio/src/lua/lua_lvgl_widget.h
@@ -796,12 +796,16 @@ class LvglWidgetTextEdit : public LvglWidgetObject
  public:
   LvglWidgetTextEdit() : LvglWidgetObject(LVGL_SIMPLEMETATABLE) {}
 
+  bool callRefs(lua_State *L) override;
   void clearRefs(lua_State *L) override;
 
+  static constexpr int DEFAULT_TEXT_EDIT_LEN = 32;
+  static constexpr int MAX_TEXT_EDIT_LEN = 128;
+
  protected:
-  const char *txt = "";
-  char value[129];
-  int maxLen = 32;
+  LvglParamFuncOrString txt = { .function = LUA_REFNIL, .txt = ""};
+  char value[MAX_TEXT_EDIT_LEN + 1];
+  int maxLen = DEFAULT_TEXT_EDIT_LEN;
 
   int setFunction = LUA_REFNIL;
 


### PR DESCRIPTION
The 'value' property of a textEdit control can be a function. If the string returned by the function changes the textEdit value is updated.

Requested on Discord - https://discord.com/channels/839849772864503828/842693696629899274/1520465665520046110

Applies to 2.11, 2.12 and 3.0

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * TextEdit content can now refresh dynamically using Lua-driven parameters/values.
* **Bug Fixes**
  * Improved refresh behavior when reopening an existing text editor, ensuring on-screen text stays in sync.
  * User edits now reliably notify change handlers and propagate updated text to Lua.
  * Text length handling was refined with clearer default/max limits and safer clamping to reduce truncation mismatches.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->