### PR TITLE
fix(switches): widen fsPreviousState to 32-bit to fix toggle detection for more than 16 switches

### DIFF
--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -206,7 +206,7 @@ void evalFunctionSwitches()
           }
         }
 
-        fsPreviousState ^= 1 << i;  // Toggle state
+        fsPreviousState ^= uint32_t(1) << i;  // Toggle state
         storageDirty(EE_MODEL);
       }
 

--- a/radio/src/switches.cpp
+++ b/radio/src/switches.cpp
@@ -92,7 +92,7 @@ uint8_t   potsPos[MAX_POTS];
 // Non pushed : SWSRC_Sx0 = -1024 = Sx(up) = state 0
 // Pushed : SWSRC_Sx2 = +1024 = Sx(down) = state 1
 
-uint16_t fsPreviousState = 0;
+uint32_t fsPreviousState = 0;
 
 uint8_t isSwitch3Pos(uint8_t idx)
 {
@@ -149,7 +149,7 @@ bool getFSPhysicalState(uint8_t index)
 
 static bool getFSPreviousPhysicalState(uint8_t index)
 {
-  return (uint8_t)(bfSingleBitGet(fsPreviousState, index) >> (index));
+  return (fsPreviousState >> index) & 1;
 }
 
 uint8_t getSwitchCountInFSGroup(uint8_t index)

--- a/radio/src/tests/switches.cpp
+++ b/radio/src/tests/switches.cpp
@@ -428,3 +428,45 @@ TEST(FlexSwitches, getSwitch)
   EXPECT_FALSE(getSwitch(SWSRC_FIRST_SWITCH + sw_idx * 3 + 1));
   EXPECT_TRUE(getSwitch(SWSRC_FIRST_SWITCH + sw_idx * 3 + 2));
 }
+
+#if defined(FUNCTION_SWITCHES)
+TEST(FunctionSwitches, holdIsNotRepeatedToggle)
+{
+  MODEL_RESET();
+  setModelDefaults();
+  switchInit();
+
+  for (uint8_t i = 0; i < switchGetMaxSwitches(); i++) {
+    if (!switchIsCustomSwitch(i)) continue;
+    // Toggle type with no group, so a phantom "switch moved" event
+    // flips the logical state and is observable
+    g_model.cfsSetType(i, SWITCH_TOGGLE);
+    g_model.cfsSetGroup(i, 0);
+    simuSetSwitch(i, -1);
+  }
+
+  setFSStartupPosition();
+  evalFunctionSwitches();  // sync previous state with all switches released
+
+  for (uint8_t i = 0; i < switchGetMaxSwitches(); i++) {
+    if (!switchIsCustomSwitch(i)) continue;
+
+    bool released = g_model.cfsState(i);
+    simuSetSwitch(i, 1);
+    evalFunctionSwitches();
+    bool pressed = g_model.cfsState(i);
+    EXPECT_NE(released, pressed) << "press did not toggle switch index " << (int)i;
+
+    // holding the switch must not generate further toggles
+    evalFunctionSwitches();
+    EXPECT_EQ(pressed, g_model.cfsState(i))
+        << "hold re-toggled switch index " << (int)i;
+    evalFunctionSwitches();
+    EXPECT_EQ(pressed, g_model.cfsState(i))
+        << "hold re-toggled switch index " << (int)i;
+
+    simuSetSwitch(i, -1);
+    evalFunctionSwitches();
+  }
+}
+#endif


### PR DESCRIPTION
The `fsPreviousState` variable was declared as `uint16_t`, which only supports up to 16 switches. On radios with more than 16 switches (like the T22), switches beyond the 16th (SW5/SW6) would have their states lost or incorrectly tracked.

This change:
- Expands `fsPreviousState` from `uint16_t` to `uint32_t` to support more switches
- Simplifies the bit extraction in `getFSPreviousPhysicalState()` using a direct shift-and-mask pattern

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved switch change detection by ensuring prior physical-state tracking supports the full range of switch inputs.
  * Corrected how previous switch-state bits are read and updated, improving reliability of toggle behavior across repeated evaluations while a switch is held.
* **Tests**
  * Added coverage to verify toggle-type function switches only change once per press (and not again when evaluation runs while the switch remains held).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->