### PR TITLE
fix(cpn): autocombobox setModel

### DIFF
--- a/companion/src/modeledit/setup_module.cpp
+++ b/companion/src/modeledit/setup_module.cpp
@@ -1103,6 +1103,5 @@ void ModulePanel::updateTrainerModeItemModel()
 
     trainerModeItemModel = new FilteredItemModel(model->trainerModeItemModel(generalSettings, firmware));
     ui->trainerMode->setModel(trainerModeItemModel);
-    ui->trainerMode->updateValue();
   }
 }

--- a/companion/src/shared/autocombobox.cpp
+++ b/companion/src/shared/autocombobox.cpp
@@ -158,7 +158,7 @@ void AutoComboBox::setFieldInit(GenericPanel * panel)
 
 void AutoComboBox::setModel(QAbstractItemModel * model)
 {
-  if (model && QComboBox::model() != model) {
+  if (model) {
     setLock(true);
     QComboBox::setModel(model);
     setLock(false);


### PR DESCRIPTION
Found by @philmoz in v3.0 testing.
Changing the item model caused a memory violation.
