### PR TITLE
fix(simulator): potential buffer overflow in SD manager

### DIFF
--- a/radio/src/gui/colorlcd/libui/file_browser.cpp
+++ b/radio/src/gui/colorlcd/libui/file_browser.cpp
@@ -155,8 +155,8 @@ const char* FileBrowser::getFullPath(const char* filename)
         full_path[i] = 0;
         break;
       }
-      if (full_path[0] == 0)
-        strcpy(full_path, ROOT_PATH);
+    if (full_path[0] == 0)
+      strcpy(full_path, ROOT_PATH);
   } else {
     if (full_path[strlen(full_path) - 1] != '/')
       strcat(full_path, "/");

--- a/radio/src/gui/colorlcd/libui/file_browser.cpp
+++ b/radio/src/gui/colorlcd/libui/file_browser.cpp
@@ -22,28 +22,13 @@
 #include "file_browser.h"
 #include "lib_file.h"
 #include "fonts.h"
+#include "sdcard.h"
 
 #include <list>
 #include <string>
 
 #define CELL_CTRL_DIR  LV_TABLE_CELL_CTRL_CUSTOM_1
 #define CELL_CTRL_FILE LV_TABLE_CELL_CTRL_CUSTOM_2
-
-static const char* getFullPath(const char* filename)
-{
-  static char full_path[FF_MAX_LFN + 1];
-  f_getcwd((TCHAR*)full_path, FF_MAX_LFN);
-  strcat(full_path, "/");
-  strcat(full_path, filename);
-  return full_path;
-}
-
-static const char* getCurrentPath()
-{
-  static char path[FF_MAX_LFN + 1];
-  f_getcwd((TCHAR*)path, FF_MAX_LFN);
-  return path;
-}
 
 static int strnatcasecmp(char const *s1, char const *s2)
 {
@@ -152,6 +137,35 @@ FileBrowser::FileBrowser(Window* parent, const rect_t& rect, const char* dir) :
   });
 }
 
+const char* FileBrowser::getCurrentPath()
+{
+  static char path[FF_MAX_LFN + 1];
+  f_getcwd((TCHAR*)path, FF_MAX_LFN);
+  return path;
+}
+
+const char* FileBrowser::getFullPath(const char* filename)
+{
+  static char full_path[FF_MAX_LFN + 1];
+  f_getcwd((TCHAR*)full_path, FF_MAX_LFN);
+
+  if (strcmp(filename, "..") == 0) {
+    for (int i = strlen(full_path) - 1; i >= 0; i -= 1)
+      if (full_path[i] == '/') {
+        full_path[i] = 0;
+        break;
+      }
+      if (full_path[0] == 0)
+        strcpy(full_path, ROOT_PATH);
+  } else {
+    if (full_path[strlen(full_path) - 1] != '/')
+      strcat(full_path, "/");
+    strcat(full_path, filename);
+  }
+
+  return full_path;
+}
+
 void FileBrowser::setFileAction(FileAction fct) { fileAction = std::move(fct); }
 void FileBrowser::setFileSelected(FileAction fct) { fileSelected = std::move(fct); }
 
@@ -244,15 +258,13 @@ void FileBrowser::onSelected(const char* name, bool is_dir)
     return;
   }
 
-  const char* path = getCurrentPath();
   const char* fullpath = getFullPath(name);  
-  if (fileSelected) fileSelected(path, name, fullpath, is_dir);
+  if (fileSelected) fileSelected(getCurrentPath(), name, fullpath, is_dir);
   selected = name;
 }
 
 void FileBrowser::onPress(const char* name, bool is_dir)
 {
-  const char* path = getCurrentPath();
   const char* fullpath = getFullPath(name);  
   if (is_dir) {
     f_chdir(fullpath);
@@ -268,13 +280,12 @@ void FileBrowser::onPress(const char* name, bool is_dir)
   }
   
   if (fileAction){
-    fileAction(path, name, fullpath, is_dir);
+    fileAction(getCurrentPath(), name, fullpath, is_dir);
   }
 }
 
 void FileBrowser::onPressLong(const char* name, bool is_dir)
 {
-  const char* path = getCurrentPath();
   const char* fullpath = getFullPath(name);  
 
   if (!selected || (selected != name)) {
@@ -282,6 +293,6 @@ void FileBrowser::onPressLong(const char* name, bool is_dir)
   }
   
   if (fileAction){
-    fileAction(path, name, fullpath, is_dir);
+    fileAction(getCurrentPath(), name, fullpath, is_dir);
   }
 }

--- a/radio/src/gui/colorlcd/libui/file_browser.h
+++ b/radio/src/gui/colorlcd/libui/file_browser.h
@@ -46,6 +46,9 @@ class FileBrowser : public TableField
   void onSelected(uint16_t row, uint16_t col) override;
   void onPress(uint16_t row, uint16_t col) override;
 
+  const char* getCurrentPath();
+  const char* getFullPath(const char* filename);
+
  protected:
   void onSelected(const char* name, bool is_dir);
   void onPress(const char* name, bool is_dir);

--- a/radio/src/gui/colorlcd/libui/file_browser.h
+++ b/radio/src/gui/colorlcd/libui/file_browser.h
@@ -46,13 +46,13 @@ class FileBrowser : public TableField
   void onSelected(uint16_t row, uint16_t col) override;
   void onPress(uint16_t row, uint16_t col) override;
 
-  const char* getCurrentPath();
-  const char* getFullPath(const char* filename);
-
  protected:
   void onSelected(const char* name, bool is_dir);
   void onPress(const char* name, bool is_dir);
   void onPressLong(const char* name, bool is_dir);
+
+  const char* getCurrentPath();
+  const char* getFullPath(const char* filename);
 
  private:
   const char* selected = nullptr;


### PR DESCRIPTION
When browsing the radio storage card in the SD manager the 'getFullPath' function may overflow the 'full_path' string in the simulator.

The 'f_chdir' function does not correctly handle '..' when passed as the filename so the current path continues to grow - e.g. after navigating a few folders it may look like //BACKUP/../SOUNDS/en/../../FIRMWARE. Eventually this will overflow the full_path buffer.

Seen in MacOS, not tested on Linux or Window. Does not happen on the radio; but the fix will work for all cases.

PR #7485 fixes the issue for 3.0.