### PR TITLE
fix(ci): missing v12 and gx15 simulator targets

### DIFF
--- a/.github/workflows/codegen_drift.yml
+++ b/.github/workflows/codegen_drift.yml
@@ -29,6 +29,10 @@ on:
       - 'radio/util/yaml_parser.tmpl'
       - 'radio/util/hw_defs/**'
       - 'radio/src/boards/hw_defs/**'
+      # web simulator radio list (also fed by the hw_defs above)
+      - 'fw.json'
+      - 'web/scripts/gen-radios-json.js'
+      - 'web/public/radios.json'
   pull_request:
     paths: *trigger-paths
   workflow_dispatch:
@@ -54,6 +58,7 @@ jobs:
       cfn: ${{ steps.filter.outputs.cfn }}
       fonts: ${{ steps.filter.outputs.fonts }}
       yaml: ${{ steps.filter.outputs.yaml }}
+      radios: ${{ steps.filter.outputs.radios }}
     steps:
       - name: Check out the repo
         uses: actions/checkout@v7
@@ -69,7 +74,7 @@ jobs:
       - name: Check the recipes this workflow calls still resolve
         run: |
           just --list >/dev/null
-          for recipe in cfn-sort gen-fonts gen-yaml; do
+          for recipe in cfn-sort gen-fonts gen-yaml gen-radios; do
             just --show "${recipe}" >/dev/null
           done
 
@@ -108,6 +113,13 @@ jobs:
               - 'radio/util/yaml_parser.tmpl'
               - 'radio/util/hw_defs/**'
               - 'radio/src/boards/hw_defs/**'
+            radios:
+              - '.github/workflows/codegen_drift.yml'
+              - '.github/actions/codegen_drift/action.yml'
+              - 'fw.json'
+              - 'radio/src/boards/hw_defs/**'
+              - 'web/scripts/gen-radios-json.js'
+              - 'web/public/radios.json'
 
   cfn-sort:
     name: Custom function sort order
@@ -180,3 +192,25 @@ jobs:
           recipe: gen-yaml
           paths: radio/src/storage/yaml
           label: YAML parsers
+
+  radios:
+    name: Web simulator radio list
+    needs: changes
+    if: needs.changes.outputs.radios == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container:
+      image: ghcr.io/edgetx/edgetx-dev:latest
+      volumes:
+        - ${{ github.workspace }}:/src
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v7
+
+      - name: Check for drift
+        uses: ./.github/actions/codegen_drift
+        with:
+          just-version: ${{ env.JUST_VERSION }}
+          recipe: gen-radios
+          paths: web/public/radios.json
+          label: Web simulator radio list

--- a/.github/workflows/companion.yml
+++ b/.github/workflows/companion.yml
@@ -47,15 +47,15 @@ jobs:
           - id: color-2
             target: [pl18u, t15, t16, t18, t22]
           - id: bw-1
-            target: [zorro, pocket, mt12, commando8, tprov2, tpros, bumblebee, t14]
+            target: [zorro, pocket, commando8, tprov2, tpros, bumblebee, t14]
           - id: bw-2
             target: [mt12, gx12, t20, t20v2, t12max, tx12mk2, boxer]
           - id: color-3
             target: [tx15, tx16s, x12s, f16]
           - id: mixed-1
-            target: [v14, v14lcd, v16, x10, x10express]
+            target: [v12, v14, v14lcd, v16, x10, x10express]
           - id: bw-3
-            target: [x7access, x9dp2019, x9e, x9e-hall]
+            target: [x7access, x9dp2019, x9e]
           - id: color-4
             target: [nb4p, st16, pa01, c14]
           - id: color-5

--- a/Justfile
+++ b/Justfile
@@ -37,9 +37,16 @@ cfn-sort:
 gen-yaml FLAVOR='':
     FLAVOR="{{ FLAVOR }}" tools/generate-yaml.sh
 
-[doc('Regenerate the YAML parsers, LVGL fonts and cfn sort order')]
+# Needs: node. Which radios are included comes from fw.json, so this only
+# picks up a new target once it is listed there.
+[doc('Regenerate the web simulator radio list (web/public/radios.json)')]
 [group('codegen')]
-codegen: gen-fonts cfn-sort gen-yaml
+gen-radios:
+    node web/scripts/gen-radios-json.js
+
+[doc('Regenerate the YAML parsers, LVGL fonts, cfn sort order and radio list')]
+[group('codegen')]
+codegen: gen-fonts cfn-sort gen-yaml gen-radios
 
 [doc('Regenerate the LVGL fonts in the dev container')]
 [group('codegen (docker)')]
@@ -60,6 +67,11 @@ docker-gen-yaml FLAVOR='':
         FETCHCONTENT_BASE_DIR=/src/.cache/fetchcontent-docker \
         tools/generate-yaml.sh
 
+[doc('Regenerate the web simulator radio list in the dev container')]
+[group('codegen (docker)')]
+docker-gen-radios:
+    {{ _docker }} node web/scripts/gen-radios-json.js
+
 [doc('Regenerate everything in the dev container')]
 [group('codegen (docker)')]
-docker-codegen: docker-gen-fonts docker-cfn-sort docker-gen-yaml
+docker-codegen: docker-gen-fonts docker-cfn-sort docker-gen-yaml docker-gen-radios

--- a/tools/build-wasm-modules.sh
+++ b/tools/build-wasm-modules.sh
@@ -223,13 +223,13 @@ else
         boxer bumblebee commando8
         gx12 mt12 pocket t12max
         t14 t20 t20v2 tpros tprov2
-        tx12mk2 zorro v12 v14 v14lcd
+        tx12mk2 zorro v14 v14lcd
         x7access x9dp2019 x9e
         # colour
         c14 el18 nb4p nv14 st16 pa01
         pl18 pl18ev pl18u
         t15 t15pro t16 t18 t22
-        tx15 tx16s tx16smk3 f16 v16
+        tx15 gx15 tx16s tx16smk3 f16 v12 v16
         x10 x10express x12s
     )
 fi

--- a/web/README.md
+++ b/web/README.md
@@ -42,13 +42,19 @@ cp output/*.wasm web/public/
 
 ### Supported Radios
 
-The radios available in the web UI are defined in `public/radios.json`. This file is **generated** from the authoritative hardware definitions in `radio/src/boards/hw_defs/`. To regenerate it (e.g. after adding a new radio target):
+The radios available in the web UI are defined in `public/radios.json`. This file is **generated** from the authoritative hardware definitions in `radio/src/boards/hw_defs/`. To regenerate it (e.g. after adding a new radio target), from the repo root:
 
 ```bash
+just gen-radios
+# or, without just:
 node web/scripts/gen-radios-json.js
 ```
 
 The script extracts inputs, switches, trims, keys, and display info from the hw_defs JSON files. Key left/right side placement matches Companion's layout.
+
+*Which* radios are included comes from the `targets` list in the repo-root `fw.json`, so a new board only appears here once it is a released target. Targets with no matching hw_defs file are skipped with a warning: `x9e-hall` always warns, as it is a build option of `x9e` rather than a board of its own.
+
+Passing flavour names as arguments limits generation to those radios only — the whole file is rewritten, so use that for inspection, not to update the committed list.
 
 ## Architecture
 

--- a/web/public/radios.json
+++ b/web/public/radios.json
@@ -2215,8 +2215,286 @@
     ]
   },
   {
+    "name": "HelloRadioSky V12",
+    "wasm": "edgetx-v12-simulator.wasm",
+    "display": {
+      "w": 320,
+      "h": 240,
+      "depth": 16
+    },
+    "inputs": [
+      {
+        "name": "LH",
+        "type": "STICK",
+        "label": "LH"
+      },
+      {
+        "name": "LV",
+        "type": "STICK",
+        "label": "LV"
+      },
+      {
+        "name": "RV",
+        "type": "STICK",
+        "label": "RV"
+      },
+      {
+        "name": "RH",
+        "type": "STICK",
+        "label": "RH"
+      },
+      {
+        "name": "P1",
+        "type": "FLEX",
+        "label": "S1",
+        "default": "POT_CENTER"
+      },
+      {
+        "name": "P2",
+        "type": "FLEX",
+        "label": "S2",
+        "default": "POT_CENTER"
+      }
+    ],
+    "switches": [
+      {
+        "name": "SA",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SB",
+        "type": "3POS",
+        "default": "3POS"
+      },
+      {
+        "name": "SC",
+        "type": "3POS",
+        "default": "3POS"
+      },
+      {
+        "name": "SD",
+        "type": "2POS",
+        "default": "TOGGLE"
+      },
+      {
+        "name": "SW1",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SW2",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SW3",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SW4",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SW5",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SW6",
+        "type": "2POS",
+        "default": "2POS"
+      }
+    ],
+    "trims": [
+      {
+        "name": "T1"
+      },
+      {
+        "name": "T2"
+      },
+      {
+        "name": "T3"
+      },
+      {
+        "name": "T4"
+      }
+    ],
+    "keys": [
+      {
+        "key": "KEY_MODEL",
+        "label": "MDL",
+        "side": "R"
+      },
+      {
+        "key": "KEY_SYS",
+        "label": "SYS",
+        "side": "L"
+      },
+      {
+        "key": "KEY_PAGEUP",
+        "label": "PAGE◀",
+        "side": "L"
+      },
+      {
+        "key": "KEY_PAGEDN",
+        "label": "PAGE▶",
+        "side": "R"
+      },
+      {
+        "key": "KEY_TELE",
+        "label": "TELE",
+        "side": "R"
+      },
+      {
+        "key": "KEY_ENTER",
+        "label": "Enter ⏎",
+        "side": "R"
+      },
+      {
+        "key": "KEY_EXIT",
+        "label": "EXIT",
+        "side": "L"
+      }
+    ]
+  },
+  {
     "name": "HelloRadioSky V14",
     "wasm": "edgetx-v14-simulator.wasm",
+    "display": {
+      "w": 128,
+      "h": 64,
+      "depth": 1
+    },
+    "inputs": [
+      {
+        "name": "LH",
+        "type": "STICK",
+        "label": "LH"
+      },
+      {
+        "name": "LV",
+        "type": "STICK",
+        "label": "LV"
+      },
+      {
+        "name": "RV",
+        "type": "STICK",
+        "label": "RV"
+      },
+      {
+        "name": "RH",
+        "type": "STICK",
+        "label": "RH"
+      },
+      {
+        "name": "P1",
+        "type": "FLEX",
+        "label": "S1",
+        "default": "POT_CENTER"
+      },
+      {
+        "name": "P2",
+        "type": "FLEX",
+        "label": "S2",
+        "default": "POT_CENTER"
+      },
+      {
+        "name": "P3",
+        "type": "FLEX",
+        "label": "S3",
+        "default": "MULTIPOS"
+      }
+    ],
+    "switches": [
+      {
+        "name": "SA",
+        "type": "2POS",
+        "default": "TOGGLE"
+      },
+      {
+        "name": "SB",
+        "type": "3POS",
+        "default": "3POS"
+      },
+      {
+        "name": "SC",
+        "type": "3POS",
+        "default": "3POS"
+      },
+      {
+        "name": "SD",
+        "type": "2POS",
+        "default": "TOGGLE"
+      },
+      {
+        "name": "SE",
+        "type": "3POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SF",
+        "type": "3POS",
+        "default": "TOGGLE"
+      }
+    ],
+    "trims": [
+      {
+        "name": "T1"
+      },
+      {
+        "name": "T2"
+      },
+      {
+        "name": "T3"
+      },
+      {
+        "name": "T4"
+      }
+    ],
+    "keys": [
+      {
+        "key": "KEY_MODEL",
+        "label": "MDL",
+        "side": "R"
+      },
+      {
+        "key": "KEY_SYS",
+        "label": "SYS",
+        "side": "L"
+      },
+      {
+        "key": "KEY_PAGEUP",
+        "label": "PAGE◀",
+        "side": "L"
+      },
+      {
+        "key": "KEY_PAGEDN",
+        "label": "PAGE▶",
+        "side": "R"
+      },
+      {
+        "key": "KEY_TELE",
+        "label": "TELE",
+        "side": "R"
+      },
+      {
+        "key": "KEY_EXIT",
+        "label": "EXIT",
+        "side": "L"
+      },
+      {
+        "key": "KEY_ENTER",
+        "label": "Enter ⏎",
+        "side": "R"
+      }
+    ]
+  },
+  {
+    "name": "HelloRadioSky V14LCD",
+    "wasm": "edgetx-v14lcd-simulator.wasm",
     "display": {
       "w": 128,
       "h": 64,
@@ -2646,6 +2924,149 @@
     ]
   },
   {
+    "name": "iFlight Commando 14",
+    "wasm": "edgetx-c14-simulator.wasm",
+    "display": {
+      "w": 480,
+      "h": 272,
+      "depth": 16
+    },
+    "inputs": [
+      {
+        "name": "LH",
+        "type": "STICK",
+        "label": "LH"
+      },
+      {
+        "name": "LV",
+        "type": "STICK",
+        "label": "LV"
+      },
+      {
+        "name": "RV",
+        "type": "STICK",
+        "label": "RV"
+      },
+      {
+        "name": "RH",
+        "type": "STICK",
+        "label": "RH"
+      },
+      {
+        "name": "P1",
+        "type": "FLEX",
+        "label": "S1",
+        "default": "POT"
+      },
+      {
+        "name": "P2",
+        "type": "FLEX",
+        "label": "S2",
+        "default": "POT"
+      },
+      {
+        "name": "SL1",
+        "type": "FLEX",
+        "label": "LS",
+        "default": "SLIDER"
+      },
+      {
+        "name": "SL2",
+        "type": "FLEX",
+        "label": "RS",
+        "default": "SLIDER"
+      }
+    ],
+    "switches": [
+      {
+        "name": "SA",
+        "type": "3POS",
+        "default": "3POS"
+      },
+      {
+        "name": "SB",
+        "type": "3POS",
+        "default": "3POS"
+      },
+      {
+        "name": "SC",
+        "type": "3POS",
+        "default": "3POS"
+      },
+      {
+        "name": "SD",
+        "type": "3POS",
+        "default": "3POS"
+      },
+      {
+        "name": "SE",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SF",
+        "type": "2POS",
+        "default": "2POS"
+      }
+    ],
+    "trims": [
+      {
+        "name": "T1"
+      },
+      {
+        "name": "T2"
+      },
+      {
+        "name": "T3"
+      },
+      {
+        "name": "T4"
+      }
+    ],
+    "keys": [
+      {
+        "key": "KEY_MODEL",
+        "label": "MDL",
+        "side": "R"
+      },
+      {
+        "key": "KEY_SYS",
+        "label": "SYS",
+        "side": "L"
+      },
+      {
+        "key": "KEY_PAGEUP",
+        "label": "PAGE◀",
+        "side": "L"
+      },
+      {
+        "key": "KEY_PAGEDN",
+        "label": "PAGE▶",
+        "side": "R"
+      },
+      {
+        "key": "KEY_UP",
+        "label": "▲",
+        "side": "L"
+      },
+      {
+        "key": "KEY_DOWN",
+        "label": "▼",
+        "side": "R"
+      },
+      {
+        "key": "KEY_EXIT",
+        "label": "EXIT",
+        "side": "L"
+      },
+      {
+        "key": "KEY_ENTER",
+        "label": "Enter ⏎",
+        "side": "R"
+      }
+    ]
+  },
+  {
     "name": "Jumper Bumblebee",
     "wasm": "edgetx-bumblebee-simulator.wasm",
     "display": {
@@ -2727,268 +3148,6 @@
         "name": "SH",
         "type": "2POS",
         "default": "TOGGLE"
-      },
-      {
-        "name": "SW1",
-        "type": "2POS",
-        "default": "2POS"
-      },
-      {
-        "name": "SW2",
-        "type": "2POS",
-        "default": "2POS"
-      },
-      {
-        "name": "SW3",
-        "type": "2POS",
-        "default": "2POS"
-      },
-      {
-        "name": "SW4",
-        "type": "2POS",
-        "default": "2POS"
-      },
-      {
-        "name": "SW5",
-        "type": "2POS",
-        "default": "2POS"
-      },
-      {
-        "name": "SW6",
-        "type": "2POS",
-        "default": "2POS"
-      }
-    ],
-    "trims": [
-      {
-        "name": "T1"
-      },
-      {
-        "name": "T2"
-      },
-      {
-        "name": "T3"
-      },
-      {
-        "name": "T4"
-      }
-    ],
-    "keys": [
-      {
-        "key": "KEY_PAGEDN",
-        "label": "PAGE▶",
-        "side": "R"
-      },
-      {
-        "key": "KEY_MENU",
-        "label": "MENU",
-        "side": "L"
-      },
-      {
-        "key": "KEY_EXIT",
-        "label": "EXIT",
-        "side": "L"
-      },
-      {
-        "key": "KEY_ENTER",
-        "label": "Enter ⏎",
-        "side": "R"
-      }
-    ]
-  },
-  {
-    "name": "Jumper T-Pro S",
-    "wasm": "edgetx-tpros-simulator.wasm",
-    "display": {
-      "w": 128,
-      "h": 64,
-      "depth": 1
-    },
-    "inputs": [
-      {
-        "name": "LH",
-        "type": "STICK",
-        "label": "LH"
-      },
-      {
-        "name": "LV",
-        "type": "STICK",
-        "label": "LV"
-      },
-      {
-        "name": "RV",
-        "type": "STICK",
-        "label": "RV"
-      },
-      {
-        "name": "RH",
-        "type": "STICK",
-        "label": "RH"
-      },
-      {
-        "name": "P1",
-        "type": "FLEX",
-        "label": "S1",
-        "default": "POT_CENTER"
-      },
-      {
-        "name": "P2",
-        "type": "FLEX",
-        "label": "S2",
-        "default": "POT_CENTER"
-      }
-    ],
-    "switches": [
-      {
-        "name": "SA",
-        "type": "3POS",
-        "default": "3POS"
-      },
-      {
-        "name": "SB",
-        "type": "3POS",
-        "default": "3POS"
-      },
-      {
-        "name": "SC",
-        "type": "2POS",
-        "default": "TOGGLE"
-      },
-      {
-        "name": "SD",
-        "type": "2POS",
-        "default": "TOGGLE"
-      },
-      {
-        "name": "SE",
-        "type": "2POS",
-        "default": "2POS"
-      },
-      {
-        "name": "SF",
-        "type": "2POS",
-        "default": "2POS"
-      }
-    ],
-    "trims": [
-      {
-        "name": "T1"
-      },
-      {
-        "name": "T2"
-      },
-      {
-        "name": "T3"
-      },
-      {
-        "name": "T4"
-      }
-    ],
-    "keys": [
-      {
-        "key": "KEY_PAGEDN",
-        "label": "PAGE▶",
-        "side": "R"
-      },
-      {
-        "key": "KEY_MENU",
-        "label": "MENU",
-        "side": "L"
-      },
-      {
-        "key": "KEY_EXIT",
-        "label": "EXIT",
-        "side": "L"
-      },
-      {
-        "key": "KEY_ENTER",
-        "label": "Enter ⏎",
-        "side": "R"
-      }
-    ]
-  },
-  {
-    "name": "Jumper T-Pro V2",
-    "wasm": "edgetx-tprov2-simulator.wasm",
-    "display": {
-      "w": 128,
-      "h": 64,
-      "depth": 1
-    },
-    "inputs": [
-      {
-        "name": "LH",
-        "type": "STICK",
-        "label": "LH"
-      },
-      {
-        "name": "LV",
-        "type": "STICK",
-        "label": "LV"
-      },
-      {
-        "name": "RV",
-        "type": "STICK",
-        "label": "RV"
-      },
-      {
-        "name": "RH",
-        "type": "STICK",
-        "label": "RH"
-      },
-      {
-        "name": "P1",
-        "type": "FLEX",
-        "label": "S1",
-        "default": "POT_CENTER"
-      },
-      {
-        "name": "P2",
-        "type": "FLEX",
-        "label": "S2",
-        "default": "POT_CENTER"
-      }
-    ],
-    "switches": [
-      {
-        "name": "SA",
-        "type": "3POS",
-        "default": "3POS"
-      },
-      {
-        "name": "SB",
-        "type": "3POS",
-        "default": "3POS"
-      },
-      {
-        "name": "SC",
-        "type": "2POS",
-        "default": "TOGGLE"
-      },
-      {
-        "name": "SD",
-        "type": "2POS",
-        "default": "TOGGLE"
-      },
-      {
-        "name": "SE",
-        "type": "2POS",
-        "default": "2POS"
-      },
-      {
-        "name": "SF",
-        "type": "2POS",
-        "default": "2POS"
-      },
-      {
-        "name": "SG",
-        "type": "2POS",
-        "default": "NONE"
-      },
-      {
-        "name": "SH",
-        "type": "2POS",
-        "default": "NONE"
       },
       {
         "name": "SW1",
@@ -4347,6 +4506,473 @@
     ]
   },
   {
+    "name": "Jumper T22",
+    "wasm": "edgetx-t22-simulator.wasm",
+    "display": {
+      "w": 480,
+      "h": 320,
+      "depth": 16
+    },
+    "inputs": [
+      {
+        "name": "LH",
+        "type": "STICK",
+        "label": "LH"
+      },
+      {
+        "name": "LV",
+        "type": "STICK",
+        "label": "LV"
+      },
+      {
+        "name": "RV",
+        "type": "STICK",
+        "label": "RV"
+      },
+      {
+        "name": "RH",
+        "type": "STICK",
+        "label": "RH"
+      },
+      {
+        "name": "P1",
+        "type": "FLEX",
+        "label": "S1",
+        "default": "POT_CENTER"
+      },
+      {
+        "name": "P2",
+        "type": "FLEX",
+        "label": "S2",
+        "default": "POT_CENTER"
+      },
+      {
+        "name": "SL1",
+        "type": "FLEX",
+        "label": "S3",
+        "default": "SLIDER"
+      },
+      {
+        "name": "SL2",
+        "type": "FLEX",
+        "label": "S4",
+        "default": "SLIDER"
+      },
+      {
+        "name": "SL3",
+        "type": "FLEX",
+        "label": "SL",
+        "default": "SLIDER"
+      },
+      {
+        "name": "SL4",
+        "type": "FLEX",
+        "label": "SR",
+        "default": "SLIDER"
+      }
+    ],
+    "switches": [
+      {
+        "name": "SA",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SB",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SC",
+        "type": "3POS",
+        "default": "3POS"
+      },
+      {
+        "name": "SD",
+        "type": "3POS",
+        "default": "3POS"
+      },
+      {
+        "name": "SE",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SF",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SG",
+        "type": "2POS",
+        "default": "TOGGLE"
+      },
+      {
+        "name": "SH",
+        "type": "2POS",
+        "default": "TOGGLE"
+      },
+      {
+        "name": "SI",
+        "type": "2POS",
+        "default": "TOGGLE"
+      },
+      {
+        "name": "SJ",
+        "type": "2POS",
+        "default": "TOGGLE"
+      },
+      {
+        "name": "SK",
+        "type": "2POS",
+        "default": "TOGGLE"
+      },
+      {
+        "name": "SL",
+        "type": "2POS",
+        "default": "TOGGLE"
+      },
+      {
+        "name": "SW1",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SW2",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SW3",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SW4",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SW5",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SW6",
+        "type": "2POS",
+        "default": "2POS"
+      }
+    ],
+    "trims": [
+      {
+        "name": "T1"
+      },
+      {
+        "name": "T2"
+      },
+      {
+        "name": "T3"
+      },
+      {
+        "name": "T4"
+      }
+    ],
+    "keys": [
+      {
+        "key": "KEY_MODEL",
+        "label": "MDL",
+        "side": "R"
+      },
+      {
+        "key": "KEY_SYS",
+        "label": "SYS",
+        "side": "L"
+      },
+      {
+        "key": "KEY_PAGEDN",
+        "label": "PAGE▶",
+        "side": "R"
+      },
+      {
+        "key": "KEY_TELE",
+        "label": "TELE",
+        "side": "R"
+      },
+      {
+        "key": "KEY_EXIT",
+        "label": "EXIT",
+        "side": "L"
+      },
+      {
+        "key": "KEY_ENTER",
+        "label": "Enter ⏎",
+        "side": "R"
+      }
+    ]
+  },
+  {
+    "name": "Jumper T-Pro S",
+    "wasm": "edgetx-tpros-simulator.wasm",
+    "display": {
+      "w": 128,
+      "h": 64,
+      "depth": 1
+    },
+    "inputs": [
+      {
+        "name": "LH",
+        "type": "STICK",
+        "label": "LH"
+      },
+      {
+        "name": "LV",
+        "type": "STICK",
+        "label": "LV"
+      },
+      {
+        "name": "RV",
+        "type": "STICK",
+        "label": "RV"
+      },
+      {
+        "name": "RH",
+        "type": "STICK",
+        "label": "RH"
+      },
+      {
+        "name": "P1",
+        "type": "FLEX",
+        "label": "S1",
+        "default": "POT_CENTER"
+      },
+      {
+        "name": "P2",
+        "type": "FLEX",
+        "label": "S2",
+        "default": "POT_CENTER"
+      }
+    ],
+    "switches": [
+      {
+        "name": "SA",
+        "type": "3POS",
+        "default": "3POS"
+      },
+      {
+        "name": "SB",
+        "type": "3POS",
+        "default": "3POS"
+      },
+      {
+        "name": "SC",
+        "type": "2POS",
+        "default": "TOGGLE"
+      },
+      {
+        "name": "SD",
+        "type": "2POS",
+        "default": "TOGGLE"
+      },
+      {
+        "name": "SE",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SF",
+        "type": "2POS",
+        "default": "2POS"
+      }
+    ],
+    "trims": [
+      {
+        "name": "T1"
+      },
+      {
+        "name": "T2"
+      },
+      {
+        "name": "T3"
+      },
+      {
+        "name": "T4"
+      }
+    ],
+    "keys": [
+      {
+        "key": "KEY_PAGEDN",
+        "label": "PAGE▶",
+        "side": "R"
+      },
+      {
+        "key": "KEY_MENU",
+        "label": "MENU",
+        "side": "L"
+      },
+      {
+        "key": "KEY_EXIT",
+        "label": "EXIT",
+        "side": "L"
+      },
+      {
+        "key": "KEY_ENTER",
+        "label": "Enter ⏎",
+        "side": "R"
+      }
+    ]
+  },
+  {
+    "name": "Jumper T-Pro V2",
+    "wasm": "edgetx-tprov2-simulator.wasm",
+    "display": {
+      "w": 128,
+      "h": 64,
+      "depth": 1
+    },
+    "inputs": [
+      {
+        "name": "LH",
+        "type": "STICK",
+        "label": "LH"
+      },
+      {
+        "name": "LV",
+        "type": "STICK",
+        "label": "LV"
+      },
+      {
+        "name": "RV",
+        "type": "STICK",
+        "label": "RV"
+      },
+      {
+        "name": "RH",
+        "type": "STICK",
+        "label": "RH"
+      },
+      {
+        "name": "P1",
+        "type": "FLEX",
+        "label": "S1",
+        "default": "POT_CENTER"
+      },
+      {
+        "name": "P2",
+        "type": "FLEX",
+        "label": "S2",
+        "default": "POT_CENTER"
+      }
+    ],
+    "switches": [
+      {
+        "name": "SA",
+        "type": "3POS",
+        "default": "3POS"
+      },
+      {
+        "name": "SB",
+        "type": "3POS",
+        "default": "3POS"
+      },
+      {
+        "name": "SC",
+        "type": "2POS",
+        "default": "TOGGLE"
+      },
+      {
+        "name": "SD",
+        "type": "2POS",
+        "default": "TOGGLE"
+      },
+      {
+        "name": "SE",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SF",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SG",
+        "type": "2POS",
+        "default": "NONE"
+      },
+      {
+        "name": "SH",
+        "type": "2POS",
+        "default": "NONE"
+      },
+      {
+        "name": "SW1",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SW2",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SW3",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SW4",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SW5",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SW6",
+        "type": "2POS",
+        "default": "2POS"
+      }
+    ],
+    "trims": [
+      {
+        "name": "T1"
+      },
+      {
+        "name": "T2"
+      },
+      {
+        "name": "T3"
+      },
+      {
+        "name": "T4"
+      }
+    ],
+    "keys": [
+      {
+        "key": "KEY_PAGEDN",
+        "label": "PAGE▶",
+        "side": "R"
+      },
+      {
+        "key": "KEY_MENU",
+        "label": "MENU",
+        "side": "L"
+      },
+      {
+        "key": "KEY_EXIT",
+        "label": "EXIT",
+        "side": "L"
+      },
+      {
+        "key": "KEY_ENTER",
+        "label": "Enter ⏎",
+        "side": "R"
+      }
+    ]
+  },
+  {
     "name": "RadioMaster Boxer",
     "wasm": "edgetx-boxer-simulator.wasm",
     "display": {
@@ -4616,6 +5242,210 @@
       },
       {
         "name": "T4"
+      }
+    ],
+    "keys": [
+      {
+        "key": "KEY_MODEL",
+        "label": "MDL",
+        "side": "R"
+      },
+      {
+        "key": "KEY_SYS",
+        "label": "SYS",
+        "side": "L"
+      },
+      {
+        "key": "KEY_PAGEUP",
+        "label": "PAGE◀",
+        "side": "L"
+      },
+      {
+        "key": "KEY_PAGEDN",
+        "label": "PAGE▶",
+        "side": "R"
+      },
+      {
+        "key": "KEY_TELE",
+        "label": "TELE",
+        "side": "R"
+      },
+      {
+        "key": "KEY_EXIT",
+        "label": "RTN",
+        "side": "L"
+      },
+      {
+        "key": "KEY_ENTER",
+        "label": "Enter ⏎",
+        "side": "R"
+      }
+    ]
+  },
+  {
+    "name": "RadioMaster GX15",
+    "wasm": "edgetx-gx15-simulator.wasm",
+    "display": {
+      "w": 480,
+      "h": 320,
+      "depth": 16
+    },
+    "inputs": [
+      {
+        "name": "LH",
+        "type": "STICK",
+        "label": "LH"
+      },
+      {
+        "name": "LV",
+        "type": "STICK",
+        "label": "LV"
+      },
+      {
+        "name": "RV",
+        "type": "STICK",
+        "label": "RV"
+      },
+      {
+        "name": "RH",
+        "type": "STICK",
+        "label": "RH"
+      },
+      {
+        "name": "P1",
+        "type": "FLEX",
+        "label": "S1",
+        "default": "POT_CENTER"
+      },
+      {
+        "name": "P2",
+        "type": "FLEX",
+        "label": "S2",
+        "default": "POT_CENTER"
+      },
+      {
+        "name": "SL1",
+        "type": "FLEX",
+        "label": "LS",
+        "default": "SLIDER"
+      },
+      {
+        "name": "SL2",
+        "type": "FLEX",
+        "label": "RS",
+        "default": "SLIDER"
+      },
+      {
+        "name": "EXT1",
+        "type": "FLEX",
+        "label": "EXT1"
+      },
+      {
+        "name": "EXT2",
+        "type": "FLEX",
+        "label": "EXT2"
+      }
+    ],
+    "switches": [
+      {
+        "name": "SA",
+        "type": "3POS",
+        "default": "3POS"
+      },
+      {
+        "name": "SB",
+        "type": "3POS",
+        "default": "3POS"
+      },
+      {
+        "name": "SC",
+        "type": "3POS",
+        "default": "3POS"
+      },
+      {
+        "name": "SD",
+        "type": "3POS",
+        "default": "3POS"
+      },
+      {
+        "name": "SE",
+        "type": "3POS",
+        "default": "3POS"
+      },
+      {
+        "name": "SF",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SG",
+        "type": "3POS",
+        "default": "3POS"
+      },
+      {
+        "name": "SH",
+        "type": "2POS",
+        "default": "TOGGLE"
+      },
+      {
+        "name": "SI",
+        "type": "2POS",
+        "default": "NONE"
+      },
+      {
+        "name": "SJ",
+        "type": "2POS",
+        "default": "NONE"
+      },
+      {
+        "name": "SW1",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SW2",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SW3",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SW4",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SW5",
+        "type": "2POS",
+        "default": "2POS"
+      },
+      {
+        "name": "SW6",
+        "type": "2POS",
+        "default": "2POS"
+      }
+    ],
+    "trims": [
+      {
+        "name": "T1"
+      },
+      {
+        "name": "T2"
+      },
+      {
+        "name": "T3"
+      },
+      {
+        "name": "T4"
+      },
+      {
+        "name": "T5"
+      },
+      {
+        "name": "T6"
       }
     ],
     "keys": [

--- a/web/scripts/gen-radios-json.js
+++ b/web/scripts/gen-radios-json.js
@@ -123,9 +123,9 @@ function processFlavour(flavour) {
   // Display / LCD info
   const disp = hw.display ?? {};
   const display = {
-    w: disp.w ?? 480,
-    h: disp.h ?? 272,
-    depth: disp.depth ?? 16,
+    w: disp.lcd_w ?? 480,
+    h: disp.lcd_h ?? 272,
+    depth: disp.lcd_depth ?? 16,
   };
 
   // WASM filename uses the flavour name directly


### PR DESCRIPTION
## Summary

The WASM simulator target lists had drifted from the supported radio set (`fw.json` / `build_fw.yml`, 44 targets) in both directions. Most visibly, **Companion ships without a V12 simulator**.

Follow-up to #7114 (HelloRadioSky V12) and #7643 (Radiomaster GX15) — both added the radio to the firmware build, but each missed one of the two simulator target lists.

| Target | `companion.yml` matrix | `build-wasm-modules.sh` default | |
|---|---|---|---|
| `v12` | ❌ missing | ✅ | #7114 updated `build_fw.yml` only |
| `gx15` | ✅ | ❌ missing | #7643 missed the local build list |
| `mt12` | ⚠️ listed twice (`bw-1` + `bw-2`) | ✅ | built twice per CI run |
| `x9e-hall` | ⚠️ built, unusable | ❌ | see below |

`x9e-hall` is not a Companion firmware — Hall sticks is a build *option* of `x9e` (`horussticks`), so `getSimulatorId()` never returns it, and `findSimulatorByName()` only truncates `x9e-hall` **down** to `x9e`. The module could never be selected, so it is dropped from both lists rather than added to the second. It remains a firmware target in `fw.json` / `build_fw.yml`.

The two lists now hold the same 43 targets, which is every `build_fw.yml` target except `x9e-hall`.

## Web simulator radio list

`web/public/radios.json` had drifted the same way, missing `c14`, `gx15`, `t22`, `v12` and `v14lcd`.

Regenerating it surfaced a bug in `gen-radios-json.js`: it read `disp.w` / `disp.h` / `disp.depth`, but the hw_defs use `lcd_w` / `lcd_h` / `lcd_depth`, so every entry silently fell back to the `480x272x16` default. The committed file has correct values, so this only bites on the next regeneration — it would have flattened the display size of all 30 mono and non-480x272 radios in one go.

With the field mapping fixed, regeneration is a no-op for existing entries: the only changes are the 5 added radios, plus `tpros`/`tprov2` moving to follow current `fw.json` ordering.

## Keeping it in sync

`radios.json` is a generated file that was drifting unnoticed, so it now gets the same treatment as the other generated files:

- `just gen-radios` (and `docker-gen-radios`), added to the `codegen` / `docker-codegen` aggregates
- a **Codegen drift** job, triggered by `fw.json`, `hw_defs/**` and the script itself
- a README note that `fw.json` — not the hw_defs — decides *which* radios are included, and that the `x9e-hall` skip warning is expected

## Testing

- `just gen-radios` verified idempotent; existing entries byte-identical after the display fix
- `just --list` / `just --show` check the new recipes resolve, matching what the drift workflow does
- Not verified locally: the `v12` WASM module has never been built in CI, so this PR's Companion run is the first real test of it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
