### PR TITLE
fix(color): in manage models, long press on selected model button clears checked state

### DIFF
--- a/radio/src/gui/colorlcd/model/model_select.cpp
+++ b/radio/src/gui/colorlcd/model/model_select.cpp
@@ -140,7 +140,6 @@ class ModelButton : public Button
             return true;
           }
         }
-        showNoImgMsg();
       }
 
       return false;
@@ -257,10 +256,12 @@ class ModelsPageBody : public Window
 
       // Long Press Handler for Models
       button->setLongPressHandler([=]() -> uint8_t {
-        button->setFocused();
-        focusedModel = model;
+        if (model != focusedModel) {
+          button->setFocused();
+          focusedModel = model;
+        }
         openMenu();
-        return 0;
+        return model == modelslist.getCurrentModel();
       });
     }
 


### PR DESCRIPTION
Before:
<img width="480" height="320" alt="screenshot_tx15_26-08-25_21-04-12" src="https://github.com/user-attachments/assets/ac12b1f9-7db5-4a17-9652-1c7fd18303b1" />

After:
<img width="480" height="320" alt="screenshot_tx15_26-08-25_21-03-17" src="https://github.com/user-attachments/assets/a53cbe9e-1400-473b-80f9-60409e252bfd" />

Also removes duplicate copy of the '(No Picture)' text - since both delayedInit() and loadImage() could add it