### PR TITLE
fix(simu): force C locale for numeric parsing in simulator

### DIFF
--- a/radio/src/targets/simu/simulib.cpp
+++ b/radio/src/targets/simu/simulib.cpp
@@ -46,6 +46,7 @@
 #endif
 
 #include <assert.h>
+#include <clocale>
 #include <deque>
 #include <stdint.h>
 
@@ -91,6 +92,11 @@ static void hostSerialInit();
 
 void simuInit()
 {
+  // Force the C locale for numeric conversions (strtof/strtod, etc.),
+  // otherwise the simulator picks up the host locale (e.g. es_ES) which
+  // uses a comma as decimal separator and breaks Lua number parsing.
+  setlocale(LC_NUMERIC, "C");
+
 #if defined(ROTARY_ENCODER_NAVIGATION)
   rotencValue = 0;
 #endif


### PR DESCRIPTION
Fixes #7453

## Summary

The Companion / SDL simulator failed to run when the host locale is not `C`/English (e.g. `LANG=es_ES.UTF-8`): all float numbers parsed by the Lua engine produced errors because `strtof`/`strtod` use the locale's decimal separator (`,` in es_ES) instead of `.`.

## Fix

Force `LC_NUMERIC` to `"C"` in `simuInit()` (`radio/src/targets/simu/simulib.cpp`), which is the shared entry point for both the SDL and the WASM simulator. This makes numeric conversions locale-independent inside the simulator while leaving the rest of the process untouched.

## Verification

Compiled a small host test that calls `setlocale(LC_NUMERIC, "C")` and confirmed `strtod("1.5")` parses correctly regardless of the host locale.

