### PR TITLE
chore(spiflash): improve the efficiency of "is block erased" detection

### DIFF
--- a/radio/src/targets/common/arm/stm32/spi_flash.cpp
+++ b/radio/src/targets/common/arm/stm32/spi_flash.cpp
@@ -270,8 +270,10 @@ uint32_t flashSpiGetSize()
 
 bool flashSpiIsErased(uint32_t address)
 {
-  // verify sector alignment
-  if((address & FLASH_SECTOR_MASK) != 0)
+  static uint8_t temp_buffer[FLASH_SECTOR_SIZE] __DMA_NO_CACHE;
+
+  // Verify sector alignment
+  if ((address & FLASH_SECTOR_MASK) != 0)
     return false;
 
   flash_wait_for_not_busy();
@@ -283,17 +285,25 @@ bool flashSpiIsErased(uint32_t address)
     flash_put_cmd_addr(FLASH_CMD_READ, address);
   }
 
-  bool ret = true;
-  for(uint32_t i = 0; i < FLASH_SECTOR_SIZE; i++) {
-    uint8_t byte = flash_rw_byte(0xFF);
-    if (byte != 0xff) {
-      ret = false;
-      break;
+  // Check first 4 bytes
+  for (uint32_t i = 0; i < 4; i++) {
+    if (flash_rw_byte(0xFF) != 0xff) {
+      flash_unselect();
+      return false;
     }
   }
 
+  // First 4 bytes all 0xFF, now need to check the remaining using DMA
+  flash_dma_read_bytes(temp_buffer, FLASH_SECTOR_SIZE - 4);
   flash_unselect();
-  return ret;
+
+  for (uint32_t i = 0; i < FLASH_SECTOR_SIZE - 4; i++) {
+    if (temp_buffer[i] != 0xff) {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 uint32_t flashSpiRead(uint32_t address, uint8_t* data, uint32_t size)


### PR DESCRIPTION
The spi_flash.cpp flashSpiIsErased function is not efficient, it only use byte by byte read and it is slow.
New strategy:
1. Read the first 4 bytes using byte by byte method
2. If the first 4 bytes shows it is erased, use DMA to ensure the whole block is erased

This can guarantee the efficiency of is erase detection for both used and erased blocks.

2.11 fix combines in #7472, no need to merge to 2.11 branch

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved flash erase verification speed by using bulk, DMA-friendly reads rather than checking every byte individually.
  * Added a two-phase sector verification approach to robustly confirm erased flash contents.
* **Maintenance**
  * Updated a bundled third-party dependency to a newer revision for ongoing compatibility and fixes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->