### PR TITLE
refactor: remove redundant x9e-hall target entry

### DIFF
--- a/.github/workflows/build_fw.yml
+++ b/.github/workflows/build_fw.yml
@@ -92,7 +92,7 @@ jobs:
           - x12s;f16
           - v14;v14lcd;v16
           - x10;x10express
-          - x7access;x9dp2019;x9e;x9e-hall
+          - x7access;x9dp2019;x9e
           - nb4p;st16
           - tx16smk3;t14;t15pro
           - t22

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -33,7 +33,7 @@ jobs:
           - x12s
           - x7access
           - x9dp2019
-          - x9e;x9e-hall
+          - x9e
           - mt12
           - nb4p
           - st16

--- a/fw.json
+++ b/fw.json
@@ -15,7 +15,6 @@
         ["FrSky QX7 Access", "x7access-"],
         ["FrSky X9D Plus 2019", "x9dp2019-"],
         ["FrSky X9E", "x9e-"],
-        ["FrSky X9E Hall", "x9e-hall-"],
         ["HelloRadioSky V12", "v12-"],
         ["HelloRadioSky V14", "v14-"],
         ["HelloRadioSky V14LCD", "v14lcd-"],

--- a/tools/build-common.sh
+++ b/tools/build-common.sh
@@ -92,9 +92,6 @@ get_target_build_options() {
         x9e)
             BUILD_OPTIONS+="-DPCB=X9E"
             ;;
-        x9e-hall)
-            BUILD_OPTIONS+="-DPCB=X9E -DSTICKS=HORUS"
-            ;;
         x10)
             BUILD_OPTIONS+="-DPCB=X10"
             ;;

--- a/web/README.md
+++ b/web/README.md
@@ -52,7 +52,7 @@ node web/scripts/gen-radios-json.js
 
 The script extracts inputs, switches, trims, keys, and display info from the hw_defs JSON files. Key left/right side placement matches Companion's layout.
 
-*Which* radios are included comes from the `targets` list in the repo-root `fw.json`, so a new board only appears here once it is a released target. Targets with no matching hw_defs file are skipped with a warning: `x9e-hall` always warns, as it is a build option of `x9e` rather than a board of its own.
+*Which* radios are included comes from the `targets` list in the repo-root `fw.json`, so a new board only appears here once it is a released target.
 
 Passing flavour names as arguments limits generation to those radios only — the whole file is rewritten, so use that for inspection, not to update the committed list.
 


### PR DESCRIPTION
The `x9e-hall` build target is redundant as it is identical to `x9e` built with `STICKS=HORUS`. Since Cloudbuild allows configuring flags on `x9e` (with `STICKS=HORUS`), `x9e-hall` can be safely dropped.

### Summary of Changes:
- Removed `["FrSky X9E Hall", "x9e-hall-"]` from `fw.json`
- Removed `x9e-hall` target case from `tools/build-common.sh`
- Removed `x9e-hall` from CI matrices in `.github/workflows/build_fw.yml` and `.github/workflows/nightly.yml`
- Updated `web/README.md` documentation

Co-authored-by: GitHub Copilot <copilot@github.com>