### PR TITLE
test: guard active model's screen/widget data against cross-model label edits

### DIFF
--- a/radio/src/tests/modelslist_labels.cpp
+++ b/radio/src/tests/modelslist_labels.cpp
@@ -1,0 +1,177 @@
+/*
+ * Copyright (C) EdgeTX
+ *
+ * Based on code named
+ *   opentx - https://github.com/opentx/opentx
+ *   th9x - http://code.google.com/p/th9x
+ *   er9x - http://code.google.com/p/er9x
+ *   gruvin9x - http://code.google.com/p/gruvin9x
+ *
+ * License GPLv2: http://www.gnu.org/licenses/gpl-2.0.html
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License version 2 as
+ * published by the Free Software Foundation.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ */
+
+// Custom-screen and topbar-widget layout data (CustomScreenData /
+// TopBarPersistentData) is stored per-process in static globals rather than
+// inside ModelData itself (see ModelData::getScreenData()/getTopbarData()),
+// because that data can be large and only the currently loaded model's copy
+// needs to be resident. Any code that reads or writes a *full* ModelData
+// buffer -- as opposed to the header-only PartialModel -- for a model other
+// than the one currently loaded therefore risks reading/writing those
+// globals on behalf of the wrong model.
+//
+// Label management (renaming/adding/removing labels) routinely touches
+// models other than the currently loaded one. These tests exercise that
+// label-management path through its public ModelMap API and assert the
+// currently loaded model's screen/topbar data is left alone, regardless of
+// what label edits are made to other models on disk.
+
+#include "gtests.h"
+#include "location.h"
+
+#include <filesystem>
+
+#include "storage/modelslist.h"
+#include "storage/sdcard_common.h"
+#include "storage/sdcard_yaml.h"
+#include "storage/yaml/yaml_datastructs.h"
+
+#if defined(COLORLCD)
+
+namespace fs = std::filesystem;
+
+class ModelMapFsTest : public ::testing::Test
+{
+ protected:
+  fs::path scratchDir;
+
+  void SetUp() override
+  {
+    scratchDir = fs::temp_directory_path() /
+                 fs::path("edgetx-gtest-modelslist-labels");
+    std::error_code ec;
+    fs::remove_all(scratchDir, ec);
+    fs::create_directories(scratchDir / "MODELS", ec);
+    ASSERT_FALSE(ec) << "could not create scratch MODELS directory";
+
+    simuFatfsSetPaths(scratchDir.string().c_str(), nullptr);
+
+    modelslist.clear();
+    modelslabels.clear();
+    memclear(&g_model, sizeof(g_model));
+  }
+
+  void TearDown() override
+  {
+    modelslist.clear();
+    modelslabels.clear();
+
+    simuFatfsSetPaths(TESTS_PATH, nullptr);
+
+    std::error_code ec;
+    fs::remove_all(scratchDir, ec);
+  }
+
+  // Writes a standalone model YAML file to <scratchDir>/MODELS/<filename>
+  // with the given label list and screen/topbar marker values. This must be
+  // called *before* the active model's own screen/topbar markers are set on
+  // g_model: since getScreenData()/getTopbarData() are shared globals, using
+  // them here to build this "other" model's fixture is itself writing
+  // through the same storage g_model uses, exactly like the code under test
+  // does. The test bodies set the active model's markers afterwards, which
+  // simulates that model actually being loaded, and is what the assertions
+  // check survives the label edit untouched.
+  void writeFixtureModel(const char* filename, const char* labels,
+                          const char* screenLayoutId, const char* widgetName)
+  {
+    ModelData model;
+    memclear(&model, sizeof(model));
+    // A real model always has a name; an entirely-default header (no name,
+    // no labels, zeroed modelId) is omitted from the written YAML altogether
+    // as a compaction optimisation, which would leave this fixture without
+    // a "header:" section at all. Giving it a name keeps the fixture
+    // realistic and avoids that unrelated edge case.
+    strAppend(model.header.name, filename, LEN_MODEL_NAME);
+    strAppend(model.header.labels, labels, LABELS_LENGTH - 1);
+    model.getScreenData(0)->LayoutId = screenLayoutId;
+    model.getTopbarData()->zones[0].widgetName = widgetName;
+
+    char path[256];
+    getModelPath(path, filename);
+    ASSERT_EQ(writeFileYaml(path, get_modeldata_nodes(), (uint8_t*)&model, 0),
+              (const char*)nullptr)
+        << "failed writing fixture model " << filename;
+  }
+};
+
+TEST_F(ModelMapFsTest, RenamingLabelOnOtherModelLeavesActiveScreenDataUntouched)
+{
+  // Seed a second, non-active model on disk with a label and screen/topbar
+  // data distinct from the active model's.
+  writeFixtureModel("model0002.yml", "Foo", "OtherLayout", "OtherWidget");
+  ModelCell* other = modelslist.addModel("model0002.yml", false);
+  ASSERT_NE(other, nullptr);
+  ASSERT_FALSE(modelslabels.addLabelToModel("Foo", other, false));
+
+  // Now "load" the active model: register its cell and mark it current, and
+  // set its screen/topbar data to its own values.
+  ModelCell* active = modelslist.addModel("model0001.yml", false);
+  ASSERT_NE(active, nullptr);
+  modelslist.setCurrentModel(active);
+  g_model.getScreenData(0)->LayoutId = "ActiveLayout";
+  g_model.getTopbarData()->zones[0].widgetName = "ActiveWidget";
+
+  // Rename a label that only exists on the other, non-active model.
+  modelslabels.renameLabel("Foo", "Bar");
+
+  // The active model's screen/topbar data must be unaffected by editing an
+  // unrelated model's labels.
+  EXPECT_STREQ(g_model.getScreenData(0)->LayoutId.c_str(), "ActiveLayout");
+  EXPECT_STREQ(g_model.getTopbarData()->zones[0].widgetName.c_str(),
+               "ActiveWidget");
+
+  // The other model's file on disk should reflect the renamed label. Read
+  // back only the header (PartialModel), not a full ModelData, so this
+  // verification step doesn't itself touch the shared screen/topbar globals.
+  PartialModel partial;
+  memclear(&partial, sizeof(partial));
+  readModelYaml("model0002.yml", (uint8_t*)&partial, sizeof(PartialModel));
+  EXPECT_STREQ(partial.header.labels, "Bar");
+}
+
+TEST_F(ModelMapFsTest,
+       AddingLabelToOtherModelWithFileUpdateLeavesActiveScreenDataUntouched)
+{
+  writeFixtureModel("model0002.yml", "", "OtherLayout", "OtherWidget");
+  ModelCell* other = modelslist.addModel("model0002.yml", false);
+  ASSERT_NE(other, nullptr);
+
+  ModelCell* active = modelslist.addModel("model0001.yml", false);
+  ASSERT_NE(active, nullptr);
+  modelslist.setCurrentModel(active);
+  g_model.getScreenData(0)->LayoutId = "ActiveLayout";
+  g_model.getTopbarData()->zones[0].widgetName = "ActiveWidget";
+
+  // update=true drives ModelMap::updateModelFile(), the second call site
+  // that reads/writes a non-active model's file on disk.
+  EXPECT_FALSE(modelslabels.addLabelToModel("Baz", other, true));
+
+  EXPECT_STREQ(g_model.getScreenData(0)->LayoutId.c_str(), "ActiveLayout");
+  EXPECT_STREQ(g_model.getTopbarData()->zones[0].widgetName.c_str(),
+               "ActiveWidget");
+
+  PartialModel partial;
+  memclear(&partial, sizeof(partial));
+  readModelYaml("model0002.yml", (uint8_t*)&partial, sizeof(PartialModel));
+  EXPECT_STREQ(partial.header.labels, "Baz");
+}
+
+#endif // defined(COLORLCD)


### PR DESCRIPTION
## Summary

PR #7709 fixed a bug where editing labels on a model other than the currently loaded one could corrupt the active model's custom-screen/widget layout. The root cause traces back to #6782, which moved `CustomScreenData`/`TopBarPersistentData` storage out of `ModelData` and into process-wide globals (`ModelData::getScreenData()`/`getTopbarData()`), without updating the label-management code (`ModelMap::renameLabel()`/`updateModelFile()` in `radio/src/storage/modelslist.cpp`), which routinely reads/writes other models' YAML files. #7709 fixed it by switching label edits to a header-only `PartialModel` read/write instead of a full `ModelData`.

This PR adds gtests, at the `ModelMap` public API boundary, that drive `ModelMap::renameLabel()` and `ModelMap::addLabelToModel(..., update=true)` against a model other than the currently active one, and assert the active model's (`g_model`) screen/topbar globals are left untouched.

## Validation

I bisected this against three points in history to confirm the tests actually catch the regression, not just assert a tautology:

- **Pre-#6782**: screen/topbar data was still embedded directly in each `ModelData` instance (no shared globals), so this class of bug couldn't occur. A modified form of the test (adapted only for the pre-#6782 API — plain `char[]` members instead of `getScreenData()`/`getTopbarData()` accessors, which didn't exist yet) **passes**, as expected.
- **Post-#6782, pre-#7709** (commit immediately before #7709 merged): the exact same test file added in this PR, unmodified, **fails** — `g_model`'s screen/topbar data gets clobbered with the other model's values when its labels are edited. This confirms the tests would have caught the #6782 regression immediately had they existed at the time.
- **Current `main`** (post-#7709): the tests **pass**.

## Test plan

- [x] `gtests-radio` built and run for a `COLORLCD` target (X10) — full suite passes (110/110), including the 2 new tests.
- [x] `gtests-radio` built and run for a mono target (X9D+) — full suite passes (122/122); the new `ModelMapFsTest` suite correctly compiles out entirely under the `#if defined(COLORLCD)` guard (0 tests from that suite, no failures).
- [x] Verified against the commit immediately preceding #7709's merge that the tests fail there (screen data corruption reproduced), and against the commit immediately preceding #6782's merge (adapted for the older API) that they pass, confirming the tests bracket the actual regression window.

🤖 Generated with [Claude Code](https://claude.com/claude-code)