### PR TITLE
fix(color): cancel widget selection timer during main view teardown

### DIFF
--- a/radio/src/gui/colorlcd/mainview/view_main.cpp
+++ b/radio/src/gui/colorlcd/mainview/view_main.cpp
@@ -107,7 +107,20 @@ ViewMain::ViewMain() :
   topbar = new TopBar(this);
 }
 
-ViewMain::~ViewMain() { _instance = nullptr; }
+ViewMain::~ViewMain()
+{
+  cancelWidgetSelectTimer();
+  _instance = nullptr;
+}
+
+void ViewMain::deleteLater()
+{
+  if (deleted()) return;
+
+  // LVGL timers run before the Window trash is emptied, so stop callbacks now.
+  cancelWidgetSelectTimer();
+  NavWindow::deleteLater();
+}
 
 void ViewMain::addMainView(WidgetsContainer* view, uint32_t viewId)
 {
@@ -268,9 +281,20 @@ void ViewMain::refreshWidgetSelectTimer()
   }
 }
 
+void ViewMain::cancelWidgetSelectTimer()
+{
+  if (widget_select_timer) {
+    lv_timer_del(widget_select_timer);
+    widget_select_timer = nullptr;
+  }
+}
+
 bool ViewMain::enableWidgetSelect(bool enable)
 {
   TRACE("enableWidgetSelect(%d)", enable);
+
+  if (!enable) cancelWidgetSelectTimer();
+
   // TODO: start timer
   if (widget_select == enable) return false;
   widget_select = enable;
@@ -297,11 +321,6 @@ bool ViewMain::enableWidgetSelect(bool enable)
     lv_obj_add_flag(tile_view, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_add_flag(tile_view, LV_OBJ_FLAG_SCROLL_CHAIN_HOR);
     lv_obj_add_flag(tile_view, LV_OBJ_FLAG_SCROLL_CHAIN_VER);
-
-    if (widget_select_timer) {
-      lv_timer_del(widget_select_timer);
-      widget_select_timer = nullptr;
-    }
   }
 
   return true;

--- a/radio/src/gui/colorlcd/mainview/view_main.h
+++ b/radio/src/gui/colorlcd/mainview/view_main.h
@@ -33,6 +33,7 @@ class ViewMain : public NavWindow
 
  public:
   ~ViewMain() override;
+  void deleteLater() override;
 
   static ViewMain* instance();
 
@@ -85,6 +86,7 @@ class ViewMain : public NavWindow
   void setEdgeTxButtonVisible(float visible);
 
   void _refreshWidgets();
+  void cancelWidgetSelectTimer();
 
   static void ws_timer(lv_timer_t* t);
 

--- a/radio/src/tests/colorlcd_view_main.cpp
+++ b/radio/src/tests/colorlcd_view_main.cpp
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+#include "gtests.h"
+
+#if defined(COLORLCD)
+
+#include "gui/colorlcd/libui/mainwindow.h"
+#include "gui/colorlcd/mainview/view_main.h"
+
+namespace {
+
+lv_timer_t* findTimerFor(const void* userData)
+{
+  for (lv_timer_t* timer = lv_timer_get_next(nullptr); timer;
+       timer = lv_timer_get_next(timer)) {
+    if (timer->user_data == userData) return timer;
+  }
+
+  return nullptr;
+}
+
+}  // namespace
+
+TEST(ViewMain, deletionCancelsWidgetSelectionTimerBeforeTrashCollection)
+{
+  ViewMain* view = ViewMain::instance();
+  const void* timerOwner = view;
+  ASSERT_EQ(findTimerFor(timerOwner), nullptr);
+
+  view->refreshWidgetSelectTimer();
+  ASSERT_NE(findTimerFor(timerOwner), nullptr);
+
+  view->deleteLater();
+  view->deleteLater();
+  EXPECT_EQ(findTimerFor(timerOwner), nullptr);
+
+  // Flush the deleted ViewMain from the Window trash list before cleaning up a
+  // stale timer left by the code under test.
+  MainWindow::instance()->shutdown();
+
+  if (lv_timer_t* staleTimer = findTimerFor(timerOwner)) {
+    lv_timer_del(staleTimer);
+  }
+}
+
+#endif


### PR DESCRIPTION
Summary of changes:

- Centralize widget-selection timer cleanup in `ViewMain`.
- Cancel the timer as soon as the view is queued for deletion, when widget selection is disabled, and again in the destructor as an ownership backstop.
- Keep deletion and cancellation idempotent while preserving the existing ten-second selection timeout.
- Add a native color-LCD regression test that verifies the owner timer is gone before deferred window destruction.

### Root cause

`ViewMain::refreshWidgetSelectTimer()` creates an LVGL timer with the owning `ViewMain` in `user_data`, and `ws_timer()` dereferences that pointer. Previously, the timer was deleted only through the normal widget-selection disable path. A view teardown could therefore leave a registered callback pointing at logically deleted or released state.

This matters before the C++ destructor as well: `Window::deleteLater()` removes the LVGL tree immediately but defers C++ destruction through the window trash list, while LVGL timers can run before that trash is drained. USB SD-card mode is a concrete lifecycle that shuts down and later recreates the main UI through `edgeTxClose(false)`, `MainWindow::shutdown()`, and `edgeTxResume()`.

The fix cancels the timer before delegating to `NavWindow::deleteLater()`. The destructor remains a fallback for direct destruction, and the normal disable path uses the same helper before any early return.

### Regression test

The new test creates the widget-selection timer, queues `ViewMain` for deletion twice, and inspects the LVGL timer list before trash collection.

- Before this fix: the assertion fails because the timer still holds the old owner pointer.
- After this fix: the timer is removed immediately, and repeated deletion remains safe.

### Validation

- Focused ASan test: 1/1 passed after reproducing the failure against `upstream/main`.
- Full native TX16S suite: 104/104 passed under ASan.
- `WERROR=1 ./tools/commit-tests.sh -btx16s`: 104/104 passed with warnings-as-errors.
- TX16S ARM Release `firmware-size`: passed with GCC ARM 14.2.1 — Flash 1574.53 KiB / 2048 KiB (76.88%); CCRAM 49.75 KiB / 64 KiB (77.74%).
- Physical radio: not run; the ownership regression is covered deterministically in the native LVGL test.
