### PR TITLE
chore: RadioMaster TX16S, add TX16S Mark II to display name

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -140,7 +140,7 @@ body:
         - RadioMaster T8
         - RadioMaster TX12 / TX12MK2
         - RadioMaster TX15
-        - RadioMaster TX16S / TX16SMK2
+        - RadioMaster TX16S / TX16S Mark II
         - RadioMaster TX16S MK3
         - RadioMaster Zorro
         - Other (Please specify below)

--- a/fw.json
+++ b/fw.json
@@ -40,7 +40,7 @@
         ["RadioMaster Pocket", "pocket-"],
         ["RadioMaster TX12MK2", "tx12mk2-"],
         ["RadioMaster TX15", "tx15-"],
-        ["RadioMaster TX16S", "tx16s-"],
+        ["RadioMaster TX16S / TX16S Mark II", "tx16s-"],
         ["RadioMaster TX16S MK3", "tx16smk3-"],
         ["RadioMaster Zorro","zorro-"]
     ],

--- a/web/public/radios.json
+++ b/web/public/radios.json
@@ -6005,7 +6005,7 @@
     ]
   },
   {
-    "name": "RadioMaster TX16S",
+    "name": "RadioMaster TX16S / TX16S Mark II",
     "wasm": "edgetx-tx16s-simulator.wasm",
     "display": {
       "w": 480,


### PR DESCRIPTION
## Summary
- The TX16S and TX16S Mark II share the same `tx16s-` firmware target, but `fw.json`'s display name only mentioned the TX16S.
- Updates the label in `fw.json` to `RadioMaster TX16S / TX16S Mark II`, matching RadioMaster's actual product branding.
- Also fixes `.github/ISSUE_TEMPLATE/bug-report.yml`, which previously used the incorrect `TX16SMK2` form.
- Also updates `web/public/radios.json`'s `tx16s` entry name to match, since it's generated from `fw.json` (`web/scripts/gen-radios-json.js`) and the "Codegen drift" CI check would otherwise flag it as out of sync.
- Display-label-only change — no functional or build impact, matching logic uses the `tx16s-` prefix, not this string.

## Test plan
- [x] `fw.json` and `web/public/radios.json` re-validated as valid JSON after the edit.
- [x] Confirmed no code paths key off this display string (only the `tx16s-` prefix is used for matching).
- [x] `web/public/radios.json` change mirrors exactly what `just gen-radios` would regenerate (only the `name` field changes; `fw.json`'s prefix and the underlying hw_defs are unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)