### PR TITLE
fix(cpn): restore macOS deployment target for Companion and simulator plugins

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -45,11 +45,22 @@ if(EdgeTX_SUPERBUILD)
       else()
         set(CACHE_VAR_TYPE :${CACHE_VAR_TYPE})
       endif()
-      list(APPEND CMAKE_ARGS "-D${CACHE_VAR}${CACHE_VAR_TYPE}=${${CACHE_VAR}}")
+      # Escape CMake's ';' so a multi-path value (CMAKE_PREFIX_PATH) stays one argument
+      # instead of splitting; LIST_SEPARATOR below restores it.
+      string(REPLACE ";" "|" CACHE_VAR_VALUE "${${CACHE_VAR}}")
+      list(APPEND CMAKE_ARGS "-D${CACHE_VAR}${CACHE_VAR_TYPE}=${CACHE_VAR_VALUE}")
     endif()
   endforeach()
   message("-- CMAKE_ARGS: ${CMAKE_ARGS}")
   message("-- CMAKE_BUILD_TYPE: ${CMAKE_BUILD_TYPE}")
+
+  # Darwin-Initialize.cmake rewrites CMAKE_OSX_DEPLOYMENT_TARGET's helpstring, so the loop
+  # above never forwards it - pass it explicitly or sub-builds get the SDK default (#7732).
+  set(EDGETX_EP_CACHE_ARGS)
+  if(APPLE AND CMAKE_OSX_DEPLOYMENT_TARGET)
+    list(APPEND EDGETX_EP_CACHE_ARGS
+      -DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=${CMAKE_OSX_DEPLOYMENT_TARGET})
+  endif()
 
   # Add explicit targets for triggering cmake in the external projects
   set_property(DIRECTORY PROPERTY EP_STEP_TARGETS configure clean)
@@ -58,8 +69,10 @@ if(EdgeTX_SUPERBUILD)
   ExternalProject_Add(native
     SOURCE_DIR ${CMAKE_SOURCE_DIR}
     BINARY_DIR ${CMAKE_BINARY_DIR}/native
+    LIST_SEPARATOR |
     CMAKE_ARGS ${CMAKE_ARGS} -Wno-dev -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
     CMAKE_CACHE_ARGS
+      ${EDGETX_EP_CACHE_ARGS}
       -DCMAKE_TOOLCHAIN_FILE:FILEPATH=${CMAKE_SOURCE_DIR}/cmake/toolchain/native.cmake
       -DEdgeTX_SUPERBUILD:BOOL=0
       -DNATIVE_BUILD:BOOL=1
@@ -71,6 +84,7 @@ if(EdgeTX_SUPERBUILD)
   ExternalProject_Add(arm-none-eabi
     SOURCE_DIR ${CMAKE_SOURCE_DIR}
     BINARY_DIR ${CMAKE_BINARY_DIR}/arm-none-eabi
+    LIST_SEPARATOR |
     CMAKE_ARGS ${CMAKE_ARGS} -Wno-dev -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
     CMAKE_CACHE_ARGS
       -DCMAKE_TOOLCHAIN_FILE:FILEPATH=${CMAKE_SOURCE_DIR}/cmake/toolchain/arm-none-eabi.cmake

--- a/companion/targets/mac/MacOSXBundleInfo.plist.in
+++ b/companion/targets/mac/MacOSXBundleInfo.plist.in
@@ -34,6 +34,8 @@
 	<true/>
 
     <!-- added since cmake/qt do not add these by default -->
+    <key>LSMinimumSystemVersion</key>
+    <string>${CMAKE_OSX_DEPLOYMENT_TARGET}</string>
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
     <key>NSHighResolutionCapable</key>

--- a/companion/targets/mac/bundle_verify.cmake.in
+++ b/companion/targets/mac/bundle_verify.cmake.in
@@ -109,9 +109,10 @@ if(_toonew)
     "Re-run with -DCOMPANION_VERIFY_BUNDLE=OFF to package anyway.")
 endif()
 
-message(STATUS
-  "Bundle verification: ${_checked} Mach-O files, no external references, "
-  "minimum macOS ${_max_minos}")
+# CPack discards message(STATUS) from install scripts, so echo via a subprocess - otherwise
+# the bundle's real macOS floor never reaches the packaging log.
+execute_process(COMMAND ${CMAKE_COMMAND} -E echo
+  "-- Bundle verification: ${_checked} Mach-O files, no external references, minimum macOS ${_max_minos}")
 
 # The bundle seal is a separate concern from the per-Mach-O signatures: dyld does not consult
 # CodeResources when loading, so a stale seal does not stop the app launching. It would matter

--- a/companion/targets/mac/bundle_verify.cmake.in
+++ b/companion/targets/mac/bundle_verify.cmake.in
@@ -27,7 +27,10 @@ endif()
 file(GLOB_RECURSE _candidates "${_app}/Contents/*")
 
 set(_offenders "")
+set(_toonew "")
 set(_checked 0)
+set(_max_minos "0.0")
+set(_target_minos "@CMAKE_OSX_DEPLOYMENT_TARGET@")
 foreach(_file IN LISTS _candidates)
   if(IS_SYMLINK "${_file}" OR IS_DIRECTORY "${_file}")
     continue()
@@ -44,6 +47,25 @@ foreach(_file IN LISTS _candidates)
     continue()
   endif()
   math(EXPR _checked "${_checked} + 1")
+
+  # macOS refuses to launch an app stamped above the running system - that is how 2.12.3
+  # became "requires macOS 15.0 or later" (issue #7732).
+  execute_process(
+    COMMAND otool -l "${_file}"
+    OUTPUT_VARIABLE _otool_l_out
+    ERROR_QUIET
+    RESULT_VARIABLE _otool_l_res
+  )
+  if(_otool_l_res EQUAL 0 AND _otool_l_out MATCHES "minos ([0-9]+(\.[0-9]+)+)")
+    set(_minos "${CMAKE_MATCH_1}")
+    if(_minos VERSION_GREATER _max_minos)
+      set(_max_minos "${_minos}")
+    endif()
+    if(_target_minos AND _minos VERSION_GREATER _target_minos)
+      file(RELATIVE_PATH _rel "${_app}" "${_file}")
+      list(APPEND _toonew "${_rel}: minos ${_minos}")
+    endif()
+  endif()
 
   string(REPLACE "\n" ";" _lines "${_otool_out}")
   foreach(_line IN LISTS _lines)
@@ -77,7 +99,19 @@ if(_offenders)
     "Re-run with -DCOMPANION_VERIFY_BUNDLE=OFF to package anyway.")
 endif()
 
-message(STATUS "Bundle verification: ${_checked} Mach-O files, no external references")
+if(_toonew)
+  list(REMOVE_DUPLICATES _toonew)
+  string(REPLACE ";" "\n  " _report "${_toonew}")
+  message(FATAL_ERROR
+    "Bundle contains Mach-O files built for a newer macOS than the deployment target "
+    "(${_target_minos}) - macOS refuses to launch an app stamped above the running "
+    "system:\n  ${_report}\n"
+    "Re-run with -DCOMPANION_VERIFY_BUNDLE=OFF to package anyway.")
+endif()
+
+message(STATUS
+  "Bundle verification: ${_checked} Mach-O files, no external references, "
+  "minimum macOS ${_max_minos}")
 
 # The bundle seal is a separate concern from the per-Mach-O signatures: dyld does not consult
 # CodeResources when loading, so a stale seal does not stop the app launching. It would matter

--- a/tools/build-companion.sh
+++ b/tools/build-companion.sh
@@ -29,8 +29,11 @@ else
 fi
 
 COMMON_OPTIONS="${COMMON_OPTIONS} -DCMAKE_BUILD_TYPE=Release -DCMAKE_MESSAGE_LOG_LEVEL=WARNING -Wno-dev -DGVARS=YES -DHELI=YES -DLUA=YES"
+# Qt 6.9's frameworks are macOS 12, so the bundle cannot start below that anyway.
+# Exported as well as passed as -D: the superbuild's forwarding loop drops this one.
 if [ "$(uname)" = "Darwin" ]; then
-    COMMON_OPTIONS="${COMMON_OPTIONS} -DCMAKE_OSX_DEPLOYMENT_TARGET='11.0'"
+    export MACOSX_DEPLOYMENT_TARGET='12.0'
+    COMMON_OPTIONS="${COMMON_OPTIONS} -DCMAKE_OSX_DEPLOYMENT_TARGET='12.0'"
 fi
 
 # find_package(... CONFIG) skips the lib/cmake/<Name> search pattern for prefixes that only


### PR DESCRIPTION
Fixes #7732 — Companion 2.12.3 will not start on macOS below 15 ("The application requires macOS 15.0 or later").

### What actually broke

Reading `LC_BUILD_VERSION` out of the shipped DMGs:

| binary | 2.12.2 | 2.12.3 |
|---|---|---|
| `companion` executable | minos **10.15** | minos **15.0** |
| 51 / 55 `libedgetx-*-simulator.dylib` | minos **10.15** | minos **15.0** |
| bundled `libSDL2-2.0.0.dylib` / `libSDL3.dylib` | 14.0 (brew, x86_64 only) | **11.0, universal** ✅ |
| Qt frameworks | 12.0 | 12.0 |

**This is not the SDL3 packaging work** (#7549, #7653) — the bundled SDL copies are correct. Everything EdgeTX itself compiles lost its deployment target and got the Xcode 16 SDK default of 15.0. `MacOSXBundleInfo.plist.in` has no `LSMinimumSystemVersion`, so LaunchServices falls back to the executable's `minos`, which is where the error text comes from verbatim.

### Root cause

`build-companion.sh` passes `-DCMAKE_OSX_DEPLOYMENT_TARGET` only to the **top-level superbuild**. Companion and the plugins are compiled in the `native` `ExternalProject`, which only receives variables the forwarding loop collects by matching the helpstring `"No help, variable specified on the command line."`. CMake's `Platform/Darwin-Initialize.cmake` re-declares that variable as a documented cache entry, replacing the helpstring — so the loop skips it and the flag never reaches the compiler. Confirmed against CMake 3.31.6 and 4.3.3.

`main` is unaffected: it configures the native build directly (`cmake -B native -S ... -DEdgeTX_SUPERBUILD:BOOL=0`), and its artifact is minos 11.0.

### Changes

- **`tools/build-companion.sh`** — export `MACOSX_DEPLOYMENT_TARGET`, which `Darwin-Initialize.cmake` reads on *every* configure including nested ones.
- **`CMakeLists.txt`** — forward `CMAKE_OSX_DEPLOYMENT_TARGET` explicitly through `CMAKE_CACHE_ARGS` (native only; irrelevant to the ARM cross build).
- **Target 12.0 rather than 11.0** — Qt 6.9's frameworks are minos 12.0, so the bundle already cannot start below macOS 12, which is what the 2.12.3 release note tells users. One number instead of three. Nobody loses access. SDL stays at 11.0 (lower is safe, and it keeps the CI cache key intact).
- **`MacOSXBundleInfo.plist.in`** — declare `LSMinimumSystemVersion`, so macOS 11 gets a clear dialog instead of an opaque dyld failure.
- **`CMakeLists.txt`, separate defect** — `LIST_SEPARATOR` + `;` escaping when building `CMAKE_ARGS`. `-DCMAKE_PREFIX_PATH='<qt>;<sdl>'` was splitting into a truncated `-DCMAKE_PREFIX_PATH=<qt>` plus a stray positional argument, so the sub-build never saw the SDL prefix that `-D` was added to provide. Latent (SDL is still found via the environment copy), but the forwarding did not do what its comment claimed.
- **`bundle_verify.cmake.in`** — fail packaging if any Mach-O in the bundle is stamped above the deployment target, and report the bundle's real floor. This class of bug shipped precisely because nothing checked it; `setup-sdl.sh` already does the equivalent for the SDL libs, which is why those were correct.

### Verification

- Top-level superbuild configure now emits `CMAKE_ARGS: -DCMAKE_PREFIX_PATH=/opt/qt|/opt/sdl` as a single entry, and the generated nested configure command carries the full prefix path with no stray argument.
- `bundle_verify.cmake.in` parses under `cmake -P`; the minos matcher was exercised against real `otool -l` fragments — 15.0 flagged, 12.0/11.0 pass, and `LC_ID_DYLIB`'s `current version 2.32.10` correctly does not false-positive.
- Real check is CI: the new gate fails the packaging step if the fix did not take, so a green macOS build is the proof. Worth confirming the artifact's `EXECUTE` row and all 55 plugin dylibs read `12.0.0`, and asking the reporter (macOS 12.7.6, Intel) to try it.

### Follow-ups (not in this PR)

A follow-up PR against `main` should carry the `11.0` → `12.0` bump, the `bundle_verify` gate, `LSMinimumSystemVersion` and the `LIST_SEPARATOR` fix — everything here except the deployment-target propagation itself, which `main` does not need. Done via https://github.com/EdgeTX/edgetx/pull/7740, as this cannot be cherry-picked into main. 

### Final check

Now reports in CI
```
-- Bundle verification: 87 Mach-O files, no external references, minimum macOS 12.0
```

