### PR TITLE
fix(color): potential EM when moving trim to subtrim

### DIFF
--- a/radio/src/gui/colorlcd/model/model_outputs.cpp
+++ b/radio/src/gui/colorlcd/model/model_outputs.cpp
@@ -220,6 +220,9 @@ ModelOutputsPage::ModelOutputsPage(PageDef& pageDef) :
 
 void ModelOutputsPage::build(Window* window)
 {
+  // build() runs again each time the tab is re-selected
+  outputButtons.clear();
+
   window->padAll(PAD_ZERO);
   window->padBottom(PAD_LARGE);
 


### PR DESCRIPTION
In 2.12, moving trim to subtrim on screen has a good change to EM on colorlcd ([reported on Discord](https://discord.com/channels/839849772864503828/1539195896502427698/1539195896502427698)). This fixes it.

main is immune to this issue due to a redesign that has happened
