### PR TITLE
fix(color): popup menu may not auto scroll to selected item

### DIFF
--- a/radio/src/gui/colorlcd/libui/menu.cpp
+++ b/radio/src/gui/colorlcd/libui/menu.cpp
@@ -293,7 +293,6 @@ class MenuWindowContent : public NavWindow
       NavWindow(parent, rect_t{}, menu_content_create)
   {
     setWindowFlag(OPAQUE);
-    lv_obj_set_style_max_height(lvobj, LCD_H - PAD_LARGE * 2, LV_PART_MAIN);
 
     coord_t w = (popupWidth > 0) ? popupWidth : MENUS_WIDTH;
 
@@ -307,6 +306,7 @@ class MenuWindowContent : public NavWindow
     header->hide();
 
     body = new MenuBody(this, rect_t{0, 0, w, LV_SIZE_CONTENT});
+    lv_obj_set_style_max_height(body->getLvObj(), LCD_H - EdgeTxStyles::STD_FONT_HEIGHT - PAD_SMALL * 2 - PAD_LARGE * 2, LV_PART_MAIN);
   }
 
   virtual void setTitle(const std::string& text)


### PR DESCRIPTION
PR #7511 broke then menu auto scroll when selecting switches/pots/axis/etc and moving a control to select it.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved menu window sizing on color displays.
  * Adjusted the menu body’s height limit to account for font and surrounding spacing, helping ensure content fits more consistently within the available screen area.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->