### PR TITLE
fix(color): Outputs widget does not update after changing 'Extended Limits'

### DIFF
--- a/radio/src/gui/colorlcd/widgets/outputs.cpp
+++ b/radio/src/gui/colorlcd/widgets/outputs.cpp
@@ -99,8 +99,9 @@ class ChannelValue : public Window
 
     int16_t value = channelOutputs[channel];
 
-    if (value != lastValue) {
+    if (value != lastValue || lastExtendedLimits != g_model.extendedLimits) {
       lastValue = value;
+      lastExtendedLimits = g_model.extendedLimits;
 
       std::string s;
       if (g_eeGeneral.ppmunit == PPM_US)
@@ -146,6 +147,7 @@ class ChannelValue : public Window
   int16_t lastValue = OUTPUT_INVALID_VALUE;
   int16_t lastScaledValue = OUTPUT_INVALID_VALUE;
   std::string lastText;
+  bool lastExtendedLimits = false;
   bool chanHasName = false;
   lv_obj_t* valueLabel = nullptr;
   lv_obj_t* chanLabel = nullptr;


### PR DESCRIPTION
Refresh Outputs widget if "Extended Limits" value changes so the bar displays are correct.