### PR TITLE
feat(lua): expose effective touch state

### DIFF
--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1790,6 +1790,31 @@ static int luaGetGeneralSettings(lua_State * L)
 }
 
 /*luadoc
+@function getTouchEnabled()
+
+Return whether the firmware currently accepts touch input.
+
+This reflects the two firmware gates used by the touch input path: the
+backlight must be on and the Disable touch special function must be inactive.
+
+@retval boolean `true` when touch input is enabled, `false` when it is disabled
+@retval nil the radio has no touch screen
+
+@status current Introduced in 3.0.0
+*/
+static int luaGetTouchEnabled(lua_State * L)
+{
+#if defined(HARDWARE_TOUCH)
+  const bool enabled =
+      isBacklightEnabled() && !isFunctionActive(FUNCTION_DISABLE_TOUCH);
+  lua_pushboolean(L, enabled);
+#else
+  lua_pushnil(L);
+#endif
+  return 1;
+}
+
+/*luadoc
 @function getGlobalTimer()
 
 Returns radio timers
@@ -3130,6 +3155,7 @@ LROT_BEGIN(etxlib, NULL, 0)
 #endif
   LROT_FUNCENTRY( getVersion, luaGetVersion )
   LROT_FUNCENTRY( getGeneralSettings, luaGetGeneralSettings )
+  LROT_FUNCENTRY( getTouchEnabled, luaGetTouchEnabled )
   LROT_FUNCENTRY( getGlobalTimer, luaGetGlobalTimer )
   LROT_FUNCENTRY( getRotEncSpeed, luaGetRotEncSpeed )
   LROT_FUNCENTRY( getRotEncMode, luaGetRotEncMode )

--- a/radio/src/tests/lua.cpp
+++ b/radio/src/tests/lua.cpp
@@ -238,6 +238,35 @@ TEST(Lua, testFloatIntegerEquality)
   luaExecStr("if math.type(0.5 * 2) ~= 'float' then error('0.5 * 2') end");
 }
 
+TEST(Lua, TouchEnabled)
+{
+#if defined(HARDWARE_TOUCH)
+  const bool previousBacklightState = boardBacklightOn;
+  globalFunctionsContext.reset();
+  modelFunctionsContext.reset();
+  boardBacklightOn = true;
+
+  luaExecStr("assert(getTouchEnabled() == true)");
+
+  modelFunctionsContext.activeFunctions =
+      (MASK_FUNC_TYPE)1 << FUNCTION_DISABLE_TOUCH;
+  luaExecStr("assert(getTouchEnabled() == false)");
+
+  modelFunctionsContext.reset();
+  globalFunctionsContext.activeFunctions =
+      (MASK_FUNC_TYPE)1 << FUNCTION_DISABLE_TOUCH;
+  luaExecStr("assert(getTouchEnabled() == false)");
+
+  globalFunctionsContext.reset();
+  boardBacklightOn = false;
+  luaExecStr("assert(getTouchEnabled() == false)");
+
+  boardBacklightOn = previousBacklightState;
+#else
+  luaExecStr("assert(getTouchEnabled() == nil)");
+#endif
+}
+
 TEST(Lua, testLegacyNames)
 {
   MODEL_RESET();


### PR DESCRIPTION
## Summary

- Add the read-only `getTouchEnabled()` API to the general Lua library on every target.
- Return `nil` on radios built without a touchscreen, so scripts can detect unsupported hardware safely.
- On touchscreen radios, report whether firmware currently accepts touch input: the backlight must be on and neither the model nor global Disable touch function may be active.
- Add regression coverage for touch enabled, model/global Disable touch, backlight off, and non-touch radios.

## Motivation

Lua widgets and applications need a reliable way to inspect the radio's effective touch-input state for indicators and custom interfaces. This remains independent of the firmware feedback discussed in #1085 and implemented by #7565.

## Semantics

`getTouchEnabled()` returns:

- `true` when the target has a touchscreen, the backlight is on, and Disable touch is inactive.
- `false` when the target has a touchscreen but touch input is currently gated by the backlight or a model/global Disable touch function.
- `nil` when the target has no touchscreen.

The API is registered unconditionally, which avoids a missing-function error in portable scripts.

## Validation

Native test suites built with warnings treated as errors:

- TX16SMK3 (touch): 125/125 passed.
- V12 (non-touch color): 120/120 passed.
- X9D+ 2019 (non-touch monochrome): 134/134 passed.

Representative Release ARM firmware-size builds also passed for TX16SMK3 and V12.

The `3.0.0` Lua documentation tag matches the version declared by current `main`.

Supersedes #7593. GitHub does not allow that closed PR to be reopened because its head was rebased/force-pushed.