### PR TITLE
fix(wasm): non-deterministic hal_settings dependency ordering

### DIFF
--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -80,7 +80,7 @@ function(GenerateDatacopy source output)
   add_custom_command(
     OUTPUT ${output}
     COMMAND ${GEN_DATACOPY_CMD} > ${output}
-    DEPENDS ${GEN_DATACOPY_DEPEND} ${CMAKE_BINARY_DIR}/CMakeCache.txt
+    DEPENDS ${GEN_DATACOPY_DEPEND} ${CMAKE_BINARY_DIR}/CMakeCache.txt hal_settings
     )
 endfunction()
 

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -62,7 +62,9 @@ endfunction()
 function(GenerateDatacopy source output)
 
   set(GEN_DATACOPY ${RADIO_DIRECTORY}/util/generate_datacopy.py)
-  set(GEN_DATACOPY_DEPEND ${CMAKE_CURRENT_SOURCE_DIR}/${source} ${GEN_DATACOPY})
+  set(GEN_DATACOPY_DEPEND
+    ${CMAKE_CURRENT_SOURCE_DIR}/${source} ${GEN_DATACOPY}
+    ${CMAKE_CURRENT_BINARY_DIR}/hal_settings.h)
 
   # Fetch defines / include directories in use
   AddCompilerFlags(GEN_DATACOPY_ARGS)
@@ -80,7 +82,7 @@ function(GenerateDatacopy source output)
   add_custom_command(
     OUTPUT ${output}
     COMMAND ${GEN_DATACOPY_CMD} > ${output}
-    DEPENDS ${GEN_DATACOPY_DEPEND} ${CMAKE_BINARY_DIR}/CMakeCache.txt hal_settings
+    DEPENDS ${GEN_DATACOPY_DEPEND} ${CMAKE_BINARY_DIR}/CMakeCache.txt
     )
 endfunction()
 

--- a/radio/src/CMakeLists.txt
+++ b/radio/src/CMakeLists.txt
@@ -223,7 +223,7 @@ if(STORAGE_MODELSLIST)
   add_definitions(-DSTORAGE_MODELSLIST)
 endif()
 
-if(RTC_BACKUP_RAM)
+if(RTC_BACKUP_RAM AND NOT WASI)
   add_definitions(-DRTC_BACKUP_RAM)
 
   GenerateDataCopy(datastructs_private.h datacopy.inc)


### PR DESCRIPTION
Problem:
Using current main wasm builds fail while generating `datacopy.inc` with error `radio/src/gui/colorlcd/mainview\datastructs_screen.h:200:42: error: use of undeclared identifier 'LCD_W'`

Analysis:
`radio/src/gui/colorlcd/mainview/datastructs_screen.h` requires `LCD_W` which is defined in hal_settings.h which will be built only after datacopy.inc is generated using the Windows build environment. Generating` datacopy.inc` depends on target hal_settings. The build sequence might be dependent on the host build environement and maybe working accidentally in other environments.

Solution:
Add `hal_settings` dependency to `function(GenerateDatacopy source output)` in `radio\src\CMakeLists.txt`

Tests:
Tested ok for TX15, TX16sMK3 and TX16s wasm module build