### PR TITLE
fix(v14): restore correct RTC battery voltage reading

### DIFF
--- a/radio/src/boards/hw_defs/v14.json
+++ b/radio/src/boards/hw_defs/v14.json
@@ -3,22 +3,18 @@
     "adcs": [
       {
         "name": "MAIN",
-        "adc": "ADC1",
+        "adc": "ADC2",
         "dma": "DMA2",
-        "dma_channel": "LL_DMA_CHANNEL_0",
-        "dma_stream": "LL_DMA_STREAM_4",
-        "dma_stream_irq": "DMA2_Stream4_IRQn",
-        "dma_stream_irq_handler": "DMA2_Stream4_IRQHandler",
+        "dma_channel": "LL_DMA_CHANNEL_1",
+        "dma_stream": "LL_DMA_STREAM_3",
+        "dma_stream_irq": "DMA2_Stream3_IRQn",
+        "dma_stream_irq_handler": "DMA2_Stream3_IRQHandler",
         "sample_time": "LL_ADC_SAMPLINGTIME_28CYCLES"
       },
       {
         "name": "EXT",
-        "adc": "ADC3",
-        "dma": "DMA2",
-        "dma_channel": "LL_DMA_CHANNEL_2",
-        "dma_stream": "LL_DMA_STREAM_0",
-        "dma_stream_irq": "DMA2_Stream0_IRQn",
-        "dma_stream_irq_handler": "DMA2_Stream0_IRQHandler",
+        "adc": "ADC1",
+        "dma": null,
         "sample_time": "LL_ADC_SAMPLINGTIME_56CYCLES"
       }
     ],
@@ -84,7 +80,7 @@
       {
         "name": "P3",
         "type": "FLEX",
-        "adc": "EXT",
+        "adc": "MAIN",
         "gpio": "GPIOC",
         "pin": "LL_GPIO_PIN_2",
         "channel": "LL_ADC_CHANNEL_12",
@@ -95,7 +91,7 @@
       {
         "name": "RTC_BAT",
         "type": "RTC_BAT",
-        "adc": "MAIN",
+        "adc": "EXT",
         "gpio": null,
         "pin": null,
         "channel": "LL_ADC_CHANNEL_VBAT"

--- a/radio/src/boards/hw_defs/v14lcd.json
+++ b/radio/src/boards/hw_defs/v14lcd.json
@@ -3,22 +3,18 @@
     "adcs": [
       {
         "name": "MAIN",
-        "adc": "ADC1",
+        "adc": "ADC2",
         "dma": "DMA2",
-        "dma_channel": "LL_DMA_CHANNEL_0",
-        "dma_stream": "LL_DMA_STREAM_4",
-        "dma_stream_irq": "DMA2_Stream4_IRQn",
-        "dma_stream_irq_handler": "DMA2_Stream4_IRQHandler",
+        "dma_channel": "LL_DMA_CHANNEL_1",
+        "dma_stream": "LL_DMA_STREAM_3",
+        "dma_stream_irq": "DMA2_Stream3_IRQn",
+        "dma_stream_irq_handler": "DMA2_Stream3_IRQHandler",
         "sample_time": "LL_ADC_SAMPLINGTIME_28CYCLES"
       },
       {
         "name": "EXT",
-        "adc": "ADC3",
-        "dma": "DMA2",
-        "dma_channel": "LL_DMA_CHANNEL_2",
-        "dma_stream": "LL_DMA_STREAM_0",
-        "dma_stream_irq": "DMA2_Stream0_IRQn",
-        "dma_stream_irq_handler": "DMA2_Stream0_IRQHandler",
+        "adc": "ADC1",
+        "dma": null,
         "sample_time": "LL_ADC_SAMPLINGTIME_56CYCLES"
       }
     ],
@@ -84,7 +80,7 @@
       {
         "name": "P3",
         "type": "FLEX",
-        "adc": "EXT",
+        "adc": "MAIN",
         "gpio": "GPIOC",
         "pin": "LL_GPIO_PIN_2",
         "channel": "LL_ADC_CHANNEL_12",
@@ -95,7 +91,7 @@
       {
         "name": "RTC_BAT",
         "type": "RTC_BAT",
-        "adc": "MAIN",
+        "adc": "EXT",
         "gpio": null,
         "pin": null,
         "channel": "LL_ADC_CHANNEL_VBAT"

--- a/radio/src/targets/common/arm/stm32/stm32_adc.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_adc.cpp
@@ -577,7 +577,11 @@ static inline DMA_Stream_TypeDef* _dma_get_stream(DMA_TypeDef *DMAx, uint32_t St
 #define DMA_Stream0_IT_MASK     (uint32_t)(DMA_LISR_FEIF0 | DMA_LISR_DMEIF0 | \
                                            DMA_LISR_TEIF0 | DMA_LISR_HTIF0 | \
                                            DMA_LISR_TCIF0)
-  
+
+#define DMA_Stream3_IT_MASK     (uint32_t)(DMA_LISR_FEIF3 | DMA_LISR_DMEIF3 | \
+                                           DMA_LISR_TEIF3 | DMA_LISR_HTIF3 | \
+                                           DMA_LISR_TCIF3)
+
 #define DMA_Stream4_IT_MASK     (uint32_t)(DMA_HISR_FEIF4 | DMA_HISR_DMEIF4 | \
                                            DMA_HISR_TEIF4 | DMA_HISR_HTIF4 | \
                                            DMA_HISR_TCIF4)
@@ -592,7 +596,9 @@ static void adc_dma_clear_flags(DMA_TypeDef* DMAx, uint32_t stream)
   if (stream == LL_DMA_STREAM_4) {
     /* Reset interrupt pending bits for DMA2 Stream4 */
     WRITE_REG(DMAx->HIFCR, DMA_Stream4_IT_MASK);
-
+  } else if (stream == LL_DMA_STREAM_3) {
+    /* Reset interrupt pending bits for DMA2 Stream3 (ADC2 on F4) */
+    WRITE_REG(DMAx->LIFCR, DMA_Stream3_IT_MASK);
   } else if (stream == LL_DMA_STREAM_0) {
     /* Reset interrupt pending bits for DMA2 Stream0 */
     WRITE_REG(DMAx->LIFCR, DMA_Stream0_IT_MASK);


### PR DESCRIPTION
Summary
- Fixes #7614, fixes #7621
- On STM32F4, VBAT is ADC1-only; sample RTC_BAT alone on ADC1 (EXT), move MAIN analogs to ADC2 (DMA2 Stream3)
- Add DMA Stream3 flag clearing in `stm32_adc.cpp` so ADC2 DMA IRQs work
