### PR TITLE
fix(color): prevent widget focus style leak

### DIFF
--- a/radio/src/gui/colorlcd/mainview/widget.cpp
+++ b/radio/src/gui/colorlcd/mainview/widget.cpp
@@ -272,11 +272,6 @@ void Widget::enableFocus(bool enable)
 {
   if (enable) {
     if (!focusBorder) {
-      lv_style_init(&borderStyle);
-      lv_style_set_line_width(&borderStyle, PAD_BORDER);
-      lv_style_set_line_opa(&borderStyle, LV_OPA_COVER);
-      lv_style_set_line_color(&borderStyle, makeLvColor(COLOR_THEME_FOCUS));
-
       borderPts[0] = {1, 1};
       borderPts[1] = {(lv_coord_t)(width() - 1), 1};
       borderPts[2] = {(lv_coord_t)(width() - 1), (lv_coord_t)(height() - 1)};
@@ -284,7 +279,10 @@ void Widget::enableFocus(bool enable)
       borderPts[4] = {1, 1};
 
       focusBorder = lv_line_create(lvobj);
-      lv_obj_add_style(focusBorder, &borderStyle, LV_PART_MAIN);
+      lv_obj_set_style_line_width(focusBorder, PAD_BORDER, LV_PART_MAIN);
+      lv_obj_set_style_line_opa(focusBorder, LV_OPA_COVER, LV_PART_MAIN);
+      lv_obj_set_style_line_color(focusBorder, makeLvColor(COLOR_THEME_FOCUS),
+                                  LV_PART_MAIN);
       lv_line_set_points(focusBorder, borderPts, 5);
 
       if (!hasFocus()) {

--- a/radio/src/gui/colorlcd/mainview/widget.h
+++ b/radio/src/gui/colorlcd/mainview/widget.h
@@ -129,7 +129,6 @@ class Widget : public ButtonBase
   bool fullscreen = false;
   bool closeFS = false;
   lv_obj_t* focusBorder = nullptr;
-  lv_style_t borderStyle;
   lv_point_t borderPts[5];
 
   void onCancel() override;

--- a/radio/src/tests/colorlcd.cpp
+++ b/radio/src/tests/colorlcd.cpp
@@ -56,7 +56,12 @@ TEST(color, ARGB)
 TEST(Widget, focusStyleDoesNotLeak)
 {
   lv_group_t* previousGroup = lv_group_get_default();
-  lv_group_set_default(nullptr);
+  lv_group_t* testGroup = lv_group_create();
+  lv_group_set_default(testGroup);
+
+  // Keep a separate object focused so the Widget focus handler is not invoked.
+  lv_obj_t* groupAnchor = lv_obj_create(nullptr);
+  lv_group_add_obj(testGroup, groupAnchor);
 
   auto exercise = [] {
     Widget widget(nullptr, nullptr, {0, 0, 64, 64}, 0, 0);
@@ -81,6 +86,8 @@ TEST(Widget, focusStyleDoesNotLeak)
   lv_mem_monitor(&after);
 
   lv_group_set_default(previousGroup);
+  lv_obj_del(groupAnchor);
+  lv_group_del(testGroup);
   EXPECT_EQ(before.free_size, after.free_size);
 }
 

--- a/radio/src/tests/colorlcd.cpp
+++ b/radio/src/tests/colorlcd.cpp
@@ -24,6 +24,7 @@
 #if defined(COLORLCD)
 
 #include "colors.h"
+#include "widget.h"
 
 TEST(color, RGB)
 {
@@ -50,6 +51,37 @@ TEST(color, ARGB)
   EXPECT_EQ(ARGB(0, 0, 0, 255), (uint16_t)0x000F);
 
   EXPECT_EQ(ARGB(128, 30, 40, 150), (uint16_t)0x8129);
+}
+
+TEST(Widget, focusStyleDoesNotLeak)
+{
+  lv_group_t* previousGroup = lv_group_get_default();
+  lv_group_set_default(nullptr);
+
+  auto exercise = [] {
+    Widget widget(nullptr, nullptr, {0, 0, 64, 64}, 0, 0);
+    for (int i = 0; i < 16; ++i) {
+      widget.enableFocus(true);
+      widget.enableFocus(false);
+    }
+    widget.enableFocus(true);
+  };
+
+  // Warm up LVGL's object allocation paths before measuring.
+  exercise();
+
+  lv_mem_monitor_t before = {};
+  lv_mem_monitor(&before);
+
+  for (int i = 0; i < 8; ++i) {
+    exercise();
+  }
+
+  lv_mem_monitor_t after = {};
+  lv_mem_monitor(&after);
+
+  lv_group_set_default(previousGroup);
+  EXPECT_EQ(before.free_size, after.free_size);
 }
 
 #endif


### PR DESCRIPTION
## Summary

- Replace the externally owned widget focus style with LVGL object-local style properties.
- Let LVGL release the focus style allocation together with the focus border object.
- Add a regression test for repeated focus toggles and destruction while focus remains enabled.

## Problem

Widget::enableFocus(true) reinitialized an already-populated lv_style_t on every selection cycle. That discarded its allocated property block, while Widget destruction also left the final block allocated.

The regression test measures the internal LVGL heap directly:

- upstream/main: 4,185,960 -> 4,180,520 bytes free (-5,440 bytes)
- this change: free heap remains stable

This is 40 bytes leaked per focus-style lifecycle in the measured scenario.

## Validation

- tools/commit-tests.sh -btx16s: 104/104 tests passed from a clean build
- Focused regression: fails on upstream/main and passes with this change
- tools/build-gh.sh -btx16s: firmware-size passed with ARM GCC 14.2.1
- TX16S firmware: Flash 1,574.47 KB (76.88%), CCRAM 49.75 KB (77.74%)

## Compatibility

The focus border keeps the same line width, opacity, theme color, and LV_PART_MAIN selector. No visual or interaction behavior is changed.