### PR TITLE
fix(ghost): do not memcpy MSP frames into the module buffer

### DIFF
--- a/radio/src/pulses/ghost.cpp
+++ b/radio/src/pulses/ghost.cpp
@@ -201,7 +201,12 @@ static void ghostSendPulses(void* ctx, uint8_t* buffer, int16_t* channels, uint8
       *p_data++ = getGhostModuleAddr();
       // and length
       *p_data++ = 12;
-      memcpy(p_data, f_data, 12);
+      // byte-wise: this buffer is non-cacheable memory on some targets, where
+      // the unaligned wide accesses memcpy emits at this offset are faulting
+      volatile uint8_t* dst = p_data;
+      for (uint8_t i = 0; i < 12; i++) {
+        *dst++ = f_data[i];
+      }
       p_data += 12; f_data += 12;
       len -= 12;
     }


### PR DESCRIPTION
# fix(ghost): do not memcpy MSP frames into the module buffer

Fixes #7607

## Problem

On H7 radios, any Lua script that sends MSP over a Ghost module locks the radio
up instantly and it watchdog-resets into EMERGENCY MODE. Reproducible with the
standard Betaflight Lua scripts: connect a Ghost-linked quad with the BF tool
(or the `bfbkgd` background script) running and the radio dies within
milliseconds, in every RF mode, with any Ghost module.

`ghostSendPulses()` writes Lua MSP frames into the module pulse buffer at a
2 byte offset, after the address and length bytes:

```c
*p_data++ = getGhostModuleAddr();   // offset 0
*p_data++ = 12;                     // offset 1
memcpy(p_data, f_data, 12);         // offset 2  <-- unaligned destination
```

That buffer is `__DMA_NO_CACHE`, which on H7 lands in `.dram`, mapped by
`MPU_Config()` as a non-cacheable DMA region that does not permit unaligned
accesses. The wide stores `memcpy()` emits at offset 2 abort, and the core is
gone before any fault handler runs -- no fault, no assert, no trace output,
just a watchdog reset.

Only Ghost MSP is affected:

- Ghost channel frames are written byte-wise from an aligned base -- fine.
- Crossfire writes its MSP frames at offset 0 (aligned) -- fine.
- F2/F4 targets keep these buffers in ordinary RAM -- fine.

## Fix

Copy byte-wise through a `volatile` pointer so the stores cannot be merged back
into unaligned wide accesses. Six lines, no behaviour change anywhere else.

## Testing

- HelloRadioSky V12 (STM32H750, external Ghost module, Ghost RX on a Betaflight
  quad): before, the radio reset as soon as a script sent MSP; after, the
  Betaflight setup tool connects and works, with `GHST_UL_MSP_REQ` going out and
  `GHST_DL_MSP_RESP` coming back. Channel control and telemetry unchanged.
- TX16S (STM32F4): builds clean, and the copy compiles to byte stores as
  intended. **Not tested on F4 hardware** -- I do not have an F4 radio with a
  Ghost module. On F2/F4 `__DMA_NO_CACHE` is ordinary RAM, so the loop is
  semantically identical to the previous `memcpy` and no behaviour change is
  expected, but a quick confirmation from someone with an F4 radio and a Ghost
  module would be appreciated before merging: bind a quad, run the Betaflight
  Lua tool over Ghost, and check that MSP still works and channel output is
  unaffected.

## Note for maintainers

Region 4 in `MPU_Config()` uses `TEX=0b001, C=0, B=1`, which is a reserved
combination in the ARMv7-M TEX/C/B encoding; "Normal, non-cacheable" (what a DMA
buffer region wants, and which permits unaligned access) is
`TEX=0b001, C=0, B=0`. Correcting that would protect every other driver writing
into these buffers from the same trap, but it touches all H7 targets, so I left
it out of this PR. Details in the issue -- happy to open a follow-up.
