### PR TITLE
simu: let the host see what a module transmits

### DIFF
--- a/radio/src/targets/simu/module_drivers.cpp
+++ b/radio/src/targets/simu/module_drivers.cpp
@@ -24,6 +24,7 @@
 #include "hal/module_port.h"
 #include "dataconstants.h"
 #include "debug.h"
+#include "simulib.h"
 
 void intmoduleStop() {}
 void intmoduleFifoError() {}
@@ -90,6 +91,43 @@ static bool txCompleted(void*) { return true; }
 static void waitForTxCompleted(void*) {}
 static int getByte(void*,uint8_t*) { return -1; }
 
+// Internal module serial: the same stub as below, except that what the
+// firmware transmits is handed to the host instead of being dropped.  Without
+// this a simulator build has no way to observe the module's side of the link
+// at all, so anything that talks to the module -- the ExpressLRS Lua tool, for
+// one -- waits forever for a reply nobody could have heard it ask for.
+static void intmoduleSendByte(void*, uint8_t b)
+{
+  simuModuleSendBuffer(0, &b, 1);
+}
+
+static void intmoduleSendBuffer(void*, const uint8_t* data, uint32_t len)
+{
+  simuModuleSendBuffer(0, data, len);
+}
+
+const etx_serial_driver_t _intmoduleSerialDriver = {
+    .init = init,
+    .deinit = deinit,
+    .sendByte = intmoduleSendByte,
+    .sendBuffer = intmoduleSendBuffer,
+    .txCompleted = txCompleted,
+    .waitForTxCompleted = waitForTxCompleted,
+    .enableRx = nullptr,
+    .getByte = getByte,
+    .getLastByte = nullptr,
+    .getBufferedBytes = nullptr,
+    .copyRxBuffer = nullptr,
+    .clearRxBuffer = nullptr,
+    .getBaudrate = nullptr,
+    .setBaudrate = nullptr,
+    .setPolarity = nullptr,
+    .setHWOption = nullptr,
+    .setReceiveCb = nullptr,
+    .setIdleCb = nullptr,
+    .setBaudrateCb = nullptr,
+};
+
 const etx_serial_driver_t _fakeSerialDriver = {
     .init = init,
     .deinit = deinit,
@@ -139,7 +177,7 @@ const etx_module_port_t _internal_ports[] = {
     .port = ETX_MOD_PORT_UART,
     .type = ETX_MOD_TYPE_SERIAL,
     .dir_flags = ETX_MOD_DIR_TX_RX | ETX_MOD_FULL_DUPLEX,
-    .drv = { .serial = &_fakeSerialDriver },
+    .drv = { .serial = &_intmoduleSerialDriver },
     .hw_def = nullptr,
   },
 #else // INTMODULE_USART
@@ -147,7 +185,7 @@ const etx_module_port_t _internal_ports[] = {
     .port = ETX_MOD_PORT_SOFT_INV,
     .type = ETX_MOD_TYPE_SERIAL,
     .dir_flags = ETX_MOD_DIR_TX,
-    .drv = { .serial = &_fakeSerialDriver },
+    .drv = { .serial = &_intmoduleSerialDriver },
     .hw_def = nullptr,
   },
 #endif

--- a/radio/src/targets/simu/simulib.h
+++ b/radio/src/targets/simu/simulib.h
@@ -188,6 +188,13 @@ void WASM_IMPORT(simuAuxSerialSetBaudrate)(uint8_t port_nr, uint32_t baudrate);
 void WASM_IMPORT(simuAuxSerialSendBuffer)(uint8_t port_nr, const uint8_t* data,
                                          uint32_t len);
 
+// Module serial bridge (firmware -> host).  module is 0 for internal, 1 for
+// external.  Called with the bytes the radio's RF module would receive on its
+// serial line -- CRSF frames, for a module running ExpressLRS.  The reverse
+// direction already exists as simuSendTelemetry() above.
+void WASM_IMPORT(simuModuleSendBuffer)(uint8_t module, const uint8_t* data,
+                                       uint32_t len);
+
 // -- Internal (not exported) --
 void simuMain();
 std::string simuFatfsGetCurrentPath();


### PR DESCRIPTION
Fixes #

Summary of changes:

The WASM/SIMU target can be told what a module *receives* but not what it
*sends*, so a host has no way to answer the radio's RF module. This adds the
missing direction.

**The gap.** `radio/src/targets/simu/module_drivers.cpp` points every module
port at `_fakeSerialDriver`, whose `sendBuffer` discards its argument. The
inbound half is already there — `simuSendTelemetry()` hands bytes to
`processCrossfireTelemetryFrame()` — so a host can inject telemetry, but
anything the firmware writes to the module is dropped before it leaves the
simulator.

**The consequence.** Nothing that expects a reply from the module can work.
Concretely: ExpressLRS ships `SCRIPTS/TOOLS/elrs.lua`, and running it off a
real SD card in a SIMU build gets as far as "Loading..." and stays there
forever. The script's CRSF `DEVICE_PING` is written to the module port and
discarded, so no host could know a reply was wanted, let alone what to reply.
The script is correct and the radio is correct; there is simply no wire.

**The change.**

- `simulib.h`: one new import, `simuModuleSendBuffer(uint8_t module, const
  uint8_t* data, uint32_t len)` — `module` is 0 for internal, 1 for external —
  documented as the reverse of the existing `simuSendTelemetry()`.
- `module_drivers.cpp`: `_intmoduleSerialDriver`, identical to the existing
  stub except that `sendByte`/`sendBuffer` hand their bytes to the host, and
  the internal module's port entries use it.

Two deliberate choices, both easy to change if you would rather they were
different:

- **Internal only.** The external port stays on `_fakeSerialDriver`. Only the
  internal path has been exercised, and a port nobody listens to seemed better
  left obviously silent than half-wired.
- **Both internal-port branches.** `INTMODULE_USART` selects which of the two
  `ETX_MOD_PORT_*` entries is compiled, and picking only one fails silently:
  the driver goes unreferenced, is dead-stripped, the import never appears in
  the `.wasm`, and the sole symptom is that no frames ever arrive. Routing both
  costs nothing and removes a very confusing failure mode.

**Tested on** `tx12mk2` (PCB=X7), which takes the soft-serial branch. With the
import in place, unmodified `elrs.lua` off a stock ExpressLRS SD card finds the
internal CRSF module, draws its parameter menu, and writes packet rate and
transmit power back to a host-side module implementation. Nothing else about
the build changes; on targets whose host does not provide the import, the
behaviour is the same as before.
