### PR TITLE
feat(lua): enable serial terminal scripts (port query, textEdit placeholder, Enter key)

### DIFF
--- a/radio/src/gui/colorlcd/libui/form.h
+++ b/radio/src/gui/colorlcd/libui/form.h
@@ -90,6 +90,21 @@ class FormField : public Window
     changeHandler = std::move(handler);
   }
 
+  // Called when the field is committed with the keyboard "Enter" key (as
+  // opposed to the "OK" checkmark). Optional: fields that don't set an
+  // enter handler simply commit like the checkmark.
+  virtual void onEnter()
+  {
+    if (enterHandler) {
+      enterHandler();
+    }
+  }
+
+  void setEnterHandler(std::function<void()> handler)
+  {
+    enterHandler = std::move(handler);
+  }
+
   inline bool isEditMode() const { return editMode; }
   virtual void setEditMode(bool newEditMode);
 
@@ -101,6 +116,7 @@ class FormField : public Window
   bool editMode = false;
   bool enabled = true;
   std::function<void()> changeHandler = nullptr;
+  std::function<void()> enterHandler = nullptr;
 };
 
 class FormLine : public Window

--- a/radio/src/gui/colorlcd/libui/keyboard_base.cpp
+++ b/radio/src/gui/colorlcd/libui/keyboard_base.cpp
@@ -68,6 +68,7 @@ static void keyboard_event_cb(lv_event_t* e)
 {
   auto code = lv_event_get_code(e);
   if (code == LV_EVENT_READY) {
+    // "OK" checkmark: commit and close (keep the text)
     Keyboard::hide(false);
   } else if (code == LV_EVENT_CANCEL) {
     Keyboard::hide(true);
@@ -75,6 +76,17 @@ static void keyboard_event_cb(lv_event_t* e)
     int32_t c = *((int32_t*)lv_event_get_param(e));
     if (c == LV_KEY_ESC) {
       Keyboard::hide(false);
+    }
+  } else if (code == LV_EVENT_VALUE_CHANGED) {
+    // The "Enter" key of a one-line field only notifies the text area, not
+    // the keyboard object, so it would otherwise do nothing. Detect it here
+    // and route it as a distinct commit-and-submit action.
+    lv_obj_t* kb = lv_event_get_target(e);
+    uint16_t id = lv_btnmatrix_get_selected_btn(kb);
+    const char* txt = lv_btnmatrix_get_btn_text(kb, id);
+    if (txt && (strcmp(txt, LV_SYMBOL_NEW_LINE) == 0 || strcmp(txt, "Enter") == 0)) {
+      auto* kbd = (Keyboard*)lv_event_get_user_data(e);
+      if (kbd) kbd->enterField();
     }
   }
 }
@@ -148,6 +160,8 @@ void Keyboard::clearField(bool wasCancelled)
     if (!wasCancelled)
       field->setEditMode(false);
     field->changeEnd();
+    // "Enter" key: fire the field's submit action after the value is committed
+    if (enterPressed) field->onEnter();
     field = nullptr;
 
     if (fieldGroup) {
@@ -156,6 +170,7 @@ void Keyboard::clearField(bool wasCancelled)
       fieldGroup = nullptr;
     }
   }
+  enterPressed = false;
 }
 
 void Keyboard::hide(bool wasCancelled)
@@ -165,6 +180,12 @@ void Keyboard::hide(bool wasCancelled)
     lv_obj_add_flag(activeKeyboard->lvobj, LV_OBJ_FLAG_HIDDEN);
     activeKeyboard = nullptr;
   }
+}
+
+void Keyboard::enterField()
+{
+  enterPressed = true;
+  hide(false);
 }
 
 bool Keyboard::attachKeyboard()

--- a/radio/src/gui/colorlcd/libui/keyboard_base.h
+++ b/radio/src/gui/colorlcd/libui/keyboard_base.h
@@ -31,12 +31,17 @@ class Keyboard : public NavWindow
   void clearField(bool wasCancelled);
   static void hide(bool wasCancelled);
 
+  // Commit the field and close the keyboard because the "Enter" key was
+  // pressed (distinct from the "OK" checkmark, so fields can send/submit).
+  void enterField();
+
   static Keyboard* keyboardWindow() { return activeKeyboard; }
 
  protected:
   static Keyboard *activeKeyboard;
 
   bool hasTwoPageKeys;
+  bool enterPressed = false;
   lv_group_t* group = nullptr;
   lv_obj_t* keyboard = nullptr;
 

--- a/radio/src/gui/colorlcd/libui/textedit.cpp
+++ b/radio/src/gui/colorlcd/libui/textedit.cpp
@@ -144,8 +144,16 @@ void TextEdit::update()
     std::string s(text, length);
     setText(s);
   } else {
-    setText("---");
+    setText(placeholder);
   }
+}
+
+void TextEdit::setPlaceholder(const char* p)
+{
+  placeholder = p ? p : "";
+  // apply live: the edit overlay may already exist (even be open)
+  if (edit) lv_textarea_set_placeholder_text(edit->getLvObj(), placeholder.c_str());
+  update();
 }
 
 void TextEdit::openEdit()
@@ -155,6 +163,7 @@ void TextEdit::openEdit()
                         {-(PAD_MEDIUM + 2), -(PAD_BORDER * 2),
                           lv_obj_get_width(lvobj), lv_obj_get_height(lvobj)},
                         text, length);
+    lv_textarea_set_placeholder_text(edit->getLvObj(), placeholder.c_str());
     edit->setChangeHandler([=]() {
       update();
       if (updateHandler) updateHandler();

--- a/radio/src/gui/colorlcd/libui/textedit.cpp
+++ b/radio/src/gui/colorlcd/libui/textedit.cpp
@@ -174,6 +174,8 @@ void TextEdit::openEdit()
       lv_group_focus_obj(lvobj);
       edit->hide();
     });
+    // forward the keyboard "Enter" key to this TextEdit's own enter handler
+    edit->setEnterHandler([=]() { onEnter(); });
   }
   edit->update();
   edit->show();

--- a/radio/src/gui/colorlcd/libui/textedit.h
+++ b/radio/src/gui/colorlcd/libui/textedit.h
@@ -36,11 +36,15 @@ class TextEdit : public TextButton
   void preview(bool edited, char* text, uint8_t length);
   void update();
 
+  // text shown when the value is empty (default "---")
+  void setPlaceholder(const char* p);
+
  protected:
   std::function<void(void)> updateHandler = nullptr;
   TextArea* edit = nullptr;
   char* text;
   uint8_t length;
+  std::string placeholder = "---";
 
   void openEdit();
 };

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -2324,6 +2324,39 @@ static int luaSetSerialBaudrate(lua_State * L)
 }
 
 /*luadoc
+@function serialGetLuaPort()
+
+Get the serial port currently configured in LUA mode, if any.
+
+@retval port_nr (number) serial port configured in LUA mode:
+                         0 = AUX1, 1 = AUX2, 2 = USB-VCP
+
+@retval name (string) port name, e.g. "AUX1"
+
+@retval nil no serial port is configured in LUA mode
+
+@status current Introduced in 3.0.0
+*/
+static int luaSerialGetLuaPort(lua_State * L)
+{
+  int port_nr = serialGetModePort(UART_MODE_LUA);
+  if (port_nr < 0) {
+    lua_pushnil(L);
+    return 1;
+  }
+
+  lua_pushinteger(L, port_nr);
+
+  const etx_serial_port_t* port = serialGetPort(port_nr);
+  if (port && port->name) {
+    lua_pushstring(L, port->name);
+    return 2;
+  }
+
+  return 1;
+}
+
+/*luadoc
 @function serialWrite(str)
 @param str (string) String to be written to the serial port.
 
@@ -3172,6 +3205,7 @@ LROT_BEGIN(etxlib, NULL, 0)
   LROT_FUNCENTRY( multiBuffer, luaMultiBuffer )
 #endif
   LROT_FUNCENTRY( setSerialBaudrate, luaSetSerialBaudrate )
+  LROT_FUNCENTRY( serialGetLuaPort, luaSerialGetLuaPort )
   LROT_FUNCENTRY( serialWrite, luaSerialWrite )
   LROT_FUNCENTRY( serialRead, luaSerialRead )
 #if defined(SWSERIALPOWER) && !defined(SIMU)

--- a/radio/src/lua/lua_lvgl_widget.cpp
+++ b/radio/src/lua/lua_lvgl_widget.cpp
@@ -2258,6 +2258,8 @@ void LvglWidgetTextEdit::parseParam(lua_State *L, const char *key)
     placeholder = luaL_checkstring(L, -1);
   } else if (!strcmp(key, "set")) {
     setFunction = ::getRef(L, LUA_REGISTRYINDEX);
+  } else if (!strcmp(key, "enter")) {
+    enterFunction = ::getRef(L, LUA_REGISTRYINDEX);
   } else {
     LvglWidgetObject::parseParam(L, key);
   }
@@ -2284,6 +2286,7 @@ void LvglWidgetTextEdit::clearRefs(lua_State *L)
 {
   txt.clearRef(L);
   clearRef(L, setFunction);
+  clearRef(L, enterFunction);
   LvglWidgetObject::clearRefs(L);
 }
 
@@ -2312,6 +2315,25 @@ void LvglWidgetTextEdit::build(lua_State *L)
                           }
                         });
   ((TextEdit*)window)->setPlaceholder(placeholder.c_str());
+  // "Enter" key on the keyboard: distinct from committing with the checkmark
+  ((TextEdit*)window)->setEnterHandler([=]() {
+    if (enterFunction != LUA_REFNIL) {
+      int t = lua_gettop(L);
+      PROTECT_LUA()
+      {
+        std::string s(value, maxLen); // Ensure string is terminated
+        if (!pcallFuncWithString(L, enterFunction, 0, s.c_str())) {
+          lvglManager->luaShowError();
+        }
+      }
+      else
+      {
+        lvglManager->luaShowError();
+      }
+      UNPROTECT_LUA();
+      lua_settop(L, t);
+    }
+  });
 }
 
 //-----------------------------------------------------------------------------

--- a/radio/src/lua/lua_lvgl_widget.cpp
+++ b/radio/src/lua/lua_lvgl_widget.cpp
@@ -2254,6 +2254,8 @@ void LvglWidgetTextEdit::parseParam(lua_State *L, const char *key)
     maxLen = luaL_checkinteger(L, -1);
     if (maxLen > MAX_TEXT_EDIT_LEN) maxLen = MAX_TEXT_EDIT_LEN;
     if (maxLen <= 0) maxLen = DEFAULT_TEXT_EDIT_LEN;
+  } else if (!strcmp(key, "placeholder")) {
+    placeholder = luaL_checkstring(L, -1);
   } else if (!strcmp(key, "set")) {
     setFunction = ::getRef(L, LUA_REGISTRYINDEX);
   } else {
@@ -2309,6 +2311,7 @@ void LvglWidgetTextEdit::build(lua_State *L)
                             lua_settop(L, t);
                           }
                         });
+  ((TextEdit*)window)->setPlaceholder(placeholder.c_str());
 }
 
 //-----------------------------------------------------------------------------

--- a/radio/src/lua/lua_lvgl_widget.h
+++ b/radio/src/lua/lua_lvgl_widget.h
@@ -809,6 +809,7 @@ class LvglWidgetTextEdit : public LvglWidgetObject
   std::string placeholder = "---";
 
   int setFunction = LUA_REFNIL;
+  int enterFunction = LUA_REFNIL;
 
   void build(lua_State *L) override;
   void parseParam(lua_State *L, const char *key) override;

--- a/radio/src/lua/lua_lvgl_widget.h
+++ b/radio/src/lua/lua_lvgl_widget.h
@@ -806,6 +806,7 @@ class LvglWidgetTextEdit : public LvglWidgetObject
   LvglParamFuncOrString txt = { .function = LUA_REFNIL, .txt = ""};
   char value[MAX_TEXT_EDIT_LEN + 1];
   int maxLen = DEFAULT_TEXT_EDIT_LEN;
+  std::string placeholder = "---";
 
   int setFunction = LUA_REFNIL;
 


### PR DESCRIPTION
Summary of changes:

These three changes all came out of writing a Lua app that turns the radio into
a serial terminal for any device with a text CLI over UART (flight controllers,
ESCs, GPS modules) through a port set to LUA mode. Each removes a concrete
obstacle. They are technically independent, but the app needs all three, so they
are kept together rather than split into PRs that could land partially.

What this is worth in practice: out in the field it turns hardware the pilot is
already holding into one more tool, with no laptop involved. Connecting to a
UART correctly is the whole setup. And the moment radios gain USB host support,
the very same app does exactly this over an ordinary USB-C cable to the flight
controller, with no wiring at all - so the groundwork here keeps paying off.

**1. `feat(lua)`: new `serialGetLuaPort()`**

A script using `serialRead()`/`serialWrite()` had no way to find out whether any
serial port is actually set to LUA mode. Without it a script can only sit there
receiving nothing, unable to tell the user why. Returns the port number and its
name, or `nil` when no port is in LUA mode.

**2. `feat(color)`: custom placeholder on text edit fields**

An empty text field always renders as `---`, both in the field itself and as the
text area placeholder while editing. That is right for settings screens but
wrong for free-form input, where an empty field should simply look empty. The
default is unchanged, so no existing screen is affected; scripts can pass
`placeholder = ""` (or hint text) to `lvgl.textEdit`.

**3. `fix(color)`: keyboard Enter key does nothing on single-line fields**

For a one-line text area LVGL sends `LV_EVENT_READY` only to the text area,
while the OK checkmark also sends it to the keyboard object - and the keyboard
object is what EdgeTX listens on. The result is that the Enter key neither
commits the value nor closes the keyboard: it does nothing at all, on every
single-line field in the radio.

The Enter key is now detected on the keyboard and routed through a new
`FormField::onEnter()`, so it commits and closes like the checkmark. A field may
additionally install an enter handler to treat Enter as "submit" as opposed to
the checkmark's "keep editing"; `lvgl.textEdit` exposes this as an `enter`
callback, which is what lets the terminal app send a typed command on Enter.

There are no local changes to the vendored LVGL.

Testing:

- Built for X10/TX16S and flashed to a TX16S MK2; the Lua app using all four
  additions runs on the radio.
- Behaviour verified against a real flight controller (IFLIGHT BLITZ F722,
  Betaflight 2025.12.5) on a UART with Configuration/MSP: `#` opens the CLI,
  commands echo and answer, and the keyboard Enter change commits/sends as
  expected.
- The placeholder default is unchanged in code (`"---"`), so existing screens
  keep their current appearance; the new behaviour only applies to fields that
  pass the parameter.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable placeholder text for text-entry fields.
  - Pressing Enter can now submit a field and trigger a configured action.
  - Lua text-edit widgets support placeholder text and Enter callbacks.
  - Added a Lua API to identify the serial port configured for Lua communication.

- **Bug Fixes**
  - Text fields now correctly display their configured placeholder when empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->