### PR TITLE
feat(radio): delay SF initial audio announcements until LUA  is done loading

### DIFF
--- a/radio/src/functions.cpp
+++ b/radio/src/functions.cpp
@@ -137,8 +137,20 @@ bool isRepeatDelayElapsed(const CustomFunctionData * functions, CustomFunctionsC
   const CustomFunctionData * cfn = &functions[index];
   tmr10ms_t tmr10ms = get_tmr10ms();
   int8_t repeatParam = CFN_PLAY_REPEAT(cfn);
-  if (!IS_SILENCE_PERIOD_ELAPSED() && repeatParam == CFN_PLAY_REPEAT_NOSTART) {
-    functionsContext.lastFunctionTime[index] = tmr10ms;
+
+  // hold prompts during startup: silence window is the floor, extended while permanent Lua scripts load
+  bool startupBusy = !IS_SILENCE_PERIOD_ELAPSED();
+#if defined(LUA)
+  if (luaState >= INTERPRETER_RELOAD_PERMANENT_SCRIPTS && luaState < INTERPRETER_RUNNING)
+    startupBusy = true;
+#endif
+
+  if (startupBusy) {
+    if (repeatParam == CFN_PLAY_REPEAT_NOSTART) {
+      functionsContext.lastFunctionTime[index] = tmr10ms;  // '!1x': suppress at startup
+    } else {
+      return false;  // defer until startup settles, don't stamp
+    }
   }
   if (!functionsContext.lastFunctionTime[index] || (repeatParam && repeatParam!=CFN_PLAY_REPEAT_NOSTART && (signed)(tmr10ms-functionsContext.lastFunctionTime[index])>=100*repeatParam)) {
     functionsContext.lastFunctionTime[index] = tmr10ms;


### PR DESCRIPTION
##  Summary of changes:

On some busy models, some users have reported sometime glitches in SF start announcements. This changes prevents doing those announcement while LUA is still loading stuff, to ease the pressure on ressources.

PS: I didn't have a setup where I could reliably test this, so while I tested when things work, I'm not 100% certain it will address the initial issue

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repeat-delay handling during startup so scripts no longer trigger prematurely while permanent scripts are reloading.
  * Repeat actions now wait until startup activity finishes, helping avoid unexpected early playback or duplicate firings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->