### PR TITLE
fix(color): rotary encoder sometimes inoperative after LUA script exit

### DIFF
--- a/radio/src/gui/colorlcd/standalone_lua.cpp
+++ b/radio/src/gui/colorlcd/standalone_lua.cpp
@@ -156,9 +156,6 @@ StandaloneLuaWindow::StandaloneLuaWindow(bool useLvgl, int initFn, int runFn) :
                       FONT(L) | COLOR_THEME_PRIMARY2 | CENTERED);
     lv_obj_clear_flag(lvobj, LV_OBJ_FLAG_SCROLLABLE);
     lv_obj_clear_flag(lvobj, LV_OBJ_FLAG_CLICK_FOCUSABLE);
-
-    lv_group_add_obj(lv_group_get_default(), lvobj);
-    lv_group_set_editing(lv_group_get_default(), true);
   }
 
   // setup LUA event handler


### PR DESCRIPTION
#7509 backport did include 2 undue line that:

StandaloneLuaWindow's constructor runs before attach() → pushLayer(true). So at constructor time, lv_group_get_default() is still the parent layer's group (the SYS/pagegroup menu). The backported lines therefore do:                                                                                                                                                                                                                                 
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
  - lv_group_add_obj(<parent menu group>, lvobj)                                                                                                                                                                                                                                                                                                                                                                                                                                   
  - lv_group_set_editing(<parent menu group>, true) ← poisons the menu's group                                                                                                                                                                                                                                                                                                                                                                                                     
                                                                                                                                                                                                                                                                                                                                                                                                                                                                                   
attach() then pushes a new layer and re-adds lvobj to the new group (lv_group_add_obj removes it from the old one), but editing = 1 is left behind on the parent group forever. On long-RTN, Layer::pop deletes the Lua group and restores the parent group as default — still stuck in edit mode, so the encoder sends LV_KEY_LEFT/RIGHT to the focused object instead of moving focus. Non-editable focus → wheel does nothing.    

Fixes #7681

Not needed for main
