### PR TITLE
chore(color): fix minor issues when moving controls to select a source

### DIFF
--- a/radio/src/gui/colorlcd/controls/sourcechoice.cpp
+++ b/radio/src/gui/colorlcd/controls/sourcechoice.cpp
@@ -181,7 +181,7 @@ void SourceChoice::openMenu()
 #if defined(AUTOSOURCE)
   menu->setWaitHandler([=]() {
     int16_t val = getMovedSource(vmin);
-    if (val) {
+    if (val && (!isValueAvailable || isValueAvailable(val))) {
       tb->resetFilter();
       menu->select(getIndexFromValue(val));
     }
@@ -190,7 +190,7 @@ void SourceChoice::openMenu()
       swsrc_t swtch = abs(getMovedSwitch());
       if (swtch && !IS_SWITCH_MULTIPOS(swtch)) {
         val = switchToMix(swtch);
-        if (val && (val >= vmin) && (val <= vmax)) {
+        if (val && (val >= vmin) && (val <= vmax) && (!isValueAvailable || isValueAvailable(val))) {
           tb->resetFilter();
           menu->select(getIndexFromValue(val));
         }

--- a/radio/src/gui/colorlcd/libui/menu.cpp
+++ b/radio/src/gui/colorlcd/libui/menu.cpp
@@ -202,7 +202,7 @@ class MenuBody : public TableField
   void onDrawBegin(uint16_t row, uint16_t col,
                    lv_obj_draw_part_dsc_t* dsc) override
   {
-    if (lines.size() == 0) return;
+    if (row >= lines.size()) return;
 
     lv_canvas_t* icon = (lv_canvas_t*)lines[row]->getIcon();
     if (!icon) return;

--- a/radio/src/gui/colorlcd/libui/menutoolbar.cpp
+++ b/radio/src/gui/colorlcd/libui/menutoolbar.cpp
@@ -93,11 +93,9 @@ MenuToolbar::~MenuToolbar() { lv_group_del(group); }
 
 void MenuToolbar::resetFilter()
 {
-  if (lv_group_get_focused(group) != lvobj) {
-    lv_group_focus_obj(lvobj);
-    choice->fillMenu(menu);
-    menu->setTitle(choice->getTitle());
-  }
+  // Nothing to do if no filter is active
+  if (allBtn && !allBtn->checked())
+    lv_event_send(allBtn->getLvObj(), LV_EVENT_CLICKED, nullptr);
 }
 
 void MenuToolbar::nextFilter()

--- a/radio/src/gui/colorlcd/libui/table.cpp
+++ b/radio/src/gui/colorlcd/libui/table.cpp
@@ -197,7 +197,7 @@ void TableField::setColumnWidth(uint16_t col, coord_t w)
 void TableField::select(uint16_t row, uint16_t col, bool force)
 {
   lv_table_t* table = (lv_table_t*)lvobj;
-  if (!force && table->row_act == row && table->col_act == row) return;
+  if (!force && table->row_act == row && table->col_act == col) return;
 
   if (row >= table->row_cnt || col >= table->col_cnt) {
     table->col_act = LV_TABLE_CELL_NONE;
@@ -214,6 +214,8 @@ void TableField::select(uint16_t row, uint16_t col, bool force)
 void TableField::adjustScroll()
 {
   lv_table_t* table = (lv_table_t*)lvobj;
+
+  if (table->row_act >= table->row_cnt) return;
 
   // only vertical scroll for now
   lv_coord_t h_before = 0;


### PR DESCRIPTION
Fixes some issues identified by @3djc and AI:
- don't rebuild the entire source picker menu when a control or switch is moved to select it.
- check that a moved control or switch is valid for the selection.
- fix some bounds checks in the menu and table classes.
