### PR TITLE
fix(lua): LED_STRIP_LENGTH is decorative LEDs only

### DIFF
--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -2906,15 +2906,20 @@ static int luaGetTrainerStatus(lua_State * L)
 
 #if (BLING_LED_STRIP_LENGTH > 0) || (CFS_LED_STRIP_LENGTH > 0)
 /*luadoc
-@function setRGBLedColor(id, rvalue, bvalue, cvalue)
+@function setRGBLedColor(id, rvalue, gvalue, bvalue)
 
-@param id: integer identifying a led in the led chain
+Set the color of a decorative ("bling") LED, or of an unused custom-function-switch LED.
 
-@param rvalue: interger, value of red channel
+@param id: integer LED index. 0 .. BLING_LED_STRIP_LENGTH-1 are decorative LEDs
+  (`LED_STRIP_LENGTH` is an alias for that count). Further indices address unused
+  custom function switch LEDs and are rejected if that switch is configured.
+  Use setCFSLedColor() to override a configured function-switch LED.
 
-@param gvalue: interger, value of green channel
+@param rvalue: integer, value of red channel
 
-@param bvalue: interger, value of blue channel
+@param gvalue: integer, value of green channel
+
+@param bvalue: integer, value of blue channel
 
 @retval: true if LED index is valid, false otherwise
 
@@ -3294,6 +3299,7 @@ LROT_BEGIN(etxcst, NULL, 0)
   LROT_NUMENTRY( FUNC_BACKLIGHT, FUNC_BACKLIGHT )
   LROT_NUMENTRY( FUNC_SCREENSHOT, FUNC_SCREENSHOT )
   LROT_NUMENTRY( FUNC_RACING_MODE, FUNC_RACING_MODE )
+  LROT_NUMENTRY( FUNC_RGB_LED, FUNC_RGB_LED )
 #if defined(FUNCTION_SWITCHES)
   LROT_NUMENTRY( FUNC_PUSH_CUST_SWITCH, FUNC_PUSH_CUST_SWITCH )
 #endif
@@ -3353,7 +3359,12 @@ LROT_BEGIN(etxcst, NULL, 0)
   LROT_NUMENTRY( PLAY_BACKGROUND, PLAY_BACKGROUND )
   LROT_NUMENTRY( TIMEHOUR, TIMEHOUR )
 #if (BLING_LED_STRIP_LENGTH > 0) || (CFS_LED_STRIP_LENGTH > 0)
-  LROT_NUMENTRY( LED_STRIP_LENGTH, BLING_LED_STRIP_LENGTH + CFS_LED_STRIP_LENGTH )
+  // LED_STRIP_LENGTH matches the Lua index space of setRGBLedColor() for
+  // decorative LEDs (index 0 is the first bling LED). CFS LEDs are separate
+  // and should be driven with setCFSLedColor().
+  LROT_NUMENTRY( LED_STRIP_LENGTH, BLING_LED_STRIP_LENGTH )
+  LROT_NUMENTRY( BLING_LED_STRIP_LENGTH, BLING_LED_STRIP_LENGTH )
+  LROT_NUMENTRY( CFS_LED_STRIP_LENGTH, CFS_LED_STRIP_LENGTH )
 #endif
   LROT_NUMENTRY( UNIT_RAW, UNIT_RAW )
   LROT_NUMENTRY( UNIT_VOLTS, UNIT_VOLTS )


### PR DESCRIPTION
Summary of changes:

Lua `setRGBLedColor(0, ...)` is already the first decorative ("bling") LED, not hardware index 0. `LED_STRIP_LENGTH` was still `bling + CFS`, so strip scripts that loop `0 .. LED_STRIP_LENGTH-1` also walked function-switch LEDs. On TX16S Mk3 / GX15 / TX15 that is 26 instead of 20, and dual-ring math (`HALF = N/2`) splits at 13 instead of 10. Configured CFS LEDs are already rejected by `setRGBLedColor()`; they belong to `setCFSLedColor()` / model on-off colours.

- `LED_STRIP_LENGTH` is now the decorative count (`BLING_LED_STRIP_LENGTH`)
- Export `BLING_LED_STRIP_LENGTH` and `CFS_LED_STRIP_LENGTH` so scripts can see both ranges
- Export `FUNC_RGB_LED` so tools do not have to hardcode enum value 25
- Document the index space on `setRGBLedColor()`

This matches the index mapping from #7304. Existing scripts that iterate `LED_STRIP_LENGTH` will now paint only the gimbal/bling LEDs, which is what they intend. Function-switch LEDs are unchanged for configured switches.

Companion change: no

Radio: TX16S Mk3 / GX15 / TX15 (20 bling + 6 CFS); also radios that only have one of the two ranges

Related: https://github.com/pigd0g/EdgeTx-RGB-Toolbox