### PR TITLE
fix(simu): use local time rather than UTC in the WASM simulator

### DIFF
--- a/companion/src/simulation/wasmsimulatorinterface.cpp
+++ b/companion/src/simulation/wasmsimulatorinterface.cpp
@@ -15,6 +15,7 @@
 
 #include "wasmsimulatorinterface.h"
 
+#include <QDateTime>
 #include <QDebug>
 #include <QFile>
 #include <QElapsedTimer>
@@ -335,6 +336,8 @@ bool WasmSimulatorInterface::resolveExports()
       wasm_runtime_lookup_function(m_moduleInst, "simuTouchUp");
   m_fnFatfsSetPaths =
       wasm_runtime_lookup_function(m_moduleInst, "simuFatfsSetPaths");
+  m_fnSetUtcOffset =
+      wasm_runtime_lookup_function(m_moduleInst, "simuSetUtcOffset");
   m_fnRotaryEncoderEvent =
       wasm_runtime_lookup_function(m_moduleInst, "simuRotaryEncoderEvent");
   m_fnGetCapability =
@@ -546,6 +549,16 @@ void WasmSimulatorInterface::start(const char * filename, bool tests)
     if (wasmSettingsPath) {
       uint32_t freeArgv[1] = {wasmSettingsPath};
       wasm_runtime_call_wasm(m_execEnv, m_fnFree, 1, freeArgv);
+    }
+  }
+
+  // WASI has no timezone support, so the module needs our UTC offset.
+  if (m_fnSetUtcOffset) {
+    uint32_t tzArgv[1] = {
+        (uint32_t)(int32_t)QDateTime::currentDateTime().offsetFromUtc()};
+    if (!wasm_runtime_call_wasm(m_execEnv, m_fnSetUtcOffset, 1, tzArgv)) {
+      qWarning() << "WASM simuSetUtcOffset failed:"
+                 << wasm_runtime_get_exception(m_moduleInst);
     }
   }
 

--- a/companion/src/simulation/wasmsimulatorinterface.cpp
+++ b/companion/src/simulation/wasmsimulatorinterface.cpp
@@ -336,8 +336,6 @@ bool WasmSimulatorInterface::resolveExports()
       wasm_runtime_lookup_function(m_moduleInst, "simuTouchUp");
   m_fnFatfsSetPaths =
       wasm_runtime_lookup_function(m_moduleInst, "simuFatfsSetPaths");
-  m_fnSetUtcOffset =
-      wasm_runtime_lookup_function(m_moduleInst, "simuSetUtcOffset");
   m_fnRotaryEncoderEvent =
       wasm_runtime_lookup_function(m_moduleInst, "simuRotaryEncoderEvent");
   m_fnGetCapability =
@@ -553,17 +551,10 @@ void WasmSimulatorInterface::start(const char * filename, bool tests)
   }
 
   // WASI has no timezone support, so the module needs our UTC offset.
-  if (m_fnSetUtcOffset) {
-    uint32_t tzArgv[1] = {
-        (uint32_t)(int32_t)QDateTime::currentDateTime().offsetFromUtc()};
-    if (!wasm_runtime_call_wasm(m_execEnv, m_fnSetUtcOffset, 1, tzArgv)) {
-      qWarning() << "WASM simuSetUtcOffset failed:"
-                 << wasm_runtime_get_exception(m_moduleInst);
-    }
-  }
-
-  uint32_t argv[1] = {(uint32_t)tests};
-  if (!wasm_runtime_call_wasm(m_execEnv, m_fnStart, 1, argv)) {
+  uint32_t argv[2] = {
+      (uint32_t)tests,
+      (uint32_t)(int32_t)QDateTime::currentDateTime().offsetFromUtc()};
+  if (!wasm_runtime_call_wasm(m_execEnv, m_fnStart, 2, argv)) {
     qWarning() << "WASM simuStart failed:"
                << wasm_runtime_get_exception(m_moduleInst);
     return;

--- a/companion/src/simulation/wasmsimulatorinterface.h
+++ b/companion/src/simulation/wasmsimulatorinterface.h
@@ -165,6 +165,7 @@ class WasmSimulatorInterface : public SimulatorInterface
     wasm_function_inst_t m_fnTouchDown = nullptr;
     wasm_function_inst_t m_fnTouchUp = nullptr;
     wasm_function_inst_t m_fnFatfsSetPaths = nullptr;
+    wasm_function_inst_t m_fnSetUtcOffset = nullptr;
     wasm_function_inst_t m_fnRotaryEncoderEvent = nullptr;
     wasm_function_inst_t m_fnGetCapability = nullptr;
 

--- a/companion/src/simulation/wasmsimulatorinterface.h
+++ b/companion/src/simulation/wasmsimulatorinterface.h
@@ -165,7 +165,6 @@ class WasmSimulatorInterface : public SimulatorInterface
     wasm_function_inst_t m_fnTouchDown = nullptr;
     wasm_function_inst_t m_fnTouchUp = nullptr;
     wasm_function_inst_t m_fnFatfsSetPaths = nullptr;
-    wasm_function_inst_t m_fnSetUtcOffset = nullptr;
     wasm_function_inst_t m_fnRotaryEncoderEvent = nullptr;
     wasm_function_inst_t m_fnGetCapability = nullptr;
 

--- a/radio/src/targets/simu/simufatfs.cpp
+++ b/radio/src/targets/simu/simufatfs.cpp
@@ -208,14 +208,14 @@ FRESULT file_stat(const std::string& realPath, FILINFO* fno)
     if (!ec) {
       auto systime = ftime_to_systime(ftime);
       auto time_t_val = std::chrono::system_clock::to_time_t(systime);
-      struct tm* ltime = localtime(&time_t_val);
+      struct tm ltime;
 
-      if (ltime) {
+      if (simuLocalTime(time_t_val, &ltime)) {
         // Convert to FatFs format
-        fno->fdate = ((ltime->tm_year - 80) << 9) | ((ltime->tm_mon + 1) << 5) |
-                     ltime->tm_mday;
+        fno->fdate = ((ltime.tm_year - 80) << 9) | ((ltime.tm_mon + 1) << 5) |
+                     ltime.tm_mday;
         fno->ftime =
-            (ltime->tm_hour << 11) | (ltime->tm_min << 5) | (ltime->tm_sec / 2);
+            (ltime.tm_hour << 11) | (ltime.tm_min << 5) | (ltime.tm_sec / 2);
       } else {
         fno->fdate = 0;
         fno->ftime = 0;
@@ -572,7 +572,7 @@ FRESULT f_utime(const TCHAR* path, const FILINFO* fno)
     ltime.tm_sec = (fno->ftime & 0x1F) * 2;
     ltime.tm_isdst = -1;
 
-    time_t timestamp = mktime(&ltime);
+    time_t timestamp = simuLocalTimeToEpoch(&ltime);
     if (timestamp == -1) {
         return FR_INVALID_PARAMETER;
     }

--- a/radio/src/targets/simu/simulib.cpp
+++ b/radio/src/targets/simu/simulib.cpp
@@ -142,6 +142,44 @@ void simuCreateDefaults()
   simuCreateDefaultSettings = true;
 }
 
+#if defined(__wasm__)
+static int32_t simuUtcOffset = 0;
+#endif
+
+void simuSetUtcOffset(int32_t seconds)
+{
+#if defined(__wasm__)
+  simuUtcOffset = seconds;
+#else
+  (void)seconds;
+#endif
+}
+
+bool simuLocalTime(time_t t, struct tm* result)
+{
+  struct tm* tmp;
+#if defined(__wasm__)
+  t += simuUtcOffset;
+  tmp = gmtime(&t);
+#else
+  tmp = localtime(&t);
+#endif
+  if (tmp == nullptr) return false;
+  *result = *tmp;
+  return true;
+}
+
+time_t simuLocalTimeToEpoch(struct tm* tm)
+{
+#if defined(__wasm__)
+  // wasi-libc's mktime() is timezone-less, i.e. equivalent to timegm()
+  time_t t = mktime(tm);
+  return t == (time_t)-1 ? t : t - simuUtcOffset;
+#else
+  return mktime(tm);
+#endif
+}
+
 void simuStart(bool tests)
 {
   if (simu_running)
@@ -171,20 +209,19 @@ void simuStart(bool tests)
 
 #if defined(RTCLOCK)
   time_t rawtime;
-  struct tm * timeinfo;
+  struct tm timeinfo;
   time (&rawtime);
-  timeinfo = localtime (&rawtime);
 
-  if (timeinfo != nullptr) {
+  if (simuLocalTime(rawtime, &timeinfo)) {
     struct gtm gti;
-    gti.tm_sec  = timeinfo->tm_sec;
-    gti.tm_min  = timeinfo->tm_min;
-    gti.tm_hour = timeinfo->tm_hour;
-    gti.tm_mday = timeinfo->tm_mday;
-    gti.tm_mon  = timeinfo->tm_mon;
-    gti.tm_year = timeinfo->tm_year;
-    gti.tm_wday = timeinfo->tm_wday;
-    gti.tm_yday = timeinfo->tm_yday;
+    gti.tm_sec  = timeinfo.tm_sec;
+    gti.tm_min  = timeinfo.tm_min;
+    gti.tm_hour = timeinfo.tm_hour;
+    gti.tm_mday = timeinfo.tm_mday;
+    gti.tm_mon  = timeinfo.tm_mon;
+    gti.tm_year = timeinfo.tm_year;
+    gti.tm_wday = timeinfo.tm_wday;
+    gti.tm_yday = timeinfo.tm_yday;
     g_rtcTime = gmktime(&gti);
   } else {
     g_rtcTime = rawtime;

--- a/radio/src/targets/simu/simulib.cpp
+++ b/radio/src/targets/simu/simulib.cpp
@@ -146,15 +146,6 @@ void simuCreateDefaults()
 static int32_t simuUtcOffset = 0;
 #endif
 
-void simuSetUtcOffset(int32_t seconds)
-{
-#if defined(__wasm__)
-  simuUtcOffset = seconds;
-#else
-  (void)seconds;
-#endif
-}
-
 bool simuLocalTime(time_t t, struct tm* result)
 {
   struct tm* tmp;
@@ -180,10 +171,16 @@ time_t simuLocalTimeToEpoch(struct tm* tm)
 #endif
 }
 
-void simuStart(bool tests)
+void simuStart(bool tests, int32_t utcOffset)
 {
   if (simu_running)
     return;
+
+#if defined(__wasm__)
+  simuUtcOffset = utcOffset;
+#else
+  (void)utcOffset;
+#endif
 
 #if !defined(COLORLCD)
   menuLevel = 0;

--- a/radio/src/targets/simu/simulib.h
+++ b/radio/src/targets/simu/simulib.h
@@ -44,18 +44,15 @@
 
 // Lifecycle: call simuInit() once, then simuFatfsSetPaths() + simuStart().
 // Poll simuIsRunning() periodically. Call simuStop() to shut down.
+// utcOffset: seconds east of UTC, DST applied; wasi-libc's localtime() always
+// reports UTC. Ignored by native builds.
 void WASM_EXPORT(simuInit)();
-void WASM_EXPORT(simuStart)(bool tests = true);
+void WASM_EXPORT(simuStart)(bool tests = true, int32_t utcOffset = 0);
 void WASM_EXPORT(simuStop)();
 bool WASM_EXPORT(simuIsRunning)();
 
 // Set SD card and settings paths before simuStart() to avoid STORAGE WARNING.
 void WASM_EXPORT(simuFatfsSetPaths)(const char * sdPath, const char * settingsPath);
-
-// wasi-libc's localtime() always reports UTC and ignores TZ, so hosts must
-// supply the local offset from UTC in seconds (positive east of UTC, DST
-// applied) before simuStart().  Defaults to 0; ignored by native builds.
-void WASM_EXPORT(simuSetUtcOffset)(int32_t seconds);
 
 // Input: keys use Board::Keys enum, switches use Board switch indices,
 // trims use Board::TrimSwitches enum (momentary press, not value).
@@ -196,7 +193,7 @@ void WASM_IMPORT(simuAuxSerialSendBuffer)(uint8_t port_nr, const uint8_t* data,
 
 // -- Internal (not exported) --
 
-// Use instead of localtime()/mktime(): applies simuSetUtcOffset() on WASM.
+// Use instead of localtime()/mktime(): applies simuStart()'s utcOffset on WASM.
 bool simuLocalTime(time_t t, struct tm* result);
 time_t simuLocalTimeToEpoch(struct tm* tm);
 

--- a/radio/src/targets/simu/simulib.h
+++ b/radio/src/targets/simu/simulib.h
@@ -24,6 +24,7 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <stddef.h>
+#include <time.h>
 
 #include <string>
 
@@ -50,6 +51,11 @@ bool WASM_EXPORT(simuIsRunning)();
 
 // Set SD card and settings paths before simuStart() to avoid STORAGE WARNING.
 void WASM_EXPORT(simuFatfsSetPaths)(const char * sdPath, const char * settingsPath);
+
+// wasi-libc's localtime() always reports UTC and ignores TZ, so hosts must
+// supply the local offset from UTC in seconds (positive east of UTC, DST
+// applied) before simuStart().  Defaults to 0; ignored by native builds.
+void WASM_EXPORT(simuSetUtcOffset)(int32_t seconds);
 
 // Input: keys use Board::Keys enum, switches use Board switch indices,
 // trims use Board::TrimSwitches enum (momentary press, not value).
@@ -189,6 +195,11 @@ void WASM_IMPORT(simuAuxSerialSendBuffer)(uint8_t port_nr, const uint8_t* data,
                                          uint32_t len);
 
 // -- Internal (not exported) --
+
+// Use instead of localtime()/mktime(): applies simuSetUtcOffset() on WASM.
+bool simuLocalTime(time_t t, struct tm* result);
+time_t simuLocalTimeToEpoch(struct tm* tm);
+
 void simuMain();
 std::string simuFatfsGetCurrentPath();
 std::string simuFatfsGetRealPath(const std::string& p);

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -448,6 +448,8 @@
       ex.simuInit();
       runner.setFatfsPaths('/', '/');
       ex.simuCreateDefaults();
+      // WASI has no timezone support, so the module needs our UTC offset.
+      ex.simuSetUtcOffset(-new Date().getTimezoneOffset() * 60);
       ex.simuStart(1);
 
       if (canvas) {

--- a/web/src/App.svelte
+++ b/web/src/App.svelte
@@ -449,8 +449,7 @@
       runner.setFatfsPaths('/', '/');
       ex.simuCreateDefaults();
       // WASI has no timezone support, so the module needs our UTC offset.
-      ex.simuSetUtcOffset(-new Date().getTimezoneOffset() * 60);
-      ex.simuStart(1);
+      ex.simuStart(1, -new Date().getTimezoneOffset() * 60);
 
       if (canvas) {
         lcdRenderer = new LcdRenderer(canvas);

--- a/web/src/lib/wasm-runner.ts
+++ b/web/src/lib/wasm-runner.ts
@@ -45,11 +45,10 @@ export interface SimulatorExports {
   free: (ptr: number) => void;
 
   simuInit: () => void;
-  simuStart: (tests: number) => void;
+  simuStart: (tests: number, utcOffset: number) => void;
   simuStop: () => void;
   simuIsRunning: () => number;
   simuFatfsSetPaths: (sdPath: number, settingsPath: number) => void;
-  simuSetUtcOffset: (seconds: number) => void;
   simuCreateDefaults: () => void;
 
   simuSetKey: (key: number, state: number) => void;

--- a/web/src/lib/wasm-runner.ts
+++ b/web/src/lib/wasm-runner.ts
@@ -49,6 +49,7 @@ export interface SimulatorExports {
   simuStop: () => void;
   simuIsRunning: () => number;
   simuFatfsSetPaths: (sdPath: number, settingsPath: number) => void;
+  simuSetUtcOffset: (seconds: number) => void;
   simuCreateDefaults: () => void;
 
   simuSetKey: (key: number, state: number) => void;


### PR DESCRIPTION
Supersedes #7656 — same bug, reshaped after review feedback on that PR.

## The bug

The WASM simulator seeds its RTC from UTC rather than local time.

The root cause is not fixable inside the module. wasi-libc compiles
`libc-top-half/musl/src/time/__tz.c` with `__wasilibc_unmodified_upstream`
undefined, so nearly the whole file is disabled and `__secs_to_zone()` is a stub
that unconditionally reports offset 0 / UTC. Confirmed against the shipped
library in wasi-sdk 25 (the version CI pins):

```
$ llvm-nm share/wasi-sysroot/lib/wasm32-wasip1-threads/libc.a
T __secs_to_zone     <- the always-UTC stub
T localtime  T gmtime  T mktime  T timegm
(no tzset, no __tzset, no timezone, no daylight — absent entirely)
```

So `localtime() == gmtime()`, setting `TZ` does nothing, and WASI's only clock
(`clock_time_get`) is UTC. The host has to supply the offset.

## The fix

`simuStart()` takes the host's UTC offset in seconds and saves it:

```c
void WASM_EXPORT(simuStart)(bool tests = true, int32_t utcOffset = 0);
```

Wall-clock conversions go through two helpers so one offset covers every call
site:

```c
bool   simuLocalTime(time_t t, struct tm* result);
time_t simuLocalTimeToEpoch(struct tm* tm);
```

On WASM they apply the offset around `gmtime`/`mktime` (wasi-libc's `mktime` is
timezone-less, i.e. already `timegm`); on native they are plain
`localtime`/`mktime`, so native builds are unaffected.

## Differences from #7656

**`int32_t` offset rather than a `time_t` timestamp.** `time_t` is 64-bit on
wasm32-wasi, which makes `simuStart` export as `(i32, i64)`. Built both and
dumped the export types:

```
#7656:     simuStart: (i32, i64) -> ()   [3 argv cells]
this PR:   simuStart: (i32, i32) -> ()   [2 argv cells]
```

WAMR's `argc` is a *cell* count, and `wasm_runtime_prepare_call_function()`
discards the caller's value outright:

```c
*ret_argc_param = func_type->param_cell_num;
```

With an i64 the host must pass 3 cells; #7656 passes `uint32_t argv[2]` with
`argc = 2`, so the interpreter reads a third cell past the end of the array. An
i32 offset needs exactly the 2 cells the host provides.

The i64 also breaks the web simulator, which calls `ex.simuStart(1)` — a missing
JS argument is `ToBigInt(undefined)` for i64, which throws `TypeError`. For i32
it coerces to 0, so an un-updated host degrades to UTC instead of crashing:

```
i32,i32 called with 1 arg -> OK (missing arg coerced)
i32,i64 called with 1 arg -> TypeError: Cannot convert undefined to a BigInt
```

**`QDateTime::currentDateTime().offsetFromUtc()` rather than the `timezone`
global.** POSIX `timezone` is the *standard-time* offset, so it is an hour out
anywhere on summer time; it also requires `tzset()` to have run, and on Windows
(Companion is MSVC) the POSIX name only exists via the non-ANSI
`#define timezone _timezone` alias.

**FAT timestamps included.** `simufatfs.cpp` uses `localtime()`/`mktime()` for
file dates in `file_stat()` and `f_utime()` and is equally UTC-bound under WASI;
both now go through the helpers.

## Hosts

- Companion passes `QDateTime::currentDateTime().offsetFromUtc()`.
- The web simulator passes `-new Date().getTimezoneOffset() * 60`.
- `sdl_simu.cpp` calls `simuStart()` unchanged — native ignores the offset.

## Testing

- `simu` (native, tx16s) and `companion` build clean.
- `tools/build-wasm-modules.sh` builds the tx16s `.wasm` clean; exported
  signature verified from the binary as `(i32, i32)`.
- Offset arithmetic round-trips (`simuLocalTime` → `simuLocalTimeToEpoch`) across
  zero, positive, negative and half-hour offsets.
- The web change is not type-checked here (no `node_modules` in my container) —
  matches the declared interface, but worth a `vite build`.
