### PR TITLE
ci(companion): add macOS arm64-only build job

### DIFF
--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -32,6 +32,7 @@ on:
           - all
           - linux
           - macos
+          - macos-arm64
           - windows
           - wasm
 
@@ -146,6 +147,35 @@ jobs:
         uses: ./.github/actions/build_companion
         with:
           os: 'macos'
+          qt-arch: 'clang_64'
+
+  build-macos-arm64:
+    name: macOS Companion (arm64)
+    runs-on: macos-15
+    needs: modules
+    if: inputs.target == 'all' || inputs.target == 'macos-arm64' || inputs.target == ''
+
+    env:
+      CMAKE_OSX_ARCHITECTURES: 'arm64'
+      CMAKE_OSX_DEPLOYMENT_TARGET: '11.0'
+
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v5
+        with:
+          submodules: recursive
+
+      - name: Download WASM modules
+        uses: actions/download-artifact@v7
+        with:
+          pattern: wasm-modules-*
+          path: wasm-modules
+          merge-multiple: true
+
+      - name: Setup and Build
+        uses: ./.github/actions/build_companion
+        with:
+          os: 'macos-arm64'
           qt-arch: 'clang_64'
 
   build-win64:


### PR DESCRIPTION
<!-- 
Please note that pull requests are NOT an appropriate way to
ask questions or for support, and will be closed. 

For feature requests or bug reports, please use the Issues tab.
For support, please use the Discussion tab or join us on Discord.

Feel free to delete any of the below which does not apply.
-->

Fixes # 
TODO

Summary of changes:


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new `macos-arm64` build option for the Companion workflow.
  * Introduced support for producing macOS Companion builds for Apple Silicon devices.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->