### PR TITLE
feat: send handset RTC to ELRS modules

### DIFF
--- a/radio/src/pulses/crossfire.cpp
+++ b/radio/src/pulses/crossfire.cpp
@@ -45,15 +45,10 @@
 
 #define MIN_FRAME_LEN 3
 
-#if defined(RTCLOCK)
-#define ELRS_HANDSET_TIME_SYNC_PERIOD 6000  // 60 seconds in 10ms ticks
-#endif
-
 #define MODULE_ALIVE_TIMEOUT  50                      // if the module has sent a valid frame within 500ms it is declared alive
 static tmr10ms_t lastAlive[NUM_MODULES];              // last time stamp module sent CRSF frames
 static bool moduleAlive[NUM_MODULES];                 // module alive status
 #if defined(RTCLOCK)
-static tmr10ms_t lastTimeSync[NUM_MODULES];
 static bool timeSyncSent[NUM_MODULES];
 #endif
 
@@ -113,18 +108,24 @@ uint8_t createCrossfireTimeFrame(uint8_t moduleIdx, uint8_t * frame)
 
   uint8_t * buf = frame;
   *buf++ = MODULE_ADDRESS;
-  *buf++ = 11;                                         // type + destination + origin + field + 6 time bytes + CRC
-  *buf++ = PARAMETER_WRITE_ID;
-  *buf++ = MODULE_ADDRESS;
+  *buf++ = 17;                              // type + dest + orig + 13 MSP bytes + CRC
+  *buf++ = MSP_WRITE_ID;
+  *buf++ = VIDEO_RECEIVER_ADDRESS;
   *buf++ = RADIO_ADDRESS;
-  *buf++ = ELRS_HANDSET_TIME_ID;
+  *buf++ = MSP_V2_STATUS_START;
+  *buf++ = 0;                               // MSP flags
+  *buf++ = MSP_ELRS_BACKPACK_SET_RTC & 0xFF;
+  *buf++ = MSP_ELRS_BACKPACK_SET_RTC >> 8;
+  *buf++ = 6;                               // MSP payload size, low byte
+  *buf++ = 0;                               // MSP payload size, high byte
   *buf++ = tm.tm_year;
   *buf++ = tm.tm_mon;
   *buf++ = tm.tm_mday;
   *buf++ = tm.tm_hour;
   *buf++ = tm.tm_min;
   *buf++ = tm.tm_sec;
-  *buf++ = crc8(frame + 2, 10);
+  *buf++ = crc8(frame + 6, 11);             // MSP CRC over flags..payload
+  *buf++ = crc8(frame + 2, 16);             // CRSF CRC over type..MSP CRC
   return buf - frame;
 }
 #endif
@@ -222,10 +223,8 @@ static void setupPulsesCrossfire(uint8_t module, uint8_t*& p_buf,
 #if defined(RTCLOCK)
     } else if (crossfireModuleStatus[module].isELRS &&
                crossfireModuleStatus[module].queryCompleted &&
-               (!timeSyncSent[module] ||
-                (get_tmr10ms() - lastTimeSync[module]) >= ELRS_HANDSET_TIME_SYNC_PERIOD)) {
+               !timeSyncSent[module]) {
       p_buf += createCrossfireTimeFrame(module, p_buf);
-      lastTimeSync[module] = get_tmr10ms();
       timeSyncSent[module] = true;
 #endif
     } else {
@@ -421,7 +420,6 @@ static void* crossfireInit(uint8_t module)
 {
 #if defined(RTCLOCK)
   timeSyncSent[module] = false;
-  lastTimeSync[module] = 0;
 #endif
 
   etx_module_state_t* mod_st = nullptr;
@@ -492,7 +490,6 @@ static void crossfireDeInit(void* ctx)
 
 #if defined(RTCLOCK)
   timeSyncSent[modulePortGetModule(mod_st)] = false;
-  lastTimeSync[modulePortGetModule(mod_st)] = 0;
 #endif
 
   memset(&crossfireModuleStatus[modulePortGetModule(mod_st)], 0,

--- a/radio/src/pulses/crossfire.cpp
+++ b/radio/src/pulses/crossfire.cpp
@@ -28,7 +28,9 @@
 #include "mixer_scheduler.h"
 #include "hal/module_driver.h"
 #include "hal/module_port.h"
+#if defined(RTCLOCK)
 #include "rtc.h"
+#endif
 
 #include "crossfire.h"
 #include "telemetry/crossfire.h"
@@ -43,13 +45,17 @@
 
 #define MIN_FRAME_LEN 3
 
+#if defined(RTCLOCK)
 #define ELRS_HANDSET_TIME_SYNC_PERIOD 6000  // 60 seconds in 10ms ticks
+#endif
 
 #define MODULE_ALIVE_TIMEOUT  50                      // if the module has sent a valid frame within 500ms it is declared alive
 static tmr10ms_t lastAlive[NUM_MODULES];              // last time stamp module sent CRSF frames
 static bool moduleAlive[NUM_MODULES];                 // module alive status
+#if defined(RTCLOCK)
 static tmr10ms_t lastTimeSync[NUM_MODULES];
 static bool timeSyncSent[NUM_MODULES];
+#endif
 
 uint8_t createCrossfireBindFrame(uint8_t moduleIdx, uint8_t * frame)
 {
@@ -97,6 +103,7 @@ uint8_t createCrossfireModelIDFrame(uint8_t moduleIdx, uint8_t * frame)
   return buf - frame;
 }
 
+#if defined(RTCLOCK)
 uint8_t createCrossfireTimeFrame(uint8_t moduleIdx, uint8_t * frame)
 {
   (void)moduleIdx;
@@ -120,6 +127,7 @@ uint8_t createCrossfireTimeFrame(uint8_t moduleIdx, uint8_t * frame)
   *buf++ = crc8(frame + 2, 10);
   return buf - frame;
 }
+#endif
 
 // Range for pulses (channels output) is [-1024:+1024]
 uint8_t createCrossfireChannelsFrame(uint8_t moduleIdx, uint8_t * frame, int16_t * pulses)
@@ -211,6 +219,7 @@ static void setupPulsesCrossfire(uint8_t module, uint8_t*& p_buf,
     } else if (moduleState[module].mode == MODULE_MODE_BIND) {
       p_buf += createCrossfireBindFrame(module, p_buf);
       moduleState[module].mode = MODULE_MODE_NORMAL;
+#if defined(RTCLOCK)
     } else if (crossfireModuleStatus[module].isELRS &&
                crossfireModuleStatus[module].queryCompleted &&
                (!timeSyncSent[module] ||
@@ -218,6 +227,7 @@ static void setupPulsesCrossfire(uint8_t module, uint8_t*& p_buf,
       p_buf += createCrossfireTimeFrame(module, p_buf);
       lastTimeSync[module] = get_tmr10ms();
       timeSyncSent[module] = true;
+#endif
     } else {
       /* TODO: nChannels */
       p_buf += createCrossfireChannelsFrame(module, p_buf, channels);
@@ -409,8 +419,10 @@ static void _soft_irq_trigger(void* param)
 
 static void* crossfireInit(uint8_t module)
 {
+#if defined(RTCLOCK)
   timeSyncSent[module] = false;
   lastTimeSync[module] = 0;
+#endif
 
   etx_module_state_t* mod_st = nullptr;
   etx_serial_init params(crsfSerialParams);
@@ -478,8 +490,10 @@ static void crossfireDeInit(void* ctx)
 {
   auto mod_st = (etx_module_state_t*)ctx;
 
+#if defined(RTCLOCK)
   timeSyncSent[modulePortGetModule(mod_st)] = false;
   lastTimeSync[modulePortGetModule(mod_st)] = 0;
+#endif
 
   memset(&crossfireModuleStatus[modulePortGetModule(mod_st)], 0,
          sizeof(CrossfireModuleStatus));

--- a/radio/src/pulses/crossfire.cpp
+++ b/radio/src/pulses/crossfire.cpp
@@ -28,6 +28,7 @@
 #include "mixer_scheduler.h"
 #include "hal/module_driver.h"
 #include "hal/module_port.h"
+#include "rtc.h"
 
 #include "crossfire.h"
 #include "telemetry/crossfire.h"
@@ -42,9 +43,13 @@
 
 #define MIN_FRAME_LEN 3
 
+#define ELRS_HANDSET_TIME_SYNC_PERIOD 6000  // 60 seconds in 10ms ticks
+
 #define MODULE_ALIVE_TIMEOUT  50                      // if the module has sent a valid frame within 500ms it is declared alive
 static tmr10ms_t lastAlive[NUM_MODULES];              // last time stamp module sent CRSF frames
 static bool moduleAlive[NUM_MODULES];                 // module alive status
+static tmr10ms_t lastTimeSync[NUM_MODULES];
+static bool timeSyncSent[NUM_MODULES];
 
 uint8_t createCrossfireBindFrame(uint8_t moduleIdx, uint8_t * frame)
 {
@@ -89,6 +94,30 @@ uint8_t createCrossfireModelIDFrame(uint8_t moduleIdx, uint8_t * frame)
   *buf++ = g_model.header.modelId[moduleIdx];         /* model ID */
   *buf++ = crc8_BA(frame + 2, 6);
   *buf++ = crc8(frame + 2, 7);
+  return buf - frame;
+}
+
+uint8_t createCrossfireTimeFrame(uint8_t moduleIdx, uint8_t * frame)
+{
+  (void)moduleIdx;
+
+  struct gtm tm;
+  gettime(&tm);
+
+  uint8_t * buf = frame;
+  *buf++ = MODULE_ADDRESS;
+  *buf++ = 11;                                         // type + destination + origin + field + 6 time bytes + CRC
+  *buf++ = PARAMETER_WRITE_ID;
+  *buf++ = MODULE_ADDRESS;
+  *buf++ = RADIO_ADDRESS;
+  *buf++ = ELRS_HANDSET_TIME_ID;
+  *buf++ = tm.tm_year;
+  *buf++ = tm.tm_mon;
+  *buf++ = tm.tm_mday;
+  *buf++ = tm.tm_hour;
+  *buf++ = tm.tm_min;
+  *buf++ = tm.tm_sec;
+  *buf++ = crc8(frame + 2, 10);
   return buf - frame;
 }
 
@@ -182,6 +211,13 @@ static void setupPulsesCrossfire(uint8_t module, uint8_t*& p_buf,
     } else if (moduleState[module].mode == MODULE_MODE_BIND) {
       p_buf += createCrossfireBindFrame(module, p_buf);
       moduleState[module].mode = MODULE_MODE_NORMAL;
+    } else if (crossfireModuleStatus[module].isELRS &&
+               crossfireModuleStatus[module].queryCompleted &&
+               (!timeSyncSent[module] ||
+                (get_tmr10ms() - lastTimeSync[module]) >= ELRS_HANDSET_TIME_SYNC_PERIOD)) {
+      p_buf += createCrossfireTimeFrame(module, p_buf);
+      lastTimeSync[module] = get_tmr10ms();
+      timeSyncSent[module] = true;
     } else {
       /* TODO: nChannels */
       p_buf += createCrossfireChannelsFrame(module, p_buf, channels);
@@ -373,6 +409,9 @@ static void _soft_irq_trigger(void* param)
 
 static void* crossfireInit(uint8_t module)
 {
+  timeSyncSent[module] = false;
+  lastTimeSync[module] = 0;
+
   etx_module_state_t* mod_st = nullptr;
   etx_serial_init params(crsfSerialParams);
 
@@ -438,6 +477,9 @@ static void* crossfireInit(uint8_t module)
 static void crossfireDeInit(void* ctx)
 {
   auto mod_st = (etx_module_state_t*)ctx;
+
+  timeSyncSent[modulePortGetModule(mod_st)] = false;
+  lastTimeSync[modulePortGetModule(mod_st)] = 0;
 
   memset(&crossfireModuleStatus[modulePortGetModule(mod_st)], 0,
          sizeof(CrossfireModuleStatus));

--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -412,7 +412,6 @@ void processCrossfireTelemetryFrame(uint8_t module, uint8_t* rxBuffer,
       }
       break;
 
-#if defined(LUA)
     default:
       if (id == DEVICE_INFO_ID && rxBuffer[4]== MODULE_ADDRESS) {
         uint8_t nameSize = rxBuffer[1] - 18;
@@ -437,10 +436,11 @@ void processCrossfireTelemetryFrame(uint8_t module, uint8_t* rxBuffer,
         crossfireModuleStatus[module].queryCompleted = true;
       }
 
+#if defined(LUA)
       // destination address and CRC are skipped
       pushTelemetryDataToQueues(rxBuffer + 1, rxBufferCount - 2);
-      break;
 #endif
+      break;
   }
 }
 

--- a/radio/src/telemetry/crossfire.h
+++ b/radio/src/telemetry/crossfire.h
@@ -50,15 +50,15 @@
 #define PING_DEVICES_ID                0x28
 #define DEVICE_INFO_ID                 0x29
 #define REQUEST_SETTINGS_ID            0x2A
-#if defined(RTCLOCK)
-#define PARAMETER_WRITE_ID             0x2D
-#endif
 #define COMMAND_ID                     0x32
 #define RADIO_ID                       0x3A
 
 #if defined(RTCLOCK)
-// ExpressLRS handset time synchronization field
-#define ELRS_HANDSET_TIME_ID           0x3C
+// MSP-over-CRSF write to the ExpressLRS backpack, via the video receiver address
+#define MSP_WRITE_ID                   0x7C
+#define VIDEO_RECEIVER_ADDRESS         0x14
+#define MSP_ELRS_BACKPACK_SET_RTC      0x030E
+#define MSP_V2_STATUS_START            0x50  // version 2, start of frame, seq 0
 #endif
 
 #define UART_SYNC                      0xC8

--- a/radio/src/telemetry/crossfire.h
+++ b/radio/src/telemetry/crossfire.h
@@ -50,8 +50,12 @@
 #define PING_DEVICES_ID                0x28
 #define DEVICE_INFO_ID                 0x29
 #define REQUEST_SETTINGS_ID            0x2A
+#define PARAMETER_WRITE_ID             0x2D
 #define COMMAND_ID                     0x32
 #define RADIO_ID                       0x3A
+
+// ExpressLRS handset time synchronization field
+#define ELRS_HANDSET_TIME_ID           0x3C
 
 #define UART_SYNC                      0xC8
 #define SUBCOMMAND_CRSF                0x10

--- a/radio/src/telemetry/crossfire.h
+++ b/radio/src/telemetry/crossfire.h
@@ -50,12 +50,16 @@
 #define PING_DEVICES_ID                0x28
 #define DEVICE_INFO_ID                 0x29
 #define REQUEST_SETTINGS_ID            0x2A
+#if defined(RTCLOCK)
 #define PARAMETER_WRITE_ID             0x2D
+#endif
 #define COMMAND_ID                     0x32
 #define RADIO_ID                       0x3A
 
+#if defined(RTCLOCK)
 // ExpressLRS handset time synchronization field
 #define ELRS_HANDSET_TIME_ID           0x3C
+#endif
 
 #define UART_SYNC                      0xC8
 #define SUBCOMMAND_CRSF                0x10

--- a/radio/src/tests/crossfire.cpp
+++ b/radio/src/tests/crossfire.cpp
@@ -21,13 +21,17 @@
 
 #include "gtest/gtest.h"
 #include "gtests.h"
+#if defined(RTCLOCK)
 #include "rtc.h"
+#endif
 #include "telemetry/telemetry.h"
 
 #if defined(CROSSFIRE)
 
 uint8_t createCrossfireChannelsFrame(uint8_t moduleIdx, uint8_t * frame, int16_t * pulses);
+#if defined(RTCLOCK)
 uint8_t createCrossfireTimeFrame(uint8_t moduleIdx, uint8_t * frame);
+#endif
 TEST(Crossfire, createCrossfireChannelsFrame)
 {
   int16_t pulsesStart[MAX_TRAINER_CHANNELS];
@@ -43,6 +47,7 @@ TEST(Crossfire, createCrossfireChannelsFrame)
   // TODO check
 }
 
+#if defined(RTCLOCK)
 TEST(Crossfire, createCrossfireTimeFrame)
 {
   struct gtm expected = {56, 34, 12, 1, 0, 126, 0, 0};
@@ -69,6 +74,7 @@ TEST(Crossfire, createCrossfireTimeFrame)
 
   g_rtcTime = previousTime;
 }
+#endif
 
 TEST(Crossfire, crc8)
 {

--- a/radio/src/tests/crossfire.cpp
+++ b/radio/src/tests/crossfire.cpp
@@ -21,11 +21,13 @@
 
 #include "gtest/gtest.h"
 #include "gtests.h"
+#include "rtc.h"
 #include "telemetry/telemetry.h"
 
 #if defined(CROSSFIRE)
 
 uint8_t createCrossfireChannelsFrame(uint8_t moduleIdx, uint8_t * frame, int16_t * pulses);
+uint8_t createCrossfireTimeFrame(uint8_t moduleIdx, uint8_t * frame);
 TEST(Crossfire, createCrossfireChannelsFrame)
 {
   int16_t pulsesStart[MAX_TRAINER_CHANNELS];
@@ -39,6 +41,33 @@ TEST(Crossfire, createCrossfireChannelsFrame)
   createCrossfireChannelsFrame(EXTERNAL_MODULE, crossfire, pulsesStart);
 
   // TODO check
+}
+
+TEST(Crossfire, createCrossfireTimeFrame)
+{
+  struct gtm expected = {56, 34, 12, 1, 0, 126, 0, 0};
+  const gtime_t previousTime = g_rtcTime;
+  g_rtcTime = gmktime(&expected);
+
+  uint8_t frame[CROSSFIRE_FRAME_MAXLEN] = {};
+  const uint8_t length = createCrossfireTimeFrame(EXTERNAL_MODULE, frame);
+
+  EXPECT_EQ(length, 13);
+  EXPECT_EQ(frame[0], MODULE_ADDRESS);
+  EXPECT_EQ(frame[1], 11);
+  EXPECT_EQ(frame[2], PARAMETER_WRITE_ID);
+  EXPECT_EQ(frame[3], MODULE_ADDRESS);
+  EXPECT_EQ(frame[4], RADIO_ADDRESS);
+  EXPECT_EQ(frame[5], ELRS_HANDSET_TIME_ID);
+  EXPECT_EQ(frame[6], 126);
+  EXPECT_EQ(frame[7], 0);
+  EXPECT_EQ(frame[8], 1);
+  EXPECT_EQ(frame[9], 12);
+  EXPECT_EQ(frame[10], 34);
+  EXPECT_EQ(frame[11], 56);
+  EXPECT_EQ(frame[12], crc8(&frame[2], frame[1] - 1));
+
+  g_rtcTime = previousTime;
 }
 
 TEST(Crossfire, crc8)
@@ -278,4 +307,3 @@ TEST(Crossfire, frameParser_multipleJumboFrames)
 }
 #endif // HARDWARE_EXTERNAL_MODULE
 #endif
-

--- a/radio/src/tests/crossfire.cpp
+++ b/radio/src/tests/crossfire.cpp
@@ -57,20 +57,23 @@ TEST(Crossfire, createCrossfireTimeFrame)
   uint8_t frame[CROSSFIRE_FRAME_MAXLEN] = {};
   const uint8_t length = createCrossfireTimeFrame(EXTERNAL_MODULE, frame);
 
-  EXPECT_EQ(length, 13);
-  EXPECT_EQ(frame[0], MODULE_ADDRESS);
-  EXPECT_EQ(frame[1], 11);
-  EXPECT_EQ(frame[2], PARAMETER_WRITE_ID);
-  EXPECT_EQ(frame[3], MODULE_ADDRESS);
-  EXPECT_EQ(frame[4], RADIO_ADDRESS);
-  EXPECT_EQ(frame[5], ELRS_HANDSET_TIME_ID);
-  EXPECT_EQ(frame[6], 126);
-  EXPECT_EQ(frame[7], 0);
-  EXPECT_EQ(frame[8], 1);
-  EXPECT_EQ(frame[9], 12);
-  EXPECT_EQ(frame[10], 34);
-  EXPECT_EQ(frame[11], 56);
-  EXPECT_EQ(frame[12], crc8(&frame[2], frame[1] - 1));
+  // MSPv2 SET_RTC addressed to the video receiver; see ExpressLRS
+  // VideoReceiverEndpoint, which decodes this and relays it to the backpack.
+  const uint8_t expectedFrame[] = {
+    MODULE_ADDRESS, 0x11,
+    MSP_WRITE_ID, VIDEO_RECEIVER_ADDRESS, RADIO_ADDRESS,
+    MSP_V2_STATUS_START, 0x00, 0x0E, 0x03, 0x06, 0x00,
+    126, 0, 1, 12, 34, 56,
+    0x92, 0x35
+  };
+
+  EXPECT_EQ(length, sizeof(expectedFrame));
+  EXPECT_EQ(memcmp(frame, expectedFrame, sizeof(expectedFrame)), 0);
+
+  // Both CRCs are crc8 poly 0xD5: the MSP one covers flags..payload, the CRSF
+  // one covers everything from the type byte to the MSP CRC inclusive.
+  EXPECT_EQ(frame[17], crc8(&frame[6], 11));
+  EXPECT_EQ(frame[18], crc8(&frame[2], 16));
 
   g_rtcTime = previousTime;
 }


### PR DESCRIPTION
## Summary

Send the radio handset RTC to an ExpressLRS transmitter module, so the ELRS backpack path can propagate the radio clock to downstream devices (VRx backpack, goggles).

The time is sent as an **MSPv2 message encapsulated in a CRSF `MSP_WRITE` frame addressed to the video receiver (`0x14`)**,  a normal MSP packet routed the way any packet reaches the VTX. ExpressLRS relays it to the backpack without interpreting it.

The frame is sent **once per module init**, after the module identifies as ELRS and its device query completes. Outgoing frames replace channel packets, so this deliberately does not resend on a timer; `timeSyncSent[]` latches and re-arms only on `crossfireInit`/`crossfireDeInit`.

Both CRCs are `crc8` poly `0xD5`: the MSP one covers flags through payload, the CRSF one covers the type byte through the MSP CRC.

## Changes from the previous revision of this PR

This PR previously sent the time as a CRSF extended **Parameter Write** frame using a phantom field id (`0x3C`), resent every 60 seconds. Review feedback on the corresponding ExpressLRS PR asked for a proper MSP packet addressed to the video receiver rather than a synthetic parameter, and for the message not to be sent repeatedly. Both are addressed here:

- `PARAMETER_WRITE_ID` and `ELRS_HANDSET_TIME_ID` are removed, neither had any other user.
- The 60-second resend and `lastTimeSync[]` are removed, leaving a single send per module init.

## Related PRs

- ExpressLRS/ExpressLRS#3741 — registers the `0x14` video receiver address and relays the MSP message to the backpack. This is the counterpart to this PR and supersedes ExpressLRS/ExpressLRS#3701, against which the original revision of this PR was written.
- ExpressLRS/Backpack#231 — the TX backpack seeds its clock from the relayed message and distributes it to the VRx over ESP-NOW
