### PR TITLE
fix(color): number edit keyboard is not sized to suit display and cursor position is wrong

### DIFF
--- a/radio/src/gui/colorlcd/libui/keyboard_number.cpp
+++ b/radio/src/gui/colorlcd/libui/keyboard_number.cpp
@@ -21,7 +21,7 @@
 #include "numberedit.h"
 #include "keys.h"
 
-constexpr coord_t KEYBOARD_HEIGHT = 90;
+LAYOUT_VAL_SCALED(KEYBOARD_HEIGHT, 90);
 NumberKeyboard* NumberKeyboard::_instance = nullptr;
 
 static const char* const number_kb_map[] = {"<<",  "-",   "+",   ">>",  "\n",
@@ -72,42 +72,42 @@ void NumberKeyboard::handleEvent(const char* btn)
 
 void NumberKeyboard::decLarge()
 {
-  ((NumberEdit*)field)->onEvent(EVT_VIRTUAL_KEY_BACKWARD);
+  field->onEvent(EVT_VIRTUAL_KEY_BACKWARD);
 }
 
 void NumberKeyboard::decSmall()
 {
-  ((NumberEdit*)field)->onEvent(EVT_VIRTUAL_KEY_MINUS);
+  field->onEvent(EVT_VIRTUAL_KEY_MINUS);
 }
 
 void NumberKeyboard::incSmall()
 {
-  ((NumberEdit*)field)->onEvent(EVT_VIRTUAL_KEY_PLUS);
+  field->onEvent(EVT_VIRTUAL_KEY_PLUS);
 }
 
 void NumberKeyboard::incLarge()
 {
-  ((NumberEdit*)field)->onEvent(EVT_VIRTUAL_KEY_FORWARD);
+  field->onEvent(EVT_VIRTUAL_KEY_FORWARD);
 }
 
 void NumberKeyboard::setMIN()
 {
-  ((NumberEdit*)field)->onEvent(EVT_VIRTUAL_KEY_MIN);
+  field->onEvent(EVT_VIRTUAL_KEY_MIN);
 }
 
 void NumberKeyboard::setMAX()
 {
-  ((NumberEdit*)field)->onEvent(EVT_VIRTUAL_KEY_MAX);
+  field->onEvent(EVT_VIRTUAL_KEY_MAX);
 }
 
 void NumberKeyboard::setDEF()
 {
-  ((NumberEdit*)field)->onEvent(EVT_VIRTUAL_KEY_DEFAULT);
+  field->onEvent(EVT_VIRTUAL_KEY_DEFAULT);
 }
 
 void NumberKeyboard::changeSign()
 {
-  ((NumberEdit*)field)->onEvent(EVT_VIRTUAL_KEY_SIGN);
+  field->onEvent(EVT_VIRTUAL_KEY_SIGN);
 }
 
 #if defined(HARDWARE_KEYS)

--- a/radio/src/gui/colorlcd/libui/numberedit.cpp
+++ b/radio/src/gui/colorlcd/libui/numberedit.cpp
@@ -35,11 +35,6 @@ class NumberArea : public FormField
   {
     setWindowFlag(NO_FOCUS);
 
-    if (parent->getTextFlags() & CENTERED)
-      etx_obj_add_style(lvobj, styles->text_align_center, LV_PART_MAIN);
-    else
-      etx_obj_add_style(lvobj, styles->text_align_right, LV_PART_MAIN);
-
     // Allow encoder acceleration
     lv_obj_add_flag(lvobj, LV_OBJ_FLAG_ENCODER_ACCEL);
 


### PR DESCRIPTION
Fix various issues with the number edit control:
- Keyboard height not scaled to LCD size
- Incorrect cast when sending events from keyboard to textarea control
- When editing a value the edit cursor is in the wrong place (tap on the control while editing to move the cursor to see)

The cursor issue only appears when the text is right or center aligned while editing.
For now the number will be left aligned while editing and center / right aligned otherwise.