### PR TITLE
feat(lua): expose Disable Touch state

### DIFF
--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1780,6 +1780,25 @@ static int luaGetGeneralSettings(lua_State * L)
   return 1;
 }
 
+#if defined(HARDWARE_TOUCH)
+/*luadoc
+@function getTouchEnabled()
+
+Return whether touch input is enabled.
+
+Touch input can be disabled by an active Disable touch special function.
+
+@retval boolean `true` when touch input is enabled, `false` when it is disabled
+
+@status current Introduced in 3.0.0
+*/
+static int luaGetTouchEnabled(lua_State * L)
+{
+  lua_pushboolean(L, !isFunctionActive(FUNCTION_DISABLE_TOUCH));
+  return 1;
+}
+#endif
+
 /*luadoc
 @function getGlobalTimer()
 
@@ -3119,6 +3138,9 @@ LROT_BEGIN(etxlib, NULL, 0)
 #endif
   LROT_FUNCENTRY( getVersion, luaGetVersion )
   LROT_FUNCENTRY( getGeneralSettings, luaGetGeneralSettings )
+#if defined(HARDWARE_TOUCH)
+  LROT_FUNCENTRY( getTouchEnabled, luaGetTouchEnabled )
+#endif
   LROT_FUNCENTRY( getGlobalTimer, luaGetGlobalTimer )
   LROT_FUNCENTRY( getRotEncSpeed, luaGetRotEncSpeed )
   LROT_FUNCENTRY( getRotEncMode, luaGetRotEncMode )

--- a/radio/src/tests/lua.cpp
+++ b/radio/src/tests/lua.cpp
@@ -198,6 +198,27 @@ TEST(Lua, Switches)
 #endif
 }
 
+#if defined(HARDWARE_TOUCH)
+TEST(Lua, TouchEnabled)
+{
+  globalFunctionsContext.reset();
+  modelFunctionsContext.reset();
+
+  luaExecStr("assert(getTouchEnabled() == true)");
+
+  modelFunctionsContext.activeFunctions =
+      (MASK_FUNC_TYPE)1 << FUNCTION_DISABLE_TOUCH;
+  luaExecStr("assert(getTouchEnabled() == false)");
+
+  modelFunctionsContext.reset();
+  globalFunctionsContext.activeFunctions =
+      (MASK_FUNC_TYPE)1 << FUNCTION_DISABLE_TOUCH;
+  luaExecStr("assert(getTouchEnabled() == false)");
+
+  globalFunctionsContext.reset();
+}
+#endif
+
 TEST(Lua, testLegacyNames)
 {
   MODEL_RESET();


### PR DESCRIPTION
## Summary

- add a read-only `getTouchEnabled()` Lua API on touch-capable builds
- expose the existing effective `FUNCTION_DISABLE_TOUCH` state used by the input path
- document the API semantics and cover both model and global special-function activation

## Motivation

Lua widgets and applications need access to radio/UI state so they can present that state in custom interfaces. This API is not intended to replace the firmware feedback discussed in #1085 or implemented by #7565; it is a general capability for Lua consumers.

Examples include a top-bar indicator, a custom control surface, or future widgets that combine touch state with other radio-state indicators.

## Semantics and scope

`getTouchEnabled()` is available only on `HARDWARE_TOUCH` builds. It returns `false` while a model or global Disable touch special function is active.

The result represents that special-function state only. A `true` result does not guarantee that touch events are currently accepted because the touch driver can suppress input for other reasons, such as while the backlight is off.

## Validation

Rebased onto current `main` and built the TX16SMK3 native radio test target in the official EdgeTX development container:

- `Lua.TouchEnabled`: 1/1 passed
- Lua test suite: 7/7 passed
- full native radio test suite: 102/102 passed

The `3.0.0` Lua documentation tag matches the version declared by current `main`.