### PR TITLE
fix(tests): make ASan optional for gtests-radio, default off on AppleClang >=17

### DIFF
--- a/radio/src/tests/CMakeLists.txt
+++ b/radio/src/tests/CMakeLists.txt
@@ -11,8 +11,24 @@ set(TESTS_BUILD_PATH ${CMAKE_CURRENT_BINARY_DIR})
 configure_file(${RADIO_SRC_DIR}/tests/location.h.in ${CMAKE_CURRENT_BINARY_DIR}/location.h @ONLY)
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
-set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS_DEBUG} -O0 -fsanitize=address")
-set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_DEBUG} -O0 ${WARNING_FLAGS} -fsanitize=address")
+# AppleClang >=17 ASan hangs at startup on recent macOS (e.g. "Tahoe").
+set(TESTS_ASAN_DEFAULT ON)
+if(APPLE AND CMAKE_CXX_COMPILER_ID STREQUAL "AppleClang" AND
+   CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL 17.0)
+  message(WARNING "Disabling ASan for gtests-radio: AppleClang "
+    "${CMAKE_CXX_COMPILER_VERSION} is known to hang at startup on this "
+    "platform. Pass -DTESTS_ASAN=ON to force it back on, e.g. with a "
+    "non-Apple clang.")
+  set(TESTS_ASAN_DEFAULT OFF)
+endif()
+option(TESTS_ASAN "Enable AddressSanitizer for gtests-radio" ${TESTS_ASAN_DEFAULT})
+
+set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS_DEBUG} -O0")
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS_DEBUG} -O0 ${WARNING_FLAGS}")
+if(TESTS_ASAN)
+  set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=address")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=address")
+endif()
 
 file(GLOB TEST_SRC_FILES ${RADIO_SRC_DIR}/tests/*.cpp
   CONFIGURE_DEPENDS "${RADIO_SRC_DIR}/tests/*.cpp")


### PR DESCRIPTION
## Summary
- AppleClang 17+ (macOS "Tahoe") hangs at startup when `gtests-radio` is built with `-fsanitize=address`, so the test binary never runs on affected machines.
- Adds a `TESTS_ASAN` CMake option (default `ON`) that is automatically switched off when that specific compiler/platform combination is detected, with a warning explaining how to force it back on (e.g. with a non-Apple clang).
- llvm does not have this issue 🤗 
- Thank you Apple... why are you still shipping clang 17 with this sort of crappy ASan spinlock bug? e.g.  
  - https://github.com/python/cpython/issues/145199
  - https://github.com/llvm/llvm-project/issues/200447
  - https://developer.apple.com/forums/thread/722167

Works for me, and also for philmoz, who was having issues with the radio tests crashing. 

## Test plan
- [x] Configured/built `gtests-radio` locally with the new option present and defaulting to `ON` on this platform (unaffected combination), confirming ASan flags are still applied as before.
- [x] Confirm on an affected AppleClang 17+/Tahoe machine that ASan is now skipped and the test binary runs.