### PR TITLE
fix(color): splash screen delay time is bypassed on H7 radios (2.12)

### DIFF
--- a/radio/src/gui/colorlcd/startup_shutdown.cpp
+++ b/radio/src/gui/colorlcd/startup_shutdown.cpp
@@ -83,11 +83,13 @@ void drawSplash()
 }
 
 static tmr10ms_t splashStartTime = 0;
+static bool splashRunning = false;
 
 void startSplash()
 {
   if (!UNEXPECTED_SHUTDOWN()) {
     splashStartTime = get_tmr10ms();
+    splashRunning = true;
     drawSplash();
   }
 }
@@ -105,9 +107,21 @@ void cancelSplash()
 void waitSplash()
 {
   // Handle color splash screen
-  if (splashStartTime) {
+  if (splashRunning) {
     inactivityCheckInputs();
     splashStartTime += SPLASH_TIMEOUT;
+
+#if defined(PWR_BUTTON_DUAL)
+    // Wait for dual power buttons to be released
+    while (pwrPressed()) {
+      WDG_RESET();
+      sleep_ms(10);
+    }
+    // Kill SYS and/or MDL events
+    killAllEvents();
+    MainWindow::instance()->run();
+#endif
+
     while (splashStartTime >= get_tmr10ms()) {
       LvglWrapper::instance()->run();
       MainWindow::instance()->run();


### PR DESCRIPTION
H7 radios start too quickly causing the splash screen timeout check code to be bypassed.

Also waits for the SYS+MDL power keys to be released on the V12 to prevent the splash screen from closing too soon.

2.12 version of #7618 