### PR TITLE
fix(audio): long timer announced as "1 hour 60" before hour rollover

### DIFF
--- a/radio/src/translations/tts/tts_cn.cpp
+++ b/radio/src/translations/tts/tts_cn.cpp
@@ -108,15 +108,15 @@ I18N_PLAY_FUNCTION(cn, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
+  if (IS_PLAY_LONG_TIMER()) {
+    seconds += 30;
+  }
+
   int hours, minutes;
   hours = seconds / 3600;
   seconds = seconds % 3600;
   minutes = seconds / 60;
   seconds = seconds % 60;
-
-  if (IS_PLAY_LONG_TIMER() && seconds >= 30) {
-    minutes += 1;
-  }
 
   if (hours > 0 || IS_PLAY_TIME()) {
     PLAY_NUMBER(hours, UNIT_HOURS, 0);

--- a/radio/src/translations/tts/tts_cz.cpp
+++ b/radio/src/translations/tts/tts_cz.cpp
@@ -169,15 +169,15 @@ I18N_PLAY_FUNCTION(cz, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
+  if (IS_PLAY_LONG_TIMER()) {
+    seconds += 30;
+  }
+
   int hours, minutes;
   hours = seconds / 3600;
   seconds = seconds % 3600;
   minutes = seconds / 60;
   seconds = seconds % 60;
-
-  if (IS_PLAY_LONG_TIMER() && seconds >= 30) {
-    minutes += 1;
-  }
 
   if (hours > 0 || IS_PLAY_TIME()) {
     PLAY_NUMBER(hours, UNIT_HOURS, FEMALE);

--- a/radio/src/translations/tts/tts_da.cpp
+++ b/radio/src/translations/tts/tts_da.cpp
@@ -104,15 +104,15 @@ I18N_PLAY_FUNCTION(da, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
+  if (IS_PLAY_LONG_TIMER()) {
+    seconds += 30;
+  }
+
   int hours, minutes;
   hours = seconds / 3600;
   seconds = seconds % 3600;
   minutes = seconds / 60;
   seconds = seconds % 60;
-
-  if (IS_PLAY_LONG_TIMER() && seconds >= 30) {
-    minutes += 1;
-  }
 
   if (hours > 0 || IS_PLAY_TIME()) {
     PLAY_NUMBER(hours, UNIT_HOURS, 0);

--- a/radio/src/translations/tts/tts_de.cpp
+++ b/radio/src/translations/tts/tts_de.cpp
@@ -149,15 +149,15 @@ I18N_PLAY_FUNCTION(de, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
+  if (IS_PLAY_LONG_TIMER()) {
+    seconds += 30;
+  }
+
   int hours, minutes;
   hours = seconds / 3600;
   seconds = seconds % 3600;
   minutes = seconds / 60;
   seconds = seconds % 60;
-
-  if (IS_PLAY_LONG_TIMER() && seconds >= 30) {
-    minutes += 1;
-  }
 
   if (hours > 0 || IS_PLAY_TIME()) {
     PLAY_NUMBER(hours, UNIT_HOURS, 0);

--- a/radio/src/translations/tts/tts_en.cpp
+++ b/radio/src/translations/tts/tts_en.cpp
@@ -107,15 +107,15 @@ I18N_PLAY_FUNCTION(en, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
+  if (IS_PLAY_LONG_TIMER()) {
+    seconds += 30;
+  }
+
   int hours, minutes;
   hours = seconds / 3600;
   seconds = seconds % 3600;
   minutes = seconds / 60;
   seconds = seconds % 60;
-
-  if (IS_PLAY_LONG_TIMER() && seconds >= 30) {
-    minutes += 1;
-  }
 
   if (hours > 0 || IS_PLAY_TIME()) {
     PLAY_NUMBER(hours, UNIT_HOURS, 0);

--- a/radio/src/translations/tts/tts_es.cpp
+++ b/radio/src/translations/tts/tts_es.cpp
@@ -155,15 +155,15 @@ I18N_PLAY_FUNCTION(es, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
+  if (IS_PLAY_LONG_TIMER()) {
+    seconds += 30;
+  }
+
   int hours, minutes;
   hours = seconds / 3600;
   seconds = seconds % 3600;
   minutes = seconds / 60;
   seconds = seconds % 60;
-
-  if (IS_PLAY_LONG_TIMER() && seconds >= 30) {
-    minutes += 1;
-  }
 
   if (hours > 0 || IS_PLAY_TIME()) {
     if (hours > 1) {

--- a/radio/src/translations/tts/tts_fr.cpp
+++ b/radio/src/translations/tts/tts_fr.cpp
@@ -139,15 +139,15 @@ I18N_PLAY_FUNCTION(fr, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
+  if (IS_PLAY_LONG_TIMER()) {
+    seconds += 30;
+  }
+
   int hours, minutes;
   hours = seconds / 3600;
   seconds = seconds % 3600;
   minutes = seconds / 60;
   seconds = seconds % 60;
-
-  if (IS_PLAY_LONG_TIMER() && seconds >= 30) {
-    minutes += 1;
-  }
 
   if (IS_PLAY_TIME() && hours == 0) {
     PUSH_NUMBER_PROMPT(FR_PROMPT_MINUIT);

--- a/radio/src/translations/tts/tts_he.cpp
+++ b/radio/src/translations/tts/tts_he.cpp
@@ -108,15 +108,15 @@ I18N_PLAY_FUNCTION(he, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
+  if (IS_PLAY_LONG_TIMER()) {
+    seconds += 30;
+  }
+
   int hours, minutes;
   hours = seconds / 3600;
   seconds = seconds % 3600;
   minutes = seconds / 60;
   seconds = seconds % 60;
-
-  if (IS_PLAY_LONG_TIMER() && seconds >= 30) {
-    minutes += 1;
-  }
 
   if (hours > 0 || IS_PLAY_TIME()) {
     PLAY_NUMBER(hours, UNIT_HOURS, 0);

--- a/radio/src/translations/tts/tts_hu.cpp
+++ b/radio/src/translations/tts/tts_hu.cpp
@@ -108,15 +108,15 @@ I18N_PLAY_FUNCTION(hu, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
+  if (IS_PLAY_LONG_TIMER()) {
+    seconds += 30;
+  }
+
   int hours, minutes;
   hours = seconds / 3600;
   seconds = seconds % 3600;
   minutes = seconds / 60;
   seconds = seconds % 60;
-
-  if (IS_PLAY_LONG_TIMER() && seconds >= 30) {
-    minutes += 1;
-  }
 
   if (hours > 0 || IS_PLAY_TIME()) {
     PLAY_NUMBER(hours, UNIT_HOURS, 0);

--- a/radio/src/translations/tts/tts_it.cpp
+++ b/radio/src/translations/tts/tts_it.cpp
@@ -158,15 +158,15 @@ I18N_PLAY_FUNCTION(it, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
+  if (IS_PLAY_LONG_TIMER()) {
+    seconds += 30;
+  }
+
   int hours, minutes;
   hours = seconds / 3600;
   seconds = seconds % 3600;
   minutes = seconds / 60;
   seconds = seconds % 60;
-
-  if (IS_PLAY_LONG_TIMER() && seconds >= 30) {
-    minutes += 1;
-  }
 
   if (hours > 0 || IS_PLAY_TIME()) {
     PLAY_NUMBER(hours, UNIT_HOURS, 0);

--- a/radio/src/translations/tts/tts_nl.cpp
+++ b/radio/src/translations/tts/tts_nl.cpp
@@ -110,15 +110,15 @@ I18N_PLAY_FUNCTION(nl, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
+  if (IS_PLAY_LONG_TIMER()) {
+    seconds += 30;
+  }
+
   int hours, minutes;
   hours = seconds / 3600;
   seconds = seconds % 3600;
   minutes = seconds / 60;
   seconds = seconds % 60;
-
-  if (IS_PLAY_LONG_TIMER() && seconds >= 30) {
-    minutes += 1;
-  }
 
   if (hours > 0 || IS_PLAY_TIME()) {
     PLAY_NUMBER(hours, UNIT_HOURS, 0);

--- a/radio/src/translations/tts/tts_pl.cpp
+++ b/radio/src/translations/tts/tts_pl.cpp
@@ -215,15 +215,15 @@ I18N_PLAY_FUNCTION(pl, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
+  if (IS_PLAY_LONG_TIMER()) {
+    seconds += 30;
+  }
+
   int hours, minutes;
   hours = seconds / 3600;
   seconds = seconds % 3600;
   minutes = seconds / 60;
   seconds = seconds % 60;
-
-  if (IS_PLAY_LONG_TIMER() && seconds >= 30) {
-    minutes += 1;
-  }
 
   if (hours > 0 || IS_PLAY_TIME()) {
     PLAY_NUMBER(hours, UNIT_HOURS, ZENSKI);

--- a/radio/src/translations/tts/tts_pt.cpp
+++ b/radio/src/translations/tts/tts_pt.cpp
@@ -143,15 +143,15 @@ I18N_PLAY_FUNCTION(pt, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
+  if (IS_PLAY_LONG_TIMER()) {
+    seconds += 30;
+  }
+
   int hours, minutes;
   hours = seconds / 3600;
   seconds = seconds % 3600;
   minutes = seconds / 60;
   seconds = seconds % 60;
-
-  if (IS_PLAY_LONG_TIMER() && seconds >= 30) {
-    minutes += 1;
-  }
 
   if (hours > 0 || IS_PLAY_TIME()) {
     if (hours > 2) {

--- a/radio/src/translations/tts/tts_ru.cpp
+++ b/radio/src/translations/tts/tts_ru.cpp
@@ -170,15 +170,15 @@ I18N_PLAY_FUNCTION(ru, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
+  if (IS_PLAY_LONG_TIMER()) {
+    seconds += 30;
+  }
+
   int hours, minutes;
   hours = seconds / 3600;
   seconds = seconds % 3600;
   minutes = seconds / 60;
   seconds = seconds % 60;
-
-  if (IS_PLAY_LONG_TIMER() && seconds >= 30) {
-    minutes += 1;
-  }
 
   if (hours > 0 || IS_PLAY_TIME()) {
     PLAY_NUMBER(hours, UNIT_HOURS, 0);

--- a/radio/src/translations/tts/tts_se.cpp
+++ b/radio/src/translations/tts/tts_se.cpp
@@ -103,15 +103,15 @@ I18N_PLAY_FUNCTION(se, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
+  if (IS_PLAY_LONG_TIMER()) {
+    seconds += 30;
+  }
+
   int hours, minutes;
   hours = seconds / 3600;
   seconds = seconds % 3600;
   minutes = seconds / 60;
   seconds = seconds % 60;
-
-  if (IS_PLAY_LONG_TIMER() && seconds >= 30) {
-    minutes += 1;
-  }
 
   if (hours > 0 || IS_PLAY_TIME()) {
     PLAY_NUMBER(hours, UNIT_HOURS, 0);

--- a/radio/src/translations/tts/tts_sk.cpp
+++ b/radio/src/translations/tts/tts_sk.cpp
@@ -165,15 +165,15 @@ I18N_PLAY_FUNCTION(sk, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
+  if (IS_PLAY_LONG_TIMER()) {
+    seconds += 30;
+  }
+
   int hours, minutes;
   hours = seconds / 3600;
   seconds = seconds % 3600;
   minutes = seconds / 60;
   seconds = seconds % 60;
-
-  if (IS_PLAY_LONG_TIMER() && seconds >= 30) {
-    minutes += 1;
-  }
 
   if (hours > 0 || IS_PLAY_TIME()) {
     PLAY_NUMBER(hours, UNIT_HOURS, ZENSKY);

--- a/radio/src/translations/tts/tts_ua.cpp
+++ b/radio/src/translations/tts/tts_ua.cpp
@@ -169,15 +169,15 @@ I18N_PLAY_FUNCTION(ua, playDuration, int seconds PLAY_DURATION_ATT)
     seconds = -seconds;
   }
 
+  if (IS_PLAY_LONG_TIMER()) {
+    seconds += 30;
+  }
+
   int hours, minutes;
   hours = seconds / 3600;
   seconds = seconds % 3600;
   minutes = seconds / 60;
   seconds = seconds % 60;
-
-  if (IS_PLAY_LONG_TIMER() && seconds >= 30) {
-    minutes += 1;
-  }
 
   if (hours > 0 || IS_PLAY_TIME()) {
     PLAY_NUMBER(hours, UNIT_HOURS, 0);


### PR DESCRIPTION
Fixes #7783

## Problem
When a timer longer than 10 minutes is announced (`PLAY_LONG_TIMER`), the value is rounded to the nearest minute. The rounding was applied **after** splitting into hours and minutes, so the extra minute never carried into the hours:

- `1:59:30` → "one hour sixty"
- `0:59:30` → "sixty minutes"

Introduced in #3293 (v2.9.0), which changed long timers from minutes-only to hours + minutes but kept the round-up on the minutes part.

## Fix
Add 30 s before the hours/minutes split, then drop the post-split `minutes += 1`. Seconds are not spoken for long timers, so this is the only effect.

Applied to all languages sharing the pattern: cn, cz, da, de, en, es, fr, he, hu, it, nl, pl, pt, ru, se, sk, ua. 

Note: jp and ko still use the pre-#3293 minutes-only path so do not exhibit the #7783 bug.

## Testing
Checked the new arithmetic on host for every value from 601 s to 10 h: the result always equals round-to-nearest-minute, and minutes never reach 60. Not tested on a radio.

@pfeerick should apply cleanly for 2.12 backport

