### PR TITLE
fix(color): radio and model settings button layout may be misaligned

### DIFF
--- a/radio/src/gui/colorlcd/libui/window.cpp
+++ b/radio/src/gui/colorlcd/libui/window.cpp
@@ -671,14 +671,14 @@ class SetupTextButton : public TextButton
 };
 
 SetupButtonGroup::SetupButtonGroup(Window* parent, const rect_t& rect, int cols,
-                                   PaddingSize padding, const PageButtonDef* pages, coord_t btnHeight) :
+                                   const PageButtonDef* pages, coord_t btnHeight) :
     Window(parent, rect)
 {
-  padAll(padding);
+  padAll(PAD_OUTLINE);
   setFlexLayout(LV_FLEX_FLOW_ROW_WRAP, PAD_SMALL);
   lv_obj_set_flex_align(lvobj, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_SPACE_EVENLY);
 
-  coord_t buttonWidth = (width() - PAD_SMALL * (cols + 1) - PAD_TINY * 2) / cols;
+  coord_t buttonWidth = (width() - PAD_SMALL * (cols + 1) - PAD_OUTLINE * 2) / cols;
 
   for (int p = 0; pages[p].title; p += 1) {
     new SetupTextButton(this, {0, 0, buttonWidth, btnHeight}, pages[p]);

--- a/radio/src/gui/colorlcd/libui/window.cpp
+++ b/radio/src/gui/colorlcd/libui/window.cpp
@@ -670,45 +670,18 @@ class SetupTextButton : public TextButton
  protected:
 };
 
-SetupButtonGroup::SetupButtonGroup(Window* parent, const rect_t& rect, const char* title, int cols,
+SetupButtonGroup::SetupButtonGroup(Window* parent, const rect_t& rect, int cols,
                                    PaddingSize padding, const PageButtonDef* pages, coord_t btnHeight) :
     Window(parent, rect)
 {
   padAll(padding);
+  setFlexLayout(LV_FLEX_FLOW_ROW_WRAP, PAD_SMALL);
+  lv_obj_set_flex_align(lvobj, LV_FLEX_ALIGN_CENTER, LV_FLEX_ALIGN_SPACE_EVENLY, LV_FLEX_ALIGN_SPACE_EVENLY);
 
   coord_t buttonWidth = (width() - PAD_SMALL * (cols + 1) - PAD_TINY * 2) / cols;
 
-  int size = 0;
-  for (; pages[size].title; size += 1);
-
-  int rows = (size + cols - 1) / cols;
-  int height = rows * btnHeight + (rows - 1) * PAD_MEDIUM + PAD_TINY * 2;
-  if (title) {
-    height += EdgeTxStyles::STD_FONT_HEIGHT + PAD_TINY;
-  }
-  setHeight(height);
-
-  if (title)
-    new Subtitle(this, title);
-
-  int n = 0;
-  int remaining = size;
-  coord_t yo = title ? EdgeTxStyles::STD_FONT_HEIGHT + PAD_TINY : 0;
-  coord_t xw = buttonWidth + PAD_SMALL;
-  coord_t xo = (width() - (cols * xw - PAD_SMALL)) / 2;
-  coord_t x, y;
-  for (int p = 0; p < size; p += 1) {
-    if (remaining < cols && (n % cols == 0)) {
-      coord_t space = ((cols - remaining) * xw) / (remaining + 1);
-      xw += space;
-      xo += space;
-    }
-    x = xo + (n % cols) * xw;
-    y = yo + (n / cols) * (btnHeight + PAD_MEDIUM);
-
-    new SetupTextButton(this, {x, y, buttonWidth, btnHeight}, pages[p]);
-    n += 1;
-    remaining -= 1;
+  for (int p = 0; pages[p].title; p += 1) {
+    new SetupTextButton(this, {0, 0, buttonWidth, btnHeight}, pages[p]);
   }
 }
 

--- a/radio/src/gui/colorlcd/libui/window.h
+++ b/radio/src/gui/colorlcd/libui/window.h
@@ -268,7 +268,7 @@ class SetupButtonGroup : public Window
 {
  public:
   SetupButtonGroup(Window* parent, const rect_t& rect, int cols,
-                   PaddingSize padding, const PageButtonDef* pages, coord_t btnHeight = EdgeTxStyles::UI_ELEMENT_HEIGHT);
+                   const PageButtonDef* pages, coord_t btnHeight = EdgeTxStyles::UI_ELEMENT_HEIGHT);
 
  protected:
 };

--- a/radio/src/gui/colorlcd/libui/window.h
+++ b/radio/src/gui/colorlcd/libui/window.h
@@ -267,7 +267,7 @@ struct PageButtonDef {
 class SetupButtonGroup : public Window
 {
  public:
-  SetupButtonGroup(Window* parent, const rect_t& rect, const char* title, int cols,
+  SetupButtonGroup(Window* parent, const rect_t& rect, int cols,
                    PaddingSize padding, const PageButtonDef* pages, coord_t btnHeight = EdgeTxStyles::UI_ELEMENT_HEIGHT);
 
  protected:

--- a/radio/src/gui/colorlcd/model/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model/model_setup.cpp
@@ -483,7 +483,9 @@ const static PageButtonDef modelSetupButtons[] = {
 
 void ModelSetupPage::build(Window * window)
 {
+  window->padBottom(PAD_LARGE);
+
   coord_t y = SetupLine::showLines(window, 0, SubPage::EDT_X, padding, setupLines);
 
-  new SetupButtonGroup(window, {0, y, LCD_W - padding * 2, 0}, nullptr, BTN_COLS, PAD_TINY, modelSetupButtons, BTN_H);
+  new SetupButtonGroup(window, {0, y, LCD_W - padding * 2, 0}, BTN_COLS, PAD_TINY, modelSetupButtons, BTN_H);
 }

--- a/radio/src/gui/colorlcd/model/model_setup.cpp
+++ b/radio/src/gui/colorlcd/model/model_setup.cpp
@@ -487,5 +487,5 @@ void ModelSetupPage::build(Window * window)
 
   coord_t y = SetupLine::showLines(window, 0, SubPage::EDT_X, padding, setupLines);
 
-  new SetupButtonGroup(window, {0, y, LCD_W - padding * 2, 0}, BTN_COLS, PAD_TINY, modelSetupButtons, BTN_H);
+  new SetupButtonGroup(window, {0, y, LCD_W - padding * 2, 0}, BTN_COLS, modelSetupButtons, BTN_H);
 }

--- a/radio/src/gui/colorlcd/radio/radio_hardware.cpp
+++ b/radio/src/gui/colorlcd/radio/radio_hardware.cpp
@@ -185,6 +185,7 @@ const static PageButtonDef debugButtons[] = {
 void RadioHardwarePage::build(Window* window)
 {
   window->setFlexLayout(LV_FLEX_FLOW_COLUMN, PAD_TINY);
+  window->padBottom(PAD_LARGE);
 
   SetupLine::showLines(window, 0, SubPage::EDT_X, padding, setupLines);
 
@@ -209,8 +210,10 @@ void RadioHardwarePage::build(Window* window)
   new SerialConfigWindow(window, grid);
 
   // Calibration
-  new SetupButtonGroup(window, {0, 0, LCD_W - padding * 2, 0}, STR_INPUTS, BTN_COLS, PAD_ZERO, calibrationButtons);
+  new Subtitle(window, STR_INPUTS);
+  new SetupButtonGroup(window, {0, 0, LCD_W - padding * 2, 0}, BTN_COLS, PAD_ZERO, calibrationButtons);
 
   // Debugs
-  new SetupButtonGroup(window, {0, 0, LCD_W - padding * 2, 0}, STR_DEBUG, FS_BTN_COLS, PAD_ZERO, debugButtons);
+  new Subtitle(window, STR_DEBUG);
+  new SetupButtonGroup(window, {0, 0, LCD_W - padding * 2, 0}, FS_BTN_COLS, PAD_ZERO, debugButtons);
 }

--- a/radio/src/gui/colorlcd/radio/radio_hardware.cpp
+++ b/radio/src/gui/colorlcd/radio/radio_hardware.cpp
@@ -211,9 +211,9 @@ void RadioHardwarePage::build(Window* window)
 
   // Calibration
   new Subtitle(window, STR_INPUTS);
-  new SetupButtonGroup(window, {0, 0, LCD_W - padding * 2, 0}, BTN_COLS, PAD_ZERO, calibrationButtons);
+  new SetupButtonGroup(window, {0, 0, LCD_W - padding * 2, 0}, BTN_COLS, calibrationButtons);
 
   // Debugs
   new Subtitle(window, STR_DEBUG);
-  new SetupButtonGroup(window, {0, 0, LCD_W - padding * 2, 0}, FS_BTN_COLS, PAD_ZERO, debugButtons);
+  new SetupButtonGroup(window, {0, 0, LCD_W - padding * 2, 0}, FS_BTN_COLS, debugButtons);
 }

--- a/radio/src/gui/colorlcd/radio/radio_setup.cpp
+++ b/radio/src/gui/colorlcd/radio/radio_setup.cpp
@@ -1075,7 +1075,7 @@ void RadioSetupPage::build(Window* window)
   new DateTimeWindow(window, {0, 0, LCD_W - padding * 2, EdgeTxStyles::UI_ELEMENT_HEIGHT * 2 + PAD_TINY * 2 + PAD_MEDIUM});
 
   // Sub-pages
-  new SetupButtonGroup(window, {0, 0, LCD_W - padding * 2, 0}, BTN_COLS, PAD_TINY, radioSetupButtons, BTN_H);
+  new SetupButtonGroup(window, {0, 0, LCD_W - padding * 2, 0}, BTN_COLS, radioSetupButtons, BTN_H);
 
   SetupLine::showLines(window, 0, SubPage::EDT_X, padding, setupLines);
 }

--- a/radio/src/gui/colorlcd/radio/radio_setup.cpp
+++ b/radio/src/gui/colorlcd/radio/radio_setup.cpp
@@ -1068,16 +1068,14 @@ const static PageButtonDef radioSetupButtons[] = {
 
 void RadioSetupPage::build(Window* window)
 {
-  coord_t y = 0;
-  Window * w;
+  window->setFlexLayout(LV_FLEX_FLOW_COLUMN, padding);
+  window->padBottom(PAD_LARGE);
 
   // Date & time picker including labels
-  w = new DateTimeWindow(window, {0, y, LCD_W - padding * 2, EdgeTxStyles::UI_ELEMENT_HEIGHT * 2 + PAD_TINY * 2 + PAD_MEDIUM});
-  y += w->height() + padding;
+  new DateTimeWindow(window, {0, 0, LCD_W - padding * 2, EdgeTxStyles::UI_ELEMENT_HEIGHT * 2 + PAD_TINY * 2 + PAD_MEDIUM});
 
   // Sub-pages
-  w = new SetupButtonGroup(window, {0, y, LCD_W - padding * 2, 0}, nullptr, BTN_COLS, PAD_TINY, radioSetupButtons, BTN_H);
-  y += w->height() + padding;
+  new SetupButtonGroup(window, {0, 0, LCD_W - padding * 2, 0}, BTN_COLS, PAD_TINY, radioSetupButtons, BTN_H);
 
-  SetupLine::showLines(window, y, SubPage::EDT_X, padding, setupLines);
+  SetupLine::showLines(window, 0, SubPage::EDT_X, padding, setupLines);
 }


### PR DESCRIPTION
Change the button layout class to use a flex layout to automatically adjust when buttons are hidden.

Can be seen on ST16 where there are no key shortcuts to override, the radio settings page has a gap where the key shortcuts button would be.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes / UI Improvements**
  * Improved setup screen layout for more consistent alignment and better space usage across buttons and sections.
  * Added extra bottom padding on multiple pages to reduce crowding and improve readability.
  * Updated setup pages so the correct button groups display in the intended areas (model setup, inputs/calibration, and debug).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->