### PR TITLE
chore(telem): unify antenna number with RSSI number for ELRS

### DIFF
--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -307,7 +307,7 @@ void processCrossfireTelemetryFrame(uint8_t module, uint8_t* rxBuffer,
             value =
                 ((unsigned)value < DIM(power_values) ? power_values[value] : 0);
           } else
-          if (i ==  RX_ANTENNA_INDEX && crossfireModuleStatus[module].isELRS) {
+          if (i == RX_ANTENNA_INDEX && crossfireModuleStatus[module].isELRS) {
             value += 1;  // 0 = Antenna 1, 1 = Antenna 2
           }
           processCrossfireTelemetryValue(i, value);

--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -306,6 +306,9 @@ void processCrossfireTelemetryFrame(uint8_t module, uint8_t* rxBuffer,
                                                    1000, 2000, 250, 50};
             value =
                 ((unsigned)value < DIM(power_values) ? power_values[value] : 0);
+          } else
+          if (i ==  RX_ANTENNA_INDEX && crossfireModuleStatus[module].isELRS) {
+            value += 1;  // 0 = Antenna 1, 1 = Antenna 2
           }
           processCrossfireTelemetryValue(i, value);
           if (i == RX_QUALITY_INDEX) {

--- a/radio/src/telemetry/crossfire.cpp
+++ b/radio/src/telemetry/crossfire.cpp
@@ -306,8 +306,8 @@ void processCrossfireTelemetryFrame(uint8_t module, uint8_t* rxBuffer,
                                                    1000, 2000, 250, 50};
             value =
                 ((unsigned)value < DIM(power_values) ? power_values[value] : 0);
-          } else
-          if (i == RX_ANTENNA_INDEX && crossfireModuleStatus[module].isELRS) {
+          } else if (i == RX_ANTENNA_INDEX &&
+                     crossfireModuleStatus[module].isELRS) {
             value += 1;  // 0 = Antenna 1, 1 = Antenna 2
           }
           processCrossfireTelemetryValue(i, value);


### PR DESCRIPTION
The ExpressLRS PR https://github.com/ExpressLRS/ExpressLRS/pull/3734 fixes the inconsistent naming of antenna selection and reporting on the ELRS side, targeted for the V4.2 release.

<img width="842" height="207" alt="image" src="https://github.com/user-attachments/assets/95a4f806-399b-45b9-b99f-4355d50ab9b3" />

This PR asks EdgeTX to follow the chosen 1-based antenna naming convention (Antenna 1, Antenna 2) for the ANT telemetry sensor and report ANT 1 and ANT 2 accordingly. Cherry-picking this PR into the 2.12.x branch would also be beneficial, even when using ExpressLRS version 4.1 or earlier.

Fixes inconsistent antenna reporting

Summary of changes:
- OTA values 0 and 1 are translated to ANT 1 and ANT 2.
- The translation is only applied when an ELRS module is connected.

