### PR TITLE
fix(color): UI issues adding and removing labels

### DIFF
--- a/radio/src/gui/colorlcd/model/model_select.cpp
+++ b/radio/src/gui/colorlcd/model/model_select.cpp
@@ -663,14 +663,8 @@ void ModelLabelsWindow::newLabel()
   new LabelDialog(tmpLabel, LABEL_LENGTH, STR_ENTER_LABEL, [=](std::string label) {
     int newlabindex = modelslabels.addLabel(label);
     if (newlabindex >= 0) {
-      std::set<uint32_t> newset;
-      newset.insert(newlabindex);
       auto labels = getLabels();
       lblselector->setNames(labels);
-      lblselector->setSelected(newset);
-      if (g_eeGeneral.labelSingleSelect)
-        lblselector->setActiveItem(newlabindex);
-      updateFilteredLabels(newset);
     }
   });
 }
@@ -869,8 +863,12 @@ void ModelLabelsWindow::buildBody(Window *window)
                 std::set<uint32_t> newset;
                 lblselector->setNames(labels);
                 lblselector->setSelected(newset);
-                if (g_eeGeneral.labelSingleSelect && selected == lblselector->getActiveItem())
-                  lblselector->setActiveItem(-1);
+                if (g_eeGeneral.labelSingleSelect) {
+                  if (selected == lblselector->getActiveItem())
+                    lblselector->setActiveItem(-1);
+                  else
+                    newset.insert(lblselector->getActiveItem());
+                }
                 mdlselector->clearButtons();
                 updateFilteredLabels(newset);
               });

--- a/radio/src/storage/modelslist.cpp
+++ b/radio/src/storage/modelslist.cpp
@@ -358,8 +358,8 @@ int ModelMap::addLabel(std::string lbl)
   if (lbl == STR_UNLABELEDMODEL) return -1;
 
   // Limit maximum label length, TODO... Truncate UTF8 Properly
-  lbl = lbl.substr(0, LABEL_LENGTH);
   removeYAMLChars(lbl);
+  lbl = lbl.substr(0, LABEL_LENGTH);
   if (lbl.size() == 0) return -1;
 
   // Add a new label if it doesn't already exist in the list


### PR DESCRIPTION
Fixes:
- adding a new label sets the new label as the filter selection hiding all models since none use the label
- removing a label when single select filter mode is enabled, and a label other than the one being removed is selected as the filter, will result in all models being shown, not just the ones that match the filter
- characters that are not allowed in labels are now removed before truncating new labels to the maximum length
