### PR TITLE
fix(lua): setRGBLedColor and LED_STRIP_LENGTH cover the bling leds only

### DIFF
--- a/radio/src/gui/gui_common.cpp
+++ b/radio/src/gui/gui_common.cpp
@@ -650,7 +650,8 @@ bool isAssignableFunctionAvailable(int function, bool modelFunctions)
     case FUNC_DISABLE_AUDIO_AMP:
       return false;
 #endif
-#if !defined(LED_STRIP_LENGTH)
+#if !defined(BLING_LED_STRIP_LENGTH) || (BLING_LED_STRIP_LENGTH == 0)
+    // No 'bling' leds to drive
     case FUNC_RGB_LED:
       return false;
 #endif

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -2913,11 +2913,12 @@ static int luaGetTrainerStatus(lua_State * L)
   #define CFS_LED_STRIP_LENGTH 0
 #endif
 
-#if (BLING_LED_STRIP_LENGTH > 0) || (CFS_LED_STRIP_LENGTH > 0)
+#if (BLING_LED_STRIP_LENGTH > 0)
 /*luadoc
 @function setRGBLedColor(id, rvalue, bvalue, cvalue)
 
-@param id: integer identifying a led in the led chain
+@param id: integer identifying a 'bling' led, 0 .. LED_STRIP_LENGTH-1.
+ Custom function switch leds are not reachable, use setCFSLedColor instead.
 
 @param rvalue: interger, value of red channel
 
@@ -2934,7 +2935,7 @@ static int luaSetRgbLedColor(lua_State * L)
 {
   uint8_t id = luaL_checkunsigned(L, 1);
 
-  if (id >= (BLING_LED_STRIP_LENGTH + CFS_LED_STRIP_LENGTH)) {
+  if (id >= BLING_LED_STRIP_LENGTH) {
     lua_pushboolean(L, false);
     return 1;
   }
@@ -2943,24 +2944,7 @@ static int luaSetRgbLedColor(lua_State * L)
   uint8_t g = luaL_checkunsigned(L, 3);
   uint8_t b = luaL_checkunsigned(L, 4);
 
-#if CFS_LED_STRIP_LENGTH > 0
-#if BLING_LED_STRIP_LENGTH > 0
-  if (id < BLING_LED_STRIP_LENGTH) {
-    rgbSetLedColor(id + BLING_LED_STRIP_START, r, g, b);
-    lua_pushboolean(L, true);
-    return 1;
-  }
-  id -= BLING_LED_STRIP_LENGTH;
-#endif
-  uint8_t swIdx = switchGetSwitchFromCustomIdx(id / CFS_LEDS_PER_SWITCH);
-  if (g_model.getSwitchType(swIdx) != SWITCH_NONE) {
-    lua_pushboolean(L, false);
-    return 1;
-  }
-  rgbSetLedColor(id + CFS_LED_STRIP_START, r, g, b);
-#else
   rgbSetLedColor(id + BLING_LED_STRIP_START, r, g, b);
-#endif
 
   lua_pushboolean(L, true);
   return 1;
@@ -3203,8 +3187,10 @@ LROT_BEGIN(etxlib, NULL, 0)
   LROT_FUNCENTRY( getSourceIndex, luaGetSourceIndex )
   LROT_FUNCENTRY( getSourceName, luaGetSourceName )
   LROT_FUNCENTRY( sources, luaSources )
-#if (BLING_LED_STRIP_LENGTH > 0) || (CFS_LED_STRIP_LENGTH > 0)
+#if (BLING_LED_STRIP_LENGTH > 0)
   LROT_FUNCENTRY( setRGBLedColor, luaSetRgbLedColor )
+#endif
+#if (BLING_LED_STRIP_LENGTH > 0) || (CFS_LED_STRIP_LENGTH > 0)
   LROT_FUNCENTRY( applyRGBLedColors, luaApplyRGBLedColors )
 #endif
 #if (CFS_LED_STRIP_LENGTH > 0)
@@ -3362,7 +3348,10 @@ LROT_BEGIN(etxcst, NULL, 0)
   LROT_NUMENTRY( PLAY_BACKGROUND, PLAY_BACKGROUND )
   LROT_NUMENTRY( TIMEHOUR, TIMEHOUR )
 #if (BLING_LED_STRIP_LENGTH > 0) || (CFS_LED_STRIP_LENGTH > 0)
-  LROT_NUMENTRY( LED_STRIP_LENGTH, BLING_LED_STRIP_LENGTH + CFS_LED_STRIP_LENGTH )
+  // Number of 'bling' LEDs, ie. the range setRGBLedColor() accepts. CFS LEDs
+  // are not part of it, they are driven by setCFSLedColor(). Kept defined,
+  // as 0, on radios that only have CFS LEDs.
+  LROT_NUMENTRY( LED_STRIP_LENGTH, BLING_LED_STRIP_LENGTH )
 #endif
   LROT_NUMENTRY( UNIT_RAW, UNIT_RAW )
   LROT_NUMENTRY( UNIT_VOLTS, UNIT_VOLTS )


### PR DESCRIPTION
This is adressing similar area as #7716, and thanks to David for highlighting that issue

The switch refactor (#6095) replaced the per-board 'strip length minus the function switch leds' expressions with BLING + CFS, so LED_STRIP_LENGTH started counting the CFS leds as well while setRGBLedColor() laid its id space out as bling first, CFS after. A script sweeping 0 .. LED_STRIP_LENGTH-1 therefore ran off the end of the bling strip and into the function switch leds: 26 instead of 20 on tx15/tx16smk3/gx15, 7 instead of 1 on t15pro/t22/v12, 12 instead of 4 on pa01, 24 instead of 12 on st16, 8 instead of 0 on gx12.

Restore the pre-refactor meaning: LED_STRIP_LENGTH is the bling led count, and setRGBLedColor() only reaches those. Function switch leds are driven by setCFSLedColor(). Dropping the CFS fall-through also removes an unchecked switchGetSwitchFromCustomIdx() result being fed to getSwitchType().

setRGBLedColor() is now registered only when there are bling leds, but LED_STRIP_LENGTH stays defined, as 0, on radios that only have CFS leds so existing sweep loops degrade to a no-op rather than failing on a nil value.

FUNC_RGB_LED is gated on the bling led count for the same reason, as the old RGB_LED_OFFSET check used to do.

