### PR TITLE
fix(tx16s): execute USB/SD interrupt-path code from RAM (USB->DFU crash on some MK1 units)

### DIFF
--- a/radio/src/boards/generic_stm32/linker/definitions.ld
+++ b/radio/src/boards/generic_stm32/linker/definitions.ld
@@ -11,3 +11,9 @@ _main_stack_start = _estack - MAIN_STACK_SIZE;
 
 /* Higest heap address */
 _heap_end = HEAP_ADDRESS;
+
+/* Fastcode defaults for scripts that do not define the section
+   (bootloader): the startup copy loop becomes a no-op */
+PROVIDE(_sfastcode = 0);
+PROVIDE(_efastcode = 0);
+PROVIDE(_fastcode_load = 0);

--- a/radio/src/boards/generic_stm32/linker/firmware.ld
+++ b/radio/src/boards/generic_stm32/linker/firmware.ld
@@ -33,6 +33,31 @@ SECTIONS
 
   _isr_load = LOADADDR(.isr_vector);
 
+  /* Hot interrupt-path code (USB device stack, MSC storage glue, SDIO
+     diskio) executed from RAM: on some TX16S units, instruction
+     fetches from the upper flash bank get corrupted under heavy
+     IRQ/DMA load (USB crash, EdgeTX#5899); claimed before .text so
+     these input sections land here. Requires non-LTO objects. */
+  .fastcode :
+  {
+    . = ALIGN(4);
+    _sfastcode = .;
+    *ll_usb*(.text .text.*)
+    *hal_pcd*(.text .text.*)
+    *usb_driver*(.text .text.*)
+    *usbd_conf*(.text .text.*)
+    *usbd_core*(.text .text.*)
+    *usbd_ioreq*(.text .text.*)
+    *usbd_ctlreq*(.text .text.*)
+    *usbd_msc*(.text .text.*)
+    *usbd_storage_msd*(.text .text.*)
+    *diskio_sdio*(.text .text.*)
+    . = ALIGN(4);
+    _efastcode = .;
+  } > REGION_BSS AT> REGION_TEXT_STORAGE
+
+  _fastcode_load = LOADADDR(.fastcode);
+
   /* Main code section */
   .text (READONLY) :
   {

--- a/radio/src/bootloader/CMakeLists.txt
+++ b/radio/src/bootloader/CMakeLists.txt
@@ -41,12 +41,12 @@ remove_definitions(-DUSB_SERIAL)
 
 if(NOT NO_LTO)
   message("-- Use LTO to compile bootloader")
-  target_compile_options(stm32cube_ll PRIVATE -flto)
-  target_compile_options(stm32usb PRIVATE -flto)
+  # stm32cube_ll, stm32usb, stm32usb_device_fw and
+  # stm32_drivers_w_dbg_fw are kept out of LTO: their objects must
+  # stay pattern-matchable by the .fastcode output section (hot
+  # USB/SD interrupt code executed from RAM, see firmware.ld)
   target_compile_options(stm32usb_device_bl PRIVATE -flto)
-  target_compile_options(stm32usb_device_fw PRIVATE -flto)
   target_compile_options(stm32_drivers PRIVATE -flto)
-  target_compile_options(stm32_drivers_w_dbg_fw PRIVATE -flto)
   target_compile_options(stm32_drivers_w_dbg_bl PRIVATE -flto)
   target_compile_options(board_bl PRIVATE -flto)
 endif()

--- a/radio/src/targets/common/arm/stm32/system_init.c
+++ b/radio/src/targets/common/arm/stm32/system_init.c
@@ -71,6 +71,15 @@ NAKED BOOTSTRAP void Reset_Handler()
     "bl naked_copy      \n"
   );
 
+  // Copy hot interrupt-path code into RAM (no-op when the linker
+  // script does not define a .fastcode section)
+  asm inline (
+    "ldr r0, =_sfastcode \n"
+    "ldr r1, =_efastcode \n"
+    "ldr r2, =_fastcode_load \n"
+    "bl naked_copy      \n"
+  );
+
 #if defined(BOOT) && defined(REQUIRE_MPU_CONFIG)
   asm inline (
     "bl MPU_Config \n"


### PR DESCRIPTION
## Problem

On some TX16S MK1 units, selecting USB joystick or mass-storage crashes the radio within seconds to minutes; with the cable plugged it then reboots into DFU. Long-standing reports: #5899, #7356, #6047, #6414, #3039, #4262 - always the same pattern: only *some* units, appeared around 2.11, 2.10.6 works, one user fixed it by swapping the main board, and the bootloader's own USB storage is immune.

## Root cause

Instrumented builds (persistent fault capture across reboots on an affected unit) recorded three crashes:

| # | active ISR | fault | stacked PC points at |
|---|---|---|---|
| 1 | OTG_FS | NOCP | a valid `pop` in `USB_EPStartXfer` |
| 2 | DMA2_Stream0 (ADC) | UNDEFINSTR | a valid `str r3, [sp, #4]` in `adc_start_read` |
| 3 | OTG_FS | UNDEFINSTR | a valid `and.w` in `HAL_PCD_IRQHandler` |

All three faulted while executing **provably valid, boundary-aligned instructions** located above `0x08100000` (flash bank 2). Stack overflow was ruled out by watermarking (~480B of 22KB used); illegal FreeRTOS-from-ISR calls were ruled out with runtime counters (zero hits).

Conclusion: on marginal units (likely shortage-era flash), instruction fetches from the upper flash bank return corrupted data under heavy IRQ/DMA load (USB + SDIO + LCD/audio DMA). This explains every historical oddity: which units crash (flash margin varies per chip), which versions crash (the linker moves the hot handlers across the bank boundary as the firmware grows), and why the bootloader is immune (its code sits at the very start of bank 1).

## Fix

Link the USB device stack (LL/PCD drivers, core, MSC class), the MSC storage glue and the SDIO diskio into a `.fastcode` output section placed in RAM and copied at startup (~14KB), so the hot interrupt paths never fetch from flash. The affected object libraries are kept out of LTO, since linker file-pattern matching cannot see through LTO partitions.

No functional change; RAM cost ~14KB (192KB part).

## Validation

A/B on an affected TX16S MK1 (2022), EdgeTX 2.12.2 base, continuous mass-storage stress reads (md5sum loop over USB from the host):

- hot code in **flash**: hard fault after ~55 s
- hot code in **RAM**: 24 minutes clean, zero faults (test stopped, not the radio)

## Full evidence

The complete diagnostic work is public on the fork:

- **Raw crash captures** (persistent fault records: PC/LR/xPSR/CFSR/HFSR, stack watermark, checkpoint trail): [`bench/logs/crash-avant-c5.log`](https://github.com/AdsumSOK/edgetx/blob/diag/usb-crash-capture/bench/logs/crash-avant-c5.log)
- **Instrumentation used to capture them** (fault handlers persisting to noinit RAM + RTC backup registers, dumped to SD at next boot): branch [`diag/usb-crash-capture`](https://github.com/AdsumSOK/edgetx/tree/diag/usb-crash-capture)
- **Test/bench history**: [`bench/logs/bench.log`](https://github.com/AdsumSOK/edgetx/blob/diag/usb-crash-capture/bench/logs/bench.log)

<details>
<summary>The three decoded crash records (2.12.2 base, TX16S MK1 2022)</summary>

```
==== crash record ====                     # crash 1
fw: pre-2.12.2-selfbuild (84b52f5e)
[bkp] fault=3 ipsr=3                       # HardFault (forced)
[bkp] pc=0810C836 lr=00000002 xpsr=21000253  # IPSR 0x53 = IRQ67 = OTG_FS
[bkp] cfsr=00080000 hfsr=40000000          # NOCP
last checkpoint: 7 (MSC read done), isr_count=7983
-> pc = valid `pop {..., pc}` in USB_EPStartXfer

==== crash record ====                     # crash 2
fw: pre-2.12.2-selfbuild (bc6b19f6)
[bkp] pc=08106B36 lr=FFFFFFF1 xpsr=81000048  # IPSR 0x48 = IRQ56 = DMA2_Stream0
[bkp] cfsr=00010000 hfsr=40000000 stack_low=1000FE20  # UNDEFINSTR, stack fine
last checkpoint: 6 (MSC read in progress), isr_count=34796
-> pc = valid `str r3, [sp, #4]` in adc_start_read

==== crash record ====                     # crash 3
fw: pre-2.12.2-selfbuild (37870f09)
[bkp] pc=0810A9F6 lr=08109F8B xpsr=81000053  # IRQ67 = OTG_FS
[bkp] cfsr=00010000 hfsr=40000000 stack_low=1000FE58  # UNDEFINSTR
last checkpoint: 7, isr_count=6953
-> pc = valid `and.w fp, fp, r2` in HAL_PCD_IRQHandler (coherent LR)
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance**
  * Improved responsiveness and timing for USB, mass-storage, and SDIO interrupt handling by running critical routines from faster memory.
* **Reliability**
  * Updated startup behavior safely supports devices with or without the optimized code section.
  * Bootloader builds now preserve the required code layout for consistent operation.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->
