### PR TITLE
fix(t22): use PB15 and PJ12 for red LED due to USART1_RX DFU overlap

### DIFF
--- a/radio/src/boards/generic_stm32/led_driver.cpp
+++ b/radio/src/boards/generic_stm32/led_driver.cpp
@@ -52,6 +52,10 @@ __weak void ledInit()
   gpio_init(LED_RED_GPIO, GPIO_OUT, GPIO_PIN_SPEED_LOW);
 #endif
 
+#if defined(LED_RED2_GPIO)
+  gpio_init(LED_RED2_GPIO, GPIO_OUT, GPIO_PIN_SPEED_LOW);
+#endif
+
 #if defined(LED_BLUE_GPIO)
   gpio_init(LED_BLUE_GPIO, GPIO_OUT, GPIO_PIN_SPEED_LOW);
 #endif
@@ -100,6 +104,9 @@ __weak void ledOff()
 #if defined(LED_RED_GPIO)
   GPIO_LED_GPIO_OFF(LED_RED_GPIO);
 #endif
+#if defined(LED_RED2_GPIO)
+  GPIO_LED_GPIO_OFF(LED_RED2_GPIO);
+#endif
 #if defined(LED_BLUE_GPIO)
   GPIO_LED_GPIO_OFF(LED_BLUE_GPIO);
 #endif
@@ -113,6 +120,9 @@ __weak void ledRed()
   ledOff();
 #if defined(LED_RED_GPIO)
   GPIO_LED_GPIO_ON(LED_RED_GPIO);
+#endif
+#if defined(LED_RED2_GPIO)
+  GPIO_LED_GPIO_ON(LED_RED2_GPIO);
 #endif
 }
 

--- a/radio/src/targets/t22/hal.h
+++ b/radio/src/targets/t22/hal.h
@@ -218,6 +218,7 @@ TIM17:	  ROTARY_ENCODER_TIMER
 #define GPIO_LED_GPIO_ON                  gpio_set
 #define GPIO_LED_GPIO_OFF                 gpio_clear
 #define LED_RED_GPIO                      GPIO_PIN(GPIOB, 15)
+#define LED_RED2_GPIO                     GPIO_PIN(GPIOJ, 12)
 #define LED_GREEN_GPIO                    GPIO_PIN(GPIOB, 13)
 #define LED_BLUE_GPIO                     GPIO_PIN(GPIOB, 12)
 


### PR DESCRIPTION
Fixes #7534 (or at least support the required hardware change, technical details in the issue itself)

## Summary of changes:
To fix an issue of buddy been unable to flash T22, there needs to be an hardware change. Red led pin will be moved from the troublemaking PB15 in current T22 boards to PJ12 in future boards.

This software change supports the red led operation for both old and new boards (old still remains non buddy flashable)