### PR TITLE
fix: stop moduleData antennaMode aliasing subType on boards without an external antenna

### DIFF
--- a/companion/src/firmwares/edgetx/yaml_moduledata.cpp
+++ b/companion/src/firmwares/edgetx/yaml_moduledata.cpp
@@ -145,6 +145,13 @@ static const YamlLookupTable moduleAntennaModeLut = {
   {  GeneralSettings::ANTENNA_MODE_EXTERNAL, "MODE_EXTERNAL"  },
 };
 
+// Firmware built before the field was made unconditional emitted antennaMode on
+// boards without an external antenna, where it aliased the top bits of subType.
+static bool hasModuleAntennaMode()
+{
+  return Boards::getCapability(getCurrentBoard(), Board::HasExternalAntenna);
+}
+
 static int exportPpmDelay(int delay) { return (delay - 300) / 50; }
 static int importPpmDelay(int delay) { return 300 + 50 * delay; }
 
@@ -204,7 +211,7 @@ Node convert<ModuleData>::encode(const ModuleData& rhs)
   node["channelsStart"] = rhs.channelsStart;
   node["channelsCount"] = rhs.channelsCount;
   node["failsafeMode"] = LookupValue(failsafeLut, rhs.failsafeMode);
-  if (rhs.antennaMode)
+  if (rhs.antennaMode && hasModuleAntennaMode())
     node["antennaMode"] = LookupValue(moduleAntennaModeLut, rhs.antennaMode);
 
   Node mod;
@@ -370,7 +377,7 @@ bool convert<ModuleData>::decode(const Node& node, ModuleData& rhs)
   node["channelsStart"] >> rhs.channelsStart;
   node["channelsCount"] >> rhs.channelsCount;
   node["failsafeMode"] >> failsafeLut >> rhs.failsafeMode;
-  if (node["antennaMode"])
+  if (node["antennaMode"] && hasModuleAntennaMode())
     node["antennaMode"] >> moduleAntennaModeLut >> rhs.antennaMode;
 
   if (node["mod"]) {
@@ -397,7 +404,7 @@ bool convert<ModuleData>::decode(const Node& node, ModuleData& rhs)
           // pxx["receiverTelemetryOff"] >> rhs.pxx.receiverTelemetryOff;
           // pxx["receiverHigherChannels"] >> rhs.pxx.receiverHigherChannels;
           // Migration: legacy raw-int antennaMode, only if not already set
-          if (!node["antennaMode"] && pxx["antennaMode"]) {
+          if (!node["antennaMode"] && pxx["antennaMode"] && hasModuleAntennaMode()) {
             pxx["antennaMode"] >> rhs.antennaMode;
           }
       } else if (mod["sbus"]) {

--- a/companion/src/tests/model_yaml_roundtrip_test.cpp
+++ b/companion/src/tests/model_yaml_roundtrip_test.cpp
@@ -39,6 +39,7 @@
 
 #include "firmwares/eeprominterface.h"
 #include "firmwares/edgetx/edgetxinterface.h"
+#include "firmwares/edgetx/yaml_moduledata.h"
 
 namespace {
 
@@ -123,4 +124,55 @@ TEST_F(ModelYamlRoundTrip, OverlongNameTruncatesAndRoundTrips)
   QByteArray y2;
   ModelData m3 = roundTrip(m2, y2);
   EXPECT_EQ(m2.name.str(), m3.name.str());
+}
+
+// A module written by a radio that emitted antennaMode must decode. The field is
+// a string enum firmware side; read as a raw int, yaml-cpp throws
+// TypedBadConversion and the whole model fails to open.
+TEST_F(ModelYamlRoundTrip, RadioWrittenAntennaModeDecodes)
+{
+  YAML::Node node = YAML::Load(
+      "type: TYPE_MULTIMODULE\n"
+      "subType: 6,7\n"
+      "channelsStart: 0\n"
+      "channelsCount: 16\n"
+      "failsafeMode: NOT_SET\n"
+      "antennaMode: MODE_PER_MODEL\n");
+
+  ModuleData md;
+  bool threw = false;
+  std::string err;
+  try {
+    node >> md;
+  } catch (const std::exception& e) {
+    threw = true;
+    err = e.what();
+  } catch (...) {
+    threw = true;
+    err = "non-std exception";
+  }
+
+  ASSERT_FALSE(threw) << "decoding threw: " << err;
+  EXPECT_EQ(md.subType, 7u) << "subType lost alongside antennaMode";
+}
+
+// The fixture selects tx16s, which has no external antenna. Such radios parse
+// antennaMode over the top two bits of subType, so writing the key back would
+// change the sub-protocol on load.
+TEST_F(ModelYamlRoundTrip, AntennaModeNotWrittenWithoutExternalAntenna)
+{
+  ASSERT_FALSE(Boards::getCapability(getCurrentBoard(), Board::HasExternalAntenna))
+      << "fixture board is expected to have no external antenna";
+
+  ModelData m;
+  m.clear();
+  m.used = true;
+  // only modules with a protocol are serialised at all
+  m.moduleData[1].protocol = PULSES_MULTIMODULE;
+  m.moduleData[1].antennaMode = GeneralSettings::ANTENNA_MODE_EXTERNAL;
+
+  QByteArray y;
+  writeModelToYaml(m, y);
+  ASSERT_TRUE(y.contains("moduleData")) << "module was not serialised";
+  EXPECT_FALSE(y.contains("antennaMode"));
 }

--- a/radio/src/datastructs_private.h
+++ b/radio/src/datastructs_private.h
@@ -284,7 +284,7 @@ PACK(struct TimerData {
   uint32_t minuteBeep:1;
   uint32_t persistent:2;
   int32_t  countdownStart:2;
-  uint8_t  showElapsed:1; 
+  uint8_t  showElapsed:1;
   uint8_t  extraHaptic:1;
   uint8_t  spare:6 SKIP;
   NOBACKUP(char name[LEN_TIMER_NAME]);
@@ -499,17 +499,15 @@ PACK(struct PpmModule {
 });
 
 PACK(struct ModuleData {
-  uint8_t type ENUM(ModuleType) CUST(r_moduleType, w_moduleType);
+  // antennaMode stays unconditional as boards differing on EXTERNAL_ANTENNA share
+  // generated YAML descriptors.
+  uint8_t type:6 ENUM(ModuleType) CUST(r_moduleType, w_moduleType);
+  int8_t  antennaMode:2 ENUM(AntennaModes);
   CUST_ATTR(subType,r_modSubtype,w_modSubtype);
   uint8_t channelsStart;
   int8_t  channelsCount CUST(r_channelsCount,w_channelsCount); // 0=8 channels
   uint8_t failsafeMode:4 ENUM(FailsafeModes);  // only 3 bits used
-  #if defined(EXTERNAL_ANTENNA)
-  uint8_t subType:2 SKIP;
-  int8_t  antennaMode:2 ENUM(AntennaModes);
-  #else
   uint8_t subType:4 SKIP;
-  #endif
 
   union {
     uint8_t raw[PXX2_MAX_RECEIVERS_PER_MODULE * PXX2_LEN_RX_NAME + 1];
@@ -888,7 +886,7 @@ PACK(struct ModelData {
   NOBACKUP(uint8_t usbJoystickIfMode:3 ENUM(USBJoystickIfMode));
   NOBACKUP(uint8_t usbJoystickCircularCut:4);
   NOBACKUP(USBJoystickChData usbJoystickCh[USBJ_MAX_JOYSTICK_CHANNELS]);
-  
+
   // Radio level tabs control (model settings)
 #if defined(COLORLCD)
   uint8_t radioThemesDisabled:2 ENUM(ModelOverridableEnable);

--- a/radio/src/storage/yaml/yaml_datastructs_128x64.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_128x64.cpp
@@ -655,7 +655,8 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
 };
 static const struct YamlNode struct_ModuleData[] = {
   YAML_IDX,
-  YAML_UNSIGNED_CUST( "type", 8, r_moduleType, w_moduleType ),
+  YAML_UNSIGNED_CUST( "type", 6, r_moduleType, w_moduleType ),
+  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
   YAML_CUSTOM("subType",r_modSubtype,w_modSubtype),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED_CUST( "channelsCount", 8, r_channelsCount, w_channelsCount ),

--- a/radio/src/storage/yaml/yaml_datastructs_c14.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_c14.cpp
@@ -731,7 +731,8 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
 };
 static const struct YamlNode struct_ModuleData[] = {
   YAML_IDX,
-  YAML_UNSIGNED_CUST( "type", 8, r_moduleType, w_moduleType ),
+  YAML_UNSIGNED_CUST( "type", 6, r_moduleType, w_moduleType ),
+  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
   YAML_CUSTOM("subType",r_modSubtype,w_modSubtype),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED_CUST( "channelsCount", 8, r_channelsCount, w_channelsCount ),

--- a/radio/src/storage/yaml/yaml_datastructs_f16.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_f16.cpp
@@ -732,7 +732,8 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
 };
 static const struct YamlNode struct_ModuleData[] = {
   YAML_IDX,
-  YAML_UNSIGNED_CUST( "type", 8, r_moduleType, w_moduleType ),
+  YAML_UNSIGNED_CUST( "type", 6, r_moduleType, w_moduleType ),
+  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
   YAML_CUSTOM("subType",r_modSubtype,w_modSubtype),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED_CUST( "channelsCount", 8, r_channelsCount, w_channelsCount ),

--- a/radio/src/storage/yaml/yaml_datastructs_gx12.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_gx12.cpp
@@ -679,7 +679,8 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
 };
 static const struct YamlNode struct_ModuleData[] = {
   YAML_IDX,
-  YAML_UNSIGNED_CUST( "type", 8, r_moduleType, w_moduleType ),
+  YAML_UNSIGNED_CUST( "type", 6, r_moduleType, w_moduleType ),
+  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
   YAML_CUSTOM("subType",r_modSubtype,w_modSubtype),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED_CUST( "channelsCount", 8, r_channelsCount, w_channelsCount ),

--- a/radio/src/storage/yaml/yaml_datastructs_gx15.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_gx15.cpp
@@ -756,7 +756,8 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
 };
 static const struct YamlNode struct_ModuleData[] = {
   YAML_IDX,
-  YAML_UNSIGNED_CUST( "type", 8, r_moduleType, w_moduleType ),
+  YAML_UNSIGNED_CUST( "type", 6, r_moduleType, w_moduleType ),
+  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
   YAML_CUSTOM("subType",r_modSubtype,w_modSubtype),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED_CUST( "channelsCount", 8, r_channelsCount, w_channelsCount ),

--- a/radio/src/storage/yaml/yaml_datastructs_nb4p.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_nb4p.cpp
@@ -722,7 +722,8 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
 };
 static const struct YamlNode struct_ModuleData[] = {
   YAML_IDX,
-  YAML_UNSIGNED_CUST( "type", 8, r_moduleType, w_moduleType ),
+  YAML_UNSIGNED_CUST( "type", 6, r_moduleType, w_moduleType ),
+  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
   YAML_CUSTOM("subType",r_modSubtype,w_modSubtype),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED_CUST( "channelsCount", 8, r_channelsCount, w_channelsCount ),

--- a/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_nv14.cpp
@@ -729,7 +729,8 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
 };
 static const struct YamlNode struct_ModuleData[] = {
   YAML_IDX,
-  YAML_UNSIGNED_CUST( "type", 8, r_moduleType, w_moduleType ),
+  YAML_UNSIGNED_CUST( "type", 6, r_moduleType, w_moduleType ),
+  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
   YAML_CUSTOM("subType",r_modSubtype,w_modSubtype),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED_CUST( "channelsCount", 8, r_channelsCount, w_channelsCount ),

--- a/radio/src/storage/yaml/yaml_datastructs_pa01.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_pa01.cpp
@@ -755,7 +755,8 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
 };
 static const struct YamlNode struct_ModuleData[] = {
   YAML_IDX,
-  YAML_UNSIGNED_CUST( "type", 8, r_moduleType, w_moduleType ),
+  YAML_UNSIGNED_CUST( "type", 6, r_moduleType, w_moduleType ),
+  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
   YAML_CUSTOM("subType",r_modSubtype,w_modSubtype),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED_CUST( "channelsCount", 8, r_channelsCount, w_channelsCount ),

--- a/radio/src/storage/yaml/yaml_datastructs_pl18.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_pl18.cpp
@@ -729,7 +729,8 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
 };
 static const struct YamlNode struct_ModuleData[] = {
   YAML_IDX,
-  YAML_UNSIGNED_CUST( "type", 8, r_moduleType, w_moduleType ),
+  YAML_UNSIGNED_CUST( "type", 6, r_moduleType, w_moduleType ),
+  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
   YAML_CUSTOM("subType",r_modSubtype,w_modSubtype),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED_CUST( "channelsCount", 8, r_channelsCount, w_channelsCount ),

--- a/radio/src/storage/yaml/yaml_datastructs_pl18u.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_pl18u.cpp
@@ -722,7 +722,8 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
 };
 static const struct YamlNode struct_ModuleData[] = {
   YAML_IDX,
-  YAML_UNSIGNED_CUST( "type", 8, r_moduleType, w_moduleType ),
+  YAML_UNSIGNED_CUST( "type", 6, r_moduleType, w_moduleType ),
+  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
   YAML_CUSTOM("subType",r_modSubtype,w_modSubtype),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED_CUST( "channelsCount", 8, r_channelsCount, w_channelsCount ),

--- a/radio/src/storage/yaml/yaml_datastructs_st16.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_st16.cpp
@@ -755,7 +755,8 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
 };
 static const struct YamlNode struct_ModuleData[] = {
   YAML_IDX,
-  YAML_UNSIGNED_CUST( "type", 8, r_moduleType, w_moduleType ),
+  YAML_UNSIGNED_CUST( "type", 6, r_moduleType, w_moduleType ),
+  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
   YAML_CUSTOM("subType",r_modSubtype,w_modSubtype),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED_CUST( "channelsCount", 8, r_channelsCount, w_channelsCount ),

--- a/radio/src/storage/yaml/yaml_datastructs_t15.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t15.cpp
@@ -740,7 +740,8 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
 };
 static const struct YamlNode struct_ModuleData[] = {
   YAML_IDX,
-  YAML_UNSIGNED_CUST( "type", 8, r_moduleType, w_moduleType ),
+  YAML_UNSIGNED_CUST( "type", 6, r_moduleType, w_moduleType ),
+  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
   YAML_CUSTOM("subType",r_modSubtype,w_modSubtype),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED_CUST( "channelsCount", 8, r_channelsCount, w_channelsCount ),

--- a/radio/src/storage/yaml/yaml_datastructs_t15pro.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t15pro.cpp
@@ -755,7 +755,8 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
 };
 static const struct YamlNode struct_ModuleData[] = {
   YAML_IDX,
-  YAML_UNSIGNED_CUST( "type", 8, r_moduleType, w_moduleType ),
+  YAML_UNSIGNED_CUST( "type", 6, r_moduleType, w_moduleType ),
+  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
   YAML_CUSTOM("subType",r_modSubtype,w_modSubtype),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED_CUST( "channelsCount", 8, r_channelsCount, w_channelsCount ),

--- a/radio/src/storage/yaml/yaml_datastructs_t20.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t20.cpp
@@ -664,7 +664,8 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
 };
 static const struct YamlNode struct_ModuleData[] = {
   YAML_IDX,
-  YAML_UNSIGNED_CUST( "type", 8, r_moduleType, w_moduleType ),
+  YAML_UNSIGNED_CUST( "type", 6, r_moduleType, w_moduleType ),
+  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
   YAML_CUSTOM("subType",r_modSubtype,w_modSubtype),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED_CUST( "channelsCount", 8, r_channelsCount, w_channelsCount ),

--- a/radio/src/storage/yaml/yaml_datastructs_t22.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_t22.cpp
@@ -755,7 +755,8 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
 };
 static const struct YamlNode struct_ModuleData[] = {
   YAML_IDX,
-  YAML_UNSIGNED_CUST( "type", 8, r_moduleType, w_moduleType ),
+  YAML_UNSIGNED_CUST( "type", 6, r_moduleType, w_moduleType ),
+  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
   YAML_CUSTOM("subType",r_modSubtype,w_modSubtype),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED_CUST( "channelsCount", 8, r_channelsCount, w_channelsCount ),

--- a/radio/src/storage/yaml/yaml_datastructs_tpro.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tpro.cpp
@@ -664,7 +664,8 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
 };
 static const struct YamlNode struct_ModuleData[] = {
   YAML_IDX,
-  YAML_UNSIGNED_CUST( "type", 8, r_moduleType, w_moduleType ),
+  YAML_UNSIGNED_CUST( "type", 6, r_moduleType, w_moduleType ),
+  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
   YAML_CUSTOM("subType",r_modSubtype,w_modSubtype),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED_CUST( "channelsCount", 8, r_channelsCount, w_channelsCount ),

--- a/radio/src/storage/yaml/yaml_datastructs_tx15.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tx15.cpp
@@ -756,7 +756,8 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
 };
 static const struct YamlNode struct_ModuleData[] = {
   YAML_IDX,
-  YAML_UNSIGNED_CUST( "type", 8, r_moduleType, w_moduleType ),
+  YAML_UNSIGNED_CUST( "type", 6, r_moduleType, w_moduleType ),
+  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
   YAML_CUSTOM("subType",r_modSubtype,w_modSubtype),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED_CUST( "channelsCount", 8, r_channelsCount, w_channelsCount ),

--- a/radio/src/storage/yaml/yaml_datastructs_tx16smk3.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_tx16smk3.cpp
@@ -757,7 +757,8 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
 };
 static const struct YamlNode struct_ModuleData[] = {
   YAML_IDX,
-  YAML_UNSIGNED_CUST( "type", 8, r_moduleType, w_moduleType ),
+  YAML_UNSIGNED_CUST( "type", 6, r_moduleType, w_moduleType ),
+  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
   YAML_CUSTOM("subType",r_modSubtype,w_modSubtype),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED_CUST( "channelsCount", 8, r_channelsCount, w_channelsCount ),

--- a/radio/src/storage/yaml/yaml_datastructs_v12.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_v12.cpp
@@ -750,13 +750,13 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
 };
 static const struct YamlNode struct_ModuleData[] = {
   YAML_IDX,
-  YAML_UNSIGNED_CUST( "type", 8, r_moduleType, w_moduleType ),
+  YAML_UNSIGNED_CUST( "type", 6, r_moduleType, w_moduleType ),
+  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
   YAML_CUSTOM("subType",r_modSubtype,w_modSubtype),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED_CUST( "channelsCount", 8, r_channelsCount, w_channelsCount ),
   YAML_ENUM("failsafeMode", 4, enum_FailsafeModes, NULL),
-  YAML_PADDING( 2 ),
-  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
+  YAML_PADDING( 4 ),
   YAML_UNION("mod", 200, union_anonymous_4_elmts, select_mod_type),
   YAML_END
 };

--- a/radio/src/storage/yaml/yaml_datastructs_x10.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x10.cpp
@@ -731,13 +731,13 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
 };
 static const struct YamlNode struct_ModuleData[] = {
   YAML_IDX,
-  YAML_UNSIGNED_CUST( "type", 8, r_moduleType, w_moduleType ),
+  YAML_UNSIGNED_CUST( "type", 6, r_moduleType, w_moduleType ),
+  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
   YAML_CUSTOM("subType",r_modSubtype,w_modSubtype),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED_CUST( "channelsCount", 8, r_channelsCount, w_channelsCount ),
   YAML_ENUM("failsafeMode", 4, enum_FailsafeModes, NULL),
-  YAML_PADDING( 2 ),
-  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
+  YAML_PADDING( 4 ),
   YAML_UNION("mod", 200, union_anonymous_4_elmts, select_mod_type),
   YAML_END
 };

--- a/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9d.cpp
@@ -655,7 +655,8 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
 };
 static const struct YamlNode struct_ModuleData[] = {
   YAML_IDX,
-  YAML_UNSIGNED_CUST( "type", 8, r_moduleType, w_moduleType ),
+  YAML_UNSIGNED_CUST( "type", 6, r_moduleType, w_moduleType ),
+  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
   YAML_CUSTOM("subType",r_modSubtype,w_modSubtype),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED_CUST( "channelsCount", 8, r_channelsCount, w_channelsCount ),

--- a/radio/src/storage/yaml/yaml_datastructs_x9dp2019.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9dp2019.cpp
@@ -655,7 +655,8 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
 };
 static const struct YamlNode struct_ModuleData[] = {
   YAML_IDX,
-  YAML_UNSIGNED_CUST( "type", 8, r_moduleType, w_moduleType ),
+  YAML_UNSIGNED_CUST( "type", 6, r_moduleType, w_moduleType ),
+  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
   YAML_CUSTOM("subType",r_modSubtype,w_modSubtype),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED_CUST( "channelsCount", 8, r_channelsCount, w_channelsCount ),

--- a/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_x9e.cpp
@@ -655,7 +655,8 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
 };
 static const struct YamlNode struct_ModuleData[] = {
   YAML_IDX,
-  YAML_UNSIGNED_CUST( "type", 8, r_moduleType, w_moduleType ),
+  YAML_UNSIGNED_CUST( "type", 6, r_moduleType, w_moduleType ),
+  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
   YAML_CUSTOM("subType",r_modSubtype,w_modSubtype),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED_CUST( "channelsCount", 8, r_channelsCount, w_channelsCount ),

--- a/radio/src/storage/yaml/yaml_datastructs_xlite.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_xlite.cpp
@@ -655,13 +655,13 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
 };
 static const struct YamlNode struct_ModuleData[] = {
   YAML_IDX,
-  YAML_UNSIGNED_CUST( "type", 8, r_moduleType, w_moduleType ),
+  YAML_UNSIGNED_CUST( "type", 6, r_moduleType, w_moduleType ),
+  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
   YAML_CUSTOM("subType",r_modSubtype,w_modSubtype),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED_CUST( "channelsCount", 8, r_channelsCount, w_channelsCount ),
   YAML_ENUM("failsafeMode", 4, enum_FailsafeModes, NULL),
-  YAML_PADDING( 2 ),
-  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
+  YAML_PADDING( 4 ),
   YAML_UNION("mod", 200, union_anonymous_4_elmts, select_mod_type),
   YAML_END
 };

--- a/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
+++ b/radio/src/storage/yaml/yaml_datastructs_xlites.cpp
@@ -660,13 +660,13 @@ static const struct YamlNode union_anonymous_4_elmts[] = {
 };
 static const struct YamlNode struct_ModuleData[] = {
   YAML_IDX,
-  YAML_UNSIGNED_CUST( "type", 8, r_moduleType, w_moduleType ),
+  YAML_UNSIGNED_CUST( "type", 6, r_moduleType, w_moduleType ),
+  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
   YAML_CUSTOM("subType",r_modSubtype,w_modSubtype),
   YAML_UNSIGNED( "channelsStart", 8 ),
   YAML_SIGNED_CUST( "channelsCount", 8, r_channelsCount, w_channelsCount ),
   YAML_ENUM("failsafeMode", 4, enum_FailsafeModes, NULL),
-  YAML_PADDING( 2 ),
-  YAML_ENUM("antennaMode", 2, enum_AntennaModes, NULL),
+  YAML_PADDING( 4 ),
   YAML_UNION("mod", 200, union_anonymous_4_elmts, select_mod_type),
   YAML_END
 };


### PR DESCRIPTION
Fixes #7733.

Fixes three defects introduced by #7113, which made the `ModuleData` bit layout conditional on `EXTERNAL_ANTENNA` while the generated YAML descriptor tables are shared between boards that differ on that flag.

### 1. Phantom `antennaMode` aliasing `subType`
`tx16s`, `t16`, `t18`, `v16` include the x10 table; `t8`, `t12`, `tlite`, `lr3pro`, `commando8` include the xlite one. Those boards describe an `antennaMode` field they do not compile, overlaying the top two bits of their live `subType`. `yaml_bits.cpp` is LSB-first, so `antennaMode == subType >> 2`.

A reported TX16S file shows it exactly: `subType: 6,3` → `3 = 0b0011` → top two bits `0` → emitted as `antennaMode: MODE_PER_MODEL`.

Companion hides the UI but round-trips the value, and writes `antennaMode` after `subType`, so the radio applies it second and overwrites `subType`. Changing an MPM sub-protocol in Companion could silently change it again on load.

### 2. `subType` narrowed 4 → 2 bits
On `x10`, `x10express`, `x12s`, `xlite`, `xlites`, `v12`. MPM sub-protocols reach 7 (DSM2, AFHDS2A, CABELL, FRSKY_R9, MT99XX) and up to 14 via telemetry, so anything above 3 truncated.

### 3. Companion could not open affected files
Already fixed on main by #7114; the 2.12.x fix is in #7736.

## Approach
`antennaMode` becomes unconditional, so every board compiles the layout its table describes. The bits come from `type` (18 of 64 values used) because `check_yaml_funcs()` pins the header to 4 bytes via `offsetof(ModuleData, ppm) == 4` and `check_size<ModuleData, 29>()`, and it must precede `CUST_ATTR(subType)` so that node stays at bit offset 8 where `r_`/`w_modSubtype` resolve the struct base. `subType` returns to 4 bits.

All 25 generated tables now share an identical `struct_ModuleData`; the entire diff across them is the `type` width plus the moved field.

Companion additionally gates encode, decode and the legacy pxx migration on `HasExternalAntenna`, which handles files already written by 2.12.3.

## Verification
- `gtests-radio` 126/126 on x10 (`EXTERNAL_ANTENNA` on) and tx16s (off)
- `gtests-companion` 14/14, including two new tests, each confirmed to fail when its fix is reverted
- Pre-fix reproduction gave the reported error verbatim: `TypedBadConversion<int>`, `bad conversion`, column 20
- Regenerated tables verified free of drift outside `struct_ModuleData`

---

This also explains why the issue only shows on models *modified* under 2.12.3: an untouched 2.12.2 file has no `antennaMode` key, and the radio only writes the phantom one when it re-saves the model.
