### PR TITLE
fix(cpn): simulator displays date and time as UTC instead of local time

### DIFF
--- a/companion/src/simulation/wasmsimulatorinterface.cpp
+++ b/companion/src/simulation/wasmsimulatorinterface.cpp
@@ -549,8 +549,14 @@ void WasmSimulatorInterface::start(const char * filename, bool tests)
     }
   }
 
-  uint32_t argv[1] = {(uint32_t)tests};
-  if (!wasm_runtime_call_wasm(m_execEnv, m_fnStart, 1, argv)) {
+  // WASM does not handle timezones. 
+  // Calculat adjusted rtc time and pass to simulator
+  time_t rawtime;
+  time(&rawtime);
+  rawtime -= timezone;
+
+  uint32_t argv[2] = {(uint32_t)tests, (uint32_t)rawtime};
+  if (!wasm_runtime_call_wasm(m_execEnv, m_fnStart, 2, argv)) {
     qWarning() << "WASM simuStart failed:"
                << wasm_runtime_get_exception(m_moduleInst);
     return;

--- a/companion/src/simulation/wasmsimulatorinterface.cpp
+++ b/companion/src/simulation/wasmsimulatorinterface.cpp
@@ -550,7 +550,7 @@ void WasmSimulatorInterface::start(const char * filename, bool tests)
   }
 
   // WASM does not handle timezones. 
-  // Calculat adjusted rtc time and pass to simulator
+  // Calculate adjusted rtc time and pass to simulator
   time_t rawtime;
   time(&rawtime);
   rawtime -= timezone;

--- a/radio/src/targets/simu/simulib.cpp
+++ b/radio/src/targets/simu/simulib.cpp
@@ -142,7 +142,7 @@ void simuCreateDefaults()
   simuCreateDefaultSettings = true;
 }
 
-void simuStart(bool tests)
+void simuStart(bool tests, time_t rawtime)
 {
   if (simu_running)
     return;
@@ -170,9 +170,11 @@ void simuStart(bool tests)
   }
 
 #if defined(RTCLOCK)
-  time_t rawtime;
+  // Time adjusted for timezone is passed from Companion
+  // Stand alone simulator does not need this
+  if (rawtime == 0)
+    time(&rawtime);
   struct tm * timeinfo;
-  time (&rawtime);
   timeinfo = localtime (&rawtime);
 
   if (timeinfo != nullptr) {

--- a/radio/src/targets/simu/simulib.h
+++ b/radio/src/targets/simu/simulib.h
@@ -44,7 +44,7 @@
 // Lifecycle: call simuInit() once, then simuFatfsSetPaths() + simuStart().
 // Poll simuIsRunning() periodically. Call simuStop() to shut down.
 void WASM_EXPORT(simuInit)();
-void WASM_EXPORT(simuStart)(bool tests = true);
+void WASM_EXPORT(simuStart)(bool tests = true, time_t rawtime = 0);
 void WASM_EXPORT(simuStop)();
 bool WASM_EXPORT(simuIsRunning)();
 


### PR DESCRIPTION
Since WASM does not handle timezones, calculate the correct raw time in companion and pass it to the simulator.
