### PR TITLE
fix(telemetry): HoTT out-of-bounds warning byte and null sensor lookup

### DIFF
--- a/radio/src/telemetry/hott.cpp
+++ b/radio/src/telemetry/hott.cpp
@@ -296,13 +296,15 @@ const HottSensor hottSensors[] = {
 };
 // clang-format on
 
+// Never returns null: falls back to the sentinel entry (name == nullptr)
 const HottSensor * getHottSensor(uint16_t id)
 {
-  for (const HottSensor * sensor = hottSensors; sensor->id; sensor++) {
+  const HottSensor * sensor = hottSensors;
+  for (; sensor->id; sensor++) {
     if (id == sensor->id)
       return sensor;
   }
-  return nullptr;
+  return sensor;
 }
 
 int16_t processHoTTdBm(int16_t value)
@@ -929,7 +931,7 @@ void hottSetDefault(int index, uint16_t id, uint8_t subId, uint8_t instance)
   telemetrySensor.instance = instance;
 
   const HottSensor * sensor = getHottSensor(id);
-  if (sensor) {
+  if (sensor->name) {
     TelemetryUnit unit = sensor->unit;
     uint8_t prec = min<uint8_t>(2, sensor->precision);
     telemetrySensor.init(sensor->name, unit, prec);


### PR DESCRIPTION
Review triggered by comments from @bsongis :)

True issue:
processHoTTWarnings() reads packet[14] (the device warnings byte) for every page 1-4 frame, but the MultiProtocol dispatcher only validated len >= 14, so with a 14-byte frame the warning code came from stale telemetryRxBuffer content and could raise a spurious HoTT warning. The frame is documented as [0]..[14]; the guard predates the warnings byte.

Possible issue if miss edit happens on HOTT data tables
getHottSensor() returned nullptr on a miss while ~60 call sites in processHottPacket() dereference the result unguarded. Return the table's sentinel entry instead so an unknown ID degrades to UNIT_RAW/precision 0; hottSetDefault() now tests sensor->name to detect a real match.
