### PR TITLE
fix(c14): LCD flush never acknowledged; tidy STICK_DEAD_ZONE on gx15 and t15pro

### DIFF
--- a/radio/src/targets/c14/lcd_driver.cpp
+++ b/radio/src/targets/c14/lcd_driver.cpp
@@ -63,6 +63,8 @@ static void startLcdRefresh(lv_disp_drv_t *disp_drv, uint16_t *buffer,
   // wait for reload
   // TODO: replace through some smarter mechanism without busy wait
   while(_frame_addr_reloaded == 0);
+
+  lcdFlushed();
 }
 
 

--- a/radio/src/targets/gx15/CMakeLists.txt
+++ b/radio/src/targets/gx15/CMakeLists.txt
@@ -7,6 +7,7 @@ option(GHOST "Ghost TX Module" ON)
 option(MODULE_SIZE_STD "Standard size TX Module" ON)
 option(LUA_MIXER "Enable LUA mixer/model scripts support" ON)
 option(DISK_CACHE "Enable SD card disk cache" ON)
+option(STICK_DEAD_ZONE "Enable sticks dead zone" OFF)
 
 set(FIRMWARE_QSPI YES)
 set(FIRMWARE_FORMAT_UF2 YES)
@@ -26,8 +27,6 @@ set(HARDWARE_EXTERNAL_MODULE YES)
 set(INTERNAL_MODULE_AFHDS3 NO)
 set(ROTARY_ENCODER YES)
 set(FUNCTION_SWITCHES_WITH_RGB YES)
-
-#option(STICKS_DEAD_ZONE "Enable sticks dead zone" YES)
 
 # IMU support
 set(IMU ON)
@@ -82,7 +81,7 @@ add_definitions(-DRTCLOCK)
 add_definitions(-DPWR_BUTTON_${PWR_BUTTON})
 add_definitions(-DGPS_USART_BAUDRATE=${INTERNAL_GPS_BAUDRATE})
 
-if(STICKS_DEAD_ZONE)
+if(STICK_DEAD_ZONE)
   add_definitions(-DSTICK_DEAD_ZONE)
 endif()
 

--- a/radio/src/targets/t15pro/CMakeLists.txt
+++ b/radio/src/targets/t15pro/CMakeLists.txt
@@ -7,6 +7,7 @@ option(GHOST "Ghost TX Module" ON)
 option(MODULE_SIZE_STD "Standard size TX Module" ON)
 option(LUA_MIXER "Enable LUA mixer/model scripts support" ON)
 option(DISK_CACHE "Enable SD card disk cache" ON)
+option(STICK_DEAD_ZONE "Enable sticks dead zone" OFF)
 
 set(FIRMWARE_QSPI YES)
 set(FIRMWARE_FORMAT_UF2 YES)
@@ -27,8 +28,6 @@ set(INTERNAL_MODULE_AFHDS3 NO)
 set(ROTARY_ENCODER YES)
 set(FUNCTION_SWITCHES YES)
 set(FUNCTION_SWITCHES_RGB_LEDS YES)
-
-#option(STICK_DEAD_ZONE "Enable sticks dead zone" YES)
 
 # IMU support
 set(IMU ON)


### PR DESCRIPTION
Two fixes found while preparing the 2.12.3 backport series (#7687). Both apply to `main` in their own right.

## `fix(c14)`: LCD flush never acknowledged, locking up the radio

#7483 moved responsibility for signalling flush completion out of `flushLcd()` and into the drivers — it no longer calls `lv_disp_flush_ready()` after invoking the flush callback, so each driver must call `lcdFlushed()` itself. Every other driver was updated at the time; `targets/c14` was missed.

`startLcdRefresh()` is synchronous — it busy-waits for the LTDC shadow register reload and returns — so nothing ever acknowledges the flush. LVGL leaves `draw_buf->flushing` set and the next refresh spins forever in the wait loop in `lv_refr.c`, since `disp_drv.wait_cb` is only populated under `SIMU`.

Expected symptoms on hardware: the radio reaches the splash screen and stops. The bootloader carries the same contract change in `boot_lcd.cpp`, and `bootloaderUF2()`'s loop is what calls `usbStart()` and drives the flashing state machine — so once it wedges on the second frame the UF2 drive never appears either, and **recovery needs DFU mode**.

Confirmed on C14 hardware. Was missed in #7494. 

## `chore(build)`: use the renamed STICK_DEAD_ZONE option on gx15 and t15pro

#7638 replaced the stale commented-out declaration with a real `option(... OFF)` for t22, tx15, tx16smk3 and v12, but missed two targets:

- **gx15** — still on the old plural name in both places, so `if(STICKS_DEAD_ZONE)` was always false
- **t15pro** — already used the singular name in the guard, but left its `option()` declaration commented out

In both cases the option was never declared, so the guard was dead and the sticks dead zone could not be enabled at all. Declaring it explicitly is also what stops the value leaking in from another target's CMake cache, which is the bug #7638 set out to fix.

No functional change — the option defaults `OFF`, so `-DSTICK_DEAD_ZONE` is still never added, and neither `yaml_datastructs_gx15.cpp` nor `yaml_datastructs_t15pro.cpp` is affected; both already carry `YAML_PADDING(3)` in that slot, matching t22. Turning either on is a separate decision that would need the YAML regenerated.

## Testing

Built clean on this branch: **c14** (1,352,276), **gx15** (1,374,460), **t15pro** (1,368,200).

