### PR TITLE
fix(simulator): sample LCD at a fixed cadence so the final frame is always painted

### DIFF
--- a/companion/src/simulation/widgets/lcdwidget.cpp
+++ b/companion/src/simulation/widgets/lcdwidget.cpp
@@ -71,14 +71,26 @@ void LcdWidget::makeScreenshot(const QString &fileName)
 
 void LcdWidget::onLcdChanged(uint8_t* lcdBuf, bool light)
 {
+  // Ingest only: store the latest frame and let frameTimer drive the repaint.
+  // Sampling on a fixed cadence caps the repaint rate without dropping the
+  // final frame of a burst, regardless of how frames are delivered.
   QMutexLocker locker(&lcdMtx);
   lightEnable = light;
   if (lcdBuf) memcpy(localBuf, lcdBuf, lcdSize);
-  if (!redrawTimer.isValid() ||
-      redrawTimer.hasExpired(LCD_WIDGET_REFRESH_PERIOD)) {
-    update();
-    redrawTimer.start();
+  dirty = true;
+  if (!frameTimer.isActive())
+    frameTimer.start();
+}
+
+void LcdWidget::onFrameTick()
+{
+  QMutexLocker locker(&lcdMtx);
+  if (!dirty) {  // idle: stop until the next frame arrives
+    frameTimer.stop();
+    return;
   }
+  dirty = false;
+  update();
 }
 
 void LcdWidget::doPaint(QPainter &p)

--- a/companion/src/simulation/widgets/lcdwidget.h
+++ b/companion/src/simulation/widgets/lcdwidget.h
@@ -26,15 +26,16 @@
 #include <QPainter>
 #include <QClipboard>
 #include <QDir>
-#include <QElapsedTimer>
 #include <QMutex>
 #include <QMutexLocker>
 #include <QMouseEvent>
+#include <QTimer>
 #include <AppDebugMessageHandler>
 
 #include "appdata.h"
 
-#define LCD_WIDGET_REFRESH_PERIOD    16  // [ms] 16 = 62.5fps
+#define LCD_WIDGET_REFRESH_PERIOD    10  // [ms] 10 = 100fps cap (color is
+                                         // firmware-limited to ~20fps anyway)
 
 class LcdWidget : public QWidget
 {
@@ -50,6 +51,8 @@ class LcdWidget : public QWidget
       bgDefaultColor(QColor(148, 156, 149)),
       fgDefaultColor(QColor(0, 0, 0))
   {
+    frameTimer.setInterval(LCD_WIDGET_REFRESH_PERIOD);
+    connect(&frameTimer, &QTimer::timeout, this, &LcdWidget::onFrameTick);
   }
 
   ~LcdWidget()
@@ -84,8 +87,10 @@ class LcdWidget : public QWidget
   QColor bgDefaultColor;
   QColor fgDefaultColor;
   QMutex lcdMtx;
-  QElapsedTimer redrawTimer;
+  QTimer frameTimer;
+  bool dirty = false;
 
+  void onFrameTick();
   void doPaint(QPainter &p);
 
   void paintEvent(QPaintEvent *) override;


### PR DESCRIPTION
## Problem

On COLORLCD radios in the **WASM simulator** (Companion), an LVGL screen could fail to repaint after a one-shot change. Easiest repro: open the **Global Variables** list, tap a GV, choose **Clear** — the values are set to 0 but the list keeps showing the old values until focus moves to another row or the GV is tapped again.

- Does **not** happen on the radio.
- Does **not** happen with the old native (`libsimulator`) Companion builds.
- Reproduces reliably in the WASM simulator (observed on macOS).

A key clue: switching to another app and back to Companion makes the screen update correctly. So the framebuffer was being copied at the right moment — the repaint just wasn't being *triggered*.

## Root cause

The bug is in the host-side `LcdWidget`, and it is independent of the firmware: the GVAR "Clear" handler only mutates model data and relies on the per-frame `checkEvents()` poll to update the row a frame later — that part is correct and identical on radio/native/WASM.

`LcdWidget::onLcdChanged()` always copied the incoming frame into `localBuf`, but only called `update()` on the **leading edge** of a 16 ms throttle (`LCD_WIDGET_REFRESH_PERIOD`). A frame arriving *inside* the throttle window was copied but never scheduled for repaint, and nothing re-triggered it — so the last frame of a burst was silently dropped until an unrelated event (e.g. window activation) forced a `paintEvent`.

This is a long-standing latent flaw (the throttle predates EdgeTX), but only the WASM host exposes it:

- **Native plugin:** `OpenTxSimulator::run()` polls the `simuLcdRefresh` flag on a 10 ms `QTimer`. That coalesces all flushes in each window into one emit and spaces repaint requests out on a fixed grid, so a one-shot frame lands well outside the 16 ms window and paints.
- **WASM module:** refresh is driven by the cross-thread, coalesced `simuLcdNotify` edge. WAMR runs the firmware in the **classic interpreter** (`WAMR_BUILD_INTERP=1`, no fast-interp/AOT/JIT), and each host→module call under the runtime mutex (e.g. the full-framebuffer `simuLcdCopy`) is comparatively expensive. The Qt event loop stalls in chunks, so queued `onLcdNotify` invocations drain in tight bursts — and the trailing GVAR frame frequently lands within 16 ms of a preceding burst frame and gets its repaint suppressed.

So the firmware was producing the frame and the host was copying it; the throttle was eating the repaint.

## Solution

Replace the per-event throttle with a **sampling model** — the same shape the rest of the stack already uses (firmware paints on its own tick, LVGL refreshes on its timer):

- `onLcdChanged()` only ingests: copy the latest frame, set `dirty`, and arm `frameTimer` if it isn't already running.
- `frameTimer` (the cadence timer) repaints when `dirty`, and **stops itself when idle**, so there is no free-running heartbeat.

The repaint rate is now capped by the timer interval directly, and the final frame of any burst is always painted on the next tick — regardless of how frames are delivered (de-bunched poll or bursty notify). The trailing frame is no longer a special case.

`LCD_WIDGET_REFRESH_PERIOD` is lowered 16 → 10 ms: COLORLCD is firmware-limited to ~20 fps (`perMain` runs every `MENU_TASK_PERIOD = 50 ms`, the only driver of `lv_timer_handler()`), so the cap never binds for color; B&W fast-refresh screens (spectrum analyser, power meter) get a smoother ceiling, and it aligns with the 10 ms host loop. Since the timer self-stops, there is no idle cost to the faster cadence.

### Note

This supersedes the earlier approach in this PR (re-introducing the native 10 ms poll in the WASM `run()` loop). That would have worked by restoring the de-bunched delivery, but it only papered over the WASM delivery pattern. Fixing `LcdWidget` addresses the actual flaw — a throttle that can drop the final frame — for every simulator backend.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * LCD display updates now refresh more smoothly and consistently.
  * Screen changes are handled more promptly for a more responsive viewing experience.

* **Bug Fixes**
  * Reduced the chance of missed or stale LCD redraws during rapid updates.
  * Improved handling of consecutive display changes so the latest frame is shown reliably.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->