### PR TITLE
fix(color): manage models buttons incorrect after renaming or removing labels

### DIFF
--- a/radio/src/gui/colorlcd/model/model_select.cpp
+++ b/radio/src/gui/colorlcd/model/model_select.cpp
@@ -272,10 +272,15 @@ class ModelsPageBody : public Window
     }
   }
 
-  void reload()
+  void clearButtons()
   {
     modelButtons.clear();
     clear();
+  }
+
+  void reload()
+  {
+    clearButtons();
     update();
   }
 
@@ -840,6 +845,7 @@ void ModelLabelsWindow::buildBody(Window *window)
                   });
               auto labels = getLabels();
               lblselector->setNames(labels);
+              mdlselector->clearButtons();
               updateFilteredLabels(modelslabels.filteredLabels(), false);
             }
           });
@@ -864,6 +870,7 @@ void ModelLabelsWindow::buildBody(Window *window)
                 lblselector->setSelected(newset);
                 if (g_eeGeneral.labelSingleSelect && selected == lblselector->getActiveItem())
                   lblselector->setActiveItem(-1);
+                mdlselector->clearButtons();
                 updateFilteredLabels(newset);
               });
           return 0;

--- a/radio/src/storage/modelslist.h
+++ b/radio/src/storage/modelslist.h
@@ -87,12 +87,6 @@ class ModelCell
   bool fetchRfData();
 };
 
-typedef struct {
-  std::string icon;
-  // Anything else?
-} SLabelDetail;
-
-typedef std::vector<std::pair<uint16_t, ModelCell *>> ModelLabelsVector;
 typedef std::vector<std::string> LabelsVector;
 typedef std::vector<ModelCell *> ModelsVector;
 typedef enum {
@@ -248,8 +242,6 @@ class ModelsList : public ModelsVector
   bool loadYaml();
   bool loadYamlDirScanner();
 };
-
-ModelLabelsVector getUniqueLabels();
 
 extern ModelsList modelslist;
 extern ModelMap modelslabels;


### PR DESCRIPTION
The model buttons on the model select page hold a pointer to a ModelCell object with the model name, filename, etc.

When labels are renamed or removed this vector of ModelCells is cleared and reloaded leaving the pointers in the model buttons in an indeterminate state.

This can result in the model buttons displaying incorrectly, with duplicate names, or multiple models being shown as active.

This PR clears the model button list after renaming or removing a label.