### PR TITLE
chore(color): use global styles for widget borders

### DIFF
--- a/radio/src/gui/colorlcd/libui/etx_lv_theme.cpp
+++ b/radio/src/gui/colorlcd/libui/etx_lv_theme.cpp
@@ -174,6 +174,15 @@ const lv_style_const_prop_t border_thin_props[] = {
 };
 LV_STYLE_CONST_MULTI_INIT(EdgeTxStyles::border_thin, border_thin_props);
 
+const lv_style_const_prop_t border_dash_line_props[] = {
+    LV_STYLE_CONST_LINE_WIDTH(PAD_BORDER),
+    LV_STYLE_CONST_LINE_OPA(LV_OPA_COVER),
+    LV_STYLE_CONST_LINE_DASH_WIDTH(PAD_TINY),
+    LV_STYLE_CONST_LINE_DASH_GAP(PAD_TINY),
+    LV_STYLE_PROP_INV,
+};
+LV_STYLE_CONST_MULTI_INIT(EdgeTxStyles::border_dash_line, border_dash_line_props);
+
 static const lv_style_const_prop_t outline_props[] = {
     LV_STYLE_CONST_OUTLINE_WIDTH(PAD_OUTLINE),
     LV_STYLE_CONST_OUTLINE_OPA(LV_OPA_COVER),

--- a/radio/src/gui/colorlcd/libui/etx_lv_theme.h
+++ b/radio/src/gui/colorlcd/libui/etx_lv_theme.h
@@ -270,6 +270,7 @@ class EdgeTxStyles
   static const lv_style_t border;
   static const lv_style_t border_transparent;
   static const lv_style_t border_thin;
+  static const lv_style_t border_dash_line;
   static const lv_style_t outline;
 
   EdgeTxStyles();

--- a/radio/src/gui/colorlcd/mainview/view_main.cpp
+++ b/radio/src/gui/colorlcd/mainview/view_main.cpp
@@ -278,7 +278,6 @@ void ViewMain::refreshWidgetSelectTimer()
 bool ViewMain::enableWidgetSelect(bool enable)
 {
   TRACE("enableWidgetSelect(%d)", enable);
-  // TODO: start timer
   if (widget_select == enable) return false;
   widget_select = enable;
 
@@ -300,6 +299,8 @@ bool ViewMain::enableWidgetSelect(bool enable)
     lv_obj_clear_flag(tile_view, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_clear_flag(tile_view, LV_OBJ_FLAG_SCROLL_CHAIN_HOR);
     lv_obj_clear_flag(tile_view, LV_OBJ_FLAG_SCROLL_CHAIN_VER);
+
+    refreshWidgetSelectTimer();
   } else {
     lv_obj_add_flag(tile_view, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_add_flag(tile_view, LV_OBJ_FLAG_SCROLL_CHAIN_HOR);

--- a/radio/src/gui/colorlcd/mainview/widget.cpp
+++ b/radio/src/gui/colorlcd/mainview/widget.cpp
@@ -166,6 +166,17 @@ Widget::Widget(const WidgetFactory* factory, Window* parent, const rect_t& rect,
     if (!fullscreen && lv_obj_get_group(lvobj)) openMenu();
     return 0;
   });
+
+  setFocusHandler([=](bool hasFocus) {
+    if (focusBorder) {
+      if (hasFocus) {
+        lv_obj_clear_flag(focusBorder, LV_OBJ_FLAG_HIDDEN);
+        ViewMain::instance()->refreshWidgetSelectTimer();
+      } else {
+        lv_obj_add_flag(focusBorder, LV_OBJ_FLAG_HIDDEN);
+      }
+    }
+  });
 }
 
 void Widget::openMenu()
@@ -272,43 +283,22 @@ void Widget::enableFocus(bool enable)
 {
   if (enable) {
     if (!focusBorder) {
-      lv_style_init(&borderStyle);
-      lv_style_set_line_width(&borderStyle, PAD_BORDER);
-      lv_style_set_line_opa(&borderStyle, LV_OPA_COVER);
-      lv_style_set_line_color(&borderStyle, makeLvColor(COLOR_THEME_FOCUS));
+      focusBorder = lv_obj_create(lvobj);
+      lv_obj_set_size(focusBorder, width(), height());
+      etx_obj_add_style(focusBorder, styles->border, LV_PART_MAIN);
+      etx_obj_add_style(focusBorder, styles->border_color[COLOR_THEME_FOCUS_INDEX], LV_PART_MAIN);
 
-      borderPts[0] = {1, 1};
-      borderPts[1] = {(lv_coord_t)(width() - 1), 1};
-      borderPts[2] = {(lv_coord_t)(width() - 1), (lv_coord_t)(height() - 1)};
-      borderPts[3] = {1, (lv_coord_t)(height() - 1)};
-      borderPts[4] = {1, 1};
-
-      focusBorder = lv_line_create(lvobj);
-      lv_obj_add_style(focusBorder, &borderStyle, LV_PART_MAIN);
-      lv_line_set_points(focusBorder, borderPts, 5);
-
-      if (!hasFocus()) {
+      if (!hasFocus())
         lv_obj_add_flag(focusBorder, LV_OBJ_FLAG_HIDDEN);
-      }
-
-      setFocusHandler([=](bool hasFocus) {
-        if (hasFocus) {
-          lv_obj_clear_flag(focusBorder, LV_OBJ_FLAG_HIDDEN);
-        } else {
-          lv_obj_add_flag(focusBorder, LV_OBJ_FLAG_HIDDEN);
-        }
-        ViewMain::instance()->refreshWidgetSelectTimer();
-      });
 
       lv_group_add_obj(lv_group_get_default(), lvobj);
     }
   } else {
     if (focusBorder) {
-      lv_obj_del(focusBorder);
-      setFocusHandler(nullptr);
       lv_group_remove_obj(lvobj);
+      lv_obj_del(focusBorder);
+      focusBorder = nullptr;
     }
-    focusBorder = nullptr;
   }
 }
 

--- a/radio/src/gui/colorlcd/mainview/widget.h
+++ b/radio/src/gui/colorlcd/mainview/widget.h
@@ -129,8 +129,6 @@ class Widget : public ButtonBase
   bool fullscreen = false;
   bool closeFS = false;
   lv_obj_t* focusBorder = nullptr;
-  lv_style_t borderStyle;
-  lv_point_t borderPts[5];
 
   void onCancel() override;
   bool onLongPress() override;

--- a/radio/src/gui/colorlcd/mainview/widgets_setup.cpp
+++ b/radio/src/gui/colorlcd/mainview/widgets_setup.cpp
@@ -56,13 +56,6 @@ SetupWidgetsPageSlot::SetupWidgetsPageSlot(Window* parent, const rect_t& rect,
   etx_obj_add_style(lvobj, styles->border, LV_STATE_FOCUSED);
   etx_obj_add_style(lvobj, styles->border_color[COLOR_THEME_FOCUS_INDEX], LV_STATE_FOCUSED);
 
-  lv_style_init(&borderStyle);
-  lv_style_set_line_width(&borderStyle, PAD_BORDER);
-  lv_style_set_line_opa(&borderStyle, LV_OPA_COVER);
-  lv_style_set_line_dash_width(&borderStyle, PAD_BORDER);
-  lv_style_set_line_dash_gap(&borderStyle, PAD_BORDER);
-  lv_style_set_line_color(&borderStyle, makeLvColor(COLOR_THEME_SECONDARY2));
-
   borderPts[0] = {1, 1};
   borderPts[1] = {(lv_coord_t)(width() - 1), 1};
   borderPts[2] = {(lv_coord_t)(width() - 1), (lv_coord_t)(height() - 1)};
@@ -70,7 +63,8 @@ SetupWidgetsPageSlot::SetupWidgetsPageSlot(Window* parent, const rect_t& rect,
   borderPts[4] = {1, 1};
 
   border = lv_line_create(lvobj);
-  lv_obj_add_style(border, &borderStyle, LV_PART_MAIN);
+  etx_obj_add_style(border, styles->border_dash_line, LV_PART_MAIN);
+  etx_obj_add_style(border, styles->line_color[COLOR_THEME_SECONDARY2_INDEX], LV_PART_MAIN);
   lv_line_set_points(border, borderPts, 5);
 
   setFocusState();

--- a/radio/src/gui/colorlcd/mainview/widgets_setup.h
+++ b/radio/src/gui/colorlcd/mainview/widgets_setup.h
@@ -69,7 +69,6 @@ class SetupWidgetsPageSlot : public ButtonBase
   WidgetsContainer* container = nullptr;
   uint8_t slotIndex = 0;
   bool openSettings = false;
-  lv_style_t borderStyle;
   lv_point_t borderPts[5];
   lv_obj_t* border;
 


### PR DESCRIPTION
Remove the local styles for widget borders when editing UI screen layout and in widget select mode.

Fixes small memory leak discovered in PR #7648 

Replaces and closes #7648 
