### PR TITLE
feat(radio): support SBUS Trainer over USB-VCP

### DIFF
--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -566,9 +566,14 @@ bool isSerialModeAvailable(uint8_t port_nr, int mode)
 #endif
 
 #if defined(USB_SERIAL)
-  // Telemetry input & SBUS trainer on VCP is not yet supported
-  if (port_nr == SP_VCP &&
-      (mode == UART_MODE_TELEMETRY || mode == UART_MODE_SBUS_TRAINER))
+  // Telemetry input on VCP is not yet supported
+  if (port_nr == SP_VCP && mode == UART_MODE_TELEMETRY)
+    return false;
+
+  // USB CDC carries no line polarity, so the two SBUS trainer modes behave
+  // identically on VCP. Offer only the one the user knows as plain SBUS:
+  // normal SBUS is inverted serial, so that is UART_MODE_SBUS_TRAINER_INV.
+  if (port_nr == SP_VCP && mode == UART_MODE_SBUS_TRAINER)
     return false;
 #endif
 

--- a/radio/src/sbus.cpp
+++ b/radio/src/sbus.cpp
@@ -21,6 +21,8 @@
 
 #include "sbus.h"
 
+#include <string.h>
+
 #include "edgetx.h"
 #include "timers_driver.h"
 
@@ -41,6 +43,13 @@ static void* _sbus_ctx = nullptr;
 static bool _sbus_aux_enabled = false;
 
 static void sbusProcessFrame(int16_t* pulses, uint8_t* sbus, uint32_t size);
+
+// The last byte of a frame is 0x00 for Futaba / FrSky, but some
+// implementations use it to carry frame flags (0x04 / 0x14 / 0x24).
+static inline bool sbusIsEndByte(uint8_t b)
+{
+  return b == SBUS_END_BYTE || b == 0x04 || b == 0x14 || b == 0x24;
+}
 
 void sbusSetReceiveCtx(void* ctx, const etx_serial_driver_t* drv)
 {
@@ -74,11 +83,95 @@ void sbusFrameReceived(void*)
   sbusProcessFrame(trainerInput, frame, received);
 }
 
+//
+// Byte-stream framer, for ports with no idle-line detection (USB-VCP).
+//
+// USB CDC gives no frame boundaries: a 25 byte frame may be split over several
+// packets, and several frames may arrive in one packet. So frames have to be
+// recovered from the stream itself.
+//
+// Invariant: _sbus_stream_len == 0, or _sbus_stream_buf[0] == SBUS_START_BYTE.
+//
+static uint8_t _sbus_stream_buf[SBUS_FRAME_SIZE];
+static uint8_t _sbus_stream_len = 0;
+
+static const etx_serial_driver_t* _sbus_stream_drv = nullptr;
+static void* _sbus_stream_ctx = nullptr;
+
+// Drop the leading byte of a rejected frame and re-sync on the next start byte
+// found in what is left. Never drops the whole buffer: a valid frame may well
+// have started inside it.
+static void sbusStreamResync()
+{
+  uint8_t i = 1;
+  while (i < _sbus_stream_len && _sbus_stream_buf[i] != SBUS_START_BYTE) i++;
+
+  _sbus_stream_len -= i;
+  if (_sbus_stream_len > 0) {
+    memmove(_sbus_stream_buf, _sbus_stream_buf + i, _sbus_stream_len);
+  }
+}
+
+void sbusStreamReceiveData(uint8_t* data, uint32_t len)
+{
+  // Trainer mode is not asking for serial input: stay out of the way.
+  if (!_sbus_aux_enabled) {
+    _sbus_stream_len = 0;
+    return;
+  }
+
+  while (len > 0) {
+    // Hunt for a start byte while no frame is being assembled
+    if (_sbus_stream_len == 0 && *data != SBUS_START_BYTE) {
+      data++; len--;
+      continue;
+    }
+
+    _sbus_stream_buf[_sbus_stream_len++] = *data++;
+    len--;
+
+    if (_sbus_stream_len < SBUS_FRAME_SIZE) continue;
+
+    if (sbusIsEndByte(_sbus_stream_buf[SBUS_FRAME_SIZE - 1])) {
+      // Complete frame. sbusProcessFrame() re-checks it, and resets the
+      // trainer validity timer if it is accepted.
+      sbusProcessFrame(trainerInput, _sbus_stream_buf, SBUS_FRAME_SIZE);
+      _sbus_stream_len = 0;
+    } else {
+      sbusStreamResync();
+    }
+  }
+}
+
+void sbusStreamStart(void* ctx, const etx_serial_driver_t* drv)
+{
+  if (!drv || !drv->setReceiveCb) return;
+
+  _sbus_stream_len = 0;
+  _sbus_stream_drv = drv;
+  _sbus_stream_ctx = ctx;
+
+  drv->setReceiveCb(ctx, sbusStreamReceiveData);
+}
+
+void sbusStreamStop()
+{
+  auto drv = _sbus_stream_drv;
+  auto ctx = _sbus_stream_ctx;
+
+  _sbus_stream_drv = nullptr;
+  _sbus_stream_ctx = nullptr;
+  _sbus_stream_len = 0;
+
+  // Release the RX stream, so the next user of the port gets it
+  if (drv && drv->setReceiveCb) drv->setReceiveCb(ctx, nullptr);
+}
+
 // Range for pulses (ppm input) is [-512:+512]
 static void sbusProcessFrame(int16_t* pulses, uint8_t* sbus, uint32_t size)
 {
   if (size != SBUS_FRAME_SIZE || sbus[0] != SBUS_START_BYTE ||
-      sbus[SBUS_FRAME_SIZE - 1] != SBUS_END_BYTE) {
+      !sbusIsEndByte(sbus[SBUS_FRAME_SIZE - 1])) {
     return;  // not a valid SBUS frame
   }
   if ((sbus[SBUS_FLAGS_IDX] & (1 << SBUS_FAILSAFE_BIT)) ||

--- a/radio/src/sbus.h
+++ b/radio/src/sbus.h
@@ -31,7 +31,21 @@ void sbusSetReceiveCtx(void* ctx, const etx_serial_driver_t* drv);
 // SBUS AUX idle callback
 void sbusAuxFrameReceived(void* param);
 
-// Enable / disable SBUS AUX
+// Enable / disable serial trainer input (both the AUX UART and the USB-VCP
+// paths). Driven by TRAINER_MODE_MASTER_SERIAL.
 void sbusAuxSetEnabled(bool enabled);
 
 void sbusFrameReceived(void* param);
+
+//
+// SBUS byte-stream framer.
+//
+// For ports that deliver arbitrarily chunked buffers and have no idle-line
+// detection to mark frame boundaries (USB-VCP). Attach / detach the driver's
+// receive callback, and keep the partial-frame state across chunks.
+//
+void sbusStreamStart(void* ctx, const etx_serial_driver_t* drv);
+void sbusStreamStop();
+
+// Receive callback: feeds a chunk of the byte stream into the framer
+void sbusStreamReceiveData(uint8_t* data, uint32_t len);

--- a/radio/src/serial.cpp
+++ b/radio/src/serial.cpp
@@ -221,7 +221,15 @@ static void serialSetCallBacks(int mode, void* ctx, const etx_serial_port_t* por
   case UART_MODE_SBUS_TRAINER_INV:
     sbusSetReceiveCtx(ctx, drv);
     if (drv && drv->setIdleCb) {
+      // Hardware UART: the idle line marks the frame boundaries
       drv->setIdleCb(ctx, sbusAuxFrameReceived, nullptr);
+    } else if (drv && drv->setReceiveCb) {
+      // No idle-line detection (USB-VCP): recover frames from the byte stream
+      sbusStreamStart(ctx, drv);
+    } else {
+      // De-init (ctx == nullptr, hence drv == nullptr), or a port that can do
+      // neither. No-op unless the framer is currently attached.
+      sbusStreamStop();
     }
     break;
 

--- a/radio/src/tests/sbus_trainer.cpp
+++ b/radio/src/tests/sbus_trainer.cpp
@@ -1,0 +1,302 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include <vector>
+
+#include "gtests.h"
+#include "gui/gui_common.h"
+#include "sbus.h"
+#include "serial.h"
+#include "trainer.h"
+
+// Tests for the SBUS byte-stream framer used by ports without idle-line
+// detection (USB-VCP). The framer has to recover 25 byte frames from a stream
+// chunked at arbitrary boundaries.
+
+namespace {
+
+constexpr uint8_t SBUS_FRAME_SIZE = 25;
+constexpr uint8_t SBUS_START = 0x0F;
+constexpr uint16_t SBUS_CENTER = 992;
+
+// Distinct value per channel, so channel ordering is checked and not just
+// channel content. Kept inside the 11 bit range.
+uint16_t testChannelValue(int ch) { return 200 + ch * 100; }
+
+// Expected trainer value for a raw SBUS channel value, per sbusProcessFrame()
+int16_t expectedPulse(uint16_t raw) { return ((int32_t)raw - SBUS_CENTER) * 5 / 8; }
+
+std::vector<uint8_t> buildFrame(uint8_t flags = 0x00, uint8_t endByte = 0x00)
+{
+  std::vector<uint8_t> frame;
+  frame.push_back(SBUS_START);
+
+  uint32_t bits = 0;
+  uint8_t bitsAvailable = 0;
+  for (int ch = 0; ch < 16; ch++) {
+    bits |= (uint32_t)(testChannelValue(ch) & 0x7FF) << bitsAvailable;
+    bitsAvailable += 11;
+    while (bitsAvailable >= 8) {
+      frame.push_back(bits & 0xFF);
+      bits >>= 8;
+      bitsAvailable -= 8;
+    }
+  }
+
+  frame.push_back(flags);
+  frame.push_back(endByte);
+  return frame;
+}
+
+void append(std::vector<uint8_t>& dst, const std::vector<uint8_t>& src)
+{
+  dst.insert(dst.end(), src.begin(), src.end());
+}
+
+// Feed a stream to the framer, split into fixed size chunks. chunkSize == 0
+// means "one single chunk", which is what a small USB packet looks like.
+void feed(std::vector<uint8_t> stream, size_t chunkSize = 0)
+{
+  if (chunkSize == 0) chunkSize = stream.size();
+
+  size_t offset = 0;
+  while (offset < stream.size()) {
+    size_t n = std::min(chunkSize, stream.size() - offset);
+    sbusStreamReceiveData(stream.data() + offset, n);
+    offset += n;
+  }
+}
+
+void expectTestChannels()
+{
+  for (int ch = 0; ch < 16; ch++) {
+    EXPECT_EQ(trainerInput[ch], expectedPulse(testChannelValue(ch)))
+        << "channel " << ch;
+  }
+}
+
+class SbusStreamTest : public ::testing::Test
+{
+ protected:
+  void SetUp() override
+  {
+    sbusStreamStop();  // clears any partial frame left by a previous test
+    sbusAuxSetEnabled(true);
+    memset(trainerInput, 0, sizeof(trainerInput));
+    trainerSetTimer(0);
+  }
+
+  void TearDown() override { sbusAuxSetEnabled(false); }
+};
+
+}  // namespace
+
+TEST_F(SbusStreamTest, singleFrame)
+{
+  feed(buildFrame());
+
+  expectTestChannels();
+  EXPECT_TRUE(isTrainerValid());
+}
+
+// A 25 byte frame is routinely split across USB packets. Every possible split
+// point has to work, including one byte at a time.
+TEST_F(SbusStreamTest, splitAcrossChunkBoundaries)
+{
+  for (size_t chunkSize = 1; chunkSize <= SBUS_FRAME_SIZE; chunkSize++) {
+    sbusStreamStop();
+    memset(trainerInput, 0, sizeof(trainerInput));
+
+    feed(buildFrame(), chunkSize);
+
+    for (int ch = 0; ch < 16; ch++) {
+      EXPECT_EQ(trainerInput[ch], expectedPulse(testChannelValue(ch)))
+          << "chunk size " << chunkSize << ", channel " << ch;
+    }
+  }
+}
+
+// Several frames may arrive in a single USB packet.
+TEST_F(SbusStreamTest, backToBackFramesInOneChunk)
+{
+  std::vector<uint8_t> stream;
+  append(stream, buildFrame());
+  append(stream, buildFrame());
+  append(stream, buildFrame());
+
+  feed(stream);
+
+  expectTestChannels();
+  EXPECT_TRUE(isTrainerValid());
+}
+
+// Bytes already in flight when the framer attaches are not a frame start.
+TEST_F(SbusStreamTest, garbagePrefixIsSkipped)
+{
+  std::vector<uint8_t> stream = {0x11, 0x22, 0x33, 0xFF, 0xAB};
+  append(stream, buildFrame());
+
+  feed(stream);
+
+  expectTestChannels();
+  EXPECT_TRUE(isTrainerValid());
+}
+
+// A frame whose end byte is wrong must be rejected, and the framer must
+// re-sync rather than discard everything it holds.
+TEST_F(SbusStreamTest, invalidEndByteIsRejectedThenResyncs)
+{
+  auto bad = buildFrame(0x00, 0xFF);
+
+  feed(bad);
+  EXPECT_FALSE(isTrainerValid()) << "frame with a bad end byte was accepted";
+
+  feed(buildFrame());
+  expectTestChannels();
+  EXPECT_TRUE(isTrainerValid());
+}
+
+// Garbage injected mid-stream (the --garbage case of the PC-side test tool):
+// a truncated frame followed by good ones must recover.
+TEST_F(SbusStreamTest, resyncAfterTruncatedFrame)
+{
+  auto frame = buildFrame();
+
+  std::vector<uint8_t> stream;
+  append(stream, frame);
+  // half a frame, then noise, then two clean frames
+  stream.insert(stream.end(), frame.begin(), frame.begin() + 12);
+  for (uint8_t b : {0x55, 0xAA, 0x37, 0x91}) stream.push_back(b);
+  append(stream, frame);
+  append(stream, frame);
+
+  feed(stream, 7);  // awkward chunking on top
+
+  expectTestChannels();
+  EXPECT_TRUE(isTrainerValid());
+}
+
+// The re-sync path has to find a start byte held *inside* the buffer, not just
+// drop the buffer: here a stray 0x0F precedes the real frame closely enough
+// that the real frame is already partly buffered when the false frame fails.
+TEST_F(SbusStreamTest, resyncFindsStartByteInsideBuffer)
+{
+  std::vector<uint8_t> stream = {SBUS_START, 0x01, 0x02};
+  append(stream, buildFrame());
+
+  feed(stream);
+
+  expectTestChannels();
+  EXPECT_TRUE(isTrainerValid());
+}
+
+// Some implementations carry frame flags in the last byte.
+TEST_F(SbusStreamTest, acceptsEndByteVariants)
+{
+  for (uint8_t endByte : {0x00, 0x04, 0x14, 0x24}) {
+    sbusStreamStop();
+    memset(trainerInput, 0, sizeof(trainerInput));
+    trainerSetTimer(0);
+
+    feed(buildFrame(0x00, endByte));
+
+    EXPECT_TRUE(isTrainerValid()) << "end byte 0x" << std::hex << (int)endByte;
+    EXPECT_EQ(trainerInput[0], expectedPulse(testChannelValue(0)));
+  }
+}
+
+// Failsafe / frame-lost frames must not drive the trainer channels.
+TEST_F(SbusStreamTest, failsafeAndFrameLostFramesAreIgnored)
+{
+  feed(buildFrame(1 << 3));  // failsafe
+  EXPECT_FALSE(isTrainerValid());
+  EXPECT_EQ(trainerInput[0], 0);
+
+  feed(buildFrame(1 << 2));  // frame lost
+  EXPECT_FALSE(isTrainerValid());
+  EXPECT_EQ(trainerInput[0], 0);
+
+  // ... but the stream is still in sync afterwards
+  feed(buildFrame());
+  expectTestChannels();
+  EXPECT_TRUE(isTrainerValid());
+}
+
+// Nothing may reach the trainer channels unless the model actually asked for
+// serial trainer input.
+TEST_F(SbusStreamTest, ignoredWhenSerialTrainerDisabled)
+{
+  sbusAuxSetEnabled(false);
+
+  feed(buildFrame());
+
+  EXPECT_FALSE(isTrainerValid());
+  for (int ch = 0; ch < 16; ch++) EXPECT_EQ(trainerInput[ch], 0) << "channel " << ch;
+}
+
+// Link loss: when frames stop arriving the trainer input has to go stale, so
+// the sticks take back control. The timer is decremented from per10ms().
+TEST_F(SbusStreamTest, inputGoesStaleWhenFramesStop)
+{
+  feed(buildFrame());
+  ASSERT_TRUE(isTrainerValid());
+
+  // 1s worth of per10ms() ticks with no data
+  for (int i = 0; i < 100; i++) {
+    EXPECT_TRUE(isTrainerValid()) << "went stale early, at tick " << i;
+    trainerDecTimer();
+  }
+
+  EXPECT_FALSE(isTrainerValid());
+}
+
+#if defined(USB_SERIAL)
+// The option has to be offered for USB-VCP in SYS -> Hardware -> Serial Port.
+// USB CDC carries no line polarity, so both SBUS trainer modes would behave
+// identically here; only the one presented to the user as plain SBUS is
+// offered, which is UART_MODE_SBUS_TRAINER_INV (normal SBUS is inverted
+// serial, so it is the MCU-inverting mode that reads "SBUS Trainer").
+TEST(SbusVcpMenu, sbusTrainerIsOfferedOnVcp)
+{
+  EXPECT_TRUE(isSerialModeAvailable(SP_VCP, UART_MODE_SBUS_TRAINER_INV));
+  EXPECT_FALSE(isSerialModeAvailable(SP_VCP, UART_MODE_SBUS_TRAINER));
+
+  // Both must still be offered on the AUX UARTs
+  EXPECT_TRUE(isSerialModeAvailable(SP_AUX1, UART_MODE_SBUS_TRAINER));
+}
+#endif
+
+// A partial frame left over when the port is released must not be completed by
+// whatever the next user of the port sends.
+TEST_F(SbusStreamTest, partialFrameIsDroppedOnStop)
+{
+  auto frame = buildFrame();
+  std::vector<uint8_t> partial(frame.begin(), frame.begin() + 20);
+  feed(partial);
+
+  sbusStreamStop();
+
+  // the remaining 5 bytes must not complete a frame
+  std::vector<uint8_t> rest(frame.begin() + 20, frame.end());
+  feed(rest);
+
+  EXPECT_FALSE(isTrainerValid());
+}

--- a/tools/sbus_vcp_test.py
+++ b/tools/sbus_vcp_test.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Drive an EdgeTX radio's trainer channels with SBUS frames over USB-VCP.
+
+Requires the radio to be set up as:
+
+  SYS -> Radio Setup  -> USB Mode      = Serial
+  SYS -> Hardware     -> Serial Port   -> USB-VCP = SBUS Trainer
+  MDL -> Setup        -> Trainer Mode  = Master/Serial
+
+Watch the result in MDL -> Channels.
+
+Do this with props off and RF disabled.
+
+Examples:
+  ./sbus_vcp_test.py --port /dev/ttyACM0 --sweep
+  ./sbus_vcp_test.py --port /dev/ttyACM0 --sweep --rate 150
+  ./sbus_vcp_test.py --port /dev/ttyACM0 --constant --stop-after 200
+  ./sbus_vcp_test.py --port /dev/ttyACM0 --sweep --garbage
+"""
+
+import argparse
+import glob
+import random
+import sys
+import time
+
+try:
+    import serial
+except ImportError:
+    sys.exit("pyserial is required: pip install pyserial")
+
+SBUS_FRAME_SIZE = 25
+SBUS_START_BYTE = 0x0F
+SBUS_END_BYTE = 0x00
+
+# Raw 11 bit channel values. EdgeTX decodes these as (raw - 992) * 5 / 8, so
+# these are the values that give the trainer input full -512..+512 travel.
+SBUS_MIN = 172
+SBUS_CENTER = 992
+SBUS_MAX = 1811
+
+NUM_CHANNELS = 16
+
+
+def encode_frame(channels, flags=0x00, end_byte=SBUS_END_BYTE):
+    """Pack 16 channels x 11 bits into a standard 25 byte SBUS frame."""
+    if len(channels) != NUM_CHANNELS:
+        raise ValueError(f"expected {NUM_CHANNELS} channels, got {len(channels)}")
+
+    frame = bytearray([SBUS_START_BYTE])
+
+    bits = 0
+    bits_available = 0
+    for value in channels:
+        bits |= (int(value) & 0x7FF) << bits_available
+        bits_available += 11
+        while bits_available >= 8:
+            frame.append(bits & 0xFF)
+            bits >>= 8
+            bits_available -= 8
+
+    frame.append(flags)
+    frame.append(end_byte)
+
+    assert len(frame) == SBUS_FRAME_SIZE, len(frame)
+    return bytes(frame)
+
+
+def triangle(phase):
+    """Triangle wave in 0.0 .. 1.0, phase in 0.0 .. 1.0."""
+    return 2 * phase if phase < 0.5 else 2 * (1.0 - phase)
+
+
+def sweep_channels(elapsed, period):
+    """Slow triangle on ch1-4, staggered so channel order is visible."""
+    channels = [SBUS_CENTER] * NUM_CHANNELS
+    for ch in range(4):
+        phase = ((elapsed / period) + ch * 0.25) % 1.0
+        channels[ch] = int(SBUS_MIN + (SBUS_MAX - SBUS_MIN) * triangle(phase))
+    return channels
+
+
+def autodetect_port():
+    candidates = sorted(glob.glob("/dev/ttyACM*") + glob.glob("/dev/ttyUSB*"))
+    if not candidates:
+        sys.exit("no /dev/ttyACM* or /dev/ttyUSB* found; pass --port explicitly")
+    if len(candidates) > 1:
+        print(f"multiple ports found {candidates}, using {candidates[0]}", file=sys.stderr)
+    return candidates[0]
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter
+    )
+    parser.add_argument("--port", help="CDC device (default: autodetect)")
+    parser.add_argument("--rate", type=float, default=100.0,
+                        help="frames per second (default: 100)")
+    parser.add_argument("--period", type=float, default=4.0,
+                        help="--sweep period in seconds (default: 4)")
+    parser.add_argument("--stop-after", type=int, metavar="N",
+                        help="send N frames then stop, holding the port open. "
+                             "The radio must fall back to the sticks within 1s.")
+    parser.add_argument("--garbage", action="store_true",
+                        help="inject random bytes mid-stream to test re-sync")
+    parser.add_argument("--garbage-every", type=int, default=50, metavar="N",
+                        help="inject garbage every N frames (default: 50)")
+
+    mode = parser.add_mutually_exclusive_group()
+    mode.add_argument("--sweep", action="store_true",
+                      help="triangle wave on ch1-4 (default)")
+    mode.add_argument("--constant", action="store_true",
+                      help="hold all channels centered")
+
+    args = parser.parse_args()
+
+    port = args.port or autodetect_port()
+    interval = 1.0 / args.rate
+
+    # Baud/parity are meaningless over USB CDC and are ignored by the radio.
+    # They are set to the nominal SBUS values only so the host driver is happy.
+    with serial.Serial(port, baudrate=100000, parity=serial.PARITY_EVEN,
+                       stopbits=serial.STOPBITS_TWO, timeout=0) as ser:
+        print(f"{port}: sending SBUS at {args.rate:g} Hz, ctrl-c to stop")
+
+        start = time.monotonic()
+        next_send = start
+        count = 0
+
+        try:
+            while True:
+                now = time.monotonic()
+
+                if args.stop_after is not None and count >= args.stop_after:
+                    print(f"sent {count} frames, stopping. Port stays open; "
+                          f"the radio should fall back to the sticks within 1s.")
+                    while True:
+                        time.sleep(1)
+
+                if args.constant:
+                    channels = [SBUS_CENTER] * NUM_CHANNELS
+                else:
+                    channels = sweep_channels(now - start, args.period)
+
+                if args.garbage and count and count % args.garbage_every == 0:
+                    noise = bytes(random.randrange(256) for _ in range(random.randrange(1, 12)))
+                    ser.write(noise)
+                    print(f"frame {count}: injected {len(noise)} garbage bytes")
+
+                ser.write(encode_frame(channels))
+                count += 1
+
+                next_send += interval
+                delay = next_send - time.monotonic()
+                if delay > 0:
+                    time.sleep(delay)
+                else:
+                    # fell behind; resynchronise the schedule
+                    next_send = time.monotonic()
+        except KeyboardInterrupt:
+            print(f"\nstopped after {count} frames")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Summary of changes:

`SYS → Hardware → Serial Port → USB-VCP` can now be set to `SBUS Trainer`. With
`MDL → Setup → Trainer Mode = Master/Serial`, a PC can drive the trainer channels by writing
standard SBUS frames to the radio's CDC device — no USB-serial dongle, and no AUX UART wiring.

Use cases: hardware-in-the-loop testing, simulators, head trackers and robotics. Trainer mode is
the right injection point for these because the physical sticks stay live and a momentary switch
gives an instant, hardware-level override — verified below.

This is what the serial refactor (#1089 / discussion #1101) was meant to enable: port →
application mapping is already user-selectable, and `SBUS Trainer` was simply excluded from the
VCP list. SpaceMouse serial input is the existing precedent for an external device over serial
driving control inputs.

### Why a new framer

The AUX SBUS path finds frame boundaries with the USART idle-line interrupt
(`drv->setIdleCb` → `sbusFrameReceived`, which requires the RX buffer to hold exactly 25 bytes at
that moment). USB CDC has no idle line — bytes arrive in arbitrarily chunked packets, so a frame
may be split across packets and several frames may arrive in one.

`sbusStream*` is therefore a byte-stream state machine: sync on `0x0F`, accumulate 25 bytes,
validate the end byte, and on failure drop a **single** byte and re-sync on the next start byte
*within* the retained buffer rather than discarding it (a valid frame may well have started
inside it).

The AUX path is untouched — it still uses the idle callback, and both paths share the existing
`sbusProcessFrame()` decoder, so trainer freshness (`trainerResetTimer()` /
`trainerInputValidityTimer`) and link-loss fallback behave identically for both.

### Notes for review

- `serialSetCallBacks()` picks the framer only when a port has no `setIdleCb` but does have
  `setReceiveCb`, so behaviour on every hardware UART is unchanged.
- The de-init branch calls `sbusStreamStop()`, which releases the CDC RX callback. Without this,
  switching USB-VCP away from `SBUS Trainer` to a mode that installs no RX callback of its own
  would leave the framer attached to the stream. (CLI happens to overwrite the pointer, so it was
  masked, but it should not be relied on.)
- USB CDC carries no line polarity, so both SBUS trainer modes would behave identically on
  VCP. Only `UART_MODE_SBUS_TRAINER_INV` is offered there, as that is the one presented to the
  user as plain SBUS (normal SBUS is inverted serial, so the MCU-inverting mode is the one
  that reads "SBUS Trainer"). The other is hidden so there are not two identical entries.
- Baud rate is likewise meaningless over CDC, and `usbSerialInit()` already ignores the requested
  `etx_serial_init` params, so nothing was needed there. Note `serialSetupPort()` must keep
  setting a non-zero baudrate for `UART_MODE_SBUS_TRAINER`, since `serialInit()` bails out early
  on `params.baudrate == 0`.
- **One shared-behaviour change, flagged deliberately:** the end-byte check was widened from
  `== 0x00` to `{0x00, 0x04, 0x14, 0x24}` (`sbusIsEndByte()`), which some implementations use to
  carry frame flags. This is a widening only — nothing that works today stops working — but it
  does apply to the AUX path too, for consistency between the two. Happy to restrict it to the
  VCP framer if preferred.

### Relationship to #4102

#4102 (draft) touches the same four files. It does **not** implement trainer over VCP — it
extends the exclusion, adding `UART_MODE_IBUS_TRAINER` to the same VCP blocklist this PR removes
`UART_MODE_SBUS_TRAINER` from, and it renames `serialGetModePort` → `hasSerialMode`.

The two are on different axes (protocol variety on UARTs vs. the VCP transport) and are
complementary, but they conflict textually in `isSerialModeAvailable()`. Happy to rebase whichever
lands second.

### Testing

**Unit tests** — 13 new cases in `radio/src/tests/sbus_trainer.cpp` (114 total pass):
frames split at every chunk boundary from 1..25 bytes, back-to-back frames in one packet, garbage
prefix, invalid end byte, re-sync after truncation, re-sync onto a start byte held inside the
buffer, end-byte variants, failsafe/frame-lost rejection, gating when trainer mode is not
Master/Serial, staleness after frames stop, partial-frame drop on port release, and a check that
the menu option is offered on VCP but the inverted variant is not.

**On a RadioMaster TX15 Max** (STM32H7), driven by `tools/sbus_vcp_test.py`:

| Check | Result |
|---|---|
| `SBUS Trainer` offered on USB-VCP | pass |
| SBUS frames drive the trainer channels | pass |
| Full ±100% travel, correct scaling | pass |
| Momentary-switch override | pass — released = sticks resume instantly, *while frames still arrive at 100 Hz* |
| Frames stop, port held open | pass — channels return to sticks in ~1 s |
| Mid-stream corruption | pass — 59 injections of 1–11 random bytes over 30 s at 100 Hz, no visible glitch |
| USB-VCP back to CLI afterwards | pass — prompt, `help`, `ls /`, `beep` all work |

**Builds:** `tx15`, `tx16s`, `t12max`.

**Not verified:** ExpressLRS passthrough flashing was not directly exercised (only the CLI it
shares a path with), and all-16-channel ordering was not checked, since the trainer block in
`mixer.cpp` applies to sticks only unless the Trainer special function is set to `Chans`.
