### PR TITLE
fix(color): quick menu may not show last selected icon correctly

### DIFF
--- a/radio/src/gui/colorlcd/setup_menus/quick_menu.cpp
+++ b/radio/src/gui/colorlcd/setup_menus/quick_menu.cpp
@@ -228,6 +228,8 @@ class QuickSubMenu
 //-----------------------------------------------------------------------------
 
 QuickMenu* QuickMenu::instance = nullptr;
+QMPage QuickMenu::curPage = QM_NONE;
+EdgeTxIcon QuickMenu::curIcon = EDGETX_ICONS_COUNT;
 
 void QuickMenu::openQuickMenu()
 {
@@ -287,7 +289,7 @@ QuickMenu::QuickMenu() :
   for (int i = 0; qmTopItems[i].icon != EDGETX_ICONS_COUNT; i += 1) {
     if (qmTopItems[i].pageAction == QM_ACTION) {
       mainMenu->addButton(qmTopItems[i].icon, STR_VAL(qmTopItems[i].qmTitle),
-                  [=]() { onSelect(true); qmTopItems[i].action(); }, qmTopItems[i].enabled);
+                  [=]() { topMenuAction(i); }, qmTopItems[i].enabled);
 #if VERSION_MAJOR > 2
     } else {
       auto sub = new QuickSubMenu(box, this, &qmTopItems[i]);
@@ -371,26 +373,30 @@ void QuickMenu::selected()
     instance->onSelect(true);
 }
 
+void QuickMenu::topMenuAction(int n)
+{
+  selected();
+  setCurrentPage(qmTopItems[n].qmPage, qmTopItems[n].icon);
+  qmTopItems[n].action();
+}
+
 void QuickMenu::openPage(QMPage page)
 {
   for (int i = FIRST_SEARCH_IDX; qmTopItems[i].icon != EDGETX_ICONS_COUNT; i += 1) {
     if (qmTopItems[i].pageAction == QM_ACTION) {
       if (qmTopItems[i].qmPage == page) {
-        QuickMenu::selected();
-        setCurrentPage(page, qmTopItems[i].icon);
-        qmTopItems[i].action();
+        topMenuAction(i);
         return;
         }
     } else {
       const PageDef* sub = qmTopItems[i].subMenuItems;
       for (int j = 0, k = 0; sub[j].icon != EDGETX_ICONS_COUNT; j += 1) {
         if (sub[j].qmPage == page) {
+          selected();
+          setCurrentPage(page, qmTopItems[i].icon);
           if (sub[j].pageAction == PAGE_ACTION) {
-            QuickMenu::selected();
-            setCurrentPage(page, qmTopItems[i].icon);
             sub[j].action();
           } else {
-            QuickMenu::selected();
             auto pg = new PageGroup(qmTopItems[i].icon, STR_VAL(qmTopItems[i].title), sub);
             pg->setCurrentTab(k);
             return;
@@ -575,10 +581,8 @@ bool QuickMenu::setupFavorite(int favIdx, int favBtn)
 
 void QuickMenu::setCurrentPage(QMPage newPage, EdgeTxIcon newIcon)
 {
-  if (instance) {
-    instance->curPage = newPage;
-    instance->curIcon = newIcon;
-  }
+  curPage = newPage;
+  curIcon = newIcon;
 }
 
 void QuickMenu::focusMainMenu()

--- a/radio/src/gui/colorlcd/setup_menus/quick_menu.cpp
+++ b/radio/src/gui/colorlcd/setup_menus/quick_menu.cpp
@@ -387,7 +387,7 @@ void QuickMenu::openPage(QMPage page)
       if (qmTopItems[i].qmPage == page) {
         topMenuAction(i);
         return;
-        }
+      }
     } else {
       const PageDef* sub = qmTopItems[i].subMenuItems;
       for (int j = 0, k = 0; sub[j].icon != EDGETX_ICONS_COUNT; j += 1) {

--- a/radio/src/gui/colorlcd/setup_menus/quick_menu.h
+++ b/radio/src/gui/colorlcd/setup_menus/quick_menu.h
@@ -153,14 +153,14 @@ class QuickMenu : public NavWindow
 
  protected:
   static QuickMenu* instance;
+  static QMPage curPage;
+  static EdgeTxIcon curIcon;
   bool inSubMenu = false;
   QuickMenuGroup* mainMenu = nullptr;
 #if VERSION_MAJOR > 2
   std::vector<QuickSubMenu*> subMenus;
 #endif
   PageGroupBase* pageGroup = nullptr;
-  QMPage curPage = QM_NONE;
-  EdgeTxIcon curIcon = EDGETX_ICONS_COUNT;
 
   void openQM(PageGroupBase* pageGroup, QMPage curPage);
   void closeQM();
@@ -170,6 +170,7 @@ class QuickMenu : public NavWindow
   void deleteLater() override;
 
   static void selected();
+  static void topMenuAction(int n);
 
 #if VERSION_MAJOR > 2
   void updateFavorites();


### PR DESCRIPTION
Fixes:
- Last selected item is not saved until quick menu opened at least once
- Manage Models does not update last selected item when activated from the quick menu

Tests:
- On startup, press MDL -> RTN -> SYS. Quick menu should highlight Model Setup / Model Settings icon
- Open quick menu, tap Model Setup, tap Flight Modes to open FM page. Open quick menu, tap Manage Models. Open quick menu - Manage Models icon should be highlighted.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved Quick Menu navigation and action handling.
  * Selecting a top-level menu item now reliably updates the active page and icon before running the item’s action.
  * Programmatically opening a page now follows the same selection-and-action behavior as using the menu.
  * Streamlined submenu navigation while keeping existing differences between items that execute an action vs. items that open a tab/page group.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->