### PR TITLE
fix(hwgen): prevent prefix collisions when resolving source names

### DIFF
--- a/radio/src/analogs.cpp
+++ b/radio/src/analogs.cpp
@@ -56,7 +56,8 @@ static int _lookup_input_idx(uint8_t type, const char* name, size_t len,
   if (!max_inputs) return -1;
 
   for (uint8_t i = 0; i < max_inputs; i++) {
-    if (!strncmp(fct(type, i), name, len)) return i;
+    const char* input_name = fct(type, i);
+    if (strlen(input_name) == len && !strncmp(input_name, name, len)) return i;
   }
 
   return -1;

--- a/radio/src/hal/adc_driver.cpp
+++ b/radio/src/hal/adc_driver.cpp
@@ -549,7 +549,8 @@ int adcGetInputIdx(const char* input, uint8_t len)
 
   do {
     for (uint8_t i = 0; i < _hal_adc_inputs[type].n_inputs; i++, idx++) {
-      if (!strncmp(_hal_adc_inputs[type].inputs[i].name, input, len))
+      const char* input_name = _hal_adc_inputs[type].inputs[i].name;
+      if (strlen(input_name) == len && !strncmp(input_name, input, len))
         return idx;
     }
   } while (++type < ADC_INPUT_ALL);

--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -308,7 +308,7 @@ int switchLookupIdx(const char* name, size_t len)
   auto max_switches = switchGetMaxAllSwitches();
   for (int i = 0; i < max_switches; i++) {
     const char *sw_name = switchGetDefaultName(i);
-    if (strncmp(sw_name, name, len) == 0) return i;
+    if (strlen(sw_name) == len && strncmp(sw_name, name, len) == 0) return i;
   }
 
   return -1;


### PR DESCRIPTION
The _lookup_input_idx, switchLookupIdx, and adcGetInputIdx functions used strncmp for prefix-only matching, causing SL (switch) to match SL1 (slider) before switch lookup. Fix by requiring exact length match via strlen check to prevent prefix collisions between analog input names and switch names.

Closes: mixer source changing from SL to S3 after power cycle on T22