### PR TITLE
feat(mpm): increase Spektrum/DSM max channels to 16 (2.12)

### DIFF
--- a/companion/src/firmwares/moduledata.cpp
+++ b/companion/src/firmwares/moduledata.cpp
@@ -384,11 +384,7 @@ int ModuleData::getMaxChannelCount()
     case PULSES_DSMX:
       return 6;
     case PULSES_MULTIMODULE:
-      if (multi.rfProtocol == MODULE_SUBTYPE_MULTI_DSM2)
-        return 12;
-      else
-        return 16;
-      break;
+      return 16;
     case PULSES_FLYSKY_AFHDS2A:
       return 14;
     case PULSES_FLYSKY_AFHDS3:

--- a/radio/src/pulses/modules_helpers.cpp
+++ b/radio/src/pulses/modules_helpers.cpp
@@ -66,7 +66,7 @@ int8_t maxModuleChannels_M8(uint8_t moduleIdx)
       return 8;  // always 16 channels in FCC / FLEX
     }
   } else if (isModuleMultimoduleDSM2(moduleIdx)) {
-    return 4;  // 12 channels
+    return 8;  // 16 channels with new MultiModule Firmware. Older firmware will still work up to 12ch.
   } else if (isModuleDSMP(moduleIdx)) {
     return 4; //  12 channels
   } else {

--- a/radio/src/pulses/multi.cpp
+++ b/radio/src/pulses/multi.cpp
@@ -366,7 +366,7 @@ void sendFrameProtocolHeader(uint8_t*& p_buf, uint8_t module, bool failsafe)
       optionValue |= 0x40; // 11ms servo refresh
     if (g_model.moduleData[module].multi.optionValue & 0x04)
       optionValue |= 0x20; // Cloned
-    optionValue |= sentModuleChannels(module); //add number of channels
+    optionValue |= sentModuleChannels(module) & 0x0F; //add number of channels, make sure is only 4 bits, 0 means 16 channels.
   }
 
   // Set the highest bit of option byte in AFHDS2A protocol to instruct MULTI to passthrough telemetry bytes instead


### PR DESCRIPTION
Fixes #7631

Summary of changes:
1. Changed Module helper to increase Ch
2. Change multi.c: Add a check that only  bits are sent as number of channels, the higher 4 bits are the flags.

Backward compatible; the older firmware will work even when set for Ch13-16.

Latest official MM 1.3.4.63  has a small bug that only supports up to Ch15.  There is already a fix for that (pascallanger/DIY-Multiprotocol-TX-Module#1179). 

