### PR TITLE
feat(v12): add AUX1 serial port on UART4

### DIFF
--- a/radio/src/targets/v12/CMakeLists.txt
+++ b/radio/src/targets/v12/CMakeLists.txt
@@ -72,7 +72,8 @@ add_definitions(
 
 set(SDRAM ON)
 
-set(AUX_SERIAL OFF CACHE BOOL "AUX serial port" FORCE)
+# UART4 on the internal 3-pin header (no switchable power rail)
+set(AUX_SERIAL YES)
 
 # Handset supports external antenna selection via hardware GPIO switch
 set(EXTERNAL_ANTENNA ON)

--- a/radio/src/targets/v12/hal.h
+++ b/radio/src/targets/v12/hal.h
@@ -24,11 +24,11 @@ STM32H750
 DMA1
 Stream0:  LED_STRIP_TIMER_DMA_STREAM
 Stream1:  INTMODULE_DMA_STREAM
-Stream2:  (free)
+Stream2:  AUX_SERIAL_DMA_RX_STREAM
 Stream3:  TELEMETRY_DMA_Stream_RX
 Stream4:  LCD_SPI_TX_DMA_STREAM
 Stream5:  INTMODULE_RX_DMA_STREAM / LCD_SPI_RX_DMA_STREAM
-Stream6:
+Stream6:  AUX_SERIAL_DMA_TX_STREAM
 Stream7:  TELEMETRY_DMA_Stream_TX
 
 DMA2
@@ -59,6 +59,7 @@ USARTS
 USART1: TELEMETRY_USART
 USART2: INTMODULE_USART
 USART6: EXTMODULE_USART
+UART4:  AUX_SERIAL_USART (external 3-pin header, PH13/PH14)
 */
 
 #ifndef _HAL_H_
@@ -253,6 +254,22 @@ USART6: EXTMODULE_USART
 #define EXTMODULE_TIMER_DMA_STREAM         LL_DMA_STREAM_3
 #define EXTMODULE_TIMER_DMA_STREAM_IRQn    DMA2_Stream3_IRQn
 #define EXTMODULE_TIMER_DMA_IRQHandler     DMA2_Stream3_IRQHandler
+
+// AUX ports
+// UART4 is broken out to the 3-pin GND/TXD/RXD header on the main board.
+// There is no switchable power rail on this connector, so AUX_SERIAL_PWR_GPIO
+// is deliberately not defined.
+#define AUX_SERIAL_TX_GPIO                 GPIO_PIN(GPIOH, 13) // PH.13
+#define AUX_SERIAL_RX_GPIO                 GPIO_PIN(GPIOH, 14) // PH.14
+#define AUX_SERIAL_USART                   UART4
+#define AUX_SERIAL_USART_IRQHandler        UART4_IRQHandler
+#define AUX_SERIAL_USART_IRQn              UART4_IRQn
+#define AUX_SERIAL_DMA_TX                  DMA1
+#define AUX_SERIAL_DMA_TX_STREAM           LL_DMA_STREAM_6
+#define AUX_SERIAL_DMA_TX_CHANNEL          LL_DMAMUX1_REQ_UART4_TX
+#define AUX_SERIAL_DMA_RX                  DMA1
+#define AUX_SERIAL_DMA_RX_STREAM           LL_DMA_STREAM_2
+#define AUX_SERIAL_DMA_RX_CHANNEL          LL_DMAMUX1_REQ_UART4_RX
 
 // Trainer Port
 #define TRAINER_IN_GPIO                 GPIO_PIN(GPIOD, 13)  // TIM4_CH2


### PR DESCRIPTION
Fixes #7760

Summary of changes:

The V12 main board has a 3-pin GND/TXD/RXD header on UART4 (PH13 = TXD,
PH14 = RXD), but the target was built with `AUX_SERIAL` forced off, so the
header could not be used for anything. This enables it as AUX1.

- `radio/src/targets/v12/CMakeLists.txt`: `set(AUX_SERIAL YES)` instead of
  the forced `OFF`, same as tx16smk3 / gx15 / tx15.
- `radio/src/targets/v12/hal.h`: `AUX_SERIAL_*` definitions for UART4 on
  PH13/PH14 with DMA1 stream 6 (TX) and stream 2 (RX) through DMAMUX, and the
  DMA/USART tables in the header comment updated to match.

UART4, PH13/PH14 and DMA1 streams 2 and 6 were all unused on this target, so
nothing else moves. The header carries only GND/TXD/RXD; a module is powered
from the always-on 3.3 V pin of the unpopulated IMU header next to it, so
there is no switchable supply, `AUX_SERIAL_PWR_GPIO` is deliberately not
defined, and no power toggle is offered for the port.

Note that the header is inside the case (back cover off to reach it). The
issue asks whether an internal-only header is acceptable as an always-on AUX
port; if not, I will change this to a plain `option(AUX_SERIAL ... OFF)` so
it can at least be enabled in a local build, which the current `FORCE`
prevents.

No Companion change: `HasAuxSerialMode` is already true for
`BOARD_HELLORADIOSKY_V12` through `IS_FAMILY_T16`, so the Serial ports
hardware settings already exist on the Companion side.

## Testing

HelloRadioSky V12 (STM32H750), DX-BT24 Bluetooth module on the header:

- SYS → HARDWARE → Serial ports now lists AUX1 with the usual modes.
- Telemetry mirror at 115200 to an Android telemetry app (Ghost external
  module).
- Lua serial in both directions (`serialWrite()` / `serialRead()`) driving the
  module's AT command set.
- Firmware built from this branch on current `main`; the same definition has
  been running on my radio since late July on the pre-merge V12 branch.

The same two-file change applies cleanly to 2.12, where the V12 target also
exists (#7113); happy to open a backport PR if wanted.
