### PR TITLE
fix(color): theme preview shows error icon when there are no theme images

### DIFF
--- a/radio/src/gui/colorlcd/libui/file_carosell.cpp
+++ b/radio/src/gui/colorlcd/libui/file_carosell.cpp
@@ -57,7 +57,7 @@ void FileCarosell::setSelected(int n)
     if (n >= 0 && n < (int)_fileNames.size()) {
       fp->setFile(_fileNames[selected].c_str());
     } else
-      fp->setFile("");
+      fp->setFile(nullptr);
   }
 
   message->show(selected == -1);


### PR DESCRIPTION
The theme preview shows the 'No theme image' message so the error icon is redundant.