### PR TITLE
docs(lua): normalize luadoc annotation style for screenshot/GlobalVariableDetails

### DIFF
--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -1634,21 +1634,17 @@ static int luaPlayTone(lua_State * L)
 }
 
 /*luadoc
-@name screenshot
+@function screenshot()
 
-@description Takes a screenshot, which is saved to the SCREENSHOTS folder on the radio SD card.
+Takes a screenshot, which is saved to the SCREENSHOTS folder on the radio SD card.
 
-@syntax screenshot()
+@retval none
 
-@return none
-
-@notes This command is currently not rate limited, so repeated frequent calls will slow down the UI and can even freeze the entire radio, so should be used with care. 
-
-@target [BW]
-@target [GS]
-@target [COLOR]
+@notice This command is currently not rate limited, so repeated frequent calls will slow down the UI and can even freeze the entire radio, so should be used with care.
 
 @status current Introduced in 2.11
+
+// targets: BW, GS, COLOR
 */
 static int luaScreenshot(lua_State * L)
 {

--- a/radio/src/lua/api_model.cpp
+++ b/radio/src/lua/api_model.cpp
@@ -1736,16 +1736,21 @@ static int luaModelSetGlobalVariable(lua_State *L)
 }
 
 /*luadoc
-@name model.getGlobalVariableDetails(index)
+@function model.getGlobalVariableDetails(index)
 
-@description Returns details about a Global Variable, but not values
+Returns details about a Global Variable, but not values
 
-@syntax val = model.getGlobalVariableDetails(index)
-@arg index required integer
-@argdesc zero based global variable index, use 0 for GV1, 8 for GV9
-@return table
-@returndesc table with keys - name (string), min (int), max, prec, unit and popup (bool) - if exists
-@apistat 2.11.0 introduced
+@param index (number) zero based global variable index, use 0 for GV1, 8 for GV9
+
+@retval table details of the global variable:
+ * `name` (string) global variable name
+ * `min` (number) minimum value
+ * `max` (number) maximum value
+ * `prec` (number) precision
+ * `unit` (number) unit
+ * `popup` (boolean) show popup - if exists
+
+@status current Introduced in 2.11.0
 */
 static int luaModelGetGlobalVariableDetails(lua_State *L)
 {
@@ -1765,17 +1770,17 @@ static int luaModelGetGlobalVariableDetails(lua_State *L)
 }
 
 /*luadoc
-@name model.setGlobalVariableDetails(index, params)
+@function model.setGlobalVariableDetails(index, params)
 
-@description Sets details about a Global Variable, but not values
+Sets details about a Global Variable, but not values
 
-@arg index required integer
-@argdesc zero based global variable index, use 0 for GV1, 8 for GV9
-@arg table params
-@argdesc see model.getGlobalVariableDetails(index) return format for table format.
-@return none
-@apistat 2.11.0 introduced
+@param index (number) zero based global variable index, use 0 for GV1, 8 for GV9
 
+@param params (table) see model.getGlobalVariableDetails(index) return format for table format
+
+@retval none
+
+@status current Introduced in 2.11.0
 */
 static int luaModelSetGlobalVariableDetails(lua_State *L)
 {


### PR DESCRIPTION
## Summary

Three Lua API functions in `radio/src/lua/api_general.cpp` and `radio/src/lua/api_model.cpp` used an older `@name`/`@description`/`@syntax` luadoc comment style instead of the `@function` style used by every other function in the Lua API:

- `screenshot()`
- `model.getGlobalVariableDetails(index)`
- `model.setGlobalVariableDetails(index, params)`

The external documentation-generation tooling used to build the Lua API reference guide only recognizes `@function`-style blocks, so these three functions were silently missing (or only partially/incorrectly documented) from generated docs, with no visible warning that anything was skipped.

This PR normalizes all three comment blocks to the standard `@function`/`@param`/`@retval`/`@status` form used elsewhere in these files. This is a comment-only change — no functional/behavioral code changed (verified: the diff touches only `/*luadoc ... */` block contents and blank lines).

## Test plan

- [x] Diffed changed hunks to confirm only comment content changed, no code lines
- [x] Confirmed no remaining `@name`/`@syntax`/`@apistat`/`@argdesc`/`@returndesc` (old-style) annotations anywhere under `radio/src/lua/`
- [x] Matched formatting/wording conventions (`@notice`, `@retval`, `@status current Introduced in ...`, `// targets: ...`) against neighboring `@function` blocks in the same files

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yCHydHbzZYCKpav38SonD