### PR TITLE
fix(color): memory leak when creating a blank model

### DIFF
--- a/radio/src/edgetx.cpp
+++ b/radio/src/edgetx.cpp
@@ -1598,7 +1598,6 @@ void edgeTxInit()
 #endif // defined(GUI)
 
 #if defined(COLORLCD)
-    LayoutFactory::deleteCustomScreens();
     LayoutFactory::loadCustomScreens();
 #endif
 

--- a/radio/src/gui/colorlcd/mainview/layout.cpp
+++ b/radio/src/gui/colorlcd/mainview/layout.cpp
@@ -149,6 +149,9 @@ void LayoutFactory::loadDefaultLayout()
 //
 void LayoutFactory::loadCustomScreens()
 {
+  // Delete old screens
+  deleteCustomScreens();
+
   unsigned i = 0;
   auto viewMain = ViewMain::instance();
 

--- a/radio/src/gui/colorlcd/mainview/screen_setup.cpp
+++ b/radio/src/gui/colorlcd/mainview/screen_setup.cpp
@@ -199,10 +199,7 @@ void ScreenSetupPage::build(Window* window)
           // Remove this screen from the model
           g_model.removeScreenLayout(customScreenIndex);
 
-          // Delete all custom screens
-          LayoutFactory::deleteCustomScreens();
-
-          // ... and reload
+          // Delete and reload custom screens
           LayoutFactory::loadCustomScreens();
 
           // adjust index if last screen deleted

--- a/radio/src/gui/colorlcd/model/model_select.cpp
+++ b/radio/src/gui/colorlcd/model/model_select.cpp
@@ -642,6 +642,8 @@ void ModelLabelsWindow::newModel()
         luaExecStandalone(path);
       }
 #endif
+    } else {
+      LayoutFactory::loadDefaultLayout();
     }
 
     // Main view layout

--- a/radio/src/gui/colorlcd/radio/hw_inputs.cpp
+++ b/radio/src/gui/colorlcd/radio/hw_inputs.cpp
@@ -127,10 +127,8 @@ HWPots::HWPots(Window* parent) :
   potsChanged = false;
 
   setCloseHandler([=]() {
-    if (potsChanged) {
-      LayoutFactory::deleteCustomScreens();
+    if (potsChanged)
       LayoutFactory::loadCustomScreens();
-    }
   });
 
   new StaticText(this, {P_NM_X, -PAD_TINY, 0, 0}, STR_NAME, COLOR_THEME_PRIMARY1_INDEX, FONT(XS));

--- a/radio/src/model_init.cpp
+++ b/radio/src/model_init.cpp
@@ -151,7 +151,6 @@ void applyDefaultTemplate()
   g_model.resetScreenData();
   LayoutFactory::deleteCustomScreens();
   LayoutFactory::deleteTopBarWidgets();
-  LayoutFactory::loadDefaultLayout();
 #endif
 
   // enable switch warnings

--- a/radio/src/storage/sdcard_common.cpp
+++ b/radio/src/storage/sdcard_common.cpp
@@ -44,7 +44,22 @@ void getModelPath(char * path, const char * filename, const char* pathName)
   strcpy(&path[len + 1], filename);
 }
 
-void storageEraseAll(bool warn)
+static void forceSave()
+{
+  storageDirty(EE_GENERAL);
+  storageDirty(EE_MODEL);
+  storageCheck(true);
+}
+
+static void storageFormat()
+{
+  sdCheckAndCreateDirectory(RADIO_PATH);
+  sdCheckAndCreateDirectory(MODELS_PATH);
+  generalDefault();
+  setModelDefaults();
+}
+
+static void storageEraseAll()
 {
   TRACE("storageEraseAll");
 
@@ -60,24 +75,11 @@ void storageEraseAll(bool warn)
   g_eeGeneral.blOffBright = 20;
 #endif
 
-  if (warn) {
-    ALERT(STR_STORAGE_WARNING, STR_BAD_RADIO_DATA, AU_BAD_RADIODATA);
-  }
-
+  ALERT(STR_STORAGE_WARNING, STR_BAD_RADIO_DATA, AU_BAD_RADIODATA);
   RAISE_ALERT(STR_STORAGE_WARNING, STR_STORAGE_FORMAT, STR_PRESS_ANY_KEY_TO_SKIP, AU_NONE);
 
   storageFormat();
-  storageDirty(EE_GENERAL);
-  storageDirty(EE_MODEL);
-  storageCheck(true);
-}
-
-void storageFormat()
-{
-  sdCheckAndCreateDirectory(RADIO_PATH);
-  sdCheckAndCreateDirectory(MODELS_PATH);
-  generalDefault();
-  setModelDefaults();
+  forceSave();
 }
 
 void storageCheck(bool immediately)
@@ -166,10 +168,7 @@ const char * createModel()
   if (index > 0) {
     setModelDefaults(index);
     memcpy(g_eeGeneral.currModelFilename, filename, sizeof(g_eeGeneral.currModelFilename));
-
-    storageDirty(EE_GENERAL);
-    storageDirty(EE_MODEL);
-    storageCheck(true);
+    forceSave();
   }
 
   postModelLoad(false);
@@ -222,12 +221,10 @@ void storageReadAll()
       simuCreateDefaultSettings = false;
       storageFormat();
       g_eeGeneral.chkSum = evalChkSum();
-      storageDirty(EE_GENERAL);
-      storageDirty(EE_MODEL);
-      storageCheck(true);
+      forceSave();
     } else
 #endif
-    storageEraseAll(true);
+    storageEraseAll();
   }
 #if !defined(STORAGE_MODELSLIST)
   else {

--- a/radio/src/storage/storage.h
+++ b/radio/src/storage/storage.h
@@ -47,8 +47,6 @@ extern tmr10ms_t rambackupDirtyTime10ms;
 //
 // Generic storage interface
 //
-void storageEraseAll(bool warn);
-void storageFormat();
 void storageReadAll();
 void storageCheck(bool immediately);
 


### PR DESCRIPTION
When creating a blank model an extra view screen is created.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved custom-screen lifecycle: screens reload more consistently during startup and after removing/updating screens, avoiding stale or lingering layouts.
  * Fixed model/template initialization so the default UI layout reliably loads when an empty template name is used.
  * Improved SD storage reset/format flow (including first-run behavior) so the full reset and save sequence completes consistently, reducing partial or inconsistent restores.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->