### PR TITLE
fix(cpn): inconsistent values for CRSF baudrate between radio and companion

### DIFF
--- a/radio/src/boards/hw_defs/c14.json
+++ b/radio/src/boards/hw_defs/c14.json
@@ -358,8 +358,6 @@
     "has_audio_mute": true,
     "has_ext_module_support": true,
     "has_int_module_support": true,
-    "sport_max_baudrate": 400000,
-    "surface": false,
     "cpu": "STM32H750xB",
     "cpu_type": "STM32H7"
   },

--- a/radio/src/boards/hw_defs/pa01.json
+++ b/radio/src/boards/hw_defs/pa01.json
@@ -320,7 +320,6 @@
     "has_audio_mute": true,
     "has_ext_module_support": true,
     "has_int_module_support": true,
-    "sport_max_baudrate": 400000,
     "cpu": "STM32H750xB",
     "cpu_type": "STM32H7"
   },

--- a/radio/src/boards/hw_defs/st16.json
+++ b/radio/src/boards/hw_defs/st16.json
@@ -422,7 +422,6 @@
     "has_audio_mute": true,
     "has_ext_module_support": true,
     "has_int_module_support": true,
-    "sport_max_baudrate": 400000,
     "cpu": "STM32H750xB",
     "cpu_type": "STM32H7"
   },

--- a/radio/src/boards/hw_defs/t15pro.json
+++ b/radio/src/boards/hw_defs/t15pro.json
@@ -396,7 +396,6 @@
     "has_audio_mute": true,
     "has_ext_module_support": true,
     "has_int_module_support": true,
-    "sport_max_baudrate": 400000,
     "cpu": "STM32H750xB",
     "cpu_type": "STM32H7"
   },

--- a/radio/src/boards/hw_defs/t22.json
+++ b/radio/src/boards/hw_defs/t22.json
@@ -497,7 +497,6 @@
     "has_audio_mute": true,
     "has_ext_module_support": true,
     "has_int_module_support": true,
-    "sport_max_baudrate": 400000,
     "cpu": "STM32H750xB",
     "cpu_type": "STM32H7"
   },

--- a/radio/src/boards/hw_defs/tx15.json
+++ b/radio/src/boards/hw_defs/tx15.json
@@ -365,7 +365,6 @@
   "hardware": {
     "has_ext_module_support": true,
     "has_int_module_support": true,
-    "sport_max_baudrate": 400000,
     "cpu": "STM32H750xB",
     "cpu_type": "STM32H7"
   },

--- a/radio/src/boards/hw_defs/tx16smk3.json
+++ b/radio/src/boards/hw_defs/tx16smk3.json
@@ -479,7 +479,6 @@
   "hardware": {
     "has_ext_module_support": true,
     "has_int_module_support": true,
-    "sport_max_baudrate": 400000,
     "cpu": "STM32H750xB",
     "cpu_type": "STM32H7"
   },

--- a/radio/src/boards/hw_defs/v12.json
+++ b/radio/src/boards/hw_defs/v12.json
@@ -373,7 +373,6 @@
   "hardware": {
     "has_ext_module_support": true,
     "has_int_module_support": true,
-    "sport_max_baudrate": 400000,
     "cpu": "STM32H750xB",
     "cpu_type": "STM32H7"
   },


### PR DESCRIPTION
Remove 'sport_max_baudrate' from H7 radio JSON files so that Companion matches firmware.

H7 radios do not use SPORT_MAX_BAUDRATE so it should not be set in the JSON files for Companion.

Fixes #7672 for main branch.

@elecpower 2.12 will need a different fix for PR 7672. The Board::SportMaxBaudRate capability should return 0 for H7 radios.