### PR TITLE
fix(fw): make editing date & time easier

### DIFF
--- a/radio/src/gui/128x64/radio_setup.cpp
+++ b/radio/src/gui/128x64/radio_setup.cpp
@@ -158,8 +158,12 @@ uint8_t viewOptCheckBox(coord_t y, const char* title, uint8_t value, uint8_t att
 void menuRadioSetup(event_t event)
 {
 #if defined(RTCLOCK)
-  struct gtm t;
-  gettime(&t);
+  static struct gtm t;
+  struct gtm ct;
+  gettime(&ct);
+
+  if (event == EVT_ENTRY)
+    t = ct;
 
   if ((menuVerticalPosition == ITEM_RADIO_SETUP_DATE + HEADER_LINE ||
        menuVerticalPosition == ITEM_RADIO_SETUP_TIME + HEADER_LINE) &&
@@ -306,11 +310,13 @@ void menuRadioSetup(event_t event)
               lcdDrawNumber(RADIO_SETUP_2ND_COLUMN-2, y, t.tm_year+TM_YEAR_BASE, rowattr);
               lcdDrawChar(lcdNextPos, y, '-');
               if (rowattr && s_editMode > 0) t.tm_year = checkIncDec(event, t.tm_year, 123, 137, 0);
+              else t.tm_year = ct.tm_year;
               break;
             case 1:
               lcdDrawNumber(lcdNextPos, y, t.tm_mon+1, rowattr|LEADING0, 2);
               lcdDrawChar(lcdNextPos, y, '-');
               if (rowattr && s_editMode > 0) t.tm_mon = checkIncDec(event, t.tm_mon, 0, 11, 0);
+              else t.tm_mon = ct.tm_mon;
               break;
             case 2:
             {
@@ -320,6 +326,7 @@ void menuRadioSetup(event_t event)
               dlim += dmon[t.tm_mon];
               lcdDrawNumber(lcdNextPos, y, t.tm_mday, rowattr|LEADING0, 2);
               if (rowattr && s_editMode > 0) t.tm_mday = checkIncDec(event, t.tm_mday, 1, dlim, 0);
+              else t.tm_mday = ct.tm_mday;
               break;
             }
           }
@@ -338,15 +345,18 @@ void menuRadioSetup(event_t event)
               lcdDrawNumber(LCD_W-6*FW-5, y, t.tm_hour, rowattr|LEADING0, 2);
               lcdDrawChar(lcdNextPos + 1, y, ':');
               if (rowattr && s_editMode > 0) t.tm_hour = checkIncDec(event, t.tm_hour, 0, 23, 0);
+              else t.tm_hour = ct.tm_hour;
               break;
             case 1:
               lcdDrawNumber(lcdNextPos + 1, y, t.tm_min, rowattr|LEADING0, 2);
               lcdDrawChar(lcdNextPos + 1, y, ':');
               if (rowattr && s_editMode > 0) t.tm_min = checkIncDec(event, t.tm_min, 0, 59, 0);
+              else t.tm_min = ct.tm_min;
               break;
             case 2:
               lcdDrawNumber(lcdNextPos + 1, y, t.tm_sec, rowattr|LEADING0, 2);
               if (rowattr && s_editMode > 0) t.tm_sec = checkIncDec(event, t.tm_sec, 0, 59, 0);
+              else t.tm_sec = ct.tm_sec;
               break;
           }
         }

--- a/radio/src/gui/212x64/radio_setup.cpp
+++ b/radio/src/gui/212x64/radio_setup.cpp
@@ -166,8 +166,12 @@ uint8_t viewOptCheckBox(coord_t y, const char* title, uint8_t value, uint8_t att
 void menuRadioSetup(event_t event)
 {
 #if defined(RTCLOCK)
-  struct gtm t;
-  gettime(&t);
+  static struct gtm t;
+  struct gtm ct;
+  gettime(&ct);
+
+  if (event == EVT_ENTRY)
+    t = ct;
 
   if ((menuVerticalPosition==ITEM_RADIO_SETUP_DATE || menuVerticalPosition==ITEM_RADIO_SETUP_TIME) &&
       (s_editMode>0) &&
@@ -313,10 +317,12 @@ void menuRadioSetup(event_t event)
             case 0:
               lcdDrawNumber(RADIO_SETUP_DATE_COLUMN, y, t.tm_year+TM_YEAR_BASE, rowattr|RIGHT);
               if (rowattr && s_editMode>0) t.tm_year = checkIncDec(event, t.tm_year, 123, 137, 0);
+              else t.tm_year = ct.tm_year;
               break;
             case 1:
               lcdDrawNumber(RADIO_SETUP_DATE_COLUMN+3*FW-2, y, t.tm_mon+1, rowattr|LEADING0|RIGHT, 2);
               if (rowattr && s_editMode>0) t.tm_mon = checkIncDec(event, t.tm_mon, 0, 11, 0);
+              else t.tm_mon = ct.tm_mon;
               break;
             case 2:
             {
@@ -326,6 +332,7 @@ void menuRadioSetup(event_t event)
               dlim += dmon[t.tm_mon];
               lcdDrawNumber(RADIO_SETUP_DATE_COLUMN+6*FW-4, y, t.tm_mday, rowattr|LEADING0|RIGHT, 2);
               if (rowattr && s_editMode>0) t.tm_mday = checkIncDec(event, t.tm_mday, 1, dlim, 0);
+              else t.tm_mday = ct.tm_mday;
               break;
             }
           }
@@ -345,14 +352,17 @@ void menuRadioSetup(event_t event)
             case 0:
               lcdDrawNumber(RADIO_SETUP_TIME_COLUMN, y, t.tm_hour, rowattr|LEADING0|RIGHT, 2);
               if (rowattr && s_editMode>0) t.tm_hour = checkIncDec(event, t.tm_hour, 0, 23, 0);
+              else t.tm_hour = ct.tm_hour;
               break;
             case 1:
               lcdDrawNumber(RADIO_SETUP_TIME_COLUMN+3*FWNUM, y, t.tm_min, rowattr|LEADING0|RIGHT, 2);
               if (rowattr && s_editMode>0) t.tm_min = checkIncDec(event, t.tm_min, 0, 59, 0);
+              else t.tm_min = ct.tm_min;
               break;
             case 2:
               lcdDrawNumber(RADIO_SETUP_TIME_COLUMN+6*FWNUM, y, t.tm_sec, rowattr|LEADING0|RIGHT, 2);
               if (rowattr && s_editMode>0) t.tm_sec = checkIncDec(event, t.tm_sec, 0, 59, 0);
+              else t.tm_sec = ct.tm_sec;
               break;
           }
         }

--- a/radio/src/gui/colorlcd/libui/numberedit.cpp
+++ b/radio/src/gui/colorlcd/libui/numberedit.cpp
@@ -231,6 +231,7 @@ NumberEdit::NumberEdit(Window* parent, const rect_t& rect, int vmin, int vmax,
 
 void NumberEdit::openEdit()
 {
+  if (onEditStart) onEditStart();
   if (edit == nullptr) {
     edit = new NumberArea(
         this,

--- a/radio/src/gui/colorlcd/libui/numberedit.h
+++ b/radio/src/gui/colorlcd/libui/numberedit.h
@@ -94,6 +94,11 @@ class NumberEdit : public TextButton
     onEdited = std::move(handler);
   }
 
+  void setOnEditStartHandler(std::function<void()> handler)
+  {
+    onEditStart = std::move(handler);
+  }
+
   int32_t getValue() const { return _getValue != nullptr ? _getValue() : 0; }
 
  protected:
@@ -103,6 +108,7 @@ class NumberEdit : public TextButton
   std::function<int()> _getValue;
   std::function<void(int)> _setValue;
   std::function<void(int)> onEdited;
+  std::function<void()> onEditStart;
   int vdefault = 0;
   int vmin;
   int vmax;

--- a/radio/src/gui/colorlcd/radio/radio_setup.cpp
+++ b/radio/src/gui/colorlcd/radio/radio_setup.cpp
@@ -55,26 +55,37 @@ class DateNumberEdit : public NumberEdit
                   std::function<int()> getValue,
                   std::function<void(int)> setValue) :
       NumberEdit(parent, {x, y, DT_EDT_W, 0}, vmin, vmax,
-                  getValue,
-                  [=](int32_t newValue) {
-                    setValue(newValue);
-                    SET_DIRTY();
-                  })
+                [=]() {
+                  if (isEditing) return editValue;
+                  return getValue();
+                },
+                [=](int newValue) {
+                  if (isEditing)
+                    editValue = newValue;
+                })
   {
-    lastValue = this->getValue();
     if (leading0)
       setDisplayHandler([](int32_t value) { return formatNumberAsString(value, LEADING0, 2); });
+    setOnEditStartHandler([=]() {
+      isEditing = true;
+      editValue = getValue();
+    });
+    setOnEditedHandler([=](int newValue) {
+      isEditing = false;
+      setValue(newValue);
+    });
 }
 
   static LAYOUT_ORIENTATION(DT_EDT_W, EdgeTxStyles::EDIT_FLD_WIDTH_NARROW, LAYOUT_SCALE(52))
 
  protected:
-  int32_t lastValue;
+  int editValue;
+  bool isEditing = false;
 
   void checkEvents() override
   {
-    if (lastValue != getValue())
-      update();
+    if (!isEditing)
+      NumberEdit::checkEvents();
   }
 };
 


### PR DESCRIPTION
Currently when editing a date or time value the underlying variable is still being updated from the RTC.
This makes it difficult to set an accurate value especially for the seconds setting.

This PR changes the behaviour so that a value being edited is no longer updated from the RTC.
When the user finished editing the value, the RTC is updated and refreshing resumes.
