### PR TITLE
fix(sport): add Betaflight Pitch/Roll sensor unit and precision (#7116)

### DIFF
--- a/radio/src/telemetry/frsky_sport.cpp
+++ b/radio/src/telemetry/frsky_sport.cpp
@@ -104,6 +104,9 @@ const FrSkySportSensor sportSensors[] = {
   FS( SERVO_FIRST_ID,             SERVO_LAST_ID,            1, STR_SENSOR_SERVO_VOLTAGE,      UNIT_VOLTS,       1 ),
   FS( SERVO_FIRST_ID,             SERVO_LAST_ID,            2, STR_SENSOR_SERVO_TEMPERATURE,  UNIT_CELSIUS,     0 ),
   FS( SERVO_FIRST_ID,             SERVO_LAST_ID,            3, STR_SENSOR_SERVO_STATUS,       UNIT_TEXT,        0 ),
+  // Betaflight S.Port telemetry - Pitch and Roll are sent as degree * 10
+  FS( 0x5230,                     0x5230,                   0, STR_SENSOR_PITCH,               UNIT_DEGREE,      1 ),
+  FS( 0x5240,                     0x5240,                   0, STR_SENSOR_ROLL,                UNIT_DEGREE,      1 ),
   FS( 0,                          0,                        0, nullptr,                       UNIT_RAW,         0 ) // sentinel
 };
 // clang-format on

--- a/radio/src/tests/frsky.cpp
+++ b/radio/src/tests/frsky.cpp
@@ -526,10 +526,10 @@ TEST(FrSkySPORT, BetaflightAngleSensors)
 
   // Betaflight S.Port telemetry sends Pitch (0x5230) and Roll (0x5240)
   // as degree * 10, which must be discovered with UNIT_DEGREE and prec 1.
-  packet[0] = 0x52;  // physical ID (DIY)
+  packet[0] = 0x52;  // physical ID
   packet[1] = 0x10;  // DATA_FRAME
-  *((uint16_t *)(packet+2)) = 0x5230;  // Pitch
-  *((int32_t *)(packet+4)) = 532;      // 53.2 deg
+  packet[2] = 0x30; packet[3] = 0x52;  // dataId = 0x5230 (little-endian)
+  packet[4] = 0x14; packet[5] = 0x02; packet[6] = 0x00; packet[7] = 0x00;  // 532 (53.2 deg)
   setSportPacketCrc(packet);
   sportProcessTelemetryPacket(0, packet, sizeof(packet));
 

--- a/radio/src/tests/frsky.cpp
+++ b/radio/src/tests/frsky.cpp
@@ -21,6 +21,8 @@
 
 #include "gtests.h"
 
+#include <cstring>
+
 void frskyDProcessPacket(const uint8_t *packet);
 bool checkSportPacket(const uint8_t *packet);
 bool checkSportPacket(const uint8_t *packet);
@@ -526,10 +528,13 @@ TEST(FrSkySPORT, BetaflightAngleSensors)
 
   // Betaflight S.Port telemetry sends Pitch (0x5230) and Roll (0x5240)
   // as degree * 10, which must be discovered with UNIT_DEGREE and prec 1.
-  packet[0] = 0x52;  // physical ID
+  // S.Port dataId and value are little-endian on the wire.
+  packet[0] = 0x52;  // physical ID (DIY)
   packet[1] = 0x10;  // DATA_FRAME
-  packet[2] = 0x30; packet[3] = 0x52;  // dataId = 0x5230 (little-endian)
-  packet[4] = 0x14; packet[5] = 0x02; packet[6] = 0x00; packet[7] = 0x00;  // 532 (53.2 deg)
+  packet[2] = 0x30;  // dataId 0x5230 (Pitch), low byte
+  packet[3] = 0x52;  // dataId 0x5230, high byte
+  int32_t value = 532;  // 53.2 deg
+  memcpy(packet + 4, &value, sizeof(value));
   setSportPacketCrc(packet);
   sportProcessTelemetryPacket(0, packet, sizeof(packet));
 
@@ -540,8 +545,10 @@ TEST(FrSkySPORT, BetaflightAngleSensors)
 
   packet[0] = 0x52;
   packet[1] = 0x10;
-  *((uint16_t *)(packet+2)) = 0x5240;  // Roll
-  *((int32_t *)(packet+4)) = -124;     // -12.4 deg
+  packet[2] = 0x40;  // dataId 0x5240 (Roll), low byte
+  packet[3] = 0x52;  // dataId 0x5240, high byte
+  value = -124;  // -12.4 deg
+  memcpy(packet + 4, &value, sizeof(value));
   setSportPacketCrc(packet);
   sportProcessTelemetryPacket(0, packet, sizeof(packet));
 

--- a/radio/src/tests/frsky.cpp
+++ b/radio/src/tests/frsky.cpp
@@ -514,3 +514,40 @@ TEST(FrSkySPORT, frskyCurrent)
   EXPECT_EQ(telemetryItems[0].valueMax, 505);
 }
 
+TEST(FrSkySPORT, BetaflightAngleSensors)
+{
+  uint8_t packet[FRSKY_SPORT_PACKET_SIZE];
+
+  MODEL_RESET();
+  TELEMETRY_RESET();
+  telemetryStreaming = TELEMETRY_TIMEOUT10ms;
+  telemetryData.telemetryValid = 0x07;
+  allowNewSensors = true;
+
+  // Betaflight S.Port telemetry sends Pitch (0x5230) and Roll (0x5240)
+  // as degree * 10, which must be discovered with UNIT_DEGREE and prec 1.
+  packet[0] = 0x52;  // physical ID (DIY)
+  packet[1] = 0x10;  // DATA_FRAME
+  *((uint16_t *)(packet+2)) = 0x5230;  // Pitch
+  *((int32_t *)(packet+4)) = 532;      // 53.2 deg
+  setSportPacketCrc(packet);
+  sportProcessTelemetryPacket(0, packet, sizeof(packet));
+
+  ASSERT_EQ(g_model.telemetrySensors[0].id, 0x5230);
+  EXPECT_EQ(g_model.telemetrySensors[0].unit, UNIT_DEGREE);
+  EXPECT_EQ(g_model.telemetrySensors[0].prec, 1);
+  EXPECT_EQ(telemetryItems[0].value, 532);
+
+  packet[0] = 0x52;
+  packet[1] = 0x10;
+  *((uint16_t *)(packet+2)) = 0x5240;  // Roll
+  *((int32_t *)(packet+4)) = -124;     // -12.4 deg
+  setSportPacketCrc(packet);
+  sportProcessTelemetryPacket(0, packet, sizeof(packet));
+
+  ASSERT_EQ(g_model.telemetrySensors[1].id, 0x5240);
+  EXPECT_EQ(g_model.telemetrySensors[1].unit, UNIT_DEGREE);
+  EXPECT_EQ(g_model.telemetrySensors[1].prec, 1);
+  EXPECT_EQ(telemetryItems[1].value, -124);
+}
+


### PR DESCRIPTION
Fixes #7116

## Summary

Betaflight S.Port telemetry sends Pitch (`0x5230`) and Roll (`0x5240`) sensors with the value encoded as degrees * 10. These IDs fall in the DIY range (`0x5100`-`0x52FF`) and were discovered without any unit or precision, so the radio displayed `-` as unit and `0.-` as precision.

## Fix

Added the two Betaflight angle sensors to the `sportSensors` table in `frsky_sport.cpp`:
- `0x5230` → Pitch, `UNIT_DEGREE`, precision 1 (value / 10)
- `0x5240` → Roll, `UNIT_DEGREE`, precision 1 (value / 10)

So a raw value of `532` is now displayed as `53.2` degrees.

## Tests

Added `FrSkySPORT.BetaflightAngleSensors` in `radio/src/tests/frsky.cpp` verifying that:
- a S.Port frame with dataId `0x5230` discovers a sensor with `UNIT_DEGREE` / precision 1 and stores the raw value
- a S.Port frame with dataId `0x5240` discovers the Roll sensor likewise (including negative values)

