### PR TITLE
fix(radio): reset statistics values on model change

### DIFF
--- a/radio/src/lua/interface.cpp
+++ b/radio/src/lua/interface.cpp
@@ -66,6 +66,7 @@ ScriptInputsOutputs scriptInputsOutputs[MAX_SCRIPTS];
 
 uint16_t maxLuaInterval = 0;
 uint16_t maxLuaDuration = 0;
+uint32_t lastLuaTime = 0;
 tmr10ms_t luaCycleStart;
 char lua_warning_info[LUA_WARNING_INFO_LEN+1];
 uint8_t errorState;

--- a/radio/src/lua/lua_api.h
+++ b/radio/src/lua/lua_api.h
@@ -208,6 +208,7 @@ extern struct our_longjmp * global_lj;
 
 extern uint16_t maxLuaInterval;
 extern uint16_t maxLuaDuration;
+extern uint32_t lastLuaTime;
 extern uint8_t instructionsPercent;
 #define LUA_TASK_PERIOD_TICKS                5   // 50 ms
 

--- a/radio/src/main.cpp
+++ b/radio/src/main.cpp
@@ -358,7 +358,6 @@ void guiMain(event_t evt)
 {
 #if defined(LUA)
   uint32_t t0 = get_tmr10ms();
-  static uint32_t lastLuaTime = 0;
   uint16_t interval = (lastLuaTime == 0 ? 0 : (t0 - lastLuaTime));
   lastLuaTime = t0;
   if (interval > maxLuaInterval) {
@@ -443,7 +442,6 @@ void guiMain(event_t evt)
 #if defined(LUA)
   // TODO better lua stopwatch
   uint32_t t0 = get_tmr10ms();
-  static uint32_t lastLuaTime = 0;
   uint16_t interval = (lastLuaTime == 0 ? 0 : (t0 - lastLuaTime));
   lastLuaTime = t0;
   if (interval > maxLuaInterval) {

--- a/radio/src/storage/storage_common.cpp
+++ b/radio/src/storage/storage_common.cpp
@@ -317,6 +317,14 @@ if(g_model.rssiSource) {
   LUA_LOAD_MODEL_SCRIPTS();
 
   SEND_FAILSAFE_1S();
+
+  // Reset debug stats for the newly loaded model (after checkAll() warnings)
+  maxMixerDuration = 0;
+#if defined(LUA)
+  maxLuaInterval = 0;
+  maxLuaDuration = 0;
+  lastLuaTime = 0;  // avoids counting the load time as one huge interval spike
+#endif
 }
 
 void storageFlushCurrentModel()


### PR DESCRIPTION
## Summary of changes:
Some of the values displayed on statistic debug screen were showing misleading values after model change, as they were still computed _during_ model change. 

This resets those value after model load so they are relevant to the current model only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved timing tracking during model loading so load-related delays no longer skew runtime measurements.
  * Reset Lua-related timing data after loading to avoid false spikes in performance stats.
  * Kept the app’s timing calculations consistent across screens by using a shared timing value.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->