### PR TITLE
fix(gx15): missing internalgps wiring

### DIFF
--- a/radio/src/targets/gx15/CMakeLists.txt
+++ b/radio/src/targets/gx15/CMakeLists.txt
@@ -7,6 +7,7 @@ option(GHOST "Ghost TX Module" ON)
 option(MODULE_SIZE_STD "Standard size TX Module" ON)
 option(LUA_MIXER "Enable LUA mixer/model scripts support" ON)
 option(DISK_CACHE "Enable SD card disk cache" ON)
+option(INTERNAL_GPS "Support for internal GPS" ON)
 option(STICK_DEAD_ZONE "Enable sticks dead zone" OFF)
 
 set(FIRMWARE_QSPI YES)
@@ -27,6 +28,7 @@ set(HARDWARE_EXTERNAL_MODULE YES)
 set(INTERNAL_MODULE_AFHDS3 NO)
 set(ROTARY_ENCODER YES)
 set(FUNCTION_SWITCHES_WITH_RGB YES)
+set(INTERNAL_GPS_BAUDRATE "9600" CACHE STRING "Baud rate for internal GPS")
 
 # IMU support
 set(IMU ON)
@@ -79,7 +81,6 @@ set(SDRAM ON)
 
 add_definitions(-DRTCLOCK)
 add_definitions(-DPWR_BUTTON_${PWR_BUTTON})
-add_definitions(-DGPS_USART_BAUDRATE=${INTERNAL_GPS_BAUDRATE})
 
 if(STICK_DEAD_ZONE)
   add_definitions(-DSTICK_DEAD_ZONE)
@@ -92,6 +93,13 @@ endif()
 if(DISK_CACHE)
   set(SRC ${SRC} disk_cache.cpp)
   add_definitions(-DDISK_CACHE)
+endif()
+
+if(INTERNAL_GPS)
+  message("-- Internal GPS enabled")
+  add_definitions(-DINTERNAL_GPS)
+  set(SRC ${SRC} gps.cpp gps_nmea.cpp gps_ubx.cpp)
+  add_definitions(-DGPS_USART_BAUDRATE=${INTERNAL_GPS_BAUDRATE})
 endif()
 
 if(FUNCTION_SWITCHES_WITH_RGB)


### PR DESCRIPTION
Summary of changes:
- GX15 was missing wiring for internal GPS... but did have a loose `add_definitions(-DGPS_USART_BAUDRATE=${INTERNAL_GPS_BAUDRATE})` knocking around