### PR TITLE
fix(radio): T22 and T15Pro mute/unmute delay

### DIFF
--- a/radio/src/targets/t15pro/hal.h
+++ b/radio/src/targets/t15pro/hal.h
@@ -308,6 +308,8 @@ USART6: EXTMODULE_USART
 
 // Audio
 #define AUDIO_MUTE_GPIO                GPIO_PIN(GPIOH, 4)
+#define AUDIO_MUTE_DELAY               200  // ms
+#define AUDIO_UNMUTE_DELAY             100  // ms
 #define AUDIO_OUTPUT_GPIO              GPIO_PIN(GPIOA, 4)
 #define AUDIO_DAC                      DAC1
 #define AUDIO_DMA_Stream               LL_DMA_STREAM_1

--- a/radio/src/targets/t22/hal.h
+++ b/radio/src/targets/t22/hal.h
@@ -153,6 +153,8 @@ TIM17:	  ROTARY_ENCODER_TIMER
 
 // Audio
 #define AUDIO_MUTE_GPIO                GPIO_PIN(GPIOH, 4)
+#define AUDIO_MUTE_DELAY               200  // ms
+#define AUDIO_UNMUTE_DELAY             100  // ms
 #define AUDIO_OUTPUT_GPIO              GPIO_PIN(GPIOA, 4)
 #define AUDIO_DAC                      DAC1
 #define AUDIO_DMA_Stream               LL_DMA_STREAM_1


### PR DESCRIPTION
## Summary of changes:

_Someone_ forgot to set mute and unmute delay for those radio ....

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable audio mute and unmute timing values for supported radio targets.
  * Audio transitions now have defined delays to help smooth muting behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->