### PR TITLE
fix(build): yaml definition file create fails

### DIFF
--- a/radio/src/storage/yaml/CMakeLists.txt
+++ b/radio/src/storage/yaml/CMakeLists.txt
@@ -101,3 +101,5 @@ add_custom_target(yaml_data
             ${RADIO_DIRECTORY}/src/myeeprom.h
             ${RADIO_DIRECTORY}/util/generate_yaml.py
 )
+
+add_dependencies(yaml_data hal_settings)


### PR DESCRIPTION
Add dependency for creation of yaml definition files.
Missed in #7411 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved build reliability by ensuring YAML data generation waits for required hardware settings to be available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->