### PR TITLE
fix(color): USB SD card mode may crash to emergency mode (#7657)

### DIFF
--- a/radio/src/gui/colorlcd/libui/mainwindow.cpp
+++ b/radio/src/gui/colorlcd/libui/mainwindow.cpp
@@ -23,6 +23,7 @@
 #include "layout.h"
 #include "etx_lv_theme.h"
 #include "sdcard.h"
+#include "view_main.h"
 
 // timers_driver.h
 uint32_t timersGetMsTick();
@@ -56,6 +57,8 @@ void MainWindow::emptyTrash()
 void MainWindow::run(bool trash)
 {
   auto start = timersGetMsTick();
+
+  ViewMain::checkWidgetSelectTimeout();
 
   auto opaque = Layer::getFirstOpaque();
   if (opaque) {

--- a/radio/src/gui/colorlcd/mainview/view_main.cpp
+++ b/radio/src/gui/colorlcd/mainview/view_main.cpp
@@ -297,25 +297,20 @@ void ViewMain::onCancel()
 
 void ViewMain::refreshWidgetSelectTimer()
 {
-  if (!widget_select_timer) {
-    widget_select_timer = lv_timer_create(ViewMain::ws_timer, 10 * 1000, this);
-  } else {
-    lv_timer_reset(widget_select_timer);
-  }
+  widgetSelectCancelTime = get_tmr10ms() + 1000; // 10 seconds
 }
 
-bool ViewMain::enableWidgetSelect(bool enable)
+void ViewMain::enableWidgetSelect(bool enable)
 {
   TRACE("enableWidgetSelect(%d)", enable);
-  // TODO: start timer
-  if (widget_select == enable) return false;
+  if (widget_select == enable) return;
   widget_select = enable;
 
   lv_obj_t* tile = lv_tileview_get_tile_act(tile_view);
-  if (!tile) return true;
+  if (!tile) return;
 
   auto cont_obj = lv_obj_get_child(tile, 0);
-  if (!cont_obj) return true;
+  if (!cont_obj) return;
 
   auto cont = (WidgetsContainer*)lv_obj_get_user_data(cont_obj);
 
@@ -329,18 +324,15 @@ bool ViewMain::enableWidgetSelect(bool enable)
     lv_obj_clear_flag(tile_view, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_clear_flag(tile_view, LV_OBJ_FLAG_SCROLL_CHAIN_HOR);
     lv_obj_clear_flag(tile_view, LV_OBJ_FLAG_SCROLL_CHAIN_VER);
+
+    refreshWidgetSelectTimer();
   } else {
     lv_obj_add_flag(tile_view, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_add_flag(tile_view, LV_OBJ_FLAG_SCROLL_CHAIN_HOR);
     lv_obj_add_flag(tile_view, LV_OBJ_FLAG_SCROLL_CHAIN_VER);
 
-    if (widget_select_timer) {
-      lv_timer_del(widget_select_timer);
-      widget_select_timer = nullptr;
-    }
+    widgetSelectCancelTime = 0;
   }
-
-  return true;
 }
 
 void ViewMain::openMenu()
@@ -348,11 +340,17 @@ void ViewMain::openMenu()
   viewMainMenu = new ViewMainMenu(this, [=]() { viewMainMenu = nullptr; });
 }
 
-void ViewMain::ws_timer(lv_timer_t* t)
+void ViewMain::checkWidgetSelectTimeout()
 {
-  ViewMain* view = (ViewMain*)t->user_data;
-  if (!view) return;
-  view->enableWidgetSelect(false);
+  if (_instance) _instance->_checkWidgetSelectTimeout();
+}
+
+void ViewMain::_checkWidgetSelectTimeout()
+{
+  if (deleted()) return;
+
+  if (widget_select && widgetSelectCancelTime < get_tmr10ms())
+    enableWidgetSelect(false);
 }
 
 bool ViewMain::onLongPress()

--- a/radio/src/gui/colorlcd/mainview/view_main.h
+++ b/radio/src/gui/colorlcd/mainview/view_main.h
@@ -54,7 +54,7 @@ class ViewMain : public NavWindow
   void enableTopbar();
   void disableTopbar();
   void updateTopbarVisibility();
-  bool enableWidgetSelect(bool enable);
+  void enableWidgetSelect(bool enable);
 
   // Get the available space in the middle of the screen
   // (without topbar)
@@ -87,6 +87,8 @@ class ViewMain : public NavWindow
   void runBackground();
   void refreshWidgetSelectTimer();
 
+  static void checkWidgetSelectTimeout();
+
  protected:
   static ViewMain* _instance;
 
@@ -94,7 +96,7 @@ class ViewMain : public NavWindow
   lv_obj_t* tile_view = nullptr;
   TopBar* topbar = nullptr;
   bool widget_select = false;
-  lv_timer_t* widget_select_timer = nullptr;
+  tmr10ms_t widgetSelectCancelTime = 0;
   ViewMainMenu* viewMainMenu = nullptr;
 
   // Widget setup requires special permissions ;-)
@@ -105,7 +107,7 @@ class ViewMain : public NavWindow
   void setTopbarVisible(float visible);
   void setEdgeTxButtonVisible(float visible);
 
-  static void ws_timer(lv_timer_t* t);
+  void _checkWidgetSelectTimeout();
 
 #if defined(HARDWARE_KEYS)
   void onPressSYS() override;


### PR DESCRIPTION
Backport of #7657 to 2.11.

Not cherry-pickable as-is: upstream hangs the replacement check off `ViewMain::_refreshWidgets()`, part of the widget-refresh mechanism that arrived in 2.12 and does not exist on 2.11.

### The bug

`ViewMain::refreshWidgetSelectTimer()` created a free-standing `lv_timer` with `this` as `user_data` to auto-cancel widget select mode after 10s, and `~ViewMain()` never deleted it.

Entering USB SD card mode calls `edgeTxClose()` -> `MainWindow::shutdown()`, which destroys `ViewMain`. The timer lives in LVGL's *global timer list*, not the `lv_obj` tree, so `lv_obj_del()` never touches it and nothing calls `lv_deinit()`. Meanwhile the USB branch of `perMain()` keeps calling `lv_timer_handler()`, so up to 10s later the orphaned callback fires on freed memory and touches the already-deleted `tile_view` - hard fault, reboot into emergency mode.

As upstream, the fix drops the LVGL timer entirely in favour of a plain `tmr10ms_t` deadline checked once per GUI cycle, so nothing can fire after teardown.

### Adaptations for 2.11

- Added a `ViewMain::checkWidgetSelectTimeout()` static, called from `MainWindow::run()` - the 2.11 stand-in for upstream's `refreshWidgets()` hook, at the same point in the same function. It uses `_instance` directly rather than the auto-vivifying `instance()`.
- Restored the `refreshWidgetSelectTimer()` call in the `enable` branch of `enableWidgetSelect()`. Upstream main already had this *before* #7657; 2.11 never did (it still carried a `// TODO: start timer` comment). Without it the deadline is never seeded, so widget select would self-cancel on the very next GUI cycle.
- Kept the `deleted()` guard, mirroring upstream's `if (!_deleted)`, covering the window where `deleteLater()` has flagged the window but the destructor has not yet run.

Upstream's two cosmetic hunks (reordering `saveViewId`, a line rewrap) were skipped as churn.

### Testing

- Builds clean on tx16s, el18, boxer and x9dp. Only tx16s/el18 actually compile the changed file, since `mainview/*.cpp` is globbed in for colour targets only - boxer and x9dp are regression builds.
- Verified working on hardware.

🤖 Generated with [Claude Code](https://claude.com/claude-code)