### PR TITLE
fix(trainer): potential crash when SBUS trainer is used

### DIFF
--- a/radio/src/serial.cpp
+++ b/radio/src/serial.cpp
@@ -499,6 +499,21 @@ void serialInit(uint8_t port_nr, int mode)
 #endif
 }
 
+#if !defined(BOOT)
+// SBUS trainer callbacks are shared with the ext module trainer: take them back
+void serialSbusTrainerSetCtx()
+{
+  int port_nr = serialGetModePort(UART_MODE_SBUS_TRAINER);
+  if (port_nr < 0) port_nr = serialGetModePort(UART_MODE_SBUS_TRAINER_INV);
+  if (port_nr < 0) return;
+
+  auto state = getSerialPortState(port_nr);
+  if (!state || !state->port || !state->usart_ctx) return;
+
+  serialSetCallBacks(state->mode, state->usart_ctx, state->port);
+}
+#endif
+
 void initSerialPorts()
 {
   for (uint8_t port_nr = 0; port_nr < MAX_AUX_SERIAL; port_nr++) {

--- a/radio/src/serial.h
+++ b/radio/src/serial.h
@@ -45,6 +45,10 @@ void initSerialPorts();
 void serialInit(uint8_t port_nr, int mode);
 void serialStop(uint8_t port_nr);
 
+#if !defined(BOOT)
+void serialSbusTrainerSetCtx();
+#endif
+
 //
 // Functions used by debug.h
 //

--- a/radio/src/targets/common/arm/stm32/stm32_serial_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/stm32_serial_driver.cpp
@@ -129,6 +129,9 @@ static inline void _usart_isr_handler(_STM32_USART n)
 {
   auto st = &(_serial_states[n]);
 
+  // port already de-initialised: IRQ was still pending
+  if (!st->sp) return;
+
   // This tricks is necessary for now to allow
   // callbacks to use the serial context while
   // keeping the callbacks re-entrant
@@ -315,7 +318,7 @@ static void* stm32_serial_init(void* hw_def, const etx_serial_init* params)
 static void stm32_serial_deinit(void* ctx)
 {
   auto st = (stm32_serial_state*)ctx;
-  if (!st) return;
+  if (!st || !st->sp) return;
 
   stm32_usart_deinit(st->sp->usart);
   stm32_serial_free_state(st);
@@ -328,7 +331,7 @@ static void stm32_serial_send_byte(void* ctx, uint8_t c)
   // only enables the corresponding IRQ
 
   auto st = (stm32_serial_state*)ctx;
-  if (!st) return;
+  if (!st || !st->sp) return;
 
   auto sp = st->sp;
   auto buf_len = sp->tx_buffer.length;
@@ -367,7 +370,7 @@ extern uint32_t _e_dram;
 static void stm32_serial_send_buffer(void* ctx, const uint8_t* data, uint32_t size)
 {
   auto st = (stm32_serial_state*)ctx;
-  if (!st) return;
+  if (!st || !st->sp) return;
 
   // try TX DMA first
   auto sp = st->sp;
@@ -396,7 +399,7 @@ static void stm32_serial_send_buffer(void* ctx, const uint8_t* data, uint32_t si
 static bool stm32_serial_tx_completed(void* ctx)
 {
   auto st = (stm32_serial_state*)ctx;
-  if (!st) return 1;
+  if (!st || !st->sp) return 1;
 
   return stm32_usart_tx_completed(st->sp->usart);
 }
@@ -404,7 +407,7 @@ static bool stm32_serial_tx_completed(void* ctx)
 static void stm32_wait_tx_completed(void* ctx)
 {
   auto st = (stm32_serial_state*)ctx;
-  if (!st) return;
+  if (!st || !st->sp) return;
 
   while(!stm32_usart_tx_completed(st->sp->usart));
 }
@@ -412,7 +415,7 @@ static void stm32_wait_tx_completed(void* ctx)
 static void stm32_enable_rx(void* ctx)
 {
   auto st = (stm32_serial_state*)ctx;
-  if (!st) return;
+  if (!st || !st->sp) return;
 
   stm32_usart_enable_rx(st->sp->usart);
 }
@@ -420,7 +423,7 @@ static void stm32_enable_rx(void* ctx)
 static int stm32_serial_get_byte(void* ctx, uint8_t* data)
 {
   auto st = (stm32_serial_state*)ctx;
-  if (!st) return -1;
+  if (!st || !st->sp) return -1;
 
   auto sp = st->sp;
   const auto& rx_buf = sp->rx_buffer;
@@ -452,7 +455,7 @@ static int stm32_serial_get_byte(void* ctx, uint8_t* data)
 static int stm32_serial_get_last_byte(void* ctx, uint32_t idx, uint8_t* data)
 {
   auto st = (stm32_serial_state*)ctx;
-  if (!st) return -1;
+  if (!st || !st->sp) return -1;
 
   auto sp = st->sp;
   const auto& rx_buf = sp->rx_buffer;
@@ -484,7 +487,7 @@ static int stm32_serial_get_last_byte(void* ctx, uint32_t idx, uint8_t* data)
 static int stm32_serial_get_buffered_bytes(void* ctx)
 {
   auto st = (stm32_serial_state*)ctx;
-  if (!st) return -1;
+  if (!st || !st->sp) return -1;
 
   auto sp = st->sp;
   const auto& rx_buf = sp->rx_buffer;
@@ -517,7 +520,7 @@ static inline void _copy_buffer_chunk(const stm32_serial_buffer& rx_buf,
 static int stm32_serial_copy_rx_buffer(void* ctx, uint8_t* buf, uint32_t len)
 {
   auto st = (stm32_serial_state*)ctx;
-  if (!st) return -1;
+  if (!st || !st->sp) return -1;
 
   auto sp = st->sp;
   const auto& rx_buf = sp->rx_buffer;
@@ -560,7 +563,7 @@ static int stm32_serial_copy_rx_buffer(void* ctx, uint8_t* buf, uint32_t len)
 static void stm32_serial_clear_rx_buffer(void* ctx)
 {
   auto st = (stm32_serial_state*)ctx;
-  if (!st) return;
+  if (!st || !st->sp) return;
 
   auto sp = st->sp;
   auto buf_st = &st->rx_buf;
@@ -578,7 +581,7 @@ static void stm32_serial_clear_rx_buffer(void* ctx)
 static uint32_t stm32_serial_get_baudrate(void* ctx)
 {
   auto st = (stm32_serial_state*)ctx;
-  if (!st) return 0;
+  if (!st || !st->sp) return 0;
 
   auto sp = st->sp;
   auto usart = sp->usart;
@@ -588,7 +591,7 @@ static uint32_t stm32_serial_get_baudrate(void* ctx)
 static void stm32_serial_set_baudrate(void* ctx, uint32_t baudrate)
 {
   auto st = (stm32_serial_state*)ctx;
-  if (!st) return;
+  if (!st || !st->sp) return;
   
   auto sp = st->sp;
   auto usart = sp->usart;
@@ -598,7 +601,7 @@ static void stm32_serial_set_baudrate(void* ctx, uint32_t baudrate)
 static void stm32_serial_hw_option(void* ctx, uint32_t option)
 {
   auto st = (stm32_serial_state*)ctx;
-  if (!st) return;
+  if (!st || !st->sp) return;
 
   auto sp = st->sp;
   auto usart = sp->usart;
@@ -608,7 +611,7 @@ static void stm32_serial_hw_option(void* ctx, uint32_t option)
 static void stm32_serial_set_idle_cb(void* ctx, void (*on_idle)(void*), void* param)
 {
   auto st = (stm32_serial_state*)ctx;
-  if (!st) return;
+  if (!st || !st->sp) return;
 
   st->callbacks.on_idle = on_idle;
   st->callbacks.on_idle_ctx = param;

--- a/radio/src/trainer.cpp
+++ b/radio/src/trainer.cpp
@@ -139,6 +139,7 @@ void checkTrainerSettings()
         break;
 
       case TRAINER_MODE_MASTER_SERIAL:
+        serialSbusTrainerSetCtx();
         sbusAuxSetEnabled(true);
         break;
 
@@ -203,6 +204,7 @@ static void trainer_init_module_sbus()
 static void trainer_stop_module_sbus()
 {
   if (!sbus_trainer_mod_st) return;
+  sbusSetReceiveCtx(nullptr, nullptr);
   modulePortDeInit(sbus_trainer_mod_st);
   modulePortSetPower(EXTERNAL_MODULE,false);
   sbus_trainer_mod_st = nullptr;


### PR DESCRIPTION
The SBUS trainer receive context is a single pair of globals in sbus.cpp, shared between the aux serial port and the external module trainer, but trainer_stop_module_sbus() never released it. modulePortDeInit() zeroes the underlying serial state, so the context was left dangling: the next IDLE IRQ on the aux port dereferenced a null sp, read a garbage USART pointer and faulted, ending in a watchdog reset (emergency mode).

This fixes it

Fixes #7644

