### PR TITLE
fix(cpn): compilation breakage due to #7438 

### DIFF
--- a/companion/src/firmwares/radiodata.cpp
+++ b/companion/src/firmwares/radiodata.cpp
@@ -366,7 +366,7 @@ QStringList RadioData::modelErrorsList()
   for(auto &model: models) {
     if (!model.isValid()) {
       ret.append("");
-      ret.append(model.name);
+      ret.append(model.name.toQString());
       ret.append(model.errorsList());
     }
   }

--- a/companion/src/print/modelprinter.cpp
+++ b/companion/src/print/modelprinter.cpp
@@ -62,9 +62,12 @@ QString formatTitle(const QString & name)
 void debugHtml(const QString & html)
 {
   QFile file("foo.html");
-  file.open(QIODevice::Truncate | QIODevice::WriteOnly);
-  file.write(html.toUtf8());
-  file.close();
+  if (file.open(QIODevice::Truncate | QIODevice::WriteOnly)) {
+    file.write(html.toUtf8());
+    file.close();
+  } else {
+    // TODO: error handling
+  }
 }
 
 QString addFont(const QString & input, const QString & color, const QString & size, const QString & face)

--- a/companion/src/shared/autobitmappedcombobox.h
+++ b/companion/src/shared/autobitmappedcombobox.h
@@ -41,7 +41,7 @@ class AutoBitMappedComboBox : public QComboBox, public AutoWidget
     virtual void insertItems(int index, const QStringList & items);
     // AutoWidget
     virtual void updateValue() override;
-    virtual void setAutoModel(QAbstractItemModel * model);
+    void setAutoModel(QAbstractItemModel * model) override;
     void setBindText(std::function<QString()> fn) = delete;
 
     void clear();

--- a/companion/src/shared/autocombobox.h
+++ b/companion/src/shared/autocombobox.h
@@ -49,7 +49,7 @@ class AutoComboBox : public QComboBox, public AutoWidget
     virtual void insertItems(int index, const QStringList & items);
     // AutoWidget
     virtual void updateValue() override;
-    virtual void setAutoModel(QAbstractItemModel * model);
+    void setAutoModel(QAbstractItemModel * model) override;
     void setBindText(std::function<QString()> fn) = delete;
 
     void clear();

--- a/companion/src/storage/appdata.cpp
+++ b/companion/src/storage/appdata.cpp
@@ -563,11 +563,6 @@ void AppData::loadNamedJS()
   }
 }
 
-static QString fmtHex(quint32 num)
-{
-  return QString::number(num, 16).toUpper();
-}
-
 void AppData::init()
 {
   qInfo().noquote() << "Settings init with" << m_settings.organizationName() << m_settings.applicationName()

--- a/companion/src/storage/firmwareinterface.cpp
+++ b/companion/src/storage/firmwareinterface.cpp
@@ -178,9 +178,12 @@ FirmwareInterface::FirmwareInterface(const QString &filename, QDialog *parent) :
   if (filename.isEmpty()) return;
 
   QFile file(filename);
-  file.open(QIODevice::ReadOnly);
-  initFlash(file.readAll());
-  file.close();
+  if (file.open(QIODevice::ReadOnly)) {
+    initFlash(file.readAll());
+    file.close();
+  } else {
+    // TODO: error handling
+  }
 }
 
 FirmwareInterface::FirmwareInterface(const QByteArray &flashData, QDialog *parent) :

--- a/companion/src/storage/labeled.cpp
+++ b/companion/src/storage/labeled.cpp
@@ -324,7 +324,7 @@ bool LabelsStorageFormat::write(RadioData & radioData)
 
     QByteArray modelData;
     if (!writeModelToYaml(model, modelData)) {
-      fatalMsg(tr("Error converting model to yaml: %1").arg(model.name));
+      fatalMsg(tr("Error converting model to yaml: %1").arg(model.name.toQString()));
       return false;
     }
 
@@ -344,7 +344,7 @@ bool LabelsStorageFormat::write(RadioData & radioData)
     if (!writeChecklist(model))
       return false;
 
-    statusMsg(tr("Model written: %1").arg(model.name));
+    statusMsg(tr("Model written: %1").arg(model.name.toQString()));
     progressSetValue(++steps);
   }
 


### PR DESCRIPTION
Broken in #7438 

Fix build.
Fix compile warnings.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of model names in validation and storage messages.
  * Added checks for file-opening failures when reading firmware data or writing debug output.
  * Prevented processing when required files cannot be opened.

* **Refactor**
  * Improved compile-time validation for automated combo box behavior.
  * Removed unused internal formatting code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->