### PR TITLE
feat(tx16smk3): add PC-controlled RGB ring feedback

### DIFF
--- a/radio/src/boards/generic_stm32/rgb_leds.cpp
+++ b/radio/src/boards/generic_stm32/rgb_leds.cpp
@@ -43,6 +43,11 @@ static uint8_t _led_colors[RGBLEDS_BYTES_PER_LED * LED_STRIP_LENGTH];
 // Read only inside _flush_and_update() when a new frame has been published.
 static uint8_t _back_colors[RGBLEDS_BYTES_PER_LED * LED_STRIP_LENGTH];
 
+#if defined(BLING_LED_STRIP_LENGTH) && (BLING_LED_STRIP_LENGTH > 0)
+static constexpr uint32_t BLING_OVERRIDE_ACTIVE = 0x01000000u;
+static volatile uint32_t _bling_override = 0;
+#endif
+
 // Seqlock-style publish using a single counter:
 //   - LSB set (odd)  → menu task is mid-batch, back buffer not consistent
 //   - LSB clear (even) → frame is published; back buffer is stable
@@ -82,6 +87,19 @@ static void _flush_and_update()
     // Skip if mid-batch (odd) or already consumed.
     if ((seq & 1u) == 0u && seq != _consumed_seq) {
       memcpy(_led_colors, _back_colors, sizeof(_led_colors));
+#if defined(BLING_LED_STRIP_LENGTH) && (BLING_LED_STRIP_LENGTH > 0)
+      uint32_t override = _bling_override;
+      if ((override & BLING_OVERRIDE_ACTIVE) != 0u) {
+        uint8_t r = (override >> 16) & 0xffu;
+        uint8_t g = (override >> 8) & 0xffu;
+        uint8_t b = override & 0xffu;
+
+        for (uint8_t led = BLING_LED_STRIP_START;
+             led < BLING_LED_STRIP_START + BLING_LED_STRIP_LENGTH; ++led) {
+          rgbleds_set_color_in_buf(_led_colors, led, r, g, b);
+        }
+      }
+#endif
       _consumed_seq = seq;
     }
     rgbleds_update(&_led_timer);
@@ -159,6 +177,23 @@ bool rgbGetState(uint8_t led)
 {
   return rgbleds_get_state_in_buf(_back_colors, led);
 }
+
+#if defined(BLING_LED_STRIP_LENGTH) && (BLING_LED_STRIP_LENGTH > 0)
+void rgbSetBlingOverride(uint8_t r, uint8_t g, uint8_t b)
+{
+  _bling_override =
+      BLING_OVERRIDE_ACTIVE | (uint32_t(r) << 16) | (uint32_t(g) << 8) | b;
+  _begin_batch();
+  rgbLedColorApply();
+}
+
+void rgbClearBlingOverride()
+{
+  _bling_override = 0;
+  _begin_batch();
+  rgbLedColorApply();
+}
+#endif
 
 void rgbLedColorApply()
 {

--- a/radio/src/boards/generic_stm32/rgb_leds.h
+++ b/radio/src/boards/generic_stm32/rgb_leds.h
@@ -38,6 +38,11 @@ void rgbLedClearAll();
 bool rgbGetState(uint8_t led);
 void rgbLedColorApply();
 
+#if defined(BLING_LED_STRIP_LENGTH) && (BLING_LED_STRIP_LENGTH > 0)
+void rgbSetBlingOverride(uint8_t r, uint8_t g, uint8_t b);
+void rgbClearBlingOverride();
+#endif
+
 // Weak hook invoked by the LED refresh timer task before publishing the
 // next frame. Boards that drive system LEDs (e.g. the 6POS position
 // indicator) implement this to update their LEDs in the timer task

--- a/radio/src/hal/usb_driver.h
+++ b/radio/src/hal/usb_driver.h
@@ -66,6 +66,9 @@ extern const etx_serial_port_t UsbSerialPort;
 void usbJoystickRestart();
 #endif
 void usbJoystickUpdate();
+#if defined(STM32) && defined(USBJ_EX) && defined(RADIO_TX16SMK3)
+void usbProcessPcFeedback();
+#endif
 
 // USB DFU
 int usbRegisterDFUMedia(const void* dfu_media);

--- a/radio/src/main.cpp
+++ b/radio/src/main.cpp
@@ -564,6 +564,10 @@ void perMain()
 
   handleUsbConnection();
 
+#if defined(STM32) && defined(USBJ_EX) && defined(RADIO_TX16SMK3)
+  usbProcessPcFeedback();
+#endif
+
 #if defined(SHARED_DSC_HEADPHONE_JACK)
   handleJackConnection();
 #endif

--- a/radio/src/targets/common/arm/stm32/usb_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/usb_driver.cpp
@@ -39,6 +39,7 @@ extern "C" {
 
 #include "stm32_hal_ll.h"
 #include "stm32_hal.h"
+#include "timers_driver.h"
 
 #include "stm32_gpio.h"
 
@@ -80,6 +81,8 @@ static constexpr uint16_t PC_FEEDBACK_REPORT_SIZE = 8;
 static volatile uint8_t pcFeedbackReport[PC_FEEDBACK_REPORT_SIZE];
 static volatile bool pcFeedbackReportPending = false;
 static bool pcFeedbackOverrideActive = false;
+static constexpr tmr10ms_t PC_FEEDBACK_TIMEOUT_10MS = 500;
+static tmr10ms_t pcFeedbackLastActivity = 0;
 
 extern "C" void usbHidFeatureReportReceived(const uint8_t* data, uint16_t len)
 {
@@ -99,7 +102,16 @@ void usbProcessPcFeedback()
       pcFeedbackOverrideActive = false;
     }
     pcFeedbackReportPending = false;
+    pcFeedbackLastActivity = 0;
     return;
+  }
+
+  if (pcFeedbackOverrideActive &&
+      (tmr10ms_t)(get_tmr10ms() - pcFeedbackLastActivity) >=
+          PC_FEEDBACK_TIMEOUT_10MS) {
+    rgbClearBlingOverride();
+    pcFeedbackOverrideActive = false;
+    pcFeedbackLastActivity = 0;
   }
 
   if (!pcFeedbackReportPending) return;
@@ -122,6 +134,7 @@ void usbProcessPcFeedback()
   constexpr uint8_t PROTOCOL_VERSION = 1;
   constexpr uint8_t COMMAND_SET_COLOR = 1;
   constexpr uint8_t COMMAND_RELEASE = 2;
+  constexpr uint8_t COMMAND_KEEPALIVE = 3;
   constexpr uint8_t TARGET_GIMBAL_RINGS = 0;
 
   if (report[0] != PROTOCOL_VERSION ||
@@ -132,12 +145,22 @@ void usbProcessPcFeedback()
   switch (report[1]) {
     case COMMAND_SET_COLOR:
       rgbSetBlingOverride(report[3], report[4], report[5]);
+      pcFeedbackLastActivity = get_tmr10ms();
       pcFeedbackOverrideActive = true;
       break;
 
     case COMMAND_RELEASE:
-      rgbClearBlingOverride();
-      pcFeedbackOverrideActive = false;
+      if (pcFeedbackOverrideActive) {
+        rgbClearBlingOverride();
+        pcFeedbackOverrideActive = false;
+      }
+      pcFeedbackLastActivity = 0;
+      break;
+
+    case COMMAND_KEEPALIVE:
+      if (pcFeedbackOverrideActive) {
+        pcFeedbackLastActivity = get_tmr10ms();
+      }
       break;
   }
 }

--- a/radio/src/targets/common/arm/stm32/usb_driver.cpp
+++ b/radio/src/targets/common/arm/stm32/usb_driver.cpp
@@ -46,6 +46,10 @@ extern "C" {
 #include "hal/usb_driver.h"
 
 #include "hal.h"
+
+#if defined(RADIO_TX16SMK3) && !defined(BOOT)
+#include "boards/generic_stm32/rgb_leds.h"
+#endif
 #include "debug.h"
 
 #if defined(USE_USB_HS)
@@ -70,6 +74,74 @@ static bool usbDriverStarted = false;
 static usbMode selectedUsbMode = DEFAULT_USB_MODE;
 
 USBD_HandleTypeDef hUsbDevice;
+
+#if defined(RADIO_TX16SMK3) && !defined(BOOT)
+static constexpr uint16_t PC_FEEDBACK_REPORT_SIZE = 8;
+static volatile uint8_t pcFeedbackReport[PC_FEEDBACK_REPORT_SIZE];
+static volatile bool pcFeedbackReportPending = false;
+static bool pcFeedbackOverrideActive = false;
+
+extern "C" void usbHidFeatureReportReceived(const uint8_t* data, uint16_t len)
+{
+  if (data == nullptr || len != PC_FEEDBACK_REPORT_SIZE) return;
+
+  for (uint16_t i = 0; i < PC_FEEDBACK_REPORT_SIZE; ++i) {
+    pcFeedbackReport[i] = data[i];
+  }
+  pcFeedbackReportPending = true;
+}
+
+void usbProcessPcFeedback()
+{
+  if (!usbPluggedInJoystickMode()) {
+    if (pcFeedbackOverrideActive) {
+      rgbClearBlingOverride();
+      pcFeedbackOverrideActive = false;
+    }
+    pcFeedbackReportPending = false;
+    return;
+  }
+
+  if (!pcFeedbackReportPending) return;
+
+  uint8_t report[PC_FEEDBACK_REPORT_SIZE];
+  uint32_t primask = __get_PRIMASK();
+  __disable_irq();
+
+  if (!pcFeedbackReportPending) {
+    __set_PRIMASK(primask);
+    return;
+  }
+
+  for (uint16_t i = 0; i < PC_FEEDBACK_REPORT_SIZE; ++i) {
+    report[i] = pcFeedbackReport[i];
+  }
+  pcFeedbackReportPending = false;
+  __set_PRIMASK(primask);
+
+  constexpr uint8_t PROTOCOL_VERSION = 1;
+  constexpr uint8_t COMMAND_SET_COLOR = 1;
+  constexpr uint8_t COMMAND_RELEASE = 2;
+  constexpr uint8_t TARGET_GIMBAL_RINGS = 0;
+
+  if (report[0] != PROTOCOL_VERSION ||
+      report[2] != TARGET_GIMBAL_RINGS) {
+    return;
+  }
+
+  switch (report[1]) {
+    case COMMAND_SET_COLOR:
+      rgbSetBlingOverride(report[3], report[4], report[5]);
+      pcFeedbackOverrideActive = true;
+      break;
+
+    case COMMAND_RELEASE:
+      rgbClearBlingOverride();
+      pcFeedbackOverrideActive = false;
+      break;
+  }
+}
+#endif
 
 int getSelectedUsbMode()
 {

--- a/radio/src/targets/common/arm/stm32/usbd_hid_joystick.c
+++ b/radio/src/targets/common/arm/stm32/usbd_hid_joystick.c
@@ -160,8 +160,8 @@ USBD_ClassTypeDef USBD_HID =
 #if defined(USBJ_EX) && defined(RADIO_TX16SMK3)
   USBD_HID_EP0_RxReady, /* EP0_RxReady */
 #else
-  NULL,                  /* EP0_RxReady */
-#endif             /* EP0_RxReady */
+  NULL,              /* EP0_RxReady */
+#endif
   USBD_HID_DataIn,   /* DataIn */
   NULL,              /* DataOut */
   NULL,              /* SOF */
@@ -299,6 +299,9 @@ static uint8_t HIDInEpAdd = HID_EPIN_ADDR;
 static uint8_t USBD_HID_Init(USBD_HandleTypeDef *pdev, uint8_t cfgidx)
 {
   UNUSED(cfgidx);
+#if defined(USBJ_EX) && defined(RADIO_TX16SMK3)
+  HID_PC_FeatureReportPending = 0U;
+#endif
 #if defined(USBJ_EX)
   uint16_t hid_in_pkt_size = usbReportSize();
 #else

--- a/radio/src/targets/common/arm/stm32/usbd_hid_joystick.c
+++ b/radio/src/targets/common/arm/stm32/usbd_hid_joystick.c
@@ -26,6 +26,15 @@
 #include "usb_joystick.h"
 #endif
 
+#if defined(USBJ_EX) && defined(RADIO_TX16SMK3)
+#define HID_PC_FEEDBACK_REPORT_SIZE 8U
+#define HID_PC_FEEDBACK_SET_REPORT 0x09U
+#define HID_PC_FEEDBACK_REPORT_VALUE 0x0300U
+
+static uint8_t HID_PC_FeatureReport[HID_PC_FEEDBACK_REPORT_SIZE];
+static uint8_t HID_PC_FeatureReportPending;
+#endif
+
 /** @addtogroup STM32_USB_DEVICE_LIBRARY
   * @{
   */
@@ -68,6 +77,9 @@
 static uint8_t USBD_HID_Init(USBD_HandleTypeDef *pdev, uint8_t cfgidx);
 static uint8_t USBD_HID_DeInit(USBD_HandleTypeDef *pdev, uint8_t cfgidx);
 static uint8_t USBD_HID_Setup(USBD_HandleTypeDef *pdev, USBD_SetupReqTypedef *req);
+#if defined(USBJ_EX) && defined(RADIO_TX16SMK3)
+static uint8_t USBD_HID_EP0_RxReady(USBD_HandleTypeDef *pdev);
+#endif
 static uint8_t USBD_HID_DataIn(USBD_HandleTypeDef *pdev, uint8_t epnum);
 #ifndef USE_USBD_COMPOSITE
 static uint8_t *USBD_HID_GetFSCfgDesc(uint16_t *length);
@@ -145,7 +157,11 @@ USBD_ClassTypeDef USBD_HID =
   USBD_HID_DeInit,
   USBD_HID_Setup,
   NULL,              /* EP0_TxSent */
-  NULL,              /* EP0_RxReady */
+#if defined(USBJ_EX) && defined(RADIO_TX16SMK3)
+  USBD_HID_EP0_RxReady, /* EP0_RxReady */
+#else
+  NULL,                  /* EP0_RxReady */
+#endif             /* EP0_RxReady */
   USBD_HID_DataIn,   /* DataIn */
   NULL,              /* DataOut */
   NULL,              /* SOF */
@@ -390,6 +406,21 @@ static uint8_t USBD_HID_Setup(USBD_HandleTypeDef *pdev, USBD_SetupReqTypedef *re
           (void)USBD_CtlSendData(pdev, (uint8_t *)&hhid->IdleState, 1U);
           break;
 
+#if defined(USBJ_EX) && defined(RADIO_TX16SMK3)
+    case HID_PC_FEEDBACK_SET_REPORT:
+      if ((req->wValue != HID_PC_FEEDBACK_REPORT_VALUE) ||
+          (req->wLength != HID_PC_FEEDBACK_REPORT_SIZE)) {
+        USBD_CtlError(pdev, req);
+        ret = USBD_FAIL;
+        break;
+      }
+
+      HID_PC_FeatureReportPending = 1U;
+      (void)USBD_CtlPrepareRx(
+          pdev, HID_PC_FeatureReport, HID_PC_FEEDBACK_REPORT_SIZE);
+      break;
+#endif
+
         default:
           USBD_CtlError(pdev, req);
           ret = USBD_FAIL;
@@ -613,6 +644,19 @@ static uint8_t *USBD_HID_GetOtherSpeedCfgDesc(uint16_t *length)
   return USBD_HID_GetFSCfgDesc(length);
 }
 #endif /* USE_USBD_COMPOSITE  */
+
+#if defined(USBJ_EX) && defined(RADIO_TX16SMK3)
+static uint8_t USBD_HID_EP0_RxReady(USBD_HandleTypeDef *pdev)
+{
+  if (HID_PC_FeatureReportPending != 0U) {
+    usbHidFeatureReportReceived(
+        HID_PC_FeatureReport, HID_PC_FEEDBACK_REPORT_SIZE);
+    HID_PC_FeatureReportPending = 0U;
+  }
+
+  return (uint8_t)USBD_OK;
+}
+#endif
 
 /**
   * @brief  USBD_HID_DataIn

--- a/radio/src/usb_joystick.cpp
+++ b/radio/src/usb_joystick.cpp
@@ -28,7 +28,7 @@
 
 #include <cmath>
 
-#define MAX_HID_REPORTDESC 160
+#define MAX_HID_REPORTDESC 192
 #define MAX_HID_REPORT 80
 
 uint8_t* _hidReportDesc = nullptr;
@@ -159,6 +159,18 @@ static const uint8_t HID_JOYSTICK_ReportDesc[] =
     0x81, 0x02,                    //       INPUT (Data,Var,Abs)
     0xc0                           //     END_COLLECTION
 };
+
+#if defined(RADIO_TX16SMK3)
+static const uint8_t HID_PC_FEEDBACK_ReportDesc[] = {
+  0x06, 0x00, 0xff,  // USAGE_PAGE (Vendor Defined 0xff00)
+  0x09, 0x01,        // USAGE (1)
+  0x15, 0x00,        //   LOGICAL_MINIMUM (0)
+  0x26, 0xff, 0x00,  //   LOGICAL_MAXIMUM (255)
+  0x75, 0x08,        //   REPORT_SIZE (8)
+  0x95, 0x08,        //   REPORT_COUNT (8)
+  0xb1, 0x02,        //   FEATURE (Data,Var,Abs)
+};
+#endif
 // clang-format on
 
 // clang-format off
@@ -509,7 +521,12 @@ int setupUSBJoystick()
       _hidReportDescSize += sizeof(HID_JOYSTICK_DpadDesc);
       _hidReportSize += 1;
     }
-
+#if defined(RADIO_TX16SMK3)
+    memcpy(_hidReportDesc + _hidReportDescSize,
+           HID_PC_FEEDBACK_ReportDesc,
+           sizeof(HID_PC_FEEDBACK_ReportDesc));
+    _hidReportDescSize += sizeof(HID_PC_FEEDBACK_ReportDesc);
+#endif
     // END_COLLECTION
     _hidReportDesc[_hidReportDescSize++] = 0xc0;
 

--- a/radio/src/usb_joystick.cpp
+++ b/radio/src/usb_joystick.cpp
@@ -28,7 +28,11 @@
 
 #include <cmath>
 
+#if defined(RADIO_TX16SMK3)
 #define MAX_HID_REPORTDESC 192
+#else
+#define MAX_HID_REPORTDESC 160
+#endif
 #define MAX_HID_REPORT 80
 
 uint8_t* _hidReportDesc = nullptr;

--- a/radio/src/usb_joystick.h
+++ b/radio/src/usb_joystick.h
@@ -111,6 +111,7 @@ extern "C" {
 #endif
 struct usbReport_t usbReportDesc();
 uint8_t usbReportSize();
+void usbHidFeatureReportReceived(const uint8_t* data, uint16_t len);
 #ifdef __cplusplus
 }
 #endif

--- a/radio/src/usb_joystick.h
+++ b/radio/src/usb_joystick.h
@@ -111,7 +111,9 @@ extern "C" {
 #endif
 struct usbReport_t usbReportDesc();
 uint8_t usbReportSize();
+#if defined(RADIO_TX16SMK3)
 void usbHidFeatureReportReceived(const uint8_t* data, uint16_t len);
+#endif
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
##  Summary of changes:

Adds host-to-radio RGB feedback for the RadioMaster TX16S MK3 through the existing Advanced USB Joystick HID interface.

- Adds an 8-byte vendor-defined HID Feature Report to Advanced Joystick mode on the TX16S MK3.
- Supports setting one color across all 20 gimbal-ring LEDs, explicitly releasing PC control, and refreshing the override with a keepalive.
- Individual ring-LED control is not included.
- Automatically releases the PC override after five seconds without a valid set-color or keepalive command.
- Immediately releases the override when USB Joystick mode disconnects.
- Applies the PC color as a front-buffer overlay, allowing EdgeTX and Lua to continue updating their normal back-buffer state.
- Leaves the six customizable function-switch LEDs under EdgeTX control.
- Restores the current EdgeTX-controlled ring color immediately when the override is released.
- Keeps the Classic Joystick report descriptor unchanged.
- Limits the increased HID descriptor allocation to the TX16S MK3.

## Motivation

Allow PC simulators and desktop applications to provide visual status feedback through the TX16S MK3's built-in gimbal-ring LEDs while using the radio as a USB joystick, without requiring separate LED hardware.


## Feature Report payload

| Byte | Meaning |
| --- | --- |
| 0 | Protocol version (`1`) |
| 1 | Command |
| 2 | Target (`0` = all gimbal-ring LEDs) |
| 3 | Red |
| 4 | Green |
| 5 | Blue |
| 6–7 | Reserved |

## Commands

| Value | Command |
| --- | --- |
| `1` | Set color and refresh the timeout |
| `2` | Release the override |
| `3` | Keepalive; refresh an active override without changing its color |

## Testing

- Built successfully for `PCB=TX16SMK3` using the EdgeTX Docker development image.
- Flashed and tested on a RadioMaster TX16S MK3.
- Verified simultaneous Advanced Joystick axis/button input and RGB updates.
- Verified operation while the EdgeTX RGB LED special function is enabled, without color flickering.
- Verified explicit release restores the current EdgeTX color.
- Verified inactivity restores EdgeTX control after approximately five seconds.
- Verified USB disconnection restores EdgeTX control.
- Verified repeated delayed keepalives maintain the override.
- Verified the radio boots and operates normally after flashing.

Final local firmware build SHA-256:

`abf0c64d300e40c9db5046df29f4d61d2c467de3a41dd589c333dcbc9da7ccaa`