### PR TITLE
fix(switch_hw_adc): adjust ADC thresholds for equal 1/3 partitions in switch driver

### DIFF
--- a/radio/src/targets/common/arm/stm32/stm32_switch_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_switch_driver.cpp
@@ -45,9 +45,9 @@ SwitchHwPos stm32_switch_get_position(const stm32_switch_t* sw)
 
     case SWITCH_HW_ADC: {
       uint16_t value = getAnalogValue(sw->Pin_high);
-      if (value > 3 * 1024)
+      if (value > ADC_MAX_VALUE*2/3)
         ret = SWITCH_HW_DOWN;
-      else if (value >= 1024)
+      else if (value >= ADC_MAX_VALUE/3)
         ret = SWITCH_HW_MID;
     } break;
   }


### PR DESCRIPTION
Some users have reported that, with a very low probability, the three-position switch may accidentally trigger the middle position when it is at either the high or low position.

## Affects

- NV14 / EL18
- PL18 / PL18EV / PL18U / PA01 / NB4P
- ST16
- V12 / V14

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved switch position detection for ADC-based hardware by using relative thresholds instead of fixed raw values.
  * This should make position mapping more consistent across ADC ranges while preserving existing behavior and inversion handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->