### PR TITLE
fix(ghost): use a usable baudrate for the telemetry mirror

### DIFF
--- a/radio/src/serial.cpp
+++ b/radio/src/serial.cpp
@@ -46,6 +46,10 @@
   #include "telemetry/crossfire.h"
 #endif
 
+#if defined(GHOST)
+  #include "telemetry/ghost.h"
+#endif
+
 #if defined(DEBUG_SEGGER_RTT)
   #include "thirdparty/Segger/SEGGER/SEGGER_RTT.h"
 #endif
@@ -298,6 +302,12 @@ static void serialSetupPort(int mode, etx_serial_init& params)
 #if defined(CROSSFIRE)
     if (isModuleCrossfire(EXTERNAL_MODULE) || isModuleCrossfire(INTERNAL_MODULE)) {
       params.baudrate = CROSSFIRE_TELEM_MIRROR_BAUDRATE;
+      break;
+    }
+#endif
+#if defined(GHOST)
+    if (isModuleGhost(EXTERNAL_MODULE) || isModuleGhost(INTERNAL_MODULE)) {
+      params.baudrate = GHOST_TELEM_MIRROR_BAUDRATE;
       break;
     }
 #endif

--- a/radio/src/telemetry/ghost.h
+++ b/radio/src/telemetry/ghost.h
@@ -119,6 +119,7 @@ enum GhostTelemetryBaudrates
 };
 #endif
 #define GHOST_BAUDRATE       400000
+#define GHOST_TELEM_MIRROR_BAUDRATE  115200
 #define GHOST_PERIOD         4000 /* us */
 
 enum GhostLineFlags


### PR DESCRIPTION
# fix(ghost): use a usable baudrate for the telemetry mirror

Fixes #7609

## Problem

With a Ghost module, a serial port set to "Telemetry mirror" emits a stream
nothing can decode, so the feature is effectively unavailable: no Bluetooth
telemetry to a phone app, no external logging.

`serialSetupPort()` special-cases Crossfire for the mirror and lets everything
else fall through to `FRSKY_TELEM_MIRROR_BAUDRATE`. That constant is 115200 only
on the TX16S and F16; elsewhere it is `FRSKY_SPORT_BAUDRATE`, 57600. Ghost has
no case at all, so on most radios its mirror runs at 57600.

That is wrong twice over. A consumer set to the usual 115200 reads the port at
half rate and gets bit-smeared bytes rather than frames. And Ghost telemetry is
about 5 kB/s while 57600 baud carries 5760 B/s, so the port saturates and drops
bytes even when both ends agree on the rate.

## Fix

Give Ghost its own case beside Crossfire's and mirror at 115200, which has the
headroom Ghost needs.

## Testing

HelloRadioSky V12 (STM32H750), Ghost module, Bluetooth LE serial module at
115200 feeding an Android telemetry app:

- before: the receiving end saw undecodable bytes such as
  `FF FE FE E0 78 00 00 18 03 00 E0 80 00 18 00 00 E0 78 3C 7E`
- after: GHST frames arrive intact and decode normally -- link statistics,
  battery pack voltage/current/capacity, GPS position, altitude, speed and
  satellites all read correctly.

Only the Ghost path changes; Crossfire and FrSky keep the baud rates they had.

## Note

The existing `// TODO: query telemetry baudrate / add setting for module` above
this code still applies. A per-port baud setting would be the general answer and
would let users match whatever hardware they attach; this PR just stops Ghost
being silently broken in the meantime.
