### PR TITLE
ci: check sim_string_list.h stays in sync with string_list.h

### DIFF
--- a/.github/actions/codegen_drift/action.yml
+++ b/.github/actions/codegen_drift/action.yml
@@ -13,24 +13,10 @@ inputs:
   label:
     description: 'Human readable name of the generated artefact'
     required: true
-  just-version:
-    description: 'Version of just to install'
-    default: '1.57.0'
 
 runs:
   using: "composite"
   steps:
-
-    - name: Install just
-      shell: bash
-      env:
-        JUST_VERSION: ${{ inputs.just-version }}
-      run: |
-        # The edgetx-dev image ships wget but not curl.
-        wget -qO- \
-          "https://github.com/casey/just/releases/download/${JUST_VERSION}/just-${JUST_VERSION}-x86_64-unknown-linux-musl.tar.gz" \
-          | tar xz -C /usr/local/bin just
-        just --version
 
     - name: Allow git to read the workspace
       shell: bash

--- a/.github/actions/codegen_drift/action.yml
+++ b/.github/actions/codegen_drift/action.yml
@@ -1,7 +1,9 @@
 name: 'Codegen drift check'
 description: >
-  Runs a Justfile codegen recipe and reports a warning - without failing the
-  build - when the committed output differs from what the recipe produces.
+  Runs a Justfile codegen recipe and fails the job when the committed output
+  differs from what the recipe produces. The job is deliberately not a
+  required status check, so drift is visible on the PR without blocking a
+  contributor who lacks the local toolchain from merging.
 
 inputs:
   recipe:
@@ -46,8 +48,9 @@ runs:
         RECIPE: ${{ inputs.recipe }}
         LABEL: ${{ inputs.label }}
       run: |
-        # Deliberately non-failing. Contributors without the local toolchain must
-        # not be blocked; this only surfaces that the committed files have drifted.
+        # This job is not a required status check (see description above), so
+        # failing here surfaces real drift on the PR without blocking a
+        # contributor who lacks the local toolchain from merging.
         # Word splitting on PATHS is intentional - it may hold several pathspecs.
         # shellcheck disable=SC2086
         changed=$(git status --porcelain -- ${PATHS})
@@ -56,13 +59,13 @@ runs:
           exit 0
         fi
 
-        echo "::warning::${LABEL} is out of date. Run 'just ${RECIPE}' and commit the result."
+        echo "::error::${LABEL} is out of date. Run 'just ${RECIPE}' and commit the result."
 
         # A full regeneration diff can run to megabytes (the fonts are the worst
         # case), so truncate well inside the 1 MiB step summary limit. Truncation
         # uses bash substring expansion rather than `head`: piping into `head`
         # would SIGPIPE the producer once it closed the pipe, and under `pipefail`
-        # that exits 141 - failing a step that must never fail.
+        # that would clobber the exit 1 below with a 141.
         # shellcheck disable=SC2086
         diff=$(git diff -- ${PATHS} || true)
         truncated="${diff:0:60000}"
@@ -71,7 +74,7 @@ runs:
         fi
 
         {
-          echo "### :warning: ${LABEL} is out of date"
+          echo "### :x: ${LABEL} is out of date"
           echo
           echo "The committed files differ from what \`just ${RECIPE}\` produces in"
           echo "\`ghcr.io/edgetx/edgetx-dev:latest\`. Run \`just ${RECIPE}\` and commit the result."
@@ -88,3 +91,5 @@ runs:
           echo
           echo "</details>"
         } >> "$GITHUB_STEP_SUMMARY"
+
+        exit 1

--- a/.github/workflows/codegen_drift.yml
+++ b/.github/workflows/codegen_drift.yml
@@ -151,7 +151,6 @@ jobs:
       - name: Check for drift
         uses: ./.github/actions/codegen_drift
         with:
-          just-version: ${{ env.JUST_VERSION }}
           recipe: cfn-sort
           paths: radio/src/cfn_sort.cpp
           label: Custom function sort order
@@ -175,7 +174,6 @@ jobs:
       - name: Check for drift
         uses: ./.github/actions/codegen_drift
         with:
-          just-version: ${{ env.JUST_VERSION }}
           recipe: gen-fonts
           paths: radio/src/fonts/lvgl
           label: LVGL fonts
@@ -199,7 +197,6 @@ jobs:
       - name: Check for drift
         uses: ./.github/actions/codegen_drift
         with:
-          just-version: ${{ env.JUST_VERSION }}
           recipe: gen-yaml
           paths: radio/src/storage/yaml
           label: YAML parsers
@@ -221,7 +218,6 @@ jobs:
       - name: Check for drift
         uses: ./.github/actions/codegen_drift
         with:
-          just-version: ${{ env.JUST_VERSION }}
           recipe: gen-radios
           paths: web/public/radios.json
           label: Web simulator radio list
@@ -243,7 +239,6 @@ jobs:
       - name: Check for drift
         uses: ./.github/actions/codegen_drift
         with:
-          just-version: ${{ env.JUST_VERSION }}
           recipe: gen-simstr
           paths: radio/src/translations/sim_string_list.h
           label: Simulator string list

--- a/.github/workflows/codegen_drift.yml
+++ b/.github/workflows/codegen_drift.yml
@@ -41,8 +41,9 @@ on:
     paths: *trigger-paths
   workflow_dispatch:
 
-# These jobs only ever report - they must never block a contributor who does not
-# have the local toolchain, so nothing here fails on drift.
+# These jobs fail on drift so it's visible on the PR, but none of them are
+# configured as required status checks - a contributor without the local
+# toolchain can still merge.
 permissions:
   contents: read
   pull-requests: read

--- a/.github/workflows/codegen_drift.yml
+++ b/.github/workflows/codegen_drift.yml
@@ -33,6 +33,10 @@ on:
       - 'fw.json'
       - 'web/scripts/gen-radios-json.js'
       - 'web/public/radios.json'
+      # simulator string list
+      - 'radio/src/translations/simstr.m4'
+      - 'radio/src/translations/string_list.h'
+      - 'radio/src/translations/sim_string_list.h'
   pull_request:
     paths: *trigger-paths
   workflow_dispatch:
@@ -59,6 +63,7 @@ jobs:
       fonts: ${{ steps.filter.outputs.fonts }}
       yaml: ${{ steps.filter.outputs.yaml }}
       radios: ${{ steps.filter.outputs.radios }}
+      simstr: ${{ steps.filter.outputs.simstr }}
     steps:
       - name: Check out the repo
         uses: actions/checkout@v7
@@ -74,7 +79,7 @@ jobs:
       - name: Check the recipes this workflow calls still resolve
         run: |
           just --list >/dev/null
-          for recipe in cfn-sort gen-fonts gen-yaml gen-radios; do
+          for recipe in cfn-sort gen-fonts gen-yaml gen-radios gen-simstr; do
             just --show "${recipe}" >/dev/null
           done
 
@@ -120,6 +125,12 @@ jobs:
               - 'radio/src/boards/hw_defs/**'
               - 'web/scripts/gen-radios-json.js'
               - 'web/public/radios.json'
+            simstr:
+              - '.github/workflows/codegen_drift.yml'
+              - '.github/actions/codegen_drift/action.yml'
+              - 'radio/src/translations/simstr.m4'
+              - 'radio/src/translations/string_list.h'
+              - 'radio/src/translations/sim_string_list.h'
 
   cfn-sort:
     name: Custom function sort order
@@ -214,3 +225,25 @@ jobs:
           recipe: gen-radios
           paths: web/public/radios.json
           label: Web simulator radio list
+
+  simstr:
+    name: Simulator string list
+    needs: changes
+    if: needs.changes.outputs.simstr == 'true' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    container:
+      image: ghcr.io/edgetx/edgetx-dev:latest
+      volumes:
+        - ${{ github.workspace }}:/src
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@v7
+
+      - name: Check for drift
+        uses: ./.github/actions/codegen_drift
+        with:
+          just-version: ${{ env.JUST_VERSION }}
+          recipe: gen-simstr
+          paths: radio/src/translations/sim_string_list.h
+          label: Simulator string list

--- a/Justfile
+++ b/Justfile
@@ -44,9 +44,15 @@ gen-yaml FLAVOR='':
 gen-radios:
     node web/scripts/gen-radios-json.js
 
-[doc('Regenerate the YAML parsers, LVGL fonts, cfn sort order and radio list')]
+# Needs: m4.
+[doc('Regenerate the simulator string list (radio/src/translations/sim_string_list.h)')]
 [group('codegen')]
-codegen: gen-fonts cfn-sort gen-yaml gen-radios
+gen-simstr:
+    m4 radio/src/translations/simstr.m4 radio/src/translations/string_list.h > radio/src/translations/sim_string_list.h
+
+[doc('Regenerate the YAML parsers, LVGL fonts, cfn sort order, radio list and simulator string list')]
+[group('codegen')]
+codegen: gen-fonts cfn-sort gen-yaml gen-radios gen-simstr
 
 [doc('Regenerate the LVGL fonts in the dev container')]
 [group('codegen (docker)')]
@@ -72,6 +78,11 @@ docker-gen-yaml FLAVOR='':
 docker-gen-radios:
     {{ _docker }} node web/scripts/gen-radios-json.js
 
+[doc('Regenerate the simulator string list in the dev container')]
+[group('codegen (docker)')]
+docker-gen-simstr:
+    {{ _docker }} m4 radio/src/translations/simstr.m4 radio/src/translations/string_list.h > radio/src/translations/sim_string_list.h
+
 [doc('Regenerate everything in the dev container')]
 [group('codegen (docker)')]
-docker-codegen: docker-gen-fonts docker-cfn-sort docker-gen-yaml docker-gen-radios
+docker-codegen: docker-gen-fonts docker-cfn-sort docker-gen-yaml docker-gen-radios docker-gen-simstr


### PR DESCRIPTION
## Summary
- `radio/src/translations/sim_string_list.h` is generated from `string_list.h` via `m4 simstr.m4 string_list.h > sim_string_list.h`, but nothing enforced that it stayed regenerated. #7718 fixed drift that had crept in; this adds a CI check so that class of drift is caught automatically instead of relying on manual review.
- Extends the existing `codegen_drift` workflow (used for fonts/cfn-sort/YAML parsers/radio list) with a new `gen-simstr` Justfile recipe and matching `simstr` job.
- The `edgetx-dev` image now ships `just` and `m4` (EdgeTX/build-edgetx#54), so the per-job `just` install/pin is dropped — only the `changes` job (which runs on a bare `ubuntu-latest` runner, not the container) still installs it.
- Also changes all five `codegen_drift` jobs (cfn-sort, fonts, yaml, radios, simstr) to fail on drift instead of only posting a `::warning::` annotation. None of these are required status checks on `main`, so this doesn't block anyone without the local toolchain — it just makes real drift visible as a red ✗ on the PR instead of a warning buried in an otherwise-green run.

## Test plan
- [x] Verified `just gen-simstr` reproduces the exact drift #7718 fixed (locally, against the pre-#7718 tree)
- [x] Verified none of the other four recipes (`gen-radios`, `cfn-sort`, `gen-fonts`, `gen-yaml`) have pre-existing drift on `main`, so switching them to fail-on-drift won't surface an unrelated false failure
- [x] CI run on this PR exercises the new `simstr` job and confirms the other four still pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)