### PR TITLE
chore: fix build warnings from compiler-flagged always-true/dead-code issues

### DIFF
--- a/radio/src/boards/helloradio-h750/sdram_driver.cpp
+++ b/radio/src/boards/helloradio-h750/sdram_driver.cpp
@@ -110,7 +110,6 @@ extern "C" void SDRAM_InitSequence(void)
 {
   FMC_SDRAM_CommandTypeDef FMC_SDRAMCommandStructure;
   uint32_t tmpr = 0;
-  uint32_t timeout = SDRAM_TIMEOUT;
 
   /* Step 3 --------------------------------------------------------------------*/
   /* Configure a clock configuration enable command */
@@ -118,12 +117,6 @@ extern "C" void SDRAM_InitSequence(void)
   FMC_SDRAMCommandStructure.CommandTarget = FMC_SDRAM_CMD_TARGET_BANK1;
   FMC_SDRAMCommandStructure.AutoRefreshNumber = 1;
   FMC_SDRAMCommandStructure.ModeRegisterDefinition = 0;
-  /* Wait until the SDRAM controller is ready */
-  //  while((__FMC_SDRAM_GET_FLAG(FMC_Bank5_6_R, FMC_SDRAM_FLAG_BUSY) != 0) &&
-  //  (timeout > 0))
-  // {
-  //   timeout--;
-  // }
   /* Send the command */
   FMC_SDRAM_SendCommand(FMC_Bank5_6_R, &FMC_SDRAMCommandStructure, 10);
 
@@ -137,15 +130,8 @@ extern "C" void SDRAM_InitSequence(void)
   FMC_SDRAMCommandStructure.CommandTarget = FMC_SDRAM_CMD_TARGET_BANK1;
   FMC_SDRAMCommandStructure.AutoRefreshNumber = 1;
   FMC_SDRAMCommandStructure.ModeRegisterDefinition = 0;
-  /* Wait until the SDRAM controller is ready */
-  // timeout = SDRAM_TIMEOUT;
-  // while((__FMC_SDRAM_GET_FLAG(FMC_Bank5_6_R, FMC_SDRAM_FLAG_BUSY) != 0) && (timeout > 0))
-  // {
-  //   timeout--;
-  // }
   /* Send the command */
   FMC_SDRAM_SendCommand(FMC_Bank5_6_R, &FMC_SDRAMCommandStructure, 10);
-  // delay_ms(1);
 
   /* Step 6 --------------------------------------------------------------------*/
   /* Configure a Auto-Refresh command */
@@ -154,16 +140,8 @@ extern "C" void SDRAM_InitSequence(void)
   FMC_SDRAMCommandStructure.AutoRefreshNumber = 8;
   FMC_SDRAMCommandStructure.ModeRegisterDefinition = 0;
 
-  /* Wait until the SDRAM controller is ready */
-  // timeout = SDRAM_TIMEOUT;
-  // while((__FMC_SDRAM_GET_FLAG(FMC_Bank5_6_R, FMC_SDRAM_FLAG_BUSY) != 0) &&
-  // (timeout > 0))
-  // {
-  //   timeout--;
-  // }
   /* Send the command */
   FMC_SDRAM_SendCommand(FMC_Bank5_6_R, &FMC_SDRAMCommandStructure, 10);
-  // delay_ms(1);
 
   /* Step 7 --------------------------------------------------------------------*/
   /* Program the external memory mode register */
@@ -179,15 +157,8 @@ extern "C" void SDRAM_InitSequence(void)
   FMC_SDRAMCommandStructure.AutoRefreshNumber = 1;
   FMC_SDRAMCommandStructure.ModeRegisterDefinition = tmpr;
 
-  /* Wait until the SDRAM controller is ready */
-  // timeout = SDRAM_TIMEOUT;
-  // while((__FMC_SDRAM_GET_FLAG(FMC_Bank5_6_R, FMC_SDRAM_FLAG_BUSY) != 0) && (timeout > 0))
-  // {
-  //   timeout--;
-  // }
   /* Send the command */
   FMC_SDRAM_SendCommand(FMC_Bank5_6_R, &FMC_SDRAMCommandStructure, 10);
-  // delay_ms(1);
 
   /* Step 8 --------------------------------------------------------------------*/
   /* Set the refresh rate counter */
@@ -195,13 +166,6 @@ extern "C" void SDRAM_InitSequence(void)
   /* Set the device refresh counter */
   FMC_SDRAM_SetAutoRefreshNumber(FMC_Bank5_6_R, 15);
   FMC_SDRAM_ProgramRefreshRate(FMC_Bank5_6_R, 1855);
-  /* Wait until the SDRAM controller is ready */
-  // timeout = SDRAM_TIMEOUT;
-  // while((__FMC_SDRAM_GET_FLAG(FMC_Bank5_6_R, FMC_SDRAM_FLAG_BUSY) != 0) && (timeout > 0))
-  // {
-  //   timeout--;
-  // }
-  // delay_ms(1);
 }
 
 extern "C" void SDRAM_Init(void)

--- a/radio/src/cli.cpp
+++ b/radio/src/cli.cpp
@@ -1233,7 +1233,7 @@ static void _sp_Tx(uint8_t* buf, uint32_t len)
   }
 }
 
-#if defined(HARDWARE_INTERNAL_MODULE) || defined(HARDWARE_EXTERNAL_MODULE)
+#if defined(HARDWARE_INTERNAL_MODULE)
 static etx_module_state_t *spModuleState = nullptr;
 
 static void spModuleInit(int port_n, int baudrate)

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -2935,18 +2935,20 @@ static int luaSetRgbLedColor(lua_State * L)
   uint8_t b = luaL_checkunsigned(L, 4);
 
 #if CFS_LED_STRIP_LENGTH > 0
-  if (id >= BLING_LED_STRIP_LENGTH) {
-    id -= BLING_LED_STRIP_LENGTH;
-    uint8_t swIdx = switchGetSwitchFromCustomIdx(id / CFS_LEDS_PER_SWITCH);
-    if (g_model.getSwitchType(swIdx) == SWITCH_NONE) {
-      rgbSetLedColor(id + CFS_LED_STRIP_START, r, g, b);
-    } else {
-      lua_pushboolean(L, false);
-      return 1;
-    }
-  } else {
+#if BLING_LED_STRIP_LENGTH > 0
+  if (id < BLING_LED_STRIP_LENGTH) {
     rgbSetLedColor(id + BLING_LED_STRIP_START, r, g, b);
+    lua_pushboolean(L, true);
+    return 1;
   }
+  id -= BLING_LED_STRIP_LENGTH;
+#endif
+  uint8_t swIdx = switchGetSwitchFromCustomIdx(id / CFS_LEDS_PER_SWITCH);
+  if (g_model.getSwitchType(swIdx) != SWITCH_NONE) {
+    lua_pushboolean(L, false);
+    return 1;
+  }
+  rgbSetLedColor(id + CFS_LED_STRIP_START, r, g, b);
 #else
   rgbSetLedColor(id + BLING_LED_STRIP_START, r, g, b);
 #endif

--- a/radio/src/targets/pa01/battery_driver.cpp
+++ b/radio/src/targets/pa01/battery_driver.cpp
@@ -220,7 +220,7 @@ void ledChargingInfo(uint16_t chargeState) {
     ledIdx = LED_CHARGING_START;
   else
     ledIdx += LED_CHARGING_START > LED_CHARGING_END ? -1 : 1;
-  for (uint8_t i = 0; i < LED_STRIP_LENGTH; i++) {
+  for (int i = 0; i < LED_STRIP_LENGTH; i++) {
     uint8_t green = 0;
     if (CHARGE_FINISHED == chargeState) {
       if (LED_CHARGING_START > LED_CHARGING_END && i <= LED_CHARGING_START && i >= LED_CHARGING_END)

--- a/radio/src/targets/pa01/sdram_driver.cpp
+++ b/radio/src/targets/pa01/sdram_driver.cpp
@@ -111,7 +111,6 @@ extern "C" void SDRAM_InitSequence(void)
 {
   FMC_SDRAM_CommandTypeDef FMC_SDRAMCommandStructure;
   uint32_t tmpr = 0;
-  // uint32_t timeout = SDRAM_TIMEOUT;
 
   /* Step 3 --------------------------------------------------------------------*/
   /* Configure a clock configuration enable command */
@@ -119,12 +118,6 @@ extern "C" void SDRAM_InitSequence(void)
   FMC_SDRAMCommandStructure.CommandTarget = FMC_SDRAM_CMD_TARGET_BANK1;
   FMC_SDRAMCommandStructure.AutoRefreshNumber = 1;
   FMC_SDRAMCommandStructure.ModeRegisterDefinition = 0;
-  /* Wait until the SDRAM controller is ready */
-  //  while((__FMC_SDRAM_GET_FLAG(FMC_Bank5_6_R, FMC_SDRAM_FLAG_BUSY) != 0) &&
-  //  (timeout > 0))
-  // {
-  //   timeout--;
-  // }
   /* Send the command */
   FMC_SDRAM_SendCommand(FMC_Bank5_6_R, &FMC_SDRAMCommandStructure, 10);
 
@@ -138,12 +131,6 @@ extern "C" void SDRAM_InitSequence(void)
   FMC_SDRAMCommandStructure.CommandTarget = FMC_SDRAM_CMD_TARGET_BANK1;
   FMC_SDRAMCommandStructure.AutoRefreshNumber = 1;
   FMC_SDRAMCommandStructure.ModeRegisterDefinition = 0;
-  /* Wait until the SDRAM controller is ready */
-  // timeout = SDRAM_TIMEOUT;
-  // while((__FMC_SDRAM_GET_FLAG(FMC_Bank5_6_R, FMC_SDRAM_FLAG_BUSY) != 0) && (timeout > 0))
-  // {
-  //   timeout--;
-  // }
   /* Send the command */
   FMC_SDRAM_SendCommand(FMC_Bank5_6_R, &FMC_SDRAMCommandStructure, 10);
   // delay_ms(1);
@@ -155,13 +142,6 @@ extern "C" void SDRAM_InitSequence(void)
   FMC_SDRAMCommandStructure.AutoRefreshNumber = 8;
   FMC_SDRAMCommandStructure.ModeRegisterDefinition = 0;
 
-  /* Wait until the SDRAM controller is ready */
-  // timeout = SDRAM_TIMEOUT;
-  // while((__FMC_SDRAM_GET_FLAG(FMC_Bank5_6_R, FMC_SDRAM_FLAG_BUSY) != 0) &&
-  // (timeout > 0))
-  // {
-  //   timeout--;
-  // }
   /* Send the command */
   FMC_SDRAM_SendCommand(FMC_Bank5_6_R, &FMC_SDRAMCommandStructure, 10);
   // delay_ms(1);
@@ -180,12 +160,6 @@ extern "C" void SDRAM_InitSequence(void)
   FMC_SDRAMCommandStructure.AutoRefreshNumber = 1;
   FMC_SDRAMCommandStructure.ModeRegisterDefinition = tmpr;
 
-  /* Wait until the SDRAM controller is ready */
-  // timeout = SDRAM_TIMEOUT;
-  // while((__FMC_SDRAM_GET_FLAG(FMC_Bank5_6_R, FMC_SDRAM_FLAG_BUSY) != 0) && (timeout > 0))
-  // {
-  //   timeout--;
-  // }
   /* Send the command */
   FMC_SDRAM_SendCommand(FMC_Bank5_6_R, &FMC_SDRAMCommandStructure, 10);
   // delay_ms(1);
@@ -196,12 +170,6 @@ extern "C" void SDRAM_InitSequence(void)
   /* Set the device refresh counter */
   FMC_SDRAM_SetAutoRefreshNumber(FMC_Bank5_6_R, 15);
   FMC_SDRAM_ProgramRefreshRate(FMC_Bank5_6_R, 1855);
-  /* Wait until the SDRAM controller is ready */
-  // timeout = SDRAM_TIMEOUT;
-  // while((__FMC_SDRAM_GET_FLAG(FMC_Bank5_6_R, FMC_SDRAM_FLAG_BUSY) != 0) && (timeout > 0))
-  // {
-  //   timeout--;
-  // }
   // delay_ms(1);
 }
 

--- a/radio/src/targets/st16/sdram_driver.cpp
+++ b/radio/src/targets/st16/sdram_driver.cpp
@@ -110,7 +110,6 @@ extern "C" void SDRAM_InitSequence(void)
 {
   FMC_SDRAM_CommandTypeDef FMC_SDRAMCommandStructure;
   uint32_t tmpr = 0;
-  // uint32_t timeout = SDRAM_TIMEOUT;
 
   /* Step 3 --------------------------------------------------------------------*/
   /* Configure a clock configuration enable command */
@@ -118,12 +117,6 @@ extern "C" void SDRAM_InitSequence(void)
   FMC_SDRAMCommandStructure.CommandTarget = FMC_SDRAM_CMD_TARGET_BANK1;
   FMC_SDRAMCommandStructure.AutoRefreshNumber = 1;
   FMC_SDRAMCommandStructure.ModeRegisterDefinition = 0;
-  /* Wait until the SDRAM controller is ready */
-  //  while((__FMC_SDRAM_GET_FLAG(FMC_Bank5_6_R, FMC_SDRAM_FLAG_BUSY) != 0) &&
-  //  (timeout > 0))
-  // {
-  //   timeout--;
-  // }
   /* Send the command */
   FMC_SDRAM_SendCommand(FMC_Bank5_6_R, &FMC_SDRAMCommandStructure, 10);
 
@@ -137,12 +130,6 @@ extern "C" void SDRAM_InitSequence(void)
   FMC_SDRAMCommandStructure.CommandTarget = FMC_SDRAM_CMD_TARGET_BANK1;
   FMC_SDRAMCommandStructure.AutoRefreshNumber = 1;
   FMC_SDRAMCommandStructure.ModeRegisterDefinition = 0;
-  /* Wait until the SDRAM controller is ready */
-  // timeout = SDRAM_TIMEOUT;
-  // while((__FMC_SDRAM_GET_FLAG(FMC_Bank5_6_R, FMC_SDRAM_FLAG_BUSY) != 0) && (timeout > 0))
-  // {
-  //   timeout--;
-  // }
   /* Send the command */
   FMC_SDRAM_SendCommand(FMC_Bank5_6_R, &FMC_SDRAMCommandStructure, 10);
   // delay_ms(1);
@@ -154,13 +141,6 @@ extern "C" void SDRAM_InitSequence(void)
   FMC_SDRAMCommandStructure.AutoRefreshNumber = 8;
   FMC_SDRAMCommandStructure.ModeRegisterDefinition = 0;
 
-  /* Wait until the SDRAM controller is ready */
-  // timeout = SDRAM_TIMEOUT;
-  // while((__FMC_SDRAM_GET_FLAG(FMC_Bank5_6_R, FMC_SDRAM_FLAG_BUSY) != 0) &&
-  // (timeout > 0))
-  // {
-  //   timeout--;
-  // }
   /* Send the command */
   FMC_SDRAM_SendCommand(FMC_Bank5_6_R, &FMC_SDRAMCommandStructure, 10);
   // delay_ms(1);
@@ -179,12 +159,6 @@ extern "C" void SDRAM_InitSequence(void)
   FMC_SDRAMCommandStructure.AutoRefreshNumber = 1;
   FMC_SDRAMCommandStructure.ModeRegisterDefinition = tmpr;
 
-  /* Wait until the SDRAM controller is ready */
-  // timeout = SDRAM_TIMEOUT;
-  // while((__FMC_SDRAM_GET_FLAG(FMC_Bank5_6_R, FMC_SDRAM_FLAG_BUSY) != 0) && (timeout > 0))
-  // {
-  //   timeout--;
-  // }
   /* Send the command */
   FMC_SDRAM_SendCommand(FMC_Bank5_6_R, &FMC_SDRAMCommandStructure, 10);
   // delay_ms(1);
@@ -195,12 +169,6 @@ extern "C" void SDRAM_InitSequence(void)
   /* Set the device refresh counter */
   FMC_SDRAM_SetAutoRefreshNumber(FMC_Bank5_6_R, 15);
   FMC_SDRAM_ProgramRefreshRate(FMC_Bank5_6_R, 1855);
-  /* Wait until the SDRAM controller is ready */
-  // timeout = SDRAM_TIMEOUT;
-  // while((__FMC_SDRAM_GET_FLAG(FMC_Bank5_6_R, FMC_SDRAM_FLAG_BUSY) != 0) && (timeout > 0))
-  // {
-  //   timeout--;
-  // }
   // delay_ms(1);
 }
 


### PR DESCRIPTION
## Summary
- `fix(cli)`: drop dead `spModuleInit`/`spModuleDeInit` compiled on EXTERNAL_MODULE-only targets (regression from #5703)
- `fix(lua)`: avoid always-true `BLING_LED_STRIP_LENGTH` comparison on bling-less targets, e.g. gx12 (regression from #6095) — hardware-tested on gx12
- `fix(pa01)`: avoid always-true `LED_CHARGING_START` comparison in `ledChargingInfo` (regression from #6392) — hardware-tested on pa01
- `fix(v12)`: drop dead SDRAM busy-wait scaffolding in `SDRAM_InitSequence` (helloradio-h750), left over from #7114
- `chore(sdram)`: drop the same dead SDRAM busy-wait scaffolding on pa01/st16, the only remaining targets carrying it since #6952

These have their origins in the same warning cleanup done for the 2.12.3 backport PR (#7687) — that PR carries the backport-appropriate subset of these fixes; this PR is the `main`-targeted equivalent plus the pa01/st16 SDRAM chore, which only applies to `main`.

## Test plan
- [x] pl18ev, gx12, pa01, v12, st16 all rebuilt locally, confirmed the targeted warnings are gone and no new warnings introduced
- [x] `fix(lua)` hardware-tested on gx12
- [x] `fix(pa01)` hardware-tested on pa01
- [ ] No functional/UI testing needed beyond the above — all fixes are warning-only preprocessor/type/dead-code adjustments with no intended behavior change

🤖 Generated with [Claude Code](https://claude.com/claude-code)