### PR TITLE
fix(cpn): re-sign macOS bundle sequentially so the seal covers SDL2

### DIFF
--- a/companion/src/CMakeLists.txt
+++ b/companion/src/CMakeLists.txt
@@ -578,14 +578,36 @@ elseif(APPLE)
             COMPONENT Runtime)
   endif()
 
-  # Re-sign bundle after all contents are installed
+  # Re-sign bundle after all contents are installed. One execute_process() per
+  # codesign: multiple COMMANDs form a pipeline and would run concurrently.
   install(CODE "
       set(app_dir \"\${CMAKE_INSTALL_PREFIX}/${companion_app_dir}\")
       execute_process(COMMAND \${CMAKE_COMMAND} -E echo \"Re-signing: \${app_dir}\")
       execute_process(
-        COMMAND codesign --remove-signature \${app_dir}
-        COMMAND codesign --force --deep -s - \${app_dir}
+        COMMAND codesign --remove-signature \"\${app_dir}\"
+        RESULT_VARIABLE _strip_result
+        ERROR_VARIABLE _strip_error
       )
+      if(NOT _strip_result EQUAL 0)
+        # Non-fatal: the bundle may legitimately be unsigned here.
+        message(WARNING \"codesign --remove-signature failed: \${_strip_error}\")
+      endif()
+      execute_process(
+        COMMAND codesign --force --deep --sign - \"\${app_dir}\"
+        RESULT_VARIABLE _sign_result
+        ERROR_VARIABLE _sign_error
+      )
+      if(NOT _sign_result EQUAL 0)
+        message(FATAL_ERROR \"codesign failed for \${app_dir}: \${_sign_error}\")
+      endif()
+      execute_process(
+        COMMAND codesign --verify --deep --strict \"\${app_dir}\"
+        RESULT_VARIABLE _verify_result
+        ERROR_VARIABLE _verify_error
+      )
+      if(NOT _verify_result EQUAL 0)
+        message(FATAL_ERROR \"codesign --verify failed for \${app_dir}: \${_verify_error}\")
+      endif()
   " COMPONENT Runtime)
 
 else()


### PR DESCRIPTION
## Problem

The macOS re-sign step passes two `codesign` invocations to a single `execute_process()`:

```cmake
execute_process(
  COMMAND codesign --remove-signature ${app_dir}
  COMMAND codesign --force --deep -s - ${app_dir}
)
```

Multiple `COMMAND` keywords in one `execute_process()` form a **pipeline** — the processes run concurrently with cmd1's stdout wired to cmd2's stdin. So the strip and the re-sign race each other on the same bundle and neither reliably lands. Neither result is checked, and `build-companion.sh` only prints the install log on failure, so this has been failing silently.

## Evidence

The shipped DMG keeps the signature `macdeployqt` wrote *before* SDL2 was installed into `Contents/Frameworks`. From the current CI artifact:

```
$ grep -c SDL2 'EdgeTX Companion 3.0.app/Contents/_CodeSignature/CodeResources'
0
```

The seal covers the eleven Qt frameworks and five ffmpeg dylibs, but has no `SDL2.framework` entry. `SDL2.framework/Versions/A/_CodeSignature/CodeResources` also still carries upstream's mtime, so `--deep` never re-signed it either.

An app bundle with unsealed content in `Contents/Frameworks` fails signature validation. Once the DMG is downloaded and quarantined, that surfaces as:

> "EdgeTX Companion 3.0" is damaged and can't be opened. You should eject the disk image.

Locally built bundles are unaffected because macOS doesn't validate the signature at launch without the quarantine attribute — which is why this went unnoticed.

## Fix

Give each `codesign` its own `execute_process()`, quote the bundle path, check the results, and verify the finished bundle so a broken signature fails the build instead of shipping. Stripping stays non-fatal since the bundle may legitimately be unsigned at that point.

## Note

This only makes the ad-hoc signature *valid*. The builds are still not notarized, so downloaded DMGs will continue to need the quarantine attribute cleared — the expected change is from "is damaged" to the softer "Apple could not verify..." with an Open Anyway path in System Settings.

## Testing

Please check the macOS Companion artifact from this run: `Contents/_CodeSignature/CodeResources` should now contain `Frameworks/SDL2.framework`.

The generated install script was dry-run locally against a stub `codesign` to confirm argument quoting survives the space in the bundle name, that the commands run sequentially, and that a non-zero exit now aborts the build:

```
argc=2 | <--remove-signature> </stage/EdgeTX Companion 3.0.app>
argc=5 | <--force> <--deep> <--sign> <-> </stage/EdgeTX Companion 3.0.app>
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)