### PR TITLE
fix(tools): YAML generation leaking build options between targets

### DIFF
--- a/radio/src/storage/yaml/yaml_datastructs_t15pro.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t15pro.cpp
@@ -455,7 +455,7 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_CUSTOM("rotEncDirection",r_rotEncDirection,nullptr),
   YAML_UNSIGNED( "rotEncMode", 3 ),
   YAML_PADDING( 2 ),
-  YAML_UNSIGNED( "stickDeadZone", 3 ),
+  YAML_PADDING( 3 ),
   YAML_SIGNED( "imuMax", 8 ),
   YAML_SIGNED( "imuOffset", 8 ),
   YAML_UNSIGNED( "imuInvert", 8 ),

--- a/radio/src/storage/yaml/yaml_datastructs_tx15.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tx15.cpp
@@ -455,7 +455,7 @@ static const struct YamlNode struct_RadioData[] = {
   YAML_CUSTOM("rotEncDirection",r_rotEncDirection,nullptr),
   YAML_UNSIGNED( "rotEncMode", 3 ),
   YAML_PADDING( 2 ),
-  YAML_UNSIGNED( "stickDeadZone", 3 ),
+  YAML_PADDING( 3 ),
   YAML_SIGNED( "imuMax", 8 ),
   YAML_SIGNED( "imuOffset", 8 ),
   YAML_UNSIGNED( "imuInvert", 8 ),

--- a/radio/src/targets/t22/CMakeLists.txt
+++ b/radio/src/targets/t22/CMakeLists.txt
@@ -7,6 +7,7 @@ option(GHOST "Ghost TX Module" ON)
 option(MODULE_SIZE_STD "Standard size TX Module" ON)
 option(LUA_MIXER "Enable LUA mixer/model scripts support" ON)
 option(DISK_CACHE "Enable SD card disk cache" ON)
+option(STICK_DEAD_ZONE "Enable sticks dead zone" OFF)
 
 set(FIRMWARE_QSPI YES)
 set(FIRMWARE_FORMAT_UF2 YES)
@@ -27,8 +28,6 @@ set(INTERNAL_MODULE_AFHDS3 NO)
 set(ROTARY_ENCODER YES)
 set(FUNCTION_SWITCHES_WITH_RGB YES)
 add_definitions(-DRGB_LEDS_900NS)
-
-#option(STICKS_DEAD_ZONE "Enable sticks dead zone" YES)
 
 # IMU support
 set(IMU ON)
@@ -78,7 +77,7 @@ add_definitions(-DRTCLOCK)
 add_definitions(-DGPS_USART_BAUDRATE=${INTERNAL_GPS_BAUDRATE})
 add_definitions(-DPWR_BUTTON_${PWR_BUTTON})
 
-if(STICKS_DEAD_ZONE)
+if(STICK_DEAD_ZONE)
   add_definitions(-DSTICK_DEAD_ZONE)
 endif()
 

--- a/radio/src/targets/tx15/CMakeLists.txt
+++ b/radio/src/targets/tx15/CMakeLists.txt
@@ -11,6 +11,7 @@ option(BLUETOOTH "FrSky BT module support" OFF)
 option(FLYSKY_GIMBAL "Serial gimbal support" OFF)
 option(KCX_BTAUDIO "KCX_BTAUDIO audio emitter installed" OFF)
 option(INTERNAL_GPS "Support for internal GPS" ON)
+option(STICK_DEAD_ZONE "Enable sticks dead zone" OFF)
 
 set(FIRMWARE_QSPI YES)
 set(FIRMWARE_FORMAT_UF2 YES)
@@ -40,8 +41,6 @@ if(BLUETOOTH)
 elseif(KCX_BTAUDIO)
   set(FLYSKY_GIMBAL OFF)
 endif()
-
-#option(STICK_DEAD_ZONE "Enable sticks dead zone" YES)
 
 # IMU support
 set(IMU ON)

--- a/radio/src/targets/tx16smk3/CMakeLists.txt
+++ b/radio/src/targets/tx16smk3/CMakeLists.txt
@@ -10,6 +10,7 @@ option(DISK_CACHE "Enable SD card disk cache" ON)
 option(BLUETOOTH "FrSky BT module support" OFF)
 option(INTERNAL_GPS "Support for internal GPS" ON)
 option(KCX_BTAUDIO "KCX_BTAUDIO audio emitter installed" OFF)
+option(STICK_DEAD_ZONE "Enable sticks dead zone" OFF)
 
 set(FIRMWARE_QSPI YES)
 set(FIRMWARE_FORMAT_UF2 YES)
@@ -42,8 +43,6 @@ elseif(KCX_BTAUDIO)
 else()
   set(AUX2_SERIAL ON)
 endif()
-
-#option(STICKS_DEAD_ZONE "Enable sticks dead zone" YES)
 
 # IMU support
 set(IMU ON)
@@ -99,7 +98,7 @@ add_definitions(-DAUDIO -DVOICE -DRTCLOCK)
 add_definitions(-DGPS_USART_BAUDRATE=${INTERNAL_GPS_BAUDRATE})
 add_definitions(-DPWR_BUTTON_${PWR_BUTTON})
 
-if(STICKS_DEAD_ZONE)
+if(STICK_DEAD_ZONE)
   add_definitions(-DSTICK_DEAD_ZONE)
 endif()
 

--- a/radio/src/targets/v12/CMakeLists.txt
+++ b/radio/src/targets/v12/CMakeLists.txt
@@ -7,6 +7,7 @@ option(GHOST "Ghost TX Module" ON)
 option(MODULE_SIZE_STD "Standard size TX Module" ON)
 option(LUA_MIXER "Enable LUA mixer/model scripts support" ON)
 option(DISK_CACHE "Enable SD card disk cache" ON)
+option(STICK_DEAD_ZONE "Enable sticks dead zone" OFF)
 
 set(FIRMWARE_QSPI YES)
 set(FIRMWARE_FORMAT_UF2 YES)
@@ -27,8 +28,6 @@ set(INTERNAL_MODULE_AFHDS3 NO)
 set(INTERNAL_EXTERNAL_ANT YES)
 set(ROTARY_ENCODER YES)
 set(FUNCTION_SWITCHES_WITH_RGB YES)
-
-#option(STICKS_DEAD_ZONE "Enable sticks dead zone" YES)
 
 # IMU is not populated on production V12/V12p units.
 set(IMU OFF)
@@ -88,7 +87,7 @@ add_definitions(-DPWR_BUTTON_${PWR_BUTTON})
 add_definitions(-DPWR_BUTTON_DUAL)
 add_definitions(-DI2C_HAS_BUS_4)
 
-if(STICKS_DEAD_ZONE)
+if(STICK_DEAD_ZONE)
   add_definitions(-DSTICK_DEAD_ZONE)
 endif()
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+asciitree
 clang
 jinja2
 pillow

--- a/tools/generate-yaml.sh
+++ b/tools/generate-yaml.sh
@@ -12,12 +12,12 @@ if [[ -n ${GCC_ARM} ]] ; then
 fi
 
 : ${FLAVOR:="x10;t15;pl18;nv14;pl18u;nb4p;x9d;x9dp2019;x9e;xlite;xlites;x7;tpro;t20;f16;gx12;st16;c14;pa01;tx15;t15pro;tx16smk3;t22;v12"}
-: ${SRCDIR:=$(dirname "$(pwd)/$0")/..}
+: ${SRCDIR:="$(dirname "$SCRIPT_DIR")"}
 
 : ${COMMON_OPTIONS:="-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_RULE_MESSAGES=OFF -Wno-dev -DDISABLE_COMPANION=YES -DCMAKE_MESSAGE_LOG_LEVEL=WARNING"}
 
 # wipe build directory clean
-rm -rf build && mkdir -p build && cd build
+cmake -E rm -rf build
 
 target_names=$(echo "$FLAVOR" | tr '[:upper:]' '[:lower:]' | tr ';' '\n')
 
@@ -33,9 +33,12 @@ do
         exit 1
     fi
 
-    cmake ${BUILD_OPTIONS} "${SRCDIR}"
-    make native-configure
-    make -C native yaml_data
+    # Own build tree per target - a shared one leaks cached options between them
+    BUILD_DIR="build/${target_name}"
 
-    rm -rf *
+    cmake ${BUILD_OPTIONS} -S "${SRCDIR}" -B "${BUILD_DIR}"
+    cmake --build "${BUILD_DIR}" --target native-configure
+    cmake --build "${BUILD_DIR}/native" --target yaml_data
+
+    cmake -E rm -rf "${BUILD_DIR}"
 done

--- a/tools/generate-yaml.sh
+++ b/tools/generate-yaml.sh
@@ -11,7 +11,7 @@ if [[ -n ${GCC_ARM} ]] ; then
   export PATH=${GCC_ARM}:$PATH
 fi
 
-: ${FLAVOR:="x10;t15;tx16s;pl18;nv14;pl18u;nb4p;x9d;x9dp2019;x9e;xlite;xlites;x7;tpro;t20;f16;gx12;st16;c14;pa01;tx15;t15pro;tx16smk3;t22;v12"}
+: ${FLAVOR:="x10;t15;pl18;nv14;pl18u;nb4p;x9d;x9dp2019;x9e;xlite;xlites;x7;tpro;t20;f16;gx12;st16;c14;pa01;tx15;t15pro;tx16smk3;t22;v12"}
 : ${SRCDIR:=$(dirname "$(pwd)/$0")/..}
 
 : ${COMMON_OPTIONS:="-DCMAKE_BUILD_TYPE=$BUILD_TYPE -DCMAKE_RULE_MESSAGES=OFF -Wno-dev -DDISABLE_COMPANION=YES -DCMAKE_MESSAGE_LOG_LEVEL=WARNING"}
@@ -37,5 +37,5 @@ do
     make native-configure
     make -C native yaml_data
 
-    rm -f CMakeCache.txt arm-none-eabi/CMakeCache.txt
+    rm -rf *
 done


### PR DESCRIPTION
Changes:
- Remove 'stickDeadZone' from radios which don't use it.
- Remove tx16s from yaml generation list (uses x10 file)
- Change STICKS_DEAD_ZONE to STICK_DEAD_ZONE for consistency
- Clear build folder between iterations when generating yaml files to prevent cross contamination (which caused bogus 'stickDeadZone' entries in TX15 and T15PRO).
