### PR TITLE
fix(cpn): recreate QAudioOutput per playback to fix silent preview on macOS

### DIFF
--- a/companion/src/modeledit/customfunctions.cpp
+++ b/companion/src/modeledit/customfunctions.cpp
@@ -31,7 +31,6 @@ CustomFunctionsPanel::CustomFunctionsPanel(QWidget * parent, ModelData * model, 
   functions(model ? model->customFn : generalSettings.customFn),
   mediaPlayerCurrent(-1),
   mediaPlayer(nullptr),
-  audioOutput(new QAudioOutput()),
   modelsUpdateCnt(0)
 {
   lock = true;
@@ -279,7 +278,7 @@ bool CustomFunctionsPanel::playSound(int index)
     stopSound(mediaPlayerCurrent);
 
   mediaPlayer = new QMediaPlayer(this);
-  mediaPlayer->setAudioOutput(audioOutput);
+  mediaPlayer->setAudioOutput(new QAudioOutput(mediaPlayer));
 
   if (functions[index].func == FuncPlaySound)
     mediaPlayer->setSource(QUrl(path.prepend("qrc")));

--- a/companion/src/modeledit/customfunctions.h
+++ b/companion/src/modeledit/customfunctions.h
@@ -110,7 +110,6 @@ class CustomFunctionsPanel : public GenericPanel
     QComboBox * fswtchRepeat[CPN_MAX_SPECIAL_FUNCTIONS];
     QComboBox * fswtchGVmode[CPN_MAX_SPECIAL_FUNCTIONS];
     QMediaPlayer * mediaPlayer;
-    QAudioOutput * audioOutput;
 
     int selectedIndex;
     int fswCapability;


### PR DESCRIPTION
Shared QAudioOutput was created once and reused across QMediaPlayer instances. On macOS/AVFoundation, deleteLater() leaves the old player alive long enough that the new player cannot claim the same audio output, so nothing plays. Fix by creating QAudioOutput as a child of each new QMediaPlayer so it is always fresh and auto-deleted with the player.

Also fixes a memory leak: the old audioOutput had no parent and was never deleted.

Fixes #7354

