### PR TITLE
chore(ci): update actions to their current major versions

### DIFF
--- a/.github/actions/build_companion/action.yml
+++ b/.github/actions/build_companion/action.yml
@@ -66,7 +66,7 @@ runs:
 
     - name: Install NSIS
       if: runner.os == 'Windows'
-      uses: repolevedavaj/install-nsis@v1.2.1
+      uses: repolevedavaj/install-nsis@v1
       with:
         nsis-version: '3.11'
 

--- a/.github/actions/python_dependencies/action.yml
+++ b/.github/actions/python_dependencies/action.yml
@@ -8,7 +8,7 @@ runs:
   using: "composite"
   steps:
 
-    - uses: actions/setup-python@v6
+    - uses: actions/setup-python@v7
       with:
         python-version: ${{ inputs.python-version }}
         cache: 'pip' # caching pip dependencies

--- a/.github/workflows/auto_close.yml
+++ b/.github/workflows/auto_close.yml
@@ -7,7 +7,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@v10
+      - uses: actions/stale@v11
         with:
           # Issue closure message
           close-issue-message: 'This issue has been closed due to no activity in over four weeks after having been marked as closure pending.'

--- a/.github/workflows/build_fw.yml
+++ b/.github/workflows/build_fw.yml
@@ -56,7 +56,7 @@ jobs:
         - ${{ github.workspace }}:/src
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -104,7 +104,7 @@ jobs:
         - ${{ github.workspace }}:/src
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 

--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -63,7 +63,7 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           submodules: true
 
@@ -105,12 +105,12 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
       - name: Download WASM modules
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: wasm-modules-*
           path: wasm-modules
@@ -139,12 +139,12 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
       - name: Download WASM modules
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: wasm-modules-*
           path: wasm-modules
@@ -175,12 +175,12 @@ jobs:
 
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v5
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
       - name: Download WASM modules
-        uses: actions/download-artifact@v7
+        uses: actions/download-artifact@v8
         with:
           pattern: wasm-modules-*
           path: wasm-modules

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -26,12 +26,12 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Configure git for mike
         if: github.event_name != 'pull_request'

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -47,7 +47,7 @@ jobs:
         - ${{ github.workspace }}:/src
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
@@ -78,7 +78,7 @@ jobs:
       contents: write
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0  # Need full history for changelog
 
@@ -124,7 +124,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Deploy nightly release
-        uses: softprops/action-gh-release@v2 #softprops/action-gh-release/pull/670 or v3 to clear nodejs log warning
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: nightly
           prerelease: true

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -19,7 +19,7 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           ref: ${{ inputs.tag }}
           fetch-depth: 0
@@ -159,7 +159,7 @@ jobs:
           ls -lh release-assets/*.zip
 
       - name: Create draft release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v3
         with:
           tag_name: ${{ inputs.tag }}
           draft: true

--- a/.github/workflows/sync_repos.yml
+++ b/.github/workflows/sync_repos.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ secrets.SYNC_PAT }}

--- a/.github/workflows/validate_fw_json.yml
+++ b/.github/workflows/validate_fw_json.yml
@@ -22,7 +22,7 @@ jobs:
     name: Validate fw.json file
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v6
+      - uses: actions/checkout@v7
 
       - name: Validate fw.json syntax and schema
         run: python3 tools/validate-json.py --syntax-only

--- a/.github/workflows/validate_hw_defs.yml
+++ b/.github/workflows/validate_hw_defs.yml
@@ -22,10 +22,10 @@ jobs:
         working-directory: radio/util/hw_defs
     steps:
       - name: Check out the repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
 
       - name: Set up uv
-        uses: astral-sh/setup-uv@v7
+        uses: astral-sh/setup-uv@v10.0.1
 
       - name: Install Python dependencies
         working-directory: .


### PR DESCRIPTION
The `main` counterpart to the sweep in #7687. That one started with `build_fw` warning that `actions/upload-artifact/merge@v4` targets Node.js 20 and was being forced onto Node.js 24 — `main` was already past that particular one, but several others here are behind, and `actions/checkout` was spread across **three different versions** (v5, v6 and v7) depending on the workflow.

| Action | Was | Now |
|---|---|---|
| `actions/checkout` | v5, v6, v7 | **v7** |
| `actions/download-artifact` | v7 | **v8** |
| `actions/setup-python` | v6 | **v7** |
| `actions/stale` | v10 | **v11** |
| `softprops/action-gh-release` | v2 | **v3** |
| `astral-sh/setup-uv` | v7 | **v10.0.1** |
| `repolevedavaj/install-nsis` | v1.2.1 | **v1** |

Already current, untouched: `actions/cache@v6`, `actions/upload-artifact@v7`, `actions/upload-artifact/merge@v7`, `dorny/paths-filter@v4`, `montudor/action-zip@v1`, `orhun/git-cliff-action@v4`, `jdpurcell/install-qt-action@v5`.

## Two that are not plain major bumps

**`astral-sh/setup-uv` is pinned to a full version, not a major.** Its bare major tags stop at **v7** — there is no `v8`, `v9` or `v10`, so a major reference cannot follow it any further and `@v10.0.1` is the only way to be current. Everything else here has a moving major and uses it.

**`jdpurcell/install-qt-action@v5` looks wrong but is right.** Its newest *tag* reads `v4.1.1`; it publishes majors as **branches** rather than tags, and `v5` resolves to a real commit. Left alone.

`install-nsis@v1` was checked to resolve to the same commit as `v1.3.0`.

The trailing note against `action-gh-release` in `nightly.yml`, pointing at its PR 670 as the way to clear a Node.js warning, is removed — v3 is what it was suggesting.

## Testing

Every changed file was parsed as YAML (11/11). Beyond that this is only verifiable by running the workflows.

> [!WARNING]
> Two of these deserve an eye on the first run. **`softprops/action-gh-release` crosses a major version and is what publishes the nightly release**, and **`setup-uv` crosses three**. Neither can be exercised from a PR.

