### PR TITLE
fix(color): make messaging dispatch mutation-safe

### DIFF
--- a/radio/src/gui/colorlcd/libui/messaging.cpp
+++ b/radio/src/gui/colorlcd/libui/messaging.cpp
@@ -19,9 +19,27 @@
 #include "messaging.h"
 
 #include <list>
-#include <algorithm>
+#include <utility>
 
-static std::list<Messaging*> subscriptions;
+struct MessagingSubscription {
+  uint32_t id;
+  std::function<void(uint32_t)> callback;
+  bool active;
+};
+
+namespace
+{
+
+std::list<MessagingSubscription> subscriptions;
+uint32_t dispatchDepth = 0;
+
+void removeInactiveSubscriptions()
+{
+  subscriptions.remove_if(
+      [](const auto& subscription) { return !subscription.active; });
+}
+
+}  // namespace
 
 Messaging::~Messaging()
 {
@@ -31,21 +49,18 @@ Messaging::~Messaging()
 void Messaging::subscribe(uint32_t _id, std::function<void(uint32_t)> cb)
 {
   unsubscribe();
-  id = _id;
-  callback = cb;
-  subscriptions.emplace_back(this);
+  subscriptions.push_back({_id, std::move(cb), true});
+  subscription = &subscriptions.back();
 }
 
 void Messaging::unsubscribe()
 {
-  if (id) {
-    auto s = std::find_if(subscriptions.begin(), subscriptions.end(),
-                              [=](Messaging* lh) -> bool { return lh == this; });
-    if (s != subscriptions.end()) subscriptions.erase(s);
-  }
+  if (!subscription) return;
 
-  callback = nullptr;
-  id = 0;
+  subscription->active = false;
+  subscription = nullptr;
+
+  if (dispatchDepth == 0) removeInactiveSubscriptions();
 }
 
 void Messaging::send(uint32_t id)
@@ -55,9 +70,18 @@ void Messaging::send(uint32_t id)
 
 void Messaging::send(uint32_t msgId, uint32_t msgData)
 {
-  for (auto it = subscriptions.rbegin(); it != subscriptions.rend(); ++it) {
-    Messaging* m = *it;
-    if (m->id == msgId && m->callback)
-      m->callback(msgData);
+  dispatchDepth++;
+
+  for (auto it = subscriptions.rbegin(); it != subscriptions.rend();) {
+    // Advance first so subscriptions added by the callback wait for the next
+    // send.
+    auto& subscription = *it++;
+    if (subscription.active && subscription.id == msgId &&
+        subscription.callback) {
+      subscription.callback(msgData);
+    }
   }
+
+  dispatchDepth--;
+  if (dispatchDepth == 0) removeInactiveSubscriptions();
 }

--- a/radio/src/gui/colorlcd/libui/messaging.h
+++ b/radio/src/gui/colorlcd/libui/messaging.h
@@ -21,6 +21,8 @@
 #include <functional>
 #include <stdint.h>
 
+struct MessagingSubscription;
+
 class Messaging
 {
  public:
@@ -38,7 +40,9 @@ class Messaging
     REFRESH_OUTPUTS_WIDGET,
   };
 
-  Messaging() {}
+  Messaging() = default;
+  Messaging(const Messaging&) = delete;
+  Messaging& operator=(const Messaging&) = delete;
   ~Messaging();
   void subscribe(uint32_t id, std::function<void(uint32_t)> cb);
   void unsubscribe();
@@ -50,6 +54,5 @@ class Messaging
   static void send(uint32_t id, uint32_t data);
 
  protected:
-  uint32_t id = 0;
-  std::function<void(uint32_t)> callback = nullptr;
+  MessagingSubscription* subscription = nullptr;
 };

--- a/radio/src/tests/messaging.cpp
+++ b/radio/src/tests/messaging.cpp
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - http://www.open-tx.org
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "gtests.h"
+
+#if defined(COLORLCD)
+
+#include <memory>
+#include <vector>
+
+#include "messaging.h"
+
+TEST(Messaging, DeliversMatchingTopicNewestFirst)
+{
+  std::vector<int> deliveries;
+  Messaging first;
+  Messaging second;
+  Messaging otherTopic;
+
+  first.subscribe(Messaging::REFRESH,
+                  [&](uint32_t data) { deliveries.push_back(data + 1); });
+  second.subscribe(Messaging::REFRESH,
+                   [&](uint32_t data) { deliveries.push_back(data + 2); });
+  otherTopic.subscribe(Messaging::COLOR_CHANGED,
+                       [&](uint32_t data) { deliveries.push_back(data + 3); });
+
+  Messaging::send(Messaging::REFRESH, 10);
+
+  EXPECT_EQ(deliveries, (std::vector<int>{12, 11}));
+}
+
+TEST(Messaging, ExplicitUnsubscribeAndDestructionStopDelivery)
+{
+  int calls = 0;
+  Messaging persistent;
+
+  persistent.subscribe(Messaging::REFRESH, [&](uint32_t) { calls += 1; });
+  Messaging::send(Messaging::REFRESH);
+  persistent.unsubscribe();
+  Messaging::send(Messaging::REFRESH);
+
+  {
+    Messaging scoped;
+    scoped.subscribe(Messaging::REFRESH, [&](uint32_t) { calls += 10; });
+    Messaging::send(Messaging::REFRESH);
+  }
+  Messaging::send(Messaging::REFRESH);
+
+  EXPECT_EQ(calls, 11);
+}
+
+TEST(Messaging, CallbackCanUnsubscribeItself)
+{
+  int calls = 0;
+  Messaging subscriber;
+
+  subscriber.subscribe(Messaging::REFRESH, [&](uint32_t) {
+    calls++;
+    subscriber.unsubscribe();
+  });
+
+  Messaging::send(Messaging::REFRESH);
+  Messaging::send(Messaging::REFRESH);
+
+  EXPECT_EQ(calls, 1);
+}
+
+TEST(Messaging, CallbackCanDestroyItself)
+{
+  int calls = 0;
+  auto subscriber = std::make_unique<Messaging>();
+
+  subscriber->subscribe(Messaging::REFRESH, [&](uint32_t) {
+    calls++;
+    subscriber.reset();
+  });
+
+  Messaging::send(Messaging::REFRESH);
+  Messaging::send(Messaging::REFRESH);
+
+  EXPECT_EQ(calls, 1);
+}
+
+TEST(Messaging, CallbackCanDestroySubscriberWaitingForDelivery)
+{
+  int removedCalls = 0;
+  auto removed = std::make_unique<Messaging>();
+  Messaging remover;
+
+  removed->subscribe(Messaging::REFRESH, [&](uint32_t) { removedCalls++; });
+  remover.subscribe(Messaging::REFRESH, [&](uint32_t) { removed.reset(); });
+
+  Messaging::send(Messaging::REFRESH);
+
+  EXPECT_EQ(removedCalls, 0);
+}
+
+TEST(Messaging, CallbackCanDestroySubscriberAlreadyDelivered)
+{
+  int deliveredCalls = 0;
+  auto delivered = std::make_unique<Messaging>();
+  Messaging remover;
+
+  remover.subscribe(Messaging::REFRESH, [&](uint32_t) { delivered.reset(); });
+  delivered->subscribe(Messaging::REFRESH, [&](uint32_t) { deliveredCalls++; });
+
+  Messaging::send(Messaging::REFRESH);
+  Messaging::send(Messaging::REFRESH);
+
+  EXPECT_EQ(deliveredCalls, 1);
+}
+
+TEST(Messaging, SubscriptionAddedDuringDeliveryWaitsForNextSend)
+{
+  int existingCalls = 0;
+  int addedCalls = 0;
+  bool added = false;
+  Messaging existing;
+  Messaging addedSubscriber;
+
+  existing.subscribe(Messaging::REFRESH, [&](uint32_t) {
+    existingCalls++;
+    if (!added) {
+      added = true;
+      addedSubscriber.subscribe(Messaging::REFRESH,
+                                [&](uint32_t) { addedCalls++; });
+    }
+  });
+
+  Messaging::send(Messaging::REFRESH);
+  EXPECT_EQ(existingCalls, 1);
+  EXPECT_EQ(addedCalls, 0);
+
+  Messaging::send(Messaging::REFRESH);
+  EXPECT_EQ(existingCalls, 2);
+  EXPECT_EQ(addedCalls, 1);
+}
+
+TEST(Messaging, ResubscriptionDuringDeliveryTakesEffectOnNextSend)
+{
+  int oldTopicCalls = 0;
+  int newTopicCalls = 0;
+  Messaging subscriber;
+
+  subscriber.subscribe(Messaging::REFRESH, [&](uint32_t) {
+    oldTopicCalls++;
+    subscriber.subscribe(Messaging::COLOR_CHANGED,
+                         [&](uint32_t) { newTopicCalls++; });
+  });
+
+  Messaging::send(Messaging::REFRESH);
+  Messaging::send(Messaging::REFRESH);
+  Messaging::send(Messaging::COLOR_CHANGED);
+
+  EXPECT_EQ(oldTopicCalls, 1);
+  EXPECT_EQ(newTopicCalls, 1);
+}
+
+TEST(Messaging, NestedSendIsDeterministic)
+{
+  std::vector<int> deliveries;
+  Messaging outer;
+  Messaging nested;
+
+  nested.subscribe(Messaging::COLOR_CHANGED,
+                   [&](uint32_t data) { deliveries.push_back(data); });
+  outer.subscribe(Messaging::REFRESH, [&](uint32_t data) {
+    deliveries.push_back(data);
+    Messaging::send(Messaging::COLOR_CHANGED, data + 1);
+  });
+
+  Messaging::send(Messaging::REFRESH, 20);
+
+  EXPECT_EQ(deliveries, (std::vector<int>{20, 21}));
+}
+
+TEST(Messaging, RepeatedSubscriptionLifetimeLeavesNoStaleDelivery)
+{
+  int calls = 0;
+
+  for (int i = 0; i < 100; i++) {
+    Messaging subscriber;
+    subscriber.subscribe(Messaging::REFRESH, [&](uint32_t) { calls++; });
+    Messaging::send(Messaging::REFRESH);
+  }
+
+  Messaging::send(Messaging::REFRESH);
+
+  EXPECT_EQ(calls, 100);
+}
+
+#endif


### PR DESCRIPTION
Summary of changes:

- Store color UI messaging callbacks in stable registry-owned subscription
  records instead of dereferencing subscriber objects during delivery.
- Defer inactive subscription cleanup until the outermost dispatch completes,
  allowing callbacks to unsubscribe, resubscribe, or destroy subscribers.
- Advance the reverse iterator before invoking a callback so subscriptions
  added during delivery take effect on the next send.
- Prevent `Messaging` copies, which cannot safely duplicate subscription
  ownership.
- Add focused host tests for ordering, topic filtering, explicit unsubscribe,
  subscriber destruction, self-destruction, mutation during delivery, nested
  sends, resubscription, and repeated lifetimes.

Root cause:

`Messaging::send()` iterated a global `std::list<Messaging *>` directly.
Appending a subscription from a callback changed what the reverse iterator
referenced, causing the existing callback to run twice during the same send.
Removing or destroying subscribers during callbacks could also invalidate the
current traversal or destroy the callback object while it was executing.

User/developer impact:

The public `subscribe()`, `unsubscribe()`, and `send()` API and newest-first
delivery order are unchanged. Color UI components can now safely change their
subscription lifetime while handling a message, and newly registered
subscribers begin receiving messages on the next send.

Validation:

- Confirmed the new tests against unmodified `upstream/main`: 9 passed and
  `SubscriptionAddedDuringDeliveryWaitsForNextSend` failed because the
  existing callback ran twice.
- Focused AddressSanitizer-enabled native tests: 10/10 passed.
- Complete TX16S native radio suite: 113/113 passed.
- TX16S production ARM firmware built successfully with GCC ARM 14.2.1 and
  `-fno-exceptions`.
- Firmware size gate passed: 76.41% flash usage, 483.08 KiB free.
