### PR TITLE
fix(color): quick menu may not highlight last selected menu icon

### DIFF
--- a/radio/src/gui/colorlcd/setup_menus/quick_menu.cpp
+++ b/radio/src/gui/colorlcd/setup_menus/quick_menu.cpp
@@ -353,8 +353,12 @@ void QuickMenu::openQM(PageGroupBase* newPageGroup, QMPage newCurPage)
       setFocus(curPage);
     } else {
 #if VERSION_MAJOR > 2
-      if (curPage == QM_MANAGE_MODELS)
-        mainMenu->setCurrent(favoritesMenuItems[0].icon == EDGETX_ICONS_COUNT ? 0 : 1);
+      for (int i = 0; qmTopItems[i].icon != EDGETX_ICONS_COUNT; i += 1) {
+        if (qmTopItems[i].qmPage == curPage && qmTopItems[i].pageAction == QM_ACTION) {
+          mainMenu->setCurrent(i);
+          break;
+        }
+      }
 #endif
       focusMainMenu();
     }


### PR DESCRIPTION
After opening and closing the 'Manage Models' page via key shortcut, opening the quick menu does not highlight 'Manage Models' as the last selected menu option.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Quick Menu navigation when managing models.
  * The menu now opens on the entry matching the current page, providing more consistent navigation across different menu configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->