### PR TITLE
fix(cpn): use JSON lookup for CFS

### DIFF
--- a/companion/src/firmwares/rawsource.cpp
+++ b/companion/src/firmwares/rawsource.cpp
@@ -241,7 +241,7 @@ QString RawSource::toString(const ModelData * model, const GeneralSettings * con
       dfltName = Boards::getSwitchInfo(index - 1, board).name.c_str();
       if (Boards::isSwitchFunc(index - 1, board)) {
         if (model) {
-          int fsindex = Boards::getSwitchTagNum(index - 1, board) - 1;
+          int fsindex = Boards::getCFSIndexForSwitch(index - 1, board);
           if (fsindex >= 0 && fsindex < CPN_MAX_SWITCHES_FUNCTION)
             custName = QString(model->customSwitches[fsindex].name).trimmed();
         }

--- a/companion/src/firmwares/rawsource.cpp
+++ b/companion/src/firmwares/rawsource.cpp
@@ -375,7 +375,7 @@ bool RawSource::isAvailable(const ModelData * const model,
       return false;
 
     if (type == SOURCE_TYPE_SWITCH && b.isSwitchFunc(abs(index) - 1, board) &&
-        !model->isFunctionSwitchSourceAllowed(b.getSwitchTagNum(abs(index) - 1, board) - 1))
+        !model->isFunctionSwitchSourceAllowed(b.getCFSIndexForSwitch(abs(index) - 1, board)))
       return false;
 
     if (type == SOURCE_TYPE_VIRTUAL_INPUT && !model->isInputValid(abs(index) - 1))

--- a/companion/src/firmwares/rawswitch.cpp
+++ b/companion/src/firmwares/rawswitch.cpp
@@ -91,8 +91,9 @@ QString RawSwitch::toString(Board::Type board, const GeneralSettings * const gen
         swName = Boards::getSwitchInfo(qr.quot, board).name.c_str();
         if (Boards::isSwitchFunc(qr.quot, board)) {
           if (modelData) {
-            int fsindex = Boards::getSwitchTagNum(qr.quot, board) - 1;
-            custName = QString(modelData->customSwitches[fsindex].name).trimmed();
+            int fsindex = Boards::getCFSIndexForSwitch(qr.quot, board);
+            if (fsindex >= 0 && fsindex < CPN_MAX_SWITCHES_FUNCTION)
+              custName = QString(modelData->customSwitches[fsindex].name).trimmed();
           }
         }
         else {


### PR DESCRIPTION
getSwitchTagNum doesn't work for CFS without numerical suffix

Fixes #7396



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved recognition and display of custom function switches.
  * Prevented invalid custom switch references from causing incorrect results or unsafe access.
  * Ensured function switch availability checks use the correct switch mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->