### PR TITLE
fix(cpn): update in-app updater's macOS asset filename pattern from osx to macos

### DIFF
--- a/companion/src/updates/updatecompanion.cpp
+++ b/companion/src/updates/updatecompanion.cpp
@@ -31,7 +31,7 @@
 
 #if defined(__APPLE__)
   #define OS_SUPPORTED_INSTALLER
-  #define OS_FILEPATTERN           "edgetx-cpn-osx"
+  #define OS_FILEPATTERN           "edgetx-cpn-macos"
   #define OS_INSTALLER_EXTN        "*.dmg"
   #define OS_INSTALL_QUESTION      QCoreApplication::translate("UpdateCompanion", "Would you like to open the disk image to install the new version of Companion?")
 #elif defined(_WIN64)


### PR DESCRIPTION
## Summary
- The macOS Companion release artifact was renamed from `edgetx-cpn-osx-*` to `edgetx-cpn-macos-*` in #6435 (main) / #7198 (2.12), which switched the CI packaging over to the shared `companion.yml` orchestrator + `build_companion` action (`os: 'macos'`).
- Companion's in-app updater (`companion/src/updates/updatecompanion.cpp`) was never updated to match, and still filtered GitHub release assets using the old `edgetx-cpn-osx` pattern (`OS_FILEPATTERN`, consumed as a `QRegularExpression` in `updateinterface.cpp`).
- As a result, the in-app update check/download flow can no longer find the macOS release asset.
- This updates `OS_FILEPATTERN` to `edgetx-cpn-macos` to match the current artifact naming.

## Test plan
- [x] Verified via `grep` that no other references to `edgetx-cpn-osx` remain in `companion/src/`.
- [x] Built Companion locally (`tools/build-companion.sh`) with this change — `companion30` compiles and links cleanly with the new pattern.
- [ ] CI build for macOS/Linux/Windows Companion targets passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)