### PR TITLE
fix(tools): install locales and fix re-run issues in Ubuntu setup scripts

### DIFF
--- a/tools/setup_buildenv_ubuntu22.04.sh
+++ b/tools/setup_buildenv_ubuntu22.04.sh
@@ -72,6 +72,7 @@ sudo apt-get -y install --no-install-recommends \
     unzip \
     file \
     gawk \
+    m4 \
     libsdl2-dev \
     python3-dev \
     python3-pip \

--- a/tools/setup_buildenv_ubuntu22.04.sh
+++ b/tools/setup_buildenv_ubuntu22.04.sh
@@ -18,13 +18,22 @@ do
 	fi
 done
 
+if ! command -v lsb_release >/dev/null 2>&1; then
+  echo "ERROR: lsb_release not found, so the Ubuntu version cannot be checked."
+  echo "Install it with: sudo apt-get install lsb-release"
+  echo "Terminating the script now."
+  exit 1
+fi
+
 if [[ $(lsb_release -rs) != "22.04" ]]; then
   echo "ERROR: Not running on Ubuntu 22.04!"
   echo "Terminating the script now."
   exit 1
 fi
 
-echo "=== Step $((STEP++)): Setting up package repositories ==="
+echo "=== Step $((STEP++)): Setting up package repositories. Please provide sudo credentials, when asked ==="
+# Refresh in case package lists are stale
+sudo apt-get -y update
 sudo apt-get -y install --no-install-recommends software-properties-common gpg gpg-agent wget ca-certificates
 sudo mkdir -p /etc/apt/keyrings
 # Set up Kitware repository for newer cmake
@@ -46,7 +55,7 @@ if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
   read
 fi
 
-echo "=== Step $((STEP++)): Updating Ubuntu package lists. Please provide sudo credentials, when asked ==="
+echo "=== Step $((STEP++)): Updating Ubuntu package lists for the newly added repositories ==="
 sudo apt-get -y update
 if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
   echo "Step finished. Please check the output above and press Enter to continue or Ctrl+C to stop."
@@ -76,6 +85,7 @@ sudo apt-get -y install --no-install-recommends \
     python-is-python3 \
     dfu-util \
     nodejs \
+    locales \
     stlink-tools \
     openocd \
     pv
@@ -86,6 +96,18 @@ fi
 
 echo "=== Step $((STEP++)): Installing lv_font_conv ==="
 sudo npm i lv_font_conv -g
+if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
+  echo "Step finished. Please check the output above and press Enter to continue or Ctrl+C to stop."
+  read
+fi
+
+echo "=== Step $((STEP++)): Generating locales used by the custom function sorter ==="
+# cfn_sorter.sh sorts with std::locale, which aborts if a locale is missing
+sudo locale-gen \
+    zh_CN.UTF-8 cs_CZ.UTF-8 da_DK.UTF-8 de_DE.UTF-8 es_ES.UTF-8 en_US.UTF-8 \
+    fi_FI.UTF-8 fr_FR.UTF-8 he_IL.UTF-8 it_IT.UTF-8 ja_JP.UTF-8 ko_KR.UTF-8 \
+    nl_NL.UTF-8 pl_PL.UTF-8 pt_PT.UTF-8 ru_RU.UTF-8 sv_SE.UTF-8 zh_TW.UTF-8 \
+    uk_UA.UTF-8
 if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
   echo "Step finished. Please check the output above and press Enter to continue or Ctrl+C to stop."
   read
@@ -137,6 +159,8 @@ if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
 fi
 
 echo "=== Step $((STEP++)): Moving GNU Arm Embedded Toolchains to /opt ==="
+# Remove first: mv into an existing directory nests instead of replacing
+sudo rm -rf /opt/gcc-arm-none-eabi
 sudo mv arm-gnu-toolchain-${GCC_ARM_VERSION}-x86_64-arm-none-eabi /opt/gcc-arm-none-eabi
 if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
   echo "Step finished. Please press Enter to continue or Ctrl+C to stop."
@@ -144,10 +168,12 @@ if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
 fi
 
 echo "=== Step $((STEP++)): Adding GNU Arm Embedded Toolchain and Qt to PATH of current user ==="
-cat >> ~/.bashrc << EOF
-export PATH="/opt/gcc-arm-none-eabi/bin:\$PATH"
-export PATH="/opt/qt/${QT_VERSION}/gcc_64/bin:\$PATH"
-EOF
+# Only append if missing, so re-runs do not duplicate
+touch ~/.bashrc
+GCC_PATH_LINE="export PATH=\"/opt/gcc-arm-none-eabi/bin:\$PATH\""
+QT_PATH_LINE="export PATH=\"/opt/qt/${QT_VERSION}/gcc_64/bin:\$PATH\""
+grep -qxF "${GCC_PATH_LINE}" ~/.bashrc || echo "${GCC_PATH_LINE}" >> ~/.bashrc
+grep -qxF "${QT_PATH_LINE}" ~/.bashrc || echo "${QT_PATH_LINE}" >> ~/.bashrc
 if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
   echo "Step finished. Please press Enter to continue or Ctrl+C to stop."
   read

--- a/tools/setup_buildenv_ubuntu24.04.sh
+++ b/tools/setup_buildenv_ubuntu24.04.sh
@@ -68,6 +68,7 @@ sudo apt-get -y install --no-install-recommends \
     unzip \
     file \
     gawk \
+    m4 \
     libsdl2-dev \
     python3-dev \
     python3-pip \

--- a/tools/setup_buildenv_ubuntu24.04.sh
+++ b/tools/setup_buildenv_ubuntu24.04.sh
@@ -18,13 +18,22 @@ do
 	fi
 done
 
+if ! command -v lsb_release >/dev/null 2>&1; then
+  echo "ERROR: lsb_release not found, so the Ubuntu version cannot be checked."
+  echo "Install it with: sudo apt-get install lsb-release"
+  echo "Terminating the script now."
+  exit 1
+fi
+
 if [[ $(lsb_release -rs) != "24.04" ]]; then
   echo "ERROR: Not running on Ubuntu 24.04!"
   echo "Terminating the script now."
   exit 1
 fi
 
-echo "=== Step $((STEP++)): Setting up package repositories ==="
+echo "=== Step $((STEP++)): Setting up package repositories. Please provide sudo credentials, when asked ==="
+# Refresh in case package lists are stale
+sudo apt-get -y update
 sudo apt-get -y install --no-install-recommends software-properties-common gpg gpg-agent wget ca-certificates
 sudo mkdir -p /etc/apt/keyrings
 # Set up Kitware repository for newer cmake
@@ -42,7 +51,7 @@ if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
   read
 fi
 
-echo "=== Step $((STEP++)): Updating Ubuntu package lists. Please provide sudo credentials, when asked ==="
+echo "=== Step $((STEP++)): Updating Ubuntu package lists for the newly added repositories ==="
 sudo apt-get -y update
 if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
   echo "Step finished. Please check the output above and press Enter to continue or Ctrl+C to stop."
@@ -72,6 +81,7 @@ sudo apt-get -y install --no-install-recommends \
     python-is-python3 \
     dfu-util \
     nodejs \
+    locales \
     stlink-tools \
     openocd \
     pv
@@ -82,6 +92,18 @@ fi
 
 echo "=== Step $((STEP++)): Installing lv_font_conv ==="
 sudo npm i lv_font_conv -g
+if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
+  echo "Step finished. Please check the output above and press Enter to continue or Ctrl+C to stop."
+  read
+fi
+
+echo "=== Step $((STEP++)): Generating locales used by the custom function sorter ==="
+# cfn_sorter.sh sorts with std::locale, which aborts if a locale is missing
+sudo locale-gen \
+    zh_CN.UTF-8 cs_CZ.UTF-8 da_DK.UTF-8 de_DE.UTF-8 es_ES.UTF-8 en_US.UTF-8 \
+    fi_FI.UTF-8 fr_FR.UTF-8 he_IL.UTF-8 it_IT.UTF-8 ja_JP.UTF-8 ko_KR.UTF-8 \
+    nl_NL.UTF-8 pl_PL.UTF-8 pt_PT.UTF-8 ru_RU.UTF-8 sv_SE.UTF-8 zh_TW.UTF-8 \
+    uk_UA.UTF-8
 if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
   echo "Step finished. Please check the output above and press Enter to continue or Ctrl+C to stop."
   read
@@ -134,6 +156,8 @@ if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
 fi
 
 echo "=== Step $((STEP++)): Moving GNU Arm Embedded Toolchains to /opt ==="
+# Remove first: mv into an existing directory nests instead of replacing
+sudo rm -rf /opt/gcc-arm-none-eabi
 sudo mv arm-gnu-toolchain-${GCC_ARM_VERSION}-x86_64-arm-none-eabi /opt/gcc-arm-none-eabi
 if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
   echo "Step finished. Please press Enter to continue or Ctrl+C to stop."
@@ -141,10 +165,12 @@ if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
 fi
 
 echo "=== Step $((STEP++)): Adding GNU Arm Embedded Toolchain and Qt to PATH of current user ==="
-cat >> ~/.bashrc << EOF
-export PATH="/opt/gcc-arm-none-eabi/bin:\$PATH"
-export PATH="/opt/qt/${QT_VERSION}/gcc_64/bin:\$PATH"
-EOF
+# Only append if missing, so re-runs do not duplicate
+touch ~/.bashrc
+GCC_PATH_LINE="export PATH=\"/opt/gcc-arm-none-eabi/bin:\$PATH\""
+QT_PATH_LINE="export PATH=\"/opt/qt/${QT_VERSION}/gcc_64/bin:\$PATH\""
+grep -qxF "${GCC_PATH_LINE}" ~/.bashrc || echo "${GCC_PATH_LINE}" >> ~/.bashrc
+grep -qxF "${QT_PATH_LINE}" ~/.bashrc || echo "${QT_PATH_LINE}" >> ~/.bashrc
 if [[ $PAUSEAFTEREACHLINE == "true" ]]; then
   echo "Step finished. Please press Enter to continue or Ctrl+C to stop."
   read


### PR DESCRIPTION
## Summary

Both Ubuntu setup scripts install `nodejs` and `lv_font_conv`, so `make_fonts.sh` works on a fresh box — but neither installed the `locales` package or generated any locales. `tools/cfn_sorter.sh` sorts using `std::locale`, so on a clean Ubuntu install it aborts:

```
terminate called after throwing an instance of 'std::runtime_error'
  what():  locale::facet::_S_create_c_locale name not valid
```

This adds the `locales` package and generates the same 19 locales the dev container image builds — matching the list already documented at the top of `cfn_sorter.sh`.

## Also fixed

Three smaller issues found while in here:

- **Re-running duplicated the PATH exports.** `cat >> ~/.bashrc` ran unconditionally, so a second run appended a second copy of both exports. Now each entry is only appended if not already present.
- **Re-running nested the toolchain instead of replacing it.** `mv arm-gnu-toolchain-… /opt/gcc-arm-none-eabi` into an *existing* directory moves it inside, producing `/opt/gcc-arm-none-eabi/arm-gnu-toolchain-…/`. It exits 0 with no warning, silently leaving a duplicate copy (~1 GB). The old directory is now removed first.
- **The version guard misreported a missing `lsb_release`** as "Not running on Ubuntu XX.XX!". It is now checked separately, with a message pointing at the `lsb-release` package.

The initial `apt-get install` also now runs after an `apt-get update`, so it works where package lists are stale or empty.

## Testing

- Reproduced the failure on a clean `ubuntu:24.04` (exit 134, the error above); with the `locales` fix applied, `cfn_sorter.sh` completes and regenerates `radio/src/cfn_sort.cpp` byte-identically to what is committed.
- Verified the 19 locales match `cfn_sorter.sh`'s documented list exactly, in both scripts.
- Ran the fixed `.bashrc` and toolchain-move logic twice in a container: one PATH entry, no nested directory, toolchain intact.
- `bash -n` passes on both scripts; `shellcheck` goes from 12 to 13 findings, the extra one being the same `read` pattern the other 12 steps already use.

Both scripts get identical changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)