### PR TITLE
chore(cpn): guard the macOS bundle's minimum system version

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,7 @@ if(EdgeTX_SUPERBUILD)
   ExternalProject_Add(native
     SOURCE_DIR ${CMAKE_SOURCE_DIR}
     BINARY_DIR ${CMAKE_BINARY_DIR}/native
+    LIST_SEPARATOR |
     CMAKE_ARGS ${CMAKE_ARGS} -Wno-dev -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
     CMAKE_CACHE_ARGS
       -DCMAKE_TOOLCHAIN_FILE:FILEPATH=${CMAKE_SOURCE_DIR}/cmake/toolchain/native.cmake
@@ -75,6 +76,7 @@ if(EdgeTX_SUPERBUILD)
   ExternalProject_Add(arm-none-eabi
     SOURCE_DIR ${CMAKE_SOURCE_DIR}
     BINARY_DIR ${CMAKE_BINARY_DIR}/arm-none-eabi
+    LIST_SEPARATOR |
     CMAKE_ARGS ${CMAKE_ARGS} -Wno-dev -DCMAKE_BUILD_TYPE=${CMAKE_BUILD_TYPE}
     CMAKE_CACHE_ARGS
       -DCMAKE_TOOLCHAIN_FILE:FILEPATH=${CMAKE_SOURCE_DIR}/cmake/toolchain/arm-none-eabi.cmake

--- a/cmake/Macros.cmake
+++ b/cmake/Macros.cmake
@@ -171,7 +171,10 @@ function(CollectCommandLineArgs out_var)
       else()
         set(_type :${_type})
       endif()
-      list(APPEND _args "-D${_var}${_type}=${${_var}}")
+      # Escape CMake's ';' so a multi-path value (CMAKE_PREFIX_PATH) stays one argument
+      # instead of splitting; callers pair this with LIST_SEPARATOR | to restore it.
+      string(REPLACE ";" "|" _value "${${_var}}")
+      list(APPEND _args "-D${_var}${_type}=${_value}")
     endif()
   endforeach()
   set(${out_var} ${_args} PARENT_SCOPE)

--- a/cmake/wasm/CMakeLists.txt
+++ b/cmake/wasm/CMakeLists.txt
@@ -25,6 +25,7 @@ include(ExternalProject)
 ExternalProject_Add(wasm
   SOURCE_DIR ${EDGETX_SOURCE_DIR}
   BINARY_DIR ${CMAKE_BINARY_DIR}/wasm-build
+  LIST_SEPARATOR |
   CMAKE_ARGS
     ${_forwarded_args}
     -Wno-dev

--- a/companion/targets/mac/MacOSXBundleInfo.plist.in
+++ b/companion/targets/mac/MacOSXBundleInfo.plist.in
@@ -34,6 +34,8 @@
 	<true/>
 
     <!-- added since cmake/qt do not add these by default -->
+    <key>LSMinimumSystemVersion</key>
+    <string>${CMAKE_OSX_DEPLOYMENT_TARGET}</string>
     <key>NSPrincipalClass</key>
     <string>NSApplication</string>
     <key>NSHighResolutionCapable</key>

--- a/companion/targets/mac/bundle_verify.cmake.in
+++ b/companion/targets/mac/bundle_verify.cmake.in
@@ -27,7 +27,10 @@ endif()
 file(GLOB_RECURSE _candidates "${_app}/Contents/*")
 
 set(_offenders "")
+set(_toonew "")
 set(_checked 0)
+set(_max_minos "0.0")
+set(_target_minos "@CMAKE_OSX_DEPLOYMENT_TARGET@")
 foreach(_file IN LISTS _candidates)
   if(IS_SYMLINK "${_file}" OR IS_DIRECTORY "${_file}")
     continue()
@@ -44,6 +47,30 @@ foreach(_file IN LISTS _candidates)
     continue()
   endif()
   math(EXPR _checked "${_checked} + 1")
+
+  # macOS refuses to launch an app stamped above the running system - that is how 2.12.3
+  # became "requires macOS 15.0 or later" (issue #7732).
+  execute_process(
+    COMMAND otool -l "${_file}"
+    OUTPUT_VARIABLE _otool_l_out
+    ERROR_QUIET
+    RESULT_VARIABLE _otool_l_res
+  )
+  # MATCHALL, not MATCHES: a universal binary reports one minos per slice and any of them
+  # can be the one that is wrong.
+  if(_otool_l_res EQUAL 0)
+    string(REGEX MATCHALL "minos [0-9]+(\.[0-9]+)+" _minos_all "${_otool_l_out}")
+    foreach(_entry IN LISTS _minos_all)
+      string(REPLACE "minos " "" _minos "${_entry}")
+      if(_minos VERSION_GREATER _max_minos)
+        set(_max_minos "${_minos}")
+      endif()
+      if(_target_minos AND _minos VERSION_GREATER _target_minos)
+        file(RELATIVE_PATH _rel "${_app}" "${_file}")
+        list(APPEND _toonew "${_rel}: minos ${_minos}")
+      endif()
+    endforeach()
+  endif()
 
   string(REPLACE "\n" ";" _lines "${_otool_out}")
   foreach(_line IN LISTS _lines)
@@ -77,7 +104,20 @@ if(_offenders)
     "Re-run with -DCOMPANION_VERIFY_BUNDLE=OFF to package anyway.")
 endif()
 
-message(STATUS "Bundle verification: ${_checked} Mach-O files, no external references")
+if(_toonew)
+  list(REMOVE_DUPLICATES _toonew)
+  string(REPLACE ";" "\n  " _report "${_toonew}")
+  message(FATAL_ERROR
+    "Bundle contains Mach-O files built for a newer macOS than the deployment target "
+    "(${_target_minos}) - macOS refuses to launch an app stamped above the running "
+    "system:\n  ${_report}\n"
+    "Re-run with -DCOMPANION_VERIFY_BUNDLE=OFF to package anyway.")
+endif()
+
+# CPack discards message(STATUS) from install scripts, so echo via a subprocess - otherwise
+# the bundle's real macOS floor never reaches the packaging log.
+execute_process(COMMAND ${CMAKE_COMMAND} -E echo
+  "-- Bundle verification: ${_checked} Mach-O files, no external references, minimum macOS ${_max_minos}")
 
 # The bundle seal is a separate concern from the per-Mach-O signatures: dyld does not consult
 # CodeResources when loading, so a stale seal does not stop the app launching. It would matter

--- a/tools/build-companion.sh
+++ b/tools/build-companion.sh
@@ -30,8 +30,9 @@ else
 fi
 
 COMMON_OPTIONS="${COMMON_OPTIONS} -DCMAKE_BUILD_TYPE=Release -DCMAKE_MESSAGE_LOG_LEVEL=WARNING -Wno-dev"
+# Qt 6.9's frameworks are macOS 12, so the bundle cannot start below that anyway.
 if [ "$(uname)" = "Darwin" ]; then
-  COMMON_OPTIONS="${COMMON_OPTIONS} -DCMAKE_OSX_DEPLOYMENT_TARGET='11.0'"
+  COMMON_OPTIONS="${COMMON_OPTIONS} -DCMAKE_OSX_DEPLOYMENT_TARGET='12.0'"
 fi
 
 # find_package(... CONFIG) skips the lib/cmake/<Name> search pattern for prefixes that only


### PR DESCRIPTION
Hardening counterpart to #7737, which fixes the 2.12 Companion regression reported in #7732 (2.12.3 shipped stamped `minos 15.0` and refused to launch below macOS 15).

**`main` is not affected by that bug.** Measured from `main`'s own CI artifact: the Companion executable is universal at `minos 11.0`, SDL at `11.0`, Qt at `12.0`, nothing at `15.0`. `main` configures the native build directly (`cmake -B native -S ... -DEdgeTX_SUPERBUILD:BOOL=0`), so the deployment target already lands on the compiler — the propagation fix in #7737 has no counterpart here and is deliberately not included.

What is included is everything that stops the same class of regression reaching `main`, plus a latent defect found alongside it.

### Changes

**Deployment target 11.0 → 12.0** (`tools/build-companion.sh`)
The bundled Qt 6.9 frameworks are `minos 12.0` in every DMG measured, so the app already cannot start below macOS 12 no matter what EdgeTX's own code targets. 11.0 buys nothing at runtime and leaves three different numbers in play. Nobody loses access. SDL stays at 11.0 — a lower floor on a dependency is harmless, and holding it steady avoids busting the CI cache key.

**Assert the floor at package time** (`companion/targets/mac/bundle_verify.cmake.in`)
The install-time check added in #7653 already walks every Mach-O in the bundle with `otool -L`. It now also reads `minos` from the same files and fails packaging if anything exceeds the deployment target. This is what would have caught #7732 before release, and it also catches a future Qt bump silently raising the floor.

The summary is echoed through `cmake -E echo` rather than `message(STATUS)`: CPack discards status output from install scripts, so the existing "no external references" line has never actually appeared in a CI log. The bundle's real floor is now recorded in every build.

**Declare the floor in the bundle** (`companion/targets/mac/MacOSXBundleInfo.plist.in`)
`LSMinimumSystemVersion` was absent, so LaunchServices fell back to the executable's own `minos` stamp — that fallback is why #7732 surfaced as the opaque "requires macOS 15.0 or later". Users below the floor now get a clean dialog.

**Keep `;`-separated values whole across the superbuild boundary** (`cmake/Macros.cmake`, `CMakeLists.txt`, `cmake/wasm/CMakeLists.txt`)
`CollectCommandLineArgs` appends `-D<var>=<value>` to a CMake list, so a value containing `;` — `CMAKE_PREFIX_PATH` with more than one prefix, which CI passes for Qt plus a source-built SDL — splits into extra entries; the sub-build sees only the first path and the rest arrive as stray positional arguments. Escaped at collection, restored by `LIST_SEPARATOR |` at all three consumers.

Dormant on `main` today (Companion does not go through the superbuild), but it is live code and it is the same file that broke on 2.12.

### Verification

Reproduced and fixed against the real macro with a two-project harness: outer `-DCMAKE_PREFIX_PATH='/opt/qt;/opt/sdl'` reaches the sub-build as `[/opt/qt]`, 1 entry, before the change and `[/opt/qt;/opt/sdl]`, 2 entries, after. Configuring the actual superbuild shows the escaped value surviving intact into `native-cfgcmd.txt`.

`bash -n` on the script, XML well-formedness on the plist, and `cmake -P` on the configured verify script all pass. The minos regex was checked against real `otool -l` output including an `LC_ID_DYLIB` fragment containing "current version 2.32.10", which it correctly ignores.

The macOS CI build here is the real test — a green package proves the new gate is satisfied, and the log line reports the floor.

Companion behaviour is unchanged apart from the macOS floor moving from an implied 12 to a declared 12.

### Results

CI now correctly indicates minimum version and verification status
```
-- Bundle verification: 32 Mach-O files, no external references, minimum macOS 12.0
```

