### PR TITLE
chore(color): remove unused 'outputButtons' vector from ModelOutputsPage class.

### DIFF
--- a/radio/src/gui/colorlcd/model/model_outputs.h
+++ b/radio/src/gui/colorlcd/model/model_outputs.h
@@ -51,7 +51,5 @@ class ModelOutputsPage : public PageGroupItem
   static constexpr coord_t TRIMB_W = LCD_W - PAD_SMALL * 2;
 
  protected:
-  std::vector<OutputLineButton*> outputButtons;
-
   void editOutput(uint8_t channel, OutputLineButton* btn);
 };


### PR DESCRIPTION
Missed when the messaging system for UI updates was added.