### PR TITLE
fix(cpn): declare simulator target before referencing it in wasm-copy step

### DIFF
--- a/companion/src/CMakeLists.txt
+++ b/companion/src/CMakeLists.txt
@@ -272,19 +272,6 @@ target_link_libraries(${COMPANION_NAME} PRIVATE
 
 PrintTargetReport("${COMPANION_NAME}")
 
-# Copy WASM simulator modules next to executables for local dev
-if(SIMULATOR_WASM_DIR)
-  foreach(_target ${COMPANION_NAME} ${SIMULATOR_NAME})
-    add_custom_command(TARGET ${_target} POST_BUILD
-      COMMAND ${CMAKE_COMMAND}
-        -DSRC_DIR=${SIMULATOR_WASM_DIR}
-        -DDST_DIR=$<TARGET_FILE_DIR:${_target}>
-        -P ${CMAKE_SOURCE_DIR}/cmake/CopyWasmModules.cmake
-      COMMENT "Copying WASM simulator modules to ${_target} output"
-    )
-  endforeach()
-endif()
-
 ############# Standalone simulator ###############
 
 set(simu_SRCS simulator.cpp )
@@ -298,6 +285,19 @@ target_link_libraries(${SIMULATOR_NAME} PRIVATE
   ${CPN_COMMON_LIB}
   ${SDL2_LIBRARIES}
 )
+
+# Copy WASM simulator modules next to executables for local dev
+if(SIMULATOR_WASM_DIR)
+  foreach(_target ${COMPANION_NAME} ${SIMULATOR_NAME})
+    add_custom_command(TARGET ${_target} POST_BUILD
+      COMMAND ${CMAKE_COMMAND}
+        -DSRC_DIR=${SIMULATOR_WASM_DIR}
+        -DDST_DIR=$<TARGET_FILE_DIR:${_target}>
+        -P ${CMAKE_SOURCE_DIR}/cmake/CopyWasmModules.cmake
+      COMMENT "Copying WASM simulator modules to ${_target} output"
+    )
+  endforeach()
+endif()
 
 add_subdirectory(tests)
 


### PR DESCRIPTION
## Summary
- The `SIMULATOR_WASM_DIR`-gated copy step in `companion/src/CMakeLists.txt` (added for local dev convenience, so `companion`/`simulator` can pick up freshly built `.wasm` simulator modules straight from the build tree without installing/packaging) referenced the `simulator` target via `add_custom_command(TARGET ${SIMULATOR_NAME} ...)` **before** `add_executable(${SIMULATOR_NAME} ...)` declared it further down the file.
- CMake requires the target to already exist at that point, so configuring with `-DSIMULATOR_WASM_DIR=...` set fails outright with `No TARGET 'simulator30' has been created in this directory.` — the whole native configure aborts, not just the `companion`/`simulator` targets.
- This variable defaults to empty and isn't referenced anywhere else in the repo (not CI, not `tools/*.sh`) — CI/packaging bundles `.wasm` modules through a separate, working `native/plugins/` + `install(DIRECTORY ...)` mechanism instead — so this ordering bug had never been exercised.
- Fix: move the copy-step block to after both `add_executable()` calls. No logic changes, pure reordering.

Was missed in #6435

## Test plan
- [x] `cmake -S . -B <dir> --toolchain cmake/toolchain/native.cmake -DEdgeTX_SUPERBUILD=0 -DNATIVE_BUILD=1 -DSIMULATOR_WASM_DIR=<dir-with-.wasm-files>` now configures cleanly against current `main` (previously failed with the error above).
- [x] Reproduced the failure by reverting just this change and re-running the same configure command — confirmed identical error.
- [x] Built `companion` and `simulator` targets afterward; the `.wasm` module was copied next to both executables as intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)