### PR TITLE
Augmenting CRSF telemetry parser for BATT frames with trailing sensor-id

### DIFF
--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -369,19 +369,19 @@ void processCrossfireTelemetryFrame(uint8_t module, uint8_t* rxBuffer,
     case BATTERY_ID:
     {
       uint8_t sensorID = 0;
-      if (rxBufferCount > 12) {
-          if (getCrossfireTelemetryValue<1>(11, value, rxBuffer)) {
-              sensorID = value;
-          }
+      if (crsfPayloadLen > 10) {
+        if (getCrossfireTelemetryValue<1>(11, value, rxBuffer)) {
+          sensorID = value;
+        }
       }
       if (getCrossfireTelemetryValue<2>(3, value, rxBuffer))
-          processCrossfireTelemetryValue(BATT_VOLTAGE_INDEX, value, sensorID);
+        processCrossfireTelemetryValue(BATT_VOLTAGE_INDEX, value, sensorID);
       if (getCrossfireTelemetryValue<2>(5, value, rxBuffer))
-          processCrossfireTelemetryValue(BATT_CURRENT_INDEX, value, sensorID);
+        processCrossfireTelemetryValue(BATT_CURRENT_INDEX, value, sensorID);
       if (getCrossfireTelemetryValue<3>(7, value, rxBuffer))
-          processCrossfireTelemetryValue(BATT_CAPACITY_INDEX, value, sensorID);
+        processCrossfireTelemetryValue(BATT_CAPACITY_INDEX, value, sensorID);
       if (getCrossfireTelemetryValue<1>(10, value, rxBuffer))
-          processCrossfireTelemetryValue(BATT_REMAINING_INDEX, value, sensorID);
+        processCrossfireTelemetryValue(BATT_REMAINING_INDEX, value, sensorID);
     }
       break;
 

--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -121,13 +121,13 @@ const CrossfireSensor & getCrossfireSensor(uint8_t id, uint8_t subId)
     return crossfireSensors[UNKNOWN_INDEX];
 }
 
-void processCrossfireTelemetryValue(uint8_t index, int32_t value)
+void processCrossfireTelemetryValue(const uint8_t index, const int32_t value, const uint8_t sensorId = 0)
 {
   if (!TELEMETRY_STREAMING())
     return;
 
   const CrossfireSensor & sensor = crossfireSensors[index];
-  setTelemetryValue(PROTOCOL_TELEMETRY_CROSSFIRE, sensor.id, 0, sensor.subId,
+  setTelemetryValue(PROTOCOL_TELEMETRY_CROSSFIRE, sensor.id + (sensorId << 8) , 0, sensor.subId,
                     value, sensor.unit, sensor.precision);
 }
 
@@ -367,14 +367,22 @@ void processCrossfireTelemetryFrame(uint8_t module, uint8_t* rxBuffer,
       break;
 
     case BATTERY_ID:
+    {
+      uint8_t sensorID = 0;
+      if (rxBufferCount > 12) {
+          if (getCrossfireTelemetryValue<1>(11, value, rxBuffer)) {
+              sensorID = value;
+          }
+      }
       if (getCrossfireTelemetryValue<2>(3, value, rxBuffer))
-        processCrossfireTelemetryValue(BATT_VOLTAGE_INDEX, value);
+          processCrossfireTelemetryValue(BATT_VOLTAGE_INDEX, value, sensorID);
       if (getCrossfireTelemetryValue<2>(5, value, rxBuffer))
-        processCrossfireTelemetryValue(BATT_CURRENT_INDEX, value);
+          processCrossfireTelemetryValue(BATT_CURRENT_INDEX, value, sensorID);
       if (getCrossfireTelemetryValue<3>(7, value, rxBuffer))
-        processCrossfireTelemetryValue(BATT_CAPACITY_INDEX, value);
+          processCrossfireTelemetryValue(BATT_CAPACITY_INDEX, value, sensorID);
       if (getCrossfireTelemetryValue<1>(10, value, rxBuffer))
-        processCrossfireTelemetryValue(BATT_REMAINING_INDEX, value);
+          processCrossfireTelemetryValue(BATT_REMAINING_INDEX, value, sensorID);
+    }
       break;
 
     case ATTITUDE_ID:


### PR DESCRIPTION
The CRSF protocol definition allows to augment existing packet definitions in a backward compatible manner. It allows to extend the payload if the overall frame structure remains valid.

The problem:
The crsf BATT sensor type does not support multiple instances. This leads to problems, if e.g. multiple ESCs sends this kind of telemetry sensor frames. 
Also, the BATT sensor is the only actually available type to measure current. 
There is a proposal to the CRSF protocol definition to add also a multi-instance current sensor frame type like VOLTS, RPM or TEMP: https://github.com/tbs-fpv/tbs-crsf-spec/issues/38

But this is not expected to be setup in the near future.

The solution:
The CRSF protocol definition allows to extend CRSF frames in a backward compatible manner by extending the payload with addition al fields. 
This could be used by CRSF devices to add an instance id to the BATT payload (at the end). 
This new frametype can be detected by the crsf parser easily and then handle the old type of BATT sensor frames as well as the new frames with instance id included. 

This PR modifies the existing CRSF parser to handle old and new BATT sensor types correctly.

As an example, the follwing branch adds the new BATT frame structure to the well known ESCape32 ESC firmware: https://github.com/wimalopaan/ESCape32/tree/wm_crsf_batt_id

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Crossfire telemetry handling for battery data from systems with multiple sensor instances.
  * Battery voltage, current, capacity, and remaining-capacity readings now preserve the correct sensor-instance identifier when such details are present in the incoming telemetry frame, reducing ambiguity between readings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->