### PR TITLE
docs(lua): remove fragile doc-site links from luadoc comments

### DIFF
--- a/radio/src/lua/api_colorlcd.cpp
+++ b/radio/src/lua/api_colorlcd.cpp
@@ -98,7 +98,7 @@ Draw a single pixel at (x,y) position
 
 @param y (positive number) y position
 
-@param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html)
+@param flags (optional) please see the Lcd functions overview
 
 @notice Taranis has an LCD display width of 212 pixels and height of 64 pixels.
 Position (0,0) is at top left. Y axis is negative, top line is 0,
@@ -230,7 +230,7 @@ Draw a text beginning at (x,y)
 
 @param text (string) text to display
 
-@param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html) for drawing flags and colors, and [Appendix](../../part_vii_-_appendix/fonts.md) for available characters in each font set.
+@param flags (optional) please see the Lcd functions overview for drawing flags and colors, and the Appendix for available characters in each font set.
 
 @param inversColor (optional with the INVERS flag) overrides the inverse text color for INVERS
 
@@ -251,7 +251,7 @@ Get the width and height of a text string drawn with flags
 
 @param text (string)
 
-@param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html)
+@param flags (optional) please see the Lcd functions overview
 
 @retval w,h (integers) width and height of the text
 
@@ -279,7 +279,7 @@ Draw text inside rectangle (x,y,w,h) with line breaks
 
 @param text (string) text to display
 
-@param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html) for drawing flags and colors, and [Appendix](../../part_vii_-_appendix/fonts.md) for available characters in each font set. RIGHT, CENTER and VCENTER are not implemented.
+@param flags (optional) please see the Lcd functions overview for drawing flags and colors, and the Appendix for available characters in each font set. RIGHT, CENTER and VCENTER are not implemented.
 
 @retval x,y (integers) point where text drawing ended
 
@@ -344,7 +344,7 @@ Display a value formatted as time at (x,y)
 
 @param value (number) time in seconds
 
-@param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html)
+@param flags (optional) please see the Lcd functions overview
 
 @param inversColor (optional with INVERS flag) overrides the inverse text color for INVERS
 
@@ -371,7 +371,7 @@ Display a number at (x,y)
 
 @param value (number) value to display
 
-@param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html)
+@param flags (optional) please see the Lcd functions overview
 
 @param inversColor (optional with INVERS flag) overrides the inverse text color for INVERS
 
@@ -397,7 +397,7 @@ Display a telemetry value at (x,y)
 @param source can be a source identifier (number) or a source name (string).
 See getValue()
 
-@param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html)
+@param flags (optional) please see the Lcd functions overview
 
 @status current Introduced in 2.0.6, changed in 2.1.0 (only telemetry sources are valid)
 */
@@ -438,7 +438,7 @@ Draw a text representation of switch at (x,y)
 @param switch (number) number of switch to display, negative number
 displays negated switch
 
-@param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html), only SMLSIZE, BLINK and INVERS.
+@param flags (optional) please see the Lcd functions overview, only SMLSIZE, BLINK and INVERS.
 
 @status current Introduced in 2.0.0
 */
@@ -466,7 +466,7 @@ Displays the name of the corresponding input as defined by the source at (x,y)
 
 @param source (number) source index
 
-@param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html)
+@param flags (optional) please see the Lcd functions overview
 
 @status current Introduced in 2.0.0
 */
@@ -716,7 +716,7 @@ Displays a bitmap pattern at (x,y)
 
 @param x,y (positive numbers) starting coordinates
 
-@param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html)
+@param flags (optional) please see the Lcd functions overview
 
 @notice Only available on radios with color display
 
@@ -753,7 +753,7 @@ Displays a bitmap pattern pie at (x,y)
 
 @param endAngle End angle
 
-@param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html)
+@param flags (optional) please see the Lcd functions overview
 
 @notice Only available on radios with color display
 
@@ -790,7 +790,7 @@ Draw a rectangle from top left corner (x,y) of specified width and height
 
 @param h (number) height in pixels
 
-@param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html)
+@param flags (optional) please see the Lcd functions overview
 
 @param t (number) thickness in pixels, defaults to 1 (only on radios with color display)
 
@@ -828,7 +828,7 @@ Draw a solid rectangle from top left corner (x,y) of specified width and height
 
 @param h (number) height in pixels
 
-@param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html)
+@param flags (optional) please see the Lcd functions overview
 
 @param opacity (number) opacity defaults to 0 (only on radios with color display)
 
@@ -865,7 +865,7 @@ Invert a rectangle zone from top left corner (x,y) of specified width and height
 
 @param h (number) height in pixels
 
-@param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html)
+@param flags (optional) please see the Lcd functions overview
 
 @notice Only available on radios with color display
 
@@ -904,7 +904,7 @@ Draw a simple gauge that is filled based upon fill value
 
 @param maxfill (number) total value of fill
 
-@param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html)
+@param flags (optional) please see the Lcd functions overview
 
 @status current Introduced in 2.0.0, changed in 2.2.0
 */
@@ -932,7 +932,7 @@ static int luaLcdDrawGauge(lua_State *L)
 /*luadoc
 @function lcd.setColor(colorIndex, color)
 
-Change an indexed color (theme colors and CUSTOM_COLOR). Please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html#color-constants)
+Change an indexed color (theme colors and CUSTOM_COLOR). Please see the Lcd functions overview for indexed color constants
 
 Please notice that changing theme colors affects not only other Lua widgets, but the entire radio interface.
 
@@ -957,7 +957,7 @@ static int luaLcdSetColor(lua_State *L)
 
 Get the color value from flags
 
-@param flags (flags) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html)
+@param flags (flags) please see the Lcd functions overview
 
 @retval color (flag) only the RGB565 color value of the input
 
@@ -1024,7 +1024,7 @@ Draw a circle at (x, y) of specified radius
 
 @param r (number) radius in pixels
 
-@param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html)
+@param flags (optional) please see the Lcd functions overview
 
 @notice Only available on radios with color display
 
@@ -1055,7 +1055,7 @@ Draw a filled circle at (x, y) of specified radius
 
 @param r (number) radius in pixels
 
-@param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html)
+@param flags (optional) please see the Lcd functions overview
 
 @notice Only available on radios with color display
 
@@ -1084,7 +1084,7 @@ Draw a triangle
 
 @param x1,y1,x2,y2,x3,y3 (positive numbers) coordinates of the three vertices
 
-@param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html)
+@param flags (optional) please see the Lcd functions overview
 
 @notice Only available on radios with color display
 
@@ -1118,7 +1118,7 @@ Draw a filled triangle
 
 @param x1,y1,x2,y2,x3,y3 (positive numbers) coordinates of the three vertices
 
-@param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html)
+@param flags (optional) please see the Lcd functions overview
 
 @notice Only available on radios with color display
 
@@ -1154,7 +1154,7 @@ Draw an arc
 
 @param start,end (positive numbers) start and end of the arc
 
-@param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html)
+@param flags (optional) please see the Lcd functions overview
 
 @notice Only available on radios with color display
 
@@ -1190,7 +1190,7 @@ Draw a pie slice
 
 @param start,end (positive numbers) start and end of the pie slice
 
-@param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html)
+@param flags (optional) please see the Lcd functions overview
 
 @notice Only available on radios with color display
 
@@ -1226,7 +1226,7 @@ Draw an arc
 
 @param start,end (positive numbers) start and end of the annulus
 
-@param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html)
+@param flags (optional) please see the Lcd functions overview
 
 @notice Only available on radios with color display
 
@@ -1260,9 +1260,9 @@ Draw a line only inside a rectangle
 
 @param xmin,xmax,ymin,ymax (positive numbers) the limits of the rectangle inside which the line is drawn
 
-@param pattern (FORCE, ERASE, DOTTED) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html)
+@param pattern (FORCE, ERASE, DOTTED) please see the Lcd functions overview
 
-@param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html)
+@param flags (optional) please see the Lcd functions overview
 
 @notice Only available on radios with color display
 
@@ -1372,7 +1372,7 @@ Draw a rectangle in perspective
 
 @param xmin,xmax,ymin,ymax (positive numbers) the limits of the rectangle
 
-@param flags (optional) please see [Lcd functions overview](../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html)
+@param flags (optional) please see the Lcd functions overview
 
 @notice Only available on radios with color display
 

--- a/radio/src/lua/api_general.cpp
+++ b/radio/src/lua/api_general.cpp
@@ -625,7 +625,7 @@ The list of valid sources is available:
  * `id`   (number) field identifier
  * `name` (string) field name
  * `desc` (string) field description
- * `unit` (number) unit identifier [Full list](../appendix/units.html)
+ * `unit` (number) unit identifier, see the Units reference for the full list
 
 @retval nil the requested field was not found
 
@@ -1505,7 +1505,7 @@ Play a numerical value (text to speech)
 
 @param value (number) number to play. Value is interpreted as integer.
 
-@param unit (number) unit identifier [Full list]((../appendix/units.html))
+@param unit (number) unit identifier, see the Units reference for the full list
 
 @param attributes (unsigned number) possible values:
  * `0 or not present` plays integral part of the number (for a number 123 it plays 123)
@@ -2001,7 +2001,7 @@ static int luaDefaultStick(lua_State * L)
 
 @param value fed to the sensor
 
-@param unit unit of the sensor [Full list](../../appendix/units.html)
+@param unit unit of the sensor, see the Units reference for the full list
 
 @param precision the precision of the sensor
  * `0 or not present` no decimal precision.


### PR DESCRIPTION
## Summary

28 Lua API functions across `radio/src/lua/api_colorlcd.cpp` and `radio/src/lua/api_general.cpp` had markdown links to specific pages on the external Lua reference guide baked directly into their `/*luadoc*/` comments:

- A mangled GitBook artifact link (a stray `<!-- LUADOC:BEGIN lcd -->`-style placeholder comment that got slugified into a literal, meaningless path — `../lcd-functions-less-than-greater-than-luadoc-begin-lcd/lcd_functions-overview.html`) on every `lcd.draw*`/`lcd.getColor`/`lcd.invertRect`/`lcd.setColor`/`lcd.sizeText` function's `flags` (or similar) parameter description.
- A broken relative path to an appendix/units page (`../appendix/units.html`, `../../appendix/units.html`) on `getFieldInfo`, `playNumber`, and `setTelemetryValue` — one of these also had a stray extra pair of parens around the link (`[Full list]((../appendix/units.html))`).

Baking a specific documentation site's internal relative URL into a firmware comment means it breaks every time that site's structure changes, and — more importantly — regenerating any downstream documentation from these comments reproduces the break indefinitely, since the broken text is the actual source of truth being extracted. This was confirmed happening in practice this week: a Lua reference guide fix for this exact link silently reverted after a fresh extraction pulled the still-broken text back out of these comments, because the fix had only patched the generated output, not the source.

This PR removes the broken markdown link syntax and replaces it with plain descriptive text (e.g. "please see the Lcd functions overview" / "see the Units reference for the full list") instead of a specific, fragile relative path. Comment-only change, no behavior change.

## Test plan

- [x] `grep -rn "luadoc-begin-lcd\|appendix/units\.html\|part_vii_-_appendix" radio/src/lua/*.cpp` — zero matches remaining anywhere in the Lua API source
- [x] Diffed changed hunks to confirm only comment content changed, no code lines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015yCHydHbzZYCKpav38SonD