### PR TITLE
fix(cpn): GX15 not configured as H7 type

### DIFF
--- a/companion/src/firmwares/boards.h
+++ b/companion/src/firmwares/boards.h
@@ -896,6 +896,7 @@ inline bool IS_STM32H7(Board::Type board)
          IS_JUMPER_T22(board) ||
          IS_RADIOMASTER_TX15(board) ||
          IS_RADIOMASTER_TX16SMK3(board) ||
+         IS_RADIOMASTER_GX15(board) ||
          IS_IFLIGHT_C14(board);
 }
 


### PR DESCRIPTION
Fix GX15 detection as H7 so it gets more gvars and telemetry sensors in companion.

main does not need this fix
