### PR TITLE
fix(radio): trims are actually controls rather than keys for backlight

### DIFF
--- a/radio/src/edgetx.cpp
+++ b/radio/src/edgetx.cpp
@@ -209,8 +209,13 @@ void per10ms()
   }
 #endif
 
-  if (keysPollingCycle()) {
+  uint8_t keyActivity = keysPollingCycle();
+  if (keyActivity & KEY_ACTIVITY_KEYS) {
     inactivityTimerReset(ActivitySource::Keys);
+  }
+  if (keyActivity & KEY_ACTIVITY_TRIMS) {
+    // Trims are controls, not keys, for backlight purposes
+    inactivityTimerReset(ActivitySource::MainControls);
   }
 
 #if defined(FUNCTION_SWITCHES)

--- a/radio/src/keys.cpp
+++ b/radio/src/keys.cpp
@@ -476,7 +476,7 @@ uint16_t keyMapping(uint16_t event)
   return event;
 }
 
-bool keysPollingCycle()
+uint8_t keysPollingCycle()
 {
   uint32_t trims_input;
   pollKeys();
@@ -508,7 +508,12 @@ bool keysPollingCycle()
     if (evt) pushTrimEvent(evt | i);
   }
 
-  return keys_input || trims_input;
+  // Report trims separately so they count as controls, not keys, for the
+  // backlight. Nav hats (USE_HATS_AS_KEYS) are folded into keys_input.
+  uint8_t activity = 0;
+  if (keys_input) activity |= KEY_ACTIVITY_KEYS;
+  if (trims_input) activity |= KEY_ACTIVITY_TRIMS;
+  return activity;
 }
 
 #if !defined(COLORLCD)

--- a/radio/src/keys.h
+++ b/radio/src/keys.h
@@ -183,7 +183,14 @@ void killTrimEvents(event_t event);
 bool keysGetState(uint8_t key);
 uint8_t keysGetTrimState(uint8_t trim);
 
-bool keysPollingCycle();
+// Activity flags returned by keysPollingCycle(). Trims are reported
+// separately so they can be treated as controls, not keys, for backlight.
+enum {
+  KEY_ACTIVITY_KEYS  = 0x01,
+  KEY_ACTIVITY_TRIMS = 0x02,
+};
+
+uint8_t keysPollingCycle();
 bool rotaryEncoderPollingCycle();
 
 #if defined(USE_HATS_AS_KEYS)


### PR DESCRIPTION
## Summary of changes:
Trims are now considered as controls rather than keys, which I think they should be

Fixes #7512

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inactivity detection by more accurately distinguishing between key/button activity and trim activity.
  * Trim activity is now treated as control activity, helping avoid entering inactivity sooner than expected.
  * When navigation controls and trims are used together, activity tracking is more reliable for keeping the device awake.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->