### PR TITLE
fix(v14): OLED brightness wraps above 235

### DIFF
--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -390,7 +390,9 @@ int Boards::getCapability(Board::Type board, Board::Capability capability)
              IS_RADIOMASTER_ZORRO(board);
 
     case MaxContrast:
-      if (IS_TARANIS_SMALL(board))
+      if (getCapability(board, LcdOLED))
+        return 254;
+      else if (IS_TARANIS_SMALL(board))
         return 30;
       else
         return 45;
@@ -399,7 +401,9 @@ int Boards::getCapability(Board::Type board, Board::Capability capability)
       return 23;
 
     case MinContrast:
-      if (IS_TARANIS_X9(board))
+      if (getCapability(board, LcdOLED))
+        return 2;
+      else if (IS_TARANIS_X9(board))
         return 0;
       else
         return 10;

--- a/companion/src/generaledit/generalsetup.cpp
+++ b/companion/src/generaledit/generalsetup.cpp
@@ -141,6 +141,15 @@ ui(new Ui::GeneralSetup)
   ui->contrastSB->setMaximum(Boards::getCapability(board, Board::MaxContrast));
   ui->contrastSB->setValue(generalSettings.contrast);
 
+  if (Boards::getCapability(board, Board::LcdOLED)) {
+    // OLED radios have no backlight - "contrast" is the panel brightness
+    ui->label_contrast->setText(tr("Brightness"));
+    ui->BLBright_SB->hide();
+    ui->BLBright_SB->setDisabled(true);
+    ui->label_BLBright->hide();
+    ui->blAlarm_LB->setText(tr("Flash display on alarm"));
+  }
+
   ui->battwarningDSB->setValue((double)generalSettings.vBatWarn / 10);
   ui->backlightautoSB->setValue(generalSettings.backlightDelay * 5);
   ui->inactimerSB->setValue(generalSettings.inactivityTimer);

--- a/companion/src/generaledit/generalsetup.ui
+++ b/companion/src/generaledit/generalsetup.ui
@@ -327,9 +327,6 @@ Mode 4:
          <height>0</height>
         </size>
        </property>
-       <property name="toolTip">
-        <string extracomment="Screen Contrast [20-45]"/>
-       </property>
        <property name="text">
         <string>Contrast</string>
        </property>

--- a/companion/src/generaledit/generalsetup.ui
+++ b/companion/src/generaledit/generalsetup.ui
@@ -656,12 +656,7 @@ p, li { white-space: pre-wrap; }
         <string/>
        </property>
        <property name="whatsThis">
-        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;LCD Screen Contrast&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Values can be 20-45&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string/>
        </property>
        <property name="suffix">
         <string> ms</string>
@@ -1737,12 +1732,7 @@ p, li { white-space: pre-wrap; }
         <string/>
        </property>
        <property name="whatsThis">
-        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:8.25pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;LCD Screen Contrast&lt;/span&gt;&lt;/p&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-size:8pt;&quot;&gt;Values can be 20-45&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+        <string/>
        </property>
        <property name="minimum">
         <number>1</number>

--- a/radio/src/targets/taranis/hal.h
+++ b/radio/src/targets/taranis/hal.h
@@ -754,7 +754,7 @@
   #define BACKLIGHT_CCMR1               TIM_CCMR1_OC1M_1 | TIM_CCMR1_OC1M_2 // Channel 1, PWM
   #define BACKLIGHT_CCER                TIM_CCER_CC1E
   #define BACKLIGHT_COUNTER_REGISTER    BACKLIGHT_TIMER->CCR1
-#elif defined(RADIO_T8) || defined(RADIO_TPROV2) || defined(RADIO_TPROS) || defined(RADIO_FAMILY_T20) || defined(RADIO_T14) || defined(RADIO_BUMBLEBEE) || defined(RADIO_GX12)
+#elif defined(RADIO_T8) || defined(RADIO_TPROV2) || defined(RADIO_TPROS) || defined(RADIO_FAMILY_T20) || defined(RADIO_T14) || defined(RADIO_BUMBLEBEE) || defined(RADIO_GX12) || defined(RADIO_V14)
   // No backlight: OLED display
 #elif defined(RADIO_COMMANDO8)
   #define BACKLIGHT_TIMER_FREQ          (PERI1_FREQUENCY * TIMER_MULT_APB1)

--- a/radio/src/targets/taranis/lcd_driver_spi.cpp
+++ b/radio/src/targets/taranis/lcd_driver_spi.cpp
@@ -37,7 +37,7 @@
 
 #if OLED_SCREEN
   #define LCD_CONTRAST_OFFSET            0
-#elif defined(RADIO_FAMILY_JUMPER_T12) || defined(MANUFACTURER_RADIOMASTER) || defined(RADIO_COMMANDO8) || defined(RADIO_TPRO) || defined(RADIO_T12MAX) || defined(RADIO_V14) || defined(RADIO_V14LCD)
+#elif defined(RADIO_FAMILY_JUMPER_T12) || defined(MANUFACTURER_RADIOMASTER) || defined(RADIO_COMMANDO8) || defined(RADIO_TPRO) || defined(RADIO_T12MAX) || defined(RADIO_V14LCD)
   #define LCD_CONTRAST_OFFSET            -10
 #else
   #define LCD_CONTRAST_OFFSET            160
@@ -177,7 +177,7 @@ void lcdStart()
     lcdWriteCommand(0x0A); // Set Vop
     lcdWriteCommand(0xa6); // Set display mode
 #else
-  #if defined(RADIO_V14) || defined(RADIO_V14LCD)
+  #if defined(RADIO_V14LCD)
     lcdWriteCommand(0xe2); // (14) Soft reset
     lcdWriteCommand(0xa1); // Set seg
     lcdWriteCommand(0xc0);  // Set com
@@ -439,7 +439,7 @@ void lcdSetRefVolt(uint8_t val)
   WAIT_FOR_DMA_END();
 #endif
 
-#if defined(RADIO_V14) || defined(RADIO_V14LCD)
+#if defined(RADIO_V14LCD)
   lcdWriteCommand(0x81);                      // Set Vop
   lcdWriteCommand(val+LCD_CONTRAST_OFFSET+20);// 0-255
 #else


### PR DESCRIPTION
## Summary

The HelloRadioSky **V14** has an SSD1309 OLED, not a reflective LCD. On OLED
radios EdgeTX has no PWM backlight at all — the "Brightness" setting *is* the
panel's contrast register, written with SSD1309 command `0x81`. A leftover
`+20` offset (dating from when V14 was still treated as a plain LCD) meant
brightness wrapped past 235: the register overflows its `uint8_t`, so the top
of the range — including the factory default of 254 — rendered nearly black
instead of full brightness.

- **Firmware**: drop the dead `+20`/`RADIO_V14` branches in
  `lcd_driver_spi.cpp` so V14 takes the same unshifted contrast path as
  GX12/T14. Also add V14 to the "no backlight: OLED display" list in
  `hal.h` — it was falling through to the PCBX7 branch and driving a phantom
  PWM backlight on a pin the OLED panel never wired (PD13/TIM4).
- **Companion**: it had no OLED awareness at all. Opening a V14/GX12 radio's
  settings clamped the real 2..254 brightness value into the small-Taranis
  10..30 contrast range and silently wrote the clamped value back on save —
  silent data loss. Reuse `Board::LcdOLED` to give OLED B&W boards (V14,
  GX12, T14, T20/T20V2, TPro variants, LR3Pro, Bumblebee) the firmware's real
  range, relabel the field "Brightness" and the alarm-flash field "Flash
  display on alarm" to match what's actually on hardware, and hide the inert
  "Backlight Brightness" field since these radios have no PWM backlight to
  control.
- **Chore**: drop copy-pasted "LCD Screen Contrast [20-45]" help text that
  had drifted onto two unrelated fields (`switchesDelay`, `speakerPitchSB`).

Non-OLED radios (X7, X9D+, etc.) are unaffected — same "Contrast" label,
same 10..30/0..45 range, Backlight Brightness still shown.

### Screenshots

**LCD - After (and OLED Before)**
<img width="780" height="480" alt="companion_34_crop" src="https://github.com/user-attachments/assets/7710105c-46d2-41ae-87c8-d3138dc258e4" />

**OLED - After**
<img width="780" height="480" alt="companion_39_crop" src="https://github.com/user-attachments/assets/130aaa62-7b74-4eed-80b0-e87cc5a1a458" />


## Test plan

- [x] Built all four affected flavours (`v14`, `v14lcd`, `gx12`, `t14`) —
      only V14 changes; the others must be (and are) unaffected.
- [x] Confirmed the phantom backlight is gone: `backlightInit`/
      `backlightEnable`/`backlightDisable` in the V14 build are now
      near-zero-size stubs, byte-identical to GX12; V14LCD still has the
      real PWM implementation.
- [x] Diffed `lcdSetRefVolt` disassembly between V14 and GX12 post-fix —
      identical instruction sequence, no `adds #20`.
- [x] On hardware (V14): brightness now increases monotonically from 2 to
      254 with no dark band at 236 and no wrap at the top; factory default
      is genuinely full brightness. *(confirmed by @pfeerick)*
- [x] Bootloader screen (V14) is now bright at the default contrast value.
      *(confirmed by @pfeerick)*
- [x] Companion: built and drove the GUI directly (Xvfb + xdotool) —
  - V14 profile: Radio Settings shows "Brightness" 2..254 (254 accepted
    without clamping), "Backlight Brightness" row hidden, "Flash display on
    alarm" label.
  - Round-tripped a V14 radio-settings file with brightness 254 through a
    full save → close → reopen — value survives (`contrast: 254` in the
    saved YAML).
  - X7 profile: still shows "Contrast" 10..30, "Backlight Brightness" row
    visible, "Backlight flash on alarm" label — unaffected.
  - Converting a V14 radio-settings file to X7 correctly re-clamps
    254→30 (a genuine hardware range difference, not a bug).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
