### PR TITLE
fix(cpn): inconsistent values for CRSF baudrate between radio and companion (2.12)

### DIFF
--- a/companion/src/firmwares/boards.cpp
+++ b/companion/src/firmwares/boards.cpp
@@ -474,7 +474,9 @@ int Boards::getCapability(Board::Type board, Board::Capability capability)
              getCapability(board, Board::JoystickAxes) + getCapability(board, Board::GyroAxes);
 
     case SportMaxBaudRate:
-      if (IS_FAMILY_T16(board) || IS_FLYSKY_NV14(board) || IS_FLYSKY_EL18(board) || IS_TARANIS_X7_ACCESS(board) ||
+      if (IS_STM32H7(board))
+        return 0;
+      else if (IS_FAMILY_T16(board) || IS_FLYSKY_NV14(board) || IS_FLYSKY_EL18(board) || IS_TARANIS_X7_ACCESS(board) ||
          (IS_TARANIS(board) && !IS_TARANIS_XLITE(board) && !IS_TARANIS_X7(board) && !IS_TARANIS_X9LITE(board)))
         return 400000;  //  400K and higher
       else


### PR DESCRIPTION
Fix for #7672 in 2.12.
